### PR TITLE
fix: update create-emdash for standalone templates repo

### DIFF
--- a/.changeset/fix-create-emdash.md
+++ b/.changeset/fix-create-emdash.md
@@ -1,0 +1,5 @@
+---
+"create-emdash": patch
+---
+
+Fix create-emdash to use all available templates from the new standalone templates repo. Templates are now selected in two steps: platform (Node.js or Cloudflare Workers) then template type (blog, starter, marketing, portfolio, blank). Downloads from `emdash-cms/templates` instead of the old monorepo path.

--- a/packages/create-emdash/package.json
+++ b/packages/create-emdash/package.json
@@ -14,10 +14,11 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",
-    "picocolors": "^1.1.1",
-    "giget": "^1.2.3"
+    "giget": "^1.2.3",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },
@@ -33,7 +34,5 @@
     "type": "git",
     "url": "git+https://github.com/emdash-cms/emdash.git",
     "directory": "packages/create-emdash"
-  },
-  "peerDependencies": {},
-  "optionalDependencies": {}
+  }
 }

--- a/packages/create-emdash/src/index.ts
+++ b/packages/create-emdash/src/index.ts
@@ -7,43 +7,84 @@
  */
 
 import { execSync } from "node:child_process";
-import { cpSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import * as p from "@clack/prompts";
 import { downloadTemplate } from "giget";
 import pc from "picocolors";
 
-type Template = "blog" | "cloudflare" | "blank";
-
 const PROJECT_NAME_PATTERN = /^[a-z0-9-]+$/;
 
-const TEMPLATES = {
+const GITHUB_REPO = "emdash-cms/templates";
+
+type Platform = "node" | "cloudflare";
+
+interface TemplateConfig {
+	name: string;
+	description: string;
+	/** Directory name in the templates repo */
+	dir: string;
+}
+
+const NODE_TEMPLATES = {
 	blog: {
 		name: "Blog",
-		description: "A blog with posts and pages (Node.js + SQLite)",
+		description: "A blog with posts, pages, and authors",
 		dir: "blog",
-		repo: "github:emdash-cms/emdash/templates/blog",
 	},
-	cloudflare: {
-		name: "Cloudflare",
-		description: "A blog on Cloudflare Workers (D1 + R2)",
-		dir: "cloudflare",
-		repo: "github:emdash-cms/emdash/templates/cloudflare",
+	starter: {
+		name: "Starter",
+		description: "A general-purpose starter with posts and pages",
+		dir: "starter",
+	},
+	marketing: {
+		name: "Marketing",
+		description: "A marketing site with landing pages and CTAs",
+		dir: "marketing",
+	},
+	portfolio: {
+		name: "Portfolio",
+		description: "A portfolio site with projects and case studies",
+		dir: "portfolio",
 	},
 	blank: {
 		name: "Blank",
-		description: "A minimal starter project",
+		description: "A minimal starter with no content or styling",
 		dir: "blank",
-		repo: "github:emdash-cms/emdash/templates/blank",
 	},
-} as const;
+} as const satisfies Record<string, TemplateConfig>;
+
+const CLOUDFLARE_TEMPLATES = {
+	blog: {
+		name: "Blog",
+		description: "A blog with posts, pages, and authors",
+		dir: "blog-cloudflare",
+	},
+	starter: {
+		name: "Starter",
+		description: "A general-purpose starter with posts and pages",
+		dir: "starter-cloudflare",
+	},
+	marketing: {
+		name: "Marketing",
+		description: "A marketing site with landing pages and CTAs",
+		dir: "marketing-cloudflare",
+	},
+	portfolio: {
+		name: "Portfolio",
+		description: "A portfolio site with projects and case studies",
+		dir: "portfolio-cloudflare",
+	},
+} as const satisfies Record<string, TemplateConfig>;
+
+type NodeTemplate = keyof typeof NODE_TEMPLATES;
+type CloudflareTemplate = keyof typeof CLOUDFLARE_TEMPLATES;
 
 /** Build select options from a config object, preserving literal key types */
 function selectOptions<K extends string>(
 	obj: Readonly<Record<K, Readonly<{ name: string; description: string }>>>,
 ): { value: K; label: string; hint: string }[] {
-	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Object.keys returns string[]; narrowed to K which is the known key union
 	return (Object.keys(obj) as K[]).map((key) => ({
 		value: key,
 		label: obj[key].name,
@@ -51,26 +92,10 @@ function selectOptions<K extends string>(
 	}));
 }
 
-function findMonorepoRoot(): string | null {
-	let dir = process.cwd();
-	while (true) {
-		if (existsSync(resolve(dir, "pnpm-workspace.yaml")) && existsSync(resolve(dir, "templates"))) {
-			return dir;
-		}
-		const parent = resolve(dir, "..");
-		if (parent === dir) return null;
-		dir = parent;
-	}
-}
-
-const useRemote = process.argv.includes("--remote");
-
 async function main() {
 	console.clear();
 
-	const monorepoRoot = useRemote ? null : findMonorepoRoot();
-
-	p.intro(`— ${pc.bgCyan(pc.black(" create-emdash "))}`);
+	p.intro(`${pc.bgCyan(pc.black(" create-emdash "))}`);
 
 	const projectName = await p.text({
 		message: "Project name?",
@@ -89,13 +114,11 @@ async function main() {
 		process.exit(0);
 	}
 
-	const projectDir = monorepoRoot
-		? resolve(monorepoRoot, "demos", projectName)
-		: resolve(process.cwd(), projectName);
+	const projectDir = resolve(process.cwd(), projectName);
 
 	if (existsSync(projectDir)) {
 		const overwrite = await p.confirm({
-			message: `Directory ${monorepoRoot ? `demos/${projectName}` : projectName} already exists. Overwrite?`,
+			message: `Directory ${projectName} already exists. Overwrite?`,
 			initialValue: false,
 		});
 
@@ -103,36 +126,63 @@ async function main() {
 			p.cancel("Operation cancelled.");
 			process.exit(0);
 		}
-
-		rmSync(projectDir, { recursive: true, force: true });
 	}
 
-	const template = await p.select<Template>({
-		message: "Which template?",
-		options: selectOptions(TEMPLATES),
-		initialValue: "blog",
+	// Step 1: pick platform
+	const platform = await p.select<Platform>({
+		message: "Where will you deploy?",
+		options: [
+			{
+				value: "node",
+				label: "Node.js",
+				hint: "SQLite + local file storage",
+			},
+			{
+				value: "cloudflare",
+				label: "Cloudflare Workers",
+				hint: "D1 + R2",
+			},
+		],
+		initialValue: "node",
 	});
 
-	if (p.isCancel(template)) {
+	if (p.isCancel(platform)) {
 		p.cancel("Operation cancelled.");
 		process.exit(0);
 	}
+
+	// Step 2: pick template
+	const templateKey =
+		platform === "node"
+			? await p.select<NodeTemplate>({
+					message: "Which template?",
+					options: selectOptions(NODE_TEMPLATES),
+					initialValue: "blog",
+				})
+			: await p.select<CloudflareTemplate>({
+					message: "Which template?",
+					options: selectOptions(CLOUDFLARE_TEMPLATES),
+					initialValue: "blog",
+				});
+
+	if (p.isCancel(templateKey)) {
+		p.cancel("Operation cancelled.");
+		process.exit(0);
+	}
+
+	const templateConfig =
+		platform === "node"
+			? NODE_TEMPLATES[templateKey as NodeTemplate]
+			: CLOUDFLARE_TEMPLATES[templateKey as CloudflareTemplate];
 
 	const s = p.spinner();
 	s.start("Creating project...");
 
 	try {
-		const templateConfig = TEMPLATES[template];
-
-		if (monorepoRoot) {
-			const templateDir = resolve(monorepoRoot, "templates", templateConfig.dir);
-			cpSync(templateDir, projectDir, { recursive: true });
-		} else {
-			await downloadTemplate(templateConfig.repo, {
-				dir: projectDir,
-				force: true,
-			});
-		}
+		await downloadTemplate(`github:${GITHUB_REPO}/${templateConfig.dir}`, {
+			dir: projectDir,
+			force: true,
+		});
 
 		// Set project name in package.json
 		const pkgPath = resolve(projectDir, "package.json");
@@ -140,12 +190,12 @@ async function main() {
 			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 			pkg.name = projectName;
 
-			// Add emdash config for CLI commands (init reads seed path from here)
-			const hasSeed = existsSync(resolve(projectDir, ".emdash", "seed.json"));
-			if (hasSeed) {
+			// Add emdash config if template has seed data
+			const seedPath = resolve(projectDir, "seed", "seed.json");
+			if (existsSync(seedPath)) {
 				pkg.emdash = {
 					label: templateConfig.name,
-					seed: ".emdash/seed.json",
+					seed: "seed/seed.json",
 				};
 			}
 
@@ -157,25 +207,18 @@ async function main() {
 		s.start("Installing dependencies...");
 		try {
 			execSync("pnpm install", {
-				cwd: monorepoRoot ?? projectDir,
+				cwd: projectDir,
 				stdio: "ignore",
 			});
 			s.stop("Dependencies installed!");
 		} catch {
 			s.stop("Failed to install dependencies");
-			p.log.warn(
-				monorepoRoot
-					? `Run ${pc.cyan("pnpm install")} from the repo root manually`
-					: `Run ${pc.cyan(`cd ${projectName} && pnpm install`)} manually`,
-			);
+			p.log.warn(`Run ${pc.cyan(`cd ${projectName} && pnpm install`)} manually`);
 		}
 
-		const filterOrCd = monorepoRoot ? `pnpm --filter ${projectName}` : `cd ${projectName}\nnpm`;
+		p.note(`cd ${projectName}\npnpm run bootstrap\npnpm run dev`, "Next steps");
 
-		p.note(`${filterOrCd} run bootstrap\n${filterOrCd} run dev`, "Next steps");
-
-		const displayPath = monorepoRoot ? `demos/${projectName}` : projectName;
-		p.outro(`${pc.green("Done!")} Your EmDash project is ready at ${pc.cyan(displayPath)}`);
+		p.outro(`${pc.green("Done!")} Your EmDash project is ready at ${pc.cyan(projectName)}`);
 	} catch (error) {
 		s.stop("Failed to create project");
 		p.log.error(error instanceof Error ? error.message : String(error));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,7 +614,7 @@ importers:
         version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest-browser-react:
         specifier: ^2.0.5
         version: 2.0.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18)
@@ -660,7 +660,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/blocks:
     dependencies:
@@ -715,7 +715,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/blocks/playground:
     dependencies:
@@ -798,7 +798,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -994,6 +994,9 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.13
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260213.1)(oxc-resolver@11.16.4)(publint@0.3.17)(typescript@5.9.3)
@@ -1024,7 +1027,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/marketplace:
     dependencies:
@@ -1055,7 +1058,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: 'catalog:'
         version: 4.71.0(@cloudflare/workers-types@4.20260305.1)
@@ -1083,7 +1086,7 @@ importers:
         version: 19.2.14
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/api-test:
     dependencies:
@@ -1105,7 +1108,7 @@ importers:
     devDependencies:
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/audit-log:
     dependencies:
@@ -1220,7 +1223,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@x402/svm':
         specifier: ^2.8.0
@@ -11662,7 +11665,7 @@ snapshots:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11696,7 +11699,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -15955,7 +15958,7 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.17)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -15986,45 +15989,6 @@ snapshots:
       '@types/node': 24.10.13
       '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/ui': 4.0.17(vitest@4.0.18)
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
-  vitest@4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.10.13
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary

- Point at `emdash-cms/templates` repo instead of the old monorepo path (`emdash-cms/emdash/templates`)
- List all 9 templates: blog, starter, marketing, portfolio, blank (Node.js) + blog, starter, marketing, portfolio (Cloudflare)
- Two-step selection: platform first (Node.js vs Cloudflare Workers), then template type
- Remove monorepo detection -- always downloads from GitHub
- Fix seed path detection (`seed/seed.json` not `.emdash/seed.json`)
- Add missing `@types/node` devDependency