### PR TITLE
fix(create-emdash): fix spinner hanging during dep install

### DIFF
--- a/.changeset/fix-create-emdash-spinner.md
+++ b/.changeset/fix-create-emdash-spinner.md
@@ -1,0 +1,5 @@
+---
+"create-emdash": patch
+---
+
+Fix spinner hanging during dependency installation by using async exec instead of execSync, which was blocking the event loop and preventing the spinner animation from updating.

--- a/packages/create-emdash/src/index.ts
+++ b/packages/create-emdash/src/index.ts
@@ -6,9 +6,12 @@
  * Usage: npm create emdash@latest
  */
 
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
 
 import * as p from "@clack/prompts";
 import { downloadTemplate } from "giget";
@@ -251,10 +254,7 @@ async function main() {
 		if (shouldInstall) {
 			s.start(`Installing dependencies with ${pc.cyan(pm)}...`);
 			try {
-				execSync(installCmd, {
-					cwd: projectDir,
-					stdio: "ignore",
-				});
+				await execAsync(installCmd, { cwd: projectDir });
 				s.stop("Dependencies installed!");
 			} catch {
 				s.stop("Failed to install dependencies");


### PR DESCRIPTION
## Summary

- Replace `execSync` with async `exec` (via `promisify`) so the clack spinner can animate while dependencies install. `execSync` blocks the event loop, preventing `setInterval` from firing.

## Testing

Lint and typecheck pass. Verified spinner animates during install.