### PR TITLE
fix: redirect to setup wizard on fresh deployments

### DIFF
--- a/.changeset/cruel-forks-float.md
+++ b/.changeset/cruel-forks-float.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Update branding

--- a/.changeset/quick-parks-smoke.md
+++ b/.changeset/quick-parks-smoke.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix crash on fresh deployments when the first request hits a public page before setup has run. The middleware now detects an empty database and redirects to the setup wizard instead of letting template helpers query missing tables.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -55,6 +55,16 @@ let runtimeInitializing = false;
 let i18nInitialized = false;
 
 /**
+ * Whether we've verified the database has been set up.
+ * On a fresh deployment the first request may hit a public page, bypassing
+ * runtime init. Without this check, template helpers like getSiteSettings()
+ * would query an empty database and crash. Once verified (or once the runtime
+ * has initialized via an admin/API request), this stays true for the worker's
+ * lifetime.
+ */
+let setupVerified = false;
+
+/**
  * Get EmDash configuration from virtual module
  */
 function getConfig(): EmDashConfig | null {
@@ -190,6 +200,28 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	if (!isEmDashRoute && !isPublicRuntimeRoute && !hasEditCookie && !hasPreviewToken) {
 		const sessionUser = await context.session?.get("user");
 		if (!sessionUser && !playgroundDb) {
+			// On a fresh deployment the database may be completely empty.
+			// Public pages call getSiteSettings() / getMenu() via getDb(), which
+			// bypasses runtime init and would crash with "no such table: options".
+			// Do a one-time lightweight probe using the same getDb() instance the
+			// page will use: if the migrations table doesn't exist, no migrations
+			// have ever run -- redirect to the setup wizard.
+			if (!setupVerified) {
+				try {
+					const { getDb } = await import("../loader.js");
+					const db = await getDb();
+					await db
+						.selectFrom("_emdash_migrations" as keyof Database)
+						.selectAll()
+						.limit(1)
+						.execute();
+					setupVerified = true;
+				} catch {
+					// Table doesn't exist -> fresh database, redirect to setup
+					return context.redirect("/_emdash/admin/setup");
+				}
+			}
+
 			const response = await next();
 			setBaselineSecurityHeaders(response);
 			return response;
@@ -209,6 +241,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		try {
 			// Get or create runtime
 			const runtime = await getRuntime(config);
+
+			// Runtime init runs migrations, so the DB is guaranteed set up
+			setupVerified = true;
 
 			// Get manifest (cached after first call)
 			const manifest = await runtime.getManifest();


### PR DESCRIPTION
## Summary

- **Fix crash on fresh CF deployments** when the first request hits a public page before admin setup. The middleware fast-path skips runtime init (no migrations), but template helpers like `getSiteSettings()` still query the DB via `getDb()`, crashing with `D1_ERROR: no such table: options`.
- **Added a one-time setup probe** in the middleware fast-path: checks if `_emdash_migrations` exists, redirects to setup wizard if not. Cached for the worker lifetime after first success -- zero ongoing cost.
- **Release workflow**: switch to GitHub App token for changeset PRs.
- **Admin branding changeset** (unrelated, bundled).

## How it works

The main middleware has a fast-path for unauthenticated public page requests that skips the heavy CMS runtime init. On a fresh database this meant no migrations ran, but page templates still called `getSiteSettings()` -> `getDb()` -> queried missing tables.

Now, before the fast-path returns, a `setupVerified` flag is checked. On first request it probes the migrations table via the same `getDb()` instance the page will use. If the table doesn't exist, it redirects to `/_emdash/admin/setup`. The flag is also set to `true` when the full runtime init succeeds (admin/API requests), so the probe is skipped entirely if those run first.

## Testing

- Lint clean (`pnpm lint:quick`)
- Typecheck clean (`pnpm typecheck`)