### PR TITLE
fix: changeset config -- ignore private packages, reduce cascade to minor

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,30 @@
 	"linked": [],
 	"access": "public",
 	"baseBranch": "main",
-	"updateInternalDependencies": "patch",
-	"bumpVersionsWithWorkspaceProtocolOnly": true
+	"updateInternalDependencies": "minor",
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"ignore": [
+		"@emdash-cms/blocks-playground",
+		"@emdash-cms/demo-cloudflare",
+		"@emdash-cms/demo-postgres",
+		"@emdash-cms/demo-preview",
+		"@emdash-cms/marketplace",
+		"@emdash-cms/playground",
+		"@emdash-cms/plugin-api-test",
+		"@emdash-cms/plugin-marketplace-test",
+		"@emdash-cms/plugin-sandboxed-test",
+		"@emdash-cms/template-blank",
+		"@emdash-cms/template-blog",
+		"@emdash-cms/template-blog-cloudflare",
+		"@emdash-cms/template-marketing",
+		"@emdash-cms/template-marketing-cloudflare",
+		"@emdash-cms/template-portfolio",
+		"@emdash-cms/template-portfolio-cloudflare",
+		"@emdash-cms/template-starter",
+		"@emdash-cms/template-starter-cloudflare",
+		"docs",
+		"emdash-demo",
+		"emdash-e2e-fixture",
+		"emdash-plugins-demo"
+	]
 }


### PR DESCRIPTION
## Summary

- Add `ignore` list for all private packages (demos, templates, test plugins, docs) so changesets stops bumping their versions and generating changelogs
- Change `updateInternalDependencies` from `"patch"` to `"minor"` -- only cascade version bumps to dependents when core gets a minor+ bump, not on every patch

## Context

PR 13 (changeset release) was bumping demos, templates, and test plugins unnecessarily. It was also promoting plugins from 0.0.x to 1.0.0 due to cascading dependency bumps. This config change fixes the first issue; the one-time 0.0.x -> 0.1.0 jump will be handled manually on the release branch.