### PR TITLE
Fix documentation link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ EmDash is in **beta preview**. We welcome contributions, feedback, plugins, them
 npm create emdash@latest
 ```
 
-See the [documentation[(https://github.com/emdash-cms/emdash/tree/main/docs)] for guides, API reference, and plugin development.
+See the [documentation](https://github.com/emdash-cms/emdash/tree/main/docs) for guides, API reference, and plugin development.
 
 ## Development
 


### PR DESCRIPTION
The Markdown syntax for the documentation link was wrong, this PR fixes it. I'll point out that there's also supposedly an Starlight docs site (I couldn't find the URL)? So we should link to that instead once its deployed.