### PR TITLE
fix(admin): debounce SEO sidebar saves

### DIFF
--- a/.changeset/fair-donkeys-ring.md
+++ b/.changeset/fair-donkeys-ring.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes SEO sidebar text fields firing a PUT on every keystroke by debouncing saves; guards against stale server responses overwriting newer local edits.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -969,7 +969,11 @@ export function ContentEditor({
 										<MagnifyingGlass className="h-4 w-4" />
 										{t`SEO`}
 									</h3>
-									<SeoPanel contentKey={item?.id} seo={item?.seo} onChange={handleSeoChange} />
+									<SeoPanel
+										contentKey={item?.id ?? `new:${collection}`}
+										seo={item?.seo}
+										onChange={handleSeoChange}
+									/>
 								</div>
 							)}
 

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -247,6 +247,13 @@ export function ContentEditor({
 		});
 	}, []);
 
+	const handleSeoChange = React.useCallback(
+		(seo: ContentSeoInput) => {
+			onSeoChange?.(seo);
+		},
+		[onSeoChange],
+	);
+
 	// Track the last saved state to determine if dirty
 	const [lastSavedData, setLastSavedData] = React.useState<string>(
 		serializeEditorState({
@@ -962,7 +969,7 @@ export function ContentEditor({
 										<MagnifyingGlass className="h-4 w-4" />
 										{t`SEO`}
 									</h3>
-									<SeoPanel seo={item?.seo} onChange={onSeoChange} />
+									<SeoPanel contentKey={item?.id} seo={item?.seo} onChange={handleSeoChange} />
 								</div>
 							)}
 

--- a/packages/admin/src/components/SeoPanel.tsx
+++ b/packages/admin/src/components/SeoPanel.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 import type { ContentSeo, ContentSeoInput } from "../lib/api";
 
 export interface SeoPanelProps {
-	contentKey?: string;
+	contentKey: string;
 	seo?: ContentSeo;
 	onChange: (seo: ContentSeoInput) => void;
 }

--- a/packages/admin/src/components/SeoPanel.tsx
+++ b/packages/admin/src/components/SeoPanel.tsx
@@ -13,36 +13,136 @@ import * as React from "react";
 import type { ContentSeo, ContentSeoInput } from "../lib/api";
 
 export interface SeoPanelProps {
+	contentKey?: string;
 	seo?: ContentSeo;
 	onChange: (seo: ContentSeoInput) => void;
 }
 
-/**
- * Compact SEO metadata editor for the content sidebar.
- */
-export function SeoPanel({ seo, onChange }: SeoPanelProps) {
+const SEO_TEXT_DEBOUNCE_MS = 500;
+
+interface SeoDraft {
+	title: string;
+	description: string;
+	canonical: string;
+	noIndex: boolean;
+}
+
+function toDraft(seo?: ContentSeo): SeoDraft {
+	return {
+		title: seo?.title ?? "",
+		description: seo?.description ?? "",
+		canonical: seo?.canonical ?? "",
+		noIndex: seo?.noIndex ?? false,
+	};
+}
+
+function toInput(draft: SeoDraft): ContentSeoInput {
+	return {
+		title: draft.title || null,
+		description: draft.description || null,
+		canonical: draft.canonical || null,
+		noIndex: draft.noIndex,
+	};
+}
+
+function serializeDraft(draft: SeoDraft): string {
+	return JSON.stringify(draft);
+}
+
+export function SeoPanel({ contentKey, seo, onChange }: SeoPanelProps) {
 	const { t } = useLingui();
-	const [title, setTitle] = React.useState(seo?.title ?? "");
-	const [description, setDescription] = React.useState(seo?.description ?? "");
-	const [canonical, setCanonical] = React.useState(seo?.canonical ?? "");
-	const [noIndex, setNoIndex] = React.useState(seo?.noIndex ?? false);
+	const propDraft = React.useMemo(() => toDraft(seo), [seo]);
+	const propSnapshot = React.useMemo(() => serializeDraft(propDraft), [propDraft]);
+	const [draft, setDraft] = React.useState<SeoDraft>(propDraft);
+	const currentDraftRef = React.useRef(draft);
+	currentDraftRef.current = draft;
+	const lastPropSnapshotRef = React.useRef(propSnapshot);
+	const lastEmittedSnapshotRef = React.useRef(propSnapshot);
+	const activeContentKeyRef = React.useRef(contentKey);
+	const activeOnChangeRef = React.useRef(onChange);
+	const pendingTextFlushTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	// Keep local state in sync when the prop changes (e.g. after save)
+	const emitChange = React.useCallback((nextDraft: SeoDraft) => {
+		const nextSnapshot = serializeDraft(nextDraft);
+		if (nextSnapshot === lastEmittedSnapshotRef.current) {
+			return;
+		}
+		lastEmittedSnapshotRef.current = nextSnapshot;
+		activeOnChangeRef.current(toInput(nextDraft));
+	}, []);
+
+	const clearPendingTextFlush = React.useCallback(() => {
+		if (pendingTextFlushTimerRef.current) {
+			clearTimeout(pendingTextFlushTimerRef.current);
+			pendingTextFlushTimerRef.current = null;
+		}
+	}, []);
+
+	const flushPendingDraft = React.useCallback(() => {
+		clearPendingTextFlush();
+		emitChange(currentDraftRef.current);
+	}, [clearPendingTextFlush, emitChange]);
+
 	React.useEffect(() => {
-		setTitle(seo?.title ?? "");
-		setDescription(seo?.description ?? "");
-		setCanonical(seo?.canonical ?? "");
-		setNoIndex(seo?.noIndex ?? false);
-	}, [seo]);
+		if (activeContentKeyRef.current === contentKey) {
+			activeOnChangeRef.current = onChange;
+			return;
+		}
+		flushPendingDraft();
+		activeContentKeyRef.current = contentKey;
+		activeOnChangeRef.current = onChange;
+		setDraft(propDraft);
+		currentDraftRef.current = propDraft;
+		lastPropSnapshotRef.current = propSnapshot;
+		lastEmittedSnapshotRef.current = propSnapshot;
+	}, [contentKey, flushPendingDraft, onChange, propDraft, propSnapshot]);
 
-	const emitChange = (patch: Partial<ContentSeoInput>) => {
-		onChange({
-			title: title || null,
-			description: description || null,
-			canonical: canonical || null,
-			noIndex,
-			...patch,
-		});
+	React.useEffect(() => {
+		return () => {
+			flushPendingDraft();
+		};
+	}, [flushPendingDraft]);
+
+	React.useEffect(() => {
+		const previousPropSnapshot = lastPropSnapshotRef.current;
+		if (propSnapshot === previousPropSnapshot) {
+			return;
+		}
+
+		const currentDraftSnapshot = serializeDraft(currentDraftRef.current);
+		const shouldSync =
+			currentDraftSnapshot === previousPropSnapshot || currentDraftSnapshot === propSnapshot;
+
+		if (shouldSync) {
+			setDraft(propDraft);
+			currentDraftRef.current = propDraft;
+			lastEmittedSnapshotRef.current = propSnapshot;
+		}
+
+		lastPropSnapshotRef.current = propSnapshot;
+	}, [propDraft, propSnapshot]);
+
+	React.useEffect(() => {
+		clearPendingTextFlush();
+
+		const nextSnapshot = serializeDraft(currentDraftRef.current);
+		if (nextSnapshot === lastEmittedSnapshotRef.current) {
+			return;
+		}
+
+		pendingTextFlushTimerRef.current = setTimeout(() => {
+			pendingTextFlushTimerRef.current = null;
+			emitChange(currentDraftRef.current);
+		}, SEO_TEXT_DEBOUNCE_MS);
+
+		return clearPendingTextFlush;
+	}, [clearPendingTextFlush, draft.canonical, draft.description, draft.title, emitChange]);
+
+	const updateDraft = (patch: Partial<SeoDraft>) => {
+		const nextDraft = { ...currentDraftRef.current, ...patch };
+		currentDraftRef.current = nextDraft;
+		setDraft(nextDraft);
+		return nextDraft;
 	};
 
 	return (
@@ -50,10 +150,9 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 			<Input
 				label={t`SEO Title`}
 				description={t`Overrides the page title in search engine results`}
-				value={title}
+				value={draft.title}
 				onChange={(e) => {
-					setTitle(e.target.value);
-					emitChange({ title: e.target.value || null });
+					updateDraft({ title: e.target.value });
 				}}
 			/>
 
@@ -61,14 +160,13 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 				<InputArea
 					label={t`Meta Description`}
 					description={
-						description
-							? t`${description.length}/160 characters`
+						draft.description
+							? t`${draft.description.length}/160 characters`
 							: t`Brief summary shown below the title in search results`
 					}
-					value={description}
+					value={draft.description}
 					onChange={(e) => {
-						setDescription(e.target.value);
-						emitChange({ description: e.target.value || null });
+						updateDraft({ description: e.target.value });
 					}}
 					rows={3}
 				/>
@@ -77,10 +175,9 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 			<Input
 				label={t`Canonical URL`}
 				description={t`Points search engines to the original version of this page, if it's duplicated from another URL`}
-				value={canonical}
+				value={draft.canonical}
 				onChange={(e) => {
-					setCanonical(e.target.value);
-					emitChange({ canonical: e.target.value || null });
+					updateDraft({ canonical: e.target.value });
 				}}
 			/>
 
@@ -90,10 +187,9 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 					<p className="text-xs text-kumo-subtle">{t`Add noindex meta tag`}</p>
 				</div>
 				<Switch
-					checked={noIndex}
+					checked={draft.noIndex}
 					onCheckedChange={(checked) => {
-						setNoIndex(checked);
-						emitChange({ noIndex: checked });
+						emitChange(updateDraft({ noIndex: checked }));
 					}}
 				/>
 			</div>

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { userEvent } from "@vitest/browser/context";
+import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { userEvent } from "vitest/browser";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
 
 import { SeoPanel } from "../../src/components/SeoPanel";
 

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { userEvent } from "@vitest/browser/context";
+import { userEvent } from "vitest/browser";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,5 +1,5 @@
-import { userEvent } from "@vitest/browser/context";
 import * as React from "react";
+import { userEvent } from "@vitest/browser/context";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -27,9 +27,12 @@ describe("SeoPanel", () => {
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		expect(onChange).not.toHaveBeenCalled();
 
-		await vi.waitFor(() => {
-			expect(onChange).toHaveBeenCalledTimes(1);
-		}, { timeout: 1500 });
+		await vi.waitFor(
+			() => {
+				expect(onChange).toHaveBeenCalledTimes(1);
+			},
+			{ timeout: 1500 },
+		);
 		expect(onChange).toHaveBeenLastCalledWith({
 			title: "SEO title",
 			description: null,

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render } from "vitest-browser-react";
 import { userEvent } from "vitest/browser";
 
 import { SeoPanel } from "../../src/components/SeoPanel";
+import { render } from "../utils/render";
 
 describe("SeoPanel", () => {
 	beforeEach(() => {
@@ -29,7 +29,7 @@ describe("SeoPanel", () => {
 
 		await vi.waitFor(() => {
 			expect(onChange).toHaveBeenCalledTimes(1);
-		}, 1500);
+		}, { timeout: 1500 });
 		expect(onChange).toHaveBeenLastCalledWith({
 			title: "SEO title",
 			description: null,

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,0 +1,201 @@
+import * as React from "react";
+import { userEvent } from "@vitest/browser/context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { SeoPanel } from "../../src/components/SeoPanel";
+
+describe("SeoPanel", () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("debounces text field saves", async () => {
+		const onChange = vi.fn();
+
+		const screen = await render(
+			<SeoPanel
+				contentKey="post-1"
+				seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+				onChange={onChange}
+			/>,
+		);
+
+		const titleInput = screen.getByLabelText("SEO Title");
+		await userEvent.type(titleInput, "SEO title");
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		expect(onChange).not.toHaveBeenCalled();
+
+		await vi.waitFor(() => {
+			expect(onChange).toHaveBeenCalledTimes(1);
+		}, 1500);
+		expect(onChange).toHaveBeenLastCalledWith({
+			title: "SEO title",
+			description: null,
+			canonical: null,
+			noIndex: false,
+		});
+	});
+
+	it("saves noindex changes immediately", async () => {
+		const onChange = vi.fn();
+
+		const screen = await render(
+			<SeoPanel
+				contentKey="post-1"
+				seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+				onChange={onChange}
+			/>,
+		);
+
+		await userEvent.click(screen.getByRole("switch"));
+
+		await vi.waitFor(() => {
+			expect(onChange).toHaveBeenCalledWith({
+				title: null,
+				description: null,
+				canonical: null,
+				noIndex: true,
+			});
+		});
+	});
+
+	it("does not overwrite newer local text when stale props arrive", async () => {
+		function Host() {
+			const [seo, setSeo] = React.useState({
+				title: "Original",
+				description: null,
+				image: null,
+				canonical: null,
+				noIndex: false,
+			});
+
+			return (
+				<>
+					<SeoPanel contentKey="post-1" seo={seo} onChange={() => {}} />
+					<button
+						type="button"
+						onClick={() =>
+							setSeo({
+								title: "Older save",
+								description: null,
+								image: null,
+								canonical: null,
+								noIndex: false,
+							})
+						}
+					>
+						Apply stale props
+					</button>
+				</>
+			);
+		}
+
+		const screen = await render(<Host />);
+		const titleInput = screen.getByLabelText("SEO Title");
+		await userEvent.clear(titleInput);
+		await userEvent.type(titleInput, "Newest local value");
+		await vi.waitFor(() => {
+			expect((titleInput.element() as HTMLInputElement).value).toBe("Newest local value");
+		});
+
+		const stalePropsButton = screen.getByRole("button", { name: "Apply stale props" });
+		await userEvent.click(stalePropsButton);
+
+		expect((titleInput.element() as HTMLInputElement).value).toBe("Newest local value");
+	});
+
+	it("resets when switching to a different content item", async () => {
+		const onChange = vi.fn();
+
+		function Host() {
+			const [contentKey, setContentKey] = React.useState("post-1");
+			const [seo, setSeo] = React.useState({
+				title: "First post",
+				description: null,
+				image: null,
+				canonical: null,
+				noIndex: false,
+			});
+
+			return (
+				<>
+					<SeoPanel contentKey={contentKey} seo={seo} onChange={onChange} />
+					<button
+						type="button"
+						onClick={() => {
+							setContentKey("post-2");
+							setSeo({
+								title: "Second post",
+								description: "Fresh content",
+								image: null,
+								canonical: null,
+								noIndex: false,
+							});
+						}}
+					>
+						Switch content
+					</button>
+				</>
+			);
+		}
+
+		const screen = await render(<Host />);
+		const titleInput = screen.getByLabelText("SEO Title");
+		await userEvent.clear(titleInput);
+		await userEvent.type(titleInput, "Unsaved local edit");
+
+		await userEvent.click(screen.getByRole("button", { name: "Switch content" }));
+
+		expect(onChange).toHaveBeenCalledWith({
+			title: "Unsaved local edit",
+			description: null,
+			canonical: null,
+			noIndex: false,
+		});
+		expect((titleInput.element() as HTMLInputElement).value).toBe("Second post");
+
+		await new Promise((resolve) => setTimeout(resolve, 700));
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("flushes pending text changes on unmount", async () => {
+		const onChange = vi.fn();
+
+		function Host() {
+			const [isVisible, setIsVisible] = React.useState(true);
+
+			return (
+				<>
+					{isVisible ? (
+						<SeoPanel
+							contentKey="post-1"
+							seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+							onChange={onChange}
+						/>
+					) : null}
+					<button type="button" onClick={() => setIsVisible(false)}>
+						Hide panel
+					</button>
+				</>
+			);
+		}
+
+		const screen = await render(<Host />);
+		const titleInput = screen.getByLabelText("SEO Title");
+		await userEvent.type(titleInput, "SEO title");
+
+		await userEvent.click(screen.getByRole("button", { name: "Hide panel" }));
+
+		expect(onChange).toHaveBeenCalledWith({
+			title: "SEO title",
+			description: null,
+			canonical: null,
+			noIndex: false,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 700));
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Closes #78

Debounces SEO sidebar text-field saves in the admin sidebar instead of issuing a PUT on every keystroke, keeps stale save responses from overwriting newer local typing, and preserves immediate `noIndex` updates.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

- `npx pnpm@10.28.0 --filter @emdash-cms/admin exec vitest run tests/components/SeoPanel.test.tsx`
- `npx pnpm@10.28.0 --filter @emdash-cms/admin typecheck`
- `npx pnpm@10.28.0 --silent lint:quick`
