### PR TITLE
Fix taxonomy links missing from admin sidebar

### DIFF
--- a/.changeset/warm-bears-kneel.md
+++ b/.changeset/warm-bears-kneel.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fix taxonomy links missing from admin sidebar

--- a/packages/admin/src/components/Shell.tsx
+++ b/packages/admin/src/components/Shell.tsx
@@ -17,6 +17,10 @@ export interface ShellProps {
 				adminPages?: Array<{ path: string; label?: string; icon?: string }>;
 			}
 		>;
+		taxonomies: Array<{
+			name: string;
+			label: string;
+		}>;
 		version?: string;
 	};
 }

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -51,7 +51,7 @@ export interface SidebarNavProps {
 				version?: string;
 			}
 		>;
-		taxonomies?: Array<{
+		taxonomies: Array<{
 			name: string;
 			label: string;
 		}>;
@@ -188,7 +188,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 		{ to: "/redirects", label: "Redirects", icon: ArrowsLeftRight, minRole: ROLE_ADMIN },
 		{ to: "/widgets", label: "Widgets", icon: GridFour, minRole: ROLE_EDITOR },
 		{ to: "/sections", label: "Sections", icon: Stack, minRole: ROLE_EDITOR },
-		...(manifest.taxonomies ?? []).map((tax) => ({
+		...manifest.taxonomies.map((tax) => ({
 			to: "/taxonomies/$taxonomy" as const,
 			label: tax.label,
 			icon: FileText,

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -51,6 +51,10 @@ export interface SidebarNavProps {
 				version?: string;
 			}
 		>;
+		taxonomies?: Array<{
+			name: string;
+			label: string;
+		}>;
 		version?: string;
 		marketplace?: string;
 	};
@@ -184,20 +188,13 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 		{ to: "/redirects", label: "Redirects", icon: ArrowsLeftRight, minRole: ROLE_ADMIN },
 		{ to: "/widgets", label: "Widgets", icon: GridFour, minRole: ROLE_EDITOR },
 		{ to: "/sections", label: "Sections", icon: Stack, minRole: ROLE_EDITOR },
-		{
-			to: "/taxonomies/$taxonomy",
-			label: "Categories",
+		...(manifest.taxonomies ?? []).map((tax) => ({
+			to: "/taxonomies/$taxonomy" as const,
+			label: tax.label,
 			icon: FileText,
-			params: { taxonomy: "category" },
+			params: { taxonomy: tax.name },
 			minRole: ROLE_EDITOR,
-		},
-		{
-			to: "/taxonomies/$taxonomy",
-			label: "Tags",
-			icon: FileText,
-			params: { taxonomy: "tag" },
-			minRole: ROLE_EDITOR,
-		},
+		})),
 		{ to: "/bylines", label: "Bylines", icon: FileText, minRole: ROLE_EDITOR },
 	];
 

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -132,6 +132,16 @@ export interface AdminManifest {
 		locales: string[];
 	};
 	/**
+	 * Taxonomy definitions for the admin sidebar.
+	 */
+	taxonomies?: Array<{
+		name: string;
+		label: string;
+		labelSingular?: string;
+		hierarchical: boolean;
+		collections: string[];
+	}>;
+	/**
 	 * Marketplace registry URL. Present when `marketplace` is configured
 	 * in the EmDash integration. Enables marketplace features in the UI.
 	 */

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -134,7 +134,7 @@ export interface AdminManifest {
 	/**
 	 * Taxonomy definitions for the admin sidebar.
 	 */
-	taxonomies?: Array<{
+	taxonomies: Array<{
 		name: string;
 		label: string;
 		labelSingular?: string;

--- a/packages/admin/tests/components/PluginManager.test.tsx
+++ b/packages/admin/tests/components/PluginManager.test.tsx
@@ -74,6 +74,7 @@ function makeManifest(overrides: Partial<AdminManifest> = {}): AdminManifest {
 		hash: "abc",
 		collections: {},
 		plugins: {},
+		taxonomies: [],
 		authMode: "passkey",
 		...overrides,
 	};

--- a/packages/admin/tests/components/Settings.test.tsx
+++ b/packages/admin/tests/components/Settings.test.tsx
@@ -36,6 +36,7 @@ const defaultManifest: AdminManifest = {
 	authMode: "passkey",
 	collections: {},
 	plugins: {},
+	taxonomies: [],
 	version: "1",
 	hash: "",
 };

--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -76,6 +76,7 @@ const MANIFEST: AdminManifest = {
 		},
 	},
 	plugins: {},
+	taxonomies: [],
 	i18n: {
 		defaultLocale: "fr",
 		locales: ["fr", "en", "de"],

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -47,6 +47,7 @@ export const GET: APIRoute = async ({ locals }) => {
 				hash: "default",
 				collections: {},
 				plugins: {},
+				taxonomies: [],
 				authMode: "passkey",
 				signupEnabled,
 			};

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -121,6 +121,16 @@ export interface EmDashManifest {
 		prefixDefaultLocale?: boolean;
 	};
 	/**
+	 * Taxonomy definitions for the admin sidebar.
+	 */
+	taxonomies: Array<{
+		name: string;
+		label: string;
+		labelSingular?: string;
+		hierarchical: boolean;
+		collections: string[];
+	}>;
+	/**
 	 * Whether the plugin marketplace is configured.
 	 * When true, the admin UI can show marketplace browse/install features.
 	 */

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1303,7 +1303,11 @@ export class EmDashRuntime {
 			collections: string[];
 		}> = [];
 		try {
-			const rows = await this.db.selectFrom("_emdash_taxonomy_defs").selectAll().execute();
+			const rows = await this.db
+				.selectFrom("_emdash_taxonomy_defs")
+				.selectAll()
+				.orderBy("name")
+				.execute();
 			manifestTaxonomies = rows.map((row) => ({
 				name: row.name,
 				label: row.label,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1313,9 +1313,7 @@ export class EmDashRuntime {
 				label: row.label,
 				labelSingular: row.label_singular ?? undefined,
 				hierarchical: row.hierarchical === 1,
-				collections: row.collections
-					? (JSON.parse(row.collections) as string[]).toSorted()
-					: [],
+				collections: row.collections ? (JSON.parse(row.collections) as string[]).toSorted() : [],
 			}));
 		} catch (error) {
 			console.debug("EmDash: Could not load taxonomy definitions:", error);

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1294,10 +1294,32 @@ export class EmDashRuntime {
 			};
 		}
 
-		// Generate hash from both collections and plugins so cache invalidates
-		// when plugins are enabled/disabled or their config changes
+		// Build taxonomies from database
+		let manifestTaxonomies: Array<{
+			name: string;
+			label: string;
+			labelSingular?: string;
+			hierarchical: boolean;
+			collections: string[];
+		}> = [];
+		try {
+			const rows = await this.db.selectFrom("_emdash_taxonomy_defs").selectAll().execute();
+			manifestTaxonomies = rows.map((row) => ({
+				name: row.name,
+				label: row.label,
+				labelSingular: row.label_singular ?? undefined,
+				hierarchical: row.hierarchical === 1,
+				collections: row.collections ? JSON.parse(row.collections) : [],
+			}));
+		} catch (error) {
+			console.debug("EmDash: Could not load taxonomy definitions:", error);
+		}
+
+		// Build manifest hash
 		const manifestHash = await hashString(
-			JSON.stringify(manifestCollections) + JSON.stringify(manifestPlugins),
+			JSON.stringify(manifestCollections) +
+				JSON.stringify(manifestPlugins) +
+				JSON.stringify(manifestTaxonomies),
 		);
 
 		// Determine auth mode
@@ -1317,6 +1339,7 @@ export class EmDashRuntime {
 			hash: manifestHash,
 			collections: manifestCollections,
 			plugins: manifestPlugins,
+			taxonomies: manifestTaxonomies,
 			authMode: authModeValue,
 			i18n,
 			marketplace: !!this.config.marketplace,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1313,7 +1313,9 @@ export class EmDashRuntime {
 				label: row.label,
 				labelSingular: row.label_singular ?? undefined,
 				hierarchical: row.hierarchical === 1,
-				collections: row.collections ? JSON.parse(row.collections) : [],
+				collections: row.collections
+					? (JSON.parse(row.collections) as string[]).toSorted()
+					: [],
 			}));
 		} catch (error) {
 			console.debug("EmDash: Could not load taxonomy definitions:", error);

--- a/packages/core/tests/unit/taxonomies/taxonomies.test.ts
+++ b/packages/core/tests/unit/taxonomies/taxonomies.test.ts
@@ -10,6 +10,78 @@ import {
 	teardownTestDatabase,
 } from "../../utils/test-db.js";
 
+describe("taxonomy manifest loading", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("should load seeded taxonomy definitions ordered by name", async () => {
+		const rows = await db.selectFrom("_emdash_taxonomy_defs").selectAll().orderBy("name").execute();
+
+		const taxonomies = rows.map((row) => ({
+			name: row.name,
+			label: row.label,
+			labelSingular: row.label_singular ?? undefined,
+			hierarchical: row.hierarchical === 1,
+			collections: row.collections ? JSON.parse(row.collections) : [],
+		}));
+
+		expect(taxonomies).toHaveLength(2);
+		expect(taxonomies[0]).toMatchObject({
+			name: "category",
+			label: "Categories",
+			hierarchical: true,
+			collections: ["posts"],
+		});
+		expect(taxonomies[1]).toMatchObject({
+			name: "tag",
+			label: "Tags",
+			hierarchical: false,
+			collections: ["posts"],
+		});
+	});
+
+	it("should include custom taxonomy definitions in manifest", async () => {
+		await db
+			.insertInto("_emdash_taxonomy_defs")
+			.values({
+				id: "taxdef_genre",
+				name: "genre",
+				label: "Genres",
+				label_singular: "Genre",
+				hierarchical: 1,
+				collections: JSON.stringify(["posts", "pages"]),
+			})
+			.execute();
+
+		const rows = await db.selectFrom("_emdash_taxonomy_defs").selectAll().orderBy("name").execute();
+
+		const taxonomies = rows.map((row) => ({
+			name: row.name,
+			label: row.label,
+			labelSingular: row.label_singular ?? undefined,
+			hierarchical: row.hierarchical === 1,
+			collections: row.collections ? JSON.parse(row.collections) : [],
+		}));
+
+		expect(taxonomies).toHaveLength(3);
+		expect(taxonomies[0].name).toBe("category");
+		expect(taxonomies[1].name).toBe("genre");
+		expect(taxonomies[2].name).toBe("tag");
+		expect(taxonomies[1]).toMatchObject({
+			label: "Genres",
+			hierarchical: true,
+			collections: ["posts", "pages"],
+		});
+	});
+});
+
 describe("TaxonomyRepository", () => {
 	let db: Kysely<Database>;
 	let repo: TaxonomyRepository;


### PR DESCRIPTION
## What does this PR do?

Closes #68

The admin sidebar hardcoded only "Categories" and "Tags" links. Any taxonomy created at runtime never showed up, so there was no way to manage its terms from the UI.

The fix loads taxonomy definitions from the database into the manifest and renders sidebar links from that list instead of a static array.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A