### PR TITLE
Reject dangerous URL schemes in menu custom links

### DIFF
--- a/.changeset/curly-pens-glow.md
+++ b/.changeset/curly-pens-glow.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Reject dangerous URL schemes in menu custom links

--- a/packages/core/src/api/schemas/menus.ts
+++ b/packages/core/src/api/schemas/menus.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 
+import { isSafeHref } from "../../utils/url.js";
+
 // ---------------------------------------------------------------------------
 // Menus: Input schemas
 // ---------------------------------------------------------------------------
 
 const menuItemType = z.string().min(1);
+
+const safeHref = z
+	.string()
+	.refine(isSafeHref, "URL must use http, https, mailto, tel, or a relative path");
 
 export const createMenuBody = z
 	.object({
@@ -25,7 +31,7 @@ export const createMenuItemBody = z
 		label: z.string().min(1),
 		referenceCollection: z.string().optional(),
 		referenceId: z.string().optional(),
-		customUrl: z.string().optional(),
+		customUrl: safeHref.optional(),
 		target: z.string().optional(),
 		titleAttr: z.string().optional(),
 		cssClasses: z.string().optional(),
@@ -37,7 +43,7 @@ export const createMenuItemBody = z
 export const updateMenuItemBody = z
 	.object({
 		label: z.string().min(1).optional(),
-		customUrl: z.string().optional(),
+		customUrl: safeHref.optional(),
 		target: z.string().optional(),
 		titleAttr: z.string().optional(),
 		cssClasses: z.string().optional(),

--- a/packages/core/src/api/schemas/menus.ts
+++ b/packages/core/src/api/schemas/menus.ts
@@ -10,7 +10,11 @@ const menuItemType = z.string().min(1);
 
 const safeHref = z
 	.string()
-	.refine(isSafeHref, "URL must use http, https, mailto, tel, or a relative path");
+	.trim()
+	.refine(
+		isSafeHref,
+		"URL must use http, https, mailto, tel, a relative path, or a fragment identifier",
+	);
 
 export const createMenuBody = z
 	.object({

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -9,6 +9,7 @@ import { sql } from "kysely";
 
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
+import { sanitizeHref } from "../utils/url.js";
 import type { Menu, MenuItem, MenuItemRow } from "./types.js";
 
 /**
@@ -235,7 +236,7 @@ async function resolveMenuItem(
 	return {
 		id: item.id,
 		label: item.label,
-		url,
+		url: sanitizeHref(url),
 		target: item.target || undefined,
 		titleAttr: item.title_attr || undefined,
 		cssClasses: item.css_classes || undefined,

--- a/packages/core/tests/unit/menus/menus.test.ts
+++ b/packages/core/tests/unit/menus/menus.test.ts
@@ -7,6 +7,7 @@ import { createDatabase } from "../../../src/database/connection.js";
 import { runMigrations } from "../../../src/database/migrations/runner.js";
 import type { Database } from "../../../src/database/types.js";
 import { getMenuWithDb, getMenusWithDb } from "../../../src/menus/index.js";
+import { sanitizeHref } from "../../../src/utils/url.js";
 
 describe("Navigation Menus", () => {
 	let db: Kysely<Database>;
@@ -234,6 +235,60 @@ describe("Navigation Menus", () => {
 			expect(menu!.items[0].url).toBe("#");
 		});
 
+		it("should sanitize data: URLs from the database", async () => {
+			const menuId = ulid();
+			const itemId = ulid();
+
+			await db
+				.insertInto("_emdash_menus")
+				.values({ id: menuId, name: "primary", label: "Primary" })
+				.execute();
+
+			await db
+				.insertInto("_emdash_menu_items")
+				.values({
+					id: itemId,
+					menu_id: menuId,
+					sort_order: 0,
+					type: "custom",
+					custom_url: "data:text/html,<script>alert(1)</script>",
+					label: "XSS",
+				})
+				.execute();
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("#");
+		});
+
+		it("should sanitize vbscript: URLs from the database", async () => {
+			const menuId = ulid();
+			const itemId = ulid();
+
+			await db
+				.insertInto("_emdash_menus")
+				.values({ id: menuId, name: "primary", label: "Primary" })
+				.execute();
+
+			await db
+				.insertInto("_emdash_menu_items")
+				.values({
+					id: itemId,
+					menu_id: menuId,
+					sort_order: 0,
+					type: "custom",
+					custom_url: "vbscript:MsgBox",
+					label: "XSS",
+				})
+				.execute();
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("#");
+		});
+
 		it("should skip items with deleted content references", async () => {
 			const menuId = ulid();
 			const itemId = ulid();
@@ -445,6 +500,55 @@ describe("Navigation Menus", () => {
 				customUrl: "javascript:alert(1)",
 			});
 			expect(result.success).toBe(false);
+		});
+
+		it("should allow tel: URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Call",
+				customUrl: "tel:+15551234567",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject empty string URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Link",
+				customUrl: "",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should trim whitespace before validating", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Link",
+				customUrl: "  https://example.com  ",
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.customUrl).toBe("https://example.com");
+			}
+		});
+
+		it("should reject whitespace-prefixed javascript: after trim", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "XSS",
+				customUrl: "  javascript:alert(1)",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("sanitizeHref", () => {
+		it("should return # for null input", () => {
+			expect(sanitizeHref(null)).toBe("#");
+		});
+
+		it("should return # for undefined input", () => {
+			expect(sanitizeHref(undefined)).toBe("#");
 		});
 	});
 });

--- a/packages/core/tests/unit/menus/menus.test.ts
+++ b/packages/core/tests/unit/menus/menus.test.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { ulid } from "ulidx";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
+import { createMenuItemBody, updateMenuItemBody } from "../../../src/api/schemas/menus.js";
 import { createDatabase } from "../../../src/database/connection.js";
 import { runMigrations } from "../../../src/database/migrations/runner.js";
 import type { Database } from "../../../src/database/types.js";
@@ -206,6 +207,33 @@ describe("Navigation Menus", () => {
 			});
 		});
 
+		it("should sanitize dangerous URLs from the database", async () => {
+			const menuId = ulid();
+			const itemId = ulid();
+
+			await db
+				.insertInto("_emdash_menus")
+				.values({ id: menuId, name: "primary", label: "Primary" })
+				.execute();
+
+			await db
+				.insertInto("_emdash_menu_items")
+				.values({
+					id: itemId,
+					menu_id: menuId,
+					sort_order: 0,
+					type: "custom",
+					custom_url: "javascript:alert(1)",
+					label: "XSS",
+				})
+				.execute();
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("#");
+		});
+
 		it("should skip items with deleted content references", async () => {
 			const menuId = ulid();
 			const itemId = ulid();
@@ -336,6 +364,87 @@ describe("Navigation Menus", () => {
 			expect(menu!.items[0].label).toBe("Home");
 			expect(menu!.items[1].label).toBe("About");
 			expect(menu!.items[2].label).toBe("Contact");
+		});
+	});
+
+	describe("menu item URL validation", () => {
+		it("should reject javascript: URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "XSS",
+				customUrl: "javascript:alert(1)",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject data: URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "XSS",
+				customUrl: "data:text/html,<script>alert(1)</script>",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should reject vbscript: URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "XSS",
+				customUrl: "vbscript:MsgBox",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should allow https URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Link",
+				customUrl: "https://example.com",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should allow relative paths", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Link",
+				customUrl: "/about",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should allow fragment links", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Link",
+				customUrl: "#section",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject case-varied javascript: URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "XSS",
+				customUrl: "JAVASCRIPT:alert(1)",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("should allow mailto URLs", () => {
+			const result = createMenuItemBody.safeParse({
+				type: "custom",
+				label: "Email",
+				customUrl: "mailto:user@example.com",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject javascript: in update schema", () => {
+			const result = updateMenuItemBody.safeParse({
+				customUrl: "javascript:alert(1)",
+			});
+			expect(result.success).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Closes #89

The menu editor accepted any URL for custom links, including `javascript:` URIs. A user with menu permissions could save a payload like `javascript:alert(1)` that executed when visitors clicked the link.

The fix validates `customUrl` in the Zod schema against an allowlist of safe schemes (http, https, mailto, tel, relative paths, fragments) and sanitizes URLs at the render layer in `resolveMenuItem()` so pre-existing data in the database is also covered.

New tests cover the reject and allow cases for both schemas and the render path.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A