### PR TITLE
chore: add CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,24 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+  merge_group:
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://www.cloudflare.com/cla/"
+          branch: "cla-signatures"
+          allowlist: dependabot[bot]
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Summary

- Add CLA Assistant GitHub Action, matching the pattern used in cloudflare/workerd
- Uses contributor-assistant/github-action v2.6.1 with Cloudflare's CLA document
- Stores signatures on a `cla-signatures` branch
- Allowlists dependabot[bot]

## Setup required

Add a `CLA_PERSONAL_ACCESS_TOKEN` repo secret (PAT with repo scope) for the action to push signature data.