### PR TITLE
fix(x402): add tsdown config and exclude middleware from Vite SSR optimizer

### DIFF
--- a/.changeset/fix-x402-vite-ssr.md
+++ b/.changeset/fix-x402-vite-ssr.md
@@ -1,0 +1,8 @@
+---
+"@emdash-cms/x402": patch
+---
+
+fix(x402): add tsdown config and exclude middleware from Vite SSR optimizer
+
+- Add `tsdown.config.ts` to build both `src/index.ts` and `src/middleware.ts` as ESM outputs
+- Add `optimizeDeps.exclude` and `ssr.optimizeDeps.exclude` for `@emdash-cms/x402` to prevent esbuild from failing on `virtual:x402/config`

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -49,7 +49,9 @@ export function x402(config: X402Config): AstroIntegration {
 		name: "@emdash-cms/x402",
 		hooks: {
 			"astro:config:setup": ({ addMiddleware, updateConfig }) => {
-				// Inject the virtual module that provides config to the middleware
+				// Inject the virtual module that provides config to the middleware.
+				// The middleware must be excluded from Vite's SSR dependency optimizer
+				// because esbuild cannot resolve virtual modules — only Vite plugins can.
 				updateConfig({
 					vite: {
 						plugins: [
@@ -65,6 +67,14 @@ export function x402(config: X402Config): AstroIntegration {
 								},
 							},
 						],
+						optimizeDeps: {
+							exclude: ["@emdash-cms/x402"],
+						},
+						ssr: {
+							optimizeDeps: {
+								exclude: ["@emdash-cms/x402"],
+							},
+						},
 					},
 				});
 

--- a/packages/x402/tsdown.config.ts
+++ b/packages/x402/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/middleware.ts"],
+	format: ["esm"],
+	dts: true,
+	clean: true,
+	external: ["astro:middleware", "virtual:x402/config"],
+});


### PR DESCRIPTION
## Summary

Fixes all three issues that make `@emdash-cms/x402` unusable in dev (#110):

1. **Missing `dist/middleware.mjs`** — adds `tsdown.config.ts` with `middleware.ts` as an entry point (same fix as #48)
2. **Vite SSR optimizer can't resolve `virtual:x402/config`** — adds `optimizeDeps.exclude` and `ssr.optimizeDeps.exclude` for `@emdash-cms/x402` in the integration's Vite config

### Why the virtual module fails

The x402 integration injects a Vite plugin to resolve `virtual:x402/config`. However, Vite's SSR dependency optimizer runs **esbuild** to pre-bundle dependencies _before_ the Vite plugin pipeline. esbuild cannot resolve virtual modules, so it errors on `import x402Config from "virtual:x402/config"` in `middleware.mjs`.

By excluding `@emdash-cms/x402` from `optimizeDeps`, Vite skips pre-bundling and lets the plugin pipeline handle the virtual module resolution at runtime.

### Supersedes

This PR supersedes #48 by including the same `tsdown.config.ts` fix plus the additional `optimizeDeps.exclude` fix.

## Test plan

- [ ] `pnpm build` in `packages/x402` produces both `dist/index.mjs` and `dist/middleware.mjs`
- [ ] Create a new EmDash site with `@astrojs/cloudflare` adapter
- [ ] Add `x402({ payTo: "...", network: "eip155:8453" })` to integrations
- [ ] `npx emdash dev` starts without `virtual:x402/config` errors
- [ ] Premium pages return 402 for requests with no payment header

🤖 Generated with [Claude Code](https://claude.com/claude-code)