### PR TITLE
fix: add explicit permissions to CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,12 @@ on:
     types: [opened, synchronize]
   merge_group:
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
@@ -15,7 +21,6 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://www.cloudflare.com/cla/"


### PR DESCRIPTION
## Summary

- Add explicit `permissions` block (actions, contents, pull-requests, statuses) required when the org's default GITHUB_TOKEN is read-only
- Remove `PERSONAL_ACCESS_TOKEN` -- not needed for same-repo signature storage per the action's docs

Fixes the "Resource not accessible by integration" error from #114.