### PR TITLE
Add E2E rollup job and exempt emdashbot from PR compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,19 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: pnpm run --filter @emdash-cms/admin test
 
+  test-e2e-rollup:
+    name: E2E Tests
+    if: always()
+    needs: [test-e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check E2E shard results
+        run: |
+          if [ "${{ needs.test-e2e.result }}" != "success" ]; then
+            echo "E2E tests failed or were cancelled"
+            exit 1
+          fi
+
   test-e2e:
     name: E2E tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-pr:
     name: Validate PR
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'emdashbot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR template


### PR DESCRIPTION
## What does this PR do?

Two changes:

1. **E2E rollup job** — adds an "E2E Tests" job that depends on all 8 shards. This gives us a single stable check name to require in the ruleset instead of requiring each shard individually.

2. **emdashbot exemption** — the changesets release PR is opened by emdashbot, which won't fill out our PR template. Exempts it from the PR compliance check alongside dependabot and renovate.

Ruleset already updated to require "E2E Tests".

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)

## AI-generated code disclosure

- [x] This PR includes AI-generated code