### PR TITLE
Preserve auth subpaths when building callback URLs

### DIFF
--- a/packages/auth/src/invite.ts
+++ b/packages/auth/src/invite.ts
@@ -4,6 +4,7 @@
 
 import { generateTokenWithHash, hashToken } from "./tokens.js";
 import type { AuthAdapter, RoleLevel, EmailMessage, User } from "./types.js";
+import { buildAuthUrl } from "./urls.js";
 
 /** Escape HTML special characters to prevent injection in email templates */
 export function escapeHtml(s: string): string {
@@ -68,7 +69,7 @@ export async function createInviteToken(
 	});
 
 	// Build invite URL
-	const url = new URL("/api/auth/invite/accept", config.baseUrl);
+	const url = buildAuthUrl(config.baseUrl, "api/auth/invite/accept");
 	url.searchParams.set("token", token);
 
 	return { url: url.toString(), email };

--- a/packages/auth/src/magic-link/index.ts
+++ b/packages/auth/src/magic-link/index.ts
@@ -5,6 +5,7 @@
 import { escapeHtml } from "../invite.js";
 import { generateTokenWithHash, hashToken } from "../tokens.js";
 import type { AuthAdapter, User, EmailMessage } from "../types.js";
+import { buildAuthUrl } from "../urls.js";
 
 const TOKEN_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -63,7 +64,7 @@ export async function sendMagicLink(
 	});
 
 	// Build magic link URL
-	const url = new URL("/api/auth/magic-link/verify", config.baseUrl);
+	const url = buildAuthUrl(config.baseUrl, "api/auth/magic-link/verify");
 	url.searchParams.set("token", token);
 
 	// Send email

--- a/packages/auth/src/oauth/consumer.ts
+++ b/packages/auth/src/oauth/consumer.ts
@@ -10,6 +10,7 @@ import type { AuthAdapter, User, RoleLevel } from "../types.js";
 import { github, fetchGitHubEmail } from "./providers/github.js";
 import { google } from "./providers/google.js";
 import type { OAuthProvider, OAuthConfig, OAuthProfile, OAuthState } from "./types.js";
+import { buildAuthUrl } from "../urls.js";
 
 export { github, google };
 
@@ -40,7 +41,10 @@ export async function createAuthorizationUrl(
 
 	const provider = getProvider(providerName);
 	const state = generateState();
-	const redirectUri = `${config.baseUrl}/api/auth/oauth/${providerName}/callback`;
+	const redirectUri = buildAuthUrl(
+		config.baseUrl,
+		`api/auth/oauth/${providerName}/callback`,
+	).toString();
 
 	// Generate PKCE code verifier for providers that support it
 	const codeVerifier = generateCodeVerifier();

--- a/packages/auth/src/signup.ts
+++ b/packages/auth/src/signup.ts
@@ -5,6 +5,7 @@
 import { escapeHtml } from "./invite.js";
 import { generateTokenWithHash, hashToken } from "./tokens.js";
 import type { AuthAdapter, RoleLevel, EmailMessage, User } from "./types.js";
+import { buildAuthUrl } from "./urls.js";
 
 const TOKEN_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -91,7 +92,7 @@ export async function requestSignup(
 	});
 
 	// Build verification URL
-	const url = new URL("/api/auth/signup/verify", config.baseUrl);
+	const url = buildAuthUrl(config.baseUrl, "api/auth/signup/verify");
 	url.searchParams.set("token", token);
 
 	// Send email

--- a/packages/auth/src/urls.test.ts
+++ b/packages/auth/src/urls.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { createInviteToken } from "./invite.js";
+import { sendMagicLink } from "./magic-link/index.js";
+import { createAuthorizationUrl } from "./oauth/consumer.js";
+import { requestSignup } from "./signup.js";
+import { Role, type AuthAdapter, type EmailMessage } from "./types.js";
+
+function createAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+	return {
+		getUserById: async () => null,
+		getUserByEmail: async () => null,
+		createUser: async () => {
+			throw new Error("Not implemented");
+		},
+		updateUser: async () => {},
+		deleteUser: async () => {},
+		countUsers: async () => 0,
+		getUsers: async () => ({ items: [] }),
+		getUserWithDetails: async () => null,
+		countAdmins: async () => 0,
+		getCredentialById: async () => null,
+		getCredentialsByUserId: async () => [],
+		createCredential: async () => {
+			throw new Error("Not implemented");
+		},
+		updateCredentialCounter: async () => {},
+		updateCredentialName: async () => {},
+		deleteCredential: async () => {},
+		countCredentialsByUserId: async () => 0,
+		createToken: async () => {},
+		getToken: async () => null,
+		deleteToken: async () => {},
+		deleteExpiredTokens: async () => {},
+		getOAuthAccount: async () => null,
+		getOAuthAccountsByUserId: async () => [],
+		createOAuthAccount: async () => {
+			throw new Error("Not implemented");
+		},
+		deleteOAuthAccount: async () => {},
+		getAllowedDomain: async () => null,
+		getAllowedDomains: async () => [],
+		createAllowedDomain: async () => {
+			throw new Error("Not implemented");
+		},
+		updateAllowedDomain: async () => {},
+		deleteAllowedDomain: async () => {},
+		...overrides,
+	};
+}
+
+describe("auth URL generation", () => {
+	const baseUrl = "https://example.com/_emdash";
+
+	it("preserves a subpath when building invite URLs", async () => {
+		const result = await createInviteToken(
+			{ baseUrl },
+			createAdapter(),
+			"invitee@example.com",
+			Role.EDITOR,
+			"admin-user",
+		);
+
+		expect(result.url).toMatch(
+			/^https:\/\/example\.com\/_emdash\/api\/auth\/invite\/accept\?token=/,
+		);
+	});
+
+	it("preserves a subpath when building magic link URLs", async () => {
+		const sentMessages: EmailMessage[] = [];
+		const adapter = createAdapter({
+			getUserByEmail: async (email) => ({
+				id: "user-1",
+				email,
+				name: null,
+				avatarUrl: null,
+				role: Role.EDITOR,
+				emailVerified: true,
+				disabled: false,
+				data: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			}),
+		});
+
+		await sendMagicLink(
+			{
+				baseUrl,
+				siteName: "Example",
+				email: async (message) => {
+					sentMessages.push(message);
+				},
+			},
+			adapter,
+			"user@example.com",
+		);
+
+		expect(sentMessages[0]?.text).toContain(
+			"https://example.com/_emdash/api/auth/magic-link/verify?token=",
+		);
+	});
+
+	it("preserves a subpath when building signup verification URLs", async () => {
+		const sentMessages: EmailMessage[] = [];
+		const adapter = createAdapter({
+			getAllowedDomain: async () => ({
+				domain: "example.com",
+				defaultRole: Role.CONTRIBUTOR,
+				enabled: true,
+				createdAt: new Date(),
+			}),
+		});
+
+		await requestSignup(
+			{
+				baseUrl,
+				siteName: "Example",
+				email: async (message) => {
+					sentMessages.push(message);
+				},
+			},
+			adapter,
+			"user@example.com",
+		);
+
+		expect(sentMessages[0]?.text).toContain(
+			"https://example.com/_emdash/api/auth/signup/verify?token=",
+		);
+	});
+
+	it("preserves a subpath when building OAuth callback URLs", async () => {
+		const stateStore = {
+			set: async () => {},
+			get: async () => null,
+			delete: async () => {},
+		};
+
+		const result = await createAuthorizationUrl(
+			{
+				baseUrl,
+				providers: {
+					github: {
+						clientId: "client-id",
+						clientSecret: "client-secret",
+					},
+				},
+			},
+			"github",
+			stateStore,
+		);
+
+		expect(result.url).toContain(
+			encodeURIComponent("https://example.com/_emdash/api/auth/oauth/github/callback"),
+		);
+	});
+});

--- a/packages/auth/src/urls.ts
+++ b/packages/auth/src/urls.ts
@@ -1,0 +1,5 @@
+export function buildAuthUrl(baseUrl: string, pathname: string): URL {
+	const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+	const normalizedPathname = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+	return new URL(normalizedPathname, normalizedBaseUrl);
+}


### PR DESCRIPTION
## Summary
- preserve `baseUrl` subpaths like `/_emdash` when building invite, magic-link, signup, and OAuth callback URLs
- centralize auth URL construction in a small helper so all flows behave consistently
- add regression tests covering subpath-based `baseUrl` values

## Why
Using `new URL("/api/auth/...", baseUrl)` resets the pathname to the origin root. When `baseUrl` already includes a subpath, generated auth links incorrectly drop that subpath and point to `/api/auth/...` instead of `/_emdash/api/auth/...`.

## Verification
- `pnpm --filter @emdash-cms/auth test`
- `pnpm --filter @emdash-cms/auth build`