### PR TITLE
fix: use Node 24 for release workflow to get npm OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -44,9 +44,6 @@ jobs:
 
       - name: Build packages
         run: pnpm build
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## What does this PR do?

Fixes the release workflow which is failing because `npm install -g npm@latest` corrupts npm's own dependencies during self-upgrade ([failed run](https://github.com/emdash-cms/emdash/actions/runs/23921209474/job/69779824542)).

The upgrade step existed because npm trusted publishing via OIDC requires npm 11.5.1+, and Node 22 only ships npm 10.x. Node 24 bundles npm 11.5.1+ natively, so we can use it directly and remove the self-upgrade step entirely.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Error from failed run:
```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```