### PR TITLE
Enable page:metadata hooks for anonymous visitors on public pages

### DIFF
--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -222,6 +222,24 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				}
 			}
 
+			// Initialize the runtime for page:metadata and page:fragments hooks.
+			// The runtime is a cached singleton — after the first request, getRuntime()
+			// is just a null-check. This enables SEO plugins to contribute meta tags,
+			// canonical URLs, robots directives, and JSON-LD schema for all visitors,
+			// not just logged-in editors.
+			const config = getConfig();
+			if (config) {
+				try {
+					const runtime = await getRuntime(config);
+					locals.emdash = {
+						collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
+						collectPageFragments: runtime.collectPageFragments.bind(runtime),
+					};
+				} catch {
+					// Non-fatal — EmDashHead will fall back to base SEO contributions
+				}
+			}
+
 			const response = await next();
 			setBaselineSecurityHeaders(response);
 			return response;


### PR DESCRIPTION
## Summary

- Initialize the runtime for anonymous visitors on public pages so `page:metadata` and `page:fragments` plugin hooks fire for all visitors
- Only attaches the two page contribution methods to `locals.emdash` (not the full admin object), preserving the existing performance optimization
- The runtime is a cached singleton — after first init, `getRuntime()` is just a null-check, so the per-request cost is negligible

## Problem

The middleware skips runtime initialization for anonymous visitors on public pages (lines 200–228). This means `EmDashHead`'s `getPageRuntime()` returns `undefined`, and it falls back to base-only SEO contributions. Plugin `page:metadata` hooks never fire for search engine crawlers or regular visitors.

## Fix

After the existing setup check, initialize the cached runtime and attach just `collectPageMetadata` and `collectPageFragments` to `locals.emdash`. This satisfies the structural check in `getPageRuntime()` so `EmDashHead` runs plugin hooks for all visitors.

## Test plan

- [ ] Verify anonymous visitors see plugin-contributed meta tags in `<head>`
- [ ] Verify logged-in editors still see the full admin toolbar and all existing functionality
- [ ] Verify performance is not impacted (runtime is cached singleton after first request)
- [ ] Verify `EmDashBodyStart`/`EmDashBodyEnd` work correctly with the minimal locals object

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)