### PR TITLE
fix(auth): secureCompare to reuse constantTimeEqual from @oslojs/crypto

### DIFF
--- a/packages/auth/src/tokens.ts
+++ b/packages/auth/src/tokens.ts
@@ -6,7 +6,9 @@
  * Tokens are opaque random values. We store only the SHA-256 hash in the database.
  */
 
-import { sha256 } from "@oslojs/crypto/sha2";
+import { hmac } from "@oslojs/crypto/hmac";
+import { sha256, SHA256 } from "@oslojs/crypto/sha2";
+import { constantTimeEqual } from "@oslojs/crypto/subtle";
 import { encodeBase64urlNoPadding, decodeBase64urlIgnorePadding } from "@oslojs/encoding";
 
 const TOKEN_BYTES = 32; // 256 bits of entropy
@@ -162,16 +164,11 @@ export function computeS256Challenge(codeVerifier: string): string {
  * Constant-time comparison to prevent timing attacks
  */
 export function secureCompare(a: string, b: string): boolean {
-	if (a.length !== b.length) return false;
+	const text = new TextEncoder();
+	const salt = crypto.getRandomValues(new Uint8Array(TOKEN_BYTES));
+	const hash = (str: string) => hmac(SHA256, salt, text.encode(str));
 
-	const aBytes = new TextEncoder().encode(a);
-	const bBytes = new TextEncoder().encode(b);
-
-	let result = 0;
-	for (let i = 0; i < aBytes.length; i++) {
-		result |= aBytes[i]! ^ bBytes[i]!;
-	}
-	return result === 0;
+	return constantTimeEqual(hash(a), hash(b));
 }
 
 // ============================================================================


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

- reuse the functionality from existing dependence: `@oslojs/crypto/*`.
- avoid early return timing side-channel attack vectors.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
