### PR TITLE
ci: add /format comment command for PRs

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -1,0 +1,97 @@
+name: Format Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  format:
+    name: Format
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/format')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+
+      - name: React to comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run formatter
+        run: pnpm format
+
+      - name: Commit and push
+        id: commit
+        run: |
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "style: format"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: React to comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const changed = '${{ steps.commit.outputs.changed }}' === 'true';
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: changed ? 'rocket' : '+1',
+            });


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Action that lets maintainers comment `/format` on a PR to auto-format the code and commit the result using the EmDashBot app token.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (link to Discussion: )
- [ ] Refactor
- [ ] Documentation
- [ ] Performance
- [ ] Tests
- [x] Chore

## How it works

- Triggered by `/format` in a PR comment
- Uses the bot app token (`APP_ID`/`APP_PRIVATE_KEY`) to check out the PR branch
- Runs `pnpm format`, commits as `emdashbot[bot]` if there are changes
- Reacts with 👀 when starting, then 🚀 if changes were pushed or 👍 if already formatted
- No-ops gracefully when formatting produces no diff

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My changes follow the project's code style
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation as needed
- [x] All existing tests pass
- [x] This PR contains AI-generated code