### PR TITLE
Fix page metadata titles without the site-name suffix

### DIFF
--- a/.changeset/fix-og-title-page-title.md
+++ b/.changeset/fix-og-title-page-title.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes base OG, Twitter, and article JSON-LD titles so they can use a page-specific title without including the site name suffix from the document title.

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -26,6 +27,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -53,6 +55,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/demos/cloudflare/src/pages/posts/[slug].astro
+++ b/demos/cloudflare/src/pages/posts/[slug].astro
@@ -98,6 +98,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/demos/playground/src/layouts/Base.astro
+++ b/demos/playground/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -26,6 +27,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -53,6 +55,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/demos/playground/src/pages/posts/[slug].astro
+++ b/demos/playground/src/pages/posts/[slug].astro
@@ -98,6 +98,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/demos/postgres/src/layouts/Base.astro
+++ b/demos/postgres/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -26,6 +27,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -53,6 +55,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/demos/postgres/src/pages/posts/[slug].astro
+++ b/demos/postgres/src/pages/posts/[slug].astro
@@ -98,6 +98,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/demos/preview/src/layouts/Base.astro
+++ b/demos/preview/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -26,6 +27,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -53,6 +55,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/demos/preview/src/pages/posts/[slug].astro
+++ b/demos/preview/src/pages/posts/[slug].astro
@@ -98,6 +98,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/demos/simple/src/layouts/Base.astro
+++ b/demos/simple/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -26,6 +27,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -53,6 +55,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/demos/simple/src/pages/posts/[slug].astro
+++ b/demos/simple/src/pages/posts/[slug].astro
@@ -98,6 +98,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/docs/src/content/docs/guides/site-settings.mdx
+++ b/docs/src/content/docs/guides/site-settings.mdx
@@ -184,16 +184,17 @@ const {
   image,
 } = Astro.props;
 
-const pageTitle = title
+const documentTitle = title
   ? `${title} | ${settings.title}`
   : settings.title;
+const ogTitle = title ?? settings.title;
 ---
 
-<title>{pageTitle}</title>
+<title>{documentTitle}</title>
 {description && <meta name="description" content={description} />}
 
 <!-- Open Graph -->
-<meta property="og:title" content={pageTitle} />
+<meta property="og:title" content={ogTitle} />
 {description && <meta property="og:description" content={description} />}
 {image && <meta property="og:image" content={image} />}
 {settings.url && <meta property="og:url" content={settings.url + Astro.url.pathname} />}

--- a/docs/src/content/docs/plugins/hooks.mdx
+++ b/docs/src/content/docs/plugins/hooks.mdx
@@ -485,7 +485,7 @@ Core validates, deduplicates, and renders the contributions. Plugins return stru
     graph: {
       "@context": "https://schema.org",
       "@type": "BlogPosting",
-      headline: event.page.title,
+      headline: event.page.pageTitle ?? event.page.title,
       description: event.page.description,
     },
   };
@@ -503,6 +503,7 @@ Core validates, deduplicates, and renders the contributions. Plugins return stru
     kind: "content" | "custom";
     pageType: string;
     title: string | null;
+    pageTitle?: string | null;
     description: string | null;
     canonical: string | null;
     image: string | null;

--- a/packages/core/src/page/context.ts
+++ b/packages/core/src/page/context.ts
@@ -12,6 +12,7 @@ interface PageContextFields {
 	kind: "content" | "custom";
 	pageType?: string;
 	title?: string | null;
+	pageTitle?: string | null;
 	description?: string | null;
 	canonical?: string | null;
 	image?: string | null;
@@ -76,6 +77,7 @@ export function createPublicPageContext(input: CreatePublicPageContextInput): Pu
 		kind: input.kind,
 		pageType: input.pageType ?? (input.kind === "content" ? "article" : "website"),
 		title: input.title ?? null,
+		pageTitle: input.pageTitle ?? null,
 		description: input.description ?? null,
 		canonical: input.canonical ?? null,
 		image: input.image ?? null,

--- a/packages/core/src/page/jsonld.ts
+++ b/packages/core/src/page/jsonld.ts
@@ -33,7 +33,7 @@ export function cleanJsonLd(obj: Record<string, unknown>): Record<string, unknow
 export function buildBlogPostingJsonLd(page: PublicPageContext): Record<string, unknown> | null {
 	if (page.pageType !== "article" || !page.canonical) return null;
 
-	const ogTitle = page.seo?.ogTitle || page.title;
+	const ogTitle = page.seo?.ogTitle ?? page.pageTitle ?? page.title;
 	const description = page.seo?.ogDescription || page.description;
 	const ogImage = page.seo?.ogImage || page.image;
 	const publishedTime = page.articleMeta?.publishedTime;

--- a/packages/core/src/page/seo-contributions.ts
+++ b/packages/core/src/page/seo-contributions.ts
@@ -20,7 +20,7 @@ export function generateBaseSeoContributions(page: PublicPageContext): PageMetad
 	const contributions: PageMetadataContribution[] = [];
 
 	const description = page.description;
-	const ogTitle = page.seo?.ogTitle || page.title;
+	const ogTitle = page.seo?.ogTitle ?? page.pageTitle ?? page.title;
 	const ogDescription = page.seo?.ogDescription || description;
 	const ogImage = page.seo?.ogImage || page.image;
 	const robots = page.seo?.robots;

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -757,7 +757,10 @@ export interface PublicPageContext {
 	locale: string | null;
 	kind: "content" | "custom";
 	pageType: string;
+	/** Full document title for the rendered page */
 	title: string | null;
+	/** Page-only title for OG/Twitter/JSON-LD headline output */
+	pageTitle?: string | null;
 	description: string | null;
 	canonical: string | null;
 	image: string | null;

--- a/packages/core/tests/unit/plugins/page-context.test.ts
+++ b/packages/core/tests/unit/plugins/page-context.test.ts
@@ -21,12 +21,14 @@ describe("createPublicPageContext", () => {
 			},
 			kind: "content",
 			title: "Hello",
+			pageTitle: "Hello",
 		});
 
 		expect(result.url).toBe("https://example.com/blog/hello");
 		expect(result.path).toBe("/blog/hello");
 		expect(result.locale).toBe("en");
 		expect(result.title).toBe("Hello");
+		expect(result.pageTitle).toBe("Hello");
 	});
 
 	it("accepts URL string input", () => {
@@ -81,6 +83,16 @@ describe("createPublicPageContext", () => {
 		});
 
 		expect(result.locale).toBeNull();
+	});
+
+	it("normalizes undefined pageTitle to null", () => {
+		const result = createPublicPageContext({
+			url: "https://example.com/about",
+			kind: "custom",
+			title: "About | My Site",
+		});
+
+		expect(result.pageTitle).toBeNull();
 	});
 
 	it("normalizes content slug undefined to null", () => {

--- a/packages/core/tests/unit/plugins/page-seo.test.ts
+++ b/packages/core/tests/unit/plugins/page-seo.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBlogPostingJsonLd } from "../../../src/page/jsonld.js";
+import { generateBaseSeoContributions } from "../../../src/page/seo-contributions.js";
+import type { PublicPageContext } from "../../../src/plugins/types.js";
+
+function createPage(overrides: Partial<PublicPageContext> = {}): PublicPageContext {
+	return {
+		url: "https://example.com/posts/hello",
+		path: "/posts/hello",
+		locale: null,
+		kind: "content",
+		pageType: "article",
+		title: "Hello World | My Site",
+		description: "Test description",
+		canonical: "https://example.com/posts/hello",
+		image: "https://example.com/og.png",
+		siteName: "My Site",
+		...overrides,
+	};
+}
+
+describe("page SEO metadata", () => {
+	it("uses pageTitle for og:title and twitter:title", () => {
+		const page = createPage({ pageTitle: "Hello World" });
+
+		const contributions = generateBaseSeoContributions(page);
+
+		expect(contributions).toContainEqual({
+			kind: "property",
+			property: "og:title",
+			content: "Hello World",
+		});
+		expect(contributions).toContainEqual({
+			kind: "meta",
+			name: "twitter:title",
+			content: "Hello World",
+		});
+	});
+
+	it("prefers explicit seo.ogTitle over pageTitle", () => {
+		const page = createPage({
+			seo: { ogTitle: "Custom OG Title" },
+			pageTitle: "Hello World",
+		});
+
+		const contributions = generateBaseSeoContributions(page);
+
+		expect(contributions).toContainEqual({
+			kind: "property",
+			property: "og:title",
+			content: "Custom OG Title",
+		});
+		expect(contributions).toContainEqual({
+			kind: "meta",
+			name: "twitter:title",
+			content: "Custom OG Title",
+		});
+	});
+
+	it("falls back to title when pageTitle is absent", () => {
+		const page = createPage();
+
+		const contributions = generateBaseSeoContributions(page);
+
+		expect(contributions).toContainEqual({
+			kind: "property",
+			property: "og:title",
+			content: "Hello World | My Site",
+		});
+	});
+
+	it("uses pageTitle for article JSON-LD headline", () => {
+		const page = createPage({
+			articleMeta: { publishedTime: "2026-04-03T12:00:00.000Z" },
+			pageTitle: "Hello World",
+		});
+
+		const graph = buildBlogPostingJsonLd(page);
+
+		expect(graph).toMatchObject({
+			headline: "Hello World",
+		});
+	});
+});

--- a/skills/building-emdash-site/references/site-features.md
+++ b/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -350,7 +350,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/blank/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blank/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/blank/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/blog-cloudflare/src/layouts/Base.astro
+++ b/templates/blog-cloudflare/src/layouts/Base.astro
@@ -13,6 +13,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -27,6 +28,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -54,6 +56,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/templates/blog-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/posts/[slug].astro
@@ -101,6 +101,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/templates/blog/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/blog/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/blog/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/blog/src/layouts/Base.astro
+++ b/templates/blog/src/layouts/Base.astro
@@ -13,6 +13,7 @@ import "../styles/theme.css";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -27,6 +28,7 @@ interface Props {
 
 const {
 	title,
+	pageTitle,
 	description,
 	image,
 	canonical,
@@ -54,6 +56,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description,
 	canonical,
 	image,

--- a/templates/blog/src/pages/posts/[slug].astro
+++ b/templates/blog/src/pages/posts/[slug].astro
@@ -101,6 +101,7 @@ const publishDate =
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	image={seo.ogImage}
 	canonical={seo.canonical}

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -23,6 +23,7 @@ const pageCtx = createPublicPageContext({
 	kind: "custom",
 	pageType: "website",
 	title: fullTitle,
+	pageTitle: title ?? siteTitle,
 	description: description || siteDescription,
 	canonical: Astro.url.href,
 	image,

--- a/templates/marketing/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -23,6 +23,7 @@ const pageCtx = createPublicPageContext({
 	kind: "custom",
 	pageType: "website",
 	title: fullTitle,
+	pageTitle: title ?? siteTitle,
 	description: description || siteDescription,
 	canonical: Astro.url.href,
 	image,

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -23,6 +23,7 @@ const pageCtx = createPublicPageContext({
 	kind: "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: title ?? siteTitle,
 	description: description || siteDescription,
 	canonical: Astro.url.href,
 	image,

--- a/templates/portfolio/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -23,6 +23,7 @@ const pageCtx = createPublicPageContext({
 	kind: "custom",
 	pageType: type,
 	title: fullTitle,
+	pageTitle: title ?? siteTitle,
 	description: description || siteDescription,
 	canonical: Astro.url.href,
 	image,

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/starter-cloudflare/src/layouts/Base.astro
+++ b/templates/starter-cloudflare/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import { resolveStarterSiteIdentity } from "../utils/site-identity";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -19,7 +20,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, canonical, content } = Astro.props;
+const { title, pageTitle, description, image, canonical, content } = Astro.props;
 const { siteTitle, siteTagline } = resolveStarterSiteIdentity(await getSiteSettings());
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 const pageDescription = description ?? siteTagline;
@@ -31,6 +32,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description: pageDescription,
 	canonical,
 	image,

--- a/templates/starter-cloudflare/src/pages/[slug].astro
+++ b/templates/starter-cloudflare/src/pages/[slug].astro
@@ -28,6 +28,7 @@ const seo = getSeoMeta(page, {
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	canonical={seo.canonical}
 	content={{ collection: "pages", id: page.data.id, slug }}

--- a/templates/starter-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/starter-cloudflare/src/pages/posts/[slug].astro
@@ -33,6 +33,7 @@ const categories = await getEntryTerms("posts", post.data.id, "category");
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	canonical={seo.canonical}
 	image={seo.ogImage}

--- a/templates/starter/.agents/skills/building-emdash-site/references/site-features.md
+++ b/templates/starter/.agents/skills/building-emdash-site/references/site-features.md
@@ -310,6 +310,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "article",
 	title: fullTitle,
+	pageTitle: post.data.title,
 	description,
 	canonical,
 	image,
@@ -450,7 +451,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, content } = Astro.props;
+const { title, pageTitle, description, image, content } = Astro.props;
 const menu = await getMenu("primary");
 
 const pageCtx = createPublicPageContext({
@@ -458,6 +459,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title,
+	pageTitle: pageTitle ?? title,
 	description,
 	image,
 	content,

--- a/templates/starter/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/hooks.md
@@ -324,7 +324,7 @@ Returns structured contributions that core validates, dedupes (first-wins), and 
 			graph: {
 				"@context": "https://schema.org",
 				"@type": "BlogPosting",
-				headline: event.page.title,
+				headline: event.page.pageTitle ?? event.page.title,
 				description: event.page.description,
 			},
 		},

--- a/templates/starter/src/layouts/Base.astro
+++ b/templates/starter/src/layouts/Base.astro
@@ -12,6 +12,7 @@ import { resolveStarterSiteIdentity } from "../utils/site-identity";
 
 interface Props {
 	title: string;
+	pageTitle?: string | null;
 	description?: string | null;
 	image?: string | null;
 	canonical?: string | null;
@@ -19,7 +20,7 @@ interface Props {
 	content?: { collection: string; id: string; slug?: string | null };
 }
 
-const { title, description, image, canonical, content } = Astro.props;
+const { title, pageTitle, description, image, canonical, content } = Astro.props;
 const { siteTitle, siteTagline } = resolveStarterSiteIdentity(await getSiteSettings());
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 const pageDescription = description ?? siteTagline;
@@ -31,6 +32,7 @@ const pageCtx = createPublicPageContext({
 	kind: content ? "content" : "custom",
 	pageType: "website",
 	title: fullTitle,
+	pageTitle: pageTitle ?? title,
 	description: pageDescription,
 	canonical,
 	image,

--- a/templates/starter/src/pages/[slug].astro
+++ b/templates/starter/src/pages/[slug].astro
@@ -28,6 +28,7 @@ const seo = getSeoMeta(page, {
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	canonical={seo.canonical}
 	content={{ collection: "pages", id: page.data.id, slug }}

--- a/templates/starter/src/pages/posts/[slug].astro
+++ b/templates/starter/src/pages/posts/[slug].astro
@@ -33,6 +33,7 @@ const categories = await getEntryTerms("posts", post.data.id, "category");
 
 <Base
 	title={seo.title}
+	pageTitle={seo.ogTitle}
 	description={seo.description}
 	canonical={seo.canonical}
 	image={seo.ogImage}


### PR DESCRIPTION
## What does this PR do?

Fixes shared page metadata title handling so Open Graph, Twitter, and article JSON-LD can use a page-specific title without inheriting the site-name suffix from the document `<title>`.

Closes #168

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Behavior check:
- Site name remains in the document `<title>`
- `og:title` uses the page title without the site-name suffix

<img width="556" height="180" alt="Site name is visible in the title tag but not in the meta og:title tag" src="https://github.com/user-attachments/assets/de700da9-c08c-4172-a717-cdc94a1287b7" />

Validation run:
- `pnpm typecheck` passed
- `pnpm typecheck:demos` passed
- `pnpm typecheck:templates` passed
- `pnpm test` passed
- `pnpm format` run
- `pnpm --silent lint:json | jq '.diagnostics | length'` returned `0`