### PR TITLE
Fix PluginBridge not exported from Cloudflare Worker entry point

### DIFF
--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -273,6 +273,10 @@ export const sandboxEnabled = false;
 	return `
 // Auto-generated sandbox runner module
 import { createSandboxRunner as _createSandboxRunner } from "${sandboxRunner}";
+// Re-export PluginBridge so it's included in the build graph.
+// The entry-point export plugin will hoist this to entry.mjs at build time,
+// making it accessible via cloudflare:workers exports at runtime.
+export { PluginBridge } from "${sandboxRunner}";
 
 export const createSandboxRunner = _createSandboxRunner;
 export const sandboxEnabled = true;

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -204,6 +204,54 @@ export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 }
 
 /**
+ * Creates a Vite plugin that ensures PluginBridge is exported from the
+ * Worker entry point when a sandbox runner is configured.
+ *
+ * The Cloudflare sandbox runner needs PluginBridge to be a named export
+ * of the main Worker module so it's accessible via cloudflare:workers
+ * exports at runtime. The Astro Cloudflare adapter only generates a
+ * default export in entry.mjs, so this plugin appends the named export
+ * during the build.
+ */
+function createPluginBridgeExportPlugin(sandboxRunner?: string): Plugin | null {
+	if (!sandboxRunner) return null;
+
+	return {
+		name: "emdash-plugin-bridge-export",
+		enforce: "post",
+		generateBundle(_, bundle) {
+			// Find the entry chunk (entry.mjs)
+			for (const [fileName, chunk] of Object.entries(bundle)) {
+				if (chunk.type === "chunk" && chunk.isEntry && fileName.endsWith(".mjs")) {
+					// Find which chunk contains the PluginBridge export from the
+					// virtual sandbox-runner module. The build graph includes it
+					// because the virtual module re-exports it.
+					let bridgeChunk: string | null = null;
+					for (const [name, c] of Object.entries(bundle)) {
+						if (
+							c.type === "chunk" &&
+							c.code.includes("PluginBridge") &&
+							c.code.includes("WorkerEntrypoint")
+						) {
+							// Use the chunk's path relative to the entry
+							bridgeChunk = name;
+							break;
+						}
+					}
+
+					if (bridgeChunk) {
+						// Compute the import path relative to entry.mjs
+						const importPath = "./" + bridgeChunk;
+						chunk.code += `\nimport { PluginBridge } from "${importPath}";\nexport { PluginBridge };\n`;
+					}
+					break;
+				}
+			}
+		},
+	};
+}
+
+/**
  * Modules that contain native Node.js addons or Node-only code.
  * These must be external in SSR to avoid bundling failures on Node.
  * On Cloudflare, the adapter handles its own externalization — setting
@@ -257,7 +305,10 @@ export function createViteConfig(
 			],
 		},
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Monorepo has both vite 6 (docs) and vite 7 (core). tsgo resolves correctly.
-		plugins: [createVirtualModulesPlugin(options)] as NonNullable<AstroConfig["vite"]>["plugins"],
+		plugins: [
+			createVirtualModulesPlugin(options),
+			...(cloudflare ? [createPluginBridgeExportPlugin(options.resolvedConfig.sandboxRunner)] : []),
+		].filter(Boolean) as NonNullable<AstroConfig["vite"]>["plugins"],
 		// Handle native modules for SSR.
 		// On Node: external keeps native addons out of the SSR bundle.
 		// On Cloudflare: skip — the adapter handles externalization, and setting


### PR DESCRIPTION
## What does this PR do?

The sandbox runner accesses PluginBridge via cloudflare:workers exports, which only contains exports from the Worker's main entry module. The Astro Cloudflare adapter generates entry.mjs with only a default export, so PluginBridge was never accessible at runtime — causing isAvailable() to return false and marketplace plugin installs to fail with SANDBOX_NOT_AVAILABLE.

Two changes:
1. The virtual sandbox-runner module now re-exports PluginBridge from the configured sandbox runner package, ensuring it's included in the Rollup build graph instead of being tree-shaken.
2. A new Vite output plugin (emdash-plugin-bridge-export) appends the PluginBridge named export to entry.mjs during generateBundle, making it visible to cloudflare:workers exports at runtime.

Closes #216

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Verified that after this change, the built `entry.mjs` includes `export { PluginBridge }` and the sandbox runner's `isAvailable()` returns true at runtime on Cloudflare Workers.