### PR TITLE
fix: sync TermFormDialog state when switching between edit targets

### DIFF
--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -120,6 +120,16 @@ function TermFormDialog({
 	const [autoSlug, setAutoSlug] = React.useState(!term);
 	const [error, setError] = React.useState<string | null>(null);
 
+	// Sync form state when the term prop changes (switching between edit targets)
+	React.useEffect(() => {
+		setLabel(term?.label || "");
+		setSlug(term?.slug || "");
+		setParentId(term?.parentId || "");
+		setDescription(term?.description || "");
+		setAutoSlug(!term);
+		setError(null);
+	}, [term]);
+
 	// Auto-generate slug from label
 	React.useEffect(() => {
 		if (autoSlug && label) {


### PR DESCRIPTION
## Summary

Fixes #220

When clicking Edit on different taxonomy terms, the form dialog retains data from the previously edited term because `React.useState` only uses its initial value on first mount — subsequent prop changes don't update state automatically.

- Add a `useEffect` in `TermFormDialog` that resets all form fields (`label`, `slug`, `parentId`, `description`, `autoSlug`, `error`) whenever the `term` prop changes
- This ensures the form always shows the correct data for the currently selected term

## Steps to reproduce the bug

1. Go to Taxonomies > Categories
2. Click Edit on "Category A" — form shows Category A's data ✓
3. Close the dialog without saving
4. Click Edit on "Category B" — form still shows Category A's data ✗ (bug)

After this fix, step 4 correctly shows Category B's data.

## Test plan

- [ ] Click Edit on a term → form shows correct data
- [ ] Close dialog, click Edit on a different term → form updates to show new term's data
- [ ] Slug auto-generation is disabled when editing an existing term (autoSlug = false)
- [ ] Slug auto-generation is enabled for new terms (Add button)
- [ ] Error state is cleared when switching between terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)