### PR TITLE
fix: chunk IDs in hydrateEntryBylines to avoid D1 SQL variable limit

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -485,6 +485,8 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
  * Uses batch queries to avoid N+1.
  *
  * Fails silently if the byline tables don't exist yet (pre-migration).
+ *
+ * IDs are chunked to stay within Cloudflare D1's bound-parameter limit.
  */
 async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]): Promise<void> {
 	if (entries.length === 0) return;
@@ -495,7 +497,18 @@ async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]):
 		const ids = entries.map((e) => dataStr(entryData(e), "id")).filter(Boolean);
 		if (ids.length === 0) return;
 
-		const bylinesMap = await getBylinesForEntries(type, ids);
+		// Chunk IDs to avoid exceeding D1's SQL bound-parameter limit.
+		// A conservative chunk size of 50 keeps each IN (...) clause well within
+		// D1's limit while minimising round-trips.
+		const CHUNK_SIZE = 50;
+		type BylinesMap = Awaited<ReturnType<typeof getBylinesForEntries>>;
+		const bylinesMap: BylinesMap = new Map();
+		for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+			const chunkMap = await getBylinesForEntries(type, ids.slice(i, i + CHUNK_SIZE));
+			for (const [k, v] of chunkMap) {
+				bylinesMap.set(k, v);
+			}
+		}
 
 		for (const entry of entries) {
 			const data = entryData(entry);


### PR DESCRIPTION
## Summary

Fixes #219.

Cloudflare D1 enforces a SQL bound-parameter limit lower than SQLite's default 999. When `getEmDashCollection` returns a large result set, `hydrateEntryBylines` passed **all** entry IDs in one call to `getBylinesForEntries`, which builds unbounded `IN (?, ?, …)` clauses across three code paths:

1. `BylineRepository.getContentBylinesMany` — `WHERE cb.content_id IN (…)`
2. `getAuthorIds` fallback — `WHERE id IN (…)`
3. `BylineRepository.findByUserIds` — `WHERE user_id IN (…)`

On collections with 50+ entries this triggers `D1_ERROR: too many SQL variables`, and byline data is silently dropped (caught by the existing `try/catch`).

## Fix

Chunk the ID array in `hydrateEntryBylines` into batches of 50 before calling `getBylinesForEntries`, then merge the result maps. This is the single control point for all three downstream queries. A batch size of 50 stays well within D1's limit while keeping round-trips low.

```ts
const CHUNK_SIZE = 50;
type BylinesMap = Awaited<ReturnType<typeof getBylinesForEntries>>;
const bylinesMap: BylinesMap = new Map();
for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
  const chunkMap = await getBylinesForEntries(type, ids.slice(i, i + CHUNK_SIZE));
  for (const [k, v] of chunkMap) {
    bylinesMap.set(k, v);
  }
}
```

## Test plan

- [ ] Deploy a collection with 60+ published entries to a Cloudflare Workers environment
- [ ] Call `getEmDashCollection('posts', { limit: 100 })` — should succeed with byline data hydrated
- [ ] Verify no `D1_ERROR: too many SQL variables` errors in the Worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)