### PR TITLE
optimize dashboard collection stats query

### DIFF
--- a/.changeset/every-onions-speak.md
+++ b/.changeset/every-onions-speak.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Optimize dashboard stats (3x fewer db queries)

--- a/packages/core/src/api/handlers/dashboard.ts
+++ b/packages/core/src/api/handlers/dashboard.ts
@@ -62,17 +62,13 @@ export async function handleDashboardStats(
 		const contentRepo = new ContentRepository(db);
 		const collectionStats: CollectionStats[] = await Promise.all(
 			collections.map(async (col) => {
-				const [total, published, draft] = await Promise.all([
-					contentRepo.count(col.slug),
-					contentRepo.count(col.slug, { status: "published" }),
-					contentRepo.count(col.slug, { status: "draft" }),
-				]);
+				const stats = await contentRepo.getStats(col.slug);
 				return {
 					slug: col.slug,
 					label: col.label,
-					total,
-					published,
-					draft,
+					total: stats.total,
+					published: stats.published,
+					draft: stats.draft,
 				};
 			}),
 		);

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -767,6 +767,27 @@ export class ContentRepository {
 		return Number(result?.count || 0);
 	}
 
+	// get overall statistics (total, published, draft) for a content type in a single query
+	async getStats(type: string): Promise<{ total: number; published: number; draft: number }> {
+		const tableName = getTableName(type);
+
+		const result = await this.db
+			.selectFrom(tableName as keyof Database)
+			.select((eb) => [
+				eb.fn.count("id").as("total"),
+				eb.fn.sum(eb.case().when("status", "=", "published").then(1).else(0).end()).as("published"),
+				eb.fn.sum(eb.case().when("status", "=", "draft").then(1).else(0).end()).as("draft"),
+			])
+			.where("deleted_at" as never, "is", null)
+			.executeTakeFirst();
+
+		return {
+			total: Number(result?.total || 0),
+			published: Number(result?.published || 0),
+			draft: Number(result?.draft || 0),
+		};
+	}
+
 	/**
 	 * Schedule content for future publishing
 	 *


### PR DESCRIPTION
## What does this PR do?

optimizes the dashboard statistics by reducing the number of database queries. it replaces three separate `count` calls with a single `getStats` query using conditional aggregation (`sum(case when...)`). this fixes a 3N query bottleneck and improves dashboard load times.

## Type of change

- [x] Performance improvement

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code