### PR TITLE
feat(marketplace): expose github.clientId from discovery + harden publish auth

### DIFF
--- a/.changeset/smooth-bugs-wave.md
+++ b/.changeset/smooth-bugs-wave.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/marketplace": patch
+---
+
+Adds the `email:status` plugin hook to EmDash core typing and hardens marketplace GitHub auth discovery for publish flows.

--- a/.github/workflows/deploy-marketplace.yml
+++ b/.github/workflows/deploy-marketplace.yml
@@ -1,4 +1,4 @@
-name: Seed Marketplace Plugins
+name: Deploy Marketplace
 
 on:
   workflow_dispatch:
@@ -6,18 +6,19 @@ on:
     branches: [main]
     paths:
       - "packages/plugins/**"
+      - "packages/marketplace/**"
       - ".github/workflows/deploy-marketplace.yml"
 
 permissions:
   contents: read
 
 concurrency:
-  group: seed-marketplace
+  group: deploy-marketplace
   cancel-in-progress: false
 
 jobs:
-  seed:
-    name: Seed Plugins
+  deploy-and-seed:
+    name: Deploy and Seed Marketplace
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,6 +33,89 @@ jobs:
 
       # Build core (produces the CLI at dist/cli/index.mjs)
       - run: pnpm run --filter emdash... build
+
+      - name: Verify deployment secrets
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          MARKETPLACE_GITHUB_CLIENT_ID: ${{ secrets.MARKETPLACE_GITHUB_CLIENT_ID }}
+          MARKETPLACE_GITHUB_CLIENT_SECRET: ${{ secrets.MARKETPLACE_GITHUB_CLIENT_SECRET }}
+          MARKETPLACE_SEED_TOKEN: ${{ secrets.MARKETPLACE_SEED_TOKEN }}
+        run: |
+          for name in \
+            CLOUDFLARE_API_TOKEN \
+            CLOUDFLARE_ACCOUNT_ID \
+            MARKETPLACE_GITHUB_CLIENT_ID \
+            MARKETPLACE_GITHUB_CLIENT_SECRET \
+            MARKETPLACE_SEED_TOKEN
+          do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+      - name: Push marketplace Worker secrets
+        working-directory: packages/marketplace
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          MARKETPLACE_GITHUB_CLIENT_ID: ${{ secrets.MARKETPLACE_GITHUB_CLIENT_ID }}
+          MARKETPLACE_GITHUB_CLIENT_SECRET: ${{ secrets.MARKETPLACE_GITHUB_CLIENT_SECRET }}
+          MARKETPLACE_SEED_TOKEN: ${{ secrets.MARKETPLACE_SEED_TOKEN }}
+        run: |
+          printf '%s' "$MARKETPLACE_GITHUB_CLIENT_ID" | pnpm exec wrangler secret put GITHUB_CLIENT_ID
+          printf '%s' "$MARKETPLACE_GITHUB_CLIENT_SECRET" | pnpm exec wrangler secret put GITHUB_CLIENT_SECRET
+          printf '%s' "$MARKETPLACE_SEED_TOKEN" | pnpm exec wrangler secret put SEED_TOKEN
+
+      - name: Deploy marketplace Worker
+        working-directory: packages/marketplace
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm deploy
+
+      - name: Smoke-check auth discovery
+        env:
+          MARKETPLACE_URL: https://marketplace.emdashcms.com
+        run: |
+          node <<'NODE'
+          const url = `${process.env.MARKETPLACE_URL}/api/v1/auth/discovery`;
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          (async () => {
+            let lastStatus = 0;
+            let lastBody = "";
+
+            for (let attempt = 1; attempt <= 24; attempt += 1) {
+              const res = await fetch(url);
+              lastStatus = res.status;
+              lastBody = await res.text();
+
+              if (res.ok) {
+                try {
+                  const body = JSON.parse(lastBody);
+                  if (body?.github?.enabled === true && typeof body.github.clientId === "string" && body.github.clientId.length > 0) {
+                    console.log(`Discovery ready on attempt ${attempt}.`);
+                    process.exit(0);
+                  }
+                } catch {}
+              }
+
+              await sleep(5000);
+            }
+
+            console.error("Discovery never reported GitHub device auth as ready.");
+            console.error(`Last status: ${lastStatus}`);
+            console.error(lastBody);
+            process.exit(1);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
 
       # Bundle and publish each standard-format plugin.
       # Only plugins with a sandbox entry can be marketplace-installed.

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -122,6 +122,10 @@ Config-based plugins:
 - Are loaded at build time and on every server start
 - Cannot be installed or removed from the admin UI
 
+<Aside type="tip" title="Paired trusted and marketplace packages">
+  If a plugin needs Node-only code in trusted installs but must stay sandbox-safe in the marketplace, publish two packages with the same plugin ID. For example, `emdash-smtp` is the trusted `astro.config.mjs` package, while `emdash-smtp-marketplace` is the sandbox-safe marketplace package.
+</Aside>
+
 <Aside type="tip">
   Use config-based plugins for first-party code and plugins you maintain yourself. Use marketplace plugins for third-party extensions where sandbox isolation provides security benefits.
 </Aside>

--- a/docs/src/content/docs/plugins/publishing.mdx
+++ b/docs/src/content/docs/plugins/publishing.mdx
@@ -101,6 +101,15 @@ The bundle command checks:
   If your backend code imports a Node.js built-in, the bundle will fail validation. Replace Node.js APIs with Web APIs or move the logic to a trusted plugin instead.
 </Aside>
 
+## Paired trusted and marketplace packages
+
+Some plugins should ship as two npm packages:
+
+- `emdash-smtp` — trusted package for `astro.config.mjs`, where Node-only transports can run
+- `emdash-smtp-marketplace` — sandbox-safe package published with `emdash plugin publish`
+
+Keep the same EmDash plugin ID in both variants, but publish separate package names so the marketplace bundle stays sandbox-safe and the trusted install keeps its full Node runtime.
+
 ## Publishing
 
 The `emdash plugin publish` command uploads your tarball to the marketplace:

--- a/docs/src/content/docs/plugins/sandbox.mdx
+++ b/docs/src/content/docs/plugins/sandbox.mdx
@@ -44,6 +44,10 @@ In trusted mode:
 	Only install trusted plugins from sources you trust — npm packages you've reviewed, or code you've written yourself. In trusted mode, a malicious plugin has the same access as your application code.
 </Aside>
 
+<Aside type="tip" title="When a plugin needs both trusted and marketplace installs">
+	If a plugin needs Node-only transports or other trusted-only APIs, ship a trusted npm package and a separate marketplace package instead of forcing both runtimes through one artifact. For example, `emdash-smtp` is the trusted package, while `emdash-smtp-marketplace` is the sandbox-safe marketplace package.
+</Aside>
+
 ## Sandboxed Mode (Cloudflare Workers)
 
 Sandboxed plugins run in isolated V8 isolates provided by Cloudflare's [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/) API. Each plugin gets its own isolate with enforced limits.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -93,10 +93,12 @@ See [Storage Options](/deployment/storage/) for details.
 **Optional.** Array of EmDash plugins.
 
 ```js
-import seoPlugin from "@emdash-cms/plugin-seo";
+import { emdashSmtp } from "emdash-smtp";
 
-plugins: [seoPlugin()];
+plugins: [emdashSmtp()];
 ```
+
+If a plugin also has a separate marketplace-safe package, keep the trusted package in `plugins` and publish the sandbox variant separately. For example, `emdash-smtp` is the trusted package used in `astro.config.mjs`, while `emdash-smtp-marketplace` stays on the marketplace publish/install path.
 
 ### `auth`
 

--- a/packages/core/src/cli/commands/publish.ts
+++ b/packages/core/src/cli/commands/publish.ts
@@ -58,6 +58,7 @@ interface MarketplaceAuthResponse {
 
 interface AuthDiscovery {
 	github: {
+		enabled?: boolean;
 		clientId: string;
 		deviceAuthorizationEndpoint: string;
 		tokenEndpoint: string;
@@ -65,6 +66,10 @@ interface AuthDiscovery {
 	marketplace: {
 		deviceTokenEndpoint: string;
 	};
+}
+
+export function createGitHubDeviceFlowBody(params: Record<string, string>): string {
+	return new URLSearchParams(params).toString();
 }
 
 /**
@@ -79,15 +84,20 @@ async function authenticateViaDeviceFlow(registryUrl: string): Promise<Marketpla
 		throw new Error(`Marketplace unreachable: ${discoveryRes.status} ${discoveryRes.statusText}`);
 	}
 	const discovery = (await discoveryRes.json()) as AuthDiscovery;
+	if (discovery.github?.enabled === false || !discovery.github?.clientId) {
+		throw new Error(
+			"Marketplace auth discovery reports GitHub device auth is unavailable. Configure both GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET on the marketplace service or provide EMDASH_MARKETPLACE_TOKEN.",
+		);
+	}
 
 	// Step 2: Request device code from GitHub
 	const deviceRes = await fetch(discovery.github.deviceAuthorizationEndpoint, {
 		method: "POST",
 		headers: {
-			"Content-Type": "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
 			Accept: "application/json",
 		},
-		body: JSON.stringify({
+		body: createGitHubDeviceFlowBody({
 			client_id: discovery.github.clientId,
 			scope: "read:user user:email",
 		}),
@@ -164,10 +174,10 @@ async function pollGitHubDeviceFlow(
 		const res = await fetch(tokenEndpoint, {
 			method: "POST",
 			headers: {
-				"Content-Type": "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
 				Accept: "application/json",
 			},
-			body: JSON.stringify({
+			body: createGitHubDeviceFlowBody({
 				client_id: clientId,
 				device_code: deviceCode,
 				grant_type: "urn:ietf:params:oauth:grant-type:device_code",

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -27,6 +27,7 @@ import type {
 	EmailBeforeSendHandler,
 	EmailDeliverHandler,
 	EmailAfterSendHandler,
+	EmailStatusHandler,
 	ContentBeforeSaveHandler,
 	ContentAfterSaveHandler,
 	ContentBeforeDeleteHandler,
@@ -72,6 +73,7 @@ type HookNameV2 =
 	| "email:beforeSend"
 	| "email:deliver"
 	| "email:afterSend"
+	| "email:status"
 	| "comment:beforeCreate"
 	| "comment:moderate"
 	| "comment:afterCreate"
@@ -99,6 +101,7 @@ interface HookHandlerMap {
 	"email:beforeSend": EmailBeforeSendHandler;
 	"email:deliver": EmailDeliverHandler;
 	"email:afterSend": EmailAfterSendHandler;
+	"email:status": EmailStatusHandler;
 	"comment:beforeCreate": CommentBeforeCreateHandler;
 	"comment:moderate": CommentModerateHandler;
 	"comment:afterCreate": CommentAfterCreateHandler;
@@ -226,6 +229,7 @@ export class HookPipeline {
 			this.registerPluginHook(plugin, "email:beforeSend");
 			this.registerPluginHook(plugin, "email:deliver");
 			this.registerPluginHook(plugin, "email:afterSend");
+			this.registerPluginHook(plugin, "email:status");
 			this.registerPluginHook(plugin, "comment:beforeCreate");
 			this.registerPluginHook(plugin, "comment:moderate");
 			this.registerPluginHook(plugin, "comment:afterCreate");
@@ -252,6 +256,7 @@ export class HookPipeline {
 		["email:beforeSend", "email:intercept"],
 		["email:afterSend", "email:intercept"],
 		["email:deliver", "email:provide"],
+		["email:status", "email:provide"],
 		// Content — beforeSave can mutate content, so requires write:content.
 		// afterSave is read-only notification, so read:content suffices.
 		["content:beforeSave", "write:content"],

--- a/packages/core/src/plugins/manifest-schema.ts
+++ b/packages/core/src/plugins/manifest-schema.ts
@@ -62,6 +62,7 @@ export const HOOK_NAMES = [
 	"email:beforeSend",
 	"email:deliver",
 	"email:afterSend",
+	"email:status",
 	"comment:beforeCreate",
 	"comment:moderate",
 	"comment:afterCreate",

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -513,6 +513,13 @@ export interface EmailAfterSendEvent {
 }
 
 /**
+ * Event passed to email:status hooks (provider readiness / health checks).
+ */
+export interface EmailStatusEvent {
+	source?: string;
+}
+
+/**
  * Handler type for email:beforeSend hooks.
  * Returns modified message, or false to cancel delivery.
  */
@@ -533,6 +540,12 @@ export type EmailAfterSendHandler = (
 	event: EmailAfterSendEvent,
 	ctx: PluginContext,
 ) => Promise<void>;
+
+/**
+ * Handler type for email:status hooks.
+ * Returns true when the provider is configured and ready to deliver email.
+ */
+export type EmailStatusHandler = (event: EmailStatusEvent, ctx: PluginContext) => Promise<boolean>;
 
 // =============================================================================
 // Comment Types
@@ -968,6 +981,7 @@ export interface PluginHooks {
 	"email:beforeSend"?: HookConfig<EmailBeforeSendHandler> | EmailBeforeSendHandler;
 	"email:deliver"?: HookConfig<EmailDeliverHandler> | EmailDeliverHandler;
 	"email:afterSend"?: HookConfig<EmailAfterSendHandler> | EmailAfterSendHandler;
+	"email:status"?: HookConfig<EmailStatusHandler> | EmailStatusHandler;
 
 	// Comment hooks
 	"comment:beforeCreate"?: HookConfig<CommentBeforeCreateHandler> | CommentBeforeCreateHandler;
@@ -1264,6 +1278,7 @@ export interface ResolvedPluginHooks {
 	"email:beforeSend"?: ResolvedHook<EmailBeforeSendHandler>;
 	"email:deliver"?: ResolvedHook<EmailDeliverHandler>;
 	"email:afterSend"?: ResolvedHook<EmailAfterSendHandler>;
+	"email:status"?: ResolvedHook<EmailStatusHandler>;
 	"comment:beforeCreate"?: ResolvedHook<CommentBeforeCreateHandler>;
 	"comment:moderate"?: ResolvedHook<CommentModerateHandler>;
 	"comment:afterCreate"?: ResolvedHook<CommentAfterCreateHandler>;

--- a/packages/core/tests/unit/cli/publish.test.ts
+++ b/packages/core/tests/unit/cli/publish.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { createGitHubDeviceFlowBody } from "../../../src/cli/commands/publish.js";
+
+describe("createGitHubDeviceFlowBody", () => {
+	it("encodes GitHub device-flow params as form data", () => {
+		const body = createGitHubDeviceFlowBody({
+			client_id: "emdash-cli",
+			scope: "read:user user:email",
+			grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		});
+
+		expect(body).toBe(
+			"client_id=emdash-cli&scope=read%3Auser+user%3Aemail&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+		);
+		expect(body).not.toContain("{");
+		expect(body).not.toContain('"client_id"');
+	});
+});

--- a/packages/core/tests/unit/plugins/define-plugin.test.ts
+++ b/packages/core/tests/unit/plugins/define-plugin.test.ts
@@ -310,12 +310,14 @@ describe("definePlugin", () => {
 					"content:beforeSave": vi.fn(),
 					"content:afterSave": vi.fn(),
 					"plugin:install": vi.fn(),
+					"email:status": vi.fn(async () => true),
 				},
 			});
 
 			expect(plugin.hooks["content:beforeSave"]).toBeDefined();
 			expect(plugin.hooks["content:afterSave"]).toBeDefined();
 			expect(plugin.hooks["plugin:install"]).toBeDefined();
+			expect(plugin.hooks["email:status"]).toBeDefined();
 		});
 
 		it("sets pluginId on all resolved hooks", () => {

--- a/packages/core/tests/unit/plugins/manifest-schema.test.ts
+++ b/packages/core/tests/unit/plugins/manifest-schema.test.ts
@@ -105,6 +105,16 @@ describe("pluginManifestSchema — route entries", () => {
 	});
 });
 
+describe("pluginManifestSchema — hook entries", () => {
+	it("should accept email:status in manifests", () => {
+		const result = pluginManifestSchema.safeParse({
+			...makeManifest({}),
+			hooks: ["email:status"],
+		});
+		expect(result.success).toBe(true);
+	});
+});
+
 describe("normalizeManifestRoute", () => {
 	it("should convert a plain string to { name } object", () => {
 		expect(normalizeManifestRoute("webhook")).toEqual({ name: "webhook" });

--- a/packages/marketplace/README.md
+++ b/packages/marketplace/README.md
@@ -2,6 +2,32 @@
 
 Standalone Cloudflare Worker that hosts the EmDash plugin marketplace — discovery, publishing, and moderation.
 
+## Production deployment
+
+The live marketplace needs these Cloudflare Worker secrets before GitHub auth can work:
+
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+- `SEED_TOKEN`
+
+`AUDIT_ENFORCEMENT` is optional; if unset, the worker defaults to `flag`.
+
+The GitHub Actions deployment workflow expects repository secrets with these names:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+- `MARKETPLACE_GITHUB_CLIENT_ID`
+- `MARKETPLACE_GITHUB_CLIENT_SECRET`
+- `MARKETPLACE_SEED_TOKEN`
+
+After deploying, verify discovery before seeding plugins:
+
+```bash
+curl -s https://marketplace.emdashcms.com/api/v1/auth/discovery | jq '.github'
+```
+
+The response must report `enabled: true` and a non-empty `clientId`. If discovery stays disabled, check that both `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` were pushed successfully.
+
 ## Development
 
 ```bash

--- a/packages/marketplace/src/routes/author.ts
+++ b/packages/marketplace/src/routes/author.ts
@@ -45,6 +45,30 @@ interface GitHubUser {
 	avatar_url: string;
 }
 
+function getGitHubOAuthConfig(
+	c: Context<AuthEnv>,
+): { clientId: string; clientSecret: string } | Response {
+	const clientId = typeof c.env.GITHUB_CLIENT_ID === "string" ? c.env.GITHUB_CLIENT_ID.trim() : "";
+	const clientSecret =
+		typeof c.env.GITHUB_CLIENT_SECRET === "string" ? c.env.GITHUB_CLIENT_SECRET.trim() : "";
+	const missing: string[] = [];
+
+	if (!clientId) missing.push("GITHUB_CLIENT_ID");
+	if (!clientSecret) missing.push("GITHUB_CLIENT_SECRET");
+
+	if (missing.length > 0) {
+		return c.json(
+			{
+				error: "GitHub OAuth is not configured on this marketplace deployment.",
+				detail: `Missing ${missing.join(", ")}.`,
+			},
+			503,
+		);
+	}
+
+	return { clientId, clientSecret };
+}
+
 /**
  * Given a GitHub access token, fetch the user, find-or-create author,
  * and return a marketplace JWT. Shared by code exchange and device flow.
@@ -105,6 +129,9 @@ const githubAuthSchema = z.object({
 });
 
 authorRoutes.post("/auth/github", async (c) => {
+	const config = getGitHubOAuthConfig(c);
+	if (config instanceof Response) return config;
+
 	let body: z.infer<typeof githubAuthSchema>;
 	try {
 		const raw = await c.req.json();
@@ -125,8 +152,8 @@ authorRoutes.post("/auth/github", async (c) => {
 				Accept: "application/json",
 			},
 			body: JSON.stringify({
-				client_id: c.env.GITHUB_CLIENT_ID,
-				client_secret: c.env.GITHUB_CLIENT_SECRET,
+				client_id: config.clientId,
+				client_secret: config.clientSecret,
 				code: body.code,
 			}),
 		});
@@ -160,6 +187,9 @@ const githubDeviceAuthSchema = z.object({
 });
 
 authorRoutes.post("/auth/github/device", async (c) => {
+	const config = getGitHubOAuthConfig(c);
+	if (config instanceof Response) return config;
+
 	let body: z.infer<typeof githubDeviceAuthSchema>;
 	try {
 		const raw = await c.req.json();
@@ -772,6 +802,7 @@ const VALID_HOOKS = [
 	"email:beforeSend",
 	"email:deliver",
 	"email:afterSend",
+	"email:status",
 	"comment:beforeCreate",
 	"comment:moderate",
 	"comment:afterCreate",

--- a/packages/marketplace/src/routes/public.ts
+++ b/packages/marketplace/src/routes/public.ts
@@ -13,9 +13,14 @@ export const publicRoutes = new Hono<{ Bindings: Env }>();
 // ── GET /auth/discovery — Auth config for CLI ───────────────────
 
 publicRoutes.get("/auth/discovery", (c) => {
+	const clientId = typeof c.env.GITHUB_CLIENT_ID === "string" ? c.env.GITHUB_CLIENT_ID.trim() : "";
+	const clientSecret =
+		typeof c.env.GITHUB_CLIENT_SECRET === "string" ? c.env.GITHUB_CLIENT_SECRET.trim() : "";
+	const enabled = clientId.length > 0 && clientSecret.length > 0;
 	return c.json({
 		github: {
-			clientId: c.env.GITHUB_CLIENT_ID,
+			enabled,
+			clientId: enabled ? clientId : "",
 			deviceAuthorizationEndpoint: "https://github.com/login/device/code",
 			tokenEndpoint: "https://github.com/login/oauth/access_token",
 		},

--- a/packages/marketplace/tests/manifest-schema.test.ts
+++ b/packages/marketplace/tests/manifest-schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { manifestSchema } from "../src/routes/author.js";
+
+describe("marketplace manifest schema", () => {
+	it("accepts email:status hooks in string and object form", () => {
+		expect(() =>
+			manifestSchema.parse({
+				id: "test-plugin",
+				version: "1.2.3",
+				capabilities: [],
+				hooks: ["email:status", { name: "email:status", exclusive: true }],
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/marketplace/tests/publish-e2e.test.ts
+++ b/packages/marketplace/tests/publish-e2e.test.ts
@@ -171,6 +171,65 @@ describe("marketplace publish e2e", () => {
 		};
 	});
 
+	it("returns discovery config with the trimmed GitHub client id when auth is fully configured", async () => {
+		env.GITHUB_CLIENT_ID = "  test-client-id\n";
+		env.GITHUB_CLIENT_SECRET = "  test-secret\n";
+
+		const res = await app.request("/api/v1/auth/discovery", {}, env);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			github: {
+				enabled: boolean;
+				clientId: string;
+				deviceAuthorizationEndpoint: string;
+				tokenEndpoint: string;
+			};
+			marketplace: {
+				deviceTokenEndpoint: string;
+			};
+		};
+
+		expect(body.github.enabled).toBe(true);
+		expect(body.github.clientId).toBe("test-client-id");
+		expect(body.github.deviceAuthorizationEndpoint).toBe("https://github.com/login/device/code");
+		expect(body.github.tokenEndpoint).toBe("https://github.com/login/oauth/access_token");
+		expect(body.marketplace.deviceTokenEndpoint).toBe("/api/v1/auth/github/device");
+	});
+
+	it("returns disabled discovery when GitHub OAuth is only partially configured", async () => {
+		env.GITHUB_CLIENT_ID = "test-client-id";
+		env.GITHUB_CLIENT_SECRET = "";
+
+		const res = await app.request("/api/v1/auth/discovery", {}, env);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { github: { enabled: boolean; clientId: string } };
+		expect(body.github.enabled).toBe(false);
+		expect(body.github.clientId).toBe("");
+	});
+
+	it("fails device auth with 503 when GitHub OAuth config is missing", async () => {
+		env.GITHUB_CLIENT_ID = "";
+		env.GITHUB_CLIENT_SECRET = "";
+
+		const res = await app.request(
+			"/api/v1/auth/github/device",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ access_token: "gho_test" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(503);
+		const body = (await res.json()) as { error: string; detail: string };
+		expect(body.error).toBe("GitHub OAuth is not configured on this marketplace deployment.");
+		expect(body.detail).toContain("GITHUB_CLIENT_ID");
+		expect(body.detail).toContain("GITHUB_CLIENT_SECRET");
+	});
+
 	it("publishes a plugin tarball via seed auth and lists it", async () => {
 		const formData = new FormData();
 		formData.append(

--- a/packages/marketplace/wrangler.jsonc
+++ b/packages/marketplace/wrangler.jsonc
@@ -1,4 +1,9 @@
 {
+	// Production deploys also require these Worker secrets:
+	// - GITHUB_CLIENT_ID
+	// - GITHUB_CLIENT_SECRET
+	// - SEED_TOKEN
+	// AUDIT_ENFORCEMENT defaults to "flag" in code if no value is provided.
 	"name": "emdash-marketplace",
 	"main": "src/index.ts",
 	"compatibility_date": "2026-02-25",


### PR DESCRIPTION
## What does this PR do?

Hardens the marketplace GitHub auth discovery/publish flow so partial or missing OAuth configuration fails clearly instead of advertising a broken device-login path.

It also adds the `email:status` hook to core typing/manifest validation, updates the deploy smoke check to require `github.enabled === true`, and adds tests covering the discovery and manifest changes.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

- `pnpm --silent lint:quick`
- `pnpm --filter @emdash-cms/marketplace exec vitest run tests/publish-e2e.test.ts tests/manifest-schema.test.ts`
- `pnpm --filter emdash exec vitest run tests/unit/cli/publish.test.ts tests/unit/plugins/define-plugin.test.ts tests/unit/plugins/manifest-schema.test.ts tests/unit/plugins/hooks.test.ts`
- `pnpm typecheck`
- `pnpm --silent lint:json | jq '.diagnostics | length'`
