### PR TITLE
fix(admin): prevent autosave from overwriting in-progress edits

### DIFF
--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -251,6 +251,13 @@ export function ContentEditor({
 
 	// Update form and last saved state when item changes (e.g., after save or restore)
 	// Stringify the data for comparison since objects are compared by reference
+	//
+	// NOTE: item?.updatedAt is intentionally excluded from the dependency array.
+	// Including it caused a circular reset loop: autosave → server updates updatedAt →
+	// query refetch → this effect fires → form state resets to server values →
+	// user's in-progress edits are lost. By depending only on actual data/slug/status
+	// changes, the form only resets when content meaningfully changes (e.g., after
+	// discard draft or restore revision), not on every timestamp bump.
 	const itemDataString = React.useMemo(() => (item ? JSON.stringify(item.data) : ""), [item?.data]);
 	React.useEffect(() => {
 		if (item) {
@@ -274,7 +281,7 @@ export function ContentEditor({
 				}),
 			);
 		}
-	}, [item?.updatedAt, itemDataString, item?.slug, item?.status]);
+	}, [itemDataString, item?.slug, item?.status]);
 
 	const activeBylines = isNew ? (selectedBylines ?? []) : internalBylines;
 

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -621,8 +621,10 @@ function ContentEditPage() {
 		}) => updateContent(collection, id, { ...data, skipRevision: true }),
 		onSuccess: () => {
 			setLastAutosaveAt(new Date());
-			// Silently update the cache without full invalidation
-			void queryClient.invalidateQueries({ queryKey: ["content", collection, id] });
+			// Don't invalidate the query here — a refetch would trigger the
+			// form-reset useEffect in ContentEditor and overwrite any edits
+			// the user made between the autosave request and the refetch response.
+			// The cache refreshes naturally on manual save, navigation, or window refocus.
 		},
 		onError: (err) => {
 			toastManager.add({


### PR DESCRIPTION
## Summary

Fixes a bug where editing content fields (title, slug, excerpt, body) in the admin editor would silently revert user input to the previous server-stored values. Normal-speed typing was nearly impossible — only rapid copy-paste would survive the revert cycle.

## Root Cause

A circular data refresh loop between autosave and the form state synchronization:

```
User types in field
  → formData updates locally, isDirty = true
  → 2s idle → autosave fires, sends formData to server
  → autosave onSuccess calls invalidateQueries(["content", collection, id])
  → React Query refetches content from server
  → Server returns item with new updatedAt timestamp
  → ContentEditor useEffect depends on item.updatedAt
  → Effect fires, calls setFormData(item.data) + setSlug(item.slug)
  → User's in-progress edits are overwritten with server values
```

The `updatedAt` timestamp changes on **every** server write, including autosave. So the form-sync effect fired after every autosave, unconditionally resetting all form state — even though the server data was identical to what the user already had (because autosave just sent it).

Additionally, React Query's default `refetchOnWindowFocus: true` combined with `staleTime: 60s` meant that even without autosave invalidation, any window focus event after 60 seconds would refetch and reset the form.

## Fix

Two changes, both in `packages/admin/`:

### 1. `src/router.tsx` — Remove `invalidateQueries` from autosave `onSuccess`

Autosave already sent the current form data to the server. There is no benefit to immediately refetching it back — and doing so triggers the form reset. The query cache refreshes naturally via:
- Manual save (`updateMutation` still invalidates)
- Discard draft / restore revision (those mutations still invalidate)
- Page navigation (React Query refetches on mount)
- Window refocus (React Query default behavior, after `staleTime`)

### 2. `src/components/ContentEditor.tsx` — Remove `item?.updatedAt` from useEffect deps

The form-sync effect's dependency array was `[item?.updatedAt, itemDataString, item?.slug, item?.status]`. The `updatedAt` timestamp changes on every write but carries no meaningful content change. Removing it means the effect only fires when **actual content** changes:

| Scenario | `itemDataString` changes? | `item?.slug` changes? | Effect fires? | Correct? |
|---|---|---|---|---|
| Initial page load | ✅ | ✅ | ✅ | ✅ |
| After autosave (same data) | ❌ | ❌ | ❌ | ✅ |
| After window-focus refetch | ❌ | ❌ | ❌ | ✅ |
| Discard draft (data reverts) | ✅ | possibly | ✅ | ✅ |
| Restore revision (data changes) | ✅ | possibly | ✅ | ✅ |
| External edit by another user | ✅ | possibly | ✅ | ✅ |

## Test Plan

- [ ] Open a published post in the admin editor
- [ ] Edit the **title** field — type at normal speed, wait 3+ seconds for autosave
- [ ] Verify the title retains your edits (no revert)
- [ ] Edit the **slug** field — same test
- [ ] Edit the **excerpt** field — same test
- [ ] Edit the **body** (Portable Text) — same test
- [ ] Click "Save" manually — verify save works and form reflects saved state
- [ ] Use "Discard Draft" — verify form resets to the published version
- [ ] Use "Restore Revision" from revision history — verify form resets to the restored version
- [ ] Switch browser tabs and return after 60+ seconds — verify no unexpected form reset

🤖 Generated with [Claude Code](https://claude.ai/claude-code)