### PR TITLE
fix(ci): query check runs instead of commit statuses for CLA labels

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,7 @@ permissions:
   actions: write
   checks: read
   contents: write
+  issues: write
   pull-requests: write
   statuses: write
 
@@ -29,8 +30,12 @@ jobs:
           allowlist: dependabot[bot]
           lock-pullrequest-aftermerge: false
 
+  label:
+    needs: CLAssistant
+    if: always() && (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    steps:
       - name: Label CLA status
-        if: always() && (github.event_name == 'pull_request_target' || github.event.issue.pull_request)
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |


### PR DESCRIPTION
## What does this PR do?

The CLA labeling step in `cla.yml` was never applying labels because it queried commit statuses (`listCommitStatusesForRef`) while the CLA Assistant action reports results as check runs. The statuses array was always empty, so the script returned early on every PR.

Switches to `checks.listForRef` and matches on the `CLAssistant` check run name and conclusion.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Verification

- Confirmed via GitHub API that `listCommitStatusesForRef` returns `[]` for PR head SHAs
- Confirmed `checks.listForRef` returns the `CLAssistant` check run with correct `conclusion` field
- Tested against both signed (PR #276: conclusion `success`) and unsigned (PR #115: conclusion `failure`) PRs