### PR TITLE
Fix autosave form reset bug

### DIFF
--- a/.changeset/fifty-papers-pick.md
+++ b/.changeset/fifty-papers-pick.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes autosave form reset bug. Autosave no longer invalidates the query cache, preventing form fields from reverting to server state after autosave completes.

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -622,8 +622,8 @@ function ContentEditPage() {
 		}) => updateContent(collection, id, { ...data, skipRevision: true }),
 		onSuccess: () => {
 			setLastAutosaveAt(new Date());
-			// Silently update the cache without full invalidation
-			void queryClient.invalidateQueries({ queryKey: ["content", collection, id] });
+			// Don't invalidate queries on autosave to prevent form reset
+			// The local form state is the source of truth during editing
 		},
 		onError: (err) => {
 			toastManager.add({


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where autosave invalidates the query cache and resets form fields to server state, causing user edits to be lost.

When editing a content entry with many custom fields, autosave fires after 2 seconds of inactivity. Upon success, it was calling `queryClient.invalidateQueries(["content", collection, id])`, which triggered a refetch from the server. This refetch updated the `item` prop, which triggered a `useEffect` in `ContentEditor` that resets form state (`formData`, `slug`, etc.) to server values.

The fix removes the `queryClient.invalidateQueries()` call from the `autosaveMutation` `onSuccess` handler. The local form state remains the source of truth during editing. Manual saves still properly invalidate and refresh the cache.

Closes #295

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (pre-existing errors in admin package unrelated to this change)
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0 (pre-existing errors unrelated to this change)
- [x] `pnpm format` has been run
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)