### PR TITLE
fix(core): remove FTS5 integrity-check to prevent D1 shadow table corruption

### DIFF
--- a/.changeset/fix-fts5-d1-integrity.md
+++ b/.changeset/fix-fts5-d1-integrity.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Remove FTS5 integrity-check from startup verification to prevent D1 shadow table corruption

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -399,7 +399,6 @@ export class FTSManager {
 			return true;
 		}
 
-
 		return false;
 	}
 

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -360,9 +360,7 @@ export class FTSManager {
 	/**
 	 * Verify FTS index integrity and rebuild if corrupted.
 	 *
-	 * Checks for two corruption indicators:
-	 * 1. Row count mismatch between content table and FTS table
-	 * 2. FTS5 integrity-check failure (catches shadow table inconsistencies)
+	 * Checks for row count mismatch between content table and FTS table.
 	 *
 	 * Returns true if the index was rebuilt, false if it was healthy.
 	 */
@@ -401,20 +399,8 @@ export class FTSManager {
 			return true;
 		}
 
-		// Check 2: FTS5 integrity check (catches shadow table corruption)
-		try {
-			await sql
-				.raw(`INSERT INTO "${ftsTable}"("${ftsTable}") VALUES('integrity-check')`)
-				.execute(this.db);
-		} catch {
-			console.warn(`FTS integrity check failed for "${collectionSlug}". Rebuilding index.`);
-			const fields = await this.getSearchableFields(collectionSlug);
-			const config = await this.getSearchConfig(collectionSlug);
-			if (fields.length > 0) {
-				await this.rebuildIndex(collectionSlug, fields, config?.weights);
-			}
-			return true;
-		}
+		// Do not run FTS5 "integrity-check": on D1 it can corrupt FTS shadow tables
+		// and trigger SQLITE_CORRUPT_VTAB failures (see issue #252).
 
 		return false;
 	}

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -399,8 +399,6 @@ export class FTSManager {
 			return true;
 		}
 
-		// Do not run FTS5 "integrity-check": on D1 it can corrupt FTS shadow tables
-		// and trigger SQLITE_CORRUPT_VTAB failures (see issue #252).
 
 		return false;
 	}


### PR DESCRIPTION
## What does this PR do?

Removes the FTS5 `integrity-check` INSERT from `verifyAndRepairIndex()` in `packages/core/src/search/fts-manager.ts`. This command corrupts D1's FTS5 shadow tables on every Worker cold start, causing all content publishing to fail with `SQLITE_CORRUPT_VTAB`.

The row-count mismatch check (Check 1) is retained -- it catches the most common corruption case without triggering D1's shadow table bug.

Closes #252

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Details

The root cause is at `fts-manager.ts:407`:

```sql
INSERT INTO "ftsTable"("ftsTable") VALUES('integrity-check')
```

This FTS5 command is safe on standard SQLite but corrupts D1's shadow tables. Once corrupted, every content UPDATE fires FTS triggers that fail with `SQLITE_CORRUPT_VTAB`, blocking all publishing across all collections.

The fix removes the integrity-check entirely. The row-count mismatch check already handles the primary corruption case (count drift between content and FTS tables). The integrity-check was meant to catch subtle shadow table inconsistencies, but on D1 it causes the very corruption it was designed to detect.

Note: 3 pre-existing auth test failures on main (invite, magic-link, signup URL assertions) are unrelated to this change.

This contribution was developed with AI assistance (Codex).