### PR TITLE
fix: preserve post_date and publish status in WXR import

### DIFF
--- a/.changeset/pretty-crews-march.md
+++ b/.changeset/pretty-crews-march.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes WXR import not preserving original post dates or publish status. Imported content now uses `wp:post_date_gmt` for `created_at` and sets `published_at` for published posts, rather than defaulting to the import time.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -385,6 +385,8 @@ export async function handleContentCreate(
 		locale?: string;
 		translationOf?: string;
 		seo?: ContentSeoInput;
+		createdAt?: string | null;
+		publishedAt?: string | null;
 	},
 ): Promise<ApiResult<ContentResponse>> {
 	try {
@@ -423,6 +425,8 @@ export async function handleContentCreate(
 				authorId: body.authorId,
 				locale: body.locale,
 				translationOf: body.translationOf,
+				createdAt: body.createdAt,
+				publishedAt: body.publishedAt,
 			});
 
 			if (body.bylines !== undefined) {

--- a/packages/core/src/astro/routes/api/import/wordpress/execute.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/execute.ts
@@ -232,6 +232,12 @@ async function importContent(
 				bylineCache,
 			);
 
+			// Preserve original WordPress dates.
+			// postDateGmt is always UTC; fall back to postDate if absent.
+			const sourceDateStr = post.postDateGmt || post.postDate;
+			const createdAt = sourceDateStr ? new Date(sourceDateStr).toISOString() : undefined;
+			const publishedAt = status === "published" && createdAt ? createdAt : undefined;
+
 			// Create the content item
 			const createResult = await emdash.handleContentCreate(collection, {
 				data,
@@ -240,6 +246,8 @@ async function importContent(
 				authorId,
 				bylines: bylineId ? [{ bylineId }] : undefined,
 				locale,
+				createdAt,
+				publishedAt,
 			});
 
 			if (createResult.success) {

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -115,6 +115,7 @@ export class ContentRepository {
 			primaryBylineId,
 			locale,
 			translationOf,
+			createdAt,
 			publishedAt,
 		} = input;
 
@@ -155,7 +156,7 @@ export class ContentRepository {
 			status,
 			authorId || null,
 			primaryBylineId ?? null,
-			now,
+			createdAt || now,
 			now,
 			publishedAt || null,
 			1,

--- a/packages/core/src/database/repositories/types.ts
+++ b/packages/core/src/database/repositories/types.ts
@@ -9,6 +9,7 @@ export interface CreateContentInput {
 	primaryBylineId?: string | null;
 	locale?: string;
 	translationOf?: string;
+	createdAt?: string | null;
 	publishedAt?: string | null;
 }
 

--- a/packages/core/tests/database/repositories/content.test.ts
+++ b/packages/core/tests/database/repositories/content.test.ts
@@ -95,6 +95,29 @@ describe("ContentRepository", () => {
 			).rejects.toThrow(EmDashValidationError);
 		});
 
+		it("should use provided createdAt instead of current time", async () => {
+			const createdAt = "2019-01-01T12:00:00.000Z";
+			const content = await repo.create({
+				type: "post",
+				data: { title: "Old Post" },
+				createdAt,
+			});
+
+			expect(content.createdAt).toBe(createdAt);
+		});
+
+		it("should use provided publishedAt when creating published content", async () => {
+			const publishedAt = "2022-03-15T09:30:00.000Z";
+			const content = await repo.create({
+				type: "post",
+				data: { title: "Published Post" },
+				status: "published",
+				publishedAt,
+			});
+
+			expect(content.publishedAt).toBe(publishedAt);
+		});
+
 		it("should throw error for duplicate type+slug", async () => {
 			await repo.create({
 				type: "post",


### PR DESCRIPTION
## What does this PR do?

WXR-imported posts were receiving `created_at` set to the import time and `published_at` set to `NULL`, regardless of the original WordPress post dates or publish status. A post written in 2019 would appear in EmDash as if it was created today, and all imported published posts had no `published_at`.

Closes #322. Related discussion: #285.

**Root cause:** `ContentRepository.create()` always used `new Date()` for `created_at` and had no way to accept an override. The `handleContentCreate()` handler and the WXR import route both lacked the plumbing to pass source dates through.

**Fix:**
- Added `createdAt` to `CreateContentInput` — if provided, used for `created_at`; otherwise falls back to `new Date()` (no behaviour change for existing callers)
- Threaded `createdAt` and `publishedAt` through `handleContentCreate()`
- In the WXR import route, extracted `wp:post_date_gmt` (fallback: `wp:post_date`) and passed it as `createdAt`; set `publishedAt` to the same value for posts with `status = "published"`

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
✓ tests/database/repositories/content.test.ts (54 tests)
```

New tests:
- `should use provided createdAt instead of current time`
- `should use provided publishedAt when creating published content`