### PR TITLE
test(smoke): add astro build verification for all demos and templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
   test-smoke:
     name: Smoke Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:17

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -180,7 +180,48 @@ async function fetchWithRetry(url: string, retries = 10, delayMs = 1500): Promis
 	throw lastError instanceof Error ? lastError : new Error(`Request failed for ${url}`);
 }
 
-describe.sequential("Site smoke matrix", () => {
+// ---------------------------------------------------------------------------
+// Build verification — runs `astro build` for every site to catch adapter
+// and bundling errors that dev mode doesn't surface.
+// ---------------------------------------------------------------------------
+
+describe.sequential("Site build verification", () => {
+	const BUILD_TIMEOUT = 120_000;
+
+	for (const site of SITE_MATRIX) {
+		if (site.mode === "typecheck") continue;
+
+		it(`${site.name} builds successfully`, { timeout: BUILD_TIMEOUT + 30_000 }, async () => {
+			await ensureBuilt();
+
+			try {
+				await execAsync("pnpm", ["exec", "astro", "build"], {
+					cwd: site.dir,
+					timeout: BUILD_TIMEOUT,
+					env: {
+						...process.env,
+						CI: "true",
+					},
+				});
+			} catch (error) {
+				const stderr =
+					error instanceof Error && "stderr" in error ? (error as { stderr: string }).stderr : "";
+				const stdout =
+					error instanceof Error && "stdout" in error ? (error as { stdout: string }).stdout : "";
+				throw new Error(`${site.name} build failed:\n\n${stderr || stdout}`.slice(0, 5000), {
+					cause: error,
+				});
+			}
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Runtime verification — boots each site with `astro dev` and checks that
+// admin + frontend respond.
+// ---------------------------------------------------------------------------
+
+describe.sequential("Site runtime verification", () => {
 	for (const site of SITE_MATRIX) {
 		if (site.mode === "typecheck") {
 			it(`${site.name} typechecks`, { timeout: 120_000 }, async () => {


### PR DESCRIPTION
## What does this PR do?

The smoke tests only ran `astro dev` for each site in the matrix. Dev mode uses Vite's on-demand compilation and never invokes the adapter's build pipeline, so build failures (e.g. in the cloudflare or playground demos) passed CI undetected.

This adds a "Site build verification" suite that runs `astro build` for every runtime site in the matrix before the existing dev-server runtime tests.

Also bumps the smoke test CI job timeout from 15 to 30 minutes to accommodate the additional build time.

## Type of change

- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code