### PR TITLE
feat(marketplace): add reviews and ratings system

### DIFF
--- a/.changeset/cuddly-terms-travel.md
+++ b/.changeset/cuddly-terms-travel.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds reviews and ratings to the marketplace. Users can submit star ratings (1-5) with optional text reviews. Plugin owners can reply to reviews. Ratings are shown on plugin detail pages after 3+ reviews.

--- a/packages/marketplace/src/app.ts
+++ b/packages/marketplace/src/app.ts
@@ -10,6 +10,7 @@ import { authorRoutes } from "./routes/author.js";
 import { devRoutes } from "./routes/dev.js";
 import { imageRoutes } from "./routes/images.js";
 import { publicRoutes } from "./routes/public.js";
+import { reviewRoutes } from "./routes/reviews.js";
 import { statsRoutes } from "./routes/stats.js";
 import { themeRoutes } from "./routes/themes.js";
 
@@ -28,6 +29,7 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 
 app.route("/api/v1", publicRoutes);
 app.route("/api/v1", authorRoutes);
+app.route("/api/v1", reviewRoutes);
 app.route("/api/v1", themeRoutes);
 app.route("/api/v1", statsRoutes);
 app.route("/api/v1", imageRoutes);

--- a/packages/marketplace/src/db/queries.ts
+++ b/packages/marketplace/src/db/queries.ts
@@ -6,6 +6,7 @@ import type {
 	PluginSearchResult,
 	PluginVersionRow,
 	PluginWithAuthor,
+	ReviewWithAuthor,
 	SearchOptions,
 	ThemeRow,
 	ThemeSearchOptions,
@@ -96,6 +97,9 @@ export async function searchPlugins(
 			break;
 		case "updated":
 			orderBy = "p.updated_at DESC";
+			break;
+		case "rating":
+			orderBy = "p.rating_avg DESC, p.rating_count DESC, p.created_at DESC";
 			break;
 		case "installs":
 		default:
@@ -197,6 +201,190 @@ export async function getPluginVersion(
 		.prepare("SELECT * FROM plugin_versions WHERE plugin_id = ? AND version = ?")
 		.bind(pluginId, version)
 		.first<PluginVersionRow>();
+}
+
+// ── Review queries ──────────────────────────────────────────────
+
+/** Strip HTML/script tags from review text. Plain text only. */
+const HTML_TAG_RE = /<[^>]*>/g;
+
+function sanitizeReviewText(text: string): string {
+	return text.replace(HTML_TAG_RE, "").trim();
+}
+
+export async function getPluginReviews(
+	db: D1Database,
+	pluginId: string,
+	opts?: { cursor?: string; limit?: number },
+): Promise<{ items: ReviewWithAuthor[]; nextCursor?: string }> {
+	const limit = clampLimit(opts?.limit);
+	const offset = decodeCursor(opts?.cursor);
+
+	const result = await db
+		.prepare(
+			`SELECT r.*, a.name AS author_name, a.avatar_url AS author_avatar_url
+			FROM reviews r
+			JOIN authors a ON a.id = r.author_id
+			WHERE r.plugin_id = ?
+			ORDER BY r.created_at DESC
+			LIMIT ? OFFSET ?`,
+		)
+		.bind(pluginId, limit + 1, offset)
+		.all<ReviewWithAuthor>();
+
+	const items = result.results ?? [];
+	let nextCursor: string | undefined;
+	if (items.length > limit) {
+		items.pop();
+		nextCursor = encodeCursor(offset + limit);
+	}
+
+	return { items, nextCursor };
+}
+
+export async function createReview(
+	db: D1Database,
+	data: { pluginId: string; authorId: string; rating: number; body?: string },
+): Promise<ReviewWithAuthor> {
+	const id = generateId();
+	const sanitizedBody = data.body ? sanitizeReviewText(data.body) : null;
+
+	await db
+		.prepare(
+			`INSERT INTO reviews (id, plugin_id, author_id, rating, body)
+			VALUES (?, ?, ?, ?, ?)`,
+		)
+		.bind(id, data.pluginId, data.authorId, data.rating, sanitizedBody)
+		.run();
+
+	// Atomically recalculate rating on the plugins table
+	await recalculatePluginRating(db, data.pluginId);
+
+	return (await db
+		.prepare(
+			`SELECT r.*, a.name AS author_name, a.avatar_url AS author_avatar_url
+			FROM reviews r JOIN authors a ON a.id = r.author_id
+			WHERE r.id = ?`,
+		)
+		.bind(id)
+		.first<ReviewWithAuthor>())!;
+}
+
+export async function updateReview(
+	db: D1Database,
+	reviewId: string,
+	authorId: string,
+	data: { rating?: number; body?: string },
+): Promise<ReviewWithAuthor | null> {
+	const existing = await db
+		.prepare("SELECT * FROM reviews WHERE id = ? AND author_id = ?")
+		.bind(reviewId, authorId)
+		.first<{ id: string; plugin_id: string }>();
+
+	if (!existing) return null;
+
+	const sets: string[] = [];
+	const bindings: unknown[] = [];
+
+	if (data.rating !== undefined) {
+		sets.push("rating = ?");
+		bindings.push(data.rating);
+	}
+	if (data.body !== undefined) {
+		sets.push("body = ?");
+		bindings.push(sanitizeReviewText(data.body));
+	}
+
+	if (sets.length === 0) {
+		return db
+			.prepare(
+				`SELECT r.*, a.name AS author_name, a.avatar_url AS author_avatar_url
+				FROM reviews r JOIN authors a ON a.id = r.author_id WHERE r.id = ?`,
+			)
+			.bind(reviewId)
+			.first<ReviewWithAuthor>();
+	}
+
+	sets.push("updated_at = datetime('now')");
+	bindings.push(reviewId);
+
+	await db
+		.prepare(`UPDATE reviews SET ${sets.join(", ")} WHERE id = ?`)
+		.bind(...bindings)
+		.run();
+
+	await recalculatePluginRating(db, existing.plugin_id);
+
+	return db
+		.prepare(
+			`SELECT r.*, a.name AS author_name, a.avatar_url AS author_avatar_url
+			FROM reviews r JOIN authors a ON a.id = r.author_id WHERE r.id = ?`,
+		)
+		.bind(reviewId)
+		.first<ReviewWithAuthor>();
+}
+
+export async function deleteReview(
+	db: D1Database,
+	reviewId: string,
+	authorId: string,
+): Promise<{ deleted: boolean; pluginId?: string }> {
+	const existing = await db
+		.prepare("SELECT plugin_id FROM reviews WHERE id = ? AND author_id = ?")
+		.bind(reviewId, authorId)
+		.first<{ plugin_id: string }>();
+
+	if (!existing) return { deleted: false };
+
+	await db.prepare("DELETE FROM reviews WHERE id = ?").bind(reviewId).run();
+	await recalculatePluginRating(db, existing.plugin_id);
+
+	return { deleted: true, pluginId: existing.plugin_id };
+}
+
+export async function addPublisherReply(
+	db: D1Database,
+	reviewId: string,
+	pluginOwnerId: string,
+	reply: string,
+): Promise<ReviewWithAuthor | null> {
+	// Verify the review exists and the caller owns the plugin
+	const review = await db
+		.prepare(
+			`SELECT r.plugin_id FROM reviews r
+			JOIN plugins p ON p.id = r.plugin_id
+			WHERE r.id = ? AND p.author_id = ?`,
+		)
+		.bind(reviewId, pluginOwnerId)
+		.first<{ plugin_id: string }>();
+
+	if (!review) return null;
+
+	await db
+		.prepare("UPDATE reviews SET publisher_reply = ?, replied_at = datetime('now') WHERE id = ?")
+		.bind(sanitizeReviewText(reply), reviewId)
+		.run();
+
+	return db
+		.prepare(
+			`SELECT r.*, a.name AS author_name, a.avatar_url AS author_avatar_url
+			FROM reviews r JOIN authors a ON a.id = r.author_id WHERE r.id = ?`,
+		)
+		.bind(reviewId)
+		.first<ReviewWithAuthor>();
+}
+
+/** Atomically recalculate rating_avg and rating_count from the reviews table. */
+async function recalculatePluginRating(db: D1Database, pluginId: string): Promise<void> {
+	await db
+		.prepare(
+			`UPDATE plugins SET
+				rating_avg = COALESCE((SELECT AVG(CAST(rating AS REAL)) FROM reviews WHERE plugin_id = ?), 0),
+				rating_count = (SELECT COUNT(*) FROM reviews WHERE plugin_id = ?)
+			WHERE id = ?`,
+		)
+		.bind(pluginId, pluginId, pluginId)
+		.run();
 }
 
 // ── Install queries ─────────────────────────────────────────────

--- a/packages/marketplace/src/db/queries.ts
+++ b/packages/marketplace/src/db/queries.ts
@@ -99,7 +99,8 @@ export async function searchPlugins(
 			orderBy = "p.updated_at DESC";
 			break;
 		case "rating":
-			orderBy = "p.rating_avg DESC, p.rating_count DESC, p.created_at DESC";
+			orderBy =
+				"CASE WHEN p.rating_count >= 3 THEN p.rating_avg END DESC, p.rating_count DESC, p.created_at DESC";
 			break;
 		case "installs":
 		default:
@@ -275,6 +276,7 @@ export async function updateReview(
 	reviewId: string,
 	authorId: string,
 	data: { rating?: number; body?: string },
+	pluginId?: string,
 ): Promise<ReviewWithAuthor | null> {
 	const existing = await db
 		.prepare("SELECT * FROM reviews WHERE id = ? AND author_id = ?")
@@ -282,6 +284,7 @@ export async function updateReview(
 		.first<{ id: string; plugin_id: string }>();
 
 	if (!existing) return null;
+	if (pluginId && existing.plugin_id !== pluginId) return null;
 
 	const sets: string[] = [];
 	const bindings: unknown[] = [];
@@ -328,6 +331,7 @@ export async function deleteReview(
 	db: D1Database,
 	reviewId: string,
 	authorId: string,
+	pluginId?: string,
 ): Promise<{ deleted: boolean; pluginId?: string }> {
 	const existing = await db
 		.prepare("SELECT plugin_id FROM reviews WHERE id = ? AND author_id = ?")
@@ -335,6 +339,7 @@ export async function deleteReview(
 		.first<{ plugin_id: string }>();
 
 	if (!existing) return { deleted: false };
+	if (pluginId && existing.plugin_id !== pluginId) return { deleted: false };
 
 	await db.prepare("DELETE FROM reviews WHERE id = ?").bind(reviewId).run();
 	await recalculatePluginRating(db, existing.plugin_id);
@@ -347,6 +352,7 @@ export async function addPublisherReply(
 	reviewId: string,
 	pluginOwnerId: string,
 	reply: string,
+	pluginId?: string,
 ): Promise<ReviewWithAuthor | null> {
 	// Verify the review exists and the caller owns the plugin
 	const review = await db
@@ -359,10 +365,16 @@ export async function addPublisherReply(
 		.first<{ plugin_id: string }>();
 
 	if (!review) return null;
+	if (pluginId && review.plugin_id !== pluginId) return null;
+
+	const sanitizedReply = sanitizeReviewText(reply);
+	if (!sanitizedReply) return null;
 
 	await db
-		.prepare("UPDATE reviews SET publisher_reply = ?, replied_at = datetime('now') WHERE id = ?")
-		.bind(sanitizeReviewText(reply), reviewId)
+		.prepare(
+			"UPDATE reviews SET publisher_reply = ?, replied_at = datetime('now'), updated_at = datetime('now') WHERE id = ?",
+		)
+		.bind(sanitizedReply, reviewId)
 		.run();
 
 	return db

--- a/packages/marketplace/src/db/schema.sql
+++ b/packages/marketplace/src/db/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS reviews (
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(plugin_id, author_id)
 );
-CREATE INDEX IF NOT EXISTS idx_reviews_plugin ON reviews(plugin_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_plugin ON reviews(plugin_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_reviews_author ON reviews(author_id);
 
 -- ── Themes ──────────────────────────────────────────────────────

--- a/packages/marketplace/src/db/schema.sql
+++ b/packages/marketplace/src/db/schema.sql
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS plugins (
   capabilities TEXT NOT NULL,
   keywords TEXT,
   has_icon INTEGER DEFAULT 0,
+  rating_avg REAL NOT NULL DEFAULT 0,
+  rating_count INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -85,6 +87,25 @@ CREATE TABLE IF NOT EXISTS installs (
   PRIMARY KEY (plugin_id, site_hash)
 );
 CREATE INDEX IF NOT EXISTS idx_installs_plugin ON installs(plugin_id);
+
+-- ── Reviews ─────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS reviews (
+  id TEXT PRIMARY KEY,
+  plugin_id TEXT NOT NULL REFERENCES plugins(id),
+  author_id TEXT NOT NULL REFERENCES authors(id),
+  rating INTEGER NOT NULL CHECK(rating BETWEEN 1 AND 5),
+  body TEXT,
+  publisher_reply TEXT,
+  replied_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(plugin_id, author_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reviews_plugin ON reviews(plugin_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_author ON reviews(author_id);
+
+-- ── Themes ──────────────────────────────────────────────────────
 
 CREATE TABLE IF NOT EXISTS themes (
   id TEXT PRIMARY KEY,

--- a/packages/marketplace/src/db/types.ts
+++ b/packages/marketplace/src/db/types.ts
@@ -19,8 +19,27 @@ export interface PluginRow {
 	capabilities: string;
 	keywords: string | null;
 	has_icon: number;
+	rating_avg: number;
+	rating_count: number;
 	created_at: string;
 	updated_at: string;
+}
+
+export interface ReviewRow {
+	id: string;
+	plugin_id: string;
+	author_id: string;
+	rating: number;
+	body: string | null;
+	publisher_reply: string | null;
+	replied_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ReviewWithAuthor extends ReviewRow {
+	author_name: string;
+	author_avatar_url: string | null;
 }
 
 export type VersionStatus = "pending" | "published" | "flagged" | "rejected";
@@ -93,7 +112,7 @@ export interface PluginSearchResult extends PluginWithAuthor {
 	latest_audit_risk_score: number | null;
 }
 
-export type SortOption = "installs" | "updated" | "created" | "name";
+export type SortOption = "installs" | "updated" | "created" | "name" | "rating";
 
 export interface SearchOptions {
 	q?: string;

--- a/packages/marketplace/src/routes/public.ts
+++ b/packages/marketplace/src/routes/public.ts
@@ -33,11 +33,11 @@ publicRoutes.get("/plugins", async (c) => {
 	const q = url.searchParams.get("q") ?? undefined;
 	const capability = url.searchParams.get("capability") ?? undefined;
 	const sortParam = url.searchParams.get("sort");
-	const validSorts = new Set(["installs", "updated", "created", "name"]);
-	let sort: "installs" | "updated" | "created" | "name" | undefined;
+	const validSorts = new Set(["installs", "updated", "created", "name", "rating"]);
+	let sort: "installs" | "updated" | "created" | "name" | "rating" | undefined;
 	if (sortParam && validSorts.has(sortParam)) {
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- validated by Set.has check above
-		sort = sortParam as "installs" | "updated" | "created" | "name";
+		sort = sortParam as "installs" | "updated" | "created" | "name" | "rating";
 	}
 	const cursor = url.searchParams.get("cursor") ?? undefined;
 	const limitStr = url.searchParams.get("limit");
@@ -123,6 +123,10 @@ publicRoutes.get("/plugins/:id", async (c) => {
 			hasIcon: plugin.has_icon === 1,
 			iconUrl: `${baseUrl}/api/v1/plugins/${plugin.id}/icon`,
 			installCount,
+			rating:
+				plugin.rating_count >= 3
+					? { average: Math.round(plugin.rating_avg * 10) / 10, count: plugin.rating_count }
+					: null,
 			createdAt: plugin.created_at,
 			updatedAt: plugin.updated_at,
 		};

--- a/packages/marketplace/src/routes/reviews.ts
+++ b/packages/marketplace/src/routes/reviews.ts
@@ -61,22 +61,35 @@ reviewRoutes.post("/plugins/:id/reviews/*/reply", reviewAuthMiddleware);
 // ── Rate limiting (simple in-memory, per author) ────────────────
 
 const REVIEW_RATE_LIMIT_MS = 60_000; // 1 review per minute per author
+const MAX_TRACKED_AUTHORS = 1000;
 const recentReviews = new Map<string, number>();
 
-function checkRateLimit(authorId: string): boolean {
-	const now = Date.now();
-	const last = recentReviews.get(authorId);
-	if (last && now - last < REVIEW_RATE_LIMIT_MS) {
-		return false;
-	}
-	recentReviews.set(authorId, now);
-	// Clean old entries periodically
-	if (recentReviews.size > 1000) {
-		for (const [key, ts] of recentReviews) {
-			if (now - ts > REVIEW_RATE_LIMIT_MS) recentReviews.delete(key);
+function pruneRecentReviews(now: number): void {
+	for (const [key, ts] of recentReviews) {
+		if (now - ts > REVIEW_RATE_LIMIT_MS) {
+			recentReviews.delete(key);
+		} else {
+			break;
 		}
 	}
-	return true;
+	// Hard cap: evict oldest entries if still over limit
+	while (recentReviews.size > MAX_TRACKED_AUTHORS) {
+		const oldest = recentReviews.keys().next().value;
+		if (oldest === undefined) break;
+		recentReviews.delete(oldest);
+	}
+}
+
+function isRateLimited(authorId: string): boolean {
+	const now = Date.now();
+	pruneRecentReviews(now);
+	const last = recentReviews.get(authorId);
+	return !!last && now - last < REVIEW_RATE_LIMIT_MS;
+}
+
+function recordRateLimit(authorId: string): void {
+	recentReviews.delete(authorId);
+	recentReviews.set(authorId, Date.now());
 }
 
 /** Reset rate limiter state. Exported for tests only. */
@@ -141,7 +154,7 @@ reviewRoutes.post("/plugins/:id/reviews", async (c) => {
 		return c.json({ error: "Invalid JSON" }, 400);
 	}
 
-	if (!checkRateLimit(author.id)) {
+	if (isRateLimited(author.id)) {
 		return c.json({ error: "Too many reviews. Please wait before submitting another." }, 429);
 	}
 
@@ -156,6 +169,9 @@ reviewRoutes.post("/plugins/:id/reviews", async (c) => {
 			rating: body.rating,
 			body: body.body,
 		});
+
+		// Only record rate limit after successful creation
+		recordRateLimit(author.id);
 
 		return c.json(
 			{
@@ -185,6 +201,7 @@ const updateReviewSchema = z.object({
 });
 
 reviewRoutes.put("/plugins/:id/reviews/:reviewId", async (c) => {
+	const pluginId = c.req.param("id");
 	const reviewId = c.req.param("reviewId");
 	const author = c.get("author");
 
@@ -200,7 +217,7 @@ reviewRoutes.put("/plugins/:id/reviews/:reviewId", async (c) => {
 	}
 
 	try {
-		const updated = await updateReview(c.env.DB, reviewId, author.id, body);
+		const updated = await updateReview(c.env.DB, reviewId, author.id, body, pluginId);
 		if (!updated) return c.json({ error: "Review not found or not yours" }, 404);
 
 		return c.json({
@@ -218,11 +235,12 @@ reviewRoutes.put("/plugins/:id/reviews/:reviewId", async (c) => {
 // ── DELETE /plugins/:id/reviews/:reviewId — Delete own review ──
 
 reviewRoutes.delete("/plugins/:id/reviews/:reviewId", async (c) => {
+	const pluginId = c.req.param("id");
 	const reviewId = c.req.param("reviewId");
 	const author = c.get("author");
 
 	try {
-		const result = await deleteReview(c.env.DB, reviewId, author.id);
+		const result = await deleteReview(c.env.DB, reviewId, author.id, pluginId);
 		if (!result.deleted) return c.json({ error: "Review not found or not yours" }, 404);
 
 		return c.json({ ok: true });
@@ -239,6 +257,7 @@ const replySchema = z.object({
 });
 
 reviewRoutes.post("/plugins/:id/reviews/:reviewId/reply", async (c) => {
+	const pluginId = c.req.param("id");
 	const reviewId = c.req.param("reviewId");
 	const author = c.get("author");
 
@@ -254,7 +273,7 @@ reviewRoutes.post("/plugins/:id/reviews/:reviewId/reply", async (c) => {
 	}
 
 	try {
-		const updated = await addPublisherReply(c.env.DB, reviewId, author.id, body.body);
+		const updated = await addPublisherReply(c.env.DB, reviewId, author.id, body.body, pluginId);
 		if (!updated) {
 			return c.json({ error: "Review not found or you don't own the plugin" }, 404);
 		}

--- a/packages/marketplace/src/routes/reviews.ts
+++ b/packages/marketplace/src/routes/reviews.ts
@@ -1,0 +1,271 @@
+import type { Context, Next } from "hono";
+import { Hono } from "hono";
+import { jwtVerify } from "jose";
+import { z } from "zod";
+
+import {
+	addPublisherReply,
+	createReview,
+	deleteReview,
+	getPlugin,
+	getPluginReviews,
+	updateReview,
+} from "../db/queries.js";
+import type { AuthorRow } from "../db/types.js";
+
+// ── Types ───────────────────────────────────────────────────────
+
+type ReviewEnv = { Bindings: Env; Variables: { author: AuthorRow } };
+
+export const reviewRoutes = new Hono<ReviewEnv>();
+
+// ── Auth middleware (JWT only, no seed token) ───────────────────
+
+// eslint-disable-next-line typescript-eslint(no-redundant-type-constituents) -- Hono middleware returns Response | void
+async function reviewAuthMiddleware(c: Context<ReviewEnv>, next: Next): Promise<Response | void> {
+	const header = c.req.header("Authorization");
+	if (!header?.startsWith("Bearer ")) {
+		return c.json({ error: "Authorization header required" }, 401);
+	}
+
+	const token = header.slice(7);
+
+	try {
+		const key = new TextEncoder().encode(c.env.GITHUB_CLIENT_SECRET);
+		const { payload } = await jwtVerify(token, key, { algorithms: ["HS256"] });
+		if (!payload.sub || typeof payload.sub !== "string") {
+			return c.json({ error: "Invalid token" }, 401);
+		}
+
+		const author = await c.env.DB.prepare("SELECT * FROM authors WHERE id = ?")
+			.bind(payload.sub)
+			.first<AuthorRow>();
+
+		if (!author) {
+			return c.json({ error: "Author not found" }, 401);
+		}
+
+		c.set("author", author);
+		return next();
+	} catch {
+		return c.json({ error: "Invalid or expired token" }, 401);
+	}
+}
+
+// Auth required for write operations
+reviewRoutes.post("/plugins/:id/reviews", reviewAuthMiddleware);
+reviewRoutes.put("/plugins/:id/reviews/*", reviewAuthMiddleware);
+reviewRoutes.delete("/plugins/:id/reviews/*", reviewAuthMiddleware);
+reviewRoutes.post("/plugins/:id/reviews/*/reply", reviewAuthMiddleware);
+
+// ── Rate limiting (simple in-memory, per author) ────────────────
+
+const REVIEW_RATE_LIMIT_MS = 60_000; // 1 review per minute per author
+const recentReviews = new Map<string, number>();
+
+function checkRateLimit(authorId: string): boolean {
+	const now = Date.now();
+	const last = recentReviews.get(authorId);
+	if (last && now - last < REVIEW_RATE_LIMIT_MS) {
+		return false;
+	}
+	recentReviews.set(authorId, now);
+	// Clean old entries periodically
+	if (recentReviews.size > 1000) {
+		for (const [key, ts] of recentReviews) {
+			if (now - ts > REVIEW_RATE_LIMIT_MS) recentReviews.delete(key);
+		}
+	}
+	return true;
+}
+
+/** Reset rate limiter state. Exported for tests only. */
+export function resetRateLimiter(): void {
+	recentReviews.clear();
+}
+
+// ── GET /plugins/:id/reviews — List reviews ─────────────────────
+
+reviewRoutes.get("/plugins/:id/reviews", async (c) => {
+	const pluginId = c.req.param("id");
+	const url = new URL(c.req.url);
+	const cursor = url.searchParams.get("cursor") ?? undefined;
+	const limitStr = url.searchParams.get("limit");
+	const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+
+	try {
+		const result = await getPluginReviews(c.env.DB, pluginId, { cursor, limit });
+
+		const items = result.items.map((r) => ({
+			id: r.id,
+			pluginId: r.plugin_id,
+			author: {
+				id: r.author_id,
+				name: r.author_name,
+				avatarUrl: r.author_avatar_url,
+			},
+			rating: r.rating,
+			body: r.body,
+			publisherReply: r.publisher_reply,
+			repliedAt: r.replied_at,
+			createdAt: r.created_at,
+			updatedAt: r.updated_at,
+		}));
+
+		return c.json({ items, nextCursor: result.nextCursor });
+	} catch (err) {
+		console.error("Failed to list reviews:", err);
+		return c.json({ error: "Internal server error" }, 500);
+	}
+});
+
+// ── POST /plugins/:id/reviews — Submit review ──────────────────
+
+const createReviewSchema = z.object({
+	rating: z.number().int().min(1).max(5),
+	body: z.string().max(5000).optional(),
+});
+
+reviewRoutes.post("/plugins/:id/reviews", async (c) => {
+	const pluginId = c.req.param("id");
+	const author = c.get("author");
+
+	let body: z.infer<typeof createReviewSchema>;
+	try {
+		const raw = await c.req.json();
+		body = createReviewSchema.parse(raw);
+	} catch (err) {
+		if (err instanceof z.ZodError) {
+			return c.json({ error: "Validation error", details: err.errors }, 400);
+		}
+		return c.json({ error: "Invalid JSON" }, 400);
+	}
+
+	if (!checkRateLimit(author.id)) {
+		return c.json({ error: "Too many reviews. Please wait before submitting another." }, 429);
+	}
+
+	try {
+		// Verify plugin exists
+		const plugin = await getPlugin(c.env.DB, pluginId);
+		if (!plugin) return c.json({ error: "Plugin not found" }, 404);
+
+		const review = await createReview(c.env.DB, {
+			pluginId,
+			authorId: author.id,
+			rating: body.rating,
+			body: body.body,
+		});
+
+		return c.json(
+			{
+				id: review.id,
+				pluginId: review.plugin_id,
+				rating: review.rating,
+				body: review.body,
+				createdAt: review.created_at,
+			},
+			201,
+		);
+	} catch (err) {
+		// UNIQUE constraint violation = already reviewed
+		if (err instanceof Error && err.message.includes("UNIQUE")) {
+			return c.json({ error: "You have already reviewed this plugin" }, 409);
+		}
+		console.error("Failed to create review:", err);
+		return c.json({ error: "Internal server error" }, 500);
+	}
+});
+
+// ── PUT /plugins/:id/reviews/:reviewId — Update own review ─────
+
+const updateReviewSchema = z.object({
+	rating: z.number().int().min(1).max(5).optional(),
+	body: z.string().max(5000).optional(),
+});
+
+reviewRoutes.put("/plugins/:id/reviews/:reviewId", async (c) => {
+	const reviewId = c.req.param("reviewId");
+	const author = c.get("author");
+
+	let body: z.infer<typeof updateReviewSchema>;
+	try {
+		const raw = await c.req.json();
+		body = updateReviewSchema.parse(raw);
+	} catch (err) {
+		if (err instanceof z.ZodError) {
+			return c.json({ error: "Validation error", details: err.errors }, 400);
+		}
+		return c.json({ error: "Invalid JSON" }, 400);
+	}
+
+	try {
+		const updated = await updateReview(c.env.DB, reviewId, author.id, body);
+		if (!updated) return c.json({ error: "Review not found or not yours" }, 404);
+
+		return c.json({
+			id: updated.id,
+			rating: updated.rating,
+			body: updated.body,
+			updatedAt: updated.updated_at,
+		});
+	} catch (err) {
+		console.error("Failed to update review:", err);
+		return c.json({ error: "Internal server error" }, 500);
+	}
+});
+
+// ── DELETE /plugins/:id/reviews/:reviewId — Delete own review ──
+
+reviewRoutes.delete("/plugins/:id/reviews/:reviewId", async (c) => {
+	const reviewId = c.req.param("reviewId");
+	const author = c.get("author");
+
+	try {
+		const result = await deleteReview(c.env.DB, reviewId, author.id);
+		if (!result.deleted) return c.json({ error: "Review not found or not yours" }, 404);
+
+		return c.json({ ok: true });
+	} catch (err) {
+		console.error("Failed to delete review:", err);
+		return c.json({ error: "Internal server error" }, 500);
+	}
+});
+
+// ── POST /plugins/:id/reviews/:reviewId/reply — Publisher reply ─
+
+const replySchema = z.object({
+	body: z.string().min(1).max(2000),
+});
+
+reviewRoutes.post("/plugins/:id/reviews/:reviewId/reply", async (c) => {
+	const reviewId = c.req.param("reviewId");
+	const author = c.get("author");
+
+	let body: z.infer<typeof replySchema>;
+	try {
+		const raw = await c.req.json();
+		body = replySchema.parse(raw);
+	} catch (err) {
+		if (err instanceof z.ZodError) {
+			return c.json({ error: "Validation error", details: err.errors }, 400);
+		}
+		return c.json({ error: "Invalid JSON" }, 400);
+	}
+
+	try {
+		const updated = await addPublisherReply(c.env.DB, reviewId, author.id, body.body);
+		if (!updated) {
+			return c.json({ error: "Review not found or you don't own the plugin" }, 404);
+		}
+
+		return c.json({
+			id: updated.id,
+			publisherReply: updated.publisher_reply,
+			repliedAt: updated.replied_at,
+		});
+	} catch (err) {
+		console.error("Failed to add publisher reply:", err);
+		return c.json({ error: "Internal server error" }, 500);
+	}
+});

--- a/packages/marketplace/tests/reviews.test.ts
+++ b/packages/marketplace/tests/reviews.test.ts
@@ -334,6 +334,41 @@ describe("review CRUD", () => {
 		expect(res.status).toBe(404);
 	});
 
+	it("rate limits repeated submissions", async () => {
+		// Create a second plugin so same author can review a different one
+		seedPlugin(d1._db, "other-plugin", "publisher-1");
+
+		// First review succeeds
+		const res1 = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+		expect(res1.status).toBe(201);
+
+		// Second review within rate limit window is rejected
+		const res2 = await app.request(
+			"/api/v1/plugins/other-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 4 }),
+			},
+			env,
+		);
+		expect(res2.status).toBe(429);
+	});
+
 	it("sanitizes HTML in review body", async () => {
 		const res = await app.request(
 			"/api/v1/plugins/test-plugin/reviews",

--- a/packages/marketplace/tests/reviews.test.ts
+++ b/packages/marketplace/tests/reviews.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Tests for the reviews and ratings system.
+ *
+ * Tests review CRUD, rating denormalization, publisher replies,
+ * auth, rate limiting, and edge cases.
+ */
+
+import { timingSafeEqual as nodeTimingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import Database from "better-sqlite3";
+import { SignJWT } from "jose";
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Polyfill crypto.subtle.timingSafeEqual (Workers API not in Node)
+const subtle = crypto.subtle as unknown as Record<string, unknown>;
+if (!subtle.timingSafeEqual) {
+	subtle.timingSafeEqual = (a: ArrayBuffer, b: ArrayBuffer): boolean => {
+		return nodeTimingSafeEqual(Buffer.from(a), Buffer.from(b));
+	};
+}
+
+import app from "../src/app.js";
+import { resetRateLimiter } from "../src/routes/reviews.js";
+
+// ── D1 mock ─────────────────────────────────────────────────────
+
+function createD1Mock() {
+	const db = new Database(":memory:");
+	const schemaPath = resolve(import.meta.dirname, "../src/db/schema.sql");
+	const schema = readFileSync(schemaPath, "utf-8");
+	db.exec(schema);
+
+	return {
+		_db: db,
+		prepare(query: string) {
+			return {
+				_query: query,
+				_bindings: [] as unknown[],
+				bind(...args: unknown[]) {
+					this._bindings = args;
+					return this;
+				},
+				async first<T = unknown>(column?: string): Promise<T | null> {
+					const stmt = db.prepare(this._query);
+					const row = stmt.get(...this._bindings) as Record<string, unknown> | undefined;
+					if (!row) return null;
+					if (column) return (row[column] ?? null) as T;
+					return row as T;
+				},
+				async all<T = unknown>(): Promise<{ results: T[] }> {
+					const stmt = db.prepare(this._query);
+					const rows = stmt.all(...this._bindings) as T[];
+					return { results: rows };
+				},
+				async run() {
+					const stmt = db.prepare(this._query);
+					const result = stmt.run(...this._bindings);
+					return {
+						success: true,
+						meta: { changes: result.changes, last_row_id: result.lastInsertRowid },
+					};
+				},
+			};
+		},
+		async batch(statements: { _query: string; _bindings: unknown[] }[]) {
+			const results = [];
+			for (const stmt of statements) {
+				const s = db.prepare(stmt._query);
+				results.push(s.run(...stmt._bindings));
+			}
+			return results;
+		},
+	};
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+const JWT_SECRET = "test-jwt-secret";
+
+function makeEnv(db: ReturnType<typeof createD1Mock>) {
+	return {
+		DB: db,
+		R2: {
+			async put() {},
+			async get() {
+				return null;
+			},
+			async head() {
+				return null;
+			},
+		},
+		SEED_TOKEN: "test-seed",
+		GITHUB_CLIENT_ID: "test",
+		GITHUB_CLIENT_SECRET: JWT_SECRET,
+		AUDIT_ENFORCEMENT: "none",
+	};
+}
+
+async function makeJwt(authorId: string): Promise<string> {
+	const key = new TextEncoder().encode(JWT_SECRET);
+	return new SignJWT({ sub: authorId })
+		.setProtectedHeader({ alg: "HS256" })
+		.setIssuedAt()
+		.setExpirationTime("1h")
+		.sign(key);
+}
+
+function seedAuthor(db: ReturnType<typeof createD1Mock>["_db"], id: string, name: string) {
+	db.prepare(
+		"INSERT OR IGNORE INTO authors (id, github_id, name, verified) VALUES (?, ?, ?, 1)",
+	).run(id, `gh-${id}`, name);
+}
+
+function seedPlugin(db: ReturnType<typeof createD1Mock>["_db"], id: string, authorId: string) {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT OR IGNORE INTO plugins (id, name, author_id, capabilities, rating_avg, rating_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 0, 0, ?, ?)`,
+	).run(id, id, authorId, JSON.stringify(["hooks"]), now, now);
+
+	db.prepare(
+		`INSERT INTO plugin_versions (id, plugin_id, version, bundle_key, bundle_size, checksum, capabilities, status, published_at)
+		VALUES (?, ?, '1.0.0', 'key', 1024, 'abc', ?, 'published', ?)`,
+	).run(`${id}-v1`, id, JSON.stringify(["hooks"]), now);
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("review CRUD", () => {
+	let d1: ReturnType<typeof createD1Mock>;
+	let env: Record<string, unknown>;
+	let reviewerToken: string;
+
+	beforeEach(async () => {
+		resetRateLimiter();
+		d1 = createD1Mock();
+		env = makeEnv(d1);
+
+		seedAuthor(d1._db, "publisher-1", "Plugin Author");
+		seedAuthor(d1._db, "reviewer-1", "Reviewer");
+		seedPlugin(d1._db, "test-plugin", "publisher-1");
+
+		reviewerToken = await makeJwt("reviewer-1");
+	});
+
+	it("creates a review", async () => {
+		const res = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 4, body: "Great plugin!" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { id: string; rating: number; body: string };
+		expect(body.rating).toBe(4);
+		expect(body.body).toBe("Great plugin!");
+	});
+
+	it("rejects duplicate review from same author", async () => {
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 4 }),
+			},
+			env,
+		);
+
+		// Reset rate limiter so the second request reaches the DB constraint check
+		resetRateLimiter();
+
+		const res = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(409);
+	});
+
+	it("lists reviews for a plugin", async () => {
+		// Create a review first
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 5, body: "Excellent!" }),
+			},
+			env,
+		);
+
+		const res = await app.request("/api/v1/plugins/test-plugin/reviews", {}, env);
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as { items: { rating: number; body: string }[] };
+		expect(data.items.length).toBe(1);
+		expect(data.items[0]!.rating).toBe(5);
+	});
+
+	it("updates own review", async () => {
+		const createRes = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 3 }),
+			},
+			env,
+		);
+		const created = (await createRes.json()) as { id: string };
+
+		const res = await app.request(
+			`/api/v1/plugins/test-plugin/reviews/${created.id}`,
+			{
+				method: "PUT",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 5, body: "Changed my mind!" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const updated = (await res.json()) as { rating: number; body: string };
+		expect(updated.rating).toBe(5);
+		expect(updated.body).toBe("Changed my mind!");
+	});
+
+	it("deletes own review", async () => {
+		const createRes = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 4 }),
+			},
+			env,
+		);
+		const created = (await createRes.json()) as { id: string };
+
+		const res = await app.request(
+			`/api/v1/plugins/test-plugin/reviews/${created.id}`,
+			{
+				method: "DELETE",
+				headers: { Authorization: `Bearer ${reviewerToken}` },
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+
+		// Verify it's gone
+		const listRes = await app.request("/api/v1/plugins/test-plugin/reviews", {}, env);
+		const data = (await listRes.json()) as { items: unknown[] };
+		expect(data.items.length).toBe(0);
+	});
+
+	it("requires auth for review submission", async () => {
+		const res = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(401);
+	});
+
+	it("validates rating range", async () => {
+		const res = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 6 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 for review on nonexistent plugin", async () => {
+		const res = await app.request(
+			"/api/v1/plugins/nonexistent/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(404);
+	});
+
+	it("sanitizes HTML in review body", async () => {
+		const res = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${reviewerToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ rating: 4, body: "Nice plugin <script>alert('xss')</script>" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(201);
+		const data = (await res.json()) as { body: string };
+		expect(data.body).toBe("Nice plugin alert('xss')");
+		expect(data.body).not.toContain("<script>");
+	});
+});
+
+describe("rating denormalization", () => {
+	let d1: ReturnType<typeof createD1Mock>;
+	let env: Record<string, unknown>;
+
+	beforeEach(async () => {
+		resetRateLimiter();
+		d1 = createD1Mock();
+		env = makeEnv(d1);
+
+		seedAuthor(d1._db, "publisher-1", "Publisher");
+		seedAuthor(d1._db, "reviewer-1", "Reviewer 1");
+		seedAuthor(d1._db, "reviewer-2", "Reviewer 2");
+		seedAuthor(d1._db, "reviewer-3", "Reviewer 3");
+		seedPlugin(d1._db, "test-plugin", "publisher-1");
+	});
+
+	it("updates rating_avg and rating_count on the plugins table", async () => {
+		const token1 = await makeJwt("reviewer-1");
+		const token2 = await makeJwt("reviewer-2");
+
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${token1}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 4 }),
+			},
+			env,
+		);
+
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${token2}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 2 }),
+			},
+			env,
+		);
+
+		const plugin = d1._db
+			.prepare("SELECT rating_avg, rating_count FROM plugins WHERE id = ?")
+			.get("test-plugin") as { rating_avg: number; rating_count: number };
+
+		expect(plugin.rating_count).toBe(2);
+		expect(plugin.rating_avg).toBe(3); // (4+2)/2
+	});
+
+	it("recalculates on review delete", async () => {
+		const token1 = await makeJwt("reviewer-1");
+		const token2 = await makeJwt("reviewer-2");
+
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${token1}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+
+		const createRes = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${token2}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 1 }),
+			},
+			env,
+		);
+		const created = (await createRes.json()) as { id: string };
+
+		// Delete the 1-star review
+		await app.request(
+			`/api/v1/plugins/test-plugin/reviews/${created.id}`,
+			{
+				method: "DELETE",
+				headers: { Authorization: `Bearer ${token2}` },
+			},
+			env,
+		);
+
+		const plugin = d1._db
+			.prepare("SELECT rating_avg, rating_count FROM plugins WHERE id = ?")
+			.get("test-plugin") as { rating_avg: number; rating_count: number };
+
+		expect(plugin.rating_count).toBe(1);
+		expect(plugin.rating_avg).toBe(5);
+	});
+
+	it("plugin detail hides rating when count < 3", async () => {
+		const token = await makeJwt("reviewer-1");
+
+		await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 5 }),
+			},
+			env,
+		);
+
+		const detailRes = await app.request("/api/v1/plugins/test-plugin", {}, env);
+		const detail = (await detailRes.json()) as { rating: unknown };
+		expect(detail.rating).toBeNull();
+	});
+
+	it("plugin detail shows rating when count >= 3", async () => {
+		const token1 = await makeJwt("reviewer-1");
+		const token2 = await makeJwt("reviewer-2");
+		const token3 = await makeJwt("reviewer-3");
+
+		for (const [token, rating] of [
+			[token1, 5],
+			[token2, 4],
+			[token3, 3],
+		] as const) {
+			await app.request(
+				"/api/v1/plugins/test-plugin/reviews",
+				{
+					method: "POST",
+					headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+					body: JSON.stringify({ rating }),
+				},
+				env,
+			);
+		}
+
+		const detailRes = await app.request("/api/v1/plugins/test-plugin", {}, env);
+		const detail = (await detailRes.json()) as { rating: { average: number; count: number } };
+		expect(detail.rating).not.toBeNull();
+		expect(detail.rating.count).toBe(3);
+		expect(detail.rating.average).toBe(4); // (5+4+3)/3
+	});
+});
+
+describe("publisher reply", () => {
+	let d1: ReturnType<typeof createD1Mock>;
+	let env: Record<string, unknown>;
+
+	beforeEach(async () => {
+		resetRateLimiter();
+		d1 = createD1Mock();
+		env = makeEnv(d1);
+
+		seedAuthor(d1._db, "publisher-1", "Publisher");
+		seedAuthor(d1._db, "reviewer-1", "Reviewer");
+		seedPlugin(d1._db, "test-plugin", "publisher-1");
+	});
+
+	it("allows plugin owner to reply to a review", async () => {
+		const reviewerToken = await makeJwt("reviewer-1");
+		const publisherToken = await makeJwt("publisher-1");
+
+		const createRes = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${reviewerToken}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 3, body: "Could be better" }),
+			},
+			env,
+		);
+		const review = (await createRes.json()) as { id: string };
+
+		const res = await app.request(
+			`/api/v1/plugins/test-plugin/reviews/${review.id}/reply`,
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${publisherToken}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ body: "Thanks for the feedback!" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as { publisherReply: string };
+		expect(data.publisherReply).toBe("Thanks for the feedback!");
+	});
+
+	it("rejects reply from non-owner", async () => {
+		const reviewerToken = await makeJwt("reviewer-1");
+
+		const createRes = await app.request(
+			"/api/v1/plugins/test-plugin/reviews",
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${reviewerToken}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ rating: 3 }),
+			},
+			env,
+		);
+		const review = (await createRes.json()) as { id: string };
+
+		// Reviewer tries to reply (not the plugin owner)
+		const res = await app.request(
+			`/api/v1/plugins/test-plugin/reviews/${review.id}/reply`,
+			{
+				method: "POST",
+				headers: { Authorization: `Bearer ${reviewerToken}`, "Content-Type": "application/json" },
+				body: JSON.stringify({ body: "Fake reply" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a complete review and rating system to the marketplace. Users can submit star ratings (1-5) with optional text reviews via GitHub auth. Plugin owners can reply to reviews. Ratings are denormalized on the plugins table and shown in plugin detail when 3+ reviews exist.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0 (1 pre-existing warning in router.tsx)
- [x] `pnpm test` passes (3 pre-existing failures in auth tests, 0 new failures)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/296

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Changes

### Schema (`packages/marketplace/src/db/schema.sql`)
- `reviews` table: id, plugin_id, author_id, rating (CHECK 1-5), body, publisher_reply, replied_at, timestamps, UNIQUE(plugin_id, author_id)
- Indexes: idx_reviews_plugin, idx_reviews_author
- `rating_avg REAL` and `rating_count INTEGER` columns on plugins table

### Review routes (`packages/marketplace/src/routes/reviews.ts`, new file)
- `GET /plugins/:id/reviews` -- paginated review list (public, cursor-based)
- `POST /plugins/:id/reviews` -- submit review (auth + rate limited, 1/min/author)
- `PUT /plugins/:id/reviews/:reviewId` -- update own review
- `DELETE /plugins/:id/reviews/:reviewId` -- delete own review
- `POST /plugins/:id/reviews/:reviewId/reply` -- publisher reply (plugin owner only)
- JWT auth middleware (same pattern as author routes, no seed token)

### Review queries (`packages/marketplace/src/db/queries.ts`)
- `getPluginReviews()` -- paginated with author JOIN
- `createReview()` -- with HTML sanitization + rating recalculation
- `updateReview()` -- own review only + rating recalculation
- `deleteReview()` -- own review only + rating recalculation
- `addPublisherReply()` -- verifies plugin ownership via JOIN
- `recalculatePluginRating()` -- atomic SQL UPDATE with AVG/COUNT subquery
- `sanitizeReviewText()` -- strips HTML tags, plain text only

### Plugin detail (`packages/marketplace/src/routes/public.ts`)
- Rating summary included when `rating_count >= 3`: `{ average, count }`
- Returns `null` when fewer than 3 reviews (prevents "5.0 (1 review)" trust issues)
- `rating` added as a sort option for search

### Design decisions
- **Plain text only** (no markdown) to minimize XSS attack surface
- **HTML stripped on write** via regex, not just on render
- **Rating hidden below 3 reviews** to prevent misleading scores
- **Atomic denormalization** via SQL subquery, no read-modify-write TOCTOU
- **In-memory rate limiting** per author (1 review/minute), with cleanup at 1000 entries

### Tests (15 new in `packages/marketplace/tests/reviews.test.ts`)
- Review CRUD: create, duplicate rejection (409), list, update, delete
- Auth: rejects unauthenticated (401), validates rating range (400)
- Edge cases: nonexistent plugin (404), HTML sanitization (strips `<script>` tags)
- Rating denormalization: avg/count update on create, recalculation on delete
- Rating display: hidden when < 3 reviews, shown when >= 3 with correct average
- Publisher reply: owner can reply (200), non-owner rejected (404)

### Migration note for production D1
```sql
ALTER TABLE plugins ADD COLUMN rating_avg REAL NOT NULL DEFAULT 0;
ALTER TABLE plugins ADD COLUMN rating_count INTEGER NOT NULL DEFAULT 0;

CREATE TABLE IF NOT EXISTS reviews (
  id TEXT PRIMARY KEY,
  plugin_id TEXT NOT NULL REFERENCES plugins(id),
  author_id TEXT NOT NULL REFERENCES authors(id),
  rating INTEGER NOT NULL CHECK(rating BETWEEN 1 AND 5),
  body TEXT,
  publisher_reply TEXT,
  replied_at TEXT,
  created_at TEXT NOT NULL DEFAULT (datetime('now')),
  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
  UNIQUE(plugin_id, author_id)
);
CREATE INDEX IF NOT EXISTS idx_reviews_plugin ON reviews(plugin_id);
CREATE INDEX IF NOT EXISTS idx_reviews_author ON reviews(author_id);
```