### PR TITLE
fix(core): return OAuth discovery 401 for unauthenticated MCP POSTs

### DIFF
--- a/.changeset/fresh-mice-battle.md
+++ b/.changeset/fresh-mice-battle.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix MCP OAuth discovery for unauthenticated POST requests.

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -211,19 +211,25 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	const isTokenAuth = bearerResult === "authenticated";
 
+	// MCP discovery/tooling is bearer-only. Session/external auth should never
+	// be consulted for this endpoint, and unauthenticated requests must return
+	// the OAuth discovery-style 401 response.
+	const method = context.request.method.toUpperCase();
+	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
+	if (isMcpEndpoint && !isTokenAuth) {
+		return mcpUnauthorizedResponse(url);
+	}
+
 	// CSRF protection: require X-EmDash-Request header on state-changing requests.
 	// Skip for token-authenticated requests (tokens aren't ambient credentials).
 	// Browsers block cross-origin custom headers, so this prevents CSRF without tokens.
 	// OAuth authorize consent is exempt: it's a standard HTML form POST that can't
 	// include custom headers. The consent flow is protected by session + single-use codes.
-	const method = context.request.method.toUpperCase();
 	const isOAuthConsent = url.pathname.startsWith("/_emdash/oauth/authorize");
-	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
 	if (
 		isApiRoute &&
 		!isTokenAuth &&
 		!isOAuthConsent &&
-		!isMcpEndpoint &&
 		isUnsafeMethod(method) &&
 		!isPublicApiRoute
 	) {
@@ -576,20 +582,14 @@ async function handlePasskeyAuth(
 	next: Parameters<Parameters<typeof defineMiddleware>[0]>[1],
 	isApiRoute: boolean,
 ): Promise<Response> {
-	const { url, locals, request, session } = context;
+	const { url, locals, session } = context;
 	const { emdash } = locals;
-	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
-	const method = request.method.toUpperCase();
 
 	try {
 		// Check session for user (session.get returns a Promise)
 		const sessionUser = await session?.get("user");
 
 		if (!sessionUser?.id) {
-			// Not authenticated
-			if (isMcpEndpoint) {
-				return mcpUnauthorizedResponse(url);
-			}
 			if (isApiRoute) {
 				return Response.json(
 					{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
@@ -599,13 +599,6 @@ async function handlePasskeyAuth(
 			const loginUrl = new URL("/_emdash/admin/login", getPublicOrigin(url, emdash?.config));
 			loginUrl.searchParams.set("redirect", url.pathname);
 			return context.redirect(loginUrl.toString());
-		}
-
-		if (isMcpEndpoint && isUnsafeMethod(method)) {
-			const csrfHeader = request.headers.get("X-EmDash-Request");
-			if (csrfHeader !== "1") {
-				return csrfRejectedResponse();
-			}
 		}
 
 		// Get full user from database

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -51,6 +51,35 @@ declare global {
 
 // Role level constants (matching @emdash-cms/auth)
 const ROLE_ADMIN = 50;
+const MCP_ENDPOINT_PATH = "/_emdash/api/mcp";
+
+function isUnsafeMethod(method: string): boolean {
+	return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
+}
+
+function csrfRejectedResponse(): Response {
+	return new Response(
+		JSON.stringify({ error: { code: "CSRF_REJECTED", message: "Missing required header" } }),
+		{
+			status: 403,
+			headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
+		},
+	);
+}
+
+function mcpUnauthorizedResponse(url: URL): Response {
+	return Response.json(
+		{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
+		{
+			status: 401,
+			headers: {
+				"WWW-Authenticate":
+					`Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource"`,
+				...MW_CACHE_HEADERS,
+			},
+		},
+	);
+}
 
 /**
  * API routes that skip auth — each handles its own access control.
@@ -190,55 +219,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// include custom headers. The consent flow is protected by session + single-use codes.
 	const method = context.request.method.toUpperCase();
 	const isOAuthConsent = url.pathname.startsWith("/_emdash/oauth/authorize");
+	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
 	if (
 		isApiRoute &&
 		!isTokenAuth &&
 		!isOAuthConsent &&
-		method !== "GET" &&
-		method !== "HEAD" &&
-		method !== "OPTIONS" &&
+		!isMcpEndpoint &&
+		isUnsafeMethod(method) &&
 		!isPublicApiRoute
 	) {
 		const csrfHeader = context.request.headers.get("X-EmDash-Request");
 		if (csrfHeader !== "1") {
-			if (url.pathname === "/_emdash/api/mcp") {
-				try {
-					const sessionUser = await context.session?.get("user");
-					// Allow tokenless MCP discovery POSTs to reach the normal 401 path.
-					// Keep CSRF protection for cookie-backed session requests.
-					if (!sessionUser?.id) {
-						// Fall through to passkey/external auth below.
-					} else {
-						return new Response(
-							JSON.stringify({
-								error: { code: "CSRF_REJECTED", message: "Missing required header" },
-							}),
-							{
-								status: 403,
-								headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-							},
-						);
-					}
-				} catch {
-					return new Response(
-						JSON.stringify({
-							error: { code: "CSRF_REJECTED", message: "Missing required header" },
-						}),
-						{
-							status: 403,
-							headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-						},
-					);
-				}
-			} else {
-				return new Response(
-					JSON.stringify({ error: { code: "CSRF_REJECTED", message: "Missing required header" } }),
-					{
-						status: 403,
-						headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-					},
-				);
-			}
+			return csrfRejectedResponse();
 		}
 	}
 
@@ -585,8 +577,10 @@ async function handlePasskeyAuth(
 	next: Parameters<Parameters<typeof defineMiddleware>[0]>[1],
 	isApiRoute: boolean,
 ): Promise<Response> {
-	const { url, locals, session } = context;
+	const { url, locals, request, session } = context;
 	const { emdash } = locals;
+	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
+	const method = request.method.toUpperCase();
 
 	try {
 		// Check session for user (session.get returns a Promise)
@@ -594,22 +588,25 @@ async function handlePasskeyAuth(
 
 		if (!sessionUser?.id) {
 			// Not authenticated
+			if (isMcpEndpoint) {
+				return mcpUnauthorizedResponse(url);
+			}
 			if (isApiRoute) {
-				const headers: Record<string, string> = { ...MW_CACHE_HEADERS };
-				// Add WWW-Authenticate on MCP endpoint 401s to trigger OAuth discovery
-				if (url.pathname === "/_emdash/api/mcp") {
-					const origin = getPublicOrigin(url, emdash?.config);
-					headers["WWW-Authenticate"] =
-						`Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
-				}
 				return Response.json(
 					{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
-					{ status: 401, headers },
+					{ status: 401, headers: MW_CACHE_HEADERS },
 				);
 			}
 			const loginUrl = new URL("/_emdash/admin/login", getPublicOrigin(url, emdash?.config));
 			loginUrl.searchParams.set("redirect", url.pathname);
 			return context.redirect(loginUrl.toString());
+		}
+
+		if (isMcpEndpoint && isUnsafeMethod(method)) {
+			const csrfHeader = request.headers.get("X-EmDash-Request");
+			if (csrfHeader !== "1") {
+				return csrfRejectedResponse();
+			}
 		}
 
 		// Get full user from database

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -201,13 +201,44 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	) {
 		const csrfHeader = context.request.headers.get("X-EmDash-Request");
 		if (csrfHeader !== "1") {
-			return new Response(
-				JSON.stringify({ error: { code: "CSRF_REJECTED", message: "Missing required header" } }),
-				{
-					status: 403,
-					headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
-				},
-			);
+			if (url.pathname === "/_emdash/api/mcp") {
+				try {
+					const sessionUser = await context.session?.get("user");
+					// Allow tokenless MCP discovery POSTs to reach the normal 401 path.
+					// Keep CSRF protection for cookie-backed session requests.
+					if (!sessionUser?.id) {
+						// Fall through to passkey/external auth below.
+					} else {
+						return new Response(
+							JSON.stringify({
+								error: { code: "CSRF_REJECTED", message: "Missing required header" },
+							}),
+							{
+								status: 403,
+								headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
+							},
+						);
+					}
+				} catch {
+					return new Response(
+						JSON.stringify({
+							error: { code: "CSRF_REJECTED", message: "Missing required header" },
+						}),
+						{
+							status: 403,
+							headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
+						},
+					);
+				}
+			} else {
+				return new Response(
+					JSON.stringify({ error: { code: "CSRF_REJECTED", message: "Missing required header" } }),
+					{
+						status: 403,
+						headers: { "Content-Type": "application/json", ...MW_CACHE_HEADERS },
+					},
+				);
+			}
 		}
 	}
 

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -67,13 +67,17 @@ function csrfRejectedResponse(): Response {
 	);
 }
 
-function mcpUnauthorizedResponse(url: URL): Response {
+function mcpUnauthorizedResponse(
+	url: URL,
+	config?: Parameters<typeof getPublicOrigin>[1],
+): Response {
+	const origin = getPublicOrigin(url, config);
 	return Response.json(
 		{ error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" } },
 		{
 			status: 401,
 			headers: {
-				"WWW-Authenticate": `Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource"`,
+				"WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
 				...MW_CACHE_HEADERS,
 			},
 		},
@@ -217,7 +221,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	const method = context.request.method.toUpperCase();
 	const isMcpEndpoint = url.pathname === MCP_ENDPOINT_PATH;
 	if (isMcpEndpoint && !isTokenAuth) {
-		return mcpUnauthorizedResponse(url);
+		return mcpUnauthorizedResponse(url, context.locals.emdash?.config);
 	}
 
 	// CSRF protection: require X-EmDash-Request header on state-changing requests.

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -73,8 +73,7 @@ function mcpUnauthorizedResponse(url: URL): Response {
 		{
 			status: 401,
 			headers: {
-				"WWW-Authenticate":
-					`Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource"`,
+				"WWW-Authenticate": `Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource"`,
 				...MW_CACHE_HEADERS,
 			},
 		},

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -51,9 +51,7 @@ async function runAuthMiddleware(opts: {
 }) {
 	const url = new URL(opts.pathname, "https://example.com");
 	const session = {
-		get: vi.fn().mockResolvedValue(
-			opts.sessionUserId ? { id: opts.sessionUserId } : null,
-		),
+		get: vi.fn().mockResolvedValue(opts.sessionUserId ? { id: opts.sessionUserId } : null),
 		set: vi.fn(),
 		destroy: vi.fn(),
 	};

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -109,6 +109,18 @@ describe("MCP discovery auth middleware", () => {
 		});
 	});
 
+	it("only reads the session once for anonymous MCP POST discovery requests", async () => {
+		const { response, next, session } = await runAuthMiddleware({
+			pathname: "/_emdash/api/mcp",
+			headers: { "Content-Type": "application/json" },
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(401);
+		expect(session.get).toHaveBeenCalledTimes(1);
+		expect(session.get).toHaveBeenCalledWith("user");
+	});
+
 	it("returns 401 with discovery metadata for invalid bearer tokens on MCP POST", async () => {
 		const { response, next } = await runAuthMiddleware({
 			pathname: "/_emdash/api/mcp",

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("virtual:emdash/auth", () => ({ authenticate: vi.fn() }));
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+vi.mock("@emdash-cms/auth", () => ({
+	TOKEN_PREFIXES: {},
+	generatePrefixedToken: vi.fn(),
+	hashPrefixedToken: vi.fn(),
+	VALID_SCOPES: [],
+	validateScopes: vi.fn(),
+	hasScope: vi.fn(() => false),
+	computeS256Challenge: vi.fn(),
+	Role: { ADMIN: 50 },
+}));
+vi.mock("@emdash-cms/auth/adapters/kysely", () => ({
+	createKyselyAdapter: vi.fn(() => ({
+		getUserById: vi.fn(async (id: string) => ({
+			id,
+			email: "admin@test.com",
+			name: "Admin",
+			role: 50,
+			disabled: 0,
+		})),
+		getUserByEmail: vi.fn(),
+	})),
+}));
+
+type AuthMiddlewareModule = typeof import("../../../src/astro/middleware/auth.js");
+
+let onRequest: AuthMiddlewareModule["onRequest"];
+
+beforeAll(async () => {
+	({ onRequest } = await import("../../../src/astro/middleware/auth.js"));
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+async function runAuthMiddleware(opts: {
+	pathname: string;
+	method?: string;
+	headers?: HeadersInit;
+	sessionUserId?: string | null;
+}) {
+	const url = new URL(opts.pathname, "https://example.com");
+	const session = {
+		get: vi.fn().mockResolvedValue(
+			opts.sessionUserId ? { id: opts.sessionUserId } : null,
+		),
+		set: vi.fn(),
+		destroy: vi.fn(),
+	};
+	const next = vi.fn(async () => new Response("ok"));
+	const response = await onRequest(
+		{
+			url,
+			request: new Request(url, {
+				method: opts.method ?? "POST",
+				headers: opts.headers,
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "initialize",
+					params: {
+						protocolVersion: "2025-03-26",
+						capabilities: {},
+						clientInfo: { name: "debug", version: "1.0" },
+					},
+				}),
+			}),
+			locals: {
+				emdash: {
+					db: {},
+					config: {},
+				},
+			},
+			session,
+			redirect: (location: string) =>
+				new Response(null, {
+					status: 302,
+					headers: { Location: location },
+				}),
+		} as Parameters<AuthMiddlewareModule["onRequest"]>[0],
+		next,
+	);
+
+	return { response, next, session };
+}
+
+describe("MCP discovery auth middleware", () => {
+	it("returns 401 with discovery metadata for unauthenticated MCP POST requests", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/mcp",
+			headers: { "Content-Type": "application/json" },
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+		);
+		await expect(response.json()).resolves.toEqual({
+			error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" },
+		});
+	});
+
+	it("returns 401 with discovery metadata for invalid bearer tokens on MCP POST", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/mcp",
+			headers: {
+				Authorization: "Bearer invalid",
+				"Content-Type": "application/json",
+			},
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+		);
+		await expect(response.json()).resolves.toEqual({
+			error: { code: "INVALID_TOKEN", message: "Invalid or expired token" },
+		});
+	});
+
+	it("still rejects session-backed MCP POST requests without the CSRF header", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/mcp",
+			headers: { "Content-Type": "application/json" },
+			sessionUserId: "user_1",
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: { code: "CSRF_REJECTED", message: "Missing required header" },
+		});
+	});
+
+	it("still rejects non-MCP API POST requests without the CSRF header", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/content/posts",
+			headers: { "Content-Type": "application/json" },
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: { code: "CSRF_REJECTED", message: "Missing required header" },
+		});
+	});
+});

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -109,7 +109,7 @@ describe("MCP discovery auth middleware", () => {
 		});
 	});
 
-	it("only reads the session once for anonymous MCP POST discovery requests", async () => {
+	it("does not read the session for anonymous MCP POST discovery requests", async () => {
 		const { response, next, session } = await runAuthMiddleware({
 			pathname: "/_emdash/api/mcp",
 			headers: { "Content-Type": "application/json" },
@@ -117,8 +117,7 @@ describe("MCP discovery auth middleware", () => {
 
 		expect(next).not.toHaveBeenCalled();
 		expect(response.status).toBe(401);
-		expect(session.get).toHaveBeenCalledTimes(1);
-		expect(session.get).toHaveBeenCalledWith("user");
+		expect(session.get).not.toHaveBeenCalled();
 	});
 
 	it("returns 401 with discovery metadata for invalid bearer tokens on MCP POST", async () => {
@@ -140,17 +139,21 @@ describe("MCP discovery auth middleware", () => {
 		});
 	});
 
-	it("still rejects session-backed MCP POST requests without the CSRF header", async () => {
-		const { response, next } = await runAuthMiddleware({
+	it("rejects MCP POST requests that only have session auth", async () => {
+		const { response, next, session } = await runAuthMiddleware({
 			pathname: "/_emdash/api/mcp",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				"X-EmDash-Request": "1",
+			},
 			sessionUserId: "user_1",
 		});
 
 		expect(next).not.toHaveBeenCalled();
-		expect(response.status).toBe(403);
+		expect(response.status).toBe(401);
+		expect(session.get).not.toHaveBeenCalled();
 		await expect(response.json()).resolves.toEqual({
-			error: { code: "CSRF_REJECTED", message: "Missing required header" },
+			error: { code: "NOT_AUTHENTICATED", message: "Not authenticated" },
 		});
 	});
 

--- a/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
+++ b/packages/core/tests/unit/auth/mcp-discovery-post.test.ts
@@ -48,6 +48,7 @@ async function runAuthMiddleware(opts: {
 	method?: string;
 	headers?: HeadersInit;
 	sessionUserId?: string | null;
+	siteUrl?: string;
 }) {
 	const url = new URL(opts.pathname, "https://example.com");
 	const session = {
@@ -76,7 +77,7 @@ async function runAuthMiddleware(opts: {
 			locals: {
 				emdash: {
 					db: {},
-					config: {},
+					config: opts.siteUrl ? { siteUrl: opts.siteUrl } : {},
 				},
 			},
 			session,
@@ -118,6 +119,20 @@ describe("MCP discovery auth middleware", () => {
 		expect(next).not.toHaveBeenCalled();
 		expect(response.status).toBe(401);
 		expect(session.get).not.toHaveBeenCalled();
+	});
+
+	it("uses the configured public origin for anonymous MCP POST discovery responses", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/mcp",
+			headers: { "Content-Type": "application/json" },
+			siteUrl: "https://public.example.com",
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer resource_metadata="https://public.example.com/.well-known/oauth-protected-resource"',
+		);
 	});
 
 	it("returns 401 with discovery metadata for invalid bearer tokens on MCP POST", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes OAuth discovery for unauthenticated MCP `POST` requests on `/_emdash/api/mcp`.

Some MCP clients, including Codex, probe the MCP endpoint with `POST` when starting auth discovery. Before this change, unauthenticated `POST /_emdash/api/mcp` requests without `X-EmDash-Request: 1` were rejected by the generic CSRF middleware with `403 CSRF_REJECTED` before the MCP auth path could return `401 Unauthorized` with the `WWW-Authenticate` header.

That prevented OAuth-capable MCP clients from starting discovery even though EmDash already exposed valid OAuth metadata endpoints.

This change:
- allows tokenless MCP discovery `POST` requests with no authenticated session to reach the existing `401 + WWW-Authenticate` response
- preserves CSRF rejection for session/cookie-backed MCP `POST` requests without `X-EmDash-Request: 1`
- keeps non-MCP API CSRF behavior unchanged
- adds regression tests for unauthenticated MCP `POST`, invalid bearer token handling, and the non-regression CSRF cases

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Ran:
- `pnpm build`
- `pnpm typecheck`
- `pnpm typecheck:demos`
- `pnpm --filter emdash exec vitest run tests/unit/auth/mcp-discovery-post.test.ts tests/unit/auth/discovery-endpoints.test.ts tests/unit/api/csrf.test.ts tests/unit/mcp/authorization.test.ts`

Notes:
- `pnpm --silent lint:json | jq '.diagnostics | length'` currently reports 3 existing warnings in unrelated files.
