### PR TITLE
test: add cover block tests

### DIFF
--- a/packages/gutenberg-to-portable-text/src/transformers/core.ts
+++ b/packages/gutenberg-to-portable-text/src/transformers/core.ts
@@ -816,7 +816,7 @@ export const cover: BlockTransformer = (block, _options, context) => {
 	const overlayColor = attrString(block.attrs, "overlayColor");
 	const customOverlayColor = attrString(block.attrs, "customOverlayColor");
 	const dimRatio = attrNumber(block.attrs, "dimRatio");
-	const minHeight = attrString(block.attrs, "minHeight");
+	const minHeight = attrNumber(block.attrs, "minHeight");
 	const minHeightUnit = attrString(block.attrs, "minHeightUnit");
 	const contentPosition = attrString(block.attrs, "contentPosition");
 
@@ -831,7 +831,7 @@ export const cover: BlockTransformer = (block, _options, context) => {
 
 	// Build min height string
 	let minHeightStr: string | undefined;
-	if (minHeight) {
+	if (minHeight !== undefined) {
 		minHeightStr = minHeightUnit ? `${minHeight}${minHeightUnit}` : `${minHeight}px`;
 	}
 

--- a/packages/gutenberg-to-portable-text/tests/converter.test.ts
+++ b/packages/gutenberg-to-portable-text/tests/converter.test.ts
@@ -11,6 +11,7 @@ import type {
 	PortableTextGalleryBlock,
 	PortableTextTableBlock,
 	PortableTextButtonsBlock,
+	PortableTextCoverBlock,
 } from "../src/types.js";
 
 const HTML_TAG_PATTERN = /<[^>]+>/g;
@@ -858,6 +859,103 @@ https://${domain}/123456
 				caption: "Third photo",
 				asset: { url: "https://example.com/photo3.jpg" },
 			});
+		});
+	});
+
+	describe("cover blocks", () => {
+		it("converts a cover block", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","id":42} -->
+<div class="wp-block-cover">
+<!-- wp:paragraph -->
+<p>Overlay text</p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toMatchObject({
+				_type: "cover",
+				backgroundImage: "https://example.com/bg.jpg",
+			});
+
+			const cover = result[0] as PortableTextCoverBlock;
+			expect(cover.content).toHaveLength(1);
+			expect(cover.content[0]).toMatchObject({ _type: "block", style: "normal" });
+		});
+
+		it.each(["left", "center", "right"] as const)(
+			"maps contentPosition %s to equivalent alignment",
+			(position) => {
+				const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","contentPosition":"${position}"} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+				const result = gutenbergToPortableText(content);
+
+				expect(result[0]).toMatchObject({ _type: "cover", alignment: position });
+			},
+		);
+
+		it("defaults minHeight unit to px when no unit is given", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","minHeight":400} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", minHeight: "400px" });
+		});
+
+		it("combines minHeight with explicit unit", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","minHeight":50,"minHeightUnit":"vh"} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", minHeight: "50vh" });
+		});
+
+		it("handles zero minHeighjt", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","minHeight":0} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", minHeight: "0px" });
+		});
+
+		it("converts dimRatio to overlayOpacity", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","dimRatio":60} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", overlayOpacity: 0.6 });
+		});
+
+		it("uses customOverlayColor over overlayColor when both are present", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","overlayColor":"primary","customOverlayColor":"#ff0000"} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", overlayColor: "#ff0000" });
+		});
+
+		it("falls back to overlayColor when no customOverlayColor", () => {
+			const content = `<!-- wp:cover {"url":"https://example.com/bg.jpg","overlayColor":"primary"} -->
+<div class="wp-block-cover"></div>
+<!-- /wp:cover -->`;
+
+			const result = gutenbergToPortableText(content);
+
+			expect(result[0]).toMatchObject({ _type: "cover", overlayColor: "primary" });
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

More gutenberg tests - this time for the cover blocks.

The `minHeight` was a string before but the tests failed, so it seems they picked up a bug and it should be a number. Let me know if not

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [ ] This PR includes AI-generated code
