### PR TITLE
fix(admin): add missing I18nProvider to router test wrapper

### DIFF
--- a/packages/admin/tests/router.test.tsx
+++ b/packages/admin/tests/router.test.tsx
@@ -18,6 +18,8 @@
  */
 
 import { Toasty } from "@cloudflare/kumo";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import * as React from "react";
@@ -87,15 +89,20 @@ const MANIFEST: AdminManifest = {
 function buildRouter() {
 	const queryClient = createTestQueryClient();
 	const router = createAdminRouter(queryClient);
-	// Toasty is provided by App.tsx (outside RouterProvider) in production.
-	// Mirror that here so Toast.useToastManager() works inside page components.
+	if (!i18n.locale) {
+		i18n.loadAndActivate({ locale: "en", messages: {} });
+	}
+	// Toasty and I18nProvider are provided by App.tsx in production.
+	// Mirror that here so useLingui() and Toast.useToastManager() work inside page components.
 	function TestApp() {
 		return (
-			<Toasty>
-				<QueryClientProvider client={queryClient}>
-					<RouterProvider router={router} />
-				</QueryClientProvider>
-			</Toasty>
+			<I18nProvider i18n={i18n}>
+				<Toasty>
+					<QueryClientProvider client={queryClient}>
+						<RouterProvider router={router} />
+					</QueryClientProvider>
+				</Toasty>
+			</I18nProvider>
 		);
 	}
 	return { router, queryClient, TestApp };


### PR DESCRIPTION
## What does this PR do?

The two locale-aware tests in `router.test.tsx` were failing because the test's `TestApp` wrapper didn't include `I18nProvider`. In production, `App.tsx` wraps the entire tree with it, but the test built its own minimal wrapper and missed it. When i18n is configured in the manifest, `LocaleSwitcher` renders and calls `useLingui()`, which crashes without the provider.

Added `I18nProvider` (with an empty English catalog) to the `buildRouter()` test helper, matching the pattern already used by `tests/utils/render.tsx`.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Before: 2 failed, 715 passed (717 total)
After: 0 failed, 717 passed (717 total)