### PR TITLE
chore(deps): bump better-sqlite3 from 11.10.0 to 12.8.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ catalogs:
       specifier: ^6.0.1
       version: 6.0.1
     better-sqlite3:
-      specifier: ^11.10.0
-      version: 11.10.0
+      specifier: ^12.8.0
+      version: 12.8.0
     publint:
       specifier: 0.3.17
       version: 0.3.17
@@ -300,7 +300,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -411,7 +411,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -472,7 +472,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -912,7 +912,7 @@ importers:
         version: 0.11.4(astro@6.1.3(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       blurhash:
         specifier: ^2.0.5
         version: 2.0.5
@@ -1088,7 +1088,7 @@ importers:
         version: 24.10.13
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1298,7 +1298,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -1329,7 +1329,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -1397,7 +1397,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -1459,7 +1459,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -1521,7 +1521,7 @@ importers:
         version: 6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2)
       better-sqlite3:
         specifier: 'catalog:'
-        version: 11.10.0
+        version: 12.8.0
       emdash:
         specifier: workspace:*
         version: link:../../packages/core
@@ -5179,8 +5179,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -12971,7 +12972,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   "@types/react": 19.2.14
   "@types/react-dom": 19.2.3
   astro: ^6.0.1
-  better-sqlite3: ^11.10.0
+  better-sqlite3: ^12.8.0
   publint: 0.3.17
   react: 19.2.4
   react-dom: 19.2.4


### PR DESCRIPTION
## What does this PR do?

Bumps `better-sqlite3` from 11.10.0 to 12.8.0 in the pnpm catalog. Includes prebuilt binaries for Node 24.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [ ] This PR includes AI-generated code

## Screenshots / test output

N/A — dependency bump only.