### PR TITLE
Per-collection sitemaps with index and lastmod

### DIFF
--- a/.changeset/per-collection-sitemaps.md
+++ b/.changeset/per-collection-sitemaps.md
@@ -1,0 +1,7 @@
+---
+"emdash": minor
+---
+
+Per-collection sitemaps with sitemap index and lastmod
+
+`/sitemap.xml` now serves a `<sitemapindex>` with one child sitemap per SEO-enabled collection. Each collection's sitemap is at `/sitemap-{collection}.xml` with `<lastmod>` on both index entries and individual URLs. Uses the collection's `url_pattern` for correct URL building.

--- a/packages/core/src/api/handlers/index.ts
+++ b/packages/core/src/api/handlers/index.ts
@@ -84,7 +84,7 @@ export {
 } from "./schema.js";
 
 // SEO handlers
-export { handleSitemapData, type SitemapContentEntry, type SitemapDataResponse } from "./seo.js";
+export { handleSitemapData, type SitemapCollectionData, type SitemapContentEntry, type SitemapDataResponse } from "./seo.js";
 
 // Plugin handlers
 export {

--- a/packages/core/src/api/handlers/index.ts
+++ b/packages/core/src/api/handlers/index.ts
@@ -84,7 +84,12 @@ export {
 } from "./schema.js";
 
 // SEO handlers
-export { handleSitemapData, type SitemapCollectionData, type SitemapContentEntry, type SitemapDataResponse } from "./seo.js";
+export {
+	handleSitemapData,
+	type SitemapCollectionData,
+	type SitemapContentEntry,
+	type SitemapDataResponse,
+} from "./seo.js";
 
 // Plugin handlers
 export {

--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -12,8 +12,10 @@ import type { ApiResult } from "../types.js";
 
 /** Raw content data for sitemap generation — the route builds the actual URLs */
 export interface SitemapContentEntry {
-	/** Content slug or ID */
-	identifier: string;
+	/** Content ID (ULID) */
+	id: string;
+	/** Content slug, or null when the entry has no slug */
+	slug: string | null;
 	/** ISO date of last modification */
 	updatedAt: string;
 }
@@ -109,7 +111,8 @@ export async function handleSitemapData(
 				const entries: SitemapContentEntry[] = [];
 				for (const row of rows.rows) {
 					entries.push({
-						identifier: row.slug || row.id,
+						id: row.id,
+						slug: row.slug,
 						updatedAt: row.updated_at,
 					});
 				}

--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -12,16 +12,26 @@ import type { ApiResult } from "../types.js";
 
 /** Raw content data for sitemap generation — the route builds the actual URLs */
 export interface SitemapContentEntry {
-	/** Collection slug (e.g., "post", "page") */
-	collection: string;
 	/** Content slug or ID */
 	identifier: string;
 	/** ISO date of last modification */
 	updatedAt: string;
 }
 
-export interface SitemapDataResponse {
+/** Per-collection sitemap data with entries and URL pattern */
+export interface SitemapCollectionData {
+	/** Collection slug (e.g., "post", "page") */
+	collection: string;
+	/** URL pattern with {slug} placeholder, or null for default /{collection}/{slug} */
+	urlPattern: string | null;
+	/** Most recent updated_at across all entries (for sitemap index lastmod) */
+	lastmod: string;
+	/** Individual content entries */
 	entries: SitemapContentEntry[];
+}
+
+export interface SitemapDataResponse {
+	collections: SitemapCollectionData[];
 }
 
 /** Maximum entries per sitemap (per spec) */
@@ -29,31 +39,36 @@ const SITEMAP_MAX_ENTRIES = 50_000;
 
 /**
  * Collect all published, indexable content across SEO-enabled collections
- * for sitemap generation.
+ * for sitemap generation, grouped by collection.
  *
  * Only includes content from collections with `has_seo = 1`.
  * Excludes content with `seo_no_index = 1` in the `_emdash_seo` table.
  *
- * Returns raw data (collection + identifier + date). The caller (route)
- * is responsible for building absolute URLs — this handler does NOT
+ * Returns raw data grouped per collection. The caller (route) is
+ * responsible for building absolute URLs — this handler does NOT
  * assume a URL structure.
  */
 export async function handleSitemapData(
 	db: Kysely<Database>,
+	/** When set, only return data for this collection. */
+	collectionSlug?: string,
 ): Promise<ApiResult<SitemapDataResponse>> {
 	try {
-		// Find all SEO-enabled collections
-		const collections = await db
+		// Find SEO-enabled collections (optionally filtered)
+		let query = db
 			.selectFrom("_emdash_collections")
-			.select(["slug"])
-			.where("has_seo", "=", 1)
-			.execute();
+			.select(["slug", "url_pattern"])
+			.where("has_seo", "=", 1);
 
-		const entries: SitemapContentEntry[] = [];
+		if (collectionSlug) {
+			query = query.where("slug", "=", collectionSlug);
+		}
+
+		const collections = await query.execute();
+
+		const result: SitemapCollectionData[] = [];
 
 		for (const col of collections) {
-			if (entries.length >= SITEMAP_MAX_ENTRIES) break;
-
 			// Validate the slug before using it as a table name identifier.
 			// Should always pass (slugs are validated on creation), but
 			// guards against corrupted DB data.
@@ -65,7 +80,6 @@ export async function handleSitemapData(
 			}
 
 			const tableName = `ec_${col.slug}`;
-			const remaining = SITEMAP_MAX_ENTRIES - entries.length;
 
 			// Query published, non-deleted content.
 			// LEFT JOIN _emdash_seo to check noindex flag.
@@ -87,16 +101,26 @@ export async function handleSitemapData(
 					AND c.deleted_at IS NULL
 					AND (s.seo_no_index IS NULL OR s.seo_no_index = 0)
 					ORDER BY c.updated_at DESC
-					LIMIT ${remaining}
+					LIMIT ${SITEMAP_MAX_ENTRIES}
 				`.execute(db);
 
+				if (rows.rows.length === 0) continue;
+
+				const entries: SitemapContentEntry[] = [];
 				for (const row of rows.rows) {
 					entries.push({
-						collection: col.slug,
 						identifier: row.slug || row.id,
 						updatedAt: row.updated_at,
 					});
 				}
+
+				result.push({
+					collection: col.slug,
+					urlPattern: col.url_pattern,
+					// Rows are ordered by updated_at DESC, so first row is the latest
+					lastmod: rows.rows[0].updated_at,
+					entries,
+				});
 			} catch (err) {
 				// Table missing or query error — skip this collection
 				console.warn(`[SITEMAP] Failed to query collection "${col.slug}":`, err);
@@ -104,7 +128,7 @@ export async function handleSitemapData(
 			}
 		}
 
-		return { success: true, data: { entries } };
+		return { success: true, data: { collections: result } };
 	} catch (error) {
 		console.error("[SITEMAP_ERROR]", error);
 		return {

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -665,6 +665,11 @@ export function injectCoreRoutes(injectRoute: InjectRoute): void {
 	});
 
 	injectRoute({
+		pattern: "/sitemap-[collection].xml",
+		entrypoint: resolveRoute("sitemap-[collection].xml.ts"),
+	});
+
+	injectRoute({
 		pattern: "/robots.txt",
 		entrypoint: resolveRoute("robots.txt.ts"),
 	});

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -177,7 +177,7 @@ function setBaselineSecurityHeaders(response: Response): void {
 
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */
 const PUBLIC_RUNTIME_ROUTES = new Set(["/sitemap.xml", "/robots.txt"]);
-const SITEMAP_COLLECTION_RE = /^\/sitemap-[\w-]+\.xml$/;
+const SITEMAP_COLLECTION_RE = /^\/sitemap-[a-z][a-z0-9_]*\.xml$/;
 
 export const onRequest = defineMiddleware(async (context, next) => {
 	const { request, locals, cookies } = context;

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -186,7 +186,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// Process /_emdash routes and public routes with an active session
 	// (logged-in editors need the runtime for toolbar/visual editing on public pages)
 	const isEmDashRoute = url.pathname.startsWith("/_emdash");
-	const isPublicRuntimeRoute = PUBLIC_RUNTIME_ROUTES.has(url.pathname) || SITEMAP_COLLECTION_RE.test(url.pathname);
+	const isPublicRuntimeRoute =
+		PUBLIC_RUNTIME_ROUTES.has(url.pathname) || SITEMAP_COLLECTION_RE.test(url.pathname);
 
 	// Check for edit mode cookie - editors viewing public pages need the runtime
 	// so auth middleware can verify their session for visual editing

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -177,6 +177,7 @@ function setBaselineSecurityHeaders(response: Response): void {
 
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */
 const PUBLIC_RUNTIME_ROUTES = new Set(["/sitemap.xml", "/robots.txt"]);
+const SITEMAP_COLLECTION_RE = /^\/sitemap-[\w-]+\.xml$/;
 
 export const onRequest = defineMiddleware(async (context, next) => {
 	const { request, locals, cookies } = context;
@@ -185,7 +186,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// Process /_emdash routes and public routes with an active session
 	// (logged-in editors need the runtime for toolbar/visual editing on public pages)
 	const isEmDashRoute = url.pathname.startsWith("/_emdash");
-	const isPublicRuntimeRoute = PUBLIC_RUNTIME_ROUTES.has(url.pathname);
+	const isPublicRuntimeRoute = PUBLIC_RUNTIME_ROUTES.has(url.pathname) || SITEMAP_COLLECTION_RE.test(url.pathname);
 
 	// Check for edit mode cookie - editors viewing public pages need the runtime
 	// so auth middleware can verify their session for visual editing

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -1,11 +1,10 @@
 /**
- * Sitemap index endpoint
+ * Per-collection sitemap endpoint
  *
- * GET /sitemap.xml - Sitemap index listing one sitemap per collection.
+ * GET /sitemap-{collection}.xml - Sitemap for a single content collection.
  *
- * Each collection with published, indexable content gets its own
- * child sitemap at /sitemap-{collection}.xml. The index includes
- * a <lastmod> per child derived from the most recently updated entry.
+ * Uses the collection's url_pattern to build URLs. Falls back to
+ * /{collection}/{slug} when no pattern is configured.
  */
 
 import type { APIRoute } from "astro";
@@ -21,11 +20,13 @@ const LT_RE = /</g;
 const GT_RE = />/g;
 const QUOT_RE = /"/g;
 const APOS_RE = /'/g;
+const SLUG_PLACEHOLDER = "{slug}";
 
-export const GET: APIRoute = async ({ locals, url }) => {
+export const GET: APIRoute = async ({ params, locals, url }) => {
 	const { emdash } = locals;
+	const collectionSlug = params.collection;
 
-	if (!emdash?.db) {
+	if (!emdash?.db || !collectionSlug) {
 		return new Response("<!-- EmDash not configured -->", {
 			status: 500,
 			headers: { "Content-Type": "application/xml" },
@@ -36,7 +37,7 @@ export const GET: APIRoute = async ({ locals, url }) => {
 		const settings = await getSiteSettingsWithDb(emdash.db);
 		const siteUrl = (settings.url || url.origin).replace(TRAILING_SLASH_RE, "");
 
-		const result = await handleSitemapData(emdash.db);
+		const result = await handleSitemapData(emdash.db, collectionSlug);
 
 		if (!result.success || !result.data) {
 			return new Response("<!-- Failed to generate sitemap -->", {
@@ -45,22 +46,33 @@ export const GET: APIRoute = async ({ locals, url }) => {
 			});
 		}
 
-		const { collections } = result.data;
+		const col = result.data.collections[0];
+		if (!col) {
+			return new Response("<!-- Collection not found or empty -->", {
+				status: 404,
+				headers: { "Content-Type": "application/xml" },
+			});
+		}
 
 		const lines: string[] = [
 			'<?xml version="1.0" encoding="UTF-8"?>',
-			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+			'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 		];
 
-		for (const col of collections) {
-			const loc = `${siteUrl}/sitemap-${encodeURIComponent(col.collection)}.xml`;
-			lines.push("  <sitemap>");
+		for (const entry of col.entries) {
+			const path = col.urlPattern
+				? col.urlPattern.replace(SLUG_PLACEHOLDER, encodeURIComponent(entry.identifier))
+				: `/${encodeURIComponent(col.collection)}/${encodeURIComponent(entry.identifier)}`;
+
+			const loc = `${siteUrl}${path}`;
+
+			lines.push("  <url>");
 			lines.push(`    <loc>${escapeXml(loc)}</loc>`);
-			lines.push(`    <lastmod>${escapeXml(col.lastmod)}</lastmod>`);
-			lines.push("  </sitemap>");
+			lines.push(`    <lastmod>${escapeXml(entry.updatedAt)}</lastmod>`);
+			lines.push("  </url>");
 		}
 
-		lines.push("</sitemapindex>");
+		lines.push("</urlset>");
 
 		return new Response(lines.join("\n"), {
 			status: 200,

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -21,6 +21,7 @@ const GT_RE = />/g;
 const QUOT_RE = /"/g;
 const APOS_RE = /'/g;
 const SLUG_PLACEHOLDER = "{slug}";
+const ID_PLACEHOLDER = "{id}";
 
 export const GET: APIRoute = async ({ params, locals, url }) => {
 	const { emdash } = locals;
@@ -60,9 +61,12 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 		];
 
 		for (const entry of col.entries) {
+			const slug = entry.slug || entry.id;
 			const path = col.urlPattern
-				? col.urlPattern.replace(SLUG_PLACEHOLDER, encodeURIComponent(entry.identifier))
-				: `/${encodeURIComponent(col.collection)}/${encodeURIComponent(entry.identifier)}`;
+				? col.urlPattern
+						.replace(SLUG_PLACEHOLDER, encodeURIComponent(slug))
+						.replace(ID_PLACEHOLDER, encodeURIComponent(entry.id))
+				: `/${encodeURIComponent(col.collection)}/${encodeURIComponent(slug)}`;
 
 			const loc = `${siteUrl}${path}`;
 

--- a/packages/core/tests/integration/seo/seo.test.ts
+++ b/packages/core/tests/integration/seo/seo.test.ts
@@ -805,7 +805,7 @@ describe("SEO", () => {
 		function flatEntries(data: {
 			collections: Array<{
 				collection: string;
-				entries: Array<{ identifier: string; updatedAt: string }>;
+				entries: Array<{ id: string; slug: string | null; updatedAt: string }>;
 			}>;
 		}) {
 			return data.collections.flatMap((c) =>
@@ -834,7 +834,7 @@ describe("SEO", () => {
 			const entries = flatEntries(result.data!);
 			expect(entries).toHaveLength(1);
 			expect(entries[0]!.collection).toBe("post");
-			expect(entries[0]!.identifier).toBe("published-post");
+			expect(entries[0]!.slug).toBe("published-post");
 		});
 
 		it("should exclude noindex content from sitemap", async () => {
@@ -860,7 +860,7 @@ describe("SEO", () => {
 			expect(result.success).toBe(true);
 			const entries = flatEntries(result.data!);
 			expect(entries).toHaveLength(1);
-			expect(entries[0]!.identifier).toBe("visible-post");
+			expect(entries[0]!.slug).toBe("visible-post");
 		});
 
 		it("should exclude deleted content from sitemap", async () => {
@@ -901,9 +901,9 @@ describe("SEO", () => {
 			expect(result.data!.collections).toHaveLength(2);
 
 			const entries = flatEntries(result.data!);
-			const identifiers = entries.map((e) => `${e.collection}/${e.identifier}`);
-			expect(identifiers).toContain("post/my-post");
-			expect(identifiers).toContain("page/about");
+			const slugs = entries.map((e) => `${e.collection}/${e.slug}`);
+			expect(slugs).toContain("post/my-post");
+			expect(slugs).toContain("page/about");
 		});
 
 		it("should exclude content from non-SEO collections", async () => {
@@ -940,7 +940,7 @@ describe("SEO", () => {
 			expect(result.data!.collections[0]!.collection).toBe("post");
 		});
 
-		it("should use ID when slug is null", async () => {
+		it("should return null slug and valid id when slug is null", async () => {
 			const created = await repo.create({
 				type: "post",
 				data: { title: "No Slug Post" },
@@ -952,7 +952,8 @@ describe("SEO", () => {
 			expect(result.success).toBe(true);
 			const entries = flatEntries(result.data!);
 			expect(entries[0]!.collection).toBe("post");
-			expect(entries[0]!.identifier).toBe(created.id);
+			expect(entries[0]!.slug).toBeNull();
+			expect(entries[0]!.id).toBe(created.id);
 		});
 
 		it("should include updatedAt and lastmod", async () => {

--- a/packages/core/tests/integration/seo/seo.test.ts
+++ b/packages/core/tests/integration/seo/seo.test.ts
@@ -801,6 +801,13 @@ describe("SEO", () => {
 	});
 
 	describe("handleSitemapData", () => {
+		/** Flatten the per-collection response into a flat list with collection tag. */
+		function flatEntries(data: { collections: Array<{ collection: string; entries: Array<{ identifier: string; updatedAt: string }> }> }) {
+			return data.collections.flatMap((c) =>
+				c.entries.map((e) => ({ collection: c.collection, ...e })),
+			);
+		}
+
 		it("should return published content from SEO-enabled collections", async () => {
 			await repo.create({
 				type: "post",
@@ -819,9 +826,10 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toHaveLength(1);
-			expect(result.data!.entries[0]!.collection).toBe("post");
-			expect(result.data!.entries[0]!.identifier).toBe("published-post");
+			const entries = flatEntries(result.data!);
+			expect(entries).toHaveLength(1);
+			expect(entries[0]!.collection).toBe("post");
+			expect(entries[0]!.identifier).toBe("published-post");
 		});
 
 		it("should exclude noindex content from sitemap", async () => {
@@ -845,8 +853,9 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toHaveLength(1);
-			expect(result.data!.entries[0]!.identifier).toBe("visible-post");
+			const entries = flatEntries(result.data!);
+			expect(entries).toHaveLength(1);
+			expect(entries[0]!.identifier).toBe("visible-post");
 		});
 
 		it("should exclude deleted content from sitemap", async () => {
@@ -862,7 +871,8 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toHaveLength(0);
+			const entries = flatEntries(result.data!);
+			expect(entries).toHaveLength(0);
 		});
 
 		it("should include content from multiple SEO-enabled collections", async () => {
@@ -883,9 +893,10 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toHaveLength(2);
+			expect(result.data!.collections).toHaveLength(2);
 
-			const identifiers = result.data!.entries.map((e) => `${e.collection}/${e.identifier}`);
+			const entries = flatEntries(result.data!);
+			const identifiers = entries.map((e) => `${e.collection}/${e.identifier}`);
 			expect(identifiers).toContain("post/my-post");
 			expect(identifiers).toContain("page/about");
 		});
@@ -920,8 +931,8 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toHaveLength(1);
-			expect(result.data!.entries[0]!.collection).toBe("post");
+			expect(result.data!.collections).toHaveLength(1);
+			expect(result.data!.collections[0]!.collection).toBe("post");
 		});
 
 		it("should use ID when slug is null", async () => {
@@ -934,11 +945,12 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries[0]!.collection).toBe("post");
-			expect(result.data!.entries[0]!.identifier).toBe(created.id);
+			const entries = flatEntries(result.data!);
+			expect(entries[0]!.collection).toBe("post");
+			expect(entries[0]!.identifier).toBe(created.id);
 		});
 
-		it("should include updatedAt from updated_at", async () => {
+		it("should include updatedAt and lastmod", async () => {
 			await repo.create({
 				type: "post",
 				slug: "test",
@@ -948,12 +960,55 @@ describe("SEO", () => {
 
 			const result = await handleSitemapData(db);
 
-			expect(result.data!.entries[0]!.updatedAt).toBeDefined();
-			// Should be a valid date string
-			expect(new Date(result.data!.entries[0]!.updatedAt).getTime()).not.toBeNaN();
+			const col = result.data!.collections[0]!;
+			expect(col.lastmod).toBeDefined();
+			expect(new Date(col.lastmod).getTime()).not.toBeNaN();
+			expect(col.entries[0]!.updatedAt).toBeDefined();
+			expect(new Date(col.entries[0]!.updatedAt).getTime()).not.toBeNaN();
 		});
 
-		it("should return empty entries when no SEO-enabled collections exist", async () => {
+		it("should include urlPattern from collection", async () => {
+			await db
+				.updateTable("_emdash_collections")
+				.set({ url_pattern: "/blog/{slug}" })
+				.where("slug", "=", "post")
+				.execute();
+
+			await repo.create({
+				type: "post",
+				slug: "test",
+				data: { title: "Test" },
+				status: "published",
+			});
+
+			const result = await handleSitemapData(db);
+
+			expect(result.data!.collections[0]!.urlPattern).toBe("/blog/{slug}");
+		});
+
+		it("should filter by collection when collectionSlug is provided", async () => {
+			await repo.create({
+				type: "post",
+				slug: "my-post",
+				data: { title: "A Post" },
+				status: "published",
+			});
+
+			await repo.create({
+				type: "page",
+				slug: "about",
+				data: { title: "About Us" },
+				status: "published",
+			});
+
+			const result = await handleSitemapData(db, "post");
+
+			expect(result.success).toBe(true);
+			expect(result.data!.collections).toHaveLength(1);
+			expect(result.data!.collections[0]!.collection).toBe("post");
+		});
+
+		it("should return empty collections when no SEO-enabled collections exist", async () => {
 			// Disable SEO on all collections
 			await db.updateTable("_emdash_collections").set({ has_seo: 0 }).execute();
 
@@ -967,14 +1022,14 @@ describe("SEO", () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toEqual([]);
+			expect(result.data!.collections).toEqual([]);
 		});
 
-		it("should return empty entries for empty database", async () => {
+		it("should return empty collections for empty database", async () => {
 			const result = await handleSitemapData(db);
 
 			expect(result.success).toBe(true);
-			expect(result.data!.entries).toEqual([]);
+			expect(result.data!.collections).toEqual([]);
 		});
 	});
 

--- a/packages/core/tests/integration/seo/seo.test.ts
+++ b/packages/core/tests/integration/seo/seo.test.ts
@@ -802,7 +802,12 @@ describe("SEO", () => {
 
 	describe("handleSitemapData", () => {
 		/** Flatten the per-collection response into a flat list with collection tag. */
-		function flatEntries(data: { collections: Array<{ collection: string; entries: Array<{ identifier: string; updatedAt: string }> }> }) {
+		function flatEntries(data: {
+			collections: Array<{
+				collection: string;
+				entries: Array<{ identifier: string; updatedAt: string }>;
+			}>;
+		}) {
 			return data.collections.flatMap((c) =>
 				c.entries.map((e) => ({ collection: c.collection, ...e })),
 			);


### PR DESCRIPTION
## What does this PR do?

Refactors sitemap generation to produce a sitemap index (`/sitemap.xml`) with one child sitemap per SEO-enabled collection (`/sitemap-{collection}.xml`), each including `<lastmod>` values.

Per-collection sitemaps make it easier to spot template and content type issues in Google Search Console, since each collection shows as a separate sitemap.

Related discussion: https://github.com/emdash-cms/emdash/discussions/408

## Type of change

- [ ] Bug fix
- [x] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/408

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

**Changes:**
- `/sitemap.xml` now serves a `<sitemapindex>` with one `<sitemap>` entry per SEO-enabled collection, each with `<lastmod>`
- New `/sitemap-{collection}.xml` routes serve per-collection `<urlset>` with `<loc>` and `<lastmod>` per URL
- `handleSitemapData` returns both `slug` and `id` per entry, allowing correct interpolation of URL patterns using `{slug}`, `{id}`, or both
- Dropped `<changefreq>` and `<priority>` (ignored by all major search engines)
- Middleware regex for sitemap routes aligned with `validateIdentifier()` rules

**Test coverage:**
- All 54 existing SEO tests updated and passing
- New tests for `urlPattern` inclusion, `lastmod` on collections, `collectionSlug` filtering, and null slug handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)