### PR TITLE
fix(emdash): patch OAuth routes to use cloudflare:workers env

### DIFF
--- a/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
@@ -89,7 +89,8 @@ export const GET: APIRoute = async ({ params, request, locals, redirect }) => {
 
 		// Get OAuth providers from environment
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = cfEnv as unknown as Record<string, unknown> ?? (import.meta.env as Record<string, unknown>);
+		const env =
+			(cfEnv as unknown as Record<string, unknown>) ?? (import.meta.env as Record<string, unknown>);
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
@@ -5,6 +5,7 @@
  */
 
 import type { APIRoute } from "astro";
+import { env as cfEnv } from "cloudflare:workers";
 
 export const prerender = false;
 
@@ -87,11 +88,8 @@ export const GET: APIRoute = async ({ params, request, locals, redirect }) => {
 		const url = new URL(request.url);
 
 		// Get OAuth providers from environment
-		// Access via locals.runtime for Cloudflare, or import.meta.env for Node
-		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- locals.runtime is injected by the Cloudflare adapter at runtime; not declared on App.Locals since the adapter is optional
-		const runtimeLocals = locals as unknown as { runtime?: { env?: Record<string, unknown> } };
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = runtimeLocals.runtime?.env ?? (import.meta.env as Record<string, unknown>);
+		const env = cfEnv as unknown as Record<string, unknown> ?? (import.meta.env as Record<string, unknown>);
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
@@ -115,7 +115,8 @@ export const GET: APIRoute = async ({ params, request, locals, session, redirect
 	try {
 		// Get OAuth providers from environment
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = cfEnv as unknown as Record<string, unknown> ?? (import.meta.env as Record<string, unknown>);
+		const env =
+			(cfEnv as unknown as Record<string, unknown>) ?? (import.meta.env as Record<string, unknown>);
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
@@ -5,6 +5,7 @@
  */
 
 import type { APIRoute } from "astro";
+import { env as cfEnv } from "cloudflare:workers";
 
 export const prerender = false;
 
@@ -113,10 +114,8 @@ export const GET: APIRoute = async ({ params, request, locals, session, redirect
 
 	try {
 		// Get OAuth providers from environment
-		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- locals.runtime is injected by the Cloudflare adapter at runtime; not declared on App.Locals since the adapter is optional
-		const runtimeLocals = locals as unknown as { runtime?: { env?: Record<string, unknown> } };
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = runtimeLocals.runtime?.env ?? (import.meta.env as Record<string, unknown>);
+		const env = cfEnv as unknown as Record<string, unknown> ?? (import.meta.env as Record<string, unknown>);
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Astro v6 removed locals.runtime.env, breaking OAuth provider config lookup on Cloudflare. Patch emdash@0.1.1 to import env from cloudflare:workers directly in both the OAuth initiation and callback routes.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
