### PR TITLE
fix: prevent 0.x minor bumps from triggering major in dependents

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,10 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "minor",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true,
+		"updateInternalDependents": "out-of-range"
+	},
 	"ignore": [
 		"@emdash-cms/blocks-playground",
 		"@emdash-cms/demo-cloudflare",

--- a/packages/plugins/atproto/package.json
+++ b/packages/plugins/atproto/package.json
@@ -26,7 +26,7 @@
 	],
 	"author": "Matt Kane",
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"emdash": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -24,7 +24,7 @@
 	],
 	"author": "Matt Kane",
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"emdash": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/plugins/webhook-notifier/package.json
+++ b/packages/plugins/webhook-notifier/package.json
@@ -24,7 +24,7 @@
 	],
 	"author": "Matt Kane",
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"emdash": "workspace:*"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What does this PR do?

Fixes the release PR (#396) incorrectly bumping `plugin-ai-moderation`, `plugin-color`, `plugin-embeds`, and `plugin-forms` to 1.0.0 when `emdash` gets a minor bump.

The root cause: changesets treats a minor in 0.x as a breaking change (per semver spec). Plugins with `emdash` as a peer dep got a major bump, jumping them to 1.0.0.

Two fixes:
1. **Changesets config**: Add `onlyUpdatePeerDependentsWhenOutOfRange` and `updateInternalDependents: "out-of-range"` so `workspace:*` ranges (which match everything) never trigger automatic major bumps in dependents.
2. **Plugin deps**: Move `emdash` from `dependencies` to `peerDependencies` in `atproto`, `audit-log`, and `webhook-notifier` to match the other plugins. Plugins shouldn't bundle emdash — they run inside it.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — config-only change. Verified by inspecting the release PR behavior.