### PR TITLE
fix(auth): add User-Agent header to GitHub API requests

### DIFF
--- a/.changeset/fix-github-oauth-user-agent.md
+++ b/.changeset/fix-github-oauth-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/auth": patch
+---
+
+Fixes GitHub OAuth login failing with 403 on accounts where email is private. GitHub's API requires a `User-Agent` header and rejects requests without it.

--- a/packages/auth/src/oauth/consumer.ts
+++ b/packages/auth/src/oauth/consumer.ts
@@ -180,6 +180,7 @@ async function fetchProfile(
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
 			Accept: "application/json",
+			"User-Agent": "emdash-cms",
 		},
 	});
 

--- a/packages/auth/src/oauth/providers/github.test.ts
+++ b/packages/auth/src/oauth/providers/github.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchGitHubEmail } from "./github.js";
+
+describe("fetchGitHubEmail", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("sends User-Agent header required by GitHub API", async () => {
+		const mockFetch = vi.mocked(fetch);
+		mockFetch.mockResolvedValue(
+			new Response(
+				JSON.stringify([{ email: "user@example.com", primary: true, verified: true }]),
+				{ status: 200 },
+			),
+		);
+
+		await fetchGitHubEmail("test-token");
+
+		const [, init] = mockFetch.mock.calls[0] ?? [];
+		const headers = init?.headers as Record<string, string> | undefined;
+		expect(headers?.["User-Agent"]).toBe("emdash-cms");
+	});
+
+	it("returns the primary verified email", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(
+				JSON.stringify([
+					{ email: "other@example.com", primary: false, verified: true },
+					{ email: "primary@example.com", primary: true, verified: true },
+				]),
+				{ status: 200 },
+			),
+		);
+
+		const email = await fetchGitHubEmail("test-token");
+
+		expect(email).toBe("primary@example.com");
+	});
+
+	it("throws when GitHub API returns 403 (e.g. missing User-Agent)", async () => {
+		vi.mocked(fetch).mockResolvedValue(new Response("Forbidden", { status: 403 }));
+
+		await expect(fetchGitHubEmail("test-token")).rejects.toThrow(
+			"Failed to fetch GitHub emails: 403",
+		);
+	});
+
+	it("throws when no verified primary email exists", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(
+				JSON.stringify([{ email: "unverified@example.com", primary: true, verified: false }]),
+				{ status: 200 },
+			),
+		);
+
+		await expect(fetchGitHubEmail("test-token")).rejects.toThrow(
+			"No verified primary email found on GitHub account",
+		);
+	});
+});

--- a/packages/auth/src/oauth/providers/github.test.ts
+++ b/packages/auth/src/oauth/providers/github.test.ts
@@ -14,10 +14,9 @@ describe("fetchGitHubEmail", () => {
 	it("sends User-Agent header required by GitHub API", async () => {
 		const mockFetch = vi.mocked(fetch);
 		mockFetch.mockResolvedValue(
-			new Response(
-				JSON.stringify([{ email: "user@example.com", primary: true, verified: true }]),
-				{ status: 200 },
-			),
+			new Response(JSON.stringify([{ email: "user@example.com", primary: true, verified: true }]), {
+				status: 200,
+			}),
 		);
 
 		await fetchGitHubEmail("test-token");

--- a/packages/auth/src/oauth/providers/github.ts
+++ b/packages/auth/src/oauth/providers/github.ts
@@ -49,6 +49,7 @@ export async function fetchGitHubEmail(accessToken: string): Promise<string> {
 			Authorization: `Bearer ${accessToken}`,
 			Accept: "application/vnd.github+json",
 			"X-GitHub-Api-Version": "2022-11-28",
+			"User-Agent": "emdash-cms",
 		},
 	});
 


### PR DESCRIPTION
## What does this PR do?

GitHub's REST API requires a `User-Agent` header and returns 403 for any request without one. Both `fetchProfile` (in `consumer.ts`) and `fetchGitHubEmail` (in `providers/github.ts`) were omitting this header, causing OAuth login to fail for users whose GitHub email is set to private.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
✓ src/oauth/providers/github.test.ts (4 tests) 22ms
  ✓ fetchGitHubEmail > sends User-Agent header required by GitHub API
  ✓ fetchGitHubEmail > returns the primary verified email
  ✓ fetchGitHubEmail > throws when GitHub API returns 403 (e.g. missing User-Agent)
  ✓ fetchGitHubEmail > throws when no verified primary email exists
```