### PR TITLE
fix(plugins): route ctx.content seo writes to the SEO panel

### DIFF
--- a/.changeset/fix-plugin-content-seo.md
+++ b/.changeset/fix-plugin-content-seo.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Fixes `ctx.content.create()` and `ctx.content.update()` so plugins can write
+to the core SEO panel. When the input `data` contains a reserved `seo` key,
+it is now extracted and routed to `_emdash_seo` via the SEO repository,
+matching the REST API shape. `ctx.content.get()` and `ctx.content.list()`
+also hydrate the `seo` field on returned items for SEO-enabled collections.

--- a/packages/core/src/database/repositories/seo.ts
+++ b/packages/core/src/database/repositories/seo.ts
@@ -37,6 +37,19 @@ export class SeoRepository {
 	constructor(private db: Kysely<Database>) {}
 
 	/**
+	 * Check whether a collection has SEO enabled (`has_seo = 1`).
+	 * Returns `false` if the collection does not exist.
+	 */
+	async isEnabled(collection: string): Promise<boolean> {
+		const row = await this.db
+			.selectFrom("_emdash_collections")
+			.select("has_seo")
+			.where("slug", "=", collection)
+			.executeTakeFirst();
+		return row?.has_seo === 1;
+	}
+
+	/**
 	 * Get SEO data for a content item. Returns null defaults if no row exists.
 	 */
 	async get(collection: string, contentId: string): Promise<ContentSeo> {

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -12,7 +12,9 @@ import { ContentRepository } from "../database/repositories/content.js";
 import { MediaRepository } from "../database/repositories/media.js";
 import { OptionsRepository } from "../database/repositories/options.js";
 import { PluginStorageRepository } from "../database/repositories/plugin-storage.js";
+import { SeoRepository } from "../database/repositories/seo.js";
 import { UserRepository } from "../database/repositories/user.js";
+import { withTransaction } from "../database/transaction.js";
 import type { Database } from "../database/types.js";
 import { validateExternalUrl, SsrfError, stripCredentialHeaders } from "../import/ssrf.js";
 import type { Storage } from "../storage/types.js";
@@ -36,6 +38,8 @@ import type {
 	UserAccess,
 	UserInfo,
 	ContentItem,
+	ContentItemSeoInput,
+	ContentWriteInput,
 	MediaItem,
 	PaginatedResult,
 	QueryOptions,
@@ -149,23 +153,65 @@ export function createStorageAccess<T extends PluginStorageConfig>(
 // =============================================================================
 
 /**
+ * Extract `seo` from a plugin-supplied content write input and return both
+ * parts. Mutates nothing — returns a new field map without the `seo` key.
+ */
+function splitSeoFromInput(input: ContentWriteInput): {
+	fields: Record<string, unknown>;
+	seo: ContentItemSeoInput | undefined;
+} {
+	const { seo, ...fields } = input;
+	// Reject non-object seo values rather than silently dropping them.
+	if (seo !== undefined && (seo === null || typeof seo !== "object" || Array.isArray(seo))) {
+		throw new Error("content.seo must be an object");
+	}
+	return { fields, seo };
+}
+
+/**
+ * Reject writing SEO to a collection that does not have it enabled.
+ * Matches the REST API behavior (VALIDATION_ERROR).
+ */
+async function assertSeoEnabled(
+	seoRepo: SeoRepository,
+	collection: string,
+	seo: ContentItemSeoInput | undefined,
+): Promise<boolean> {
+	const hasSeo = await seoRepo.isEnabled(collection);
+	if (seo !== undefined && !hasSeo) {
+		throw new Error(
+			`Collection "${collection}" does not have SEO enabled. ` +
+				`Remove the seo field or enable SEO on this collection.`,
+		);
+	}
+	return hasSeo;
+}
+
+/**
  * Create read-only content access
  */
 export function createContentAccess(db: Kysely<Database>): ContentAccess {
 	const contentRepo = new ContentRepository(db);
+	const seoRepo = new SeoRepository(db);
 
 	return {
 		async get(collection: string, id: string): Promise<ContentItem | null> {
 			const item = await contentRepo.findById(collection, id);
 			if (!item) return null;
 
-			return {
+			const result: ContentItem = {
 				id: item.id,
 				type: item.type,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
 			};
+
+			if (await seoRepo.isEnabled(collection)) {
+				result.seo = await seoRepo.get(collection, item.id);
+			}
+
+			return result;
 		},
 
 		async list(
@@ -188,14 +234,27 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 				orderBy,
 			});
 
+			const items: ContentItem[] = result.items.map((item) => ({
+				id: item.id,
+				type: item.type,
+				data: item.data,
+				createdAt: item.createdAt,
+				updatedAt: item.updatedAt,
+			}));
+
+			if (items.length > 0 && (await seoRepo.isEnabled(collection))) {
+				const seoMap = await seoRepo.getMany(
+					collection,
+					items.map((i) => i.id),
+				);
+				for (const item of items) {
+					const seo = seoMap.get(item.id);
+					if (seo) item.seo = seo;
+				}
+			}
+
 			return {
-				items: result.items.map((item) => ({
-					id: item.id,
-					type: item.type,
-					data: item.data,
-					createdAt: item.createdAt,
-					updatedAt: item.updatedAt,
-				})),
+				items,
 				cursor: result.nextCursor,
 				hasMore: !!result.nextCursor,
 			};
@@ -204,47 +263,97 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 }
 
 /**
- * Create full content access with write operations
+ * Create full content access with write operations.
+ *
+ * `create` and `update` accept a reserved `seo` key in their `data`
+ * argument. When present, it is routed to the core SEO panel
+ * (`_emdash_seo`) via `SeoRepository.upsert`, in the same transaction as
+ * the content write. The returned `ContentItem.seo` reflects the resulting
+ * SEO state for SEO-enabled collections.
  */
 export function createContentAccessWithWrite(db: Kysely<Database>): ContentAccessWithWrite {
-	const contentRepo = new ContentRepository(db);
 	const readAccess = createContentAccess(db);
 
 	return {
 		...readAccess,
 
-		async create(collection: string, data: Record<string, unknown>): Promise<ContentItem> {
-			const item = await contentRepo.create({
-				type: collection,
-				data,
-			});
+		async create(collection: string, data: ContentWriteInput): Promise<ContentItem> {
+			const { fields, seo } = splitSeoFromInput(data);
 
-			return {
-				id: item.id,
-				type: item.type,
-				data: item.data,
-				createdAt: item.createdAt,
-				updatedAt: item.updatedAt,
-			};
+			return withTransaction(db, async (trx) => {
+				const trxContentRepo = new ContentRepository(trx);
+				const trxSeoRepo = new SeoRepository(trx);
+
+				const hasSeo = await assertSeoEnabled(trxSeoRepo, collection, seo);
+
+				const item = await trxContentRepo.create({
+					type: collection,
+					data: fields,
+				});
+
+				const result: ContentItem = {
+					id: item.id,
+					type: item.type,
+					data: item.data,
+					createdAt: item.createdAt,
+					updatedAt: item.updatedAt,
+				};
+
+				if (hasSeo) {
+					result.seo =
+						seo !== undefined
+							? await trxSeoRepo.upsert(collection, item.id, seo)
+							: await trxSeoRepo.get(collection, item.id);
+				}
+
+				return result;
+			});
 		},
 
-		async update(
-			collection: string,
-			id: string,
-			data: Record<string, unknown>,
-		): Promise<ContentItem> {
-			const item = await contentRepo.update(collection, id, { data });
+		async update(collection: string, id: string, data: ContentWriteInput): Promise<ContentItem> {
+			const { fields, seo } = splitSeoFromInput(data);
 
-			return {
-				id: item.id,
-				type: item.type,
-				data: item.data,
-				createdAt: item.createdAt,
-				updatedAt: item.updatedAt,
-			};
+			return withTransaction(db, async (trx) => {
+				const trxContentRepo = new ContentRepository(trx);
+				const trxSeoRepo = new SeoRepository(trx);
+
+				const hasSeo = await assertSeoEnabled(trxSeoRepo, collection, seo);
+
+				// Pass the `data` payload to ContentRepository.update only when
+				// there are field updates — passing an empty object would still
+				// bump updated_at/version, but we want a seo-only call to touch
+				// only the SEO table. ContentRepository.update handles the no-op
+				// path by returning the current row.
+				const hasFieldUpdates = Object.keys(fields).length > 0;
+				const item = hasFieldUpdates
+					? await trxContentRepo.update(collection, id, { data: fields })
+					: await (async () => {
+							const existing = await trxContentRepo.findById(collection, id);
+							if (!existing) throw new Error("Content not found");
+							return existing;
+						})();
+
+				const result: ContentItem = {
+					id: item.id,
+					type: item.type,
+					data: item.data,
+					createdAt: item.createdAt,
+					updatedAt: item.updatedAt,
+				};
+
+				if (hasSeo) {
+					result.seo =
+						seo !== undefined
+							? await trxSeoRepo.upsert(collection, item.id, seo)
+							: await trxSeoRepo.get(collection, item.id);
+				}
+
+				return result;
+			});
 		},
 
 		async delete(collection: string, id: string): Promise<boolean> {
+			const contentRepo = new ContentRepository(db);
 			return contentRepo.delete(collection, id);
 		},
 	};

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -162,12 +162,45 @@ export interface KVAccess {
 }
 
 /**
+ * SEO metadata for a content item, as stored in the core SEO panel.
+ *
+ * Only present on items in collections with `has_seo = 1`. For collections
+ * without SEO enabled, `ContentItem.seo` is `undefined`.
+ */
+export interface ContentItemSeo {
+	title: string | null;
+	description: string | null;
+	image: string | null;
+	canonical: string | null;
+	noIndex: boolean;
+}
+
+/**
+ * SEO input accepted by content write operations.
+ *
+ * All fields are optional — only fields that are present overwrite existing
+ * values. An empty object is treated as a no-op.
+ */
+export interface ContentItemSeoInput {
+	title?: string | null;
+	description?: string | null;
+	image?: string | null;
+	canonical?: string | null;
+	noIndex?: boolean;
+}
+
+/**
  * Content item returned from content API
  */
 export interface ContentItem {
 	id: string;
 	type: string;
 	data: Record<string, unknown>;
+	/**
+	 * SEO metadata, populated when the collection has SEO enabled
+	 * (`has_seo = 1`). `undefined` for non-SEO collections.
+	 */
+	seo?: ContentItemSeo;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -182,6 +215,18 @@ export interface ContentListOptions {
 }
 
 /**
+ * Input accepted by `content.create` / `content.update`.
+ *
+ * Most entries are field slugs mapped to their values. The reserved `seo`
+ * key is extracted and routed to the core SEO panel (the `_emdash_seo`
+ * table), matching the shape accepted by the REST API. Passing `seo` for a
+ * collection that does not have SEO enabled throws a validation error.
+ */
+export type ContentWriteInput = Record<string, unknown> & {
+	seo?: ContentItemSeoInput;
+};
+
+/**
  * Content access interface - capability-gated
  */
 export interface ContentAccess {
@@ -190,8 +235,8 @@ export interface ContentAccess {
 	list(collection: string, options?: ContentListOptions): Promise<PaginatedResult<ContentItem>>;
 
 	// Write operations (requires write:content) - optional on interface
-	create?(collection: string, data: Record<string, unknown>): Promise<ContentItem>;
-	update?(collection: string, id: string, data: Record<string, unknown>): Promise<ContentItem>;
+	create?(collection: string, data: ContentWriteInput): Promise<ContentItem>;
+	update?(collection: string, id: string, data: ContentWriteInput): Promise<ContentItem>;
 	delete?(collection: string, id: string): Promise<boolean>;
 }
 
@@ -199,8 +244,8 @@ export interface ContentAccess {
  * Full content access with write operations
  */
 export interface ContentAccessWithWrite extends ContentAccess {
-	create(collection: string, data: Record<string, unknown>): Promise<ContentItem>;
-	update(collection: string, id: string, data: Record<string, unknown>): Promise<ContentItem>;
+	create(collection: string, data: ContentWriteInput): Promise<ContentItem>;
+	update(collection: string, id: string, data: ContentWriteInput): Promise<ContentItem>;
 	delete(collection: string, id: string): Promise<boolean>;
 }
 

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -34,6 +34,7 @@ import type { ResolvedPlugin } from "../../../src/plugins/types.js";
 const NOT_ALLOWED_FETCH_REGEX = /not allowed to fetch from host/;
 const NO_ALLOWED_FETCH_REGEX = /not allowed to fetch/;
 const NO_NETWORK_FETCH_REGEX = /does not have the "network:fetch" capability/;
+const SEO_NOT_ENABLED_REGEX = /does not have SEO enabled/;
 
 /**
  * Create a minimal resolved plugin for testing
@@ -166,6 +167,161 @@ describe("Capability Enforcement Integration (v2)", () => {
 				// Verify it was created
 				const found = await access.get("posts", created.id);
 				expect(found).not.toBeNull();
+			});
+		});
+
+		describe("SEO panel integration", () => {
+			beforeEach(async () => {
+				// Register the "posts" collection with SEO enabled so the plugin
+				// content API routes `seo` writes to the core SEO panel.
+				await sql`
+					INSERT INTO _emdash_collections (slug, label, label_singular, has_seo)
+					VALUES ('posts', 'Posts', 'Post', 1)
+				`.execute(db);
+			});
+
+			it("returns seo defaults from get() for SEO-enabled collections", async () => {
+				const access = createContentAccess(db);
+				const post = await access.get("posts", "post-1");
+
+				expect(post).not.toBeNull();
+				expect(post!.seo).toEqual({
+					title: null,
+					description: null,
+					image: null,
+					canonical: null,
+					noIndex: false,
+				});
+			});
+
+			it("omits seo from get() for collections without SEO enabled", async () => {
+				// Reset has_seo on posts so it behaves like a non-SEO collection
+				await db
+					.updateTable("_emdash_collections")
+					.set({ has_seo: 0 })
+					.where("slug", "=", "posts")
+					.execute();
+
+				const access = createContentAccess(db);
+				const post = await access.get("posts", "post-1");
+
+				expect(post).not.toBeNull();
+				expect(post!.seo).toBeUndefined();
+			});
+
+			it("update() routes `seo` to the SEO panel instead of failing on missing column", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				// Regression for #374: previously this threw
+				// "SQLite error: no such column: seo"
+				const updated = await access.update("posts", "post-1", {
+					seo: {
+						title: "Custom SEO Title",
+						description: "A better meta description",
+						canonical: "https://example.com/canonical",
+						noIndex: false,
+					},
+				});
+
+				expect(updated.seo).toEqual({
+					title: "Custom SEO Title",
+					description: "A better meta description",
+					image: null,
+					canonical: "https://example.com/canonical",
+					noIndex: false,
+				});
+
+				// Verify it persisted via a subsequent read
+				const fresh = await access.get("posts", "post-1");
+				expect(fresh!.seo?.title).toBe("Custom SEO Title");
+				expect(fresh!.seo?.description).toBe("A better meta description");
+			});
+
+			it("update() accepts field updates alongside seo in a single call", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				const updated = await access.update("posts", "post-1", {
+					title: "Updated Title",
+					seo: {
+						title: "SEO Title",
+						description: "SEO Description",
+					},
+				});
+
+				expect(updated.data.title).toBe("Updated Title");
+				expect(updated.seo?.title).toBe("SEO Title");
+				expect(updated.seo?.description).toBe("SEO Description");
+			});
+
+			it("update() only overwrites explicitly-set seo fields (partial updates)", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				await access.update("posts", "post-1", {
+					seo: { title: "Initial Title", description: "Initial Description" },
+				});
+
+				const updated = await access.update("posts", "post-1", {
+					seo: { title: "Updated Title" },
+				});
+
+				expect(updated.seo?.title).toBe("Updated Title");
+				// description must not be clobbered by a partial update
+				expect(updated.seo?.description).toBe("Initial Description");
+			});
+
+			it("create() routes `seo` to the SEO panel", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				const created = await access.create("posts", {
+					title: "New Post",
+					content: "Body",
+					seo: {
+						title: "Brand New SEO",
+						description: "New Description",
+					},
+				});
+
+				expect(created.data.title).toBe("New Post");
+				expect(created.seo?.title).toBe("Brand New SEO");
+				expect(created.seo?.description).toBe("New Description");
+
+				const fresh = await access.get("posts", created.id);
+				expect(fresh!.seo?.title).toBe("Brand New SEO");
+			});
+
+			it("update() throws when seo is provided on a collection without SEO enabled", async () => {
+				// Disable SEO on posts
+				await db
+					.updateTable("_emdash_collections")
+					.set({ has_seo: 0 })
+					.where("slug", "=", "posts")
+					.execute();
+
+				const access = createContentAccessWithWrite(db);
+
+				await expect(
+					access.update("posts", "post-1", {
+						seo: { title: "Won't work" },
+					}),
+				).rejects.toThrow(SEO_NOT_ENABLED_REGEX);
+			});
+
+			it("list() hydrates seo for each item in SEO-enabled collections", async () => {
+				const access = createContentAccessWithWrite(db);
+
+				await access.update("posts", "post-1", {
+					seo: { title: "Post One SEO" },
+				});
+				await access.update("posts", "post-2", {
+					seo: { title: "Post Two SEO" },
+				});
+
+				const result = await access.list("posts");
+				expect(result.items).toHaveLength(2);
+
+				const byId = new Map(result.items.map((i) => [i.id, i]));
+				expect(byId.get("post-1")?.seo?.title).toBe("Post One SEO");
+				expect(byId.get("post-2")?.seo?.title).toBe("Post Two SEO");
 			});
 		});
 	});


### PR DESCRIPTION
## What does this PR do?

Fixes `ctx.content.create()` / `ctx.content.update()` so plugins can write to the core SEO panel. Previously, passing a `seo` key in the input failed with `SQLite error: no such column: seo` because SEO fields live in the separate `_emdash_seo` table, not on the content row. Plugins could not programmatically populate the SEO panel, which blocked WordPress/Yoast importers, AI-assisted SEO tools, and content automation plugins.

The plugin content adapter now mirrors the REST API behavior:

- `createContentAccessWithWrite.create` / `update` extract the reserved `seo` key from the input and route it to `SeoRepository.upsert`, running content + SEO writes inside a single `withTransaction` so either both succeed or neither does.
- Writing `seo` to a collection without `has_seo = 1` throws a validation error matching the REST API (`Collection "<x>" does not have SEO enabled`).
- `createContentAccess.get` / `list` hydrate `ContentItem.seo` for SEO-enabled collections, so plugins can read current SEO state before doing non-destructive updates (also requested in the issue).
- Partial SEO updates preserve existing fields (via the existing `SeoRepository.upsert` `COALESCE` logic).
- A small `SeoRepository.isEnabled(collection)` helper encapsulates the `has_seo` lookup used by both the plugin context and the new tests.
- `ContentItem`, `ContentItemSeo`, `ContentItemSeoInput`, and `ContentWriteInput` are exported from `plugins/types.ts` so plugin authors get full typings.

Closes #374

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0 (for files touched by this PR)
- [x] `pnpm test` passes (2257 tests; 8 new regression tests for #374)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _(n/a — bug fix)_

## AI-generated code disclosure

- [x] This PR includes AI-generated code

Implemented with Claude Code (Opus 4.6). A human reviewed every change, ran the test suite, and wrote the regression tests against the exact repro from the issue. Reviewers may want to pay extra attention to: the transaction boundary in `createContentAccessWithWrite.update` (the seo-only path intentionally skips `ContentRepository.update` so it does not bump `updated_at`/`version` when only SEO changed — open to flipping this if the project prefers always bumping on any write), and the decision to reserve `seo` as a magic key inside the flat `data` map rather than introducing a new envelope shape.

## Screenshots / test output

```
 ✓ tests/integration/plugins/capabilities.test.ts (60 tests) 2081ms

 Test Files  1 passed (1)
      Tests  60 passed (60)
```

New tests added in `packages/core/tests/integration/plugins/capabilities.test.ts` under `Content Access > SEO panel integration`:

- `get()` returns SEO defaults for SEO-enabled collections
- `get()` omits seo for non-SEO collections
- `update()` routes `seo` to the SEO panel (direct regression test for #374)
- `update()` accepts field updates alongside seo in one call
- `update()` partial seo updates do not clobber existing fields
- `create()` routes `seo` to the SEO panel
- `update()` throws when seo is provided on a non-SEO collection
- `list()` hydrates seo for each item in SEO-enabled collections