### PR TITLE
fix: use fixed versioning group for all published packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,16 +7,26 @@
 		}
 	],
 	"commit": false,
-	"fixed": [],
+	"fixed": [
+		[
+			"emdash",
+			"@emdash-cms/admin",
+			"@emdash-cms/blocks",
+			"@emdash-cms/cloudflare",
+			"@emdash-cms/plugin-ai-moderation",
+			"@emdash-cms/plugin-atproto",
+			"@emdash-cms/plugin-audit-log",
+			"@emdash-cms/plugin-color",
+			"@emdash-cms/plugin-embeds",
+			"@emdash-cms/plugin-forms",
+			"@emdash-cms/plugin-webhook-notifier"
+		]
+	],
 	"linked": [],
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "minor",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
-	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-		"onlyUpdatePeerDependentsWhenOutOfRange": true,
-		"updateInternalDependents": "out-of-range"
-	},
 	"ignore": [
 		"@emdash-cms/blocks-playground",
 		"@emdash-cms/demo-cloudflare",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,15 +11,19 @@
 		[
 			"emdash",
 			"@emdash-cms/admin",
+			"@emdash-cms/auth",
 			"@emdash-cms/blocks",
 			"@emdash-cms/cloudflare",
+			"@emdash-cms/gutenberg-to-portable-text",
 			"@emdash-cms/plugin-ai-moderation",
 			"@emdash-cms/plugin-atproto",
 			"@emdash-cms/plugin-audit-log",
 			"@emdash-cms/plugin-color",
 			"@emdash-cms/plugin-embeds",
 			"@emdash-cms/plugin-forms",
-			"@emdash-cms/plugin-webhook-notifier"
+			"@emdash-cms/plugin-webhook-notifier",
+			"@emdash-cms/x402",
+			"create-emdash"
 		]
 	],
 	"linked": [],


### PR DESCRIPTION
## What does this PR do?

Replaces the experimental `onlyUpdatePeerDependentsWhenOutOfRange` / `updateInternalDependents` config (from #447) with a `fixed` versioning group containing all published packages.

**Why #447 didn't work:** `workspace:*` is internally resolved to the exact current version (e.g. `0.1.1`) when changesets evaluates range satisfaction. Since `0.2.0` never satisfies `0.1.1`, the "out of range" check always fires — the experimental options can't help for 0.x packages. This is a known upstream issue (changesets/changesets#822, #1797).

**What `fixed` does:** All packages in the group always share the same version number. A changeset touching any one of them bumps them all together, eliminating the peer-dep major-bump cascade entirely.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — config-only change.