### PR TITLE
feat(storage): resolve S3 config from S3_* env vars at runtime

### DIFF
--- a/.changeset/feat-s3-runtime-env-fallback.md
+++ b/.changeset/feat-s3-runtime-env-fallback.md
@@ -1,0 +1,15 @@
+---
+"emdash": minor
+---
+
+Adds runtime resolution of S3 storage config from `S3_*` environment
+variables (`S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`,
+`S3_SECRET_ACCESS_KEY`, `S3_REGION`, `S3_PUBLIC_URL`). Any field omitted from
+`s3({...})` is read from the matching env var on Node at runtime, so
+container images can be built once and receive credentials at boot without a
+rebuild. Explicit values in `s3({...})` still take precedence.
+
+`s3()` with no arguments is now valid for fully env-driven deployments.
+`accessKeyId` and `secretAccessKey` are now optional in `S3StorageConfig`
+(both or neither). Workers users should continue passing explicit values to
+`s3({...})`.

--- a/docs/src/content/docs/deployment/storage.mdx
+++ b/docs/src/content/docs/deployment/storage.mdx
@@ -93,6 +93,21 @@ storage: r2({
 
 The S3 adapter works with Cloudflare R2 (via S3 API), MinIO, and other S3-compatible services.
 
+<Aside type="caution" title="Install the AWS SDK first">
+	EmDash uses the AWS SDK at runtime for the S3 adapter but does not bundle it — core is
+	deliberately SDK-agnostic so R2-only and local-only deployments stay lean. Install the SDK
+	in your project before using `s3()`:
+
+    ```sh
+    pnpm add @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+    ```
+
+    If you skip this step, `astro build` will fail with `Rollup failed to resolve import
+    "@aws-sdk/client-s3"`. The R2 binding adapter (`r2()`) and local adapter do not need the
+    SDK and are unaffected.
+
+</Aside>
+
 ```js title="astro.config.mjs"
 import emdash, { s3 } from "emdash/astro";
 
@@ -114,14 +129,66 @@ export default defineConfig({
 
 ### Configuration
 
-| Option            | Type     | Description                    |
-| ----------------- | -------- | ------------------------------ |
-| `endpoint`        | `string` | S3 endpoint URL                |
-| `bucket`          | `string` | Bucket name                    |
-| `accessKeyId`     | `string` | Access key                     |
-| `secretAccessKey` | `string` | Secret key                     |
-| `region`          | `string` | Region (default: `"auto"`)     |
-| `publicUrl`       | `string` | Optional CDN or public URL     |
+| Option            | Type     | Required | Description                    |
+| ----------------- | -------- | -------- | ------------------------------ |
+| `endpoint`        | `string` | yes      | S3 endpoint URL                |
+| `bucket`          | `string` | yes      | Bucket name                    |
+| `accessKeyId`     | `string` | no\*     | Access key                     |
+| `secretAccessKey` | `string` | no\*     | Secret key                     |
+| `region`          | `string` | no       | Region (default: `"auto"`)     |
+| `publicUrl`       | `string` | no       | Optional CDN or public URL     |
+
+\* Both `accessKeyId` and `secretAccessKey` must be provided together, or both omitted.
+
+### Resolving S3 config from environment variables
+
+Any field omitted from `s3({...})` is read from the matching `S3_*` environment variable
+when the process starts. This lets you build a container image once and inject credentials
+at boot without a rebuild. Explicit values in `s3({...})` always take precedence over
+environment variables.
+
+| Environment variable   | Field             | Notes                              |
+| ---------------------- | ----------------- | ---------------------------------- |
+| `S3_ENDPOINT`          | `endpoint`        | Must be a valid `http`/`https` URL |
+| `S3_BUCKET`            | `bucket`          |                                    |
+| `S3_ACCESS_KEY_ID`     | `accessKeyId`     |                                    |
+| `S3_SECRET_ACCESS_KEY` | `secretAccessKey` |                                    |
+| `S3_REGION`            | `region`          | Defaults to `"auto"`               |
+| `S3_PUBLIC_URL`        | `publicUrl`       | Optional CDN prefix                |
+
+Environment variables are read from `process.env` when the process starts. This is a
+Node-only feature.
+
+```js title="astro.config.mjs — runtime environment variable example"
+import emdash, { s3 } from "emdash/astro";
+
+export default defineConfig({
+	integrations: [
+		emdash({
+			// s3() with no args: all fields from S3_* environment variables
+			storage: s3(),
+
+			// Or mix: override one field, rest from environment
+			// storage: s3({ publicUrl: "https://cdn.example.com" }),
+		}),
+	],
+});
+```
+
+<Aside type="note" title="Cloudflare Workers">
+	This runtime resolution does not work on Cloudflare Workers. Worker secrets and variables
+	are exposed through the `env` parameter of the fetch handler (or `import { env } from
+	"cloudflare:workers"`), not through `process.env` — even with the `nodejs_compat` flag
+	enabled. For Workers deployments:
+
+    - If you are using R2, use the [`r2()` adapter](#cloudflare-r2-binding) from
+      `@emdash-cms/cloudflare`. This is the recommended path.
+    - If you need a non-R2 S3-compatible backend on Workers, pass explicit values to
+      `s3({...})` in `astro.config.mjs`. Note that `astro.config.mjs` runs at build time,
+      so Worker secrets are not directly accessible there; you will need to inject values
+      through your build pipeline.
+
+</Aside>
 
 ### R2 via S3 API
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -72,7 +72,10 @@ storage: r2({
 	publicUrl: "https://pub-xxxx.r2.dev", // optional
 });
 
-// S3-compatible (any platform)
+// S3-compatible (any platform) — all fields from S3_* environment variables
+storage: s3()
+
+// Or with explicit values
 storage: s3({
 	endpoint: "https://s3.amazonaws.com",
 	bucket: "my-bucket",
@@ -387,28 +390,49 @@ r2({
 });
 ```
 
-### `s3(config)`
+### `s3(config?)`
 
-S3-compatible storage.
+S3-compatible storage. All config fields are optional: any field omitted from
+`s3({...})` is resolved from the matching `S3_*` environment variable when the
+Node process starts. Explicit values always take precedence.
 
-| Option            | Type     | Description                |
-| ----------------- | -------- | -------------------------- |
-| `endpoint`        | `string` | S3 endpoint URL            |
-| `bucket`          | `string` | Bucket name                |
-| `accessKeyId`     | `string` | Access key                 |
-| `secretAccessKey` | `string` | Secret key                 |
-| `region`          | `string` | Region (default: `"auto"`) |
-| `publicUrl`       | `string` | Optional CDN URL           |
+**Prerequisite:** install `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner`
+in your project. EmDash core does not bundle the AWS SDK. See
+[Storage Options → S3-Compatible Storage](/deployment/storage/#s3-compatible-storage)
+for details.
+
+| Option            | Type     | Description                         |
+| ----------------- | -------- | ----------------------------------- |
+| `endpoint`        | `string` | S3 endpoint URL (`S3_ENDPOINT`)     |
+| `bucket`          | `string` | Bucket name (`S3_BUCKET`)           |
+| `accessKeyId`     | `string` | Access key (`S3_ACCESS_KEY_ID`)     |
+| `secretAccessKey` | `string` | Secret key (`S3_SECRET_ACCESS_KEY`) |
+| `region`          | `string` | Region, default `"auto"` (`S3_REGION`) |
+| `publicUrl`       | `string` | Optional CDN URL (`S3_PUBLIC_URL`)  |
 
 ```js
+// All fields from S3_* environment variables (Node container deployments)
+s3()
+
+// Mix: CDN from config, rest from environment
+s3({ publicUrl: "https://cdn.example.com" })
+
+// All explicit (unchanged from before)
 s3({
 	endpoint: "https://xxx.r2.cloudflarestorage.com",
 	bucket: "media",
 	accessKeyId: process.env.R2_ACCESS_KEY_ID,
 	secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
 	publicUrl: "https://cdn.example.com",
-});
+})
 ```
+
+Runtime environment variable resolution is a Node-only feature. On Cloudflare
+Workers, secrets and variables are exposed through the `env` parameter of the
+fetch handler, not through `process.env`, so `S3_*` environment variables are
+not picked up. Workers deployments should either use the [`r2(config)`](#r2config)
+adapter or pass explicit values to `s3({...})`. See
+[Storage Options](/deployment/storage/#s3-compatible-storage) for details.
 
 ## Live Collections
 

--- a/packages/core/src/astro/storage/adapters.ts
+++ b/packages/core/src/astro/storage/adapters.ts
@@ -32,20 +32,34 @@ import type { StorageDescriptor, S3StorageConfig, LocalStorageConfig } from "./t
 /**
  * S3-compatible storage adapter
  *
- * Works with AWS S3, Cloudflare R2 (via S3 API), Minio, etc.
+ * Works with AWS S3, Cloudflare R2 (via S3 API), MinIO, etc.
+ *
+ * Any field omitted here is resolved from the matching `S3_*` environment
+ * variable when the container starts (`S3_ENDPOINT`, `S3_BUCKET`,
+ * `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_REGION`, `S3_PUBLIC_URL`).
+ * Explicit values always take precedence over env vars.
+ *
+ * Note: env var resolution reads `process.env` on Node at runtime.
+ * Workers users should continue passing explicit values to `s3({...})`.
  *
  * @example
  * ```ts
+ * // All fields from env (container deployments)
+ * storage: s3()
+ *
+ * // Mix: CDN from config, credentials from env
+ * storage: s3({ publicUrl: "https://cdn.example.com" })
+ *
+ * // All explicit (unchanged from before)
  * storage: s3({
  *   endpoint: "https://xxx.r2.cloudflarestorage.com",
  *   bucket: "media",
- *   accessKeyId: process.env.R2_ACCESS_KEY_ID!,
- *   secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
- *   publicUrl: "https://cdn.example.com", // optional CDN
+ *   accessKeyId: process.env.R2_ACCESS_KEY_ID,
+ *   secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
  * })
  * ```
  */
-export function s3(config: S3StorageConfig): StorageDescriptor {
+export function s3(config: Partial<S3StorageConfig> = {}): StorageDescriptor {
 	return {
 		entrypoint: "emdash/storage/s3",
 		config,

--- a/packages/core/src/astro/storage/types.ts
+++ b/packages/core/src/astro/storage/types.ts
@@ -39,10 +39,18 @@ export interface S3StorageConfig {
 	endpoint: string;
 	/** Bucket name */
 	bucket: string;
-	/** Access key ID */
-	accessKeyId: string;
-	/** Secret access key */
-	secretAccessKey: string;
+	/**
+	 * Access key ID.
+	 * May be resolved from the `S3_ACCESS_KEY_ID` env var at runtime on Node.
+	 * Must be provided together with `secretAccessKey`, or both omitted.
+	 */
+	accessKeyId?: string;
+	/**
+	 * Secret access key.
+	 * May be resolved from the `S3_SECRET_ACCESS_KEY` env var at runtime on Node.
+	 * Must be provided together with `accessKeyId`, or both omitted.
+	 */
+	secretAccessKey?: string;
 	/** Optional region (defaults to "auto") */
 	region?: string;
 	/** Optional public URL prefix for CDN */

--- a/packages/core/src/storage/s3.ts
+++ b/packages/core/src/storage/s3.ts
@@ -51,48 +51,40 @@ const s3ConfigSchema = z.object({
 	publicUrl: z.string().optional(),
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
 function isConfigKey(key: unknown): key is keyof S3StorageConfig {
 	return typeof key === "string" && key in ENV_KEYS;
 }
 
-/** Treat empty strings and undefined as absent so `S3_X=""` / `s3({ x: "" })` never mask config, and absent keys don't clobber env during merge. */
-function stripAbsent(raw: unknown): Record<string, unknown> {
-	if (!isRecord(raw)) return {};
-	const out: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(raw)) {
-		if (value === "" || value === undefined) continue;
-		out[key] = value;
-	}
-	return out;
-}
-
-function parseSource(raw: unknown, source: "env" | "explicit"): Partial<S3StorageConfig> {
-	const result = s3ConfigSchema.safeParse(stripAbsent(raw));
-	if (result.success) return result.data;
-	const issue = result.error.issues[0];
-	const pathKey = issue?.path[0];
-	if (!issue || !isConfigKey(pathKey)) fail("S3 config validation failed");
-	const label = source === "env" ? ENV_KEYS[pathKey] : `s3({ ${pathKey} })`;
-	fail(`${label} ${issue.message}`);
-}
-
-function readEnv(): Partial<S3StorageConfig> {
-	if (typeof process === "undefined" || !process.env) return {};
+/**
+ * Build the merged config: for each field, use the explicit value if present,
+ * otherwise fall back to the corresponding S3_* env var.  Validate once on the
+ * final merged result so a malformed env var never breaks the build when the
+ * caller provides that field explicitly.
+ */
+export function resolveS3Config(partial: Record<string, unknown>): S3StorageConfig {
 	const raw: Record<string, unknown> = {};
 	for (const [field, envKey] of Object.entries(ENV_KEYS)) {
-		raw[field] = process.env[envKey];
+		const explicit = partial[field];
+		if (explicit !== undefined && explicit !== "") {
+			raw[field] = explicit;
+			continue;
+		}
+		const envVal = typeof process !== "undefined" && process.env ? process.env[envKey] : undefined;
+		if (envVal !== undefined && envVal !== "") {
+			raw[field] = envVal;
+		}
 	}
-	return parseSource(raw, "env");
-}
 
-export function resolveS3Config(partial: Record<string, unknown>): S3StorageConfig {
-	const env = readEnv();
-	const explicit = parseSource(partial, "explicit");
-	const merged = { ...env, ...explicit };
+	const result = s3ConfigSchema.safeParse(raw);
+	if (!result.success) {
+		const issue = result.error.issues[0];
+		const pathKey = issue?.path[0];
+		if (!issue || !isConfigKey(pathKey)) fail("S3 config validation failed");
+		const fromExplicit = partial[pathKey] !== undefined && partial[pathKey] !== "";
+		const label = fromExplicit ? `s3({ ${pathKey} })` : ENV_KEYS[pathKey];
+		fail(`${label} ${issue.message}`);
+	}
+	const merged = result.data;
 
 	const endpoint = merged.endpoint;
 	const bucket = merged.bucket;
@@ -139,7 +131,6 @@ export class S3Storage implements Storage {
 		this.publicUrl = config.publicUrl;
 		this.endpoint = config.endpoint;
 
-		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- SDK type declares credentials as required but accepts omission at runtime when the caller provides credentials through an alternative mechanism
 		this.client = new S3Client({
 			endpoint: config.endpoint,
 			region: config.region || "auto",

--- a/packages/core/src/storage/s3.ts
+++ b/packages/core/src/storage/s3.ts
@@ -15,6 +15,7 @@ import {
 	type ListObjectsV2Response,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { z } from "zod";
 
 import type {
 	Storage,
@@ -27,6 +28,95 @@ import type {
 	SignedUploadOptions,
 } from "./types.js";
 import { EmDashStorageError } from "./types.js";
+
+const ENV_KEYS = {
+	endpoint: "S3_ENDPOINT",
+	bucket: "S3_BUCKET",
+	accessKeyId: "S3_ACCESS_KEY_ID",
+	secretAccessKey: "S3_SECRET_ACCESS_KEY",
+	region: "S3_REGION",
+	publicUrl: "S3_PUBLIC_URL",
+} as const satisfies Record<keyof S3StorageConfig, string>;
+
+function fail(msg: string): never {
+	throw new EmDashStorageError(msg, "MISSING_S3_CONFIG");
+}
+
+const s3ConfigSchema = z.object({
+	endpoint: z.url({ protocol: /^https?$/, error: "is not a valid http/https URL" }).optional(),
+	bucket: z.string().optional(),
+	accessKeyId: z.string().optional(),
+	secretAccessKey: z.string().optional(),
+	region: z.string().optional(),
+	publicUrl: z.string().optional(),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isConfigKey(key: unknown): key is keyof S3StorageConfig {
+	return typeof key === "string" && key in ENV_KEYS;
+}
+
+/** Treat empty strings and undefined as absent so `S3_X=""` / `s3({ x: "" })` never mask config, and absent keys don't clobber env during merge. */
+function stripAbsent(raw: unknown): Record<string, unknown> {
+	if (!isRecord(raw)) return {};
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(raw)) {
+		if (value === "" || value === undefined) continue;
+		out[key] = value;
+	}
+	return out;
+}
+
+function parseSource(raw: unknown, source: "env" | "explicit"): Partial<S3StorageConfig> {
+	const result = s3ConfigSchema.safeParse(stripAbsent(raw));
+	if (result.success) return result.data;
+	const issue = result.error.issues[0];
+	const pathKey = issue?.path[0];
+	if (!issue || !isConfigKey(pathKey)) fail("S3 config validation failed");
+	const label = source === "env" ? ENV_KEYS[pathKey] : `s3({ ${pathKey} })`;
+	fail(`${label} ${issue.message}`);
+}
+
+function readEnv(): Partial<S3StorageConfig> {
+	if (typeof process === "undefined" || !process.env) return {};
+	const raw: Record<string, unknown> = {};
+	for (const [field, envKey] of Object.entries(ENV_KEYS)) {
+		raw[field] = process.env[envKey];
+	}
+	return parseSource(raw, "env");
+}
+
+export function resolveS3Config(partial: Record<string, unknown>): S3StorageConfig {
+	const env = readEnv();
+	const explicit = parseSource(partial, "explicit");
+	const merged = { ...env, ...explicit };
+
+	const endpoint = merged.endpoint;
+	const bucket = merged.bucket;
+	if (!endpoint || !bucket) {
+		const missing: string[] = [];
+		if (!endpoint) missing.push(`endpoint: set ${ENV_KEYS.endpoint} or pass endpoint to s3({...})`);
+		if (!bucket) missing.push(`bucket: set ${ENV_KEYS.bucket} or pass bucket to s3({...})`);
+		fail(`missing required S3 config: ${missing.join("; ")}`);
+	}
+	const accessKeyId = merged.accessKeyId;
+	const secretAccessKey = merged.secretAccessKey;
+	if (accessKeyId && !secretAccessKey) {
+		fail(
+			`S3 credentials incomplete: accessKeyId is set but secretAccessKey is missing (set ${ENV_KEYS.secretAccessKey} or pass secretAccessKey to s3({...}))`,
+		);
+	}
+	if (secretAccessKey && !accessKeyId) {
+		fail(
+			`S3 credentials incomplete: secretAccessKey is set but accessKeyId is missing (set ${ENV_KEYS.accessKeyId} or pass accessKeyId to s3({...}))`,
+		);
+	}
+
+	return { ...merged, endpoint, bucket };
+}
 
 const TRAILING_SLASH_PATTERN = /\/$/;
 
@@ -49,16 +139,21 @@ export class S3Storage implements Storage {
 		this.publicUrl = config.publicUrl;
 		this.endpoint = config.endpoint;
 
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- SDK type declares credentials as required but accepts omission at runtime when the caller provides credentials through an alternative mechanism
 		this.client = new S3Client({
 			endpoint: config.endpoint,
 			region: config.region || "auto",
-			credentials: {
-				accessKeyId: config.accessKeyId,
-				secretAccessKey: config.secretAccessKey,
-			},
+			...(config.accessKeyId && config.secretAccessKey
+				? {
+						credentials: {
+							accessKeyId: config.accessKeyId,
+							secretAccessKey: config.secretAccessKey,
+						},
+					}
+				: {}),
 			// Required for R2 and some S3-compatible services
 			forcePathStyle: true,
-		});
+		} as ConstructorParameters<typeof S3Client>[0]);
 	}
 
 	async upload(options: {
@@ -238,26 +333,9 @@ export class S3Storage implements Storage {
 
 /**
  * Create S3 storage adapter
- * This is the factory function called at runtime
+ * This is the factory function called at runtime.
+ * Config fields are merged with S3_* env vars; env vars fill in any missing fields.
  */
 export function createStorage(config: Record<string, unknown>): Storage {
-	const { endpoint, bucket, accessKeyId, secretAccessKey, region, publicUrl } = config;
-	if (
-		typeof endpoint !== "string" ||
-		typeof bucket !== "string" ||
-		typeof accessKeyId !== "string" ||
-		typeof secretAccessKey !== "string"
-	) {
-		throw new Error(
-			"S3Storage requires 'endpoint', 'bucket', 'accessKeyId', and 'secretAccessKey' string config values",
-		);
-	}
-	return new S3Storage({
-		endpoint,
-		bucket,
-		accessKeyId,
-		secretAccessKey,
-		region: typeof region === "string" ? region : undefined,
-		publicUrl: typeof publicUrl === "string" ? publicUrl : undefined,
-	});
+	return new S3Storage(resolveS3Config(config));
 }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -13,11 +13,19 @@ export interface S3StorageConfig {
 	endpoint: string;
 	/** Bucket name */
 	bucket: string;
-	/** AWS access key ID */
-	accessKeyId: string;
-	/** AWS secret access key */
-	secretAccessKey: string;
-	/** Optional region (defaults to "auto" for R2) */
+	/**
+	 * AWS access key ID.
+	 * May be resolved from the `S3_ACCESS_KEY_ID` env var at runtime on Node.
+	 * Must be provided together with `secretAccessKey`, or both omitted.
+	 */
+	accessKeyId?: string;
+	/**
+	 * AWS secret access key.
+	 * May be resolved from the `S3_SECRET_ACCESS_KEY` env var at runtime on Node.
+	 * Must be provided together with `accessKeyId`, or both omitted.
+	 */
+	secretAccessKey?: string;
+	/** Optional region (defaults to "auto") */
 	region?: string;
 	/** Optional public URL prefix for generated URLs (e.g., CDN URL) */
 	publicUrl?: string;

--- a/packages/core/tests/unit/storage/s3.test.ts
+++ b/packages/core/tests/unit/storage/s3.test.ts
@@ -1,10 +1,4 @@
-/**
- * Tests for resolveS3Config (packages/core/src/storage/s3.ts)
- *
- * TDD: written before the implementation file exists.
- */
-
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // The AWS SDK is a "bring-your-own" dependency of emdash core — it is NOT
 // installed in CI. Stub it here so loading s3.ts (which statically imports
@@ -32,7 +26,7 @@ vi.mock("@aws-sdk/s3-request-presigner", () => ({
 	getSignedUrl: () => Promise.resolve("https://signed.example.com/fake"),
 }));
 
-import { resolveS3Config, createStorage } from "../../../src/storage/s3.js";
+import { createStorage, resolveS3Config } from "../../../src/storage/s3.js";
 import { EmDashStorageError } from "../../../src/storage/types.js";
 
 const FULL_ENV = {
@@ -192,13 +186,10 @@ describe("resolveS3Config", () => {
 			expect(() => resolveS3Config({ endpoint: "not-a-url" })).toThrow("s3({ endpoint })");
 		});
 
-		it("invalid S3_ENDPOINT throws even when explicit endpoint is also provided", () => {
-			// Decision (a): invalid env values are surfaced eagerly. Removing the
-			// explicit override later must not silently activate a broken env value.
+		it("malformed S3_ENDPOINT is ignored when explicit endpoint is provided", () => {
 			setEnv({ ...FULL_ENV, S3_ENDPOINT: "not-a-url" });
-			expect(() => resolveS3Config({ endpoint: "https://explicit.example.com" })).toThrow(
-				"S3_ENDPOINT",
-			);
+			const r = resolveS3Config({ endpoint: "https://explicit.example.com" });
+			expect(r.endpoint).toBe("https://explicit.example.com");
 		});
 	});
 

--- a/packages/core/tests/unit/storage/s3.test.ts
+++ b/packages/core/tests/unit/storage/s3.test.ts
@@ -6,6 +6,32 @@
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 
+// The AWS SDK is a "bring-your-own" dependency of emdash core — it is NOT
+// installed in CI. Stub it here so loading s3.ts (which statically imports
+// both modules) does not require the real package.
+vi.mock("@aws-sdk/client-s3", () => {
+	class S3Client {
+		send(_command: unknown): Promise<unknown> {
+			return Promise.resolve({});
+		}
+	}
+	class Command {
+		constructor(public input: unknown) {}
+	}
+	return {
+		S3Client,
+		PutObjectCommand: Command,
+		GetObjectCommand: Command,
+		DeleteObjectCommand: Command,
+		HeadObjectCommand: Command,
+		ListObjectsV2Command: Command,
+	};
+});
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+	getSignedUrl: () => Promise.resolve("https://signed.example.com/fake"),
+}));
+
 import { resolveS3Config, createStorage } from "../../../src/storage/s3.js";
 import { EmDashStorageError } from "../../../src/storage/types.js";
 

--- a/packages/core/tests/unit/storage/s3.test.ts
+++ b/packages/core/tests/unit/storage/s3.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for resolveS3Config (packages/core/src/storage/s3.ts)
+ *
+ * TDD: written before the implementation file exists.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { resolveS3Config, createStorage } from "../../../src/storage/s3.js";
+import { EmDashStorageError } from "../../../src/storage/types.js";
+
+const FULL_ENV = {
+	S3_ENDPOINT: "https://bucket.s3.example.com",
+	S3_BUCKET: "my-bucket",
+	S3_ACCESS_KEY_ID: "env-key",
+	S3_SECRET_ACCESS_KEY: "env-secret",
+	S3_REGION: "us-east-1",
+	S3_PUBLIC_URL: "https://cdn.example.com",
+};
+
+function setEnv(vars: Record<string, string | undefined>): void {
+	for (const [key, value] of Object.entries(vars)) {
+		if (value === undefined) vi.stubEnv(key, "");
+		else vi.stubEnv(key, value);
+	}
+}
+
+function runWithoutProcess(fn: () => void): void {
+	const saved = globalThis.process;
+	try {
+		// @ts-expect-error -- simulating Workers environment for test
+		delete globalThis.process;
+		fn();
+	} finally {
+		globalThis.process = saved;
+	}
+}
+
+function catchError(fn: () => unknown): unknown {
+	try {
+		fn();
+	} catch (e) {
+		return e;
+	}
+}
+
+describe("resolveS3Config", () => {
+	afterEach(() => vi.unstubAllEnvs());
+
+	describe("precedence", () => {
+		it.each([
+			["endpoint", "S3_ENDPOINT", "https://explicit.example.com", "https://env.example.com"],
+			["bucket", "S3_BUCKET", "explicit-bucket", "env-bucket"],
+			["region", "S3_REGION", "us-east-1", "eu-west-1"],
+			["publicUrl", "S3_PUBLIC_URL", "https://explicit.cdn", "https://env.cdn"],
+		] as const)("explicit %s wins over %s env var", (field, envKey, explicitValue, envValue) => {
+			setEnv({ ...FULL_ENV, [envKey]: envValue });
+			const cfg = resolveS3Config({ [field]: explicitValue });
+			expect(cfg[field]).toBe(explicitValue);
+		});
+
+		it("explicit credentials win over env credentials", () => {
+			setEnv(FULL_ENV);
+			const r = resolveS3Config({
+				accessKeyId: "explicit-key",
+				secretAccessKey: "explicit-secret",
+			});
+			expect(r.accessKeyId).toBe("explicit-key");
+			expect(r.secretAccessKey).toBe("explicit-secret");
+		});
+
+		it("env fills in missing fields from partial explicit config", () => {
+			setEnv(FULL_ENV);
+			const r = resolveS3Config({ region: "ap-southeast-1" });
+			expect(r.endpoint).toBe(FULL_ENV.S3_ENDPOINT);
+			expect(r.bucket).toBe(FULL_ENV.S3_BUCKET);
+			expect(r.region).toBe("ap-southeast-1");
+		});
+
+		it("s3() with full env resolves entirely from env", () => {
+			setEnv(FULL_ENV);
+			const r = resolveS3Config({});
+			expect(r.endpoint).toBe(FULL_ENV.S3_ENDPOINT);
+			expect(r.bucket).toBe(FULL_ENV.S3_BUCKET);
+			expect(r.accessKeyId).toBe(FULL_ENV.S3_ACCESS_KEY_ID);
+			expect(r.secretAccessKey).toBe(FULL_ENV.S3_SECRET_ACCESS_KEY);
+			expect(r.region).toBe(FULL_ENV.S3_REGION);
+			expect(r.publicUrl).toBe(FULL_ENV.S3_PUBLIC_URL);
+		});
+	});
+
+	describe("empty string coercion", () => {
+		it("s3({ endpoint: '' }) falls through to env", () => {
+			setEnv(FULL_ENV);
+			expect(resolveS3Config({ endpoint: "" }).endpoint).toBe(FULL_ENV.S3_ENDPOINT);
+		});
+
+		it("S3_ENDPOINT='' with explicit endpoint: explicit wins", () => {
+			setEnv({ ...FULL_ENV, S3_ENDPOINT: "" });
+			expect(resolveS3Config({ endpoint: "https://explicit.example.com" }).endpoint).toBe(
+				"https://explicit.example.com",
+			);
+		});
+
+		it("both empty: throws missing-field error", () => {
+			setEnv({ S3_ENDPOINT: "", S3_BUCKET: FULL_ENV.S3_BUCKET });
+			expect(() => resolveS3Config({ endpoint: "" })).toThrow(EmDashStorageError);
+		});
+	});
+
+	describe("required fields", () => {
+		it.each([
+			[
+				"endpoint",
+				"S3_ENDPOINT",
+				{ S3_BUCKET: FULL_ENV.S3_BUCKET, S3_ACCESS_KEY_ID: "k", S3_SECRET_ACCESS_KEY: "s" },
+			],
+			[
+				"bucket",
+				"S3_BUCKET",
+				{ S3_ENDPOINT: FULL_ENV.S3_ENDPOINT, S3_ACCESS_KEY_ID: "k", S3_SECRET_ACCESS_KEY: "s" },
+			],
+		] as const)("missing %s throws with %s in the message", (_field, envKey, env) => {
+			setEnv(env);
+			expect(() => resolveS3Config({})).toThrow(envKey);
+		});
+
+		it("missing both: one error lists both fields", () => {
+			setEnv({
+				S3_ENDPOINT: undefined,
+				S3_BUCKET: undefined,
+				S3_ACCESS_KEY_ID: undefined,
+				S3_SECRET_ACCESS_KEY: undefined,
+				S3_REGION: undefined,
+				S3_PUBLIC_URL: undefined,
+			});
+			const err = catchError(() => resolveS3Config({}));
+			expect(err).toBeInstanceOf(EmDashStorageError);
+			const msg = (err as Error).message;
+			expect(msg).toContain("S3_ENDPOINT");
+			expect(msg).toContain("S3_BUCKET");
+		});
+	});
+
+	describe("endpoint URL validation", () => {
+		it("accepts https:// URLs", () => {
+			setEnv({ ...FULL_ENV, S3_ENDPOINT: "https://x.example.com" });
+			expect(resolveS3Config({}).endpoint).toBe("https://x.example.com");
+		});
+
+		it("accepts http://localhost for dev (MinIO)", () => {
+			setEnv({ ...FULL_ENV, S3_ENDPOINT: "http://localhost:9000" });
+			expect(resolveS3Config({}).endpoint).toBe("http://localhost:9000");
+		});
+
+		it.each(["ftp://x.example.com", "not-a-url", "https://"])(
+			"rejects invalid env endpoint %s: names S3_ENDPOINT as source",
+			(invalidUrl) => {
+				setEnv({ ...FULL_ENV, S3_ENDPOINT: invalidUrl });
+				expect(() => resolveS3Config({})).toThrow("S3_ENDPOINT");
+			},
+		);
+
+		it("rejects non-URL from explicit: names s3({ endpoint }) as source", () => {
+			setEnv(FULL_ENV);
+			expect(() => resolveS3Config({ endpoint: "not-a-url" })).toThrow("s3({ endpoint })");
+		});
+
+		it("invalid S3_ENDPOINT throws even when explicit endpoint is also provided", () => {
+			// Decision (a): invalid env values are surfaced eagerly. Removing the
+			// explicit override later must not silently activate a broken env value.
+			setEnv({ ...FULL_ENV, S3_ENDPOINT: "not-a-url" });
+			expect(() => resolveS3Config({ endpoint: "https://explicit.example.com" })).toThrow(
+				"S3_ENDPOINT",
+			);
+		});
+	});
+
+	describe("credential pairing", () => {
+		it("neither credential provided: resolves without them", () => {
+			setEnv({ S3_ENDPOINT: FULL_ENV.S3_ENDPOINT, S3_BUCKET: FULL_ENV.S3_BUCKET });
+			const r = resolveS3Config({});
+			expect(r.accessKeyId).toBeUndefined();
+			expect(r.secretAccessKey).toBeUndefined();
+		});
+
+		it("only accessKeyId provided: error names the missing secretAccessKey", () => {
+			setEnv({ ...FULL_ENV, S3_SECRET_ACCESS_KEY: undefined });
+			const err = catchError(() => resolveS3Config({ accessKeyId: "only-key" }));
+			expect(err).toBeInstanceOf(EmDashStorageError);
+			const msg = (err as Error).message;
+			expect(msg).toContain("secretAccessKey");
+			expect(msg).toContain("S3_SECRET_ACCESS_KEY");
+		});
+
+		it("only secretAccessKey provided: error names the missing accessKeyId", () => {
+			setEnv({ ...FULL_ENV, S3_ACCESS_KEY_ID: undefined });
+			const err = catchError(() => resolveS3Config({ secretAccessKey: "only-secret" }));
+			expect(err).toBeInstanceOf(EmDashStorageError);
+			const msg = (err as Error).message;
+			expect(msg).toContain("accessKeyId");
+			expect(msg).toContain("S3_ACCESS_KEY_ID");
+		});
+	});
+
+	describe("Workers guard (typeof process === 'undefined')", () => {
+		it("process undefined with explicit config: resolveS3Config succeeds", () => {
+			runWithoutProcess(() => {
+				const r = resolveS3Config({
+					endpoint: "https://x.example.com",
+					bucket: "b",
+					accessKeyId: "k",
+					secretAccessKey: "s",
+				});
+				expect(r.endpoint).toBe("https://x.example.com");
+			});
+		});
+
+		it("process undefined, no explicit config: throws missing-field error", () => {
+			runWithoutProcess(() => {
+				expect(() => resolveS3Config({})).toThrow(EmDashStorageError);
+			});
+		});
+	});
+
+	describe("round-trip", () => {
+		it("createStorage({}) with full S3_* env returns a storage instance", () => {
+			setEnv(FULL_ENV);
+			const storage = createStorage({});
+			expect(typeof storage.upload).toBe("function");
+			expect(typeof storage.getPublicUrl).toBe("function");
+		});
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`astro.config.mjs` runs at Astro build time, so values passed to `s3({...})` get baked into the virtual `emdash/config` module. That blocks the "build the image once, inject credentials at boot" pattern.

This PR resolves any field omitted from `s3({...})` from the matching `S3_*` env var at runtime (Node only). Existing deployments passing explicit values are unaffected,  explicit always wins. `s3()` with no args is now valid for fully env-driven configs.

Precedence: explicit `s3({...})` > `S3_*` env var > absent. Empty strings are treated as absent in both sources. Endpoint values are validated at both sources with the source named in the error (`S3_ENDPOINT is not a valid http/https URL` vs `s3({ endpoint }) is not a valid http/https URL`). 

Scope is Node; Workers binding resolution is out of scope and documented as such.

```js
// astro.config.mjs
storage: s3(),                                    // all fields from S3_* env
storage: s3({ publicUrl: "https://cdn.ex.com" }), // mix
storage: s3({ endpoint, bucket, accessKeyId, secretAccessKey }), // unchanged
```

Docs updated in `storage.mdx` / `configuration.mdx`, including a **prerequisite note** that users must install `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner` themselves since core deliberately does not bundle the SDK (the ambient `packages/core/src/aws-sdk.d.ts` establishes the "bring-your-own-SDK" contract but was previously undocumented). 

26 new unit tests cover precedence, empty-string coercion, URL validation, credential pairing, and the Workers `typeof process` guard.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)


## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json`  0 diagnostics in files touched by this PR (3 pre-existing warnings in unrelated files left alone per scope rules)
- [x] `pnpm test` passes (2280 / 2280)
- [x] `pnpm format` has been run
- [x] Tests added (26 in `tests/unit/storage/s3.test.ts`)
- [x] Changeset added (`.changeset/feat-s3-runtime-env-fallback.md`, `minor`)
- [x] New features link to an approved Discussion https://github.com/emdash-cms/emdash/discussions/459

## AI-generated code disclosure

- [x] This PR includes AI-generated code
