### PR TITLE
fix(plugins): expose slug and status on ContentItem

### DIFF
--- a/.changeset/plugin-content-item-slug.md
+++ b/.changeset/plugin-content-item-slug.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds `slug` and `status` to `ContentItem` in the plugin content API. `ctx.content.get()` / `ctx.content.list()` now surface these fields so plugins can match content items by slug and filter by publication status without re-querying the database.

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -162,6 +162,8 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 			return {
 				id: item.id,
 				type: item.type,
+				slug: item.slug,
+				status: item.status,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
@@ -192,6 +194,8 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 				items: result.items.map((item) => ({
 					id: item.id,
 					type: item.type,
+					slug: item.slug,
+					status: item.status,
 					data: item.data,
 					createdAt: item.createdAt,
 					updatedAt: item.updatedAt,
@@ -222,6 +226,8 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 			return {
 				id: item.id,
 				type: item.type,
+				slug: item.slug,
+				status: item.status,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
@@ -238,6 +244,8 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 			return {
 				id: item.id,
 				type: item.type,
+				slug: item.slug,
+				status: item.status,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -167,6 +167,16 @@ export interface KVAccess {
 export interface ContentItem {
 	id: string;
 	type: string;
+	/**
+	 * Human-readable slug, unique per collection. `null` when the item has
+	 * no slug yet (e.g. a freshly created draft before the first save).
+	 */
+	slug: string | null;
+	/**
+	 * Publication status of the item (`draft`, `published`, etc.). Mirrors
+	 * the top-level `status` column on the content row.
+	 */
+	status: string;
 	data: Record<string, unknown>;
 	createdAt: string;
 	updatedAt: string;

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -121,12 +121,30 @@ describe("Capability Enforcement Integration (v2)", () => {
 				expect(post!.data.title).toBe("Hello World");
 			});
 
+			it("exposes slug and status on items returned from get()", async () => {
+				const access = createContentAccess(db);
+				const post = await access.get("posts", "post-1");
+
+				expect(post).not.toBeNull();
+				expect(post!.slug).toBe("hello-world");
+				expect(post!.status).toBe("published");
+			});
+
 			it("can list content", async () => {
 				const access = createContentAccess(db);
 				const result = await access.list("posts");
 
 				expect(result.items).toHaveLength(2);
 				expect(result.hasMore).toBe(false);
+			});
+
+			it("exposes slug and status on items returned from list()", async () => {
+				const access = createContentAccess(db);
+				const result = await access.list("posts", { orderBy: { slug: "asc" } });
+
+				const bySlug = new Map(result.items.map((item) => [item.slug, item]));
+				expect(bySlug.get("hello-world")?.status).toBe("published");
+				expect(bySlug.get("second-post")?.status).toBe("draft");
 			});
 
 			it("returns null for non-existent content", async () => {
@@ -162,6 +180,8 @@ describe("Capability Enforcement Integration (v2)", () => {
 
 				expect(created.id).toBeDefined();
 				expect(created.data.title).toBe("New Post");
+				expect(created).toHaveProperty("slug");
+				expect(created).toHaveProperty("status");
 
 				// Verify it was created
 				const found = await access.get("posts", created.id);


### PR DESCRIPTION
## What does this PR do?

The plugin content API (`ctx.content.get()` / `ctx.content.list()`) returned `ContentItem` without the `slug` or `status` fields, even though the underlying row has both and the REST API already surfaces them at the top level. This made it surprisingly painful to match external data to EmDash content by slug — migration plugins, SEO plugins, and WXR importers had to fall back to fragile title matching.

This PR adds `slug` (nullable — a freshly created draft may not have one yet) and `status` to `ContentItem`, and populates them in both the read-only and read/write content access adapters in `packages/core/src/plugins/context.ts`. The data was already on the repository-level `ContentItem`; the plugin adapter was just dropping it on the floor.

Closes #373

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0 new diagnostics (only the pre-existing `packages/admin/src/router.tsx` warning remains, unrelated to this change)
- [x] `pnpm test` passes (targeted: `packages/core` capabilities integration suite — 54 tests pass, including the new cases covering slug/status on `get()`, `list()`, and `create()`)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _(N/A — bug fix)_

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

 ✓ tests/integration/plugins/capabilities.test.ts (54 tests) 2660ms

 Test Files  1 passed (1)
      Tests  54 passed (54)

New test cases added:

- exposes `slug` and `status` on items returned from `get()`
- exposes `slug` and `status` on items returned from `list()`
- extended `can create new content` to assert `slug` and `status` are present on the created item