### PR TITLE
fix: replace code block with section in webhook notifier payload preview

### DIFF
--- a/.changeset/funny-nails-wave.md
+++ b/.changeset/funny-nails-wave.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-webhook-notifier": patch
+---
+
+fix: replace code block with section in webhook notifier payload preview

--- a/packages/plugins/webhook-notifier/src/sandbox-entry.ts
+++ b/packages/plugins/webhook-notifier/src/sandbox-entry.ts
@@ -507,7 +507,7 @@ async function buildSettingsPage(ctx: PluginContext) {
 				},
 				{ type: "divider" },
 				{ type: "section", text: "**Payload Preview**" },
-				{ type: "code", code: payloadPreview, language: "json" },
+				{ type: "section", text: "```json\n" + payloadPreview + "\n```" },
 				{
 					type: "actions",
 					elements: [


### PR DESCRIPTION
## What does this PR do?

  The webhook notifier settings page was crashing in the admin UI when opened. The error was:

  > TypeError: Cannot read properties of undefined (reading 'classes')

This happened because the settings page used a `{ type: "code", language: "json" }` block to render the payload preview. This triggered the admin renderer's syntax highlighter, which crashed when it could not find the JSON language definition.

  Fixed by replacing the `type: "code"` block with a `type: "section"` block that renders the payload preview as plain fenced markdown text — no syntax highlighter involved.

  **Issue:** https://github.com/emdash-cms/emdash/issues/440

  **To reproduce:**
  1. Register `webhookNotifierPlugin()` in `astro.config.mjs`
  2. Open admin panel → click **Webhook Notifier** in the sidebar
  3. Page crashes with `TypeError: Cannot read properties of undefined (reading 'classes')`

  **To verify the fix:**
  1. Apply this PR and rebuild: `pnpm --filter @emdash-cms/plugin-webhook-notifier build`
  2. Open admin panel → Webhook Notifier settings page
  3. Page loads normally, payload preview is visible, no console errors

  Closes #440

  ## Type of change

  - [x] Bug fix
  - [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
  - [ ] Refactor (no behavior change)
  - [ ] Documentation
  - [ ] Performance improvement
  - [ ] Tests
  - [ ] Chore (dependencies, CI, tooling)

  ## Checklist

  - [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
  - [x] `pnpm typecheck` passes
  - [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
  - [x] `pnpm test` passes (or targeted tests for my change)
  - [x] `pnpm format` has been run
  - [ ] I have added/updated tests for my changes (if applicable)
  - [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

  ## AI-generated code disclosure

  - [x] This PR includes AI-generated code

  ## Screenshots / test output

  **Before:** Page crashes with `TypeError: Cannot read properties of undefined (reading 'classes')` and shows "Something went wrong".

  **After:** Webhook notifier settings page loads normally with the payload preview visible and zero console errors.