### PR TITLE
Fix locale switching in dev mode

### DIFF
--- a/.changeset/poor-clubs-design.md
+++ b/.changeset/poor-clubs-design.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes locale switching in dev mode by redirecting locale catalog imports to dist/

--- a/.changeset/poor-clubs-design.md
+++ b/.changeset/poor-clubs-design.md
@@ -1,5 +1,0 @@
----
-"emdash": patch
----
-
-Fixes locale switching in dev mode by redirecting locale catalog imports to dist/

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -50,6 +50,7 @@ import {
 	generateBlockComponentsModule,
 } from "./virtual-modules.js";
 
+const LOCALE_MESSAGES_RE = /[/\\]([a-z]{2}(?:-[A-Z]{2})?)[/\\]messages\.mjs$/;
 /**
  * Vite plugin that compiles Lingui macros in admin source files.
  * Only active in dev mode when the admin package is aliased to source for HMR.
@@ -64,6 +65,16 @@ function linguiMacroPlugin(adminSourcePath: string, adminDistPath: string): Plug
 	return {
 		name: "emdash-lingui-macro",
 		enforce: "pre",
+		resolveId(id, importer) {
+			// Redirect relative locale catalog imports (e.g. ./de/messages.mjs) from
+			// within admin source to the compiled dist/locales/ directory, since
+			// lingui compile only runs during build — not in dev watch mode.
+			if (!importer?.startsWith(adminSourcePath)) return;
+			const match = id.match(LOCALE_MESSAGES_RE);
+			if (match?.[1]) {
+				return resolve(adminDistPath, "locales", match[1], "messages.mjs");
+			}
+		},
 		async transform(code, id) {
 			if (!id.startsWith(adminSourcePath) || !code.includes("@lingui")) return;
 			const { transformAsync } = (await import(babelCorePath)) as typeof import("@babel/core");


### PR DESCRIPTION
## What does this PR do?

Fixes locale switching in dev mode when the admin package is aliased to source for HMR.

When running the dev server with source alias active, clicking on "Deutsch" in the locale switcher was failing because `lingui compile` only runs during build (not in dev watch mode), so compiled `.mjs` catalog files don't exist in `src/locales/<locale>/` — they only exist in `dist/locales/`.

This PR adds a `resolveId` hook to `linguiMacroPlugin` that redirects relative locale catalog imports (e.g. `./de/messages.mjs`) from within admin source to the compiled dist location.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0 (3 pre-existing warnings on main, unchanged)
- [x] `pnpm test` passes (1 unrelated marketplace test failure also present on main)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (dev-only fix, no changeset needed)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

**Before:** Clicking Deutsch triggers a console error and the import fails, reverting the cookie.

**After:** Locale switches successfully, UI re-renders with German strings.