### PR TITLE
fix: ContentListPage triggers React hook-order error #300 on fast navigation

### DIFF
--- a/.changeset/better-olives-shop.md
+++ b/.changeset/better-olives-shop.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+fix: move useMemo above early returns in ContentListPage

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -320,6 +320,10 @@ function ContentListPage() {
 		},
 	});
 
+	const items = React.useMemo(() => {
+		return data?.pages.flatMap((page) => page.items) || [];
+	}, [data]);
+
 	if (!manifest) {
 		return <LoadingScreen />;
 	}
@@ -342,10 +346,6 @@ function ContentListPage() {
 			search: { locale: locale || undefined },
 		});
 	};
-
-	const items = React.useMemo(() => {
-		return data?.pages.flatMap((page) => page.items) || [];
-	}, [data]);
 
 	return (
 		<ContentList


### PR DESCRIPTION
## What does this PR do?

  `ContentListPage` in `packages/admin/src/router.tsx` had a `React.useMemo()` hook called **after** three early returns:

  ```tsx
  if (!manifest) return <LoadingScreen />;
  if (!collectionConfig) return <NotFoundPage />;
  if (error) return <ErrorScreen />;

  const items = React.useMemo(...); // ← hook after early returns (wrong)
  ```

This violates React's Rules of Hooks — hooks must always be called in the same order on every render. When any of those early returns fired (e.g. during fast navigation while `manifest` is still loading), React executed fewer hooks than expected and crashed with:

  > Minified React error #300 — Rendered fewer hooks than expected

  Fixed by moving the `useMemo` call above all early returns so it is always executed on every render.

  **Issue:** https://github.com/emdash-cms/emdash/issues/439

  **To reproduce:**
  1. Open the admin panel → Posts page
  2. Navigate quickly between pages in the admin
  3. React error #300 appears: `Rendered fewer hooks than expected`

  **To verify the fix:**
  1. Apply this PR
  2. Navigate quickly between admin pages
  3. No React hook-order error occurs

  Closes #439

  ## Type of change

  - [x] Bug fix
  - [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
  - [ ] Refactor (no behavior change)
  - [ ] Documentation
  - [ ] Performance improvement
  - [ ] Tests
  - [ ] Chore (dependencies, CI, tooling)

  ## Checklist

  - [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
  - [x] `pnpm typecheck` passes
  - [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
  - [x] `pnpm test` passes (or targeted tests for my change)
  - [x] `pnpm format` has been run
  - [ ] I have added/updated tests for my changes (if applicable)
  - [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
  - [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

  ## AI-generated code disclosure

  - [x] This PR includes AI-generated code

  ## Screenshots / test output

  **Before:** React error #300 `Rendered fewer hooks than expected` during fast navigation on the Posts page.

  **After:** No hook-order error — `useMemo` is now always called before any early returns.