### PR TITLE
docs: add translation guide and i18n developer guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,9 @@ Closes #
 <!-- Check one. If "Feature", a prior Discussion is required — see below. -->
 
 - [ ] Bug fix
-- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
+- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
 - [ ] Refactor (no behavior change)
+- [ ] Translation
 - [ ] Documentation
 - [ ] Performance improvement
 - [ ] Tests
@@ -20,7 +21,7 @@ Closes #
 
 - [ ] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
 - [ ] `pnpm typecheck` passes
-- [ ] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
+- [ ] `pnpm lint` passes
 - [ ] `pnpm test` passes (or targeted tests for my change)
 - [ ] `pnpm format` has been run
 - [ ] I have added/updated tests for my changes (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@ Closes #
 - [ ] `pnpm test` passes (or targeted tests for my change)
 - [ ] `pnpm format` has been run
 - [ ] I have added/updated tests for my changes (if applicable)
+- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
 - [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
 - [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ This updates `packages/admin/src/locales/*/messages.po` with any new or changed 
 ### What to wrap
 
 - Button labels, headings, descriptions, error messages, placeholder text — anything a user reads.
-- Don't wrap: log messages, developer-facing errors, HTML attributes that aren't displayed (like `aria-label` on decorative elements), or strings that are the same in every language (brand names, URLs).
+- Don't wrap: log messages, developer-facing errors, HTML attributes that aren't user-visible, or strings that are the same in every language (brand names, URLs). Do wrap `aria-label` when it labels an interactive control, because screen readers announce it to users. For decorative elements, avoid `aria-label` and use `aria-hidden="true"` instead.
 
 For the full translation contributor guide, see [Translating EmDash](https://docs.emdashcms.com/contributing/translating/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,55 @@ Your site will use `workspace:*` links to the local packages, so any changes you
 4. Check authorization with `requirePerm()` on all state-changing routes.
 5. Register the route in `packages/core/src/astro/integration/routes.ts`.
 
+## Internationalization (i18n)
+
+The admin UI is translatable using [Lingui](https://lingui.dev). All user-visible strings in `packages/admin/src/` should be wrapped for translation.
+
+### Making strings translatable
+
+Use the `t` tagged template for plain strings and `<Trans>` for strings containing JSX:
+
+```tsx
+import { Trans, useLingui } from "@lingui/react/macro";
+
+function MyComponent() {
+	const { t } = useLingui();
+
+	return (
+		<div>
+			{/* Plain strings */}
+			<h1>{t`Settings`}</h1>
+			<label>{t`Email address`}</label>
+
+			{/* Strings with interpolation */}
+			<p>{t`Authentication error: ${error}`}</p>
+
+			{/* Strings containing JSX elements */}
+			<p>
+				<Trans>
+					Don't have an account? <a href="/signup">Sign up</a>
+				</Trans>
+			</p>
+		</div>
+	);
+}
+```
+
+After adding or changing translatable strings, run extraction to update the PO catalogs:
+
+```bash
+pnpm run locale:extract
+```
+
+This updates `packages/admin/src/locales/*/messages.po` with any new or changed strings. Commit the updated PO files alongside your code changes.
+
+### What to wrap
+
+- Button labels, headings, descriptions, error messages, placeholder text — anything a user reads.
+- Don't wrap: log messages, developer-facing errors, HTML attributes that aren't displayed (like `aria-label` on decorative elements), or strings that are the same in every language (brand names, URLs).
+
+For the full translation contributor guide, see [Translating EmDash](https://docs.emdashcms.com/contributing/translating/).
+
 ## Contribution Policy
 
 ### What we accept
@@ -193,6 +242,7 @@ Your site will use `workspace:*` links to the local packages, so any changes you
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | **Bug fixes**    | Open a PR directly. Include a failing test that reproduces the bug.                                                                  |
 | **Docs / typos** | Open a PR directly.                                                                                                                  |
+| **Translations** | Open a PR directly. See [Translating EmDash](https://docs.emdashcms.com/contributing/translating/).                                  |
 | **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) first. Wait for approval before writing code. |
 | **Refactors**    | Open a Discussion first. Refactors are opinionated and need alignment.                                                               |
 | **Performance**  | Open a Discussion first with benchmarks showing the improvement.                                                                     |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,15 +325,6 @@ When in doubt, run `pnpm changeset` and it will only show packages that aren't i
 - Ensure `pnpm typecheck` and `pnpm lint` pass before pushing.
 - Run relevant tests.
 
-## What's Intentionally Missing (For Now)
-
-These are known gaps — don't try to fix them unless specifically asked:
-
-- **Rate limiting** — no brute-force protection on auth endpoints
-- **Password auth** — passkeys + magic links + OAuth only, by design
-- **Plugin marketplace** — architecture exists, runtime installation is post-beta
-- **Real-time collaboration** — planned for v1
-
 ## Getting Help
 
 - Read `AGENTS.md` for architecture and code patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to EmDash
 
-> **Beta.** EmDash is published to npm. During development you work inside the monorepo -- packages use `workspace:*` links, so everything "just works" without publishing.
+> **Beta.** EmDash is published to npm. During development you work inside the monorepo — packages use `workspace:*` links, so everything "just works" without publishing.
 
 ## Prerequisites
 
@@ -11,26 +11,31 @@
 ## Quick Setup
 
 ```bash
-git clone <repo-url> && cd emdash
+git clone https://github.com/emdash-cms/emdash.git && cd emdash
 pnpm install
 pnpm build          # build all packages (required before first run)
 ```
 
 ### Run the Demo
 
-The `demos/simple/` app is the primary development target. It is kept in sync with `templates/blog/` and uses Node.js + SQLite — no Cloudflare account needed.
+The `demos/simple/` app is the primary development target. It uses Node.js + SQLite — no Cloudflare account needed.
 
 ```bash
-pnpm --filter emdash-demo seed   # seed sample content
 pnpm --filter emdash-demo dev    # http://localhost:4321
 ```
 
-Open the admin at `http://localhost:4321/_emdash/admin`.
+Open the admin at `http://localhost:4321/_emdash/admin`. The setup wizard runs automatically on first launch — it creates the database, runs migrations, and prompts you to create an admin account.
 
-In dev mode, passkey auth is bypassed automatically. If you hit the login screen, visit:
+In dev mode, you can skip passkey auth with the dev bypass:
 
 ```
 http://localhost:4321/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
+```
+
+To populate the demo with sample content:
+
+```bash
+pnpm --filter emdash-demo seed
 ```
 
 ### Run with Cloudflare (optional)
@@ -42,32 +47,11 @@ http://localhost:4321/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
 Templates in `templates/` are workspace members and can be run directly:
 
 ```bash
-# First time: set up database and seed content
-pnpm --filter @emdash-cms/template-portfolio bootstrap
-
-# Run the dev server
-pnpm --filter @emdash-cms/template-portfolio dev
+pnpm --filter @emdash-cms/template-portfolio bootstrap   # first time
+pnpm --filter @emdash-cms/template-portfolio dev          # run dev server
 ```
 
-Available templates:
-
-| Template  | Filter Name                      |
-| --------- | -------------------------------- |
-| Blog      | `@emdash-cms/template-blog`      |
-| Portfolio | `@emdash-cms/template-portfolio` |
-| Marketing | `@emdash-cms/template-marketing` |
-
-Edit files in `templates/{name}/src/` and changes hot reload.
-
-**Cloudflare variants** (`*-cloudflare`) share source with their base templates via `scripts/sync-cloudflare-templates.sh`. Run that script after editing base template shared files.
-
-Demo/template sync is handled by `scripts/sync-blog-demos.sh`:
-
-- Full sync: `templates/blog` -> `demos/simple`
-- Frontend sync (keep runtime-specific config/files):
-  - `templates/blog-cloudflare` -> `demos/cloudflare`
-  - `templates/blog-cloudflare` -> `demos/preview`
-  - `templates/blog` -> `demos/postgres`
+Available templates: `blog`, `portfolio`, `marketing`. Use `@emdash-cms/template-{name}` as the filter.
 
 To start fresh, delete the database and re-bootstrap:
 
@@ -75,6 +59,26 @@ To start fresh, delete the database and re-bootstrap:
 rm templates/portfolio/data.db
 pnpm --filter @emdash-cms/template-portfolio bootstrap
 ```
+
+## Repository Layout
+
+This is a pnpm monorepo. Here's what each directory is for:
+
+| Directory                 | What it is                                                                                    | When you'd work here           |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------ |
+| `packages/core/`          | The main `emdash` package — Astro integration, REST API, database, schema management, plugins | Most core development          |
+| `packages/admin/`         | React SPA for the admin UI (`@emdash-cms/admin`)                                              | Admin UI changes, translations |
+| `packages/auth/`          | Authentication — passkeys, OAuth, magic links (`@emdash-cms/auth`)                            | Auth flow changes              |
+| `packages/cloudflare/`    | Cloudflare Workers adapter + plugin sandbox (`@emdash-cms/cloudflare`)                        | Cloudflare-specific features   |
+| `packages/blocks/`        | Portable Text block definitions (`@emdash-cms/blocks`)                                        | Content block types            |
+| `packages/create-emdash/` | `create-emdash` CLI scaffolder                                                                | Project scaffolding            |
+| `packages/plugins/`       | First-party plugins (each subdirectory is a package)                                          | Plugin development             |
+| `demos/simple/`           | Primary dev/test app (Node.js + SQLite)                                                       | Running and testing locally    |
+| `demos/cloudflare/`       | Cloudflare Workers demo (D1)                                                                  | Testing on CF runtime          |
+| `templates/`              | Starter templates (blog, portfolio, marketing + CF variants)                                  | Template development           |
+| `docs/`                   | Documentation site (Starlight)                                                                | Docs changes                   |
+| `e2e/`                    | Playwright test fixtures                                                                      | E2E test infrastructure        |
+| `i18n/`                   | Translation status dashboard (Lunaria)                                                        | Translation tracking           |
 
 ## Development Workflow
 
@@ -97,11 +101,11 @@ Changes to `packages/core/src/` will be picked up by the demo's dev server autom
 Run these before committing:
 
 ```bash
-pnpm typecheck       # TypeScript (packages)
-pnpm typecheck:demos # TypeScript (Astro demos)
+pnpm typecheck             # TypeScript (packages)
+pnpm typecheck:demos       # TypeScript (Astro demos)
 pnpm --silent lint:quick   # fast lint (< 1s) — run often
 pnpm --silent lint:json    # full type-aware lint (~10s) — run before commits
-pnpm format          # auto-format with oxfmt
+pnpm format                # auto-format with oxfmt (tabs, not spaces)
 ```
 
 Type checking **must** pass. Lint **must** pass. Don't commit with known failures.
@@ -109,67 +113,34 @@ Type checking **must** pass. Lint **must** pass. Don't commit with known failure
 ### Tests
 
 ```bash
-pnpm test                              # all packages
+pnpm test                            # all packages
 pnpm --filter emdash test            # core only
 pnpm --filter emdash test --watch    # watch mode
-pnpm test:e2e                          # Playwright (requires demo running)
+pnpm test:e2e                        # Playwright (requires demo running)
 ```
 
 Tests use real in-memory SQLite — no mocking. Each test gets a fresh database.
 
-## Repository Layout
+### Building Your Own Site (Inside the Monorepo)
 
-```
-emdash/
-├── packages/
-│   ├── core/              # emdash — the main package (Astro integration + APIs + admin)
-│   ├── auth/              # @emdash-cms/auth — passkeys, OAuth, magic links
-│   ├── admin/             # @emdash-cms/admin — React admin SPA
-│   ├── cloudflare/        # @emdash-cms/cloudflare — CF adapter + plugin sandbox
-│   ├── create-emdash/   # create-emdash — project scaffolder
-│   ├── gutenberg-to-portable-text/  # WP block → Portable Text converter
-│   └── plugins/           # first-party plugins (each dir = package)
-├── demos/
-│   ├── simple/            # emdash-demo — primary dev/test app (Node.js + SQLite)
-│   ├── cloudflare/        # Cloudflare Workers demo (D1)
-│   ├── plugins-demo/      # plugin development testbed
-│   └── ...
-├── templates/             # starter templates (blog, portfolio, marketing + cloudflare variants)
-├── docs/                  # public documentation site (Starlight)
-└── e2e/                   # Playwright test fixtures
+Copy a template into `demos/`, give it a unique `name` in `package.json`, run `pnpm install`, and start developing:
+
+```bash
+cp -r templates/blog demos/my-site
+# edit demos/my-site/package.json to set a unique name
+pnpm install
+pnpm --filter my-site dev
 ```
 
-The main package is **`packages/core`**. Most of your work will happen there.
-
-## Building Your Own Site (Inside the Monorepo)
-
-The easiest way to build a real site during development is to add it as a workspace member.
-
-1. Copy `templates/blog/` (or `templates/blank/`) into `demos/`:
-
-   ```bash
-   cp -r templates/blog demos/my-site
-   ```
-
-2. Edit `demos/my-site/package.json` — set a unique `name` field.
-
-3. Run `pnpm install` from the root to link workspace dependencies.
-
-4. Start developing:
-
-   ```bash
-   pnpm --filter my-site dev
-   ```
-
-Your site will use `workspace:*` links to the local packages, so any changes you make to core will be reflected immediately (with watch mode).
+Your site uses `workspace:*` links to the local packages, so core changes are reflected immediately (with watch mode).
 
 ## Key Architectural Concepts
 
 - **Schema lives in the database**, not in code. `_emdash_collections` and `_emdash_fields` are the source of truth.
 - **Real SQL tables** per collection (`ec_posts`, `ec_products`), not EAV.
-- **Kysely** for all queries. Never interpolate into SQL -- see `AGENTS.md` for the full rules.
+- **Kysely** for all queries. Never interpolate into SQL — see `AGENTS.md` for the full rules.
 - **Handler layer** (`api/handlers/*.ts`) holds business logic. Route files are thin wrappers.
-- **Middleware chain**: runtime init -> setup check -> auth -> request context.
+- **Middleware chain**: runtime init → setup check → auth → request context.
 
 ## Adding a Migration
 
@@ -356,12 +327,12 @@ When in doubt, run `pnpm changeset` and it will only show packages that aren't i
 
 ## What's Intentionally Missing (For Now)
 
-These are known gaps -- don't try to fix them unless specifically asked:
+These are known gaps — don't try to fix them unless specifically asked:
 
-- **Rate limiting** -- no brute-force protection on auth endpoints
-- **Password auth** -- passkeys + magic links + OAuth only, by design
-- **Plugin marketplace** -- architecture exists, runtime installation is post-beta
-- **Real-time collaboration** -- planned for v1
+- **Rate limiting** — no brute-force protection on auth endpoints
+- **Password auth** — passkeys + magic links + OAuth only, by design
+- **Plugin marketplace** — architecture exists, runtime installation is post-beta
+- **Real-time collaboration** — planned for v1
 
 ## Getting Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ pnpm build          # build all packages (required before first run)
 The `demos/simple/` app is the primary development target. It uses Node.js + SQLite — no Cloudflare account needed.
 
 ```bash
-pnpm --filter emdash-demo dev    # http://localhost:4321
+cd demos/simple
+pnpm dev    # http://localhost:4321
 ```
 
 Open the admin at `http://localhost:4321/_emdash/admin`. The setup wizard runs automatically on first launch — it creates the database, runs migrations, and prompts you to create an admin account.
@@ -35,7 +36,7 @@ http://localhost:4321/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
 To populate the demo with sample content:
 
 ```bash
-pnpm --filter emdash-demo seed
+pnpm seed
 ```
 
 ### Run with Cloudflare (optional)
@@ -47,17 +48,18 @@ pnpm --filter emdash-demo seed
 Templates in `templates/` are workspace members and can be run directly:
 
 ```bash
-pnpm --filter @emdash-cms/template-portfolio bootstrap   # first time
-pnpm --filter @emdash-cms/template-portfolio dev          # run dev server
+cd templates/portfolio
+pnpm bootstrap   # first time — set up database and seed content
+pnpm dev         # run dev server
 ```
 
-Available templates: `blog`, `portfolio`, `marketing`. Use `@emdash-cms/template-{name}` as the filter.
+Available templates: `blog`, `portfolio`, `marketing`.
 
 To start fresh, delete the database and re-bootstrap:
 
 ```bash
 rm templates/portfolio/data.db
-pnpm --filter @emdash-cms/template-portfolio bootstrap
+cd templates/portfolio && pnpm bootstrap
 ```
 
 ## Repository Layout
@@ -88,24 +90,22 @@ For iterating on core packages alongside the demo, run two terminals:
 
 ```bash
 # Terminal 1 — rebuild packages/core on change
-pnpm --filter emdash dev
+cd packages/core && pnpm dev
 
 # Terminal 2 — run the demo
-pnpm --filter emdash-demo dev
+cd demos/simple && pnpm dev
 ```
 
 Changes to `packages/core/src/` will be picked up by the demo's dev server automatically.
 
 ### Checks
 
-Run these before committing:
+Run these from the repo root before committing:
 
 ```bash
-pnpm typecheck             # TypeScript (packages)
-pnpm typecheck:demos       # TypeScript (Astro demos)
-pnpm --silent lint:quick   # fast lint (< 1s) — run often
-pnpm --silent lint:json    # full type-aware lint (~10s) — run before commits
-pnpm format                # auto-format with oxfmt (tabs, not spaces)
+pnpm typecheck    # TypeScript (packages)
+pnpm lint         # full type-aware lint
+pnpm format       # auto-format with oxfmt (tabs, not spaces)
 ```
 
 Type checking **must** pass. Lint **must** pass. Don't commit with known failures.
@@ -113,10 +113,10 @@ Type checking **must** pass. Lint **must** pass. Don't commit with known failure
 ### Tests
 
 ```bash
-pnpm test                            # all packages
-pnpm --filter emdash test            # core only
-pnpm --filter emdash test --watch    # watch mode
-pnpm test:e2e                        # Playwright (requires demo running)
+pnpm test                                    # all packages
+cd packages/core && pnpm test                # core only
+cd packages/core && pnpm test --watch        # watch mode
+pnpm test:e2e                                # Playwright (starts its own server)
 ```
 
 Tests use real in-memory SQLite — no mocking. Each test gets a fresh database.
@@ -129,7 +129,7 @@ Copy a template into `demos/`, give it a unique `name` in `package.json`, run `p
 cp -r templates/blog demos/my-site
 # edit demos/my-site/package.json to set a unique name
 pnpm install
-pnpm --filter my-site dev
+cd demos/my-site && pnpm dev
 ```
 
 Your site uses `workspace:*` links to the local packages, so core changes are reflected immediately (with watch mode).
@@ -209,16 +209,16 @@ For the full translation contributor guide, see [Translating EmDash](https://doc
 
 ### What we accept
 
-| Type             | Process                                                                                                                              |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **Bug fixes**    | Open a PR directly. Include a failing test that reproduces the bug.                                                                  |
-| **Docs / typos** | Open a PR directly.                                                                                                                  |
-| **Translations** | Open a PR directly. See [Translating EmDash](https://docs.emdashcms.com/contributing/translating/).                                  |
-| **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) first. Wait for approval before writing code. |
-| **Refactors**    | Open a Discussion first. Refactors are opinionated and need alignment.                                                               |
-| **Performance**  | Open a Discussion first with benchmarks showing the improvement.                                                                     |
+| Type             | Process                                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Bug fixes**    | Open a PR directly. Include a failing test that reproduces the bug.                                                             |
+| **Docs / typos** | Open a PR directly.                                                                                                             |
+| **Translations** | Open a PR directly. See [Translating EmDash](https://docs.emdashcms.com/contributing/translating/).                             |
+| **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) and wait for a maintainer to approve it. |
+| **Refactors**    | Open a Discussion first. Refactors are opinionated and need alignment.                                                          |
+| **Performance**  | Open a Discussion first with benchmarks showing the improvement.                                                                |
 
-**PRs that add features without a prior approved Discussion will be closed.** This isn't about gatekeeping — it's about not wasting your time on work that might not align with the project's direction. Talk to us first and we'll figure out the right approach together.
+**Feature PRs without prior maintainer approval will be closed.** This isn't about gatekeeping — it's about not wasting your time on work that might not align with the project's direction. Open a Discussion, let us talk it through, and wait for a maintainer to give the go-ahead before writing code.
 
 ### AI-generated PRs
 
@@ -322,7 +322,7 @@ When in doubt, run `pnpm changeset` and it will only show packages that aren't i
 - Branch from `main`.
 - Commit messages: describe _why_, not just _what_.
 - Fill out the PR template completely. PRs with an empty template will be closed.
-- Ensure `pnpm typecheck` and `pnpm --silent lint:json` pass before pushing.
+- Ensure `pnpm typecheck` and `pnpm lint` pass before pushing.
 - Run relevant tests.
 
 ## What's Intentionally Missing (For Now)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -96,7 +96,10 @@ export default defineConfig({
 				{
 					label: "Contributing",
 					collapsed: true,
-					items: [{ label: "Contributor Guide", slug: "contributing" }],
+					items: [
+						{ label: "Contributor Guide", slug: "contributing" },
+						{ label: "Translating EmDash", slug: "contributing/translating" },
+					],
 				},
 
 				{

--- a/docs/src/content/docs/contributing/index.mdx
+++ b/docs/src/content/docs/contributing/index.mdx
@@ -25,12 +25,13 @@ For the full contributor reference — repo layout, architecture, code conventio
 2. **Start the demo**
 
    ```bash
-   pnpm --filter emdash-demo dev
+   cd demos/simple
+   pnpm dev
    ```
 
    The setup wizard runs automatically on first launch — it creates the database, runs migrations, and prompts you to create an admin account.
 
-   To populate with sample content: `pnpm --filter emdash-demo seed`
+   To populate with sample content: `pnpm seed`
 
 3. **Open the admin**
 
@@ -48,25 +49,24 @@ For the full contributor reference — repo layout, architecture, code conventio
 
 ### Watch Mode
 
-For iterating on core packages alongside the demo:
+For iterating on core packages alongside the demo, run two terminals:
 
 ```bash
 # Terminal 1 — rebuild packages/core on change
-pnpm --filter emdash dev
+cd packages/core && pnpm dev
 
 # Terminal 2 — run the demo
-pnpm --filter emdash-demo dev
+cd demos/simple && pnpm dev
 ```
 
 ### Checks
 
-Run these before committing:
+Run these before committing (from the repo root):
 
 ```bash
-pnpm typecheck             # TypeScript
-pnpm --silent lint:quick   # fast lint (< 1s) — run often
-pnpm --silent lint:json    # full type-aware lint — run before commits
-pnpm format                # auto-format (oxfmt, tabs)
+pnpm typecheck    # TypeScript
+pnpm lint         # full type-aware lint
+pnpm format       # auto-format (oxfmt, tabs)
 ```
 
 <Aside type="caution">
@@ -83,17 +83,17 @@ pnpm test
 </TabItem>
 <TabItem label="Core only">
 ```bash
-pnpm --filter emdash test
+cd packages/core && pnpm test
 ```
 </TabItem>
 <TabItem label="Watch mode">
 ```bash
-pnpm --filter emdash test --watch
+cd packages/core && pnpm test --watch
 ```
 </TabItem>
 <TabItem label="E2E">
 ```bash
-pnpm test:e2e    # requires demo running
+pnpm test:e2e    # starts its own server
 ```
 </TabItem>
 </Tabs>
@@ -102,22 +102,14 @@ Tests use real in-memory SQLite — no mocking. Each test gets a fresh database.
 
 ## What We Accept
 
-| Type             | Process                                                                                             |
-| ---------------- | --------------------------------------------------------------------------------------------------- |
-| **Bug fixes**    | Open a PR directly. Include a failing test.                                                         |
-| **Docs / typos** | Open a PR directly.                                                                                 |
-| **Translations** | Open a PR directly. See [Translating EmDash](/contributing/translating/).                            |
-| **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) first.       |
-| **Refactors**    | Open a Discussion first.                                                                            |
+| Type             | Process                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| **Bug fixes**    | Open a PR directly. Include a failing test.                                                   |
+| **Docs / typos** | Open a PR directly.                                                                           |
+| **Translations** | Open a PR directly. See [Translating EmDash](/contributing/translating/).                      |
+| **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) and wait for a maintainer to approve it. |
+| **Refactors**    | Open a Discussion first.                                                                      |
 
-Feature PRs without a prior approved Discussion will be closed.
+Feature PRs without prior maintainer approval will be closed.
 
-## Architecture at a Glance
-
-- **Schema lives in the database**, not in code. `_emdash_collections` and `_emdash_fields` are the source of truth. Each collection gets a real SQL table (`ec_posts`, `ec_products`) with typed columns.
-- **Kysely** for all queries. Never interpolate into SQL.
-- **Handler layer** (`api/handlers/*.ts`) holds business logic. Route files are thin wrappers that parse input, call handlers, and format responses.
-- **Middleware chain**: runtime init → setup check → auth → request context (AsyncLocalStorage).
-- **Plugins** use `definePlugin()` and hook into the request lifecycle. See [Plugin System](/plugins/overview/).
-
-For deeper architecture details, see [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md) and `AGENTS.md` in the repo root.
+For the full contribution policy, changeset guide, repo layout, and architecture overview, see [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md).

--- a/docs/src/content/docs/contributing/index.mdx
+++ b/docs/src/content/docs/contributing/index.mdx
@@ -1,115 +1,42 @@
 ---
 title: Contributing to EmDash
-description: Architecture overview, local development setup, and contribution guidelines.
+description: How to set up a development environment and contribute to EmDash.
 ---
 
-import { Aside, Card, CardGrid, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
-This guide covers how to set up a local development environment, understand the codebase architecture, and contribute to EmDash.
+EmDash is a pnpm monorepo. The main package is `packages/core` (published as `emdash`) — it contains the Astro integration, REST API, database layer, schema management, and plugin system. The admin UI lives in `packages/admin`.
 
-## Repository Structure
-
-EmDash is a **pnpm monorepo** with multiple packages:
-
-```
-emdash/
-├── packages/
-│   ├── core/              # emdash — Astro integration, APIs, admin (main package)
-│   ├── auth/              # @emdash-cms/auth — Authentication (passkeys, OAuth, magic links)
-│   ├── cloudflare/        # @emdash-cms/cloudflare — Cloudflare adapter + sandbox runner
-│   ├── admin/             # @emdash-cms/admin — Admin React SPA
-│   ├── create-emdash/   # create-emdash — project scaffolder
-│   ├── gutenberg-to-portable-text/ # WordPress block → Portable Text converter
-│   └── plugins/           # First-party plugins (each subdirectory is its own package)
-├── demos/
-│   ├── simple/            # emdash-demo — primary dev/test demo (Node.js)
-│   ├── cloudflare/        # Cloudflare Workers demo
-│   └── ...                # plugins-demo, showcase, wordpress-import
-└── docs/                  # Documentation site (Starlight)
-```
-
-The main package is `packages/core`. It contains:
-
-```
-packages/core/src/
-├── astro/
-│   ├── integration/       # Astro integration entry point + virtual module generation
-│   ├── middleware/        # Auth, setup check, request context (ALS)
-│   └── routes/
-│       ├── api/           # REST API route handlers
-│       └── admin-shell.astro # Admin SPA shell
-├── database/
-│   ├── migrations/        # Numbered migration files (001_initial.ts, ...)
-│   │   └── runner.ts      # StaticMigrationProvider — register migrations here
-│   ├── repositories/      # Data access layer (content, media, settings, ...)
-│   └── types.ts           # Kysely Database type
-├── plugins/
-│   ├── types.ts           # Plugin API types
-│   ├── define-plugin.ts   # definePlugin()
-│   ├── context.ts         # PluginContext factory
-│   ├── hooks.ts           # HookPipeline
-│   ├── manager.ts         # PluginManager (trusted plugins)
-│   └── sandbox/           # Sandbox interface + no-op runner
-├── schema/
-│   └── registry.ts        # SchemaRegistry — manages ec_* tables
-├── media/                 # Media providers (local, types)
-├── auth/                  # Challenge store, OAuth state store
-├── query.ts               # getEmDashCollection, getEmDashEntry
-├── loader.ts              # Astro LiveLoader implementation
-└── emdash-runtime.ts    # EmDashRuntime — central orchestrator
-```
-
-## Prerequisites
-
-- **Node.js** 22 or higher
-- **pnpm** 10 or higher
-- **Git**
-
-```bash
-# Install pnpm if you don't have it
-npm install -g pnpm
-```
+For the full contributor reference — repo layout, architecture, code conventions, changeset policy — see [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md).
 
 ## Local Setup
 
 <Steps>
 
-1. **Clone the repository**
+1. **Clone and install**
 
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/emdash-cms/emdash.git
    cd emdash
-   ```
-
-2. **Install dependencies**
-
-   ```bash
    pnpm install
+   pnpm build    # required before first run
    ```
 
-3. **Build packages** (required before running the demo)
-
-   ```bash
-   pnpm build
-   ```
-
-4. **Seed the demo database** (`demos/simple/`)
-
-   ```bash
-   pnpm --filter emdash-demo seed
-   ```
-
-5. **Start the development server**
+2. **Start the demo**
 
    ```bash
    pnpm --filter emdash-demo dev
    ```
 
-6. **Open the admin**
+   The setup wizard runs automatically on first launch — it creates the database, runs migrations, and prompts you to create an admin account.
+
+   To populate with sample content: `pnpm --filter emdash-demo seed`
+
+3. **Open the admin**
 
    Visit [http://localhost:4321/_emdash/admin](http://localhost:4321/_emdash/admin)
 
-   In development mode, use the dev bypass endpoint to skip passkey authentication:
+   In dev mode, you can skip passkey auth with the bypass endpoint:
 
    ```
    http://localhost:4321/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
@@ -121,17 +48,32 @@ npm install -g pnpm
 
 ### Watch Mode
 
-For package development, use watch mode alongside the demo:
+For iterating on core packages alongside the demo:
 
 ```bash
-# Terminal 1: Watch packages/core for changes
+# Terminal 1 — rebuild packages/core on change
 pnpm --filter emdash dev
 
-# Terminal 2: Run the demo (demos/simple/)
+# Terminal 2 — run the demo
 pnpm --filter emdash-demo dev
 ```
 
-### Running Tests
+### Checks
+
+Run these before committing:
+
+```bash
+pnpm typecheck             # TypeScript
+pnpm --silent lint:quick   # fast lint (< 1s) — run often
+pnpm --silent lint:json    # full type-aware lint — run before commits
+pnpm format                # auto-format (oxfmt, tabs)
+```
+
+<Aside type="caution">
+  Type checking and linting must both pass. Don't commit with known failures.
+</Aside>
+
+### Tests
 
 <Tabs>
 <TabItem label="All tests">
@@ -139,7 +81,7 @@ pnpm --filter emdash-demo dev
 pnpm test
 ```
 </TabItem>
-<TabItem label="Core package only">
+<TabItem label="Core only">
 ```bash
 pnpm --filter emdash test
 ```
@@ -149,311 +91,33 @@ pnpm --filter emdash test
 pnpm --filter emdash test --watch
 ```
 </TabItem>
-<TabItem label="E2E tests">
+<TabItem label="E2E">
 ```bash
-pnpm test:e2e
+pnpm test:e2e    # requires demo running
 ```
 </TabItem>
 </Tabs>
 
-### Type Checking and Linting
+Tests use real in-memory SQLite — no mocking. Each test gets a fresh database.
 
-```bash
-# Type check TypeScript packages
-pnpm typecheck
+## What We Accept
 
-# Type check Astro demos
-pnpm typecheck:demos
+| Type             | Process                                                                                             |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| **Bug fixes**    | Open a PR directly. Include a failing test.                                                         |
+| **Docs / typos** | Open a PR directly.                                                                                 |
+| **Translations** | Open a PR directly. See [Translating EmDash](/contributing/translating/).                            |
+| **Features**     | Open a [Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas) first.       |
+| **Refactors**    | Open a Discussion first.                                                                            |
 
-# Fast lint (< 1s) — run after every edit
-pnpm lint:quick
+Feature PRs without a prior approved Discussion will be closed.
 
-# Full lint with type-aware rules (~10s) — run before commits
-pnpm lint:json
-```
+## Architecture at a Glance
 
-<Aside type="caution">
-  Type checking must pass after every round of edits. Run `pnpm typecheck` before committing.
-</Aside>
+- **Schema lives in the database**, not in code. `_emdash_collections` and `_emdash_fields` are the source of truth. Each collection gets a real SQL table (`ec_posts`, `ec_products`) with typed columns.
+- **Kysely** for all queries. Never interpolate into SQL.
+- **Handler layer** (`api/handlers/*.ts`) holds business logic. Route files are thin wrappers that parse input, call handlers, and format responses.
+- **Middleware chain**: runtime init → setup check → auth → request context (AsyncLocalStorage).
+- **Plugins** use `definePlugin()` and hook into the request lifecycle. See [Plugin System](/plugins/overview/).
 
-### Formatting
-
-```bash
-pnpm format
-```
-
-EmDash uses **oxfmt** (Oxc formatter). The config is in `.oxfmtrc.json`. Tabs, not spaces.
-
-## Architecture Overview
-
-### Core Concepts
-
-**D1 is the source of truth.** Schema lives in two system tables:
-- `_emdash_collections` — collection metadata
-- `_emdash_fields` — field definitions
-
-When you create a collection, EmDash runs `ALTER TABLE` to create a real `ec_*` table with typed columns. There's no EAV (Entity-Attribute-Value) approach.
-
-**Middleware chain** (in order for every request):
-
-1. **Runtime init** — creates database connection, initializes `EmDashRuntime`
-2. **Setup check** — redirects to setup wizard if not configured
-3. **Auth** — validates session, populates `locals.user`
-4. **Request context** — sets up AsyncLocalStorage for preview/edit mode
-
-**Handler layer:** business logic lives in `api/handlers/*.ts`. Route files are thin wrappers that parse input, call handlers, and format responses. Handlers return `ApiResponse<T> = { success: boolean; data?: T; error?: { code, message } }`.
-
-### Key Files
-
-| File | Purpose |
-|------|---------|
-| `src/astro/integration/index.ts` | Astro integration entry point; generates virtual modules |
-| `src/emdash-runtime.ts` | Central runtime; orchestrates DB, plugins, storage |
-| `src/schema/registry.ts` | Manages `ec_*` table creation/modification |
-| `src/database/migrations/runner.ts` | StaticMigrationProvider; register new migrations here |
-| `src/plugins/manager.ts` | Loads and orchestrates trusted plugins |
-
-### Database Patterns
-
-EmDash uses **Kysely** for all queries. Key rules:
-
-```ts
-// CORRECT: parameterized values
-const post = await db
-  .selectFrom("ec_posts")
-  .selectAll()
-  .where("slug", "=", slug)  // parameterized
-  .executeTakeFirst();
-
-// CORRECT: validated identifier in raw SQL
-validateIdentifier(tableName);
-const result = await sql.raw(`SELECT * FROM ${tableName}`).execute(db);
-
-// WRONG: never interpolate unvalidated values into SQL
-const result = await sql.raw(`SELECT * FROM ${userInput}`).execute(db);
-```
-
-Never use `sql.raw()` with string interpolation for values. Use `sql.ref()` for identifiers, and the Kysely fluent API for everything else.
-
-### Adding a Migration
-
-<Steps>
-
-1. Create `packages/core/src/database/migrations/NNN_description.ts`:
-
-   ```ts
-   import type { Kysely } from "kysely";
-
-   export async function up(db: Kysely<unknown>): Promise<void> {
-     await db.schema
-       .createTable("my_table")
-       .addColumn("id", "text", (col) => col.primaryKey())
-       .addColumn("name", "text", (col) => col.notNull())
-       .execute();
-   }
-
-   export async function down(db: Kysely<unknown>): Promise<void> {
-     await db.schema.dropTable("my_table").execute();
-   }
-   ```
-
-2. Register it in `packages/core/src/database/migrations/runner.ts`:
-
-   ```ts
-   import * as m018 from "./018_my_migration.js";
-
-   // Add to getMigrations() return value:
-   "018_my_migration": m018,
-   ```
-
-</Steps>
-
-<Aside>
-  Migrations are statically imported (not auto-discovered) for Workers bundler compatibility. Always register new migrations in `runner.ts`.
-</Aside>
-
-### Adding an API Route
-
-Route files live in `packages/core/src/astro/routes/api/`. Follow these conventions:
-
-```ts
-// packages/core/src/astro/routes/api/my-resource.ts
-import type { APIRoute } from "astro";
-import type { User } from "@emdash-cms/auth";
-import { apiError, handleError } from "#api/error.js";
-import { requirePerm } from "#api/authorize.js";
-import { parseBody } from "#api/parse.js";
-import { z } from "zod";
-
-export const prerender = false;
-
-const createInput = z.object({
-  name: z.string().min(1),
-});
-
-export const POST: APIRoute = async ({ request, locals }) => {
-  const { emdash } = locals;
-  const user = (locals as { user?: User }).user;
-
-  if (!emdash) return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
-
-  // requirePerm returns a 403 Response if denied, or null if authorized
-  const denied = requirePerm(user, "content:edit_any");
-  if (denied) return denied;
-
-  const body = await parseBody(request, createInput);
-  if (body instanceof Response) return body;
-
-  try {
-    // business logic here
-    return Response.json({ success: true });
-  } catch (error) {
-    return handleError(error, "Failed to create resource", "CREATE_ERROR");
-  }
-};
-```
-
-Then register the route in `packages/core/src/astro/integration/routes.ts`.
-
-### Plugin Development
-
-Plugins are defined with `definePlugin()` and registered in the Astro config. See the [Plugin System documentation](/plugins/overview/) for the full API.
-
-For local plugin development:
-
-```bash
-# Create a local plugin in packages/
-pnpm --filter emdash dev  # Watch mode
-```
-
-Link your plugin in the demo's `astro.config.mjs`:
-
-```ts
-import myPlugin from "../../packages/my-plugin/src/index.ts";
-
-emdash({
-  plugins: [myPlugin()],
-});
-```
-
-## Testing Patterns
-
-Tests live in `packages/core/tests/`. The structure mirrors source:
-
-```
-tests/
-├── unit/          # Pure function tests
-├── integration/   # Real DB tests (in-memory SQLite)
-└── e2e/           # Playwright browser tests
-```
-
-**Database tests use real SQLite**, not mocks:
-
-```ts
-import { describe, it, beforeEach, afterEach } from "vitest";
-import { setupTestDatabase } from "../utils/test-db.js";
-import type { Kysely } from "kysely";
-import type { Database } from "../../src/database/types.js";
-
-describe("ContentRepository", () => {
-  let db: Kysely<Database>;
-
-  beforeEach(async () => {
-    db = await setupTestDatabase();
-  });
-
-  afterEach(async () => {
-    await db.destroy();
-  });
-
-  it("creates a content entry", async () => {
-    // test with real DB
-  });
-});
-```
-
-**E2E tests** use Playwright with the dev bypass for authentication:
-
-```ts
-await page.goto(
-  "http://localhost:4321/_emdash/api/setup/dev-bypass?redirect=/_emdash/admin"
-);
-```
-
-## Code Conventions
-
-### Imports
-
-Always use `.js` extensions for internal imports (ESM requirement):
-
-```ts
-// Correct
-import { ContentRepository } from "../../database/repositories/content.js";
-
-// Wrong
-import { ContentRepository } from "../../database/repositories/content";
-```
-
-Use `import type` for type-only imports:
-
-```ts
-import type { Kysely } from "kysely";
-import type { User } from "@emdash-cms/auth";
-```
-
-### Error Handling
-
-Use the shared error utilities in API routes:
-
-```ts
-// Error responses
-return apiError("NOT_FOUND", "Content not found", 404);
-
-// Catch blocks
-catch (error) {
-  return handleError(error, "Failed to update content", "CONTENT_UPDATE_ERROR");
-}
-```
-
-### Authorization
-
-Every state-changing route must check authorization. Use `requirePerm()` from `#api/authorize.js` — it returns a `Response` (403) if denied, or `null` if authorized:
-
-```ts
-import { requirePerm } from "#api/authorize.js";
-
-const denied = requirePerm(user, "content:edit_any");
-if (denied) return denied;
-```
-
-For ownership-scoped actions, use `requireOwnerPerm()`:
-
-```ts
-import { requireOwnerPerm } from "#api/authorize.js";
-
-const denied = requireOwnerPerm(user, item.authorId, "content:edit_own", "content:edit_any");
-if (denied) return denied;
-```
-
-## Commit and PR Process
-
-1. Create a feature branch from `main`
-2. Make changes, ensure `pnpm typecheck` and `pnpm lint:json` pass
-3. Run relevant tests
-4. Commit with a descriptive message
-5. Open a PR targeting `main`
-
-Commit messages should describe *why*, not just *what*:
-
-```
-# Good
-fix: prevent media MIME sniffing with X-Content-Type-Options header
-
-# Less good  
-fix: add header to media endpoint
-```
-
-## Getting Help
-
-- Read `AGENTS.md` for architecture decisions and code patterns
-- Check the [documentation site](https://docs.emdashcms.com) for guides and API reference
+For deeper architecture details, see [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md) and `AGENTS.md` in the repo root.


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the translation workflow, both for translators and for developers writing translatable admin UI code.

- Add "Translating EmDash" to the docs site Contributing sidebar
- Add i18n section to CONTRIBUTING.md covering Lingui `t` templates, `<Trans>` components, and `pnpm run locale:extract` workflow
- Add Translations row to the contribution policy table linking to the full guide

## Type of change

- [x] Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code