### PR TITLE
fix: enforce permission checks on content, media, and translation endpoints

### DIFF
--- a/.changeset/enforce-permission-checks.md
+++ b/.changeset/enforce-permission-checks.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Enforces permission checks on content status transitions, media provider endpoints, and translation group creation.

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -31,7 +31,7 @@ export const contentCreateBody = z
 	.object({
 		data: z.record(z.string(), z.unknown()),
 		slug: z.string().nullish(),
-		status: z.string().optional(),
+		status: z.enum(["draft"]).optional(),
 		bylines: z.array(contentBylineInputSchema).optional(),
 		locale: localeCode.optional(),
 		translationOf: z.string().optional(),
@@ -43,7 +43,7 @@ export const contentUpdateBody = z
 	.object({
 		data: z.record(z.string(), z.unknown()).optional(),
 		slug: z.string().nullish(),
-		status: z.string().optional(),
+		status: z.enum(["draft"]).optional(),
 		authorId: z.string().nullish(),
 		bylines: z.array(contentBylineInputSchema).optional(),
 		_rev: z

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -7,8 +7,8 @@
 
 import type { APIRoute } from "astro";
 
-import { requirePerm } from "#api/authorize.js";
-import { apiError, unwrapResult } from "#api/error.js";
+import { requirePerm, requireOwnerPerm } from "#api/authorize.js";
+import { apiError, mapErrorStatus, unwrapResult } from "#api/error.js";
 import { parseBody, parseQuery, isParseError } from "#api/parse.js";
 import { contentListQuery, contentCreateBody } from "#api/schemas.js";
 
@@ -39,8 +39,36 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const body = await parseBody(request, contentCreateBody);
 	if (isParseError(body)) return body;
 
-	if (!emdash?.handleContentCreate) {
+	if (!emdash?.handleContentCreate || !emdash?.handleContentGet) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
+
+	// Creating a translation requires edit permission on the source item
+	if (body.translationOf) {
+		const source = await emdash.handleContentGet(collection, body.translationOf);
+		if (!source.success) {
+			return apiError(
+				source.error?.code ?? "NOT_FOUND",
+				source.error?.message ?? "Translation source not found",
+				mapErrorStatus(source.error?.code),
+			);
+		}
+		const sourceData =
+			source.data && typeof source.data === "object"
+				? (source.data as Record<string, unknown>)
+				: undefined;
+		const sourceItem =
+			sourceData?.item && typeof sourceData.item === "object"
+				? (sourceData.item as Record<string, unknown>)
+				: sourceData;
+		const sourceAuthor = typeof sourceItem?.authorId === "string" ? sourceItem.authorId : "";
+		const translationDenied = requireOwnerPerm(
+			user,
+			sourceAuthor,
+			"content:edit_own",
+			"content:edit_any",
+		);
+		if (translationDenied) return translationDenied;
 	}
 
 	// Auto-set authorId to current user when creating content

--- a/packages/core/src/astro/routes/api/media/providers/[providerId]/[itemId].ts
+++ b/packages/core/src/astro/routes/api/media/providers/[providerId]/[itemId].ts
@@ -7,6 +7,7 @@
 
 import type { APIRoute } from "astro";
 
+import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 
 export const prerender = false;
@@ -15,7 +16,9 @@ export const prerender = false;
  * Get a single media item from a provider
  */
 export const GET: APIRoute = async ({ params, locals }) => {
-	const { emdash } = locals;
+	const { emdash, user } = locals;
+	const denied = requirePerm(user, "media:read");
+	if (denied) return denied;
 	const { providerId, itemId } = params;
 
 	if (!providerId || !itemId) {
@@ -56,7 +59,9 @@ export const GET: APIRoute = async ({ params, locals }) => {
  * Delete a media item from a provider
  */
 export const DELETE: APIRoute = async ({ params, locals }) => {
-	const { emdash } = locals;
+	const { emdash, user } = locals;
+	const denied = requirePerm(user, "media:delete_any");
+	if (denied) return denied;
 	const { providerId, itemId } = params;
 
 	if (!providerId || !itemId) {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Permission, RoleLevel } from "@emdash-cms/auth";
-import { canActOnOwn, Role } from "@emdash-cms/auth";
+import { canActOnOwn, hasPermission, Role } from "@emdash-cms/auth";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
@@ -299,7 +299,7 @@ export function createMcpServer(): McpServer {
 				status: z
 					.enum(["draft", "published"])
 					.optional()
-					.describe("Initial status (default 'draft')"),
+					.describe("Initial status (default 'draft'). Requires publish permission."),
 				locale: z
 					.string()
 					.optional()
@@ -317,11 +317,49 @@ export function createMcpServer(): McpServer {
 			requireScope(extra, "content:write");
 			requireRole(extra, Role.CONTRIBUTOR);
 			const { emdash, userId } = getExtra(extra);
+
+			// Creating a translation requires edit permission on the source item
+			if (args.translationOf) {
+				const source = await emdash.handleContentGet(args.collection, args.translationOf);
+				if (!source.success) return unwrap(source);
+				requireOwnership(
+					extra,
+					extractContentAuthorId(source.data),
+					"content:edit_own",
+					"content:edit_any",
+				);
+			}
+
+			// Publishing requires publish permission — create as draft then publish
+			if (args.status === "published") {
+				const user = { id: userId, role: getExtra(extra).userRole };
+				if (!hasPermission(user, "content:publish_own" as Permission)) {
+					throw new McpError(
+						ErrorCode.InvalidRequest,
+						"Insufficient permissions: publishing requires content:publish_own",
+					);
+				}
+				const result = await emdash.handleContentCreate(args.collection, {
+					data: args.data,
+					slug: args.slug,
+					authorId: userId,
+					locale: args.locale,
+					translationOf: args.translationOf,
+				});
+				if (!result.success) return unwrap(result);
+				const itemId = extractContentId(result.data);
+				if (itemId) {
+					const published = await emdash.handleContentPublish(args.collection, itemId);
+					if (!published.success) return unwrap(published);
+					return unwrap(published);
+				}
+				return unwrap(result);
+			}
+
 			return unwrap(
 				await emdash.handleContentCreate(args.collection, {
 					data: args.data,
 					slug: args.slug,
-					status: args.status,
 					authorId: userId,
 					locale: args.locale,
 					translationOf: args.translationOf,
@@ -347,7 +385,10 @@ export function createMcpServer(): McpServer {
 					.optional()
 					.describe("Field values to update (only include changed fields)"),
 				slug: z.string().optional().describe("New URL slug"),
-				status: z.enum(["draft", "published"]).optional().describe("New status"),
+				status: z
+					.enum(["draft", "published"])
+					.optional()
+					.describe("New status. Setting to 'published' requires publish permission."),
 				_rev: z
 					.string()
 					.optional()
@@ -372,6 +413,28 @@ export function createMcpServer(): McpServer {
 			);
 
 			const resolvedId = extractContentId(existing.data) ?? args.id;
+
+			// Publishing requires publish permission — update data then publish via dedicated handler
+			if (args.status === "published") {
+				requireOwnership(
+					extra,
+					extractContentAuthorId(existing.data),
+					"content:publish_own",
+					"content:publish_any",
+				);
+				// Apply data/slug updates first (if any), then publish
+				if (args.data || args.slug) {
+					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
+						data: args.data,
+						slug: args.slug,
+						authorId: userId,
+						_rev: args._rev,
+					});
+					if (!updateResult.success) return unwrap(updateResult);
+				}
+				return unwrap(await emdash.handleContentPublish(args.collection, resolvedId));
+			}
+
 			return unwrap(
 				await emdash.handleContentUpdate(args.collection, resolvedId, {
 					data: args.data,

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -386,7 +386,9 @@ export function createMcpServer(): McpServer {
 				status: z
 					.enum(["draft", "published"])
 					.optional()
-					.describe("New status. Setting to 'published' requires publish permission."),
+					.describe(
+						"New status. Setting to 'published' requires publish permission. Setting to 'draft' unpublishes the item and also requires publish permission.",
+					),
 				_rev: z
 					.string()
 					.optional()

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -349,9 +349,7 @@ export function createMcpServer(): McpServer {
 				if (!result.success) return unwrap(result);
 				const itemId = extractContentId(result.data);
 				if (itemId) {
-					const published = await emdash.handleContentPublish(args.collection, itemId);
-					if (!published.success) return unwrap(published);
-					return unwrap(published);
+					return unwrap(await emdash.handleContentPublish(args.collection, itemId));
 				}
 				return unwrap(result);
 			}
@@ -414,7 +412,7 @@ export function createMcpServer(): McpServer {
 
 			const resolvedId = extractContentId(existing.data) ?? args.id;
 
-			// Publishing requires publish permission — update data then publish via dedicated handler
+			// Status transitions route through dedicated handlers for proper revision management
 			if (args.status === "published") {
 				requireOwnership(
 					extra,
@@ -422,7 +420,6 @@ export function createMcpServer(): McpServer {
 					"content:publish_own",
 					"content:publish_any",
 				);
-				// Apply data/slug updates first (if any), then publish
 				if (args.data || args.slug) {
 					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
 						data: args.data,
@@ -435,11 +432,29 @@ export function createMcpServer(): McpServer {
 				return unwrap(await emdash.handleContentPublish(args.collection, resolvedId));
 			}
 
+			if (args.status === "draft") {
+				requireOwnership(
+					extra,
+					extractContentAuthorId(existing.data),
+					"content:publish_own",
+					"content:publish_any",
+				);
+				if (args.data || args.slug) {
+					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
+						data: args.data,
+						slug: args.slug,
+						authorId: userId,
+						_rev: args._rev,
+					});
+					if (!updateResult.success) return unwrap(updateResult);
+				}
+				return unwrap(await emdash.handleContentUnpublish(args.collection, resolvedId));
+			}
+
 			return unwrap(
 				await emdash.handleContentUpdate(args.collection, resolvedId, {
 					data: args.data,
 					slug: args.slug,
-					status: args.status,
 					authorId: userId,
 					_rev: args._rev,
 				}),

--- a/packages/core/tests/unit/api/schemas.test.ts
+++ b/packages/core/tests/unit/api/schemas.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect } from "vitest";
 
-import { contentUpdateBody, httpUrl } from "../../../src/api/schemas/index.js";
+import { contentCreateBody, contentUpdateBody, httpUrl } from "../../../src/api/schemas/index.js";
+
+describe("contentCreateBody schema", () => {
+	it("accepts status 'draft'", () => {
+		const result = contentCreateBody.parse({ data: { title: "Hi" }, status: "draft" });
+		expect(result.status).toBe("draft");
+	});
+
+	it("accepts omitted status", () => {
+		const result = contentCreateBody.parse({ data: { title: "Hi" } });
+		expect(result.status).toBeUndefined();
+	});
+
+	it("rejects status 'published'", () => {
+		expect(() => contentCreateBody.parse({ data: { title: "Hi" }, status: "published" })).toThrow();
+	});
+
+	it("rejects status 'scheduled'", () => {
+		expect(() => contentCreateBody.parse({ data: { title: "Hi" }, status: "scheduled" })).toThrow();
+	});
+});
 
 describe("contentUpdateBody schema", () => {
 	it("should pass through skipRevision when present", () => {
@@ -18,6 +38,24 @@ describe("contentUpdateBody schema", () => {
 		};
 		const result = contentUpdateBody.parse(input);
 		expect(result.skipRevision).toBeUndefined();
+	});
+
+	it("accepts status 'draft'", () => {
+		const result = contentUpdateBody.parse({ data: { title: "Hi" }, status: "draft" });
+		expect(result.status).toBe("draft");
+	});
+
+	it("accepts omitted status", () => {
+		const result = contentUpdateBody.parse({ data: { title: "Hi" } });
+		expect(result.status).toBeUndefined();
+	});
+
+	it("rejects status 'published'", () => {
+		expect(() => contentUpdateBody.parse({ data: { title: "Hi" }, status: "published" })).toThrow();
+	});
+
+	it("rejects status 'scheduled'", () => {
+		expect(() => contentUpdateBody.parse({ data: { title: "Hi" }, status: "scheduled" })).toThrow();
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Adds missing permission enforcement in three areas:

1. **Content status field** -- The create and update Zod schemas now restrict `status` to `"draft"`. Publishing must go through the dedicated `/publish` endpoint which handles revision promotion and permission checks correctly. The MCP tools retain the `status: "published"` option but now route through the publish handler with proper permission gating.

2. **Media provider item endpoints** -- The GET and DELETE handlers for `media/providers/[providerId]/[itemId]` were missing `requirePerm()` calls. Added `media:read` for GET and `media:delete_any` for DELETE, matching the pattern in the sibling index.ts.

3. **Translation group creation** -- Creating a translation via `translationOf` in the content create endpoint now requires `content:edit_own`/`content:edit_any` on the source item. Same check added in the MCP `content_create` tool.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code