### PR TITLE
fix: data integrity and correctness improvements

### DIFF
--- a/.changeset/fix-data-integrity.md
+++ b/.changeset/fix-data-integrity.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin demotion guard, OAuth consent flow, device flow token exchange, preview token scoping, and revision cleanup on permanent delete.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -788,6 +788,9 @@ export async function handleContentPermanentDelete(
 				// Clean up comments for permanently deleted content
 				const commentRepo = new CommentRepository(trx);
 				await commentRepo.deleteByContent(collection, resolvedId);
+				// Clean up revisions for permanently deleted content
+				const revisionRepo = new RevisionRepository(trx);
+				await revisionRepo.deleteByEntry(collection, resolvedId);
 			}
 
 			return wasDeleted;

--- a/packages/core/src/api/handlers/device-flow.ts
+++ b/packages/core/src/api/handlers/device-flow.ts
@@ -20,6 +20,7 @@ import {
 	TOKEN_PREFIXES,
 	VALID_SCOPES,
 } from "../../auth/api-tokens.js";
+import { withTransaction } from "../../database/transaction.js";
 import type { Database } from "../../database/types.js";
 import type { ApiResult } from "../types.js";
 import { lookupOAuthClient } from "./oauth-clients.js";
@@ -306,59 +307,66 @@ export async function handleDeviceTokenExchange(
 			};
 		}
 
-		// Atomically consume the device code using DELETE...RETURNING.
-		// This prevents TOCTOU: two concurrent requests race on the DELETE,
-		// and only one gets a row back.
-		const consumed = await db
-			.deleteFrom("_emdash_device_codes")
-			.where("device_code", "=", input.device_code)
-			.where("status", "=", "authorized")
-			.returningAll()
-			.executeTakeFirst();
+		// Generate tokens before consuming the device code so that if
+		// generation fails, the code is still available for retry.
+		const accessToken = generatePrefixedToken(TOKEN_PREFIXES.OAUTH_ACCESS);
+		const accessExpires = expiresAt(ACCESS_TOKEN_TTL_SECONDS);
+		const refreshToken = generatePrefixedToken(TOKEN_PREFIXES.OAUTH_REFRESH);
+		const refreshExpires = expiresAt(REFRESH_TOKEN_TTL_SECONDS);
 
-		if (!consumed) {
+		// Atomically consume the device code and create tokens in a single
+		// transaction. DELETE...RETURNING prevents TOCTOU: two concurrent
+		// requests race on the DELETE, only one gets a row back. Wrapping
+		// in a transaction ensures the code isn't consumed if token storage fails.
+		const result = await withTransaction(db, async (trx) => {
+			const consumed = await trx
+				.deleteFrom("_emdash_device_codes")
+				.where("device_code", "=", input.device_code)
+				.where("status", "=", "authorized")
+				.returningAll()
+				.executeTakeFirst();
+
+			if (!consumed) return null;
+
+			if (!consumed.user_id) return null;
+
+			const scopes = JSON.parse(consumed.scopes) as string[];
+
+			await trx
+				.insertInto("_emdash_oauth_tokens")
+				.values({
+					token_hash: accessToken.hash,
+					token_type: "access",
+					user_id: consumed.user_id,
+					scopes: JSON.stringify(scopes),
+					client_type: "cli",
+					expires_at: accessExpires,
+					refresh_token_hash: refreshToken.hash,
+				})
+				.execute();
+
+			await trx
+				.insertInto("_emdash_oauth_tokens")
+				.values({
+					token_hash: refreshToken.hash,
+					token_type: "refresh",
+					user_id: consumed.user_id,
+					scopes: JSON.stringify(scopes),
+					client_type: "cli",
+					expires_at: refreshExpires,
+					refresh_token_hash: null,
+				})
+				.execute();
+
+			return { scopes };
+		});
+
+		if (!result) {
 			return {
 				success: false,
 				error: { code: "INVALID_GRANT", message: "Device code already consumed" },
 			};
 		}
-
-		const scopes = JSON.parse(consumed.scopes) as string[];
-
-		// Generate access token
-		const accessToken = generatePrefixedToken(TOKEN_PREFIXES.OAUTH_ACCESS);
-		const accessExpires = expiresAt(ACCESS_TOKEN_TTL_SECONDS);
-
-		// Generate refresh token
-		const refreshToken = generatePrefixedToken(TOKEN_PREFIXES.OAUTH_REFRESH);
-		const refreshExpires = expiresAt(REFRESH_TOKEN_TTL_SECONDS);
-
-		// Store both tokens
-		await db
-			.insertInto("_emdash_oauth_tokens")
-			.values({
-				token_hash: accessToken.hash,
-				token_type: "access",
-				user_id: consumed.user_id!,
-				scopes: JSON.stringify(scopes),
-				client_type: "cli",
-				expires_at: accessExpires,
-				refresh_token_hash: refreshToken.hash,
-			})
-			.execute();
-
-		await db
-			.insertInto("_emdash_oauth_tokens")
-			.values({
-				token_hash: refreshToken.hash,
-				token_type: "refresh",
-				user_id: consumed.user_id!,
-				scopes: JSON.stringify(scopes),
-				client_type: "cli",
-				expires_at: refreshExpires,
-				refresh_token_hash: null,
-			})
-			.execute();
 
 		return {
 			success: true,
@@ -367,7 +375,7 @@ export async function handleDeviceTokenExchange(
 				refresh_token: refreshToken.raw,
 				token_type: "Bearer",
 				expires_in: ACCESS_TOKEN_TTL_SECONDS,
-				scope: scopes.join(" "),
+				scope: result.scopes.join(" "),
 			},
 		};
 	} catch {

--- a/packages/core/src/api/handlers/device-flow.ts
+++ b/packages/core/src/api/handlers/device-flow.ts
@@ -306,8 +306,24 @@ export async function handleDeviceTokenExchange(
 			};
 		}
 
-		// Authorized! Generate tokens.
-		const scopes = JSON.parse(row.scopes) as string[];
+		// Atomically consume the device code using DELETE...RETURNING.
+		// This prevents TOCTOU: two concurrent requests race on the DELETE,
+		// and only one gets a row back.
+		const consumed = await db
+			.deleteFrom("_emdash_device_codes")
+			.where("device_code", "=", input.device_code)
+			.where("status", "=", "authorized")
+			.returningAll()
+			.executeTakeFirst();
+
+		if (!consumed) {
+			return {
+				success: false,
+				error: { code: "INVALID_GRANT", message: "Device code already consumed" },
+			};
+		}
+
+		const scopes = JSON.parse(consumed.scopes) as string[];
 
 		// Generate access token
 		const accessToken = generatePrefixedToken(TOKEN_PREFIXES.OAUTH_ACCESS);
@@ -323,7 +339,7 @@ export async function handleDeviceTokenExchange(
 			.values({
 				token_hash: accessToken.hash,
 				token_type: "access",
-				user_id: row.user_id,
+				user_id: consumed.user_id!,
 				scopes: JSON.stringify(scopes),
 				client_type: "cli",
 				expires_at: accessExpires,
@@ -336,18 +352,12 @@ export async function handleDeviceTokenExchange(
 			.values({
 				token_hash: refreshToken.hash,
 				token_type: "refresh",
-				user_id: row.user_id,
+				user_id: consumed.user_id!,
 				scopes: JSON.stringify(scopes),
 				client_type: "cli",
 				expires_at: refreshExpires,
 				refresh_token_hash: null,
 			})
-			.execute();
-
-		// Consume the device code (delete it)
-		await db
-			.deleteFrom("_emdash_device_codes")
-			.where("device_code", "=", input.device_code)
 			.execute();
 
 		return {

--- a/packages/core/src/astro/routes/api/admin/users/[id]/disable.ts
+++ b/packages/core/src/astro/routes/api/admin/users/[id]/disable.ts
@@ -9,6 +9,7 @@ import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import type { APIRoute } from "astro";
 
 import { apiError, apiSuccess, handleError } from "#api/error.js";
+import { withTransaction } from "#db/transaction.js";
 
 export const prerender = false;
 
@@ -43,20 +44,25 @@ export const POST: APIRoute = async ({ params, locals }) => {
 			return apiError("NOT_FOUND", "User not found", 404);
 		}
 
-		// Check if this would leave no active admins
-		if (targetUser.role === Role.ADMIN) {
-			const adminCount = await adapter.countAdmins();
-			if (adminCount <= 1) {
-				return apiError(
-					"VALIDATION_ERROR",
-					"Cannot disable the last admin. Promote another user first.",
-					400,
-				);
+		// Wrap admin check + disable in a transaction to prevent two
+		// concurrent requests from both passing the count check.
+		const lastAdminBlocked = await withTransaction(emdash.db, async (trx) => {
+			const trxAdapter = createKyselyAdapter(trx);
+			if (targetUser.role === Role.ADMIN) {
+				const adminCount = await trxAdapter.countAdmins();
+				if (adminCount <= 1) return true;
 			}
-		}
+			await trxAdapter.updateUser(id, { disabled: true });
+			return false;
+		});
 
-		// Disable user
-		await adapter.updateUser(id, { disabled: true });
+		if (lastAdminBlocked) {
+			return apiError(
+				"VALIDATION_ERROR",
+				"Cannot disable the last admin. Promote another user first.",
+				400,
+			);
+		}
 
 		// SEC-43: Revoke all OAuth tokens for the disabled user.
 		// Without this, existing refresh tokens remain valid for up to 90 days.

--- a/packages/core/src/astro/routes/api/admin/users/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/users/[id]/index.ts
@@ -109,6 +109,18 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 			return apiError("SELF_ROLE_CHANGE", "Cannot change your own role", 400);
 		}
 
+		// Prevent demoting the last admin
+		if (role !== undefined && role < Role.ADMIN && targetUser.role === Role.ADMIN) {
+			const adminCount = await adapter.countAdmins();
+			if (adminCount <= 1) {
+				return apiError(
+					"LAST_ADMIN",
+					"Cannot demote the last admin. Promote another user first.",
+					400,
+				);
+			}
+		}
+
 		// Check email uniqueness if changing email
 		if (body.email && body.email !== targetUser.email) {
 			const existing = await adapter.getUserByEmail(body.email);

--- a/packages/core/src/astro/routes/api/admin/users/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/users/[id]/index.ts
@@ -12,6 +12,7 @@ import type { APIRoute } from "astro";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { userUpdateBody } from "#api/schemas.js";
+import { withTransaction } from "#db/transaction.js";
 
 export const prerender = false;
 
@@ -109,18 +110,6 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 			return apiError("SELF_ROLE_CHANGE", "Cannot change your own role", 400);
 		}
 
-		// Prevent demoting the last admin
-		if (role !== undefined && role < Role.ADMIN && targetUser.role === Role.ADMIN) {
-			const adminCount = await adapter.countAdmins();
-			if (adminCount <= 1) {
-				return apiError(
-					"LAST_ADMIN",
-					"Cannot demote the last admin. Promote another user first.",
-					400,
-				);
-			}
-		}
-
 		// Check email uniqueness if changing email
 		if (body.email && body.email !== targetUser.email) {
 			const existing = await adapter.getUserByEmail(body.email);
@@ -129,12 +118,32 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 			}
 		}
 
-		// Update user
-		await adapter.updateUser(id, {
-			name: body.name,
-			email: body.email,
-			role,
+		// Wrap admin demotion guard + update in a transaction to prevent
+		// two concurrent demotions from both passing the count check.
+		const isDemotingAdmin =
+			role !== undefined && role < Role.ADMIN && targetUser.role === Role.ADMIN;
+
+		const lastAdminBlocked = await withTransaction(emdash.db, async (trx) => {
+			const trxAdapter = createKyselyAdapter(trx);
+			if (isDemotingAdmin) {
+				const adminCount = await trxAdapter.countAdmins();
+				if (adminCount <= 1) return true;
+			}
+			await trxAdapter.updateUser(id, {
+				name: body.name,
+				email: body.email,
+				role,
+			});
+			return false;
 		});
+
+		if (lastAdminBlocked) {
+			return apiError(
+				"LAST_ADMIN",
+				"Cannot demote the last admin. Promote another user first.",
+				400,
+			);
+		}
 
 		// Fetch updated user
 		const updated = await adapter.getUserById(id);

--- a/packages/core/src/astro/routes/api/oauth/authorize.ts
+++ b/packages/core/src/astro/routes/api/oauth/authorize.ts
@@ -47,12 +47,12 @@ function csrfCookieHeader(token: string, request: Request, siteUrl?: string): st
 	// so JS never needs to read the cookie. HttpOnly adds defense-in-depth.
 	// Secure is set when:
 	//   - siteUrl is configured and uses https (proxy case — request may be http internally), OR
-	//   - the actual request is over https (non-proxy case, preserve existing behavior — H-2)
+	//   - the actual request is over https (non-proxy case, preserve existing behaviour)
 	const isSecure = siteUrl
 		? siteUrl.startsWith("https:")
 		: new URL(request.url).protocol === "https:";
 	const secure = isSecure ? "; Secure" : "";
-	return `${CSRF_COOKIE_NAME}=${token}; Path=/_emdash/api/oauth/authorize; HttpOnly; SameSite=Strict${secure}`;
+	return `${CSRF_COOKIE_NAME}=${token}; Path=/_emdash/oauth/authorize; HttpOnly; SameSite=Strict${secure}`;
 }
 
 /** Extract the CSRF token from the request's cookies. */

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -427,8 +427,15 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 			if (isPreviewMode && !isEditMode) {
 				const dbId = entryDatabaseId(baseEntry);
 				if (preview!.id !== dbId && preview!.id !== id) {
-					// Token doesn't match this entry — fall through to published-only path
-					break;
+					// Token doesn't match — serve only if publicly visible, without draft access
+					if (isVisible(baseEntry)) {
+						return successResult(wrapEntry(baseEntry), {
+							isPreview: false,
+							fallbackLocale,
+							cacheHint: cacheHint ?? {},
+						});
+					}
+					return { entry: null, isPreview: false, cacheHint: {} };
 				}
 			}
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -422,6 +422,16 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 
 			if (!baseEntry) continue; // Try next locale in chain
 
+			// Preview tokens are item-scoped: verify the resolved entry matches.
+			// Edit mode (authenticated editors) has collection-wide draft access.
+			if (isPreviewMode && !isEditMode) {
+				const dbId = entryDatabaseId(baseEntry);
+				if (preview!.id !== dbId && preview!.id !== id) {
+					// Token doesn't match this entry — fall through to published-only path
+					break;
+				}
+			}
+
 			// Check if entry has a draft revision — if so, re-fetch with revision data
 			const baseData = entryData(baseEntry);
 			const draftRevisionId = dataStr(baseData, "draftRevisionId") || undefined;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -435,7 +435,8 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 							cacheHint: cacheHint ?? {},
 						});
 					}
-					return { entry: null, isPreview: false, cacheHint: {} };
+					// Not visible — try next locale in fallback chain
+					continue;
 				}
 			}
 

--- a/packages/core/tests/integration/auth/device-flow.test.ts
+++ b/packages/core/tests/integration/auth/device-flow.test.ts
@@ -229,6 +229,36 @@ describe("Device Token Exchange: Error Cases", () => {
 		expect(result.error.code).toBe("INVALID_GRANT");
 	});
 
+	it("should reject a second exchange for an already-consumed device code", async () => {
+		const codeResult = await handleDeviceCodeRequest(
+			db,
+			{ client_id: "emdash-cli" },
+			"https://example.com/_emdash/device",
+		);
+		expect(codeResult.success).toBe(true);
+		if (!codeResult.success) return;
+
+		await handleDeviceAuthorize(db, "user-1", Role.ADMIN, {
+			user_code: codeResult.data.user_code,
+		});
+
+		// First exchange succeeds
+		const first = await handleDeviceTokenExchange(db, {
+			device_code: codeResult.data.device_code,
+			grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		});
+		expect(first.success).toBe(true);
+
+		// Second exchange fails — device code was consumed atomically
+		const second = await handleDeviceTokenExchange(db, {
+			device_code: codeResult.data.device_code,
+			grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		});
+		expect(second.success).toBe(false);
+		if (second.success) return;
+		expect(second.error.code).toBe("INVALID_GRANT");
+	});
+
 	it("should report expired device codes", async () => {
 		// Create a device code that's already expired
 		await db

--- a/packages/core/tests/integration/seo/seo.test.ts
+++ b/packages/core/tests/integration/seo/seo.test.ts
@@ -13,6 +13,7 @@ import { handleSitemapData } from "../../../src/api/handlers/seo.js";
 import { createDatabase } from "../../../src/database/connection.js";
 import { runMigrations } from "../../../src/database/migrations/runner.js";
 import { ContentRepository } from "../../../src/database/repositories/content.js";
+import { RevisionRepository } from "../../../src/database/repositories/revision.js";
 import { SeoRepository } from "../../../src/database/repositories/seo.js";
 import type { ContentItem } from "../../../src/database/repositories/types.js";
 import type { Database } from "../../../src/database/types.js";
@@ -432,6 +433,29 @@ describe("SEO", () => {
 			// SEO row should be gone
 			const seo = await seoRepo.get("post", id);
 			expect(seo.title).toBeNull();
+		});
+
+		it("should clean up revisions on permanent delete", async () => {
+			const createResult = await handleContentCreate(db, "post", {
+				data: { title: "Test Post" },
+			});
+			const id = createResult.data!.item.id;
+
+			// Create some revisions
+			const revisionRepo = new RevisionRepository(db);
+			await revisionRepo.create({ collection: "post", entryId: id, data: { title: "v1" } });
+			await revisionRepo.create({ collection: "post", entryId: id, data: { title: "v2" } });
+
+			const before = await revisionRepo.findByEntry("post", id);
+			expect(before).toHaveLength(2);
+
+			// Soft delete first, then permanent delete
+			await repo.delete("post", id);
+			await handleContentPermanentDelete(db, "post", id);
+
+			// Revisions should be gone
+			const after = await revisionRepo.findByEntry("post", id);
+			expect(after).toHaveLength(0);
 		});
 
 		it("should not hydrate SEO for collections without has_seo", async () => {


### PR DESCRIPTION
## What does this PR do?

Five independent correctness fixes:

1. **Last admin demotion guard** -- The user update endpoint (PUT) now checks `countAdmins()` before allowing demotion from ADMIN, matching the guard already present on the disable endpoint.

2. **OAuth CSRF cookie path** -- The CSRF double-submit cookie was set with `Path=/_emdash/api/oauth/authorize` but the route is mounted at `/_emdash/oauth/authorize`. The browser never sent the cookie, breaking the OAuth consent flow entirely. Removed the stale `/api` segment.

3. **Device flow token exchange atomicity** -- Replaced the non-atomic SELECT-then-DELETE pattern with `DELETE...RETURNING`, matching the pattern already used in the authorization code exchange (SEC-39). Prevents double token issuance from concurrent poll requests.

4. **Preview token item scope** -- Preview tokens encode a specific content item ID, but `getEmDashEntry` only checked the collection, not the item. A token for `posts:abc` could view drafts of any post. Now enforces item-level scope after resolving the entry from the database.

5. **Revision cleanup on permanent delete** -- `handleContentPermanentDelete` cleaned up SEO and comments but not revisions. Wired in the existing `RevisionRepository.deleteByEntry()` method that was never called.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code