### PR TITLE
fix: prevent changesets from bumping 0.x to 1.0.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,17 +15,13 @@
 			"@emdash-cms/blocks",
 			"@emdash-cms/cloudflare",
 			"@emdash-cms/gutenberg-to-portable-text",
-			"@emdash-cms/plugin-ai-moderation",
-			"@emdash-cms/plugin-atproto",
-			"@emdash-cms/plugin-audit-log",
-			"@emdash-cms/plugin-color",
-			"@emdash-cms/plugin-embeds",
-			"@emdash-cms/plugin-forms",
-			"@emdash-cms/plugin-webhook-notifier",
 			"@emdash-cms/x402",
 			"create-emdash"
 		]
 	],
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	},
 	"linked": [],
 	"access": "public",
 	"baseBranch": "main",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Block accidental major releases
+        if: ${{ !inputs.publish-only }}
+        run: |
+          if pnpm changeset status 2>&1 | grep -q "Packages to be bumped at major"; then
+            echo "::error::Major version bump detected. This is blocked while in 0.x pre-release."
+            pnpm changeset status 2>&1
+            exit 1
+          fi
+
       - name: Create Release Pull Request or Publish
         if: ${{ !inputs.publish-only }}
         id: changesets

--- a/packages/plugins/ai-moderation/package.json
+++ b/packages/plugins/ai-moderation/package.json
@@ -24,7 +24,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*",
+		"emdash": "workspace:>=0.1.0",
 		"react": "^18.0.0 || ^19.0.0",
 		"@phosphor-icons/react": "^2.1.10",
 		"@cloudflare/kumo": "^1.0.0"

--- a/packages/plugins/api-test/package.json
+++ b/packages/plugins/api-test/package.json
@@ -22,7 +22,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*",
+		"emdash": "workspace:>=0.1.0",
 		"react": "^18.0.0 || ^19.0.0",
 		"@phosphor-icons/react": "^2.1.10"
 	},

--- a/packages/plugins/atproto/package.json
+++ b/packages/plugins/atproto/package.json
@@ -27,7 +27,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*"
+		"emdash": "workspace:>=0.1.0"
 	},
 	"devDependencies": {
 		"tsdown": "catalog:",

--- a/packages/plugins/audit-log/package.json
+++ b/packages/plugins/audit-log/package.json
@@ -25,7 +25,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*"
+		"emdash": "workspace:>=0.1.0"
 	},
 	"devDependencies": {
 		"tsdown": "catalog:",

--- a/packages/plugins/color/package.json
+++ b/packages/plugins/color/package.json
@@ -22,7 +22,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*",
+		"emdash": "workspace:>=0.1.0",
 		"react": "^18.0.0 || ^19.0.0"
 	},
 	"devDependencies": {

--- a/packages/plugins/embeds/package.json
+++ b/packages/plugins/embeds/package.json
@@ -25,7 +25,7 @@
 	"license": "MIT",
 	"peerDependencies": {
 		"astro": ">=6.0.0-beta.0",
-		"emdash": "workspace:*"
+		"emdash": "workspace:>=0.1.0"
 	},
 	"dependencies": {
 		"@emdash-cms/blocks": "workspace:*",

--- a/packages/plugins/forms/package.json
+++ b/packages/plugins/forms/package.json
@@ -26,7 +26,7 @@
 	"license": "MIT",
 	"peerDependencies": {
 		"astro": ">=6.0.0-beta.0",
-		"emdash": "workspace:*",
+		"emdash": "workspace:>=0.1.0",
 		"react": "^18.0.0 || ^19.0.0",
 		"@phosphor-icons/react": "^2.1.10",
 		"@cloudflare/kumo": "^1.0.0"

--- a/packages/plugins/webhook-notifier/package.json
+++ b/packages/plugins/webhook-notifier/package.json
@@ -25,7 +25,7 @@
 	"author": "Matt Kane",
 	"license": "MIT",
 	"peerDependencies": {
-		"emdash": "workspace:*"
+		"emdash": "workspace:>=0.1.0"
 	},
 	"devDependencies": {
 		"tsdown": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,7 +1120,7 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
       react:
         specifier: ^18.0.0 || ^19.0.0
@@ -1142,7 +1142,7 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
       react:
         specifier: ^18.0.0 || ^19.0.0
@@ -1151,7 +1151,7 @@ importers:
   packages/plugins/atproto:
     dependencies:
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
     devDependencies:
       tsdown:
@@ -1167,7 +1167,7 @@ importers:
   packages/plugins/audit-log:
     dependencies:
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
     devDependencies:
       tsdown:
@@ -1180,7 +1180,7 @@ importers:
   packages/plugins/color:
     dependencies:
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
       react:
         specifier: ^18.0.0 || ^19.0.0
@@ -1202,7 +1202,7 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0(astro@6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
 
   packages/plugins/forms:
@@ -1217,7 +1217,7 @@ importers:
         specifier: '>=6.0.0-beta.0'
         version: 6.0.0-beta.20(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
       react:
         specifier: ^18.0.0 || ^19.0.0
@@ -1255,7 +1255,7 @@ importers:
   packages/plugins/webhook-notifier:
     dependencies:
       emdash:
-        specifier: workspace:*
+        specifier: workspace:>=0.1.0
         version: link:../../core
     devDependencies:
       tsdown:


### PR DESCRIPTION
## What does this PR do?

The changesets release PR was bumping all packages from `0.1.1` to `1.0.0` instead of `0.2.0`. This was caused by changesets' peer dependency logic: when `emdash` gets a `minor` bump, every plugin that peer-depends on it with `workspace:*` (which resolves to the exact old version) triggers `shouldBumpMajor`, and the `fixed` group propagates that major bump to all packages.

Three changes to fix:

1. **Remove plugins from the `fixed` group** — they peer-depend on `emdash`, which triggers the major escalation. Core packages remain fixed together.
2. **Enable `onlyUpdatePeerDependentsWhenOutOfRange`** — by default changesets always escalates peer dep bumps to major without checking the range. This flag makes it actually check.
3. **Change plugin peer deps from `workspace:*` to `workspace:>=0.1.0`** — `workspace:*` resolves to the exact old version (e.g. `0.1.1`), which any bump falls outside of. `>=0.1.0` satisfies any 0.x version, preventing the escalation.

Verified with `changeset status`: core packages bump to minor, plugins to patch, no majors.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code