### PR TITLE
fix(admin): add JSON field editor in content forms

### DIFF
--- a/.changeset/five-heads-care.md
+++ b/.changeset/five-heads-care.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds JSON field editor in admin UI content forms

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1326,6 +1326,7 @@ function JsonFieldEditor({
 	onChange: (value: unknown) => void;
 	required?: boolean;
 }) {
+	const { t } = useLingui();
 	const [text, setText] = React.useState(value);
 	const [error, setError] = React.useState<string | null>(null);
 
@@ -1337,17 +1338,22 @@ function JsonFieldEditor({
 
 	const handleChange = (newText: string) => {
 		setText(newText);
-		if (newText.trim() === "") {
+		setError(null);
+	};
+
+	const handleBlur = () => {
+		const trimmed = text.trim();
+		if (trimmed === "") {
 			setError(null);
 			onChange(null);
 			return;
 		}
 		try {
-			const parsed = JSON.parse(newText);
+			const parsed = JSON.parse(trimmed);
 			setError(null);
 			onChange(parsed);
 		} catch {
-			setError("Invalid JSON");
+			setError(t`Invalid JSON`);
 		}
 	};
 
@@ -1358,6 +1364,7 @@ function JsonFieldEditor({
 				id={id}
 				value={text}
 				onChange={(e) => handleChange(e.target.value)}
+				onBlur={handleBlur}
 				rows={8}
 				placeholder="{}"
 				required={required}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1282,6 +1282,20 @@ function FieldRenderer({
 			);
 		}
 
+		case "json": {
+			const jsonString =
+				typeof value === "string" ? value : value != null ? JSON.stringify(value, null, 2) : "";
+			return (
+				<JsonFieldEditor
+					label={label}
+					id={id}
+					value={jsonString}
+					onChange={handleChange}
+					required={field.required}
+				/>
+			);
+		}
+
 		default:
 			// Default to text input
 			return (
@@ -1294,6 +1308,64 @@ function FieldRenderer({
 				/>
 			);
 	}
+}
+
+/**
+ * JSON field editor with syntax validation
+ */
+function JsonFieldEditor({
+	label,
+	id,
+	value,
+	onChange,
+	required,
+}: {
+	label: string;
+	id: string;
+	value: string;
+	onChange: (value: unknown) => void;
+	required?: boolean;
+}) {
+	const [text, setText] = React.useState(value);
+	const [error, setError] = React.useState<string | null>(null);
+
+	// Sync from parent when value changes externally
+	React.useEffect(() => {
+		setText(value);
+		setError(null);
+	}, [value]);
+
+	const handleChange = (newText: string) => {
+		setText(newText);
+		if (newText.trim() === "") {
+			setError(null);
+			onChange(null);
+			return;
+		}
+		try {
+			const parsed = JSON.parse(newText);
+			setError(null);
+			onChange(parsed);
+		} catch {
+			setError("Invalid JSON");
+		}
+	};
+
+	return (
+		<div>
+			<InputArea
+				label={label}
+				id={id}
+				value={text}
+				onChange={(e) => handleChange(e.target.value)}
+				rows={8}
+				placeholder="{}"
+				required={required}
+				className="font-mono text-sm"
+			/>
+			{error && <p className="text-sm text-kumo-danger mt-1">{error}</p>}
+		</div>
+	);
 }
 
 /**

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -261,6 +261,27 @@ describe("ContentEditor", () => {
 			await expect.element(all[1]!).not.toBeChecked();
 			await expect.element(all[2]!).toBeChecked();
 		});
+
+		it("renders json fields as a textarea", async () => {
+			const screen = await renderEditor({
+				fields: { metadata: { kind: "json", label: "Metadata" } },
+				isNew: true,
+			});
+			const textarea = screen.getByLabelText("Metadata");
+			await expect.element(textarea).toBeInTheDocument();
+			// JSON field uses a textarea element
+			expect(textarea.element().tagName).toBe("TEXTAREA");
+		});
+
+		it("renders json fields with object values as formatted JSON", async () => {
+			const jsonData = { foo: "bar", num: 42 };
+			const screen = await renderEditor({
+				fields: { metadata: { kind: "json", label: "Metadata" } },
+				item: makeItem({ data: { title: "Test", body: "", metadata: jsonData } }),
+			});
+			const textarea = screen.getByLabelText("Metadata");
+			await expect.element(textarea).toHaveValue(JSON.stringify(jsonData, null, 2));
+		});
 	});
 
 	describe("saving", () => {


### PR DESCRIPTION
## What does this PR do?

The JSON field type was selectable in the schema editor, but had no dedicated input renderer in the content editor. It fell through to the default text `Input`, which rendered empty for object values since `typeof value === "string"` is false for objects.

This adds a `JsonFieldEditor` component that:
- Serializes object values to formatted JSON for display
- Parses user input back to a JS value on change
- Shows inline validation feedback for invalid JSON

Closes #405

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Two new tests added in `ContentEditor.test.tsx`:
- `renders json fields as a textarea` — verifies the JSON field renders a `<textarea>` element
- `renders json fields with object values as formatted JSON` — verifies object data is serialized as pretty-printed JSON