### PR TITLE
fix(admin): show nav items in mobile sidebar drawer

### DIFF
--- a/.changeset/dark-cats-say.md
+++ b/.changeset/dark-cats-say.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes mobile sidebar nav sections not displaying their pages

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -307,6 +307,11 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 			.emdash-sidebar[data-state="collapsed"] [data-sidebar="group-content"] {
 				grid-template-rows: 1fr !important;
 			}
+			/* Mobile drawer: kumo's Sheet has no data-state attribute, so group-content
+			   stays at grid-rows-[0fr] (hidden). Force it open in the mobile sidebar. */
+			.emdash-sidebar[data-mobile="true"] [data-sidebar="group-content"] {
+				grid-template-rows: 1fr !important;
+			}
 			/* Collapsed separators — thin centered line */
 			.emdash-sidebar[data-state="collapsed"] [data-sidebar="separator"] {
 				margin: 0.375rem 0.625rem;


### PR DESCRIPTION
## What does this PR do?

Fixes the mobile sidebar not displaying navigation pages within sections (Content, Manage, Admin, Plugins). The section headers were visible but all pages inside them were hidden.

**Root cause:** Kumo's `Sidebar` component renders the mobile sidebar inside a Sheet/Dialog. The inner `div[data-sidebar="sidebar"]` gets `data-mobile="true"` but no `data-state` attribute. Kumo's `SidebarGroupContent` uses `grid-rows-[0fr]` as default (hidden) and only shows content via `group-data-[state=expanded]/sidebar:grid-rows-[1fr]`. Without `data-state="expanded"` on mobile, the selector never matches and all collapsible group content stays invisible.

**Fix:** Adds a CSS override targeting `.emdash-sidebar[data-mobile="true"] [data-sidebar="group-content"]` to force `grid-template-rows: 1fr` in the mobile drawer.

Closes #454

## Type of change

- [x] Bug fix
- [ ] Feature (requires [approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm --silent lint:json | jq '.diagnostics | length'` returns 0
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

This is a CSS-only fix targeting the mobile sidebar drawer. The change is a single `grid-template-rows: 1fr !important` override scoped to `[data-mobile="true"]`, matching the existing pattern used for collapsed sidebar icon mode.