### PR TITLE
fix(core): read manifest version from package.json at build time

### DIFF
--- a/.changeset/fix-manifest-version.md
+++ b/.changeset/fix-manifest-version.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes manifest version being hardcoded to "0.1.0". The version and git commit SHA are now injected at build time via tsdown/Vite `define`, reading from package.json and `git rev-parse`.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ export interface SidebarNavProps {
 			label: string;
 		}>;
 		version?: string;
+		commit?: string;
 		marketplace?: string;
 	};
 }
@@ -415,6 +416,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 				<KumoSidebar.Footer>
 					<p className="emdash-nav-label px-3 py-2 text-[11px] text-white/30">
 						EmDash CMS v{manifest.version || "0.0.0"}
+						{manifest.commit && ` (${manifest.commit})`}
 					</p>
 				</KumoSidebar.Footer>
 			</KumoSidebar>

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import type { AstroConfig } from "astro";
 import type { Plugin } from "vite";
 
+import { COMMIT, VERSION } from "../../version.js";
 import type { EmDashConfig, PluginDescriptor } from "./runtime.js";
 import {
 	VIRTUAL_CONFIG_ID,
@@ -278,6 +279,12 @@ export function createViteConfig(
 	const useSource = adminSourcePath !== undefined;
 
 	return {
+		// Astro SSR routes resolve version.ts from source (not tsdown dist),
+		// so Vite needs its own define pass for the __EMDASH_*__ placeholders.
+		define: {
+			__EMDASH_VERSION__: JSON.stringify(VERSION),
+			__EMDASH_COMMIT__: JSON.stringify(COMMIT),
+		},
 		resolve: {
 			dedupe: ["@emdash-cms/admin", "react", "react-dom"],
 			// Array form so more-specific entries are checked first.

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -11,6 +11,7 @@ import type { APIRoute } from "astro";
 
 import { getAuthMode } from "#auth/mode.js";
 
+import { COMMIT, VERSION } from "../../../version.js";
 import type { EmDashManifest } from "../../types.js";
 
 export const prerender = false;
@@ -43,7 +44,8 @@ export const GET: APIRoute = async ({ locals }) => {
 				signupEnabled,
 			}
 		: {
-				version: "0.1.0",
+				version: VERSION,
+				commit: COMMIT,
 				hash: "default",
 				collections: {},
 				plugins: {},

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -102,6 +102,7 @@ export type ManifestAuthMode = string;
  */
 export interface EmDashManifest {
 	version: string;
+	commit?: string;
 	hash: string;
 	collections: Record<string, ManifestCollection>;
 	plugins: Record<string, ManifestPlugin>;

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -38,6 +38,7 @@ import type {
 } from "./plugins/types.js";
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
+import { COMMIT, VERSION } from "./version.js";
 
 const LEADING_SLASH_PATTERN = /^\//;
 
@@ -1352,7 +1353,8 @@ export class EmDashRuntime {
 				: undefined;
 
 		return {
-			version: "0.1.0",
+			version: VERSION,
+			commit: COMMIT,
 			hash: manifestHash,
 			collections: manifestCollections,
 			plugins: manifestPlugins,

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,12 @@
+/**
+ * Build-time version constants, replaced by tsdown/Vite `define`.
+ * Falls back to "dev" when running uncompiled (tests, dev).
+ */
+
+declare const __EMDASH_VERSION__: string;
+declare const __EMDASH_COMMIT__: string;
+
+export const VERSION: string =
+	typeof __EMDASH_VERSION__ !== "undefined" ? __EMDASH_VERSION__ : "dev";
+
+export const COMMIT: string = typeof __EMDASH_COMMIT__ !== "undefined" ? __EMDASH_COMMIT__ : "dev";

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,4 +1,16 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
 import { defineConfig } from "tsdown";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf-8")) as { version: string };
+const commit = (() => {
+	try {
+		return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+	} catch {
+		return "unknown";
+	}
+})();
 
 export default defineConfig({
 	entry: [
@@ -45,6 +57,10 @@ export default defineConfig({
 	format: "esm",
 	dts: true,
 	clean: true,
+	define: {
+		__EMDASH_VERSION__: JSON.stringify(pkg.version),
+		__EMDASH_COMMIT__: JSON.stringify(commit),
+	},
 	// Externalize native modules, dialect-specific packages, and internal shared modules
 	external: [
 		// Native modules that use __filename


### PR DESCRIPTION
## What does this PR do?

The admin UI always displays "EmDash CMS v0.1.0" because the version is hardcoded in three places (`emdash-runtime.ts`, manifest route fallback, and `generateManifest`). This PR replaces the hardcoded string with build-time constants injected via `define` in both tsdown and Vite.

**How it works:**
- `tsdown.config.ts` reads `package.json` version + `git rev-parse --short HEAD` at build time, injects them via `define`
- `src/version.ts` exports `VERSION` and `COMMIT` using `__EMDASH_*__` placeholders (standard dunder convention for build-time replacement)
- `vite-config.ts` re-injects the same values for Astro SSR routes (which go through Vite's pipeline, not tsdown)
- Falls back to `"dev"` when running uncompiled (tests, dev without prior build)

Works on both Node and Cloudflare Workers, zero runtime file I/O, no `createRequire` or `fs` at runtime.

Also adds an optional `commit` field to `EmDashManifest` for build traceability.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Build output confirms values are inlined:
```
dist/version-B3oOFWyh.mjs:
  const VERSION = "0.2.0";
  const COMMIT = "deb7828";
```

All 2351 core tests passing.
