### PR TITLE
Migrate templates and demos to Astro Fonts API

### DIFF
--- a/demos/cloudflare/astro.config.mjs
+++ b/demos/cloudflare/astro.config.mjs
@@ -12,7 +12,7 @@ import {
 } from "@emdash-cms/cloudflare";
 import { formsPlugin } from "@emdash-cms/plugin-forms";
 import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -96,5 +96,21 @@ export default defineConfig({
 			},
 		},
 	},
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
+	],
 	devToolbar: { enabled: false },
 });

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -75,7 +75,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -7,6 +7,7 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
 import "../styles/theme.css";
 
@@ -74,12 +75,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
@@ -388,13 +385,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/demos/cloudflare/src/styles/theme.css
+++ b/demos/cloudflare/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/demos/playground/astro.config.mjs
+++ b/demos/playground/astro.config.mjs
@@ -1,7 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { playgroundDatabase } from "@emdash-cms/cloudflare";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -23,6 +23,22 @@ export default defineConfig({
 				middlewareEntrypoint: "@emdash-cms/cloudflare/db/playground-middleware",
 			},
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/demos/playground/src/layouts/Base.astro
+++ b/demos/playground/src/layouts/Base.astro
@@ -75,7 +75,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />

--- a/demos/playground/src/layouts/Base.astro
+++ b/demos/playground/src/layouts/Base.astro
@@ -7,6 +7,7 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
 import "../styles/theme.css";
 
@@ -74,12 +75,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
@@ -388,13 +385,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/demos/playground/src/styles/theme.css
+++ b/demos/playground/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/demos/postgres/astro.config.mjs
+++ b/demos/postgres/astro.config.mjs
@@ -1,6 +1,6 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 import { postgres } from "emdash/db";
 
@@ -16,6 +16,22 @@ export default defineConfig({
 				connectionString: process.env.DATABASE_URL || "postgres://localhost:5432/emdash_dev",
 			}),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/demos/postgres/src/layouts/Base.astro
+++ b/demos/postgres/src/layouts/Base.astro
@@ -75,7 +75,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />

--- a/demos/postgres/src/layouts/Base.astro
+++ b/demos/postgres/src/layouts/Base.astro
@@ -7,6 +7,7 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
 import "../styles/theme.css";
 
@@ -74,12 +75,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
@@ -388,13 +385,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/demos/postgres/src/styles/theme.css
+++ b/demos/postgres/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/demos/preview/astro.config.mjs
+++ b/demos/preview/astro.config.mjs
@@ -1,7 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { previewDatabase } from "@emdash-cms/cloudflare";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -13,6 +13,22 @@ export default defineConfig({
 			// DO-backed preview database — populated from source site snapshots
 			database: previewDatabase({ binding: "PREVIEW_DB" }),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/demos/preview/src/layouts/Base.astro
+++ b/demos/preview/src/layouts/Base.astro
@@ -75,7 +75,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />

--- a/demos/preview/src/layouts/Base.astro
+++ b/demos/preview/src/layouts/Base.astro
@@ -7,6 +7,7 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
 import "../styles/theme.css";
 
@@ -74,12 +75,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
@@ -388,13 +385,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/demos/preview/src/styles/theme.css
+++ b/demos/preview/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/demos/simple/astro.config.mjs
+++ b/demos/simple/astro.config.mjs
@@ -1,7 +1,7 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
 import { auditLogPlugin } from "@emdash-cms/plugin-audit-log";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash, { local } from "emdash/astro";
 import { sqlite } from "emdash/db";
 
@@ -33,6 +33,22 @@ export default defineConfig({
 			// HTTPS reverse proxy: uncomment so all origin-dependent features match browser
 			// siteUrl: "https://emdash.local:8443",
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 	// Example: allowed hosts for reverse proxy

--- a/demos/simple/src/layouts/Base.astro
+++ b/demos/simple/src/layouts/Base.astro
@@ -75,7 +75,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />

--- a/demos/simple/src/layouts/Base.astro
+++ b/demos/simple/src/layouts/Base.astro
@@ -7,6 +7,7 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
 import "../styles/theme.css";
 
@@ -74,12 +75,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
@@ -388,13 +385,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/demos/simple/src/styles/theme.css
+++ b/demos/simple/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/templates/blog-cloudflare/astro.config.mjs
+++ b/templates/blog-cloudflare/astro.config.mjs
@@ -3,7 +3,7 @@ import react from "@astrojs/react";
 import { d1, r2, sandbox } from "@emdash-cms/cloudflare";
 import { formsPlugin } from "@emdash-cms/plugin-forms";
 import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -23,6 +23,22 @@ export default defineConfig({
 			sandboxRunner: sandbox(),
 			marketplace: "https://marketplace.emdashcms.com",
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/blog-cloudflare/src/layouts/Base.astro
+++ b/templates/blog-cloudflare/src/layouts/Base.astro
@@ -8,6 +8,7 @@ import {
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
@@ -75,12 +76,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
@@ -400,13 +397,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/templates/blog-cloudflare/src/layouts/Base.astro
+++ b/templates/blog-cloudflare/src/layouts/Base.astro
@@ -76,7 +76,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}

--- a/templates/blog-cloudflare/src/styles/theme.css
+++ b/templates/blog-cloudflare/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/templates/blog/astro.config.mjs
+++ b/templates/blog/astro.config.mjs
@@ -1,7 +1,7 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
 import { auditLogPlugin } from "@emdash-cms/plugin-audit-log";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash, { local } from "emdash/astro";
 import { sqlite } from "emdash/db";
 
@@ -24,6 +24,22 @@ export default defineConfig({
 			}),
 			plugins: [auditLogPlugin()],
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["sans-serif"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-mono",
+			weights: [400, 500],
+			fallbacks: ["monospace"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/blog/src/layouts/Base.astro
+++ b/templates/blog/src/layouts/Base.astro
@@ -8,6 +8,7 @@ import {
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
@@ -75,12 +76,8 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600;14..32,700&family=JetBrains+Mono:wght@400;500&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
@@ -400,13 +397,6 @@ const isLoggedIn = !!Astro.locals.user;
 				--emdash-search-border: var(--color-border);
 				--emdash-search-hover: var(--color-surface);
 				--emdash-search-highlight: var(--color-text);
-
-				/* Typography */
-				--font-sans:
-					"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-					sans-serif;
-				--font-mono:
-					"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
 				/* Type scale - more refined */
 				--font-size-xs: 0.8125rem;

--- a/templates/blog/src/layouts/Base.astro
+++ b/templates/blog/src/layouts/Base.astro
@@ -76,7 +76,7 @@ const isLoggedIn = !!Astro.locals.user;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}

--- a/templates/blog/src/styles/theme.css
+++ b/templates/blog/src/styles/theme.css
@@ -27,11 +27,6 @@
 	--color-accent-ring: color-mix(in srgb, var(--color-accent) 25%, transparent);
 	*/
 
-	/* --- Fonts ---
-	--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-	--font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-	*/
-
 	/* --- Type scale ---
 	--font-size-xs: 0.8125rem;
 	--font-size-sm: 0.875rem;

--- a/templates/marketing-cloudflare/astro.config.mjs
+++ b/templates/marketing-cloudflare/astro.config.mjs
@@ -1,7 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { d1, r2 } from "@emdash-cms/cloudflare";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -17,6 +17,15 @@ export default defineConfig({
 			database: d1({ binding: "DB", session: "auto" }),
 			storage: r2({ binding: "MEDIA" }),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700, 800],
+			fallbacks: ["sans-serif"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -44,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<link
 			href="https://unpkg.com/@phosphor-icons/web@2.1.2/src/regular/style.css"
 			rel="stylesheet"

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 
 interface Props {
 	title?: string;
@@ -43,32 +44,11 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			rel="preload"
-			as="style"
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-		/>
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
 		<link
 			href="https://unpkg.com/@phosphor-icons/web@2.1.2/src/regular/style.css"
 			rel="stylesheet"
 		/>
-		<style>
-			/* Fallback font with metrics adjusted to match Inter */
-			@font-face {
-				font-family: "Inter Fallback";
-				src: local("Arial");
-				size-adjust: 107%;
-				ascent-override: 90%;
-				descent-override: 25%;
-				line-gap-override: 0%;
-			}
-		</style>
 		<script is:inline>
 			// Apply theme immediately to prevent flash
 			(function () {
@@ -256,8 +236,6 @@ const pageCtx = createPublicPageContext({
 				--color-warning: #f59e0b;
 
 				/* Typography */
-				--font-sans:
-					"Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
 				--font-mono: ui-monospace, "SF Mono", monospace;
 
 				--font-size-xs: 0.75rem;

--- a/templates/marketing/astro.config.mjs
+++ b/templates/marketing/astro.config.mjs
@@ -1,6 +1,6 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash, { local } from "emdash/astro";
 import { sqlite } from "emdash/db";
 
@@ -22,6 +22,15 @@ export default defineConfig({
 				baseUrl: "/_emdash/api/media/file",
 			}),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-sans",
+			weights: [400, 500, 600, 700, 800],
+			fallbacks: ["sans-serif"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -44,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-sans" />
+		<Font cssVariable="--font-sans" preload />
 		<link
 			href="https://unpkg.com/@phosphor-icons/web@2.1.2/src/regular/style.css"
 			rel="stylesheet"

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 
 interface Props {
 	title?: string;
@@ -43,32 +44,11 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			rel="preload"
-			as="style"
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-		/>
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-sans" />
 		<link
 			href="https://unpkg.com/@phosphor-icons/web@2.1.2/src/regular/style.css"
 			rel="stylesheet"
 		/>
-		<style>
-			/* Fallback font with metrics adjusted to match Inter */
-			@font-face {
-				font-family: "Inter Fallback";
-				src: local("Arial");
-				size-adjust: 107%;
-				ascent-override: 90%;
-				descent-override: 25%;
-				line-gap-override: 0%;
-			}
-		</style>
 		<script is:inline>
 			// Apply theme immediately to prevent flash
 			(function () {
@@ -256,8 +236,6 @@ const pageCtx = createPublicPageContext({
 				--color-warning: #f59e0b;
 
 				/* Typography */
-				--font-sans:
-					"Inter", "Inter Fallback", system-ui, -apple-system, sans-serif;
 				--font-mono: ui-monospace, "SF Mono", monospace;
 
 				--font-size-xs: 0.75rem;

--- a/templates/portfolio-cloudflare/astro.config.mjs
+++ b/templates/portfolio-cloudflare/astro.config.mjs
@@ -1,7 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { d1, r2 } from "@emdash-cms/cloudflare";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash from "emdash/astro";
 
 export default defineConfig({
@@ -17,6 +17,15 @@ export default defineConfig({
 			database: d1({ binding: "DB", session: "auto" }),
 			storage: r2({ binding: "MEDIA" }),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Playfair Display",
+			cssVariable: "--font-serif",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["serif"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 
 interface Props {
 	title?: string;
@@ -43,12 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-serif" />
 		<link
 			rel="alternate"
 			type="application/rss+xml"
@@ -210,7 +206,6 @@ const pageCtx = createPublicPageContext({
 				--color-accent-muted: #a78bfa;
 
 				/* Typography */
-				--font-serif: "Playfair Display", Georgia, serif;
 				--font-sans: system-ui, -apple-system, sans-serif;
 				--font-mono: ui-monospace, monospace;
 

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -44,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-serif" />
+		<Font cssVariable="--font-serif" preload />
 		<link
 			rel="alternate"
 			type="application/rss+xml"

--- a/templates/portfolio/astro.config.mjs
+++ b/templates/portfolio/astro.config.mjs
@@ -1,6 +1,6 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import emdash, { local } from "emdash/astro";
 import { sqlite } from "emdash/db";
 
@@ -22,6 +22,15 @@ export default defineConfig({
 				baseUrl: "/_emdash/api/media/file",
 			}),
 		}),
+	],
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Playfair Display",
+			cssVariable: "--font-serif",
+			weights: [400, 500, 600, 700],
+			fallbacks: ["serif"],
+		},
 	],
 	devToolbar: { enabled: false },
 });

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
+import { Font } from "astro:assets";
 
 interface Props {
 	title?: string;
@@ -43,12 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&display=swap"
-			rel="stylesheet"
-		/>
+		<Font cssVariable="--font-serif" />
 		<link
 			rel="alternate"
 			type="application/rss+xml"
@@ -210,7 +206,6 @@ const pageCtx = createPublicPageContext({
 				--color-accent-muted: #a78bfa;
 
 				/* Typography */
-				--font-serif: "Playfair Display", Georgia, serif;
 				--font-sans: system-ui, -apple-system, sans-serif;
 				--font-mono: ui-monospace, monospace;
 

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -44,7 +44,7 @@ const pageCtx = createPublicPageContext({
 		<title>{fullTitle}</title>
 		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
-		<Font cssVariable="--font-serif" />
+		<Font cssVariable="--font-serif" preload />
 		<link
 			rel="alternate"
 			type="application/rss+xml"


### PR DESCRIPTION
## What does this PR do?

Replaces Google Fonts `<link>` tags with Astro 6's built-in Fonts API across all templates (blog, marketing, portfolio + cloudflare variants) and demos (simple, preview, postgres, playground, cloudflare).

Fonts are now declared in `astro.config.mjs` via `fontProviders.google()` and rendered with the `<Font>` component. This means fonts are downloaded and self-hosted at build time — no runtime requests to `fonts.googleapis.com` — with automatic optimized fallback font generation.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — templates and demos only, no published package changes.