### PR TITLE
fix: add defensive identifier validation to all SQL interpolation points

### DIFF
--- a/.changeset/petite-grapes-fly.md
+++ b/.changeset/petite-grapes-fly.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds defensive identifier validation to all SQL interpolation points to prevent injection via dynamic identifiers.

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
@@ -15,6 +15,7 @@ import { getSiteBaseUrl } from "#api/site-url.js";
 import { sendCommentNotification } from "#comments/notifications.js";
 import { createComment, type CommentHookRunner } from "#comments/service.js";
 import { CommentRepository } from "#db/repositories/comment.js";
+import { validateIdentifier } from "#db/validate.js";
 import { extractRequestMeta } from "#plugins/request-meta.js";
 import type { CollectionCommentSettings, ModerationDecision } from "#plugins/types.js";
 
@@ -106,6 +107,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		}
 
 		// Verify the content item exists, is published, and not soft-deleted
+		validateIdentifier(collection, "collection");
 		const contentRow = await emdash.db
 			.selectFrom(`ec_${collection}` as never)
 			.select(["id" as never, "slug" as never, "author_id" as never, "published_at" as never])

--- a/packages/core/src/astro/routes/api/import/wordpress/rewrite-urls.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/rewrite-urls.ts
@@ -17,6 +17,7 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { wpRewriteUrlsBody } from "#api/schemas.js";
+import { validateIdentifier } from "#db/validate.js";
 import { normalizeMediaValue } from "#media/normalize.js";
 import type { MediaProvider } from "#media/types.js";
 import type { EmDashHandlers } from "#types";
@@ -280,6 +281,7 @@ async function rewriteUrls(
 			continue;
 
 		// Get table name
+		validateIdentifier(collection.slug, "collection slug");
 		const tableName = `ec_${collection.slug}`;
 
 		try {

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -199,8 +199,8 @@ async function getAuthorId(
 	collection: string,
 	entryId: string,
 ): Promise<string | null> {
+	validateIdentifier(collection, "collection");
 	const tableName = `ec_${collection}`;
-	validateIdentifier(tableName, "content table");
 
 	const result = await sql<{ author_id: string | null }>`
 		SELECT author_id FROM ${sql.ref(tableName)}
@@ -220,8 +220,8 @@ async function getAuthorIds(
 	collection: string,
 	entryIds: string[],
 ): Promise<Map<string, string>> {
+	validateIdentifier(collection, "collection");
 	const tableName = `ec_${collection}`;
-	validateIdentifier(tableName, "content table");
 
 	const map = new Map<string, string>();
 	for (const chunk of chunks(entryIds, SQL_BATCH_SIZE)) {

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -14,6 +14,7 @@ import type { ColumnDataType, Kysely, RawBuilder } from "kysely";
 import { sql } from "kysely";
 
 import type { DatabaseDialectType } from "../db/adapters.js";
+import { validateIdentifier, validateJsonFieldName } from "./validate.js";
 
 export type { DatabaseDialectType };
 
@@ -131,6 +132,8 @@ export function binaryType(db: Kysely<any>): ColumnDataType {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export function jsonExtractExpr(db: Kysely<any>, column: string, path: string): string {
+	validateIdentifier(column, "JSON column name");
+	validateJsonFieldName(path, "JSON path");
 	if (isPostgres(db)) {
 		return `${column}->>'${path}'`;
 	}

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -3,6 +3,7 @@ import { ulid } from "ulidx";
 
 import { slugify } from "../../utils/slugify.js";
 import type { Database } from "../types.js";
+import { validateIdentifier } from "../validate.js";
 import { RevisionRepository } from "./revision.js";
 import type {
 	CreateContentInput,
@@ -41,6 +42,7 @@ const SYSTEM_COLUMNS = new Set([
  * Get the table name for a collection type
  */
 function getTableName(type: string): string {
+	validateIdentifier(type, "collection type");
 	return `ec_${type}`;
 }
 
@@ -168,6 +170,7 @@ export class ContentRepository {
 		if (data && typeof data === "object") {
 			for (const [key, value] of Object.entries(data)) {
 				if (!SYSTEM_COLUMNS.has(key)) {
+					validateIdentifier(key, "content field name");
 					columns.push(key);
 					values.push(serializeValue(value));
 				}
@@ -578,6 +581,7 @@ export class ContentRepository {
 		if (input.data !== undefined && typeof input.data === "object") {
 			for (const [key, value] of Object.entries(input.data)) {
 				if (!SYSTEM_COLUMNS.has(key)) {
+					validateIdentifier(key, "content field name");
 					updates[key] = serializeValue(value);
 				}
 			}

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1083,6 +1083,7 @@ export class ContentRepository {
 		for (const [key, value] of Object.entries(data)) {
 			if (SYSTEM_COLUMNS.has(key)) continue;
 			if (key.startsWith("_")) continue; // revision metadata
+			validateIdentifier(key, "content field name");
 			updates[key] = serializeValue(value);
 		}
 

--- a/packages/core/src/database/validate.ts
+++ b/packages/core/src/database/validate.ts
@@ -80,16 +80,6 @@ export function validateIdentifier(value: string, label = "identifier"): void {
 }
 
 /**
- * Validate that a string is a safe SQL identifier, allowing hyphens.
- *
- * Like `validateIdentifier` but also permits hyphens, which appear in
- * plugin IDs (e.g., "my-plugin"). Matches `/^[a-z][a-z0-9_-]*$/`.
- *
- * @param value - The string to validate
- * @param label - Human-readable label for error messages
- * @throws {IdentifierError} If the value is not valid
- */
-/**
  * Validate that a string is a safe JSON field name for use in json_extract paths.
  *
  * More permissive than `validateIdentifier` — allows camelCase (mixed case)
@@ -120,6 +110,16 @@ export function validateJsonFieldName(value: string, label = "JSON field name"):
 	}
 }
 
+/**
+ * Validate that a string is a safe SQL identifier, allowing hyphens.
+ *
+ * Like `validateIdentifier` but also permits hyphens, which appear in
+ * plugin IDs (e.g., "my-plugin"). Matches `/^[a-z][a-z0-9_-]*$/`.
+ *
+ * @param value - The string to validate
+ * @param label - Human-readable label for error messages
+ * @throws {IdentifierError} If the value is not valid
+ */
 export function validatePluginIdentifier(value: string, label = "plugin identifier"): void {
 	if (!value || typeof value !== "string") {
 		throw new IdentifierError(`${label} must be a non-empty string`, String(value));

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -23,6 +23,7 @@ import { isSqlite } from "./database/dialect-helpers.js";
 import { runMigrations } from "./database/migrations/runner.js";
 import { RevisionRepository } from "./database/repositories/revision.js";
 import type { ContentItem as ContentItemInternal } from "./database/repositories/types.js";
+import { validateIdentifier } from "./database/validate.js";
 import { normalizeMediaValue } from "./media/normalize.js";
 import type { MediaProvider, MediaProviderCapabilities } from "./media/types.js";
 import type { SandboxedPlugin, SandboxRunner } from "./plugins/sandbox/types.js";
@@ -1540,6 +1541,7 @@ export class EmDashRuntime {
 							});
 
 							// Update entry to point to new draft (metadata only, not data columns)
+							validateIdentifier(collection, "collection");
 							const tableName = `ec_${collection}`;
 							await sql`
 								UPDATE ${sql.ref(tableName)}

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -16,6 +16,7 @@ import { Kysely, sql, type Dialect } from "kysely";
 
 import { currentTimestampValue, isPostgres } from "./database/dialect-helpers.js";
 import { decodeCursor, encodeCursor } from "./database/repositories/types.js";
+import { validateIdentifier } from "./database/validate.js";
 import type { Database } from "./index.js";
 import { getRequestContext } from "./request-context.js";
 
@@ -50,6 +51,7 @@ const SYSTEM_COLUMNS = new Set([
  * Get the table name for a collection type
  */
 function getTableName(type: string): string {
+	validateIdentifier(type, "collection type");
 	return `ec_${type}`;
 }
 

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -8,6 +8,7 @@ import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
 import type { Database } from "../database/types.js";
+import { validateIdentifier } from "../database/validate.js";
 import { getDb } from "../loader.js";
 import { sanitizeHref } from "../utils/url.js";
 import type { Menu, MenuItem, MenuItemRow } from "./types.js";
@@ -273,6 +274,9 @@ async function resolveContentUrl(
 	}
 
 	try {
+		// Validate collection name before interpolating into table reference
+		validateIdentifier(collection, "menu item collection");
+
 		// Dynamic content tables (ec_*) aren't in the Database type, so use sql
 		const result = await sql<{ slug: string }>`
 			SELECT slug FROM ${sql.ref(`ec_${collection}`)} WHERE id = ${entryId} LIMIT 1

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -6,6 +6,7 @@ import { ulid } from "ulidx";
 import { currentTimestamp, listTablesLike, tableExists } from "../database/dialect-helpers.js";
 import { withTransaction } from "../database/transaction.js";
 import type { CollectionTable, Database, FieldTable } from "../database/types.js";
+import { validateIdentifier } from "../database/validate.js";
 import { FTSManager } from "../search/fts-manager.js";
 import {
 	type Collection,
@@ -684,6 +685,7 @@ export class SchemaRegistry {
 	 * Get table name for a collection
 	 */
 	private getTableName(slug: string): string {
+		validateIdentifier(slug, "collection slug");
 		return `ec_${slug}`;
 	}
 
@@ -691,6 +693,7 @@ export class SchemaRegistry {
 	 * Get column name for a field
 	 */
 	private getColumnName(slug: string): string {
+		validateIdentifier(slug, "field slug");
 		return slug;
 	}
 

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -39,6 +39,7 @@ export class FTSManager {
 	 * Uses _emdash_ prefix to clearly mark as internal/system table
 	 */
 	getFtsTableName(collectionSlug: string): string {
+		validateIdentifier(collectionSlug, "collection slug");
 		return `_emdash_fts_${collectionSlug}`;
 	}
 
@@ -46,6 +47,7 @@ export class FTSManager {
 	 * Get the content table name for a collection
 	 */
 	getContentTableName(collectionSlug: string): string {
+		validateIdentifier(collectionSlug, "collection slug");
 		return `ec_${collectionSlug}`;
 	}
 

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -101,6 +101,7 @@ export class FTSManager {
 	 * Create triggers to keep FTS table in sync with content table
 	 */
 	private async createTriggers(collectionSlug: string, searchableFields: string[]): Promise<void> {
+		this.validateInputs(collectionSlug, searchableFields);
 		const ftsTable = this.getFtsTableName(collectionSlug);
 		const contentTable = this.getContentTableName(collectionSlug);
 		const fieldList = searchableFields.join(", ");
@@ -147,6 +148,7 @@ export class FTSManager {
 	 * Drop triggers for a collection
 	 */
 	private async dropTriggers(collectionSlug: string): Promise<void> {
+		this.validateInputs(collectionSlug);
 		const ftsTable = this.getFtsTableName(collectionSlug);
 
 		await sql.raw(`DROP TRIGGER IF EXISTS "${ftsTable}_insert"`).execute(this.db);


### PR DESCRIPTION
## What does this PR do?

Adds `validateIdentifier()` / `validateJsonFieldName()` guards at every code path that interpolates dynamic identifiers into raw SQL. This is defense-in-depth -- all current callers pass validated identifiers, but these guards prevent future regressions if callers change or new callers are added.

Findings H2, H3, M18, M25, L9 from the code quality review.

## What changed

- `jsonExtractExpr()`: validates `column` and `path` params before interpolation
- `ContentRepository.getTableName()`: validates collection type
- `ContentRepository.create()`/`update()`/`syncDataColumns()`: validates data field keys
- `loader.ts getTableName()`: validates collection type (primary read path)
- `SchemaRegistry.getTableName()`/`getColumnName()`: validates slugs
- `resolveContentUrl()`: validates menu item collection name
- `FTSManager.getFtsTableName()`/`getContentTableName()`/`createTriggers()`/`dropTriggers()`: validates slugs
- `emdash-runtime.ts`: validates collection before `ec_$` construction
- `bylines/index.ts`: validates collection slug before prefixing (fixed ordering from validate-after-prefix to validate-before-prefix)
- Comments route and WordPress rewrite-urls route: validates collection identifiers
- Moved orphaned JSDoc to `validatePluginIdentifier` where it belongs

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation -- N/A
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion -- N/A (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Testing

- `pnpm lint` clean (0 diagnostics)
- `pnpm typecheck` passes for all changed packages
- Core tests pass (2015 passed, 6 skipped; 22 pre-existing failures in auth/import packages due to Vite resolution issue on this machine)
- Two rounds of adversarial review confirmed all `ec_$` interpolation points are now covered