### PR TITLE
fix: wrap concurrent operations in transactions for atomicity

### DIFF
--- a/.changeset/poor-feet-watch.md
+++ b/.changeset/poor-feet-watch.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes atomicity gaps: content update _rev check, menu reorder, byline delete, and seed content creation now run inside transactions.

--- a/.changeset/poor-feet-watch.md
+++ b/.changeset/poor-feet-watch.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes atomicity gaps: content update _rev check, menu reorder, byline delete, and seed content creation now run inside transactions.
+Fixes atomicity gaps: content update \_rev check, menu reorder, byline delete, and seed content creation now run inside transactions.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -503,29 +503,29 @@ export async function handleContentUpdate(
 		// Resolve slug → ID if needed
 		const resolvedId = (await resolveId(repo, collection, id)) ?? id;
 
-		// Validate _rev if provided (optimistic concurrency)
-		if (body._rev) {
-			const existing = await repo.findById(collection, resolvedId);
-			if (!existing) {
-				return {
-					success: false,
-					error: { code: "NOT_FOUND", message: `Content item not found: ${id}` },
-				};
-			}
-
-			const revCheck = validateRev(body._rev, existing);
-			if (!revCheck.valid) {
-				return {
-					success: false,
-					error: { code: "CONFLICT", message: revCheck.message },
-				};
-			}
-		}
-
-		// Wrap content + SEO writes in a transaction for atomicity
+		// Wrap content + SEO writes in a transaction for atomicity.
+		// The _rev check is inside the transaction so the read-then-write
+		// is atomic -- no concurrent write can slip between the check and update.
 		const item = await withTransaction(db, async (trx) => {
 			const trxRepo = new ContentRepository(trx);
 			const bylineRepo = new BylineRepository(trx);
+
+			// Validate _rev if provided (optimistic concurrency)
+			if (body._rev) {
+				const existing = await trxRepo.findById(collection, resolvedId);
+				if (!existing) {
+					throw Object.assign(new Error(`Content item not found: ${id}`), {
+						apiError: { code: "NOT_FOUND" as const, status: 404 },
+					});
+				}
+
+				const revCheck = validateRev(body._rev, existing);
+				if (!revCheck.valid) {
+					throw Object.assign(new Error(revCheck.message), {
+						apiError: { code: "CONFLICT" as const, status: 409 },
+					});
+				}
+			}
 
 			// Capture old slug before update for auto-redirect
 			let oldSlug: string | undefined;
@@ -598,6 +598,17 @@ export async function handleContentUpdate(
 			data: { item, _rev: encodeRev(item) },
 		};
 	} catch (error) {
+		// Handle structured errors thrown from inside the transaction
+		// (rev check failures, not-found)
+		if (error instanceof Error && "apiError" in error) {
+			const { code, status: _status } = (
+				error as Error & { apiError: { code: string; status: number } }
+			).apiError;
+			return {
+				success: false,
+				error: { code, message: error.message },
+			};
+		}
 		console.error("Content update error:", error);
 		return {
 			success: false,

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -510,30 +510,30 @@ export async function handleContentUpdate(
 			const trxRepo = new ContentRepository(trx);
 			const bylineRepo = new BylineRepository(trx);
 
+			// Read existing item once for both _rev check and old slug capture
+			const existing =
+				body._rev || body.slug ? await trxRepo.findById(collection, resolvedId) : null;
+
 			// Validate _rev if provided (optimistic concurrency)
 			if (body._rev) {
-				const existing = await trxRepo.findById(collection, resolvedId);
 				if (!existing) {
 					throw Object.assign(new Error(`Content item not found: ${id}`), {
-						apiError: { code: "NOT_FOUND" as const, status: 404 },
+						apiError: { code: "NOT_FOUND" as const },
 					});
 				}
 
 				const revCheck = validateRev(body._rev, existing);
 				if (!revCheck.valid) {
 					throw Object.assign(new Error(revCheck.message), {
-						apiError: { code: "CONFLICT" as const, status: 409 },
+						apiError: { code: "CONFLICT" as const },
 					});
 				}
 			}
 
 			// Capture old slug before update for auto-redirect
 			let oldSlug: string | undefined;
-			if (body.slug) {
-				const existing = await trxRepo.findById(collection, resolvedId);
-				if (existing?.slug && existing.slug !== body.slug) {
-					oldSlug = existing.slug;
-				}
+			if (body.slug && existing?.slug && existing.slug !== body.slug) {
+				oldSlug = existing.slug;
 			}
 
 			const updated = await trxRepo.update(collection, resolvedId, {
@@ -601,9 +601,7 @@ export async function handleContentUpdate(
 		// Handle structured errors thrown from inside the transaction
 		// (rev check failures, not-found)
 		if (error instanceof Error && "apiError" in error) {
-			const { code, status: _status } = (
-				error as Error & { apiError: { code: string; status: number } }
-			).apiError;
+			const { code } = (error as Error & { apiError: { code: string } }).apiError;
 			return {
 				success: false,
 				error: { code, message: error.message },

--- a/packages/core/src/api/handlers/menus.ts
+++ b/packages/core/src/api/handlers/menus.ts
@@ -8,6 +8,7 @@
 import type { Kysely } from "kysely";
 import { ulid } from "ulidx";
 
+import { withTransaction } from "../../database/transaction.js";
 import type { Database, MenuItemTable, MenuTable } from "../../database/types.js";
 import type { ApiResult } from "../types.js";
 
@@ -464,24 +465,26 @@ export async function handleMenuItemReorder(
 			};
 		}
 
-		for (const item of items) {
-			await db
-				.updateTable("_emdash_menu_items")
-				.set({
-					parent_id: item.parentId,
-					sort_order: item.sortOrder,
-				})
-				.where("id", "=", item.id)
-				.where("menu_id", "=", menu.id)
-				.execute();
-		}
+		const updatedItems = await withTransaction(db, async (trx) => {
+			for (const item of items) {
+				await trx
+					.updateTable("_emdash_menu_items")
+					.set({
+						parent_id: item.parentId,
+						sort_order: item.sortOrder,
+					})
+					.where("id", "=", item.id)
+					.where("menu_id", "=", menu.id)
+					.execute();
+			}
 
-		const updatedItems = await db
-			.selectFrom("_emdash_menu_items")
-			.selectAll()
-			.where("menu_id", "=", menu.id)
-			.orderBy("sort_order", "asc")
-			.execute();
+			return trx
+				.selectFrom("_emdash_menu_items")
+				.selectAll()
+				.where("menu_id", "=", menu.id)
+				.orderBy("sort_order", "asc")
+				.execute();
+		});
 
 		return { success: true, data: updatedItems };
 	} catch {

--- a/packages/core/src/database/repositories/byline.ts
+++ b/packages/core/src/database/repositories/byline.ts
@@ -3,6 +3,7 @@ import { ulid } from "ulidx";
 
 import { chunks, SQL_BATCH_SIZE } from "../../utils/chunks.js";
 import { listTablesLike } from "../dialect-helpers.js";
+import { withTransaction } from "../transaction.js";
 import type { BylineTable, Database } from "../types.js";
 import { validateIdentifier } from "../validate.js";
 import {
@@ -197,7 +198,7 @@ export class BylineRepository {
 		const existing = await this.findById(id);
 		if (!existing) return false;
 
-		await this.db.transaction().execute(async (trx) => {
+		await withTransaction(this.db, async (trx) => {
 			await trx.deleteFrom("_emdash_content_bylines").where("byline_id", "=", id).execute();
 
 			await trx.deleteFrom("_emdash_bylines").where("id", "=", id).execute();

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -15,6 +15,7 @@ import { ContentRepository } from "../database/repositories/content.js";
 import { MediaRepository } from "../database/repositories/media.js";
 import { RedirectRepository } from "../database/repositories/redirect.js";
 import { TaxonomyRepository } from "../database/repositories/taxonomy.js";
+import { withTransaction } from "../database/transaction.js";
 import type { Database } from "../database/types.js";
 import type { MediaValue } from "../fields/types.js";
 import { ssrfSafeFetch, validateExternalUrl } from "../import/ssrf.js";
@@ -342,7 +343,6 @@ export async function applySeed(
 	// 7. Content (created before menus so refs can resolve)
 	if (includeContent && seed.content) {
 		const contentRepo = new ContentRepository(db);
-		const bylineRepo = new BylineRepository(db);
 
 		// Create content entries
 		for (const [collectionSlug, entries] of Object.entries(seed.content)) {
@@ -366,25 +366,30 @@ export async function applySeed(
 							result,
 						);
 
+						// Update content + bylines + taxonomies atomically
 						const status = entry.status || "published";
-						await contentRepo.update(collectionSlug, existing.id, {
-							status,
-							data: resolvedData,
+						await withTransaction(db, async (trx) => {
+							const trxContentRepo = new ContentRepository(trx);
+							const trxBylineRepo = new BylineRepository(trx);
+
+							await trxContentRepo.update(collectionSlug, existing.id, {
+								status,
+								data: resolvedData,
+							});
+
+							await applyContentBylines(
+								trxBylineRepo,
+								collectionSlug,
+								existing.id,
+								entry,
+								seedBylineIdMap,
+								true,
+							);
+							await applyContentTaxonomies(trx, collectionSlug, existing.id, entry, true);
 						});
 
 						seedIdMap.set(entry.id, existing.id);
 						result.content.updated++;
-
-						// Update bylines and taxonomy assignments
-						await applyContentBylines(
-							bylineRepo,
-							collectionSlug,
-							existing.id,
-							entry,
-							seedBylineIdMap,
-							true,
-						);
-						await applyContentTaxonomies(db, collectionSlug, existing.id, entry, true);
 						continue;
 					}
 
@@ -410,24 +415,30 @@ export async function applySeed(
 					}
 				}
 
-				// Create entry
+				// Create entry + bylines + taxonomies atomically
 				const status = entry.status || "published";
-				const created = await contentRepo.create({
-					type: collectionSlug,
-					slug: entry.slug,
-					status,
-					data: resolvedData,
-					locale: entry.locale,
-					translationOf,
-					// Set published_at for published content so RSS/Archives work correctly
-					publishedAt: status === "published" ? new Date().toISOString() : null,
+				const created = await withTransaction(db, async (trx) => {
+					const trxContentRepo = new ContentRepository(trx);
+					const trxBylineRepo = new BylineRepository(trx);
+
+					const item = await trxContentRepo.create({
+						type: collectionSlug,
+						slug: entry.slug,
+						status,
+						data: resolvedData,
+						locale: entry.locale,
+						translationOf,
+						publishedAt: status === "published" ? new Date().toISOString() : null,
+					});
+
+					await applyContentBylines(trxBylineRepo, collectionSlug, item.id, entry, seedBylineIdMap);
+					await applyContentTaxonomies(trx, collectionSlug, item.id, entry, false);
+
+					return item;
 				});
 
 				seedIdMap.set(entry.id, created.id);
 				result.content.created++;
-
-				await applyContentBylines(bylineRepo, collectionSlug, created.id, entry, seedBylineIdMap);
-				await applyContentTaxonomies(db, collectionSlug, created.id, entry, false);
 			}
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes four atomicity gaps identified in the code quality review (findings H1, M4, M7, M17).

- **Content update (H1):** Moved the `_rev` optimistic concurrency check inside the transaction so the read-then-write is atomic. A concurrent write between the rev check and update can no longer succeed. Also deduplicated a redundant `findById` call when both `_rev` and `slug` are provided.
- **Menu reorder (M4):** Wrapped sequential menu item position updates in `withTransaction()` to prevent partial reorder if a crash occurs mid-loop.
- **Byline delete (M7):** Replaced `db.transaction().execute()` with `withTransaction()` for D1 compatibility (D1 doesn't support native transactions; `withTransaction` handles the fallback).
- **Seed content (M17):** Wrapped each content entry creation/update + bylines + taxonomies in a per-entry transaction. A crash mid-seed no longer leaves orphaned content without its associated bylines/taxonomies.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)

## AI-generated code disclosure

- [x] This PR includes AI-generated code