### PR TITLE
i18n(fr): add French translations (178/178 strings)

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -2,7 +2,7 @@ import type { LinguiConfig } from "@lingui/conf";
 
 const config: LinguiConfig = {
 	sourceLocale: "en",
-	locales: ["en", "de"],
+	locales: ["en", "de", "fr"],
 	catalogs: [
 		{
 			path: "<rootDir>/packages/admin/src/locales/{locale}/messages",

--- a/lunaria.config.ts
+++ b/lunaria.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
 			label: "Deutsch",
 			lang: "de",
 		},
+		{
+			label: "Français",
+			lang: "fr",
+		},
 	],
 	files: [
 		{

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -279,7 +279,7 @@ msgstr "Embeds"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
-msgstr "Activer la recherche plein texte sur cette collection"
+msgstr "Permettre la recherche dans le contenu de cette collection"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:280

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -1,0 +1,754 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-12 19:53+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+msgid " (default)"
+msgstr " (par défaut)"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — aucune traduction"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — voir la traduction"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
+msgid "1 year"
+msgstr "1 an"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
+msgid "30 days"
+msgstr "30 jours"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
+msgid "7 days"
+msgstr "7 jours"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:43
+msgid "90 days"
+msgstr "90 jours"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Admin"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Administrateur"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Toutes les langues"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Tous les rôles"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "Autoriser les utilisateurs de domaines spécifiques à s'inscrire"
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
+msgid "API Tokens"
+msgstr "Tokens d'API"
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "En tant qu'administrateur, vous pouvez inviter d'autres utilisateurs depuis la section Utilisateurs."
+
+#: packages/admin/src/components/LoginPage.tsx:253
+msgid "Authentication error: {error}"
+msgstr "Erreur d'authentification : {error}"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Auteur"
+
+#: packages/admin/src/components/LoginPage.tsx:174
+#: packages/admin/src/components/LoginPage.tsx:210
+msgid "Back to login"
+msgstr "Retour à la connexion"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+msgid "Back to settings"
+msgstr "Retour aux paramètres"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:101
+#: packages/admin/src/components/PortableTextEditor.tsx:729
+msgid "Bullet List"
+msgstr "Liste à puces"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Peut créer du contenu"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Peut gérer tout le contenu"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Peut publier son propre contenu"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Peut consulter le contenu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+msgid "Cancel"
+msgstr "Annuler"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "Catégories"
+
+#: packages/admin/src/components/LoginPage.tsx:158
+msgid "Check your email"
+msgstr "Vérifiez votre e-mail"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "Choisissez votre langue d'administration préférée"
+
+#: packages/admin/src/components/LoginPage.tsx:169
+msgid "Click the link in the email to sign in."
+msgstr "Cliquez sur le lien dans l'e-mail pour vous connecter."
+
+#: packages/admin/src/components/WelcomeModal.tsx:54
+msgid "Close"
+msgstr "Fermer"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:93
+#: packages/admin/src/components/PortableTextEditor.tsx:759
+msgid "Code Block"
+msgstr "Bloc de code"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/PortableTextEditor.tsx:1431
+msgid "Content"
+msgstr "Contenu"
+
+#: packages/admin/src/components/Widgets.tsx:88
+msgid "Content Block"
+msgstr "Bloc de contenu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
+msgid "Content Read"
+msgstr "Lecture du contenu"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+msgid "Content Types"
+msgstr "Types de contenu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
+msgid "Content Write"
+msgstr "Écriture du contenu"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Contributeur"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copied to clipboard"
+msgstr "Copié dans le presse-papiers"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
+msgid "Copy this token now — it won't be shown again."
+msgstr "Copiez ce token maintenant — il ne sera plus affiché."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:211
+msgid "Copy token"
+msgstr "Copier le token"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:730
+msgid "Create a bullet list"
+msgstr "Créer une liste à puces"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:740
+msgid "Create a numbered list"
+msgstr "Créer une liste numérotée"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
+msgid "Create New Token"
+msgstr "Créer un nouveau token"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Créez des tokens d'accès personnels pour un accès programmatique à l'API"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+msgid "Create Token"
+msgstr "Créer un token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Create, update, delete content"
+msgstr "Créer, modifier, supprimer du contenu"
+
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+msgid "Created {0}"
+msgstr "Créé le {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:121
+msgid "Created At"
+msgstr "Créé le"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+msgid "Creating..."
+msgstr "Création en cours..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:226
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
+msgid "Dismiss"
+msgstr "Fermer"
+
+#: packages/admin/src/components/Widgets.tsx:95
+msgid "Display a navigation menu"
+msgstr "Afficher un menu de navigation"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:769
+msgid "Divider"
+msgstr "Séparateur"
+
+#: packages/admin/src/components/LoginPage.tsx:358
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Pas encore de compte ? <0>S'inscrire</0>"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+msgid "draft, published, or archived"
+msgstr "brouillon, publié ou archivé"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:69
+msgid "Drafts"
+msgstr "Brouillons"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:403
+msgid "e.g., CI/CD Pipeline"
+msgstr "ex. : pipeline CI/CD"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Éditeur"
+
+#: packages/admin/src/components/Settings.tsx:115
+msgid "Email"
+msgstr "E-mail"
+
+#: packages/admin/src/components/LoginPage.tsx:183
+msgid "Email address"
+msgstr "Adresse e-mail"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:1443
+msgid "Embed a {0}"
+msgstr "Insérer un {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1446
+msgid "Embeds"
+msgstr "Embeds"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:85
+msgid "Enable full-text search on this collection"
+msgstr "Activer la recherche plein texte sur cette collection"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:280
+msgid "Expires {0}"
+msgstr "Expire le {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
+msgid "Expiry"
+msgstr "Expiration"
+
+#: packages/admin/src/components/LoginPage.tsx:127
+#: packages/admin/src/components/LoginPage.tsx:132
+msgid "Failed to send magic link"
+msgstr "Échec de l'envoi du lien de connexion"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Accès complet"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Full admin access"
+msgstr "Accès administrateur complet"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "Général"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Commencer"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:61
+#: packages/admin/src/components/PortableTextEditor.tsx:699
+msgid "Heading 1"
+msgstr "Titre 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:69
+#: packages/admin/src/components/PortableTextEditor.tsx:709
+msgid "Heading 2"
+msgstr "Titre 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:77
+#: packages/admin/src/components/PortableTextEditor.tsx:719
+msgid "Heading 3"
+msgstr "Titre 3"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
+msgid "Hide token"
+msgstr "Masquer le token"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:103
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:160
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Si un compte existe pour <0>{email}</0>, nous vous avons envoyé un lien de connexion."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1413
+msgid "Image"
+msgstr "Image"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+msgid "Import"
+msgstr "Importer"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:750
+msgid "Insert a blockquote"
+msgstr "Insérer une citation"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:760
+msgid "Insert a code block"
+msgstr "Insérer un bloc de code"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:770
+msgid "Insert a horizontal rule"
+msgstr "Insérer un séparateur horizontal"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1428
+msgid "Insert a reusable section"
+msgstr "Insérer une section réutilisable"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1414
+msgid "Insert an image"
+msgstr "Insérer une image"
+
+#: packages/admin/src/components/Settings.tsx:129
+msgid "Language"
+msgstr "Langue"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:700
+msgid "Large section heading"
+msgstr "Titre principal"
+
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+msgid "Last used {0}"
+msgstr "Dernière utilisation le {0}"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Loading..."
+msgstr "Chargement..."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Langue"
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "Gérez vos clés d'accès et votre authentification"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1417
+msgid "Media"
+msgstr "Médias"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+msgid "Media Library"
+msgstr "Médiathèque"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:64
+msgid "Media Read"
+msgstr "Lecture des médias"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:69
+msgid "Media Write"
+msgstr "Écriture des médias"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:710
+msgid "Medium section heading"
+msgstr "Titre secondaire"
+
+#: packages/admin/src/components/Widgets.tsx:94
+msgid "Menu"
+msgstr "Menu"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+msgid "Menus"
+msgstr "Menus"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Modify collection schemas"
+msgstr "Modifier les schémas de collections"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Navigation"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "nouvel onglet"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
+msgid "No API tokens yet. Create one to get started."
+msgstr "Aucun token d'API pour l'instant. Créez-en un pour commencer."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
+msgid "No expiry"
+msgstr "Sans expiration"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:940
+msgid "No results"
+msgstr "Aucun résultat"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "Aucun résultat trouvé"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:109
+#: packages/admin/src/components/PortableTextEditor.tsx:739
+msgid "Numbered List"
+msgstr "Liste numérotée"
+
+#: packages/admin/src/components/LoginPage.tsx:313
+msgid "Or continue with"
+msgstr "Ou se connecter avec"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:53
+msgid "Paragraph"
+msgstr "Paragraphe"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+msgid "Plugins"
+msgstr "Plugins"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:79
+msgid "Preview"
+msgstr "Aperçu"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:80
+msgid "Preview content before publishing"
+msgstr "Prévisualiser le contenu avant publication"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:133
+msgid "Published At"
+msgstr "Publié le"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:85
+#: packages/admin/src/components/PortableTextEditor.tsx:749
+msgid "Quote"
+msgstr "Citation"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Read collection schemas"
+msgstr "Lire les schémas de collections"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Read content entries"
+msgstr "Lire les entrées de contenu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Read media files"
+msgstr "Lire les fichiers médias"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:74
+msgid "Revisions"
+msgstr "Révisions"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Revoke token"
+msgstr "Révoquer le token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:301
+msgid "Revoke?"
+msgstr "Révoquer ?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoking..."
+msgstr "Révocation en cours..."
+
+#: packages/admin/src/components/Widgets.tsx:89
+msgid "Rich text content"
+msgstr "Texte enrichi"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Rôle {role}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:70
+msgid "Save content as draft before publishing"
+msgstr "Enregistrer le contenu en brouillon avant publication"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
+msgid "Schema Read"
+msgstr "Lecture du schéma"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:79
+msgid "Schema Write"
+msgstr "Écriture du schéma"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
+msgid "Scopes"
+msgstr "Scopes"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:277
+msgid "Scopes: {0}"
+msgstr "Scopes : {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:84
+msgid "Search"
+msgstr "Recherche"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "Optimisation et vérification pour les moteurs de recherche"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Rechercher des pages et du contenu..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1427
+msgid "Section"
+msgstr "Section"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+msgid "Sections"
+msgstr "Sections"
+
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "Sécurité"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+msgid "Security Settings"
+msgstr "Paramètres de sécurité"
+
+#: packages/admin/src/components/Settings.tsx:98
+msgid "Self-Signup Domains"
+msgstr "Domaines d'inscription autorisés"
+
+#: packages/admin/src/components/LoginPage.tsx:206
+msgid "Send magic link"
+msgstr "Envoyer un lien de connexion"
+
+#: packages/admin/src/components/LoginPage.tsx:206
+msgid "Sending..."
+msgstr "Envoi en cours..."
+
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/Settings.tsx:62
+msgid "Settings"
+msgstr "Paramètres"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
+msgid "Show token"
+msgstr "Afficher le token"
+
+#: packages/admin/src/components/LoginPage.tsx:283
+msgid "Sign in to your site"
+msgstr "Connectez-vous à votre site"
+
+#: packages/admin/src/components/LoginPage.tsx:284
+msgid "Sign in with email"
+msgstr "Se connecter avec un e-mail"
+
+#: packages/admin/src/components/LoginPage.tsx:340
+msgid "Sign in with email link"
+msgstr "Se connecter avec un lien par e-mail"
+
+#: packages/admin/src/components/LoginPage.tsx:304
+msgid "Sign in with Passkey"
+msgstr "Se connecter avec une clé d'accès"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Identité du site, logo, favicon et préférences de lecture"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:109
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:720
+msgid "Small section heading"
+msgstr "Petit titre"
+
+#: packages/admin/src/components/Settings.tsx:75
+msgid "Social Links"
+msgstr "Liens sociaux"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "Liens vers les profils de réseaux sociaux"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:115
+msgid "Status"
+msgstr "Statut"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Abonné"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "Tags"
+
+#: packages/admin/src/components/LoginPage.tsx:170
+msgid "The link will expire in 15 minutes."
+msgstr "Le lien expirera dans 15 minutes."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "pour fermer"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "pour sélectionner"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:190
+msgid "Token created: {0}"
+msgstr "Token créé : {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:400
+msgid "Token Name"
+msgstr "Nom du token"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:75
+msgid "Track content history"
+msgstr "Suivre l'historique du contenu"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "Unique identifier (ULID)"
+msgstr "Identifiant unique (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Rôle inconnu"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:127
+msgid "Updated At"
+msgstr "Modifié le"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Upload and delete media"
+msgstr "Téléverser et supprimer des médias"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+msgid "URL-friendly identifier"
+msgstr "Identifiant adapté aux URL"
+
+#: packages/admin/src/components/LoginPage.tsx:351
+msgid "Use your registered passkey to sign in securely."
+msgstr "Utilisez votre clé d'accès enregistrée pour vous connecter en toute sécurité."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+msgid "Users"
+msgstr "Utilisateurs"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "Consulter l'état du fournisseur d'e-mail et envoyer un e-mail de test"
+
+#: packages/admin/src/components/LoginPage.tsx:352
+msgid "We'll send you a link to sign in without a password."
+msgstr "Nous vous enverrons un lien pour vous connecter sans mot de passe."
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Bienvenue sur EmDash, {firstName} !"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Bienvenue sur EmDash !"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "When the entry was created"
+msgstr "Date de création de l'entrée"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "When the entry was last modified"
+msgstr "Date de dernière modification de l'entrée"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "When the entry was published"
+msgstr "Date de publication de l'entrée"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+msgid "Widgets"
+msgstr "Widgets"
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Vous pouvez créer et modifier votre propre contenu."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Vous pouvez gérer le contenu, les médias, les menus et les taxonomies."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Vous pouvez consulter le site et y contribuer."
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "Vous avez un accès complet pour gérer ce site, y compris les utilisateurs, les paramètres et tout le contenu."
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Votre compte a bien été créé."
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Votre rôle"


### PR DESCRIPTION
## What does this PR do?

Adds complete French (fr) locale for the EmDash admin UI.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

AI tools were used to draft the initial translations. Every string was then reviewed by a fluent French speaker through:

1. A **linguistic review** (register, tone, naturalness, French typography, anglicisms)
2. A **technical term review** (over-translation, CMS terminology conventions)

All translations were verified in the running admin UI.

## Translation details

**Coverage:** 178/178 strings (100%)

### Technical terms kept in English

Several English technical terms were intentionally kept untranslated. This reflects how the francophone dev/CMS community actually uses these terms in practice:

| Term kept in English | Why not translated |
|---|---|
| **Token** (not "jeton") | Standard in the FR dev community. Stripe FR, GitHub FR, Vercel FR, Cloudflare FR all use "token". |
| **Scopes** (not "portées") | In the OAuth/API context, "scopes" is universally used as-is. Google OAuth FR, GitHub FR, Auth0 FR all keep "scopes". |
| **Dashboard** (not "tableau de bord") | Modern CMS/SaaS tools (Ghost, Strapi, Directus, Payload) use "Dashboard" in FR. |
| **Plugins** (not "extensions") | Code/UI consistency -- the codebase uses `plugins` everywhere. |
| **Tags** (not "étiquettes") | Shorter, universally understood in modern CMS tools. |
| **Embeds** (not "integrations") | "Integrations" in French means third-party connectors, not inline content blocks. Avoids confusion. |
| **Slug**, **SEO**, **Widget**, **ID**, **ULID** | Standard technical terms with no established French equivalent. |

**Passkey** was translated to **"clé d'accès"**, aligning with Apple FR, Google FR, and Microsoft FR official terminology.

These choices are opinionated. If native French speakers feel differently about any of these, feedback is very welcome.

### Notable translation choices

| English | French | Rationale |
|---|---|---|
| Magic link | Lien de connexion | "Lien magique" would sound odd in French |
| Media Library | Médiathèque | Standard French term, used by WordPress FR |
| Self-Signup Domains | Domaines d'inscription autorisés | Functional translation rather than literal |
| Heading descriptions | Titre principal / Titre secondaire / Petit titre | Hierarchical naming, more natural than size-based (grand/moyen/petit) |
| Dismiss (token banner) | Fermer | "Ignorer" has a negative connotation in French |
| (default) | (par défaut) | "Défaut" alone means "flaw" in French |

## Open questions for native speakers

Some translations could go either way. Feedback welcome: 

### "Heading" descriptions (Titre principal / secondaire / Petit titre) 
 
The current translation uses a hierarchical approach:
- **Heading 1** → "Titre principal" (main heading)
- **Heading 2** → "Titre secondaire" (secondary heading) 
- **Heading 3** → "Petit titre" (small heading)

"Petit titre" feels a bit off for H3. Alternatives considered: 
- "Sous-titre" (but could be confused with subtitles/captions) 
- "Intertitre" (editorial term, accurate but niche)
- Keep "Heading 1/2/3" untranslated like other technical terms?

### "Full-text search" → "Recherche dans le contenu" 

Translated as "Permettre la recherche dans le contenu de cette collection". I'm not fully convinced by this phrasing, would appreciate another perspective.

## Screenshots / test output

`pnpm run locale:extract` output:
```
Catalog statistics for packages/admin/src/locales/{locale}/messages:
+--------------+-------------+---------+
| Language     | Total count | Missing |
+--------------+-------------+---------+
| en (source)  |     178     |    -    |
| de           |     178     |   138   |
| fr           |     178     |    0    |
+--------------+-------------+---------+
```
