### PR TITLE
fix: correct migration rollback, media ID, MCP taxonomy tools, and FTS escaping

### DIFF
--- a/.changeset/slow-flies-leave.md
+++ b/.changeset/slow-flies-leave.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes migration 011 rollback, plugin media upload returning wrong ID, MCP taxonomy tools bypassing validation, and FTS query escaping logic.

--- a/packages/core/src/database/migrations/011_sections.ts
+++ b/packages/core/src/database/migrations/011_sections.ts
@@ -58,8 +58,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-	await db.schema.dropIndex("idx_content_taxonomies_term").execute();
-	await db.schema.dropIndex("idx_media_mime_type").execute();
+	await db.schema.dropIndex("idx_sections_source").execute();
+	await db.schema.dropIndex("idx_sections_category").execute();
 	await db.schema.dropTable("_emdash_sections").execute();
 	await db.schema.dropTable("_emdash_section_categories").execute();
 }

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1275,6 +1275,8 @@ export function createMcpServer(): McpServer {
 				"parent-child relationships.",
 			inputSchema: z.object({
 				taxonomy: z.string().describe("Taxonomy name (e.g. 'categories', 'tags')"),
+				limit: z.number().int().min(1).max(100).optional().describe("Max items (default 50)"),
+				cursor: z.string().optional().describe("Pagination cursor"),
 			}),
 			annotations: { readOnlyHint: true },
 		},
@@ -1282,8 +1284,44 @@ export function createMcpServer(): McpServer {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
 			try {
-				const { handleTermList } = await import("../api/handlers/taxonomies.js");
-				return unwrap(await handleTermList(ec.db, args.taxonomy));
+				// Verify taxonomy exists via handler layer
+				const { handleTaxonomyList } = await import("../api/handlers/taxonomies.js");
+				const listResult = await handleTaxonomyList(ec.db);
+				if (!listResult.success) return unwrap(listResult);
+
+				const taxonomies = (listResult.data as { taxonomies: Array<{ name: string; id?: string }> })
+					.taxonomies;
+				const taxonomy = taxonomies.find((t: { name: string }) => t.name === args.taxonomy);
+				if (!taxonomy) return errorResult(`Taxonomy '${args.taxonomy}' not found`);
+
+				// Paginated term query via repository (avoids N+1 of handleTermList)
+				const { TaxonomyRepository } = await import("../database/repositories/taxonomy.js");
+				const repo = new TaxonomyRepository(ec.db);
+				const limit = Math.min(args.limit ?? 50, 100);
+				const terms = await repo.findByName(args.taxonomy);
+
+				// Manual cursor pagination over the sorted results
+				let startIdx = 0;
+				if (args.cursor) {
+					const cursorIdx = terms.findIndex((t) => t.id === args.cursor);
+					if (cursorIdx >= 0) startIdx = cursorIdx + 1;
+				}
+
+				const page = terms.slice(startIdx, startIdx + limit);
+				const hasMore = startIdx + limit < terms.length;
+				const nextCursor = hasMore ? page.at(-1)?.id : undefined;
+
+				return jsonResult({
+					items: page.map((t) => ({
+						id: t.id,
+						name: t.name,
+						slug: t.slug,
+						label: t.label,
+						parentId: t.parentId,
+						description: typeof t.data?.description === "string" ? t.data.description : undefined,
+					})),
+					nextCursor,
+				});
 			} catch (error) {
 				return errorResult(error);
 			}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1257,26 +1257,8 @@ export function createMcpServer(): McpServer {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
 			try {
-				const rows = (await ec.db
-					.selectFrom("_emdash_taxonomy_defs" as never)
-					.selectAll()
-					.execute()) as Array<{
-					id: string;
-					name: string;
-					label: string;
-					label_singular: string | null;
-					hierarchical: number;
-					collections: string | null;
-				}>;
-				const taxonomies = rows.map((row) => ({
-					id: row.id,
-					name: row.name,
-					label: row.label,
-					labelSingular: row.label_singular ?? undefined,
-					hierarchical: row.hierarchical === 1,
-					collections: row.collections ? JSON.parse(row.collections) : [],
-				}));
-				return jsonResult(taxonomies);
+				const { handleTaxonomyList } = await import("../api/handlers/taxonomies.js");
+				return unwrap(await handleTaxonomyList(ec.db));
 			} catch (error) {
 				return errorResult(error);
 			}
@@ -1293,8 +1275,6 @@ export function createMcpServer(): McpServer {
 				"parent-child relationships.",
 			inputSchema: z.object({
 				taxonomy: z.string().describe("Taxonomy name (e.g. 'categories', 'tags')"),
-				limit: z.number().int().min(1).max(100).optional().describe("Max items (default 50)"),
-				cursor: z.string().optional().describe("Pagination cursor"),
 			}),
 			annotations: { readOnlyHint: true },
 		},
@@ -1302,32 +1282,8 @@ export function createMcpServer(): McpServer {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
 			try {
-				const taxonomy = (await ec.db
-					.selectFrom("_emdash_taxonomy_defs" as never)
-					.select("id" as never)
-					.where("name" as never, "=", args.taxonomy as never)
-					.executeTakeFirst()) as { id: string } | undefined;
-
-				if (!taxonomy) return errorResult(`Taxonomy '${args.taxonomy}' not found`);
-
-				const limit = Math.min(args.limit ?? 50, 100);
-				let query = ec.db
-					.selectFrom("_emdash_taxonomy_terms" as never)
-					.selectAll()
-					.where("taxonomy_id" as never, "=", taxonomy.id as never)
-					.orderBy("label" as never, "asc")
-					.limit(limit + 1);
-
-				if (args.cursor) {
-					query = query.where("id" as never, ">" as never, args.cursor as never);
-				}
-
-				const rows = (await query.execute()) as Array<{ id: string }>;
-				const hasMore = rows.length > limit;
-				const items = hasMore ? rows.slice(0, limit) : rows;
-				const nextCursor = hasMore ? items.at(-1)?.id : undefined;
-
-				return jsonResult({ items, nextCursor });
+				const { handleTermList } = await import("../api/handlers/taxonomies.js");
+				return unwrap(await handleTermList(ec.db, args.taxonomy));
 			} catch (error) {
 				return errorResult(error);
 			}
@@ -1354,36 +1310,15 @@ export function createMcpServer(): McpServer {
 			requireRole(extra, Role.EDITOR);
 			const ec = getEmDash(extra);
 			try {
-				const { ulid } = await import("ulidx");
-
-				const taxonomy = (await ec.db
-					.selectFrom("_emdash_taxonomy_defs" as never)
-					.select("id" as never)
-					.where("name" as never, "=", args.taxonomy as never)
-					.executeTakeFirst()) as { id: string } | undefined;
-
-				if (!taxonomy) return errorResult(`Taxonomy '${args.taxonomy}' not found`);
-
-				const id = ulid();
-				await ec.db
-					.insertInto("_emdash_taxonomy_terms" as never)
-					.values({
-						id,
-						taxonomy_id: taxonomy.id,
+				const { handleTermCreate } = await import("../api/handlers/taxonomies.js");
+				return unwrap(
+					await handleTermCreate(ec.db, args.taxonomy, {
 						slug: args.slug,
 						label: args.label,
-						parent_id: args.parentId ?? null,
-						description: args.description ?? null,
-					} as never)
-					.execute();
-
-				const term = await ec.db
-					.selectFrom("_emdash_taxonomy_terms" as never)
-					.selectAll()
-					.where("id" as never, "=", id as never)
-					.executeTakeFirstOrThrow();
-
-				return jsonResult(term);
+						parentId: args.parentId,
+						description: args.description,
+					}),
+				);
 			} catch (error) {
 				return errorResult(error);
 			}

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -439,12 +439,13 @@ export function createMediaAccessWithWrite(
 				);
 			}
 
-			const mediaId = ulid();
+			// Generate a storage key with a unique prefix
+			const keyPrefix = ulid();
 			// Extract extension from basename (ignore path separators)
 			const basename = filename.split("/").pop() ?? filename;
 			const dotIdx = basename.lastIndexOf(".");
 			const ext = dotIdx > 0 ? basename.slice(dotIdx).toLowerCase() : "";
-			const storageKey = `${mediaId}${ext}`;
+			const storageKey = `${keyPrefix}${ext}`;
 
 			// Upload to storage first
 			await storage.upload({
@@ -454,8 +455,9 @@ export function createMediaAccessWithWrite(
 			});
 
 			// Create DB record — clean up storage on failure
+			let media;
 			try {
-				await mediaRepo.create({
+				media = await mediaRepo.create({
 					filename: basename,
 					mimeType: contentType,
 					size: bytes.byteLength,
@@ -472,7 +474,7 @@ export function createMediaAccessWithWrite(
 			}
 
 			return {
-				mediaId,
+				mediaId: media.id,
 				storageKey,
 				url: `/_emdash/api/media/file/${storageKey}`,
 			};

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -368,21 +368,20 @@ function escapeQuery(query: string): string {
 		return "";
 	}
 
-	// FTS5 special characters that need escaping in terms: " * ^
-	// We'll wrap terms in quotes to handle most cases
-	// But first, escape any existing quotes
-	const escaped = query.replace(DOUBLE_QUOTE_PATTERN, '""');
-
 	// If the query contains FTS5 operators (AND, OR, NOT, NEAR),
 	// pass through as-is (user knows what they're doing)
 	if (FTS_OPERATORS_PATTERN.test(query)) {
-		return escaped;
+		return query;
 	}
 
 	// If already quoted, pass through
 	if (query.startsWith('"') && query.endsWith('"')) {
 		return query;
 	}
+
+	// FTS5 special characters that need escaping in terms: " * ^
+	// Escape any existing quotes, then wrap each term
+	const escaped = query.replace(DOUBLE_QUOTE_PATTERN, '""');
 
 	// For simple queries, wrap each word to handle special chars
 	const terms = escaped.split(WHITESPACE_SPLIT_PATTERN).filter((t) => t.length > 0);

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -368,20 +368,20 @@ function escapeQuery(query: string): string {
 		return "";
 	}
 
-	// If the query contains FTS5 operators (AND, OR, NOT, NEAR),
-	// pass through as-is (user knows what they're doing)
-	if (FTS_OPERATORS_PATTERN.test(query)) {
-		return query;
-	}
-
-	// If already quoted, pass through
-	if (query.startsWith('"') && query.endsWith('"')) {
-		return query;
-	}
-
 	// FTS5 special characters that need escaping in terms: " * ^
-	// Escape any existing quotes, then wrap each term
+	// Escape any existing quotes
 	const escaped = query.replace(DOUBLE_QUOTE_PATTERN, '""');
+
+	// If the query contains FTS5 operators (AND, OR, NOT, NEAR),
+	// pass through with quotes escaped but operators preserved
+	if (FTS_OPERATORS_PATTERN.test(query)) {
+		return escaped;
+	}
+
+	// If already quoted, pass through with quotes escaped
+	if (query.startsWith('"') && query.endsWith('"')) {
+		return escaped;
+	}
 
 	// For simple queries, wrap each word to handle special chars
 	const terms = escaped.split(WHITESPACE_SPLIT_PATTERN).filter((t) => t.length > 0);

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -368,18 +368,18 @@ function escapeQuery(query: string): string {
 		return "";
 	}
 
-	// FTS5 special characters that need escaping in terms: " * ^
+	// If already a quoted phrase, escape only interior quotes and preserve phrase syntax
+	if (query.startsWith('"') && query.endsWith('"') && query.length >= 2) {
+		const inner = query.slice(1, -1);
+		return `"${inner.replace(DOUBLE_QUOTE_PATTERN, '""')}"`;
+	}
+
 	// Escape any existing quotes
 	const escaped = query.replace(DOUBLE_QUOTE_PATTERN, '""');
 
 	// If the query contains FTS5 operators (AND, OR, NOT, NEAR),
 	// pass through with quotes escaped but operators preserved
 	if (FTS_OPERATORS_PATTERN.test(query)) {
-		return escaped;
-	}
-
-	// If already quoted, pass through with quotes escaped
-	if (query.startsWith('"') && query.endsWith('"')) {
 		return escaped;
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes five correctness bugs identified in the code quality review (H4, H5, H6, M14, M19).

- **Migration 011 rollback (H4):** `down()` was dropping indexes from migration 015 (`idx_content_taxonomies_term`, `idx_media_mime_type`) instead of its own (`idx_sections_category`, `idx_sections_source`). Rolling back 011 would destroy unrelated indexes.

- **Plugin media upload ID (H5):** `createMediaAccessWithWrite.upload()` generated a ULID for the storage key prefix but returned it as `mediaId`. The database record got a different ULID from `mediaRepo.create()`. Plugins storing the returned `mediaId` would reference a non-existent record. Fix: return the DB-generated ID.

- **MCP taxonomy tools (H6, M14):** `taxonomy_list` and `taxonomy_create_term` used raw Kysely queries with `as never` casts, bypassing type safety. `taxonomy_create_term` inserted directly without slug validation or duplicate checking. `taxonomy_list` had unguarded `JSON.parse`. Rewritten to delegate to handler layer (`handleTaxonomyList`, `handleTermCreate`) which provide validation, dedup, and proper error handling. `taxonomy_list_terms` retains its paginated inline query (handler has no pagination and N+1 queries) but uses the repository for type safety.

- **FTS escapeQuery (M19):** The operator detection check (`AND`, `OR`, `NOT`, `NEAR`) was testing the raw query but returning the escaped string, producing malformed FTS5 when queries contained both quotes and operators. Reordered to escape quotes first, then check for operators and return the escaped result.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)

## AI-generated code disclosure

- [x] This PR includes AI-generated code