### PR TITLE
fix(admin): use import.meta.glob for locale catalog resolution

### DIFF
--- a/.changeset/rich-drinks-hug.md
+++ b/.changeset/rich-drinks-hug.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Fixes admin failing to load when installed from npm due to broken locale catalog resolution.

--- a/packages/admin/src/locales/index.ts
+++ b/packages/admin/src/locales/index.ts
@@ -1,4 +1,5 @@
 import type { Messages } from "@lingui/core";
+
 import { DEFAULT_LOCALE } from "./config.js";
 
 export { useLocale } from "./useLocale.js";

--- a/packages/admin/src/locales/index.ts
+++ b/packages/admin/src/locales/index.ts
@@ -7,3 +7,12 @@ export {
 	resolveLocale,
 } from "./config.js";
 export type { SupportedLocale } from "./config.js";
+
+const LOCALE_LOADERS = import.meta.glob<{ messages: Record<string, unknown> }>("./**/messages.mjs");
+
+export async function loadMessages(locale: string): Promise<Record<string, unknown>> {
+	const key = `./${locale}/messages.mjs`;
+	const loader = LOCALE_LOADERS[key] ?? LOCALE_LOADERS["./en/messages.mjs"]!;
+	const { messages } = await loader();
+	return messages;
+}

--- a/packages/admin/src/locales/index.ts
+++ b/packages/admin/src/locales/index.ts
@@ -1,3 +1,6 @@
+import type { Messages } from "@lingui/core";
+import { DEFAULT_LOCALE } from "./config.js";
+
 export { useLocale } from "./useLocale.js";
 export {
 	SUPPORTED_LOCALES,
@@ -8,11 +11,17 @@ export {
 } from "./config.js";
 export type { SupportedLocale } from "./config.js";
 
-const LOCALE_LOADERS = import.meta.glob<{ messages: Record<string, unknown> }>("./**/messages.mjs");
+const LOCALE_LOADERS = import.meta.glob<{ messages: Messages }>("./**/messages.mjs");
 
-export async function loadMessages(locale: string): Promise<Record<string, unknown>> {
+export async function loadMessages(locale: string): Promise<Messages> {
 	const key = `./${locale}/messages.mjs`;
-	const loader = LOCALE_LOADERS[key] ?? LOCALE_LOADERS["./en/messages.mjs"]!;
+	const fallbackKey = `./${DEFAULT_LOCALE}/messages.mjs`;
+	const loader = LOCALE_LOADERS[key] ?? LOCALE_LOADERS[fallbackKey];
+	if (!loader) {
+		throw new Error(
+			`No locale catalog found for "${locale}" or "${DEFAULT_LOCALE}". Run \`pnpm locale:compile\` to generate catalogs.`,
+		);
+	}
 	const { messages } = await loader();
 	return messages;
 }

--- a/packages/admin/tests/lib/locales.test.ts
+++ b/packages/admin/tests/lib/locales.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+
+import { loadMessages, SUPPORTED_LOCALES } from "../../src/locales/index.js";
+
+for (const { code } of SUPPORTED_LOCALES) {
+	test(`loadMessages resolves catalog for supported locale "${code}"`, async () => {
+		const messages = await loadMessages(code);
+		expect(messages).toBeDefined();
+		expect(typeof messages).toBe("object");
+		expect(Object.keys(messages).length).toBeGreaterThan(0);
+	});
+}
+
+test("loadMessages falls back to English for unknown locale", async () => {
+	const [fallback, english] = await Promise.all([loadMessages("xx"), loadMessages("en")]);
+	expect(fallback).toEqual(english);
+});

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -293,10 +293,6 @@ export function createViteConfig(
 			// "@emdash-cms/admin/styles.css" through the source directory.
 			alias: [
 				{ find: "@emdash-cms/admin/styles.css", replacement: resolve(adminDistPath, "styles.css") },
-				{
-					find: "@emdash-cms/admin/locales/*",
-					replacement: resolve(adminDistPath, "locales", "*"),
-				},
 				{ find: "@emdash-cms/admin", replacement: useSource ? adminSourcePath : adminDistPath },
 			],
 		},

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -12,10 +12,10 @@ import AdminWrapper from "emdash/routes/PluginRegistry";
 
 export const prerender = false;
 
-import { resolveLocale } from "@emdash-cms/admin/locales";
+import { resolveLocale, loadMessages } from "@emdash-cms/admin/locales";
 
 const resolvedLocale = resolveLocale(Astro.request);
-const { messages } = await import(`@emdash-cms/admin/locales/${resolvedLocale}/messages.mjs`);
+const messages = await loadMessages(resolvedLocale);
 ---
 
 <!doctype html>


### PR DESCRIPTION
## What does this PR do?

Fixes admin failing to load when `emdash` is installed from npm (non-monorepo). The dynamic `import()` in `admin.astro` used a template literal to load locale catalogs cross-package (`@emdash-cms/admin/locales/${locale}/messages.mjs`), which Vite's SSR module runner couldn't resolve.

The Vite alias entry intended to handle this used `*` in the `find` string, but Vite treats that as a literal character — so the alias was a no-op.

Moves locale loading into the admin package via a `loadMessages()` function that uses `import.meta.glob` to discover catalogs at build time with reliable relative paths.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Locale unit tests pass:
```
✓ chromium tests/lib/locales.test.ts (3 tests) 9ms
```