### PR TITLE
fix(templates): add pnpm.onlyBuiltDependencies for native addons

### DIFF
--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -24,5 +24,8 @@
     "@astrojs/check": "catalog:"
   },
   "peerDependencies": {},
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+  }
 }

--- a/templates/blog-cloudflare/package.json
+++ b/templates/blog-cloudflare/package.json
@@ -27,5 +27,8 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "workerd"]
 	}
 }

--- a/templates/blog/package.json
+++ b/templates/blog/package.json
@@ -29,5 +29,8 @@
     "@astrojs/check": "catalog:"
   },
   "peerDependencies": {},
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+  }
 }

--- a/templates/marketing-cloudflare/package.json
+++ b/templates/marketing-cloudflare/package.json
@@ -25,5 +25,8 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "workerd"]
 	}
 }

--- a/templates/marketing/package.json
+++ b/templates/marketing/package.json
@@ -26,5 +26,8 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
 	}
 }

--- a/templates/portfolio-cloudflare/package.json
+++ b/templates/portfolio-cloudflare/package.json
@@ -28,5 +28,8 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "workerd"]
 	}
 }

--- a/templates/portfolio/package.json
+++ b/templates/portfolio/package.json
@@ -26,5 +26,8 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
 	}
 }

--- a/templates/starter-cloudflare/package.json
+++ b/templates/starter-cloudflare/package.json
@@ -25,5 +25,8 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "workerd"]
 	}
 }

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -24,5 +24,8 @@
     "@astrojs/check": "catalog:"
   },
   "peerDependencies": {},
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+  }
 }


### PR DESCRIPTION
## What does this PR do?

pnpm v10 blocks postinstall/build scripts by default for security. The monorepo root allowlists native deps via `pnpm.onlyBuiltDependencies`, but when templates are installed standalone (e.g. in the `emdash-cms/templates` repo CI, or by end users cloning a template), there's no root config to inherit from. This caused `better-sqlite3`'s native binary to never compile, failing all non-Cloudflare smoke tests in https://github.com/emdash-cms/templates/actions/runs/24316862520.

Adds `pnpm.onlyBuiltDependencies` to each template's `package.json`:
- Non-Cloudflare templates: `["better-sqlite3", "esbuild"]`
- Cloudflare templates: `["esbuild", "workerd"]`

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code