### PR TITLE
fix(admin): use loadMessages in useLocale hook

### DIFF
--- a/.changeset/metal-tools-camp.md
+++ b/.changeset/metal-tools-camp.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes client-side locale switching and replaces toggle buttons with a Select dropdown.

--- a/e2e/tests/settings-pages.spec.ts
+++ b/e2e/tests/settings-pages.spec.ts
@@ -162,6 +162,37 @@ test.describe("SEO Settings", () => {
 	});
 });
 
+test.describe("Language Switcher", () => {
+	test.beforeEach(async ({ admin }) => {
+		await admin.devBypassAuth();
+	});
+
+	test("settings page shows language select", async ({ admin, page }) => {
+		await admin.goto("/settings");
+		await admin.waitForShell();
+
+		const languageSelect = page.locator('[aria-label="Language"]');
+		await expect(languageSelect).toBeVisible();
+	});
+
+	test("switching language updates the UI", async ({ admin, page }) => {
+		await admin.goto("/settings");
+		await admin.waitForShell();
+
+		// Switch to German
+		await page.locator('[aria-label="Language"]').click();
+		await page.locator("[role='option']", { hasText: "Deutsch" }).click();
+
+		await expect(page.locator("h1")).toContainText("Einstellungen", { timeout: 5000 });
+
+		// Switch back — the select now shows "Deutsch" as its value
+		await page.locator("[role='combobox']", { hasText: "Deutsch" }).click();
+		await page.locator("[role='option']", { hasText: "English" }).click();
+
+		await expect(page.locator("h1")).toContainText("Settings", { timeout: 5000 });
+	});
+});
+
 test.describe("Email Settings", () => {
 	test.beforeEach(async ({ admin }) => {
 		await admin.devBypassAuth();

--- a/packages/admin/src/components/Settings.tsx
+++ b/packages/admin/src/components/Settings.tsx
@@ -1,3 +1,4 @@
+import { Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	Gear,
@@ -15,7 +16,6 @@ import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchManifest } from "../lib/api";
-import { cn } from "../lib/utils.js";
 import { SUPPORTED_LOCALES } from "../locales/index.js";
 import { useLocale } from "../locales/useLocale.js";
 
@@ -130,22 +130,13 @@ export function Settings() {
 								<div className="text-sm text-kumo-subtle">{t`Choose your preferred admin language`}</div>
 							</div>
 						</div>
-						<div className="flex gap-1">
-							{SUPPORTED_LOCALES.map((l) => (
-								<button
-									key={l.code}
-									onClick={() => setLocale(l.code)}
-									className={cn(
-										"rounded-md px-3 py-1.5 text-sm transition-colors",
-										l.code === locale
-											? "bg-kumo-brand/10 text-kumo-brand font-medium"
-											: "hover:bg-kumo-tint",
-									)}
-								>
-									{l.label}
-								</button>
-							))}
-						</div>
+						<Select
+							aria-label={t`Language`}
+							className="w-45"
+							value={locale}
+							onValueChange={(v) => v && setLocale(v)}
+							items={Object.fromEntries(SUPPORTED_LOCALES.map((l) => [l.code, l.label]))}
+						/>
 					</div>
 				</div>
 			)}

--- a/packages/admin/src/locales/useLocale.ts
+++ b/packages/admin/src/locales/useLocale.ts
@@ -2,6 +2,7 @@ import { useLingui } from "@lingui/react";
 import * as React from "react";
 
 import { SUPPORTED_LOCALE_CODES } from "./config.js";
+import { loadMessages } from "./index.js";
 
 function setCookie(code: string) {
 	const secure = window.location.protocol === "https:" ? "; Secure" : "";
@@ -20,10 +21,9 @@ export function useLocale() {
 		(code: string) => {
 			if (code === i18n.locale || !SUPPORTED_LOCALE_CODES.has(code)) return;
 			setCookie(code);
-			void import(`./${code}/messages.mjs`)
-				.then(({ messages }) => i18n.loadAndActivate({ locale: code, messages }))
+			void loadMessages(code)
+				.then((messages) => i18n.loadAndActivate({ locale: code, messages }))
 				.catch(() => {
-					// Revert cookie on failure so the user isn't stuck
 					setCookie(i18n.locale);
 				});
 		},


### PR DESCRIPTION
## What does this PR do?

Follow-up to #499. The client-side locale switcher in `useLocale.ts` had the same dynamic import issue — `import(\`./${code}/messages.mjs\`)` fails at runtime in the browser when resolved through Vite aliases. Reuses the glob-based `loadMessages` from the fix in #499.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code