### PR TITLE
fix: clone response before setting baseline security headers

### DIFF
--- a/.changeset/nine-coats-smoke.md
+++ b/.changeset/nine-coats-smoke.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes TypeError when setting baseline security headers on Cloudflare responses with immutable headers.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -160,20 +160,26 @@ async function getRuntime(config: EmDashConfig): Promise<EmDashRuntime> {
  * Baseline security headers applied to all responses.
  * Admin routes get additional headers (strict CSP) from auth middleware.
  */
-function setBaselineSecurityHeaders(response: Response): void {
+function setBaselineSecurityHeaders(response: Response): Response {
+	const headers = new Headers(response.headers);
 	// Prevent MIME type sniffing
-	response.headers.set("X-Content-Type-Options", "nosniff");
+	headers.set("X-Content-Type-Options", "nosniff");
 	// Control referrer information
-	response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+	headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 	// Restrict access to sensitive browser APIs
-	response.headers.set(
+	headers.set(
 		"Permissions-Policy",
 		"camera=(), microphone=(), geolocation=(), payment=()",
 	);
 	// Prevent clickjacking (non-admin routes; admin CSP uses frame-ancestors)
-	if (!response.headers.has("Content-Security-Policy")) {
-		response.headers.set("X-Frame-Options", "SAMEORIGIN");
+	if (!headers.has("Content-Security-Policy")) {
+		headers.set("X-Frame-Options", "SAMEORIGIN");
 	}
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
 }
 
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */
@@ -245,8 +251,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			}
 
 			const response = await next();
-			setBaselineSecurityHeaders(response);
-			return response;
+			return setBaselineSecurityHeaders(response);
 		}
 	}
 
@@ -416,8 +421,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 				// Wrap the request in ALS with the per-request db
 				return runWithContext({ editMode: false, db: sessionDb }, async () => {
-					const response = await next();
-					setBaselineSecurityHeaders(response);
+					const response = setBaselineSecurityHeaders(await next());
 
 					// Set bookmark cookie for authenticated users only — they need
 					// read-your-writes consistency across requests. Anonymous visitors
@@ -445,8 +449,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		}
 
 		const response = await next();
-		setBaselineSecurityHeaders(response);
-		return response;
+		return setBaselineSecurityHeaders(response);
 	}; // end doInit
 
 	if (playgroundDb) {

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -167,10 +167,7 @@ function setBaselineSecurityHeaders(response: Response): Response {
 	// Control referrer information
 	headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 	// Restrict access to sensitive browser APIs
-	headers.set(
-		"Permissions-Policy",
-		"camera=(), microphone=(), geolocation=(), payment=()",
-	);
+	headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
 	// Prevent clickjacking (non-admin routes; admin CSP uses frame-ancestors)
 	if (!headers.has("Content-Security-Policy")) {
 		headers.set("X-Frame-Options", "SAMEORIGIN");

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -161,22 +161,14 @@ async function getRuntime(config: EmDashConfig): Promise<EmDashRuntime> {
  * Admin routes get additional headers (strict CSP) from auth middleware.
  */
 function setBaselineSecurityHeaders(response: Response): Response {
-	const headers = new Headers(response.headers);
-	// Prevent MIME type sniffing
-	headers.set("X-Content-Type-Options", "nosniff");
-	// Control referrer information
-	headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-	// Restrict access to sensitive browser APIs
-	headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
-	// Prevent clickjacking (non-admin routes; admin CSP uses frame-ancestors)
-	if (!headers.has("Content-Security-Policy")) {
-		headers.set("X-Frame-Options", "SAMEORIGIN");
+	const res = new Response(response.body, response);
+	res.headers.set("X-Content-Type-Options", "nosniff");
+	res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+	res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
+	if (!res.headers.has("Content-Security-Policy")) {
+		res.headers.set("X-Frame-Options", "SAMEORIGIN");
 	}
-	return new Response(response.body, {
-		status: response.status,
-		statusText: response.statusText,
-		headers,
-	});
+	return res;
 }
 
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */


### PR DESCRIPTION
## What does this PR do?

`setBaselineSecurityHeaders` in `packages/core/src/astro/middleware.ts` calls `response.headers.set()` directly on the Response returned by `next()`. On Cloudflare, some responses (e.g. `/_image/*` from Astro's image transform endpoint) have immutable headers, causing `TypeError: Can't modify immutable headers.`

This PR changes the function to create a new `Response` with cloned headers before modifying them. The original response body, status, and statusText are preserved. All three call sites in the middleware are updated.

Closes #506

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

`pnpm --silent lint:quick` returns 0 diagnostics.