### PR TITLE
ci: auto-extract locale catalogs on merge to main

### DIFF
--- a/.github/workflows/auto-extract.yml
+++ b/.github/workflows/auto-extract.yml
@@ -43,13 +43,14 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          non_locale=$(git diff --name-only | grep -v '^packages/admin/src/locales/' || true)
+          git add -A
+          non_locale=$(git diff --staged --name-only | grep -v '^packages/admin/src/locales/' || true)
           if [ -n "$non_locale" ]; then
             echo "::error::Extraction modified files outside locales:"
             echo "$non_locale"
             exit 1
           fi
-          if git diff --quiet -- 'packages/admin/src/locales/'; then
+          if git diff --staged --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -60,6 +61,5 @@ jobs:
         run: |
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git add packages/admin/src/locales/
           git commit -m "chore: extract locale catalogs"
           git push

--- a/.github/workflows/auto-extract.yml
+++ b/.github/workflows/auto-extract.yml
@@ -1,0 +1,65 @@
+name: Auto Extract
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-extract
+  cancel-in-progress: true
+
+jobs:
+  extract:
+    name: Extract
+    if: github.actor != 'emdashbot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm locale:extract
+
+      - name: Check for changes
+        id: diff
+        run: |
+          non_locale=$(git diff --name-only | grep -v '^packages/admin/src/locales/' || true)
+          if [ -n "$non_locale" ]; then
+            echo "::error::Extraction modified files outside locales:"
+            echo "$non_locale"
+            exit 1
+          fi
+          if git diff --quiet -- 'packages/admin/src/locales/'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git add packages/admin/src/locales/
+          git commit -m "chore: extract locale catalogs"
+          git push

--- a/.github/workflows/auto-extract.yml
+++ b/.github/workflows/auto-extract.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: auto-extract
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   extract:
@@ -61,5 +61,6 @@ jobs:
         run: |
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "chore: extract locale catalogs"
+          git commit -m "chore: extract locale catalogs [skip ci]"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/auto-extract.yml
+++ b/.github/workflows/auto-extract.yml
@@ -44,10 +44,10 @@ jobs:
         id: diff
         run: |
           git add -A
-          non_locale=$(git diff --staged --name-only | grep -v '^packages/admin/src/locales/' || true)
-          if [ -n "$non_locale" ]; then
-            echo "::error::Extraction modified files outside locales:"
-            echo "$non_locale"
+          invalid_changes=$(git diff --staged --name-status --no-renames | awk '$1 !~ /^(A|M)$/ || $2 !~ /^packages\/admin\/src\/locales\/[^/]+\/messages\.po$/ { print }' || true)
+          if [ -n "$invalid_changes" ]; then
+            echo "::error::Extraction produced unexpected staged changes. Only added or modified packages/admin/src/locales/*/messages.po files are allowed:"
+            echo "$invalid_changes"
             exit 1
           fi
           if git diff --staged --quiet; then


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions workflow that automatically runs `pnpm locale:extract` after PRs merge to `main`. If the `.po` catalogs are out of date, the bot commits the updated files directly to `main`.

This eliminates merge conflicts on `.po` files caused by line number references shifting across PRs — contributors no longer need to run extraction themselves.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run

## AI-generated code disclosure

- [x] This PR includes AI-generated code