### PR TITLE
perf: cache byline existence, URL patterns, and redirect rules on hot path

### DIFF
--- a/.changeset/afraid-facts-tie.md
+++ b/.changeset/afraid-facts-tie.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Reduces logged-out page load queries by caching byline existence, URL patterns, and redirect rules at worker level with proper invalidation.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,6 +141,8 @@
     "#media/*": "./src/media/*",
     "#mcp/*": "./src/mcp/*",
     "#comments/*": "./src/comments/*",
+    "#bylines/*": "./src/bylines/*",
+    "#redirects/*": "./src/redirects/*",
     "#types": "./src/astro/types.js"
   },
   "scripts": {

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -5,6 +5,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import { invalidateRedirectCache } from "../../astro/middleware/redirect.js";
 import { BylineRepository } from "../../database/repositories/byline.js";
 import type { ContentBylineInput } from "../../database/repositories/byline.js";
 import { CommentRepository } from "../../database/repositories/comment.js";
@@ -592,6 +593,11 @@ export async function handleContentUpdate(
 
 			return updated;
 		});
+
+		// Invalidate redirect cache if slug changed (auto-redirect may have been created)
+		if (body.slug) {
+			invalidateRedirectCache();
+		}
 
 		return {
 			success: true,

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -5,7 +5,6 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
-import { invalidateRedirectCache } from "../../astro/middleware/redirect.js";
 import { BylineRepository } from "../../database/repositories/byline.js";
 import type { ContentBylineInput } from "../../database/repositories/byline.js";
 import { CommentRepository } from "../../database/repositories/comment.js";
@@ -23,6 +22,7 @@ import { withTransaction } from "../../database/transaction.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
 import { isI18nEnabled } from "../../i18n/config.js";
+import { invalidateRedirectCache } from "../../redirects/cache.js";
 import { encodeRev, validateRev } from "../rev.js";
 import type { ApiResult, ContentListResponse, ContentResponse } from "../types.js";
 
@@ -565,6 +565,7 @@ export async function handleContentUpdate(
 					resolvedId,
 					collectionRow?.url_pattern ?? null,
 				);
+				invalidateRedirectCache();
 			}
 
 			// Sync non-translatable fields to sibling locales in the same
@@ -593,11 +594,6 @@ export async function handleContentUpdate(
 
 			return updated;
 		});
-
-		// Invalidate redirect cache if slug changed (auto-redirect may have been created)
-		if (body.slug) {
-			invalidateRedirectCache();
-		}
 
 		return {
 			success: true,

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -16,27 +16,15 @@
 
 import { defineMiddleware } from "astro:middleware";
 
-import type { Redirect } from "../../database/repositories/redirect.js";
 import { RedirectRepository } from "../../database/repositories/redirect.js";
-import type { CompiledPattern } from "../../redirects/patterns.js";
-import { compilePattern, interpolateDestination, matchPattern } from "../../redirects/patterns.js";
+import {
+	getCachedPatternRules,
+	matchCachedPatterns,
+	setCachedPatternRules,
+} from "../../redirects/cache.js";
 
 /** Paths that should never be intercepted by redirects */
 const SKIP_PREFIXES = ["/_emdash", "/_image"];
-
-/**
- * Cached pattern rules with compiled regexes.
- * Invalidated when redirects are created, updated, or deleted.
- */
-let cachedPatternRules: Array<{ redirect: Redirect; compiled: CompiledPattern }> | null = null;
-
-/**
- * Invalidate the cached redirect pattern rules.
- * Call when redirects are created, updated, or deleted.
- */
-export function invalidateRedirectCache(): void {
-	cachedPatternRules = null;
-}
 
 /** Static asset extensions -- don't redirect file requests */
 const ASSET_EXTENSION = /\.\w{1,10}$/;
@@ -77,23 +65,19 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		}
 
 		// 2. Pattern match (cached: compile once, match every request)
-		if (!cachedPatternRules) {
+		let rules = getCachedPatternRules();
+		if (!rules) {
 			const patterns = await repo.findEnabledPatternRules();
-			cachedPatternRules = patterns.map((r) => ({
-				redirect: r,
-				compiled: compilePattern(r.source),
-			}));
+			rules = setCachedPatternRules(patterns);
 		}
 
-		for (const { redirect, compiled } of cachedPatternRules) {
-			const params = matchPattern(compiled, pathname);
-			if (params) {
-				const dest = interpolateDestination(redirect.destination, params);
-				if (dest.startsWith("//") || dest.startsWith("/\\")) return next();
-				repo.recordHit(redirect.id).catch(() => {});
-				const code = isRedirectCode(redirect.type) ? redirect.type : 301;
-				return context.redirect(dest, code);
-			}
+		const patternMatch = matchCachedPatterns(rules, pathname);
+		if (patternMatch) {
+			const { redirect, destination } = patternMatch;
+			if (destination.startsWith("//") || destination.startsWith("/\\")) return next();
+			repo.recordHit(redirect.id).catch(() => {});
+			const code = isRedirectCode(redirect.type) ? redirect.type : 301;
+			return context.redirect(destination, code);
 		}
 
 		// No redirect matched -- proceed and check for 404

--- a/packages/core/src/astro/middleware/redirect.ts
+++ b/packages/core/src/astro/middleware/redirect.ts
@@ -16,10 +16,27 @@
 
 import { defineMiddleware } from "astro:middleware";
 
+import type { Redirect } from "../../database/repositories/redirect.js";
 import { RedirectRepository } from "../../database/repositories/redirect.js";
+import type { CompiledPattern } from "../../redirects/patterns.js";
+import { compilePattern, interpolateDestination, matchPattern } from "../../redirects/patterns.js";
 
 /** Paths that should never be intercepted by redirects */
 const SKIP_PREFIXES = ["/_emdash", "/_image"];
+
+/**
+ * Cached pattern rules with compiled regexes.
+ * Invalidated when redirects are created, updated, or deleted.
+ */
+let cachedPatternRules: Array<{ redirect: Redirect; compiled: CompiledPattern }> | null = null;
+
+/**
+ * Invalidate the cached redirect pattern rules.
+ * Call when redirects are created, updated, or deleted.
+ */
+export function invalidateRedirectCache(): void {
+	cachedPatternRules = null;
+}
 
 /** Static asset extensions -- don't redirect file requests */
 const ASSET_EXTENSION = /\.\w{1,10}$/;
@@ -48,21 +65,35 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	try {
 		const repo = new RedirectRepository(emdash.db);
-		const match = await repo.matchPath(pathname);
 
-		if (match) {
-			// Reject protocol-relative URLs (e.g. //evil.com or /\evil.com) from interpolation.
-			// Browsers normalize backslashes to forward slashes, so /\ is equivalent to //.
-			if (
-				match.resolvedDestination.startsWith("//") ||
-				match.resolvedDestination.startsWith("/\\")
-			) {
-				return next();
+		// 1. Exact match (fast, indexed)
+		const exact = await repo.findExactMatch(pathname);
+		if (exact) {
+			const dest = exact.destination;
+			if (dest.startsWith("//") || dest.startsWith("/\\")) return next();
+			repo.recordHit(exact.id).catch(() => {});
+			const code = isRedirectCode(exact.type) ? exact.type : 301;
+			return context.redirect(dest, code);
+		}
+
+		// 2. Pattern match (cached: compile once, match every request)
+		if (!cachedPatternRules) {
+			const patterns = await repo.findEnabledPatternRules();
+			cachedPatternRules = patterns.map((r) => ({
+				redirect: r,
+				compiled: compilePattern(r.source),
+			}));
+		}
+
+		for (const { redirect, compiled } of cachedPatternRules) {
+			const params = matchPattern(compiled, pathname);
+			if (params) {
+				const dest = interpolateDestination(redirect.destination, params);
+				if (dest.startsWith("//") || dest.startsWith("/\\")) return next();
+				repo.recordHit(redirect.id).catch(() => {});
+				const code = isRedirectCode(redirect.type) ? redirect.type : 301;
+				return context.redirect(dest, code);
 			}
-			// Fire-and-forget hit recording (don't block the redirect)
-			repo.recordHit(match.redirect.id).catch(() => {});
-			const code = isRedirectCode(match.redirect.type) ? match.redirect.type : 301;
-			return context.redirect(match.resolvedDestination, code);
 		}
 
 		// No redirect matched -- proceed and check for 404

--- a/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
@@ -5,6 +5,7 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { bylineUpdateBody } from "#api/schemas.js";
+import { invalidateBylineCache } from "#bylines/index.js";
 import { BylineRepository } from "#db/repositories/byline.js";
 
 export const prerender = false;
@@ -80,6 +81,7 @@ export const DELETE: APIRoute = async ({ params, locals }) => {
 		const repo = new BylineRepository(emdash.db);
 		const deleted = await repo.delete(params.id!);
 		if (!deleted) return apiError("NOT_FOUND", "Byline not found", 404);
+		invalidateBylineCache();
 		return apiSuccess({ deleted: true });
 	} catch (error) {
 		return handleError(error, "Failed to delete byline", "BYLINE_DELETE_ERROR");

--- a/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
@@ -62,6 +62,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		});
 
 		if (!byline) return apiError("NOT_FOUND", "Byline not found", 404);
+		invalidateBylineCache();
 		return apiSuccess(byline);
 	} catch (error) {
 		return handleError(error, "Failed to update byline", "BYLINE_UPDATE_ERROR");

--- a/packages/core/src/astro/routes/api/admin/bylines/index.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/index.ts
@@ -5,6 +5,7 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { bylineCreateBody, bylinesListQuery } from "#api/schemas.js";
+import { invalidateBylineCache } from "#bylines/index.js";
 import { BylineRepository } from "#db/repositories/byline.js";
 
 export const prerender = false;
@@ -65,6 +66,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			isGuest: body.isGuest,
 		});
 
+		invalidateBylineCache();
 		return apiSuccess(byline, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create byline", "BYLINE_CREATE_ERROR");

--- a/packages/core/src/astro/routes/api/redirects/[id].ts
+++ b/packages/core/src/astro/routes/api/redirects/[id].ts
@@ -17,7 +17,7 @@ import {
 } from "#api/handlers/redirects.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { updateRedirectBody } from "#api/schemas.js";
-import { invalidateRedirectCache } from "#astro/middleware/redirect.js";
+import { invalidateRedirectCache } from "#redirects/cache.js";
 
 export const prerender = false;
 

--- a/packages/core/src/astro/routes/api/redirects/[id].ts
+++ b/packages/core/src/astro/routes/api/redirects/[id].ts
@@ -17,6 +17,7 @@ import {
 } from "#api/handlers/redirects.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { updateRedirectBody } from "#api/schemas.js";
+import { invalidateRedirectCache } from "#astro/middleware/redirect.js";
 
 export const prerender = false;
 
@@ -57,6 +58,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleRedirectUpdate(db, id, body);
+		invalidateRedirectCache();
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to update redirect", "REDIRECT_UPDATE_ERROR");
@@ -77,6 +79,7 @@ export const DELETE: APIRoute = async ({ params, locals }) => {
 
 	try {
 		const result = await handleRedirectDelete(db, id);
+		invalidateRedirectCache();
 		return unwrapResult(result);
 	} catch (error) {
 		return handleError(error, "Failed to delete redirect", "REDIRECT_DELETE_ERROR");

--- a/packages/core/src/astro/routes/api/redirects/index.ts
+++ b/packages/core/src/astro/routes/api/redirects/index.ts
@@ -12,7 +12,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleRedirectCreate, handleRedirectList } from "#api/handlers/redirects.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createRedirectBody, redirectsListQuery } from "#api/schemas.js";
-import { invalidateRedirectCache } from "#astro/middleware/redirect.js";
+import { invalidateRedirectCache } from "#redirects/cache.js";
 
 export const prerender = false;
 

--- a/packages/core/src/astro/routes/api/redirects/index.ts
+++ b/packages/core/src/astro/routes/api/redirects/index.ts
@@ -12,6 +12,7 @@ import { handleError, unwrapResult } from "#api/error.js";
 import { handleRedirectCreate, handleRedirectList } from "#api/handlers/redirects.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { createRedirectBody, redirectsListQuery } from "#api/schemas.js";
+import { invalidateRedirectCache } from "#astro/middleware/redirect.js";
 
 export const prerender = false;
 
@@ -45,6 +46,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleRedirectCreate(db, body);
+		invalidateRedirectCache();
 		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create redirect", "REDIRECT_CREATE_ERROR");

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
@@ -19,8 +19,6 @@ import { parseBody, parseQuery, isParseError } from "#api/parse.js";
 import { collectionGetQuery, updateCollectionBody } from "#api/schemas.js";
 import type { UpdateCollectionInput } from "#schema/types.js";
 
-import { invalidateUrlPatternCache } from "../../../../../query.js";
-
 export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
@@ -61,7 +59,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- parseBody validates via Zod
 		body as UpdateCollectionInput,
 	);
-	invalidateUrlPatternCache();
+	emdash!.invalidateManifest();
 	return unwrapResult(result);
 };
 
@@ -79,6 +77,6 @@ export const DELETE: APIRoute = async ({ params, url, locals }) => {
 	const result = await handleSchemaCollectionDelete(emdash!.db, slug, {
 		force,
 	});
-	invalidateUrlPatternCache();
+	emdash!.invalidateManifest();
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/index.ts
@@ -19,6 +19,8 @@ import { parseBody, parseQuery, isParseError } from "#api/parse.js";
 import { collectionGetQuery, updateCollectionBody } from "#api/schemas.js";
 import type { UpdateCollectionInput } from "#schema/types.js";
 
+import { invalidateUrlPatternCache } from "../../../../../query.js";
+
 export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
@@ -59,6 +61,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- parseBody validates via Zod
 		body as UpdateCollectionInput,
 	);
+	invalidateUrlPatternCache();
 	return unwrapResult(result);
 };
 
@@ -76,5 +79,6 @@ export const DELETE: APIRoute = async ({ params, url, locals }) => {
 	const result = await handleSchemaCollectionDelete(emdash!.db, slug, {
 		force,
 	});
+	invalidateUrlPatternCache();
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/schema/collections/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/index.ts
@@ -14,6 +14,8 @@ import { parseBody, isParseError } from "#api/parse.js";
 import { createCollectionBody } from "#api/schemas.js";
 import type { CreateCollectionInput } from "#schema/types.js";
 
+import { invalidateUrlPatternCache } from "../../../../query.js";
+
 export const prerender = false;
 
 export const GET: APIRoute = async ({ locals }) => {
@@ -43,5 +45,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
 	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Zod schema output narrowed to CreateCollectionInput
 	const result = await handleSchemaCollectionCreate(emdash!.db, body as CreateCollectionInput);
+	invalidateUrlPatternCache();
 	return unwrapResult(result, 201);
 };

--- a/packages/core/src/astro/routes/api/schema/collections/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/index.ts
@@ -14,8 +14,6 @@ import { parseBody, isParseError } from "#api/parse.js";
 import { createCollectionBody } from "#api/schemas.js";
 import type { CreateCollectionInput } from "#schema/types.js";
 
-import { invalidateUrlPatternCache } from "../../../../query.js";
-
 export const prerender = false;
 
 export const GET: APIRoute = async ({ locals }) => {
@@ -45,6 +43,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
 	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Zod schema output narrowed to CreateCollectionInput
 	const result = await handleSchemaCollectionCreate(emdash!.db, body as CreateCollectionInput);
-	invalidateUrlPatternCache();
+	emdash!.invalidateManifest();
 	return unwrapResult(result, 201);
 };

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -42,9 +42,15 @@ async function hasAnyBylines(): Promise<boolean> {
 			SELECT id FROM _emdash_bylines LIMIT 1
 		`.execute(db);
 		hasBylines = result.rows.length > 0;
-	} catch {
-		// Table doesn't exist yet (pre-migration) -- no bylines
-		hasBylines = false;
+	} catch (error: unknown) {
+		// Only treat "no such table" as a safe false -- anything else should
+		// not be cached so the next request retries.
+		const message = error instanceof Error ? error.message : "";
+		if (message.includes("no such table")) {
+			hasBylines = false;
+		} else {
+			return false;
+		}
 	}
 
 	return hasBylines;

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -15,6 +15,42 @@ import { getDb } from "../loader.js";
 import { chunks, SQL_BATCH_SIZE } from "../utils/chunks.js";
 
 /**
+ * Cached result of "does any byline exist in the database?"
+ * null = not yet checked, true/false = cached result.
+ * Invalidated when bylines are created or deleted.
+ */
+let hasBylines: boolean | null = null;
+
+/**
+ * Invalidate the cached "has any bylines" check.
+ * Call this when bylines are created, updated, or deleted.
+ */
+export function invalidateBylineCache(): void {
+	hasBylines = null;
+}
+
+/**
+ * Check if any bylines exist in the database. Result is cached
+ * for the lifetime of the worker/process and invalidated on writes.
+ */
+async function hasAnyBylines(): Promise<boolean> {
+	if (hasBylines !== null) return hasBylines;
+
+	try {
+		const db = await getDb();
+		const result = await sql<{ id: string }>`
+			SELECT id FROM _emdash_bylines LIMIT 1
+		`.execute(db);
+		hasBylines = result.rows.length > 0;
+	} catch {
+		// Table doesn't exist yet (pre-migration) -- no bylines
+		hasBylines = false;
+	}
+
+	return hasBylines;
+}
+
+/**
  * Get a byline by ID.
  *
  * @example
@@ -131,6 +167,12 @@ export async function getBylinesForEntries(
 	}
 
 	if (entryIds.length === 0) {
+		return result;
+	}
+
+	// Skip DB queries entirely when no bylines have been created.
+	// The cache is invalidated when bylines are created/deleted.
+	if (!(await hasAnyBylines())) {
 		return result;
 	}
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -36,6 +36,7 @@ import type {
 	PageMetadataContribution,
 	PageFragmentContribution,
 } from "./plugins/types.js";
+import { invalidateUrlPatternCache } from "./query.js";
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
 
@@ -1364,11 +1365,12 @@ export class EmDashRuntime {
 	}
 
 	/**
-	 * Invalidate the cached manifest (no-op now that we don't cache).
-	 * Kept for API compatibility.
+	 * Invalidate cached data derived from the manifest/schema.
+	 * Called when collections are created, updated, or deleted.
 	 */
 	invalidateManifest(): void {
-		// No-op - manifest is rebuilt on each request
+		// Invalidate the URL pattern cache used by resolveEmDashPath
+		invalidateUrlPatternCache();
 	}
 
 	// =========================================================================

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -637,6 +637,22 @@ function patternToRegex(pattern: string): { regex: RegExp; paramNames: string[] 
 	return { regex: new RegExp(`^${regexStr}$`), paramNames };
 }
 
+/** Cached compiled URL patterns for resolveEmDashPath */
+interface CachedPattern {
+	slug: string;
+	regex: RegExp;
+	paramNames: string[];
+}
+let cachedUrlPatterns: CachedPattern[] | null = null;
+
+/**
+ * Invalidate the cached URL patterns used by resolveEmDashPath.
+ * Call when collection URL patterns change (schema updates).
+ */
+export function invalidateUrlPatternCache(): void {
+	cachedUrlPatterns = null;
+}
+
 /**
  * Resolve a URL path to a content entry by matching against collection URL patterns.
  *
@@ -659,32 +675,39 @@ function patternToRegex(pattern: string): { regex: RegExp; paramNames: string[] 
 export async function resolveEmDashPath<T = Record<string, unknown>>(
 	path: string,
 ): Promise<ResolvePathResult<T> | null> {
-	const { getDb } = await import("./loader.js");
-	const { SchemaRegistry } = await import("./schema/registry.js");
-	const db = await getDb();
-	const registry = new SchemaRegistry(db);
-	const collections = await registry.listCollections();
+	// Build and cache compiled patterns on first call
+	if (!cachedUrlPatterns) {
+		const { getDb } = await import("./loader.js");
+		const { SchemaRegistry } = await import("./schema/registry.js");
+		const db = await getDb();
+		const registry = new SchemaRegistry(db);
+		const collections = await registry.listCollections();
 
-	for (const collection of collections) {
-		if (!collection.urlPattern) continue;
+		cachedUrlPatterns = [];
+		for (const collection of collections) {
+			if (!collection.urlPattern) continue;
+			const { regex, paramNames } = patternToRegex(collection.urlPattern);
+			cachedUrlPatterns.push({ slug: collection.slug, regex, paramNames });
+		}
+	}
 
-		const { regex, paramNames } = patternToRegex(collection.urlPattern);
-		const match = path.match(regex);
+	for (const pattern of cachedUrlPatterns) {
+		const match = path.match(pattern.regex);
 		if (!match) continue;
 
 		// Extract params
 		const params: Record<string, string> = {};
-		for (let i = 0; i < paramNames.length; i++) {
-			params[paramNames[i]] = match[i + 1];
+		for (let i = 0; i < pattern.paramNames.length; i++) {
+			params[pattern.paramNames[i]] = match[i + 1];
 		}
 
 		// Look up entry by slug (most common pattern)
 		const slug = params.slug;
 		if (!slug) continue;
 
-		const { entry } = await getEmDashEntry<string, T>(collection.slug, slug);
+		const { entry } = await getEmDashEntry<string, T>(pattern.slug, slug);
 		if (entry) {
-			return { entry, collection: collection.slug, params };
+			return { entry, collection: pattern.slug, params };
 		}
 	}
 

--- a/packages/core/src/redirects/cache.ts
+++ b/packages/core/src/redirects/cache.ts
@@ -1,0 +1,68 @@
+/**
+ * Redirect pattern cache.
+ *
+ * Module-level cache for compiled redirect pattern rules. The middleware
+ * populates this on first request; route handlers invalidate it on writes.
+ *
+ * This module deliberately has NO Astro imports so it can be safely imported
+ * from handlers, seed, CLI, and tests without dragging in `astro:middleware`.
+ */
+
+import type { Redirect } from "../database/repositories/redirect.js";
+import type { CompiledPattern } from "./patterns.js";
+import { compilePattern, interpolateDestination, matchPattern } from "./patterns.js";
+
+export interface CachedRedirectRule {
+	redirect: Redirect;
+	compiled: CompiledPattern;
+}
+
+/**
+ * Cached pattern rules with compiled regexes.
+ * null = not yet populated, array = cached.
+ */
+let cachedPatternRules: CachedRedirectRule[] | null = null;
+
+/**
+ * Invalidate the cached redirect pattern rules.
+ * Call when redirects are created, updated, or deleted.
+ */
+export function invalidateRedirectCache(): void {
+	cachedPatternRules = null;
+}
+
+/**
+ * Get the cached compiled pattern rules, or null if the cache is cold.
+ */
+export function getCachedPatternRules(): CachedRedirectRule[] | null {
+	return cachedPatternRules;
+}
+
+/**
+ * Populate the pattern rules cache from a list of enabled pattern redirects.
+ */
+export function setCachedPatternRules(redirects: Redirect[]): CachedRedirectRule[] {
+	cachedPatternRules = redirects.map((r) => ({
+		redirect: r,
+		compiled: compilePattern(r.source),
+	}));
+	return cachedPatternRules;
+}
+
+/**
+ * Match a path against the cached pattern rules.
+ * Returns the resolved destination and matching redirect, or null.
+ */
+export function matchCachedPatterns(
+	rules: CachedRedirectRule[],
+	pathname: string,
+): { redirect: Redirect; destination: string } | null {
+	for (const { redirect, compiled } of rules) {
+		const params = matchPattern(compiled, pathname);
+		if (params) {
+			const dest = interpolateDestination(redirect.destination, params);
+			return { redirect, destination: dest };
+		}
+	}
+	return null;
+}

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -636,6 +636,16 @@ export async function applySeed(
 		}
 	}
 
+	// Invalidate caches that may have been affected by seed data.
+	// Seed creates bylines, redirects, and collections, all of which
+	// have module-level caches in the hot path.
+	const { invalidateBylineCache } = await import("../bylines/index.js");
+	const { invalidateRedirectCache } = await import("../astro/middleware/redirect.js");
+	const { invalidateUrlPatternCache } = await import("../query.js");
+	invalidateBylineCache();
+	invalidateRedirectCache();
+	invalidateUrlPatternCache();
+
 	return result;
 }
 

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -640,7 +640,7 @@ export async function applySeed(
 	// Seed creates bylines, redirects, and collections, all of which
 	// have module-level caches in the hot path.
 	const { invalidateBylineCache } = await import("../bylines/index.js");
-	const { invalidateRedirectCache } = await import("../astro/middleware/redirect.js");
+	const { invalidateRedirectCache } = await import("../redirects/cache.js");
 	const { invalidateUrlPatternCache } = await import("../query.js");
 	invalidateBylineCache();
 	invalidateRedirectCache();


### PR DESCRIPTION
## What does this PR do?

Three non-breaking performance optimizations for the logged-out page load path. Reduces warm page loads from 3-6 DB queries to 1-2.

### Byline hydration short-circuit

Added a module-level `hasBylines` cache in `bylines/index.ts`. On first call, checks `SELECT id FROM _emdash_bylines LIMIT 1`. When false (most sites don't use bylines), `getBylinesForEntries` returns immediately with empty arrays -- skipping 1-3 DB queries per page. Invalidated on byline create/update/delete routes and at end of seed apply.

### resolveEmDashPath pattern caching

`resolveEmDashPath` was creating a `SchemaRegistry`, querying all collections, and compiling URL pattern regexes on every call. Now caches compiled patterns at module level. Invalidated via `invalidateManifest()` on schema changes and at end of seed apply.

### Redirect pattern rules caching

The redirect middleware was calling `findEnabledPatternRules()` (unbounded query) and compiling regexes on every request. Now caches compiled patterns at module level. Exact matches still hit the DB (indexed, fast). Pattern rules compiled once, matched in memory. Invalidated on redirect CRUD routes, auto-redirect on slug change, and at end of seed apply.

### Cache invalidation

All three caches are invalidated:
- On their respective CRUD routes (byline create/update/delete, redirect create/update/delete, schema changes)
- On content slug change (redirect cache -- auto-redirect may have been created)
- At end of `applySeed` (all three caches)

All changes are non-breaking. `entry.bylines` is always populated (empty array when no bylines exist). URL pattern matching and redirect matching return identical results. Only difference is fewer DB queries.

## Type of change

- [x] Performance improvement

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)

## AI-generated code disclosure

- [x] This PR includes AI-generated code