### PR TITLE
chore: add worker_loaders binding to Cloudflare templates

### DIFF
--- a/templates/blog-cloudflare/wrangler.jsonc
+++ b/templates/blog-cloudflare/wrangler.jsonc
@@ -18,4 +18,10 @@
 			"bucket_name": "my-emdash-media",
 		},
 	],
+	// Worker Loader for plugin sandboxing
+	"worker_loaders": [
+		{
+			"binding": "LOADER",
+		},
+	],
 }

--- a/templates/marketing-cloudflare/wrangler.jsonc
+++ b/templates/marketing-cloudflare/wrangler.jsonc
@@ -18,4 +18,10 @@
 			"bucket_name": "my-marketing-media",
 		},
 	],
+	// Worker Loader for plugin sandboxing
+	"worker_loaders": [
+		{
+			"binding": "LOADER",
+		},
+	],
 }

--- a/templates/portfolio-cloudflare/wrangler.jsonc
+++ b/templates/portfolio-cloudflare/wrangler.jsonc
@@ -18,4 +18,10 @@
 			"bucket_name": "my-portfolio-media",
 		},
 	],
+	// Worker Loader for plugin sandboxing
+	"worker_loaders": [
+		{
+			"binding": "LOADER",
+		},
+	],
 }

--- a/templates/starter-cloudflare/wrangler.jsonc
+++ b/templates/starter-cloudflare/wrangler.jsonc
@@ -18,4 +18,10 @@
 			"bucket_name": "my-emdash-media",
 		},
 	],
+	// Worker Loader for plugin sandboxing
+	"worker_loaders": [
+		{
+			"binding": "LOADER",
+		},
+	],
 }


### PR DESCRIPTION
## What does this PR do?

Adds the `worker_loaders` binding to all four Cloudflare templates, matching the existing configuration in `demos/cloudflare/wrangler.jsonc`. This binding (`LOADER`) is needed for plugin sandboxing on Workers.

Templates updated:
- `templates/blog-cloudflare/wrangler.jsonc`
- `templates/marketing-cloudflare/wrangler.jsonc`
- `templates/portfolio-cloudflare/wrangler.jsonc`
- `templates/starter-cloudflare/wrangler.jsonc`

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — template-only change (no published package affected, no changeset needed).