### PR TITLE
feat: enable MCP by default, fix Cloudflare workerd crash

### DIFF
--- a/.changeset/twenty-banks-burn.md
+++ b/.changeset/twenty-banks-burn.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes MCP server crash ("exports is not defined") on Cloudflare in dev mode by pre-bundling the MCP SDK's CJS dependencies for workerd.

--- a/.changeset/twenty-banks-burn.md
+++ b/.changeset/twenty-banks-burn.md
@@ -1,5 +1,7 @@
 ---
-"emdash": patch
+"emdash": minor
 ---
+
+Enables the MCP server endpoint by default. The endpoint at `/_emdash/api/mcp` requires bearer token auth, so it has no effect unless a client is configured. Set `mcp: false` to disable.
 
 Fixes MCP server crash ("exports is not defined") on Cloudflare in dev mode by pre-bundling the MCP SDK's CJS dependencies for workerd.

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -228,10 +228,9 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 					injectBuiltinAuthRoutes(injectRoute);
 				}
 
-				// Inject MCP endpoint when enabled
-				if (resolvedConfig.mcp) {
+				// Inject MCP endpoint (always on — bearer-token-only, no cost if unused)
+				if (resolvedConfig.mcp !== false) {
 					injectMcpRoute(injectRoute);
-					logger.info("MCP server enabled at /_emdash/api/mcp");
 				}
 
 				// In playground mode, inject the playground middleware FIRST.

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -223,23 +223,17 @@ export interface EmDashConfig {
 	auth?: AuthDescriptor;
 
 	/**
-	 * Enable the MCP (Model Context Protocol) server endpoint.
+	 * MCP (Model Context Protocol) server endpoint.
 	 *
-	 * When enabled, exposes an MCP Streamable HTTP server at
-	 * `/_emdash/api/mcp` that allows AI agents and tools to interact
-	 * with the CMS using the standardized MCP protocol.
+	 * Exposes an MCP Streamable HTTP server at `/_emdash/api/mcp`
+	 * that allows AI agents and tools to interact with the CMS using
+	 * the standardized MCP protocol.
 	 *
-	 * Authentication is handled by the existing EmDash auth middleware —
-	 * agents must authenticate with an API token or session cookie.
+	 * Enabled by default. The endpoint requires bearer token auth, so
+	 * it has no effect unless the user creates an API token and
+	 * configures a client. Set to `false` to disable.
 	 *
-	 * @default false
-	 *
-	 * @example
-	 * ```ts
-	 * emdash({
-	 *   mcp: true,
-	 * })
-	 * ```
+	 * @default true
 	 */
 	mcp?: boolean;
 

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -345,6 +345,10 @@ export function createViteConfig(
 							"emdash > @emdash-cms/auth > @oslojs/crypto/ecdsa",
 							"emdash > @emdash-cms/auth > @oslojs/crypto/sha2",
 							"emdash > @emdash-cms/auth > @oslojs/webauthn",
+							// MCP SDK — server/index.js statically imports ajv (CJS-only).
+							// Pre-bundling converts CJS to ESM so workerd can load it.
+							"emdash > @modelcontextprotocol/sdk > ajv",
+							"emdash > @modelcontextprotocol/sdk > ajv-formats",
 							// React (commonly used, may be hoisted)
 							"react",
 							"react/jsx-dev-runtime",

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -76,6 +76,12 @@ const SITE_MATRIX: SiteCase[] = [
 		port: 4617,
 		startupTimeoutMs: 120_000,
 	},
+	{
+		name: "templates/starter-cloudflare",
+		dir: resolve(WORKSPACE_ROOT, "templates/starter-cloudflare"),
+		port: 4618,
+		startupTimeoutMs: 120_000,
+	},
 ];
 
 async function waitForServer(url: string, timeoutMs: number): Promise<void> {
@@ -162,13 +168,72 @@ describe("Site build verification", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Helpers — shared server lifecycle for runtime tests
+// ---------------------------------------------------------------------------
+
+interface BootedServer {
+	baseUrl: string;
+	process: ReturnType<typeof spawn>;
+	output: string;
+}
+
+async function bootSite(site: SiteCase): Promise<BootedServer> {
+	await ensureBuilt();
+
+	// Remove stale database files so each run starts fresh.
+	for (const file of ["data.db", "data.db-wal", "data.db-shm"]) {
+		rmSync(join(site.dir, file), { force: true });
+	}
+
+	const baseUrl = `http://localhost:${site.port}`;
+	const serverProcess = spawn("pnpm", ["exec", "astro", "dev", "--port", String(site.port)], {
+		cwd: site.dir,
+		env: {
+			...process.env,
+			CI: "true",
+		},
+		stdio: "pipe",
+	});
+
+	let output = "";
+	serverProcess.stdout?.on("data", (data: Buffer) => {
+		output += data.toString();
+	});
+	serverProcess.stderr?.on("data", (data: Buffer) => {
+		output += data.toString();
+	});
+
+	const waitPath = site.waitPath ?? "/_emdash/admin/";
+	await waitForServer(`${baseUrl}${waitPath}`, site.startupTimeoutMs);
+
+	return {
+		baseUrl,
+		process: serverProcess,
+		get output() {
+			return output;
+		},
+	};
+}
+
+function killServer(serverProcess: ReturnType<typeof spawn>): Promise<void> {
+	serverProcess.kill("SIGTERM");
+	return new Promise((done) => {
+		setTimeout(() => {
+			if (!serverProcess.killed) {
+				serverProcess.kill("SIGKILL");
+			}
+			setTimeout(done, 500);
+		}, 1200);
+	});
+}
+
+// ---------------------------------------------------------------------------
 // Runtime verification — boots each site with `astro dev` and checks that
 // admin + frontend respond.
 // ---------------------------------------------------------------------------
 
 describe.sequential("Site runtime verification", () => {
 	for (const site of SITE_MATRIX) {
-		const waitPath = site.waitPath ?? "/_emdash/admin/";
 		const setupPath = site.setupPath ?? "/_emdash/api/setup/dev-bypass?redirect=/";
 		const frontendPath = site.frontendPath ?? "/";
 		const frontendStatuses = site.frontendStatuses ?? [200, 302, 307, 308];
@@ -178,44 +243,18 @@ describe.sequential("Site runtime verification", () => {
 			`${site.name} boots and serves admin + frontend`,
 			{ timeout: site.startupTimeoutMs + 120_000 },
 			async () => {
-				await ensureBuilt();
-
-				// Remove stale database files so each run starts fresh.
-				// SQLite demos use data.db; WAL/SHM sidecars may also exist.
-				for (const file of ["data.db", "data.db-wal", "data.db-shm"]) {
-					rmSync(join(site.dir, file), { force: true });
-				}
-
-				const baseUrl = `http://localhost:${site.port}`;
-				const serverProcess = spawn("pnpm", ["exec", "astro", "dev", "--port", String(site.port)], {
-					cwd: site.dir,
-					env: {
-						...process.env,
-						CI: "true",
-					},
-					stdio: "pipe",
-				});
-
-				let output = "";
-				serverProcess.stdout?.on("data", (data: Buffer) => {
-					output += data.toString();
-				});
-				serverProcess.stderr?.on("data", (data: Buffer) => {
-					output += data.toString();
-				});
+				const server = await bootSite(site);
 
 				try {
-					await waitForServer(`${baseUrl}${waitPath}`, site.startupTimeoutMs);
-
 					if (setupPath) {
-						const setupRes = await fetchWithRetry(`${baseUrl}${setupPath}`);
+						const setupRes = await fetchWithRetry(`${server.baseUrl}${setupPath}`);
 						expect(setupRes.status).toBeLessThan(500);
 					}
 
-					const adminRes = await fetchWithRetry(`${baseUrl}/_emdash/admin/`);
+					const adminRes = await fetchWithRetry(`${server.baseUrl}/_emdash/admin/`);
 					expect(adminRes.status).toBeLessThan(500);
 
-					const frontendRes = await fetchWithRetry(`${baseUrl}${frontendPath}`);
+					const frontendRes = await fetchWithRetry(`${server.baseUrl}${frontendPath}`);
 					expect(frontendStatuses).toContain(frontendRes.status);
 
 					const body = await frontendRes.text();
@@ -225,18 +264,132 @@ describe.sequential("Site runtime verification", () => {
 				} catch (error) {
 					throw new Error(
 						`${site.name} smoke failed: ${error instanceof Error ? error.message : String(error)}\n\n` +
-							output.slice(-3000),
+							server.output.slice(-3000),
 						{ cause: error },
 					);
 				} finally {
-					serverProcess.kill("SIGTERM");
-					await new Promise((resolveSleep) => setTimeout(resolveSleep, 1200));
-					if (!serverProcess.killed) {
-						serverProcess.kill("SIGKILL");
-						await new Promise((resolveSleep) => setTimeout(resolveSleep, 500));
-					}
+					await killServer(server.process);
 				}
 			},
 		);
 	}
 });
+
+// ---------------------------------------------------------------------------
+// MCP endpoint verification — boots one Node and one Cloudflare site, gets a
+// bearer token, and verifies the MCP server responds to tools/list.
+// ---------------------------------------------------------------------------
+
+const MCP_SITES: SiteCase[] = SITE_MATRIX.filter(
+	(s) => s.name === "templates/blog" || s.name === "templates/starter-cloudflare",
+);
+
+describe.sequential("MCP endpoint verification", () => {
+	for (const site of MCP_SITES) {
+		it(
+			`${site.name} MCP tools/list responds with tools`,
+			{ timeout: site.startupTimeoutMs + 120_000 },
+			async () => {
+				const server = await bootSite(site);
+
+				try {
+					// Run dev-bypass with ?token=1 to get a bearer token
+					const setupRes = await fetchWithRetry(
+						`${server.baseUrl}/_emdash/api/setup/dev-bypass?token=1`,
+					);
+					expect(setupRes.status).toBeLessThan(500);
+
+					const setupBody = (await setupRes.json()) as {
+						data?: { token?: string };
+					};
+					const token = setupBody.data?.token;
+					expect(token).toBeTruthy();
+
+					// Send MCP initialize
+					const initRes = await fetch(`${server.baseUrl}/_emdash/api/mcp`, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							Accept: "application/json, text/event-stream",
+							Authorization: `Bearer ${token}`,
+						},
+						body: JSON.stringify({
+							jsonrpc: "2.0",
+							method: "initialize",
+							params: {
+								protocolVersion: "2025-03-26",
+								capabilities: {},
+								clientInfo: { name: "smoke-test", version: "1.0" },
+							},
+							id: 1,
+						}),
+					});
+					expect(initRes.status).toBe(200);
+
+					// Parse SSE response to extract JSON
+					const initText = await initRes.text();
+					const initData = parseSSE(initText);
+					expect(initData).toHaveProperty("result.serverInfo.name", "emdash");
+
+					// Send initialized notification + tools/list in one request
+					// (stateless mode — each request is independent, so we send
+					// the full sequence: notifications/initialized then tools/list)
+					const listRes = await fetch(`${server.baseUrl}/_emdash/api/mcp`, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							Accept: "application/json, text/event-stream",
+							Authorization: `Bearer ${token}`,
+						},
+						body: JSON.stringify([
+							{
+								jsonrpc: "2.0",
+								method: "notifications/initialized",
+							},
+							{
+								jsonrpc: "2.0",
+								method: "tools/list",
+								params: {},
+								id: 2,
+							},
+						]),
+					});
+					expect(listRes.status).toBe(200);
+
+					const listText = await listRes.text();
+					const listData = parseSSE(listText);
+					expect(listData).toHaveProperty("result.tools");
+					const tools = (listData as { result: { tools: unknown[] } }).result.tools;
+					expect(tools.length).toBeGreaterThan(0);
+
+					// Verify some expected tools exist
+					const toolNames = tools.map((t: unknown) => (t as { name: string }).name);
+					expect(toolNames).toContain("content_list");
+					expect(toolNames).toContain("schema_list_collections");
+				} catch (error) {
+					throw new Error(
+						`${site.name} MCP smoke failed: ${error instanceof Error ? error.message : String(error)}\n\n` +
+							server.output.slice(-3000),
+						{ cause: error },
+					);
+				} finally {
+					await killServer(server.process);
+				}
+			},
+		);
+	}
+});
+
+/**
+ * Parse the first JSON-RPC message from an SSE text response.
+ * MCP stateless mode returns `event: message\ndata: {...}\n\n`.
+ */
+function parseSSE(text: string): unknown {
+	for (const line of text.split("\n")) {
+		if (line.startsWith("data: ")) {
+			return JSON.parse(line.slice(6));
+		}
+	}
+	// Fall back to parsing as plain JSON (non-SSE response)
+	return JSON.parse(text);
+}


### PR DESCRIPTION
## What does this PR do?

1. **Fixes "exports is not defined"** when hitting the MCP endpoint on Cloudflare in dev mode. The MCP SDK statically imports `ajv` (CJS-only) through its server module chain. In workerd's ESM context there is no CJS `exports` global. Adding `ajv` and `ajv-formats` to `ssr.optimizeDeps.include` lets esbuild convert them to ESM during pre-bundling.

2. **Enables MCP by default.** The endpoint requires bearer token auth, so it's completely inert unless a user creates an API token and configures a client. Set `mcp: false` to disable.

3. **Adds MCP smoke test.** Boots one Node site (`templates/blog`) and one Cloudflare site (`templates/starter-cloudflare`), gets a bearer token via dev-bypass, and verifies `tools/list` returns expected tools. This would have caught the workerd regression.

4. **Adds `templates/starter-cloudflare` to the site matrix** smoke tests.

## Type of change

- [x] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Testing

**Manual verification:**
- Started starter-cloudflare dev server with MCP enabled
- Created API token, sent MCP `initialize` + `tools/list` -- both succeeded
- Without the ajv fix, same request crashes with "exports is not defined"

**Automated:**
- New MCP smoke test covers the full flow on both Node and Cloudflare adapters