### PR TITLE
i18n(ja): add Japanese translations

### DIFF
--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -13,9 +13,32 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: packages/admin/src/components/ContentEditor.tsx:897
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 msgid " (default)"
 msgstr "（デフォルト）"
+
+#. placeholder {0}: filteredItems.length
+#: packages/admin/src/components/ContentList.tsx:251
+msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{0, plural, one {\"{searchQuery}\"に一致する#件} other {\"{searchQuery}\"に一致する#件}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr "{0, plural, one {#件のメディアファイル} other {#件のメディアファイル}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {#人のユーザー} other {#人のユーザー}}"
+
+#. placeholder {0}: filteredItems.length
+#. placeholder {1}: hasMore ? "+" : ""
+#. placeholder {2}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:255
+msgid "{0, plural, one {#{1} item} other {#{2} items}}"
+msgstr "{0, plural, one {#{1}件} other {#{2}件}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
@@ -24,6 +47,14 @@ msgstr "{label} — 翻訳なし"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — 翻訳を表示"
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr "{totalDrafts, plural, one {#件の下書き} other {#件の下書き}}"
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr "{totalScheduled, plural, one {#件の予約} other {#件の予約}}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
@@ -41,14 +72,36 @@ msgstr "7日"
 msgid "90 days"
 msgstr "90日"
 
+#: packages/admin/src/components/ContentList.tsx:204
+#: packages/admin/src/components/ContentList.tsx:309
+msgid "Actions"
+msgstr "操作"
+
+#: packages/admin/src/components/ContentEditor.tsx:1488
+msgid "Add"
+msgstr "追加"
+
+#: packages/admin/src/components/ContentList.tsx:140
+msgid "Add New"
+msgstr "新規追加"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
+#: packages/admin/src/components/Sidebar.tsx:402
 #: packages/admin/src/components/users/roleDefinitions.ts:42
 msgid "Admin"
 msgstr "管理者"
 
+#: packages/admin/src/components/Sidebar.tsx:349
+msgid "Admin navigation"
+msgstr "管理ナビゲーション"
+
 #: packages/admin/src/components/WelcomeModal.tsx:25
 msgid "Administrator"
 msgstr "管理者"
+
+#: packages/admin/src/components/ContentList.tsx:167
+msgid "All"
+msgstr "すべて"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
@@ -68,6 +121,10 @@ msgstr "特定のドメインからのユーザー登録を許可"
 msgid "API Tokens"
 msgstr "APIトークン"
 
+#: packages/admin/src/components/ContentList.tsx:557
+msgid "archived"
+msgstr "アーカイブ済み"
+
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "管理者として、ユーザーセクションから他のユーザーを招待できます。"
@@ -80,6 +137,10 @@ msgstr "認証エラー: {error}"
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "投稿者"
+
+#: packages/admin/src/components/ContentEditor.tsx:485
+msgid "Back to {collectionLabel} list"
+msgstr "{collectionLabel}一覧に戻る"
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
@@ -94,6 +155,11 @@ msgstr "設定に戻る"
 #: packages/admin/src/components/PortableTextEditor.tsx:729
 msgid "Bullet List"
 msgstr "箇条書きリスト"
+
+#: packages/admin/src/components/ContentEditor.tsx:863
+#: packages/admin/src/components/Sidebar.tsx:201
+msgid "Bylines"
+msgstr "署名"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -111,6 +177,13 @@ msgstr "自分のコンテンツを公開可能"
 msgid "Can view content"
 msgstr "コンテンツを閲覧可能"
 
+#: packages/admin/src/components/ContentEditor.tsx:573
+#: packages/admin/src/components/ContentEditor.tsx:777
+#: packages/admin/src/components/ContentEditor.tsx:829
+#: packages/admin/src/components/ContentEditor.tsx:1591
+#: packages/admin/src/components/ContentEditor.tsx:1644
+#: packages/admin/src/components/ContentList.tsx:445
+#: packages/admin/src/components/ContentList.tsx:516
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
 msgid "Cancel"
@@ -119,6 +192,10 @@ msgstr "キャンセル"
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "カテゴリ"
+
+#: packages/admin/src/components/ContentEditor.tsx:1348
+msgid "Change"
+msgstr "変更"
 
 #: packages/admin/src/components/LoginPage.tsx:158
 msgid "Check your email"
@@ -141,12 +218,18 @@ msgstr "閉じる"
 msgid "Code Block"
 msgstr "コードブロック"
 
+#: packages/admin/src/components/Sidebar.tsx:185
+msgid "Comments"
+msgstr "コメント"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "確認"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "コンテンツ"
 
@@ -159,6 +242,7 @@ msgid "Content Read"
 msgstr "コンテンツ読み取り"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "コンテンツタイプ"
 
@@ -183,6 +267,10 @@ msgstr "今すぐこのトークンをコピーしてください。再表示は
 msgid "Copy token"
 msgstr "トークンをコピー"
 
+#: packages/admin/src/components/ContentEditor.tsx:1615
+msgid "Create"
+msgstr "作成"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:730
 msgid "Create a bullet list"
 msgstr "箇条書きリストを作成"
@@ -190,6 +278,10 @@ msgstr "箇条書きリストを作成"
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "番号付きリストを作成"
+
+#: packages/admin/src/components/ContentEditor.tsx:1563
+msgid "Create byline"
+msgstr "署名を作成"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
@@ -205,6 +297,10 @@ msgstr "プログラムからのAPIアクセス用にパーソナルアクセス
 msgid "Create Token"
 msgstr "トークンを作成"
 
+#: packages/admin/src/components/ContentList.tsx:219
+msgid "Create your first one"
+msgstr "最初のコンテンツを作成しましょう"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "コンテンツの作成・更新・削除"
@@ -218,13 +314,59 @@ msgstr "作成日: {0}"
 msgid "Created At"
 msgstr "作成日時"
 
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:797
+msgid "Created: {0}"
+msgstr "作成日: {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1615
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Creating..."
 msgstr "作成中..."
 
+#: packages/admin/src/components/ContentEditor.tsx:900
+msgid "current"
+msgstr "現在"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "ダーク"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "ダーク"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:171
+#: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "ダッシュボード"
+
+#: packages/admin/src/components/ContentList.tsx:201
+msgid "Date"
+msgstr "日付"
+
+#: packages/admin/src/components/ContentList.tsx:527
+msgid "Delete Permanently"
+msgstr "完全に削除"
+
+#: packages/admin/src/components/ContentList.tsx:507
+msgid "Delete Permanently?"
+msgstr "完全に削除しますか？"
+
+#: packages/admin/src/components/ContentList.tsx:306
+msgid "Deleted"
+msgstr "削除済み"
+
+#: packages/admin/src/components/ContentEditor.tsx:558
+#: packages/admin/src/components/ContentEditor.tsx:580
+msgid "Discard changes"
+msgstr "変更を破棄"
+
+#: packages/admin/src/components/ContentEditor.tsx:564
+msgid "Discard draft changes?"
+msgstr "下書きの変更を破棄しますか？"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:226
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
@@ -235,6 +377,15 @@ msgstr "閉じる"
 msgid "Display a navigation menu"
 msgstr "ナビゲーションメニューを表示"
 
+#: packages/admin/src/components/ContentEditor.tsx:1566
+#: packages/admin/src/components/ContentEditor.tsx:1628
+msgid "Display name"
+msgstr "表示名"
+
+#: packages/admin/src/components/ContentEditor.tsx:534
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "集中モード (⌘⇧\\)"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:769
 msgid "Divider"
 msgstr "区切り線"
@@ -243,17 +394,51 @@ msgstr "区切り線"
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "アカウントをお持ちでないですか？ <0>新規登録</0>"
 
+#: packages/admin/src/components/ContentEditor.tsx:1509
+msgid "Down"
+msgstr "下へ"
+
+#: packages/admin/src/components/ContentList.tsx:553
+msgid "draft"
+msgstr "下書き"
+
+#: packages/admin/src/components/ContentEditor.tsx:728
+msgid "Draft"
+msgstr "下書き"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:117
 msgid "draft, published, or archived"
 msgstr "下書き、公開済み、またはアーカイブ済み"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:69
+#: packages/admin/src/components/Dashboard.tsx:188
 msgid "Drafts"
 msgstr "下書き"
+
+#: packages/admin/src/components/ContentList.tsx:418
+msgid "Duplicate {title}"
+msgstr "{title}を複製"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:403
 msgid "e.g., CI/CD Pipeline"
 msgstr "例: CI/CDパイプライン"
+
+#: packages/admin/src/components/ContentEditor.tsx:909
+#: packages/admin/src/components/ContentEditor.tsx:1518
+msgid "Edit"
+msgstr "編集"
+
+#: packages/admin/src/components/ContentEditor.tsx:502
+msgid "Edit {collectionLabel}"
+msgstr "{collectionLabel}を編集"
+
+#: packages/admin/src/components/ContentList.tsx:410
+msgid "Edit {title}"
+msgstr "{title}を編集"
+
+#: packages/admin/src/components/ContentEditor.tsx:1625
+msgid "Edit byline"
+msgstr "署名を編集"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
@@ -281,6 +466,23 @@ msgstr "埋め込み"
 msgid "Enable full-text search on this collection"
 msgstr "このコレクションで全文検索を有効にする"
 
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1123
+msgid "Enter {0}..."
+msgstr "{0}を入力..."
+
+#: packages/admin/src/components/ContentEditor.tsx:533
+msgid "Enter distraction-free mode"
+msgstr "集中モードに入る"
+
+#: packages/admin/src/components/ContentEditor.tsx:1144
+msgid "Enter markdown content..."
+msgstr "マークダウンを入力..."
+
+#: packages/admin/src/components/ContentEditor.tsx:496
+msgid "Exit distraction-free mode"
+msgstr "集中モードを終了"
+
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:280
 msgid "Expires {0}"
@@ -290,10 +492,18 @@ msgstr "有効期限: {0}"
 msgid "Expiry"
 msgstr "有効期限"
 
+#: packages/admin/src/components/ContentEditor.tsx:1609
+msgid "Failed to create byline"
+msgstr "署名の作成に失敗しました"
+
 #: packages/admin/src/components/LoginPage.tsx:127
 #: packages/admin/src/components/LoginPage.tsx:132
 msgid "Failed to send magic link"
 msgstr "マジックリンクの送信に失敗しました"
+
+#: packages/admin/src/components/ContentEditor.tsx:1659
+msgid "Failed to update byline"
+msgstr "署名の更新に失敗しました"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -343,6 +553,7 @@ msgid "Image"
 msgstr "画像"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "インポート"
 
@@ -380,19 +591,52 @@ msgstr "大見出し"
 msgid "Last used {0}"
 msgstr "最終使用日: {0}"
 
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "ライト"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "ライト"
+
+#: packages/admin/src/components/ContentEditor.tsx:613
+msgid "Live View"
+msgstr "ライブビュー"
+
+#: packages/admin/src/components/ContentList.tsx:290
+#: packages/admin/src/components/ContentList.tsx:338
+msgid "Load More"
+msgstr "もっと読み込む"
+
+#: packages/admin/src/components/ContentList.tsx:290
+#: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "読み込み中..."
 
+#: packages/admin/src/components/ContentList.tsx:197
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
 msgid "Locale"
 msgstr "ロケール"
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr "ログアウト"
+
+#: packages/admin/src/components/Sidebar.tsx:390
+msgid "Manage"
+msgstr "管理"
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "パスキーと認証の管理"
 
+#: packages/admin/src/components/Sidebar.tsx:214
+msgid "Marketplace"
+msgstr "マーケットプレイス"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
+#: packages/admin/src/components/Sidebar.tsx:180
 msgid "Media"
 msgstr "メディア"
 
@@ -417,6 +661,7 @@ msgid "Menu"
 msgstr "メニュー"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "メニュー"
 
@@ -424,25 +669,73 @@ msgstr "メニュー"
 msgid "Modify collection schemas"
 msgstr "コレクションスキーマを変更"
 
+#: packages/admin/src/components/ContentList.tsx:439
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "\"{title}\"をゴミ箱に移動しますか？後で復元できます。"
+
+#: packages/admin/src/components/ContentList.tsx:430
+msgid "Move {title} to trash"
+msgstr "{title}をゴミ箱に移動"
+
+#: packages/admin/src/components/ContentEditor.tsx:814
+#: packages/admin/src/components/ContentEditor.tsx:836
+#: packages/admin/src/components/ContentList.tsx:452
+msgid "Move to Trash"
+msgstr "ゴミ箱に移動"
+
+#: packages/admin/src/components/ContentEditor.tsx:820
+#: packages/admin/src/components/ContentList.tsx:437
+msgid "Move to Trash?"
+msgstr "ゴミ箱に移動しますか？"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "ナビゲーション"
+
+#: packages/admin/src/components/ContentEditor.tsx:502
+msgid "New {collectionLabel}"
+msgstr "新しい{collectionLabel}"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "新しいタブ"
 
+#: packages/admin/src/components/ContentList.tsx:278
+msgid "Next page"
+msgstr "次のページ"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:212
+msgid "No {0} yet."
+msgstr "まだ{0}がありません。"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "APIトークンはまだありません。作成して使い始めましょう。"
+
+#: packages/admin/src/components/ContentEditor.tsx:1550
+msgid "No bylines selected."
+msgstr "署名が選択されていません。"
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr "コレクションが設定されていません"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "無期限"
 
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr "最近のアクティビティはありません"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "結果なし"
+
+#: packages/admin/src/components/ContentList.tsx:226
+msgid "No results for \"{searchQuery}\""
+msgstr "\"{searchQuery}\"の検索結果はありません"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:452
 msgid "No results found"
@@ -457,14 +750,37 @@ msgstr "番号付きリスト"
 msgid "Or continue with"
 msgstr "または次の方法で続行"
 
+#: packages/admin/src/components/ContentEditor.tsx:851
+msgid "Ownership"
+msgstr "所有者"
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "段落"
 
+#: packages/admin/src/components/ContentList.tsx:576
+msgid "pending"
+msgstr "保留中"
+
+#: packages/admin/src/components/ContentEditor.tsx:726
+msgid "Pending changes"
+msgstr "未保存の変更"
+
+#: packages/admin/src/components/ContentList.tsx:510
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "\"{title}\"を完全に削除しますか？この操作は取り消せません。"
+
+#: packages/admin/src/components/ContentList.tsx:499
+msgid "Permanently delete {title}"
+msgstr "{title}を完全に削除"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/Sidebar.tsx:207
+#: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "プラグイン"
 
+#: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
 msgid "Preview"
 msgstr "プレビュー"
@@ -473,9 +789,39 @@ msgstr "プレビュー"
 msgid "Preview content before publishing"
 msgstr "公開前にコンテンツをプレビュー"
 
+#: packages/admin/src/components/ContentEditor.tsx:547
+msgid "Preview draft"
+msgstr "下書きをプレビュー"
+
+#: packages/admin/src/components/ContentList.tsx:266
+msgid "Previous page"
+msgstr "前のページ"
+
+#: packages/admin/src/components/ContentEditor.tsx:602
+#: packages/admin/src/components/ContentEditor.tsx:707
+msgid "Publish"
+msgstr "公開"
+
+#: packages/admin/src/components/ContentEditor.tsx:592
+msgid "Publish changes"
+msgstr "変更を公開"
+
+#: packages/admin/src/components/ContentList.tsx:551
+msgid "published"
+msgstr "公開済み"
+
+#: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/Dashboard.tsx:187
+msgid "Published"
+msgstr "公開済み"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
 msgid "Published At"
 msgstr "公開日時"
+
+#: packages/admin/src/components/ContentEditor.tsx:1558
+msgid "Quick create byline"
+msgstr "署名をクイック作成"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:85
 #: packages/admin/src/components/PortableTextEditor.tsx:749
@@ -493,6 +839,26 @@ msgstr "コンテンツエントリを読み取り"
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
 msgid "Read media files"
 msgstr "メディアファイルを読み取り"
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr "最近のアクティビティ"
+
+#: packages/admin/src/components/Sidebar.tsx:191
+msgid "Redirects"
+msgstr "リダイレクト"
+
+#: packages/admin/src/components/ContentEditor.tsx:1527
+msgid "Remove"
+msgstr "削除"
+
+#: packages/admin/src/components/ContentEditor.tsx:1356
+msgid "Remove image"
+msgstr "画像を削除"
+
+#: packages/admin/src/components/ContentList.tsx:487
+msgid "Restore {title}"
+msgstr "{title}を復元"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
 msgid "Revisions"
@@ -518,9 +884,54 @@ msgstr "リッチテキストコンテンツ"
 msgid "Role {role}"
 msgstr "ロール: {role}"
 
+#: packages/admin/src/components/ContentEditor.tsx:1532
+msgid "Role label"
+msgstr "ロールラベル"
+
+#: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Save"
+msgstr "保存"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "公開前にコンテンツを下書きとして保存"
+
+#: packages/admin/src/components/ContentEditor.tsx:522
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr "保存済み"
+
+#: packages/admin/src/components/ContentEditor.tsx:517
+#: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saving..."
+msgstr "保存中..."
+
+#: packages/admin/src/components/ContentEditor.tsx:766
+msgid "Schedule"
+msgstr "予約公開"
+
+#: packages/admin/src/components/ContentEditor.tsx:752
+msgid "Schedule for"
+msgstr "公開予約日時"
+
+#: packages/admin/src/components/ContentEditor.tsx:789
+msgid "Schedule for later"
+msgstr "後で公開予約"
+
+#: packages/admin/src/components/ContentList.tsx:555
+msgid "scheduled"
+msgstr "予約済み"
+
+#: packages/admin/src/components/ContentEditor.tsx:729
+msgid "Scheduled"
+msgstr "予約済み"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:739
+msgid "Scheduled for: {0}"
+msgstr "公開予約: {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
@@ -543,6 +954,16 @@ msgstr "スコープ: {0}"
 msgid "Search"
 msgstr "検索"
 
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:151
+msgid "Search {0}"
+msgstr "{0}を検索"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:150
+msgid "Search {0}..."
+msgstr "{0}を検索..."
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "検索エンジン最適化と検証"
@@ -556,6 +977,7 @@ msgid "Section"
 msgstr "セクション"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "セクション"
 
@@ -564,8 +986,21 @@ msgid "Security"
 msgstr "セキュリティ"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
 msgid "Security Settings"
 msgstr "セキュリティ設定"
+
+#: packages/admin/src/components/ContentEditor.tsx:1380
+msgid "Select {label}"
+msgstr "{label}を選択"
+
+#: packages/admin/src/components/ContentEditor.tsx:1471
+msgid "Select byline..."
+msgstr "署名を選択..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1371
+msgid "Select image"
+msgstr "画像を選択"
 
 #: packages/admin/src/components/Settings.tsx:98
 msgid "Self-Signup Domains"
@@ -579,12 +1014,15 @@ msgstr "マジックリンクを送信"
 msgid "Sending..."
 msgstr "送信中..."
 
+#: packages/admin/src/components/ContentEditor.tsx:941
 #: packages/admin/src/components/Settings.tsx:81
 msgid "SEO"
 msgstr "SEO"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/Header.tsx:93
 #: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:224
 msgid "Settings"
 msgstr "設定"
 
@@ -612,6 +1050,9 @@ msgstr "パスキーでサインイン"
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "サイト情報、ロゴ、ファビコン、閲覧設定"
 
+#: packages/admin/src/components/ContentEditor.tsx:710
+#: packages/admin/src/components/ContentEditor.tsx:1574
+#: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
 msgid "Slug"
 msgstr "スラッグ"
@@ -628,6 +1069,8 @@ msgstr "ソーシャルリンク"
 msgid "Social media profile links"
 msgstr "ソーシャルメディアのプロフィールリンク"
 
+#: packages/admin/src/components/ContentEditor.tsx:716
+#: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
 msgid "Status"
 msgstr "ステータス"
@@ -637,6 +1080,10 @@ msgstr "ステータス"
 msgid "Subscriber"
 msgstr "購読者"
 
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "システム ({resolvedLabel})"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "タグ"
@@ -645,6 +1092,31 @@ msgstr "タグ"
 msgid "The link will expire in 15 minutes."
 msgstr "リンクの有効期限は15分です。"
 
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr "テーマ: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:218
+msgid "Themes"
+msgstr "テーマ"
+
+#: packages/admin/src/components/ContentEditor.tsx:1384
+msgid "This field is required"
+msgstr "この項目は必須です"
+
+#: packages/admin/src/components/ContentEditor.tsx:823
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "アイテムをゴミ箱に移動します。後でゴミ箱から復元できます。"
+
+#: packages/admin/src/components/ContentEditor.tsx:567
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "公開済みバージョンに戻ります。下書きの変更は失われます。"
+
+#: packages/admin/src/components/ContentList.tsx:190
+#: packages/admin/src/components/ContentList.tsx:303
+msgid "Title"
+msgstr "タイトル"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "閉じる"
@@ -652,6 +1124,11 @@ msgstr "閉じる"
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
 msgstr "選択"
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr "テーマを切り替え（現在: {label}）"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:190
@@ -666,6 +1143,27 @@ msgstr "トークン名"
 msgid "Track content history"
 msgstr "コンテンツの変更履歴を追跡"
 
+#: packages/admin/src/components/ContentEditor.tsx:919
+msgid "Translate"
+msgstr "翻訳"
+
+#: packages/admin/src/components/ContentEditor.tsx:877
+msgid "Translations"
+msgstr "翻訳"
+
+#: packages/admin/src/components/ContentList.tsx:173
+msgid "Trash"
+msgstr "ゴミ箱"
+
+#: packages/admin/src/components/ContentList.tsx:317
+msgid "Trash is empty"
+msgstr "ゴミ箱は空です"
+
+#: packages/admin/src/components/ContentEditor.tsx:1679
+#: packages/admin/src/components/ContentEditor.tsx:1694
+msgid "Unassigned"
+msgstr "未割り当て"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "Unique identifier (ULID)"
 msgstr "一意識別子 (ULID)"
@@ -678,13 +1176,38 @@ msgstr "不明"
 msgid "Unknown role"
 msgstr "不明なロール"
 
+#: packages/admin/src/components/ContentEditor.tsx:596
+msgid "Unpublish"
+msgstr "非公開にする"
+
+#: packages/admin/src/components/ContentEditor.tsx:741
+msgid "Unschedule"
+msgstr "予約を解除"
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr "無題"
+
+#: packages/admin/src/components/ContentEditor.tsx:1506
+msgid "Up"
+msgstr "上へ"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "更新日時"
 
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:798
+msgid "Updated: {0}"
+msgstr "更新日: {0}"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "メディアのアップロードと削除"
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr "メディアをアップロード"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
 msgid "URL-friendly identifier"
@@ -694,13 +1217,31 @@ msgstr "URLに適した識別子"
 msgid "Use your registered passkey to sign in securely."
 msgstr "登録済みのパスキーで安全にサインインできます。"
 
+#: packages/admin/src/components/ContentEditor.tsx:1219
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "一覧ページや記事の上部に表示されるメインビジュアルとして使用されます"
+
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+msgid "User"
+msgstr "ユーザー"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:206
 msgid "Users"
 msgstr "ユーザー"
 
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "メールプロバイダーの状態を確認し、テストメールを送信"
+
+#: packages/admin/src/components/ContentList.tsx:401
+msgid "View published {title}"
+msgstr "公開済みの{title}を表示"
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr "サイトを表示"
 
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
@@ -727,6 +1268,7 @@ msgid "When the entry was published"
 msgstr "エントリの公開日時"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "ウィジェット"
 

--- a/packages/admin/src/locales/ja/messages.po
+++ b/packages/admin/src/locales/ja/messages.po
@@ -1,0 +1,755 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-04 12:28+0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ja\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+msgid " (default)"
+msgstr "（デフォルト）"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — 翻訳なし"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — 翻訳を表示"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
+msgid "1 year"
+msgstr "1年"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
+msgid "30 days"
+msgstr "30日"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
+msgid "7 days"
+msgstr "7日"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:43
+msgid "90 days"
+msgstr "90日"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "管理者"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "管理者"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "すべての言語"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "すべてのロール"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "特定のドメインからのユーザー登録を許可"
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
+msgid "API Tokens"
+msgstr "APIトークン"
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "管理者として、ユーザーセクションから他のユーザーを招待できます。"
+
+#: packages/admin/src/components/LoginPage.tsx:253
+msgid "Authentication error: {error}"
+msgstr "認証エラー: {error}"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "投稿者"
+
+#: packages/admin/src/components/LoginPage.tsx:174
+#: packages/admin/src/components/LoginPage.tsx:210
+msgid "Back to login"
+msgstr "ログインに戻る"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+msgid "Back to settings"
+msgstr "設定に戻る"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:101
+#: packages/admin/src/components/PortableTextEditor.tsx:729
+msgid "Bullet List"
+msgstr "箇条書きリスト"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "コンテンツを作成可能"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "すべてのコンテンツを管理可能"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "自分のコンテンツを公開可能"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "コンテンツを閲覧可能"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "カテゴリ"
+
+#: packages/admin/src/components/LoginPage.tsx:158
+msgid "Check your email"
+msgstr "メールを確認してください"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "管理画面の言語を選択"
+
+#: packages/admin/src/components/LoginPage.tsx:169
+msgid "Click the link in the email to sign in."
+msgstr "メール内のリンクをクリックしてサインインしてください。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:54
+msgid "Close"
+msgstr "閉じる"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:93
+#: packages/admin/src/components/PortableTextEditor.tsx:759
+msgid "Code Block"
+msgstr "コードブロック"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Confirm"
+msgstr "確認"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/PortableTextEditor.tsx:1431
+msgid "Content"
+msgstr "コンテンツ"
+
+#: packages/admin/src/components/Widgets.tsx:88
+msgid "Content Block"
+msgstr "コンテンツブロック"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
+msgid "Content Read"
+msgstr "コンテンツ読み取り"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+msgid "Content Types"
+msgstr "コンテンツタイプ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
+msgid "Content Write"
+msgstr "コンテンツ書き込み"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "寄稿者"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copied to clipboard"
+msgstr "クリップボードにコピーしました"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
+msgid "Copy this token now — it won't be shown again."
+msgstr "今すぐこのトークンをコピーしてください。再表示はされません。"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:211
+msgid "Copy token"
+msgstr "トークンをコピー"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:730
+msgid "Create a bullet list"
+msgstr "箇条書きリストを作成"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:740
+msgid "Create a numbered list"
+msgstr "番号付きリストを作成"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
+msgid "Create New Token"
+msgstr "新しいトークンを作成"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
+msgid "Create personal access tokens for programmatic API access"
+msgstr "プログラムからのAPIアクセス用にパーソナルアクセストークンを作成"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+msgid "Create Token"
+msgstr "トークンを作成"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Create, update, delete content"
+msgstr "コンテンツの作成・更新・削除"
+
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+msgid "Created {0}"
+msgstr "作成日: {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:121
+msgid "Created At"
+msgstr "作成日時"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+msgid "Creating..."
+msgstr "作成中..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:226
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
+msgid "Dismiss"
+msgstr "閉じる"
+
+#: packages/admin/src/components/Widgets.tsx:95
+msgid "Display a navigation menu"
+msgstr "ナビゲーションメニューを表示"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:769
+msgid "Divider"
+msgstr "区切り線"
+
+#: packages/admin/src/components/LoginPage.tsx:358
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "アカウントをお持ちでないですか？ <0>新規登録</0>"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+msgid "draft, published, or archived"
+msgstr "下書き、公開済み、またはアーカイブ済み"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:69
+msgid "Drafts"
+msgstr "下書き"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:403
+msgid "e.g., CI/CD Pipeline"
+msgstr "例: CI/CDパイプライン"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "編集者"
+
+#: packages/admin/src/components/Settings.tsx:115
+msgid "Email"
+msgstr "メール"
+
+#: packages/admin/src/components/LoginPage.tsx:183
+msgid "Email address"
+msgstr "メールアドレス"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:1443
+msgid "Embed a {0}"
+msgstr "{0}を埋め込む"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1446
+msgid "Embeds"
+msgstr "埋め込み"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:85
+msgid "Enable full-text search on this collection"
+msgstr "このコレクションで全文検索を有効にする"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:280
+msgid "Expires {0}"
+msgstr "有効期限: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:429
+msgid "Expiry"
+msgstr "有効期限"
+
+#: packages/admin/src/components/LoginPage.tsx:127
+#: packages/admin/src/components/LoginPage.tsx:132
+msgid "Failed to send magic link"
+msgstr "マジックリンクの送信に失敗しました"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "フルアクセス"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Full admin access"
+msgstr "管理者フルアクセス"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "一般"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "はじめる"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:61
+#: packages/admin/src/components/PortableTextEditor.tsx:699
+msgid "Heading 1"
+msgstr "見出し1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:69
+#: packages/admin/src/components/PortableTextEditor.tsx:709
+msgid "Heading 2"
+msgstr "見出し2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:77
+#: packages/admin/src/components/PortableTextEditor.tsx:719
+msgid "Heading 3"
+msgstr "見出し3"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
+msgid "Hide token"
+msgstr "トークンを非表示"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:103
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:160
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "<0>{email}</0>のアカウントが存在する場合、サインインリンクを送信しました。"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1413
+msgid "Image"
+msgstr "画像"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+msgid "Import"
+msgstr "インポート"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:750
+msgid "Insert a blockquote"
+msgstr "引用を挿入"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:760
+msgid "Insert a code block"
+msgstr "コードブロックを挿入"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:770
+msgid "Insert a horizontal rule"
+msgstr "水平線を挿入"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1428
+msgid "Insert a reusable section"
+msgstr "再利用可能なセクションを挿入"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1414
+msgid "Insert an image"
+msgstr "画像を挿入"
+
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr "言語"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:700
+msgid "Large section heading"
+msgstr "大見出し"
+
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+msgid "Last used {0}"
+msgstr "最終使用日: {0}"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Loading..."
+msgstr "読み込み中..."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "ロケール"
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "パスキーと認証の管理"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1417
+msgid "Media"
+msgstr "メディア"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+msgid "Media Library"
+msgstr "メディアライブラリ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:64
+msgid "Media Read"
+msgstr "メディア読み取り"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:69
+msgid "Media Write"
+msgstr "メディア書き込み"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:710
+msgid "Medium section heading"
+msgstr "中見出し"
+
+#: packages/admin/src/components/Widgets.tsx:94
+msgid "Menu"
+msgstr "メニュー"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+msgid "Menus"
+msgstr "メニュー"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Modify collection schemas"
+msgstr "コレクションスキーマを変更"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "ナビゲーション"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "新しいタブ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
+msgid "No API tokens yet. Create one to get started."
+msgstr "APIトークンはまだありません。作成して使い始めましょう。"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
+msgid "No expiry"
+msgstr "無期限"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:940
+msgid "No results"
+msgstr "結果なし"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "結果が見つかりませんでした"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:109
+#: packages/admin/src/components/PortableTextEditor.tsx:739
+msgid "Numbered List"
+msgstr "番号付きリスト"
+
+#: packages/admin/src/components/LoginPage.tsx:313
+msgid "Or continue with"
+msgstr "または次の方法で続行"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:53
+msgid "Paragraph"
+msgstr "段落"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+msgid "Plugins"
+msgstr "プラグイン"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:79
+msgid "Preview"
+msgstr "プレビュー"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:80
+msgid "Preview content before publishing"
+msgstr "公開前にコンテンツをプレビュー"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:133
+msgid "Published At"
+msgstr "公開日時"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:85
+#: packages/admin/src/components/PortableTextEditor.tsx:749
+msgid "Quote"
+msgstr "引用"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Read collection schemas"
+msgstr "コレクションスキーマを読み取り"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Read content entries"
+msgstr "コンテンツエントリを読み取り"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Read media files"
+msgstr "メディアファイルを読み取り"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:74
+msgid "Revisions"
+msgstr "リビジョン"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
+msgid "Revoke token"
+msgstr "トークンを取り消す"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:301
+msgid "Revoke?"
+msgstr "取り消しますか？"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoking..."
+msgstr "取り消し中..."
+
+#: packages/admin/src/components/Widgets.tsx:89
+msgid "Rich text content"
+msgstr "リッチテキストコンテンツ"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "ロール: {role}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:70
+msgid "Save content as draft before publishing"
+msgstr "公開前にコンテンツを下書きとして保存"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
+msgid "Schema Read"
+msgstr "スキーマ読み取り"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:79
+msgid "Schema Write"
+msgstr "スキーマ書き込み"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
+msgid "Scopes"
+msgstr "スコープ"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:277
+msgid "Scopes: {0}"
+msgstr "スコープ: {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:84
+msgid "Search"
+msgstr "検索"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "検索エンジン最適化と検証"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "ページやコンテンツを検索..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1427
+msgid "Section"
+msgstr "セクション"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+msgid "Sections"
+msgstr "セクション"
+
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "セキュリティ"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+msgid "Security Settings"
+msgstr "セキュリティ設定"
+
+#: packages/admin/src/components/Settings.tsx:98
+msgid "Self-Signup Domains"
+msgstr "セルフサインアップドメイン"
+
+#: packages/admin/src/components/LoginPage.tsx:206
+msgid "Send magic link"
+msgstr "マジックリンクを送信"
+
+#: packages/admin/src/components/LoginPage.tsx:206
+msgid "Sending..."
+msgstr "送信中..."
+
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/Settings.tsx:62
+msgid "Settings"
+msgstr "設定"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
+msgid "Show token"
+msgstr "トークンを表示"
+
+#: packages/admin/src/components/LoginPage.tsx:283
+msgid "Sign in to your site"
+msgstr "サイトにサインイン"
+
+#: packages/admin/src/components/LoginPage.tsx:284
+msgid "Sign in with email"
+msgstr "メールでサインイン"
+
+#: packages/admin/src/components/LoginPage.tsx:340
+msgid "Sign in with email link"
+msgstr "メールリンクでサインイン"
+
+#: packages/admin/src/components/LoginPage.tsx:304
+msgid "Sign in with Passkey"
+msgstr "パスキーでサインイン"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "サイト情報、ロゴ、ファビコン、閲覧設定"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:109
+msgid "Slug"
+msgstr "スラッグ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:720
+msgid "Small section heading"
+msgstr "小見出し"
+
+#: packages/admin/src/components/Settings.tsx:75
+msgid "Social Links"
+msgstr "ソーシャルリンク"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "ソーシャルメディアのプロフィールリンク"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:115
+msgid "Status"
+msgstr "ステータス"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "購読者"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "タグ"
+
+#: packages/admin/src/components/LoginPage.tsx:170
+msgid "The link will expire in 15 minutes."
+msgstr "リンクの有効期限は15分です。"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "閉じる"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "選択"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:190
+msgid "Token created: {0}"
+msgstr "トークンを作成しました: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:400
+msgid "Token Name"
+msgstr "トークン名"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:75
+msgid "Track content history"
+msgstr "コンテンツの変更履歴を追跡"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "Unique identifier (ULID)"
+msgstr "一意識別子 (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "不明"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "不明なロール"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:127
+msgid "Updated At"
+msgstr "更新日時"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Upload and delete media"
+msgstr "メディアのアップロードと削除"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+msgid "URL-friendly identifier"
+msgstr "URLに適した識別子"
+
+#: packages/admin/src/components/LoginPage.tsx:351
+msgid "Use your registered passkey to sign in securely."
+msgstr "登録済みのパスキーで安全にサインインできます。"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+msgid "Users"
+msgstr "ユーザー"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "メールプロバイダーの状態を確認し、テストメールを送信"
+
+#: packages/admin/src/components/LoginPage.tsx:352
+msgid "We'll send you a link to sign in without a password."
+msgstr "パスワード不要のサインインリンクをお送りします。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "EmDashへようこそ、{firstName}さん！"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "EmDashへようこそ！"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "When the entry was created"
+msgstr "エントリの作成日時"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "When the entry was last modified"
+msgstr "エントリの最終更新日時"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "When the entry was published"
+msgstr "エントリの公開日時"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+msgid "Widgets"
+msgstr "ウィジェット"
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "自分のコンテンツを作成・編集できます。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "コンテンツ、メディア、メニュー、タクソノミーを管理できます。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "サイトの閲覧と投稿ができます。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "ユーザー、設定、すべてのコンテンツを含む、サイト全体の管理権限があります。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "アカウントが正常に作成されました。"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "あなたのロール"

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -34,6 +34,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "fr", label: "Français", enabled: true }, // French
 	{ code: "de", label: "Deutsch", enabled: true }, // German
+	{ code: "ja", label: "日本語", enabled: true }, // Japanese
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 ];
 

--- a/packages/admin/tests/lib/locales.test.ts
+++ b/packages/admin/tests/lib/locales.test.ts
@@ -100,7 +100,7 @@ describe("resolveLocale", () => {
 	});
 
 	test("skips unsupported languages in accept-language list", () => {
-		expect(resolveLocale(makeRequest({ "accept-language": "ja, ko, de" }))).toBe("de");
+		expect(resolveLocale(makeRequest({ "accept-language": "xx, yy, de" }))).toBe("de");
 	});
 
 	// Malformed input


### PR DESCRIPTION
## What does this PR do?

Add Japanese (日本語) locale to the EmDash admin UI. Translates all currently extracted strings (~178 message IDs) covering settings, login, welcome modal, API tokens, command palette, rich text editor, roles, content type editor, and widgets.

## Type of change

- [x] Translation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Tested locally with `demos/simple` dev server. Settings page and other Lingui-wrapped UI elements display correctly in Japanese. Sidebar and content list strings remain in English as they are not yet wrapped in Lingui macros (same limitation as all other locales).