### PR TITLE
feat(core): allow `nlweb` rel in page:metadata link contributions

### DIFF
--- a/.changeset/nlweb-link-rel.md
+++ b/.changeset/nlweb-link-rel.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Add `nlweb` to the allowed `rel` values for `page:metadata` link contributions, letting plugins inject `<link rel="nlweb" href="...">` tags for agent/conversational endpoint discovery.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -57,6 +57,7 @@ const VALID_LINK_REL = new Set([
 	"alternate",
 	"author",
 	"license",
+	"nlweb",
 	"site.standard.document",
 ]);
 

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -876,6 +876,7 @@ export type PageMetadataLinkRel =
 	| "alternate"
 	| "author"
 	| "license"
+	| "nlweb"
 	| "site.standard.document";
 
 export type PageMetadataContribution =

--- a/packages/core/tests/unit/plugins/page-metadata.test.ts
+++ b/packages/core/tests/unit/plugins/page-metadata.test.ts
@@ -71,6 +71,16 @@ describe("resolvePageMetadata", () => {
 		]);
 	});
 
+	it("resolves nlweb link for agent discovery", () => {
+		const contributions: PageMetadataContribution[] = [
+			{ kind: "link", rel: "nlweb", href: "https://example.com/nlweb" },
+		];
+
+		const result = resolvePageMetadata(contributions);
+
+		expect(result.links).toEqual([{ rel: "nlweb", href: "https://example.com/nlweb" }]);
+	});
+
 	it("resolves JSON-LD", () => {
 		const graph = { "@type": "Article", name: "Test" };
 		const contributions: PageMetadataContribution[] = [{ kind: "jsonld", id: "article", graph }];


### PR DESCRIPTION
## What does this PR do?

Adds `"nlweb"` to the `PageMetadataLinkRel` allowlist so plugins can contribute `<link rel="nlweb" href="...">` tags via the `page:metadata` hook.

**Motivation:** agent/LLM discovery increasingly uses NLWeb-style link tags to advertise a conversational endpoint for a site. Today a plugin that wants to emit this has no path through the typed `page:metadata` contribution — the allowlist rejects the `rel` value at the sandbox boundary in `emdash-runtime.ts`. An SEO plugin currently being built (seo-graph / emdash-plugin-seo) needs this for parity with what the equivalent Astro integration already does.

**Scope:** minimal. One entry each in:
- `packages/core/src/plugins/types.ts` — `PageMetadataLinkRel` union
- `packages/core/src/emdash-runtime.ts` — `VALID_LINK_REL` Set (sandbox-safe allowlist)
- `packages/core/tests/unit/plugins/page-metadata.test.ts` — resolve/dedupe test

No behavior change for anything that wasn't rejected before. No new capability, no new hook.

## Type of change

- [x] Feature (small — new allowlist entry, no new API surface)

Opened as **draft** so the tiny design decision (the value `"nlweb"` vs. e.g. `"service"`) can be confirmed before merge. Happy to rename if reviewers prefer a more generic rel.

## Checklist

- [x] `pnpm typecheck` passes (core)
- [x] `pnpm test` passes (page-metadata suite: 29/29)
- [x] `pnpm format` run
- [x] Test added (`resolves nlweb link for agent discovery`)
- [x] Changeset added (`emdash` minor — new public API value)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

---

Part of a small upstream-API series opened in coordination: this (trivial) PR is the only one submitted directly; the related `page:robots`, `notfound`, and `content:validate` hook proposals will come via Discussions first per CONTRIBUTING.md.