### PR TITLE
feat(i18n): wrap all remaining admin UI components with Lingui macros

### DIFF
--- a/.changeset/lucky-hats-sing.md
+++ b/.changeset/lucky-hats-sing.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Wraps all remaining admin UI components with Lingui macros, completing full i18n coverage of the admin interface. Catalog grows from 296 to 1,216 message IDs. Covers media library, menus, sections, redirects, taxonomies, content types, field editor, plugins, marketplace, SEO panels, setup wizard, auth flows, and all settings pages.

--- a/packages/admin/src/components/CapabilityConsentDialog.tsx
+++ b/packages/admin/src/components/CapabilityConsentDialog.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { ShieldCheck, ShieldWarning, Warning } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -49,6 +50,7 @@ export function CapabilityConsentDialog({
 	onConfirm,
 	onCancel,
 }: CapabilityConsentDialogProps) {
+	const { t } = useLingui();
 	const newSet = new Set(newCapabilities);
 	const isUpdate = mode === "update" || newCapabilities.length > 0;
 
@@ -57,7 +59,7 @@ export function CapabilityConsentDialog({
 			className="fixed inset-0 z-50 flex items-center justify-center"
 			role="dialog"
 			aria-modal="true"
-			aria-label="Capability consent"
+			aria-label={t`Capability consent`}
 		>
 			{/* Backdrop */}
 			<div className="absolute inset-0 bg-black/50" onClick={() => !isPending && onCancel()} />
@@ -67,12 +69,12 @@ export function CapabilityConsentDialog({
 				{/* Header */}
 				<div className="border-b px-6 py-4">
 					<h2 className="text-lg font-semibold">
-						{isUpdate ? "Review New Permissions" : "Plugin Permissions"}
+						{isUpdate ? t`Review New Permissions` : t`Plugin Permissions`}
 					</h2>
 					<p className="mt-1 text-sm text-kumo-subtle">
 						{isUpdate
-							? `${pluginName} is requesting additional permissions:`
-							: `${pluginName} requires the following permissions:`}
+							? t`${pluginName} is requesting additional permissions:`
+							: t`${pluginName} requires the following permissions:`}
 					</p>
 				</div>
 
@@ -98,7 +100,7 @@ export function CapabilityConsentDialog({
 									<span className={cn(isNew && "font-medium")}>
 										{describeCapability(cap, allowedHosts)}
 									</span>
-									{isNew && <span className="ml-2 text-xs text-warning font-medium">NEW</span>}
+									{isNew && <span className="ml-2 text-xs text-warning font-medium">{t`NEW`}</span>}
 								</div>
 							</div>
 						);
@@ -121,8 +123,8 @@ export function CapabilityConsentDialog({
 							)}
 							<span>
 								{auditVerdict === "warn"
-									? "Security audit flagged potential concerns with this plugin."
-									: "Security audit flagged this plugin as potentially unsafe."}
+									? t`Security audit flagged potential concerns with this plugin.`
+									: t`Security audit flagged this plugin as potentially unsafe.`}
 							</span>
 						</div>
 					)}
@@ -134,16 +136,16 @@ export function CapabilityConsentDialog({
 				{/* Actions */}
 				<div className="flex justify-end gap-3 border-t px-6 py-4">
 					<Button variant="ghost" onClick={onCancel} disabled={isPending}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 					<Button onClick={onConfirm} disabled={isPending}>
 						{isPending
 							? isUpdate
-								? "Updating..."
-								: "Installing..."
+								? t`Updating...`
+								: t`Installing...`
 							: isUpdate
-								? "Accept & Update"
-								: "Accept & Install"}
+								? t`Accept & Update`
+								: t`Accept & Install`}
 					</Button>
 				</div>
 			</div>

--- a/packages/admin/src/components/ConfirmDialog.tsx
+++ b/packages/admin/src/components/ConfirmDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Dialog } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 import { DialogError, getMutationError } from "./DialogError.js";
@@ -43,6 +44,7 @@ export function ConfirmDialog({
 	onConfirm,
 	children,
 }: ConfirmDialogProps) {
+	const { t } = useLingui();
 	return (
 		<Dialog.Root open={open} onOpenChange={(o) => !o && onClose()} disablePointerDismissal>
 			<Dialog className="p-6" size="sm">
@@ -52,7 +54,7 @@ export function ConfirmDialog({
 				<DialogError message={getMutationError(error)} className="mt-3" />
 				<div className="mt-6 flex justify-end gap-2">
 					<Button variant="secondary" onClick={onClose}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 					<Button variant={variant} disabled={isPending} onClick={onConfirm}>
 						{isPending ? pendingLabel : confirmLabel}

--- a/packages/admin/src/components/ContentPickerModal.tsx
+++ b/packages/admin/src/components/ContentPickerModal.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Dialog, Input, Loader } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
@@ -33,6 +34,7 @@ function getItemTitle(item: { data: Record<string, unknown>; slug: string | null
 }
 
 export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPickerModalProps) {
+	const { t } = useLingui();
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const debouncedSearch = useDebouncedValue(searchQuery, 300);
 	const [selectedCollection, setSelectedCollection] = React.useState<string>("");
@@ -112,20 +114,20 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 			<Dialog className="p-6 max-w-2xl h-[80vh] flex flex-col" size="lg">
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-						Select Content
+						{t`Select Content`}
 					</Dialog.Title>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
-								<span className="sr-only">Close</span>
+								<span className="sr-only">{t`Close`}</span>
 							</Button>
 						)}
 					/>
@@ -136,7 +138,7 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 					<div className="relative flex-1">
 						<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 						<Input
-							placeholder="Search content..."
+							placeholder={t`Search content...`}
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 							className="pl-10"
@@ -164,20 +166,20 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 				<div className="flex-1 overflow-y-auto py-4">
 					{contentLoading ? (
 						<div className="flex items-center justify-center h-32">
-							<div className="text-kumo-subtle">Loading content...</div>
+							<div className="text-kumo-subtle">{t`Loading content...`}</div>
 						</div>
 					) : filteredItems.length === 0 ? (
 						<div className="flex flex-col items-center justify-center h-32 text-center">
 							{searchQuery ? (
 								<>
 									<MagnifyingGlass className="h-8 w-8 text-kumo-subtle mb-2" />
-									<p className="text-kumo-subtle">No content found</p>
-									<p className="text-sm text-kumo-subtle">Try adjusting your search</p>
+									<p className="text-kumo-subtle">{t`No content found`}</p>
+									<p className="text-sm text-kumo-subtle">{t`Try adjusting your search`}</p>
 								</>
 							) : (
 								<>
 									<FolderOpen className="h-8 w-8 text-kumo-subtle mb-2" />
-									<p className="text-kumo-subtle">No content in this collection</p>
+									<p className="text-kumo-subtle">{t`No content in this collection`}</p>
 								</>
 							)}
 						</div>
@@ -209,10 +211,10 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 												)}
 											/>
 											{status === "published"
-												? "Published"
+												? t`Published`
 												: status === "published_with_changes"
-													? "Modified"
-													: "Draft"}
+													? t`Modified`
+													: t`Draft`}
 											{item.slug && (
 												<>
 													<span className="text-kumo-subtle/50">/</span>
@@ -233,10 +235,10 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 									>
 										{isLoadingMore ? (
 											<>
-												<Loader size="sm" /> Loading...
+												<Loader size="sm" /> {t`Loading...`}
 											</>
 										) : (
-											"Load more"
+											t`Load more`
 										)}
 									</Button>
 								</div>
@@ -248,7 +250,7 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 				{/* Footer */}
 				<div className="flex justify-end gap-2 pt-4 border-t">
 					<Button variant="outline" onClick={() => onOpenChange(false)}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 				</div>
 			</Dialog>

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, buttonVariants } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Plus, Pencil, Trash, Database, FileText, Warning, Check } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -25,6 +26,7 @@ export function ContentTypeList({
 	onDelete,
 	onRegisterOrphan,
 }: ContentTypeListProps) {
+	const { t } = useLingui();
 	const [deleteTarget, setDeleteTarget] = React.useState<SchemaCollection | null>(null);
 	const hasOrphans = orphanedTables && orphanedTables.length > 0;
 
@@ -33,12 +35,12 @@ export function ContentTypeList({
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-2xl font-bold">Content Types</h1>
-					<p className="text-kumo-subtle text-sm">Define the structure of your content</p>
+					<h1 className="text-2xl font-bold">{t`Content Types`}</h1>
+					<p className="text-kumo-subtle text-sm">{t`Define the structure of your content`}</p>
 				</div>
 				<Link to="/content-types/new" className={buttonVariants()}>
 					<Plus className="mr-2 h-4 w-4" aria-hidden="true" />
-					New Content Type
+					{t`New Content Type`}
 				</Link>
 			</div>
 
@@ -49,11 +51,10 @@ export function ContentTypeList({
 						<Warning className="h-5 w-5 text-amber-600 dark:text-amber-400 mt-0.5" />
 						<div className="flex-1">
 							<h3 className="font-medium text-amber-800 dark:text-amber-200">
-								Unregistered Content Tables Found
+								{t`Unregistered Content Tables Found`}
 							</h3>
 							<p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
-								The following tables contain content but aren't registered as collections. Register
-								them to manage this content in the admin.
+								{t`The following tables contain content but aren't registered as collections. Register them to manage this content in the admin.`}
 							</p>
 							<div className="mt-3 space-y-2">
 								{orphanedTables.map((orphan) => (
@@ -64,7 +65,7 @@ export function ContentTypeList({
 										<div>
 											<code className="text-sm font-medium">{orphan.slug}</code>
 											<span className="text-xs text-kumo-subtle ml-2">
-												({orphan.rowCount} items)
+												({orphan.rowCount} {t`items`})
 											</span>
 										</div>
 										<Button
@@ -73,7 +74,7 @@ export function ContentTypeList({
 											icon={<Check />}
 											onClick={() => onRegisterOrphan?.(orphan.slug)}
 										>
-											Register
+											{t`Register`}
 										</Button>
 									</div>
 								))}
@@ -89,19 +90,19 @@ export function ContentTypeList({
 					<thead>
 						<tr className="border-b bg-kumo-tint/50">
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Name
+								{t`Name`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Slug
+								{t`Slug`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Source
+								{t`Source`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Features
+								{t`Features`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-right text-sm font-medium">
-								Actions
+								{t`Actions`}
 							</th>
 						</tr>
 					</thead>
@@ -109,15 +110,15 @@ export function ContentTypeList({
 						{isLoading ? (
 							<tr>
 								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
-									Loading collections...
+									{t`Loading collections...`}
 								</td>
 							</tr>
 						) : collections.length === 0 && !hasOrphans ? (
 							<tr>
 								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
-									No content types yet.{" "}
+									{t`No content types yet.`}{" "}
 									<Link to="/content-types/new" className="text-kumo-brand underline">
-										Create your first one
+										{t`Create your first one`}
 									</Link>
 								</td>
 							</tr>
@@ -137,14 +138,14 @@ export function ContentTypeList({
 			<ConfirmDialog
 				open={!!deleteTarget}
 				onClose={() => setDeleteTarget(null)}
-				title="Delete Content Type?"
+				title={t`Delete Content Type?`}
 				description={
 					deleteTarget
-						? `Are you sure you want to delete "${deleteTarget.label}"? This will also delete all content in this collection.`
+						? t`Are you sure you want to delete "${deleteTarget.label}"? This will also delete all content in this collection.`
 						: ""
 				}
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={false}
 				error={null}
 				onConfirm={() => {
@@ -164,6 +165,7 @@ interface ContentTypeRowProps {
 }
 
 function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
+	const { t } = useLingui();
 	const isFromCode = collection.source === "code";
 
 	return (
@@ -214,7 +216,7 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 					<Link
 						to="/content-types/$slug"
 						params={{ slug: collection.slug }}
-						aria-label={`Edit ${collection.label}`}
+						aria-label={t`Edit ${collection.label}`}
 						className={buttonVariants({ variant: "ghost", shape: "square" })}
 					>
 						<Pencil className="h-4 w-4" aria-hidden="true" />
@@ -223,7 +225,7 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 						<Button
 							variant="ghost"
 							shape="square"
-							aria-label={`Delete ${collection.label}`}
+							aria-label={t`Delete ${collection.label}`}
 							onClick={() => onRequestDelete?.(collection)}
 						>
 							<Trash className="h-4 w-4 text-kumo-danger" aria-hidden="true" />
@@ -236,8 +238,9 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 }
 
 function SourceBadge({ source }: { source?: string }) {
+	const { t } = useLingui();
 	if (source === "code") {
-		return <Badge variant="secondary">Code</Badge>;
+		return <Badge variant="secondary">{t`Code`}</Badge>;
 	}
-	return <Badge variant="secondary">Dashboard</Badge>;
+	return <Badge variant="secondary">{t`Dashboard`}</Badge>;
 }

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, buttonVariants } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, Pencil, Trash, Database, FileText, Warning, Check } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
@@ -65,7 +66,7 @@ export function ContentTypeList({
 										<div>
 											<code className="text-sm font-medium">{orphan.slug}</code>
 											<span className="text-xs text-kumo-subtle ml-2">
-												({orphan.rowCount} {t`items`})
+												{plural(orphan.rowCount, { one: "(# item)", other: "(# items)" })}
 											</span>
 										</div>
 										<Button

--- a/packages/admin/src/components/DeviceAuthorizePage.tsx
+++ b/packages/admin/src/components/DeviceAuthorizePage.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -146,10 +147,12 @@ export function DeviceAuthorizePage() {
 		setCode(value);
 	}
 
+	const { t } = useLingui();
+
 	if (isLoading) {
 		return (
 			<PageWrapper>
-				<p className="text-kumo-subtle text-sm">Checking authentication...</p>
+				<p className="text-kumo-subtle text-sm">{t`Checking authentication...`}</p>
 			</PageWrapper>
 		);
 	}
@@ -157,7 +160,7 @@ export function DeviceAuthorizePage() {
 	if (!user) {
 		return (
 			<PageWrapper>
-				<p className="text-kumo-subtle text-sm">Redirecting to login...</p>
+				<p className="text-kumo-subtle text-sm">{t`Redirecting to login...`}</p>
 			</PageWrapper>
 		);
 	}
@@ -170,8 +173,8 @@ export function DeviceAuthorizePage() {
 					<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-kumo-brand/10 mb-4">
 						<TerminalIcon className="w-6 h-6 text-kumo-brand" />
 					</div>
-					<h1 className="text-xl font-semibold tracking-tight">Authorize Device</h1>
-					<p className="text-kumo-subtle text-sm mt-1.5">Enter the code from your terminal</p>
+					<h1 className="text-xl font-semibold tracking-tight">{t`Authorize Device`}</h1>
+					<p className="text-kumo-subtle text-sm mt-1.5">{t`Enter the code from your terminal`}</p>
 				</div>
 
 				{/* Success state */}
@@ -180,19 +183,19 @@ export function DeviceAuthorizePage() {
 						<div className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/50 mb-3">
 							<CheckIcon className="w-5 h-5 text-green-600 dark:text-green-400" />
 						</div>
-						<h2 className="font-medium text-green-900 dark:text-green-100">Device authorized</h2>
+						<h2 className="font-medium text-green-900 dark:text-green-100">{t`Device authorized`}</h2>
 						<p className="text-sm text-green-700 dark:text-green-300 mt-1">
-							You can close this page and return to your terminal.
+							{t`You can close this page and return to your terminal.`}
 						</p>
-						<p className="text-xs text-kumo-subtle mt-3">Signed in as {user.email}</p>
+						<p className="text-xs text-kumo-subtle mt-3">{t`Signed in as ${user.email}`}</p>
 					</div>
 				)}
 
 				{/* Denied state */}
 				{pageState === "denied" && (
 					<div className="rounded-lg border border-kumo-line p-6 text-center">
-						<h2 className="font-medium">Authorization denied</h2>
-						<p className="text-sm text-kumo-subtle mt-1">The device will not be granted access.</p>
+						<h2 className="font-medium">{t`Authorization denied`}</h2>
+						<p className="text-sm text-kumo-subtle mt-1">{t`The device will not be granted access.`}</p>
 						<Button
 							className="mt-4"
 							variant="outline"
@@ -201,7 +204,7 @@ export function DeviceAuthorizePage() {
 								setCode("");
 							}}
 						>
-							Try another code
+							{t`Try another code`}
 						</Button>
 					</div>
 				)}
@@ -217,13 +220,13 @@ export function DeviceAuthorizePage() {
 								</div>
 								<div className="min-w-0">
 									<p className="text-sm font-medium truncate">{user.name || user.email}</p>
-									<p className="text-xs text-kumo-subtle">{ROLE_NAMES[user.role] || "User"}</p>
+									<p className="text-xs text-kumo-subtle">{ROLE_NAMES[user.role] || t`User`}</p>
 								</div>
 							</div>
 
 							{/* Code input */}
 							<label className="block text-sm font-medium mb-2" htmlFor="user-code">
-								Device code
+								{t`Device code`}
 							</label>
 							<Input
 								id="user-code"
@@ -253,7 +256,7 @@ export function DeviceAuthorizePage() {
 										pageState === "submitting"
 									}
 								>
-									{pageState === "submitting" ? "Authorizing..." : "Authorize"}
+									{pageState === "submitting" ? t`Authorizing...` : t`Authorize`}
 								</Button>
 								<Button
 									type="button"
@@ -264,15 +267,15 @@ export function DeviceAuthorizePage() {
 										pageState === "submitting"
 									}
 								>
-									Deny
+									{t`Deny`}
 								</Button>
 							</div>
 						</div>
 
 						<p className="text-xs text-kumo-subtle text-center mt-4">
-							This will grant CLI access with your permissions.
+							{t`This will grant CLI access with your permissions.`}
 							<br />
-							Only authorize codes you recognize.
+							{t`Only authorize codes you recognize.`}
 						</p>
 					</form>
 				)}

--- a/packages/admin/src/components/FieldEditor.tsx
+++ b/packages/admin/src/components/FieldEditor.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, Input, InputArea } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	TextT,
 	TextAlignLeft,
@@ -42,103 +43,12 @@ export interface FieldEditorProps {
 	isSaving?: boolean;
 }
 
-const FIELD_TYPES: {
+interface FieldTypeConfig {
 	type: FieldType;
 	label: string;
 	description: string;
 	icon: React.ElementType;
-}[] = [
-	{
-		type: "string",
-		label: "Short Text",
-		description: "Single line text input",
-		icon: TextT,
-	},
-	{
-		type: "text",
-		label: "Long Text",
-		description: "Multi-line plain text",
-		icon: TextAlignLeft,
-	},
-	{
-		type: "number",
-		label: "Number",
-		description: "Decimal number",
-		icon: Hash,
-	},
-	{
-		type: "integer",
-		label: "Integer",
-		description: "Whole number",
-		icon: Hash,
-	},
-	{
-		type: "boolean",
-		label: "Boolean",
-		description: "True/false toggle",
-		icon: ToggleLeft,
-	},
-	{
-		type: "datetime",
-		label: "Date & Time",
-		description: "Date and time picker",
-		icon: Calendar,
-	},
-	{
-		type: "select",
-		label: "Select",
-		description: "Single choice from options",
-		icon: List,
-	},
-	{
-		type: "multiSelect",
-		label: "Multi Select",
-		description: "Multiple choices from options",
-		icon: ListChecks,
-	},
-	{
-		type: "portableText",
-		label: "Rich Text",
-		description: "Rich text editor",
-		icon: FileText,
-	},
-	{
-		type: "image",
-		label: "Image",
-		description: "Image from media library",
-		icon: ImageIcon,
-	},
-	{
-		type: "file",
-		label: "File",
-		description: "File from media library",
-		icon: File,
-	},
-	{
-		type: "reference",
-		label: "Reference",
-		description: "Link to another content item",
-		icon: LinkSimple,
-	},
-	{
-		type: "json",
-		label: "JSON",
-		description: "Arbitrary JSON data",
-		icon: BracketsCurly,
-	},
-	{
-		type: "slug",
-		label: "Slug",
-		description: "URL-friendly identifier",
-		icon: Link,
-	},
-	{
-		type: "repeater",
-		label: "Repeater",
-		description: "Repeating group of fields",
-		icon: Rows,
-	},
-];
+}
 
 interface RepeaterSubFieldState {
 	slug: string;
@@ -213,6 +123,7 @@ function getInitialFormState(field?: SchemaField): FieldFormState {
  * Field editor dialog for creating/editing fields
  */
 export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: FieldEditorProps) {
+	const { t } = useLingui();
 	const [formState, setFormState] = React.useState(() => getInitialFormState(field));
 
 	// Reset state when dialog opens
@@ -226,6 +137,100 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 	const { minLength, maxLength, min, max, pattern, options } = formState;
 	const setField = <K extends keyof FieldFormState>(key: K, value: FieldFormState[K]) =>
 		setFormState((prev) => ({ ...prev, [key]: value }));
+
+	// Build field types inside the component so t`` works
+	const FIELD_TYPES: FieldTypeConfig[] = [
+		{
+			type: "string",
+			label: t`Short Text`,
+			description: t`Single line text input`,
+			icon: TextT,
+		},
+		{
+			type: "text",
+			label: t`Long Text`,
+			description: t`Multi-line plain text`,
+			icon: TextAlignLeft,
+		},
+		{
+			type: "number",
+			label: t`Number`,
+			description: t`Decimal number`,
+			icon: Hash,
+		},
+		{
+			type: "integer",
+			label: t`Integer`,
+			description: t`Whole number`,
+			icon: Hash,
+		},
+		{
+			type: "boolean",
+			label: t`Boolean`,
+			description: t`True/false toggle`,
+			icon: ToggleLeft,
+		},
+		{
+			type: "datetime",
+			label: t`Date & Time`,
+			description: t`Date and time picker`,
+			icon: Calendar,
+		},
+		{
+			type: "select",
+			label: t`Select`,
+			description: t`Single choice from options`,
+			icon: List,
+		},
+		{
+			type: "multiSelect",
+			label: t`Multi Select`,
+			description: t`Multiple choices from options`,
+			icon: ListChecks,
+		},
+		{
+			type: "portableText",
+			label: t`Rich Text`,
+			description: t`Rich text editor`,
+			icon: FileText,
+		},
+		{
+			type: "image",
+			label: t`Image`,
+			description: t`Image from media library`,
+			icon: ImageIcon,
+		},
+		{
+			type: "file",
+			label: t`File`,
+			description: t`File from media library`,
+			icon: File,
+		},
+		{
+			type: "reference",
+			label: t`Reference`,
+			description: t`Link to another content item`,
+			icon: LinkSimple,
+		},
+		{
+			type: "json",
+			label: t`JSON`,
+			description: t`Arbitrary JSON data`,
+			icon: BracketsCurly,
+		},
+		{
+			type: "slug",
+			label: t`Slug`,
+			description: t`URL-friendly identifier`,
+			icon: Link,
+		},
+		{
+			type: "repeater",
+			label: t`Repeater`,
+			description: t`Repeating group of fields`,
+			icon: Rows,
+		},
+	];
 
 	// Auto-generate slug from label
 	const handleLabelChange = (value: string) => {
@@ -308,27 +313,27 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 		onSave(input);
 	};
 
-	const typeConfig = FIELD_TYPES.find((t) => t.type === selectedType);
+	const typeConfig = FIELD_TYPES.find((fieldType) => fieldType.type === selectedType);
 
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog className="p-6 max-w-2xl" size="lg">
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-						{field ? "Edit Field" : step === "type" ? "Add Field" : "Configure Field"}
+						{field ? t`Edit Field` : step === "type" ? t`Add Field` : t`Configure Field`}
 					</Dialog.Title>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
-								<span className="sr-only">Close</span>
+								<span className="sr-only">{t`Close`}</span>
 							</Button>
 						)}
 					/>
@@ -375,7 +380,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 										className="ml-auto"
 										onClick={() => setField("step", "type")}
 									>
-										Change
+										{t`Change`}
 									</Button>
 								)}
 							</div>
@@ -384,14 +389,14 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 						{/* Basic info */}
 						<div className="grid grid-cols-2 gap-4">
 							<Input
-								label="Label"
+								label={t`Label`}
 								value={label}
 								onChange={(e) => handleLabelChange(e.target.value)}
-								placeholder="Field Label"
+								placeholder={t`Field Label`}
 							/>
 							<div>
 								<Input
-									label="Slug"
+									label={t`Slug`}
 									value={slug}
 									onChange={(e) => setField("slug", e.target.value)}
 									placeholder="field_slug"
@@ -399,7 +404,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 								/>
 								{field && (
 									<p className="text-xs text-kumo-subtle mt-2">
-										Field slugs cannot be changed after creation
+										{t`Field slugs cannot be changed after creation`}
 									</p>
 								)}
 							</div>
@@ -414,7 +419,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 									onChange={(e) => setField("required", e.target.checked)}
 									className="rounded border-kumo-line"
 								/>
-								<span className="text-sm">Required</span>
+								<span className="text-sm">{t`Required`}</span>
 							</label>
 							<label className="flex items-center space-x-2">
 								<input
@@ -423,7 +428,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 									onChange={(e) => setField("unique", e.target.checked)}
 									className="rounded border-kumo-line"
 								/>
-								<span className="text-sm">Unique</span>
+								<span className="text-sm">{t`Unique`}</span>
 							</label>
 							{(selectedType === "string" ||
 								selectedType === "text" ||
@@ -436,7 +441,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 										onChange={(e) => setField("searchable", e.target.checked)}
 										className="rounded border-kumo-line"
 									/>
-									<span className="text-sm">Searchable</span>
+									<span className="text-sm">{t`Searchable`}</span>
 								</label>
 							)}
 						</div>
@@ -444,26 +449,26 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 						{/* Type-specific validation */}
 						{(selectedType === "string" || selectedType === "text" || selectedType === "slug") && (
 							<div className="space-y-4">
-								<h4 className="font-medium text-sm">Validation</h4>
+								<h4 className="font-medium text-sm">{t`Validation`}</h4>
 								<div className="grid grid-cols-2 gap-4">
 									<Input
-										label="Min Length"
+										label={t`Min Length`}
 										type="number"
 										value={minLength}
 										onChange={(e) => setField("minLength", e.target.value)}
-										placeholder="No minimum"
+										placeholder={t`No minimum`}
 									/>
 									<Input
-										label="Max Length"
+										label={t`Max Length`}
 										type="number"
 										value={maxLength}
 										onChange={(e) => setField("maxLength", e.target.value)}
-										placeholder="No maximum"
+										placeholder={t`No maximum`}
 									/>
 								</div>
 								{selectedType === "string" && (
 									<Input
-										label="Pattern (Regex)"
+										label={t`Pattern (Regex)`}
 										value={pattern}
 										onChange={(e) => setField("pattern", e.target.value)}
 										placeholder="^[a-z]+$"
@@ -474,21 +479,21 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 
 						{(selectedType === "number" || selectedType === "integer") && (
 							<div className="space-y-4">
-								<h4 className="font-medium text-sm">Validation</h4>
+								<h4 className="font-medium text-sm">{t`Validation`}</h4>
 								<div className="grid grid-cols-2 gap-4">
 									<Input
-										label="Min Value"
+										label={t`Min Value`}
 										type="number"
 										value={min}
 										onChange={(e) => setField("min", e.target.value)}
-										placeholder="No minimum"
+										placeholder={t`No minimum`}
 									/>
 									<Input
-										label="Max Value"
+										label={t`Max Value`}
 										type="number"
 										value={max}
 										onChange={(e) => setField("max", e.target.value)}
-										placeholder="No maximum"
+										placeholder={t`No maximum`}
 									/>
 								</div>
 							</div>
@@ -496,7 +501,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 
 						{(selectedType === "select" || selectedType === "multiSelect") && (
 							<InputArea
-								label="Options (one per line)"
+								label={t`Options (one per line)`}
 								value={options}
 								onChange={(e) => setField("options", e.target.value)}
 								placeholder={"Option 1\nOption 2\nOption 3"}
@@ -507,7 +512,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 						{selectedType === "repeater" && (
 							<div className="space-y-4">
 								<div className="flex items-center justify-between">
-									<h4 className="font-medium text-sm">Sub-Fields</h4>
+									<h4 className="font-medium text-sm">{t`Sub-Fields`}</h4>
 									<Button
 										variant="outline"
 										size="sm"
@@ -522,13 +527,13 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 											}))
 										}
 									>
-										Add Sub-Field
+										{t`Add Sub-Field`}
 									</Button>
 								</div>
 
 								{formState.subFields.length === 0 && (
 									<p className="text-sm text-kumo-subtle text-center py-4">
-										Add at least one sub-field to define the repeater structure.
+										{t`Add at least one sub-field to define the repeater structure.`}
 									</p>
 								)}
 
@@ -537,7 +542,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 										<div className="flex-1 space-y-2">
 											<div className="grid grid-cols-2 gap-2">
 												<Input
-													label="Label"
+													label={t`Label`}
 													value={sf.label}
 													onChange={(e) => {
 														const updated = [...formState.subFields];
@@ -551,10 +556,10 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 														};
 														setFormState((prev) => ({ ...prev, subFields: updated }));
 													}}
-													placeholder="Field label"
+													placeholder={t`Field label`}
 												/>
 												<div>
-													<label className="text-sm font-medium">Type</label>
+													<label className="text-sm font-medium">{t`Type`}</label>
 													<select
 														className="w-full mt-1 rounded-md border px-3 py-2 text-sm"
 														value={sf.type}
@@ -564,13 +569,13 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 															setFormState((prev) => ({ ...prev, subFields: updated }));
 														}}
 													>
-														<option value="string">Short Text</option>
-														<option value="text">Long Text</option>
-														<option value="number">Number</option>
-														<option value="integer">Integer</option>
-														<option value="boolean">Boolean</option>
-														<option value="datetime">Date & Time</option>
-														<option value="select">Select</option>
+														<option value="string">{t`Short Text`}</option>
+														<option value="text">{t`Long Text`}</option>
+														<option value="number">{t`Number`}</option>
+														<option value="integer">{t`Integer`}</option>
+														<option value="boolean">{t`Boolean`}</option>
+														<option value="datetime">{t`Date & Time`}</option>
+														<option value="select">{t`Select`}</option>
 													</select>
 												</div>
 											</div>
@@ -584,7 +589,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 														setFormState((prev) => ({ ...prev, subFields: updated }));
 													}}
 												/>
-												Required
+												{t`Required`}
 											</label>
 										</div>
 										<Button
@@ -596,7 +601,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 													subFields: prev.subFields.filter((_, j) => j !== i),
 												}))
 											}
-											aria-label="Remove sub-field"
+											aria-label={t`Remove sub-field`}
 										>
 											<Trash className="h-4 w-4 text-kumo-danger" />
 										</Button>
@@ -605,18 +610,18 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 
 								<div className="grid grid-cols-2 gap-4">
 									<Input
-										label="Min Items"
+										label={t`Min Items`}
 										type="number"
 										value={formState.minItems}
 										onChange={(e) => setField("minItems", e.target.value)}
 										placeholder="0"
 									/>
 									<Input
-										label="Max Items"
+										label={t`Max Items`}
 										type="number"
 										value={formState.maxItems}
 										onChange={(e) => setField("maxItems", e.target.value)}
-										placeholder="No limit"
+										placeholder={t`No limit`}
 									/>
 								</div>
 							</div>
@@ -627,7 +632,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 				{step === "config" && (
 					<div className="flex flex-col-reverse gap-2 py-2 sm:flex-row sm:justify-end sm:space-x-2">
 						<Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
-							Cancel
+							{t`Cancel`}
 						</Button>
 						<Button
 							onClick={handleSave}
@@ -638,7 +643,7 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 								(selectedType === "repeater" && formState.subFields.length === 0)
 							}
 						>
-							{isSaving ? "Saving..." : field ? "Update Field" : "Add Field"}
+							{isSaving ? t`Saving...` : field ? t`Update Field` : t`Add Field`}
 						</Button>
 					</div>
 				)}

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Badge, Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
 	PuzzlePiece,
@@ -48,6 +49,7 @@ export interface MarketplaceBrowseProps {
 }
 
 export function MarketplaceBrowse({ installedPluginIds = new Set() }: MarketplaceBrowseProps) {
+	const { t } = useLingui();
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const [sort, setSort] = React.useState<SortOption>("installs");
 	const [capability, setCapability] = React.useState<string>("");
@@ -80,8 +82,8 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 		<div className="space-y-6">
 			{/* Header */}
 			<div>
-				<h1 className="text-3xl font-bold">Marketplace</h1>
-				<p className="mt-1 text-kumo-subtle">Browse and install plugins to extend your site.</p>
+				<h1 className="text-3xl font-bold">{t`Marketplace`}</h1>
+				<p className="mt-1 text-kumo-subtle">{t`Browse and install plugins to extend your site.`}</p>
 			</div>
 
 			{/* Search + Sort */}
@@ -90,7 +92,7 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 					<MagnifyingGlass className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
 					<input
 						type="search"
-						placeholder="Search plugins..."
+						placeholder={t`Search plugins...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						className="w-full rounded-md border bg-kumo-base px-3 py-2 pl-9 text-sm placeholder:text-kumo-subtle focus:outline-none focus:ring-2 focus:ring-kumo-ring"
@@ -100,9 +102,9 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 					value={capability}
 					onChange={(e) => setCapability(e.target.value)}
 					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
-					aria-label="Filter by capability"
+					aria-label={t`Filter by capability`}
 				>
-					<option value="">All capabilities</option>
+					<option value="">{t`All capabilities`}</option>
 					{Object.entries(CAPABILITY_LABELS).map(([value, label]) => (
 						<option key={value} value={value}>
 							{label}
@@ -116,7 +118,7 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 						if (isSortOption(v)) setSort(v);
 					}}
 					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
-					aria-label="Sort plugins"
+					aria-label={t`Sort plugins`}
 				>
 					{Object.entries(SORT_LABELS).map(([value, label]) => (
 						<option key={value} value={value}>
@@ -130,13 +132,13 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 			{error && (
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">
 					<Warning className="mx-auto h-8 w-8 text-kumo-danger" />
-					<h3 className="mt-3 font-medium text-kumo-danger">Unable to reach marketplace</h3>
+					<h3 className="mt-3 font-medium text-kumo-danger">{t`Unable to reach marketplace`}</h3>
 					<p className="mt-1 text-sm text-kumo-subtle">
-						{error instanceof Error ? error.message : "An error occurred"}
+						{error instanceof Error ? error.message : t`An error occurred`}
 					</p>
 					<Button variant="ghost" className="mt-4" onClick={() => void refetch()}>
 						<ArrowsClockwise className="mr-2 h-4 w-4" />
-						Retry
+						{t`Retry`}
 					</Button>
 				</div>
 			)}
@@ -168,11 +170,11 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 					{plugins.length === 0 ? (
 						<div className="rounded-lg border bg-kumo-base p-8 text-center">
 							<PuzzlePiece className="mx-auto h-12 w-12 text-kumo-subtle" />
-							<h3 className="mt-4 text-lg font-medium">No plugins found</h3>
+							<h3 className="mt-4 text-lg font-medium">{t`No plugins found`}</h3>
 							<p className="mt-2 text-sm text-kumo-subtle">
 								{debouncedQuery
-									? `No results for "${debouncedQuery}". Try a different search term.`
-									: "The marketplace is empty. Check back later for new plugins."}
+									? t`No results for "${debouncedQuery}". Try a different search term.`
+									: t`The marketplace is empty. Check back later for new plugins.`}
 							</p>
 						</div>
 					) : (
@@ -193,7 +195,7 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 										onClick={() => void fetchNextPage()}
 										disabled={isFetchingNextPage}
 									>
-										{isFetchingNextPage ? "Loading..." : "Load more"}
+										{isFetchingNextPage ? t`Loading...` : t`Load more`}
 									</Button>
 								</div>
 							)}
@@ -215,6 +217,7 @@ interface PluginCardProps {
 }
 
 function PluginCard({ plugin, isInstalled }: PluginCardProps) {
+	const { t } = useLingui();
 	const navigate = useNavigate();
 	const auditVerdict = plugin.latestVersion?.audit?.verdict;
 	const imageVerdict = plugin.latestVersion?.imageAudit?.verdict;
@@ -235,7 +238,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 						alt=""
 						className={`h-10 w-10 rounded-lg object-cover ${isImageFlagged ? "blur-sm" : ""}`}
 						loading="lazy"
-						aria-label={isImageFlagged ? "Icon blurred due to image audit" : undefined}
+						aria-label={isImageFlagged ? t`Icon blurred due to image audit` : undefined}
 					/>
 				) : (
 					<PluginAvatar name={plugin.name} />
@@ -255,7 +258,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 									void navigate({ to: "/plugins-manager" });
 								}}
 							>
-								<Badge variant="secondary">Installed</Badge>
+								<Badge variant="secondary">{t`Installed`}</Badge>
 							</span>
 						)}
 					</div>
@@ -282,7 +285,7 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 					{auditVerdict && <AuditBadge verdict={auditVerdict} />}
 					{plugin.capabilities.length > 0 && (
 						<span className="text-xs text-kumo-subtle">
-							{plugin.capabilities.length} permission{plugin.capabilities.length !== 1 ? "s" : ""}
+							{t`${plugin.capabilities.length} permission${plugin.capabilities.length !== 1 ? "s" : ""}`}
 						</span>
 					)}
 				</div>
@@ -305,14 +308,15 @@ function PluginAvatar({ name }: { name: string }) {
 }
 
 export function AuditBadge({ verdict }: { verdict: "pass" | "warn" | "fail" }) {
+	const { t } = useLingui();
 	if (verdict === "pass") {
 		return (
 			<span
 				className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-green-500/10 text-green-600"
-				title="Security audit passed"
+				title={t`Security audit passed`}
 			>
 				<ShieldCheck className="h-3 w-3" />
-				Pass
+				{t`Pass`}
 			</span>
 		);
 	}
@@ -320,20 +324,20 @@ export function AuditBadge({ verdict }: { verdict: "pass" | "warn" | "fail" }) {
 		return (
 			<span
 				className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-warning/10 text-warning"
-				title="Security audit flagged concerns"
+				title={t`Security audit flagged concerns`}
 			>
 				<Warning className="h-3 w-3" />
-				Warn
+				{t`Warn`}
 			</span>
 		);
 	}
 	return (
 		<span
 			className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs bg-kumo-danger/10 text-kumo-danger"
-			title="Security audit failed"
+			title={t`Security audit failed`}
 		>
 			<ShieldWarning className="h-3 w-3" />
-			Fail
+			{t`Fail`}
 		</span>
 	);
 }

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Badge, Button } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
@@ -285,7 +286,10 @@ function PluginCard({ plugin, isInstalled }: PluginCardProps) {
 					{auditVerdict && <AuditBadge verdict={auditVerdict} />}
 					{plugin.capabilities.length > 0 && (
 						<span className="text-xs text-kumo-subtle">
-							{t`${plugin.capabilities.length} permission${plugin.capabilities.length !== 1 ? "s" : ""}`}
+							{plural(plugin.capabilities.length, {
+								one: "# permission",
+								other: "# permissions",
+							})}
 						</span>
 					)}
 				</div>

--- a/packages/admin/src/components/MarketplacePluginDetail.tsx
+++ b/packages/admin/src/components/MarketplacePluginDetail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Badge, Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowLeft,
 	DownloadSimple,
@@ -50,6 +51,7 @@ export function MarketplacePluginDetail({
 	pluginId,
 	installedPluginIds = new Set(),
 }: MarketplacePluginDetailProps) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [showConsent, setShowConsent] = React.useState(false);
 	const [showUninstallConfirm, setShowUninstallConfirm] = React.useState(false);
@@ -115,12 +117,12 @@ export function MarketplacePluginDetail({
 				<BackLink />
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">
 					<Warning className="mx-auto h-8 w-8 text-kumo-danger" />
-					<h3 className="mt-3 font-medium text-kumo-danger">Failed to load plugin</h3>
+					<h3 className="mt-3 font-medium text-kumo-danger">{t`Failed to load plugin`}</h3>
 					<p className="mt-1 text-sm text-kumo-subtle">
-						{error instanceof Error ? error.message : "Plugin not found"}
+						{error instanceof Error ? error.message : t`Plugin not found`}
 					</p>
 					<Link to="/plugins/marketplace" className="mt-4 inline-block text-kumo-brand text-sm">
-						Back to marketplace
+						{t`Back to marketplace`}
 					</Link>
 				</div>
 			</div>
@@ -147,7 +149,7 @@ export function MarketplacePluginDetail({
 							src={iconSrc}
 							alt=""
 							className={`h-16 w-16 rounded-xl object-cover ${isImageFlagged ? "blur-md" : ""}`}
-							aria-label={isImageFlagged ? "Icon blurred due to image audit" : undefined}
+							aria-label={isImageFlagged ? t`Icon blurred due to image audit` : undefined}
 						/>
 					) : (
 						<div className="flex h-16 w-16 items-center justify-center rounded-xl bg-kumo-brand/10 text-kumo-brand text-2xl font-bold">
@@ -178,27 +180,27 @@ export function MarketplacePluginDetail({
 					{isInstalled ? (
 						<>
 							<Badge variant="secondary" className="text-sm px-3 py-1">
-								Installed
+								{t`Installed`}
 							</Badge>
 							<Button
 								variant="outline"
 								className="text-kumo-danger hover:text-kumo-danger"
 								onClick={() => setShowUninstallConfirm(true)}
 							>
-								Uninstall
+								{t`Uninstall`}
 							</Button>
 						</>
 					) : isAuditFailed ? (
 						<div className="flex flex-col items-end gap-1">
 							<Button disabled variant="secondary">
-								Install blocked
+								{t`Install blocked`}
 							</Button>
-							<span className="text-xs text-kumo-danger">Failed security audit</span>
+							<span className="text-xs text-kumo-danger">{t`Failed security audit`}</span>
 						</div>
 					) : (
 						<Button onClick={() => setShowConsent(true)}>
 							<DownloadSimple className="mr-2 h-4 w-4" />
-							Install
+							{t`Install`}
 						</Button>
 					)}
 				</div>
@@ -208,7 +210,7 @@ export function MarketplacePluginDetail({
 			<div className="flex flex-wrap items-center gap-4 rounded-lg border bg-kumo-tint/30 p-3 text-sm">
 				<div className="flex items-center gap-1.5">
 					<DownloadSimple className="h-4 w-4 text-kumo-subtle" />
-					<span>{plugin.installCount.toLocaleString()} installs</span>
+					<span>{t`${plugin.installCount.toLocaleString()} installs`}</span>
 				</div>
 				{latest?.audit && <AuditBadge verdict={latest.audit.verdict} />}
 				{plugin.license && <span className="text-kumo-subtle">{plugin.license}</span>}
@@ -220,7 +222,7 @@ export function MarketplacePluginDetail({
 						className="flex items-center gap-1 text-kumo-brand hover:underline"
 					>
 						<GithubLogo className="h-4 w-4" />
-						Source
+						{t`Source`}
 					</a>
 				)}
 				{plugin.homepageUrl && isSafeUrl(plugin.homepageUrl) && (
@@ -231,7 +233,7 @@ export function MarketplacePluginDetail({
 						className="flex items-center gap-1 text-kumo-brand hover:underline"
 					>
 						<Globe className="h-4 w-4" />
-						Website
+						{t`Website`}
 					</a>
 				)}
 			</div>
@@ -239,7 +241,7 @@ export function MarketplacePluginDetail({
 			{/* Screenshots */}
 			{screenshots.length > 0 && (
 				<div>
-					<h2 className="mb-3 text-lg font-semibold">Screenshots</h2>
+					<h2 className="mb-3 text-lg font-semibold">{t`Screenshots`}</h2>
 					<div className="flex gap-3 overflow-x-auto pb-2">
 						{screenshots.map((url, i) => (
 							<button
@@ -249,10 +251,10 @@ export function MarketplacePluginDetail({
 							>
 								<img
 									src={url}
-									alt={`Screenshot ${i + 1}`}
+									alt={t`Screenshot ${i + 1}`}
 									className={`h-40 w-auto object-cover ${isImageFlagged ? "blur-md" : ""}`}
 									loading="lazy"
-									aria-label={isImageFlagged ? "Screenshot blurred due to image audit" : undefined}
+									aria-label={isImageFlagged ? t`Screenshot blurred due to image audit` : undefined}
 								/>
 							</button>
 						))}
@@ -270,7 +272,7 @@ export function MarketplacePluginDetail({
 						</div>
 					) : (
 						<div className="rounded-lg border bg-kumo-base p-6 text-center text-kumo-subtle">
-							No detailed description available.
+							{t`No detailed description available.`}
 						</div>
 					)}
 				</div>
@@ -279,10 +281,10 @@ export function MarketplacePluginDetail({
 				<div className="space-y-4">
 					{/* Capabilities */}
 					<div className="rounded-lg border bg-kumo-base p-4">
-						<h3 className="text-sm font-semibold mb-2">Permissions</h3>
+						<h3 className="text-sm font-semibold mb-2">{t`Permissions`}</h3>
 						{plugin.capabilities.length === 0 ? (
 							<p className="text-xs text-kumo-subtle">
-								This plugin requires no special permissions.
+								{t`This plugin requires no special permissions.`}
 							</p>
 						) : (
 							<ul className="space-y-1.5">
@@ -299,7 +301,7 @@ export function MarketplacePluginDetail({
 					{/* Keywords */}
 					{plugin.keywords && plugin.keywords.length > 0 && (
 						<div className="rounded-lg border bg-kumo-base p-4">
-							<h3 className="text-sm font-semibold mb-2">Keywords</h3>
+							<h3 className="text-sm font-semibold mb-2">{t`Keywords`}</h3>
 							<div className="flex flex-wrap gap-1">
 								{plugin.keywords.map((kw) => (
 									<span key={kw} className="rounded-md bg-kumo-tint px-2 py-0.5 text-xs">
@@ -313,11 +315,11 @@ export function MarketplacePluginDetail({
 					{/* Audit summary */}
 					{latest?.audit && (
 						<div className="rounded-lg border bg-kumo-base p-4">
-							<h3 className="text-sm font-semibold mb-2">Security Audit</h3>
+							<h3 className="text-sm font-semibold mb-2">{t`Security Audit`}</h3>
 							<div className="flex items-center gap-2">
 								<AuditBadge verdict={latest.audit.verdict} />
 								<span className="text-xs text-kumo-subtle">
-									Risk score: {latest.audit.riskScore}/100
+									{t`Risk score: ${latest.audit.riskScore}/100`}
 								</span>
 							</div>
 						</div>
@@ -326,11 +328,13 @@ export function MarketplacePluginDetail({
 					{/* Version info */}
 					{latest && (
 						<div className="rounded-lg border bg-kumo-base p-4">
-							<h3 className="text-sm font-semibold mb-2">Version</h3>
+							<h3 className="text-sm font-semibold mb-2">{t`Version`}</h3>
 							<div className="space-y-1 text-xs text-kumo-subtle">
 								<div>v{latest.version}</div>
-								{latest.minEmDashVersion && <div>Requires EmDash {latest.minEmDashVersion}</div>}
-								<div>Published {new Date(latest.publishedAt).toLocaleDateString()}</div>
+								{latest.minEmDashVersion && (
+									<div>{t`Requires EmDash ${latest.minEmDashVersion}`}</div>
+								)}
+								<div>{t`Published ${new Date(latest.publishedAt).toLocaleDateString()}`}</div>
 								{latest.bundleSize > 0 && <div>{formatBytes(latest.bundleSize)}</div>}
 							</div>
 						</div>
@@ -388,13 +392,14 @@ export function MarketplacePluginDetail({
 // ---------------------------------------------------------------------------
 
 function BackLink() {
+	const { t } = useLingui();
 	return (
 		<Link
 			to="/plugins/marketplace"
 			className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 		>
 			<ArrowLeft className="h-4 w-4" />
-			Back to marketplace
+			{t`Back to marketplace`}
 		</Link>
 	);
 }
@@ -414,6 +419,7 @@ function ScreenshotLightbox({
 	onClose,
 	onNavigate,
 }: ScreenshotLightboxProps) {
+	const { t } = useLingui();
 	const handleKeyDown = React.useCallback(
 		(e: KeyboardEvent) => {
 			if (e.key === "Escape") onClose();
@@ -433,12 +439,12 @@ function ScreenshotLightbox({
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
 			role="dialog"
 			aria-modal="true"
-			aria-label="Screenshot viewer"
+			aria-label={t`Screenshot viewer`}
 		>
 			<button
 				onClick={onClose}
 				className="absolute right-4 top-4 rounded-full bg-black/50 p-2 text-white hover:bg-black/70"
-				aria-label="Close"
+				aria-label={t`Close`}
 			>
 				<X className="h-5 w-5" />
 			</button>
@@ -447,7 +453,7 @@ function ScreenshotLightbox({
 				<button
 					onClick={() => onNavigate(index - 1)}
 					className="absolute left-4 rounded-full bg-black/50 p-2 text-white hover:bg-black/70"
-					aria-label="Previous screenshot"
+					aria-label={t`Previous screenshot`}
 				>
 					<CaretLeft className="h-5 w-5" />
 				</button>
@@ -455,7 +461,7 @@ function ScreenshotLightbox({
 
 			<img
 				src={screenshots[index]}
-				alt={`Screenshot ${index + 1} of ${screenshots.length}`}
+				alt={t`Screenshot ${index + 1} of ${screenshots.length}`}
 				className={`max-h-[85vh] max-w-[90vw] rounded-lg object-contain ${
 					isBlurred ? "blur-md" : ""
 				}`}
@@ -465,7 +471,7 @@ function ScreenshotLightbox({
 				<button
 					onClick={() => onNavigate(index + 1)}
 					className="absolute right-4 rounded-full bg-black/50 p-2 text-white hover:bg-black/70"
-					aria-label="Next screenshot"
+					aria-label={t`Next screenshot`}
 				>
 					<CaretRight className="h-5 w-5" />
 				</button>

--- a/packages/admin/src/components/MediaDetailPanel.tsx
+++ b/packages/admin/src/components/MediaDetailPanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Input, InputArea } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { X, Trash, Calendar, HardDrive, Ruler } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -26,6 +27,7 @@ export interface MediaDetailPanelProps {
  * Slide-out panel for viewing and editing media metadata
  */
 export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelProps) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 
 	// Form state - controlled inputs
@@ -126,10 +128,10 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 			>
 				{/* Header */}
 				<div className="flex items-center justify-between p-4 border-b">
-					<h2 className="font-semibold truncate pr-2">Media Details</h2>
-					<Button variant="ghost" shape="square" aria-label="Close" onClick={onClose}>
+					<h2 className="font-semibold truncate pr-2">{t`Media Details`}</h2>
+					<Button variant="ghost" shape="square" aria-label={t`Close`} onClick={onClose}>
 						<X className="h-4 w-4" />
-						<span className="sr-only">Close</span>
+						<span className="sr-only">{t`Close`}</span>
 					</Button>
 				</div>
 
@@ -166,13 +168,13 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 					<div className="p-4 border-b space-y-3">
 						<div className="flex items-center gap-2 text-sm">
 							<HardDrive className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">Size:</span>
+							<span className="text-kumo-subtle">{t`Size:`}</span>
 							<span>{formatFileSize(item.size)}</span>
 						</div>
 						{item.width && item.height && (
 							<div className="flex items-center gap-2 text-sm">
 								<Ruler className="h-4 w-4 text-kumo-subtle" />
-								<span className="text-kumo-subtle">Dimensions:</span>
+								<span className="text-kumo-subtle">{t`Dimensions:`}</span>
 								<span>
 									{item.width} × {item.height}
 								</span>
@@ -180,7 +182,7 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 						)}
 						<div className="flex items-center gap-2 text-sm">
 							<Calendar className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">Uploaded:</span>
+							<span className="text-kumo-subtle">{t`Uploaded:`}</span>
 							<span>{formatDate(item.createdAt)}</span>
 						</div>
 					</div>
@@ -188,28 +190,28 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 					{/* Editable Fields */}
 					<div className="p-4 space-y-4">
 						<Input
-							label="Filename"
+							label={t`Filename`}
 							value={filename}
 							onChange={(e) => setFilename(e.target.value)}
 							disabled // Filename editing needs backend support
-							description="Filename cannot be changed after upload"
+							description={t`Filename cannot be changed after upload`}
 						/>
 
 						{isImage && (
 							<>
 								<Input
-									label="Alt Text"
+									label={t`Alt Text`}
 									value={alt}
 									onChange={(e) => setAlt(e.target.value)}
-									placeholder="Describe this image for accessibility"
-									description="Used by screen readers and when image fails to load"
+									placeholder={t`Describe this image for accessibility`}
+									description={t`Used by screen readers and when image fails to load`}
 								/>
 
 								<InputArea
-									label="Caption"
+									label={t`Caption`}
 									value={caption}
 									onChange={(e) => setCaption(e.target.value)}
-									placeholder="Optional caption for display"
+									placeholder={t`Optional caption for display`}
 									rows={2}
 								/>
 							</>
@@ -226,18 +228,18 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 						onClick={handleDelete}
 						disabled={deleteMutation.isPending}
 					>
-						{deleteMutation.isPending ? "Deleting..." : "Delete"}
+						{deleteMutation.isPending ? t`Deleting...` : t`Delete`}
 					</Button>
 					<div className="flex gap-2">
 						<Button variant="outline" size="sm" onClick={onClose}>
-							Cancel
+							{t`Cancel`}
 						</Button>
 						<Button
 							size="sm"
 							onClick={handleSave}
 							disabled={!hasChanges || updateMutation.isPending}
 						>
-							{updateMutation.isPending ? "Saving..." : "Save"}
+							{updateMutation.isPending ? t`Saving...` : t`Save`}
 						</Button>
 					</div>
 				</div>
@@ -249,10 +251,10 @@ export function MediaDetailPanel({ item, onClose, onDeleted }: MediaDetailPanelP
 					setShowDeleteConfirm(false);
 					deleteMutation.reset();
 				}}
-				title="Delete Media?"
-				description={`Delete "${item.filename}"? This cannot be undone.`}
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				title={t`Delete Media?`}
+				description={t`Delete "${item.filename}"? This cannot be undone.`}
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={deleteMutation.isPending}
 				error={deleteMutation.error}
 				onConfirm={() => deleteMutation.mutate()}

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1,4 +1,6 @@
 import { Button, Input, Loader } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import { Upload, Image, SquaresFour, List, MagnifyingGlass, Check, X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
@@ -34,6 +36,7 @@ export function MediaLibrary({
 	onDelete,
 	onItemUpdated,
 }: MediaLibraryProps) {
+	const { t } = useLingui();
 	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
 	const [selectedItem, setSelectedItem] = React.useState<MediaItem | null>(null);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");
@@ -134,17 +137,17 @@ export function MediaLibrary({
 				if (failed === 0) {
 					setUploadState({
 						status: "success",
-						message: total === 1 ? "File uploaded" : `${total} files uploaded`,
+						message: plural(total, { one: "File uploaded", other: "# files uploaded" }),
 					});
 				} else if (uploaded === 0) {
 					setUploadState({
 						status: "error",
-						message: total === 1 ? "Upload failed" : `All ${total} uploads failed`,
+						message: plural(total, { one: "Upload failed", other: "All # uploads failed" }),
 					});
 				} else {
 					setUploadState({
 						status: "error",
-						message: `${uploaded} uploaded, ${failed} failed`,
+						message: t`${uploaded} uploaded, ${failed} failed`,
 					});
 				}
 			} else if (activeProviderInfo?.capabilities.upload) {
@@ -170,17 +173,17 @@ export function MediaLibrary({
 				if (failed === 0) {
 					setUploadState({
 						status: "success",
-						message: total === 1 ? "File uploaded" : `${total} files uploaded`,
+						message: plural(total, { one: "File uploaded", other: "# files uploaded" }),
 					});
 				} else if (uploaded === 0) {
 					setUploadState({
 						status: "error",
-						message: total === 1 ? "Upload failed" : `All ${total} uploads failed`,
+						message: plural(total, { one: "Upload failed", other: "All # uploads failed" }),
 					});
 				} else {
 					setUploadState({
 						status: "error",
-						message: `${uploaded} uploaded, ${failed} failed`,
+						message: t`${uploaded} uploaded, ${failed} failed`,
 					});
 				}
 
@@ -220,13 +223,13 @@ export function MediaLibrary({
 		<div className="space-y-6">
 			{/* Header */}
 			<div className="flex items-center justify-between">
-				<h1 className="text-2xl font-bold">Media Library</h1>
-				<div className="flex rounded-md border" role="group" aria-label="View mode">
+				<h1 className="text-2xl font-bold">{t`Media Library`}</h1>
+				<div className="flex rounded-md border" role="group" aria-label={t`View mode`}>
 					<Button
 						variant={viewMode === "grid" ? "secondary" : "ghost"}
 						shape="square"
 						onClick={() => setViewMode("grid")}
-						aria-label="Grid view"
+						aria-label={t`Grid view`}
 						aria-pressed={viewMode === "grid"}
 					>
 						<SquaresFour className="h-4 w-4" aria-hidden="true" />
@@ -235,7 +238,7 @@ export function MediaLibrary({
 						variant={viewMode === "list" ? "secondary" : "ghost"}
 						shape="square"
 						onClick={() => setViewMode("list")}
-						aria-label="List view"
+						aria-label={t`List view`}
 						aria-pressed={viewMode === "list"}
 					>
 						<List className="h-4 w-4" aria-hidden="true" />
@@ -282,11 +285,9 @@ export function MediaLibrary({
 						<div className="flex items-center gap-2 text-sm text-kumo-subtle">
 							<Loader size="sm" />
 							<span>
-								Uploading
-								{uploadState.progress &&
-									uploadState.progress.total > 1 &&
-									` ${uploadState.progress.current}/${uploadState.progress.total}`}
-								...
+								{uploadState.progress && uploadState.progress.total > 1
+									? t`Uploading ${uploadState.progress.current}/${uploadState.progress.total}...`
+									: t`Uploading...`}
 							</span>
 						</div>
 					)}
@@ -310,7 +311,7 @@ export function MediaLibrary({
 								disabled={uploadState.status === "uploading"}
 								icon={uploadState.status === "uploading" ? <Loader size="sm" /> : <Upload />}
 							>
-								Upload to {activeProviderInfo?.name || "Library"}
+								{t`Upload to ${activeProviderInfo?.name || t`Library`}`}
 							</Button>
 							<input
 								ref={fileInputRef}
@@ -319,7 +320,7 @@ export function MediaLibrary({
 								accept="image/*,video/*,audio/*,.pdf,.doc,.docx,.xls,.xlsx"
 								className="sr-only"
 								onChange={handleFileSelect}
-								aria-label="Upload files"
+								aria-label={t`Upload files`}
 							/>
 						</>
 					)}
@@ -332,7 +333,7 @@ export function MediaLibrary({
 					<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 					<Input
 						type="search"
-						placeholder="Search..."
+						placeholder={t`Search...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						className="pl-9"
@@ -348,24 +349,24 @@ export function MediaLibrary({
 			) : activeProvider === "local" && currentItems.length === 0 ? (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Image className="mx-auto h-12 w-12 text-kumo-subtle" aria-hidden="true" />
-					<h2 className="mt-4 text-lg font-medium">No media yet</h2>
+					<h2 className="mt-4 text-lg font-medium">{t`No media yet`}</h2>
 					<p className="mt-2 text-sm text-kumo-subtle">
-						Upload images, videos, and documents to get started.
+						{t`Upload images, videos, and documents to get started.`}
 					</p>
 					<Button className="mt-4" onClick={() => fileInputRef.current?.click()} icon={<Upload />}>
-						Upload Files
+						{t`Upload Files`}
 					</Button>
 				</div>
 			) : activeProvider !== "local" && currentProviderItems.length === 0 ? (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Image className="mx-auto h-12 w-12 text-kumo-subtle" aria-hidden="true" />
-					<h2 className="mt-4 text-lg font-medium">No media found</h2>
+					<h2 className="mt-4 text-lg font-medium">{t`No media found`}</h2>
 					<p className="mt-2 text-sm text-kumo-subtle">
 						{canSearch && searchQuery
-							? "Try a different search term"
+							? t`Try a different search term`
 							: canUpload
-								? "Upload media to get started"
-								: "No media available from this provider"}
+								? t`Upload media to get started`
+								: t`No media available from this provider`}
 					</p>
 				</div>
 			) : viewMode === "grid" ? (
@@ -411,11 +412,11 @@ export function MediaLibrary({
 					<table className="w-full">
 						<thead>
 							<tr className="border-b bg-kumo-tint/50">
-								<th className="px-4 py-3 text-left text-sm font-medium">Preview</th>
-								<th className="px-4 py-3 text-left text-sm font-medium">Filename</th>
-								<th className="px-4 py-3 text-left text-sm font-medium">Type</th>
-								<th className="px-4 py-3 text-left text-sm font-medium">Size</th>
-								<th className="px-4 py-3 text-right text-sm font-medium">Actions</th>
+								<th className="px-4 py-3 text-left text-sm font-medium">{t`Preview`}</th>
+								<th className="px-4 py-3 text-left text-sm font-medium">{t`Filename`}</th>
+								<th className="px-4 py-3 text-left text-sm font-medium">{t`Type`}</th>
+								<th className="px-4 py-3 text-left text-sm font-medium">{t`Size`}</th>
+								<th className="px-4 py-3 text-right text-sm font-medium">{t`Actions`}</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -577,6 +578,7 @@ interface MediaListItemProps {
 }
 
 function MediaListItem({ item, selected, onClick }: MediaListItemProps) {
+	const { t } = useLingui();
 	const isImage = item.mimeType.startsWith("image/");
 
 	return (
@@ -607,7 +609,7 @@ function MediaListItem({ item, selected, onClick }: MediaListItemProps) {
 			<td className="px-4 py-3 text-sm text-kumo-subtle">{formatFileSize(item.size)}</td>
 			<td className="px-4 py-3 text-right">
 				<span className="text-sm text-kumo-subtle">
-					{item.alt ? "Alt text set" : "No alt text"}
+					{item.alt ? t`Alt text set` : t`No alt text`}
 				</span>
 			</td>
 		</tr>
@@ -623,6 +625,7 @@ interface ProviderListItemProps {
 }
 
 function ProviderListItem({ item, selected, onClick, onDimensionsLoaded }: ProviderListItemProps) {
+	const { t } = useLingui();
 	const isImage = item.mimeType.startsWith("image/");
 
 	const handleImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
@@ -663,7 +666,7 @@ function ProviderListItem({ item, selected, onClick, onDimensionsLoaded }: Provi
 			</td>
 			<td className="px-4 py-3 text-right">
 				<span className="text-sm text-kumo-subtle">
-					{item.alt ? "Alt text set" : "No alt text"}
+					{item.alt ? t`Alt text set` : t`No alt text`}
 				</span>
 			</td>
 		</tr>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -7,6 +7,8 @@
  */
 
 import { Button, Dialog, Input, Label, Loader } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import { Upload, Image, Check, Globe, MagnifyingGlass } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -65,6 +67,7 @@ export function MediaPickerModal({
 	mimeTypeFilter = "image/",
 	title = "Select Image",
 }: MediaPickerModalProps) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [selectedItem, setSelectedItem] = React.useState<SelectedMedia | null>(null);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");
@@ -277,7 +280,7 @@ export function MediaPickerModal({
 		try {
 			url = new URL(imageUrl.trim());
 		} catch {
-			setUrlError("Please enter a valid URL");
+			setUrlError(t`Please enter a valid URL`);
 			return;
 		}
 
@@ -301,7 +304,7 @@ export function MediaPickerModal({
 			onOpenChange(false);
 			setImageUrl("");
 		} catch {
-			setUrlError("Could not load image from URL");
+			setUrlError(t`Could not load image from URL`);
 		} finally {
 			setIsProbing(false);
 		}
@@ -342,17 +345,17 @@ export function MediaPickerModal({
 						{title}
 					</Dialog.Title>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
-								<span className="sr-only">Close</span>
+								<span className="sr-only">{t`Close`}</span>
 							</Button>
 						)}
 					/>
@@ -360,14 +363,14 @@ export function MediaPickerModal({
 
 				{/* URL Input */}
 				<div className="border-b pb-4">
-					<Label>Insert from URL</Label>
+					<Label>{t`Insert from URL`}</Label>
 					<div className="flex gap-2 mt-1.5">
 						<div className="flex-1 relative">
 							<Globe className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 							<Input
 								type="url"
 								placeholder="https://example.com/image.jpg"
-								aria-label="Image URL"
+								aria-label={t`Image URL`}
 								value={imageUrl}
 								onChange={(e) => {
 									setImageUrl(e.target.value);
@@ -378,7 +381,7 @@ export function MediaPickerModal({
 							/>
 						</div>
 						<Button onClick={handleUrlSubmit} disabled={!imageUrl.trim() || isProbing}>
-							{isProbing ? <Loader size="sm" /> : "Insert"}
+							{isProbing ? <Loader size="sm" /> : t`Insert`}
 						</Button>
 					</div>
 					{urlError && <p className="text-sm text-kumo-danger mt-1">{urlError}</p>}
@@ -390,7 +393,7 @@ export function MediaPickerModal({
 						<span className="w-full border-t" />
 					</div>
 					<div className="relative flex justify-center text-xs uppercase">
-						<span className="bg-kumo-base px-2 text-kumo-subtle">or choose from library</span>
+						<span className="bg-kumo-base px-2 text-kumo-subtle">{t`or choose from library`}</span>
 					</div>
 				</div>
 
@@ -433,8 +436,8 @@ export function MediaPickerModal({
 							<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 							<Input
 								type="search"
-								placeholder="Search..."
-								aria-label="Search media"
+								placeholder={t`Search...`}
+								aria-label={t`Search media`}
 								value={searchQuery}
 								onChange={(e) => setSearchQuery(e.target.value)}
 								className="pl-9"
@@ -442,7 +445,7 @@ export function MediaPickerModal({
 						</div>
 					) : (
 						<p className="text-sm text-kumo-subtle">
-							{items.length} item{items.length !== 1 ? "s" : ""}
+							{plural(items.length, { one: "# item", other: "# items" })}
 						</p>
 					)}
 
@@ -455,7 +458,7 @@ export function MediaPickerModal({
 								onClick={() => fileInputRef.current?.click()}
 								disabled={isUploading}
 							>
-								{isUploading ? "Uploading..." : "Upload"}
+								{isUploading ? t`Uploading...` : t`Upload`}
 							</Button>
 							<input
 								ref={fileInputRef}
@@ -471,7 +474,7 @@ export function MediaPickerModal({
 
 				{/* Upload error */}
 				<DialogError
-					message={uploadError ? `Upload failed: ${uploadError}` : null}
+					message={uploadError ? t`Upload failed: ${uploadError}` : null}
 					className="mb-3"
 				/>
 
@@ -484,13 +487,13 @@ export function MediaPickerModal({
 					) : items.length === 0 ? (
 						<div className="flex flex-col items-center justify-center h-full text-center p-8">
 							<Image className="h-12 w-12 text-kumo-subtle mb-4" aria-hidden="true" />
-							<h3 className="text-lg font-medium">No media found</h3>
+							<h3 className="text-lg font-medium">{t`No media found`}</h3>
 							<p className="text-sm text-kumo-subtle mt-1">
 								{canSearch && searchQuery
-									? "Try a different search term"
+									? t`Try a different search term`
 									: canUpload
-										? "Upload an image to get started"
-										: "No media available from this provider"}
+										? t`Upload an image to get started`
+										: t`No media available from this provider`}
 							</p>
 							{canUpload && !searchQuery && (
 								<Button
@@ -498,7 +501,7 @@ export function MediaPickerModal({
 									icon={<Upload />}
 									onClick={() => fileInputRef.current?.click()}
 								>
-									Upload Image
+									{t`Upload Image`}
 								</Button>
 							)}
 						</div>
@@ -506,7 +509,7 @@ export function MediaPickerModal({
 						<ul
 							className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3 p-1"
 							role="listbox"
-							aria-label="Available media"
+							aria-label={t`Available media`}
 						>
 							{activeProvider === "local"
 								? (items as MediaItem[]).map((item) => (
@@ -564,20 +567,20 @@ export function MediaPickerModal({
 					<div className="flex-1 text-sm text-kumo-subtle">
 						{selectedItem && (
 							<span>
-								Selected: <strong>{selectedItem.item.filename}</strong>
+								{t`Selected:`} <strong>{selectedItem.item.filename}</strong>
 								{selectedItem.providerId !== "local" && (
 									<span className="ml-2 text-xs">
-										(from {providers?.find((p) => p.id === selectedItem.providerId)?.name})
+										{t`(from ${providers?.find((p) => p.id === selectedItem.providerId)?.name})`}
 									</span>
 								)}
 							</span>
 						)}
 					</div>
 					<Button variant="outline" onClick={handleClose}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 					<Button onClick={handleConfirm} disabled={!selectedItem}>
-						Insert
+						{t`Insert`}
 					</Button>
 				</div>
 			</Dialog>
@@ -600,6 +603,7 @@ function MediaPickerItem({
 	onDoubleClick,
 	onDimensionsDetected,
 }: MediaPickerItemProps) {
+	const { t } = useLingui();
 	const isImage = item.mimeType.startsWith("image/");
 	const needsDimensions = isImage && (!item.width || !item.height);
 
@@ -626,7 +630,7 @@ function MediaPickerItem({
 				)}
 				onClick={onClick}
 				onDoubleClick={onDoubleClick}
-				aria-label={`${item.filename}${selected ? " (selected)" : ""}`}
+				aria-label={t`${item.filename}${selected ? t` (selected)` : ""}`}
 			>
 				{isImage ? (
 					<img
@@ -681,6 +685,7 @@ function ProviderMediaItem({
 	onDoubleClick,
 	onDimensionsLoaded,
 }: ProviderMediaItemProps) {
+	const { t } = useLingui();
 	const isImage = item.mimeType.startsWith("image/");
 	const needsDimensions = isImage && (!item.width || !item.height);
 
@@ -707,7 +712,7 @@ function ProviderMediaItem({
 				)}
 				onClick={onClick}
 				onDoubleClick={onDoubleClick}
-				aria-label={`${item.filename}${selected ? " (selected)" : ""}`}
+				aria-label={t`${item.filename}${selected ? t` (selected)` : ""}`}
 			>
 				{isImage && item.previewUrl ? (
 					<img

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -65,9 +65,10 @@ export function MediaPickerModal({
 	onOpenChange,
 	onSelect,
 	mimeTypeFilter = "image/",
-	title = "Select Image",
+	title: providedTitle,
 }: MediaPickerModalProps) {
 	const { t } = useLingui();
+	const title = providedTitle ?? t`Select Image`;
 	const queryClient = useQueryClient();
 	const [selectedItem, setSelectedItem] = React.useState<SelectedMedia | null>(null);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Dialog, Input, Select, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	Plus,
 	Trash,
@@ -31,6 +32,7 @@ import { ContentPickerModal } from "./ContentPickerModal";
 import { DialogError, getMutationError } from "./DialogError.js";
 
 export function MenuEditor() {
+	const { t } = useLingui();
 	const { name } = useParams({ from: "/_admin/menus/$name" });
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -60,7 +62,7 @@ export function MenuEditor() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["menu", name] });
 			setIsAddOpen(false);
-			toastManager.add({ title: "Item added", description: "Menu item has been added." });
+			toastManager.add({ title: t`Item added`, description: t`Menu item has been added.` });
 		},
 		onError: (error: Error) => {
 			setAddError(error.message);
@@ -72,13 +74,13 @@ export function MenuEditor() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["menu", name] });
 			toastManager.add({
-				title: "Item deleted",
-				description: "Menu item has been deleted.",
+				title: t`Item deleted`,
+				description: t`Menu item has been deleted.`,
 			});
 		},
 		onError: (error: Error) => {
 			toastManager.add({
-				title: "Error",
+				title: t`Error`,
 				description: error.message,
 				type: "error",
 			});
@@ -97,8 +99,8 @@ export function MenuEditor() {
 			void queryClient.invalidateQueries({ queryKey: ["menu", name] });
 			setEditingItem(null);
 			toastManager.add({
-				title: "Item updated",
-				description: "Menu item has been updated.",
+				title: t`Item updated`,
+				description: t`Menu item has been updated.`,
 			});
 		},
 		onError: (error: Error) => {
@@ -111,13 +113,13 @@ export function MenuEditor() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["menu", name] });
 			toastManager.add({
-				title: "Order saved",
-				description: "Menu order has been updated.",
+				title: t`Order saved`,
+				description: t`Menu order has been updated.`,
 			});
 		},
 		onError: (error: Error) => {
 			toastManager.add({
-				title: "Error",
+				title: t`Error`,
 				description: error.message,
 				type: "error",
 			});
@@ -193,7 +195,7 @@ export function MenuEditor() {
 	if (isLoading) {
 		return (
 			<div className="flex items-center justify-center h-64">
-				<div className="text-kumo-subtle">Loading menu...</div>
+				<div className="text-kumo-subtle">{t`Loading menu...`}</div>
 			</div>
 		);
 	}
@@ -201,7 +203,7 @@ export function MenuEditor() {
 	if (!menu) {
 		return (
 			<div className="text-center py-12">
-				<p className="text-kumo-subtle">Menu not found</p>
+				<p className="text-kumo-subtle">{t`Menu not found`}</p>
 			</div>
 		);
 	}
@@ -213,14 +215,14 @@ export function MenuEditor() {
 					<Button
 						variant="ghost"
 						size="sm"
-						aria-label="Back"
+						aria-label={t`Back`}
 						onClick={() => navigate({ to: "/menus" })}
 					>
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 					<div>
 						<h1 className="text-3xl font-bold">{menu.label}</h1>
-						<p className="text-kumo-subtle">Edit menu items</p>
+						<p className="text-kumo-subtle">{t`Edit menu items`}</p>
 					</div>
 				</div>
 				<div className="flex gap-2">
@@ -229,7 +231,7 @@ export function MenuEditor() {
 						variant="outline"
 						onClick={() => setIsContentPickerOpen(true)}
 					>
-						Add Content
+						{t`Add Content`}
 					</Button>
 					<Dialog.Root
 						open={isAddOpen}
@@ -241,58 +243,58 @@ export function MenuEditor() {
 						<Dialog.Trigger
 							render={(props) => (
 								<Button {...props} icon={<Plus />}>
-									Add Custom Link
+									{t`Add Custom Link`}
 								</Button>
 							)}
 						/>
 						<Dialog className="p-6" size="lg">
 							<div className="flex items-start justify-between gap-4 mb-4">
 								<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-									Add Custom Link
+									{t`Add Custom Link`}
 								</Dialog.Title>
 								<Dialog.Close
-									aria-label="Close"
+									aria-label={t`Close`}
 									render={(props) => (
 										<Button
 											{...props}
 											variant="ghost"
 											shape="square"
-											aria-label="Close"
+											aria-label={t`Close`}
 											className="absolute right-4 top-4"
 										>
 											<X className="h-4 w-4" />
-											<span className="sr-only">Close</span>
+											<span className="sr-only">{t`Close`}</span>
 										</Button>
 									)}
 								/>
 							</div>
 							<form onSubmit={handleAddCustomLink} className="space-y-4">
-								<Input label="Label" name="label" required placeholder="Home" />
+								<Input label={t`Label`} name="label" required placeholder="Home" />
 								<Input
-									label="URL"
+									label={t`URL`}
 									name="url"
 									type="text"
 									required
 									pattern="(https?://.+|/.*)"
-									title="Enter a URL (https://…) or a relative path (/…)"
+									title={t`Enter a URL (https://…) or a relative path (/…)`}
 									placeholder="https://example.com or /about"
 								/>
 								<Select
-									label="Target"
+									label={t`Target`}
 									name="target"
 									defaultValue=""
-									items={{ "": "Same window", _blank: "New window" }}
+									items={{ "": t`Same window`, _blank: t`New window` }}
 								>
-									<Select.Option value="">Same window</Select.Option>
-									<Select.Option value="_blank">New window</Select.Option>
+									<Select.Option value="">{t`Same window`}</Select.Option>
+									<Select.Option value="_blank">{t`New window`}</Select.Option>
 								</Select>
 								<DialogError message={addError || getMutationError(createMutation.error)} />
 								<div className="flex justify-end gap-2">
 									<Button type="button" variant="outline" onClick={() => setIsAddOpen(false)}>
-										Cancel
+										{t`Cancel`}
 									</Button>
 									<Button type="submit" disabled={createMutation.isPending}>
-										{createMutation.isPending ? "Adding..." : "Add"}
+										{createMutation.isPending ? t`Adding...` : t`Add`}
 									</Button>
 								</div>
 							</form>
@@ -310,18 +312,18 @@ export function MenuEditor() {
 			{localItems.length === 0 ? (
 				<div className="border rounded-lg p-12 text-center">
 					<LinkIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" />
-					<h3 className="text-lg font-semibold mb-2">No menu items yet</h3>
-					<p className="text-kumo-subtle mb-4">Add links to build your navigation menu</p>
+					<h3 className="text-lg font-semibold mb-2">{t`No menu items yet`}</h3>
+					<p className="text-kumo-subtle mb-4">{t`Add links to build your navigation menu`}</p>
 					<div className="flex justify-center gap-2">
 						<Button
 							icon={<FileIcon />}
 							variant="outline"
 							onClick={() => setIsContentPickerOpen(true)}
 						>
-							Add Content
+							{t`Add Content`}
 						</Button>
 						<Button icon={<Plus />} onClick={() => setIsAddOpen(true)}>
-							Add Custom Link
+							{t`Add Custom Link`}
 						</Button>
 					</div>
 				</div>
@@ -339,14 +341,14 @@ export function MenuEditor() {
 											{item.reference_collection ?? item.type}
 										</span>
 									)}
-									{item.target === "_blank" && " (opens in new window)"}
+									{item.target === "_blank" && t` (opens in new window)`}
 								</div>
 							</div>
 							<div className="flex gap-2">
 								<Button
 									variant="ghost"
 									size="sm"
-									aria-label="Move up"
+									aria-label={t`Move up`}
 									onClick={() => moveItem(index, "up")}
 									disabled={index === 0}
 								>
@@ -355,19 +357,19 @@ export function MenuEditor() {
 								<Button
 									variant="ghost"
 									size="sm"
-									aria-label="Move down"
+									aria-label={t`Move down`}
 									onClick={() => moveItem(index, "down")}
 									disabled={index === localItems.length - 1}
 								>
 									<CaretDown className="h-4 w-4" />
 								</Button>
 								<Button variant="outline" size="sm" onClick={() => setEditingItem(item)}>
-									Edit
+									{t`Edit`}
 								</Button>
 								<Button
 									variant="outline"
 									size="sm"
-									aria-label="Delete"
+									aria-label={t`Delete`}
 									onClick={() => deleteMutation.mutate(item.id)}
 								>
 									<Trash className="h-4 w-4" />
@@ -390,54 +392,54 @@ export function MenuEditor() {
 				<Dialog className="p-6" size="lg">
 					<div className="flex items-start justify-between gap-4 mb-4">
 						<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-							Edit Menu Item
+							{t`Edit Menu Item`}
 						</Dialog.Title>
 						<Dialog.Close
-							aria-label="Close"
+							aria-label={t`Close`}
 							render={(props) => (
 								<Button
 									{...props}
 									variant="ghost"
 									shape="square"
-									aria-label="Close"
+									aria-label={t`Close`}
 									className="absolute right-4 top-4"
 								>
 									<X className="h-4 w-4" />
-									<span className="sr-only">Close</span>
+									<span className="sr-only">{t`Close`}</span>
 								</Button>
 							)}
 						/>
 					</div>
 					{editingItem && (
 						<form onSubmit={handleUpdateItem} className="space-y-4">
-							<Input label="Label" name="label" required defaultValue={editingItem.label} />
+							<Input label={t`Label`} name="label" required defaultValue={editingItem.label} />
 							{editingItem.type === "custom" && (
 								<Input
-									label="URL"
+									label={t`URL`}
 									name="url"
 									type="text"
 									required
 									pattern="(https?://.+|/.*)"
-									title="Enter a URL (https://…) or a relative path (/…)"
+									title={t`Enter a URL (https://…) or a relative path (/…)`}
 									defaultValue={editingItem.custom_url || ""}
 								/>
 							)}
 							<Select
-								label="Target"
+								label={t`Target`}
 								name="target"
 								defaultValue={editingItem.target || ""}
-								items={{ "": "Same window", _blank: "New window" }}
+								items={{ "": t`Same window`, _blank: t`New window` }}
 							>
-								<Select.Option value="">Same window</Select.Option>
-								<Select.Option value="_blank">New window</Select.Option>
+								<Select.Option value="">{t`Same window`}</Select.Option>
+								<Select.Option value="_blank">{t`New window`}</Select.Option>
 							</Select>
 							<DialogError message={editError || getMutationError(updateMutation.error)} />
 							<div className="flex justify-end gap-2">
 								<Button type="button" variant="outline" onClick={() => setEditingItem(null)}>
-									Cancel
+									{t`Cancel`}
 								</Button>
 								<Button type="submit" disabled={updateMutation.isPending}>
-									{updateMutation.isPending ? "Saving..." : "Save"}
+									{updateMutation.isPending ? t`Saving...` : t`Save`}
 								</Button>
 							</div>
 						</form>

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -269,7 +269,7 @@ export function MenuEditor() {
 								/>
 							</div>
 							<form onSubmit={handleAddCustomLink} className="space-y-4">
-								<Input label={t`Label`} name="label" required placeholder="Home" />
+								<Input label={t`Label`} name="label" required placeholder={t`Home`} />
 								<Input
 									label={t`URL`}
 									name="url"
@@ -277,7 +277,7 @@ export function MenuEditor() {
 									required
 									pattern="(https?://.+|/.*)"
 									title={t`Enter a URL (https://…) or a relative path (/…)`}
-									placeholder="https://example.com or /about"
+									placeholder={t`https://example.com or /about`}
 								/>
 								<Select
 									label={t`Target`}

--- a/packages/admin/src/components/MenuList.tsx
+++ b/packages/admin/src/components/MenuList.tsx
@@ -134,7 +134,7 @@ export function MenuList() {
 								</p>
 							</div>
 							<div>
-								<Input label={t`Label`} name="label" required placeholder="Primary Navigation" />
+								<Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} />
 								<p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p>
 							</div>
 							<DialogError message={createError || getMutationError(createMutation.error)} />

--- a/packages/admin/src/components/MenuList.tsx
+++ b/packages/admin/src/components/MenuList.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Dialog, Input, Toast, buttonVariants } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -16,6 +17,7 @@ import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 
 export function MenuList() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 	const toastManager = Toast.useToastManager();
@@ -34,8 +36,8 @@ export function MenuList() {
 			void queryClient.invalidateQueries({ queryKey: ["menus"] });
 			setIsCreateOpen(false);
 			toastManager.add({
-				title: "Menu created",
-				description: `Menu "${menu.label}" has been created.`,
+				title: t`Menu created`,
+				description: t`Menu "${menu.label}" has been created.`,
 			});
 			void navigate({ to: "/menus/$name", params: { name: menu.name } });
 		},
@@ -50,8 +52,8 @@ export function MenuList() {
 			void queryClient.invalidateQueries({ queryKey: ["menus"] });
 			setDeleteMenuName(null);
 			toastManager.add({
-				title: "Menu deleted",
-				description: "The menu has been deleted.",
+				title: t`Menu deleted`,
+				description: t`The menu has been deleted.`,
 			});
 		},
 	});
@@ -70,7 +72,7 @@ export function MenuList() {
 	if (isLoading) {
 		return (
 			<div className="flex items-center justify-center h-64">
-				<div className="text-kumo-subtle">Loading menus...</div>
+				<div className="text-kumo-subtle">{t`Loading menus...`}</div>
 			</div>
 		);
 	}
@@ -79,8 +81,8 @@ export function MenuList() {
 		<div className="space-y-6">
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-3xl font-bold">Menus</h1>
-					<p className="text-kumo-subtle">Manage navigation menus for your site</p>
+					<h1 className="text-3xl font-bold">{t`Menus`}</h1>
+					<p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p>
 				</div>
 				<Dialog.Root
 					open={isCreateOpen}
@@ -92,27 +94,27 @@ export function MenuList() {
 					<Dialog.Trigger
 						render={(props) => (
 							<Button {...props} icon={<Plus />}>
-								Create Menu
+								{t`Create Menu`}
 							</Button>
 						)}
 					/>
 					<Dialog className="p-6" size="lg">
 						<div className="flex items-start justify-between gap-4 mb-4">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								Create New Menu
+								{t`Create New Menu`}
 							</Dialog.Title>
 							<Dialog.Close
-								aria-label="Close"
+								aria-label={t`Close`}
 								render={(props) => (
 									<Button
 										{...props}
 										variant="ghost"
 										shape="square"
-										aria-label="Close"
+										aria-label={t`Close`}
 										className="absolute right-4 top-4"
 									>
 										<X className="h-4 w-4" />
-										<span className="sr-only">Close</span>
+										<span className="sr-only">{t`Close`}</span>
 									</Button>
 								)}
 							/>
@@ -120,28 +122,28 @@ export function MenuList() {
 						<form onSubmit={handleCreate} className="space-y-4">
 							<div>
 								<Input
-									label="Name"
+									label={t`Name`}
 									name="name"
 									required
 									placeholder="primary"
 									pattern="[a-z0-9-]+"
-									title="Only lowercase letters, numbers, and hyphens"
+									title={t`Only lowercase letters, numbers, and hyphens`}
 								/>
 								<p className="text-sm text-kumo-subtle mt-1">
-									URL-friendly identifier (e.g., "primary", "footer")
+									{t`URL-friendly identifier (e.g., "primary", "footer")`}
 								</p>
 							</div>
 							<div>
-								<Input label="Label" name="label" required placeholder="Primary Navigation" />
-								<p className="text-sm text-kumo-subtle mt-1">Display name for admin interface</p>
+								<Input label={t`Label`} name="label" required placeholder="Primary Navigation" />
+								<p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p>
 							</div>
 							<DialogError message={createError || getMutationError(createMutation.error)} />
 							<div className="flex justify-end gap-2">
 								<Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}>
-									Cancel
+									{t`Cancel`}
 								</Button>
 								<Button type="submit" disabled={createMutation.isPending}>
-									{createMutation.isPending ? "Creating..." : "Create"}
+									{createMutation.isPending ? t`Creating...` : t`Create`}
 								</Button>
 							</div>
 						</form>
@@ -152,10 +154,10 @@ export function MenuList() {
 			{!menus || menus.length === 0 ? (
 				<div className="border rounded-lg p-12 text-center">
 					<ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" />
-					<h3 className="text-lg font-semibold mb-2">No menus yet</h3>
-					<p className="text-kumo-subtle mb-4">Create your first navigation menu to get started</p>
+					<h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3>
+					<p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p>
 					<Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}>
-						Create Menu
+						{t`Create Menu`}
 					</Button>
 				</div>
 			) : (
@@ -180,13 +182,13 @@ export function MenuList() {
 									className={buttonVariants({ variant: "outline", size: "sm" })}
 								>
 									<Pencil className="h-4 w-4 mr-2" />
-									Edit
+									{t`Edit`}
 								</Link>
 								<Button
 									variant="outline"
 									size="sm"
 									onClick={() => setDeleteMenuName(menu.name)}
-									aria-label={`Delete ${menu.name} menu`}
+									aria-label={t`Delete ${menu.name} menu`}
 								>
 									<Trash className="h-4 w-4" />
 								</Button>
@@ -202,10 +204,10 @@ export function MenuList() {
 					setDeleteMenuName(null);
 					deleteMutation.reset();
 				}}
-				title="Delete Menu"
-				description="Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				title={t`Delete Menu`}
+				description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`}
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={deleteMutation.isPending}
 				error={deleteMutation.error}
 				onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)}

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Badge, Button, Switch, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	PuzzlePiece,
 	Gear,
@@ -49,6 +50,7 @@ export interface PluginManagerProps {
 }
 
 export function PluginManager({ manifest }: PluginManagerProps) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
 	const hasMarketplace = !!manifest?.marketplace;
@@ -78,14 +80,14 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			toastManager.add({
-				title: "Plugin enabled",
-				description: `${plugin.name} is now active`,
+				title: t`Plugin enabled`,
+				description: t`${plugin.name} is now active`,
 			});
 		},
 		onError: (err) => {
 			toastManager.add({
-				title: "Failed to enable plugin",
-				description: err instanceof Error ? err.message : "An error occurred",
+				title: t`Failed to enable plugin`,
+				description: err instanceof Error ? err.message : t`An error occurred`,
 				type: "error",
 			});
 		},
@@ -97,14 +99,14 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			toastManager.add({
-				title: "Plugin disabled",
-				description: `${plugin.name} has been deactivated`,
+				title: t`Plugin disabled`,
+				description: t`${plugin.name} has been deactivated`,
 			});
 		},
 		onError: (err) => {
 			toastManager.add({
-				title: "Failed to disable plugin",
-				description: err instanceof Error ? err.message : "An error occurred",
+				title: t`Failed to disable plugin`,
+				description: err instanceof Error ? err.message : t`An error occurred`,
 				type: "error",
 			});
 		},
@@ -120,8 +122,8 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 	if (isLoading) {
 		return (
 			<div className="space-y-6">
-				<h1 className="text-3xl font-bold">Plugins</h1>
-				<div className="text-kumo-subtle">Loading plugins...</div>
+				<h1 className="text-3xl font-bold">{t`Plugins`}</h1>
+				<div className="text-kumo-subtle">{t`Loading plugins...`}</div>
 			</div>
 		);
 	}
@@ -129,8 +131,8 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 	if (error) {
 		return (
 			<div className="space-y-6">
-				<h1 className="text-3xl font-bold">Plugins</h1>
-				<div className="text-kumo-danger">Failed to load plugins: {error.message}</div>
+				<h1 className="text-3xl font-bold">{t`Plugins`}</h1>
+				<div className="text-kumo-danger">{t`Failed to load plugins: ${error.message}`}</div>
 			</div>
 		);
 	}
@@ -138,7 +140,7 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 	return (
 		<div className="space-y-6">
 			<div className="flex items-center justify-between">
-				<h1 className="text-3xl font-bold">Plugins</h1>
+				<h1 className="text-3xl font-bold">{t`Plugins`}</h1>
 				<div className="flex items-center gap-3">
 					{hasMarketplacePlugins && (
 						<Button
@@ -149,23 +151,23 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 							<ArrowsClockwise
 								className={cn("mr-2 h-4 w-4", isCheckingUpdates && "animate-spin")}
 							/>
-							Check for updates
+							{t`Check for updates`}
 						</Button>
 					)}
 					{hasMarketplace && (
 						<Link to="/plugins/marketplace">
 							<Button variant="ghost">
 								<Storefront className="mr-2 h-4 w-4" />
-								Marketplace
+								{t`Marketplace`}
 							</Button>
 						</Link>
 					)}
-					<span className="text-sm text-kumo-subtle">{plugins?.length ?? 0} plugins</span>
+					<span className="text-sm text-kumo-subtle">{t`${plugins?.length ?? 0} plugins`}</span>
 				</div>
 			</div>
 
 			<p className="text-kumo-subtle">
-				Manage installed plugins. Enable or disable plugins to control their functionality.
+				{t`Manage installed plugins. Enable or disable plugins to control their functionality.`}
 			</p>
 
 			<div className="grid gap-4">
@@ -185,18 +187,18 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 			{plugins?.length === 0 && (
 				<div className="rounded-lg border bg-kumo-base p-8 text-center">
 					<PuzzlePiece className="mx-auto h-12 w-12 text-kumo-subtle" />
-					<h3 className="mt-4 text-lg font-medium">No plugins configured</h3>
+					<h3 className="mt-4 text-lg font-medium">{t`No plugins configured`}</h3>
 					<p className="mt-2 text-sm text-kumo-subtle">
 						{hasMarketplace ? (
 							<>
-								Browse the{" "}
+								{t`Browse the`}{" "}
 								<Link to="/plugins/marketplace" className="text-kumo-brand hover:underline">
-									marketplace
+									{t`marketplace`}
 								</Link>{" "}
-								to install plugins, or add them to your astro.config.mjs.
+								{t`to install plugins, or add them to your astro.config.mjs.`}
 							</>
 						) : (
-							"Add plugins to your astro.config.mjs to extend EmDash functionality."
+							t`Add plugins to your astro.config.mjs to extend EmDash functionality.`
 						)}
 					</p>
 				</div>
@@ -223,6 +225,7 @@ function PluginCard({
 	isToggling,
 	hasMarketplace,
 }: PluginCardProps) {
+	const { t } = useLingui();
 	const [expanded, setExpanded] = React.useState(false);
 	const [showUpdateConsent, setShowUpdateConsent] = React.useState(false);
 	const [showUninstallConfirm, setShowUninstallConfirm] = React.useState(false);
@@ -240,8 +243,8 @@ function PluginCard({
 			void queryClient.invalidateQueries({ queryKey: ["plugin-updates"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			toastManager.add({
-				title: "Plugin updated",
-				description: `${plugin.name} updated to v${updateInfo?.latest}`,
+				title: t`Plugin updated`,
+				description: t`${plugin.name} updated to v${updateInfo?.latest}`,
 			});
 		},
 	});
@@ -253,8 +256,8 @@ function PluginCard({
 			void queryClient.invalidateQueries({ queryKey: ["plugins"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
 			toastManager.add({
-				title: "Plugin uninstalled",
-				description: `${plugin.name} has been removed`,
+				title: t`Plugin uninstalled`,
+				description: t`${plugin.name} has been removed`,
 			});
 		},
 	});
@@ -302,11 +305,11 @@ function PluginCard({
 						<div className="flex items-center gap-2">
 							<h3 className="font-semibold truncate">{plugin.name}</h3>
 							<span className="text-xs text-kumo-subtle">v{plugin.version}</span>
-							{!plugin.enabled && <Badge variant="secondary">Disabled</Badge>}
-							{isMarketplace && <Badge variant="secondary">Marketplace</Badge>}
+							{!plugin.enabled && <Badge variant="secondary">{t`Disabled`}</Badge>}
+							{isMarketplace && <Badge variant="secondary">{t`Marketplace`}</Badge>}
 							{hasUpdate && (
 								<Badge variant="outline" className="border-kumo-brand text-kumo-brand">
-									v{updateInfo.latest} available
+									{t`v${updateInfo.latest} available`}
 								</Badge>
 							)}
 						</div>
@@ -321,19 +324,19 @@ function PluginCard({
 							{plugin.hasAdminPages && (
 								<span className="flex items-center gap-1">
 									<FileText className="h-3 w-3" />
-									Pages
+									{t`Pages`}
 								</span>
 							)}
 							{plugin.hasDashboardWidgets && (
 								<span className="flex items-center gap-1">
 									<SquaresFour className="h-3 w-3" />
-									Widgets
+									{t`Widgets`}
 								</span>
 							)}
 							{plugin.hasHooks && (
 								<span className="flex items-center gap-1">
 									<WebhooksLogo className="h-3 w-3" />
-									Hooks
+									{t`Hooks`}
 								</span>
 							)}
 							{plugin.capabilities.length > 0 && (
@@ -342,8 +345,7 @@ function PluginCard({
 									title={plugin.capabilities.map((c) => CAPABILITY_LABELS[c] ?? c).join(", ")}
 								>
 									<ShieldCheck className="h-3 w-3" />
-									{plugin.capabilities.length} permission
-									{plugin.capabilities.length !== 1 ? "s" : ""}
+									{t`${plugin.capabilities.length} permission${plugin.capabilities.length !== 1 ? "s" : ""}`}
 								</span>
 							)}
 						</div>
@@ -358,7 +360,7 @@ function PluginCard({
 								onClick={() => setShowUpdateConsent(true)}
 								disabled={updateMutation.isPending}
 							>
-								{updateMutation.isPending ? "Updating..." : `Update to v${updateInfo.latest}`}
+								{updateMutation.isPending ? t`Updating...` : t`Update to v${updateInfo.latest}`}
 							</Button>
 						)}
 
@@ -366,16 +368,16 @@ function PluginCard({
 							<Link to="/plugins/marketplace/$pluginId" params={{ pluginId: plugin.id }}>
 								<Button variant="ghost" size="sm">
 									<Storefront className="mr-1.5 h-3.5 w-3.5" />
-									View in Marketplace
+									{t`View in Marketplace`}
 								</Button>
 							</Link>
 						)}
 
 						{plugin.hasAdminPages && plugin.enabled && (
 							<Link to="/plugins/$pluginId/$" params={{ pluginId: plugin.id, _splat: "settings" }}>
-								<Button variant="ghost" shape="square" aria-label="Settings">
+								<Button variant="ghost" shape="square" aria-label={t`Settings`}>
 									<Gear className="h-4 w-4" />
-									<span className="sr-only">Settings</span>
+									<span className="sr-only">{t`Settings`}</span>
 								</Button>
 							</Link>
 						)}
@@ -384,18 +386,20 @@ function PluginCard({
 							checked={plugin.enabled}
 							onCheckedChange={handleToggle}
 							disabled={isToggling}
-							aria-label={plugin.enabled ? "Disable plugin" : "Enable plugin"}
+							aria-label={plugin.enabled ? t`Disable plugin` : t`Enable plugin`}
 						/>
 
 						<Button
 							variant="ghost"
 							shape="square"
-							aria-label={expanded ? "Collapse details" : "Expand details"}
+							aria-label={expanded ? t`Collapse details` : t`Expand details`}
 							onClick={() => setExpanded(!expanded)}
 							aria-expanded={expanded}
 						>
 							{expanded ? <CaretDown className="h-4 w-4" /> : <CaretRight className="h-4 w-4" />}
-							<span className="sr-only">{expanded ? "Collapse" : "Expand"} details</span>
+							<span className="sr-only">
+								{expanded ? t`Collapse` : t`Expand`} {t`details`}
+							</span>
 						</Button>
 					</div>
 				</div>
@@ -407,7 +411,7 @@ function PluginCard({
 						{plugin.capabilities.length > 0 && (
 							<div>
 								<h4 className="text-xs font-medium text-kumo-subtle uppercase tracking-wider mb-1">
-									Capabilities
+									{t`Capabilities`}
 								</h4>
 								<div className="flex flex-wrap gap-1">
 									{plugin.capabilities.map((cap) => (
@@ -427,10 +431,10 @@ function PluginCard({
 						{isMarketplace && (
 							<div>
 								<h4 className="text-xs font-medium text-kumo-subtle uppercase tracking-wider mb-1">
-									Source
+									{t`Source`}
 								</h4>
 								<span className="text-xs text-kumo-subtle">
-									Installed from marketplace (v{plugin.marketplaceVersion || plugin.version})
+									{t`Installed from marketplace (v${plugin.marketplaceVersion || plugin.version})`}
 								</span>
 							</div>
 						)}
@@ -439,7 +443,7 @@ function PluginCard({
 						{plugin.package && (
 							<div>
 								<h4 className="text-xs font-medium text-kumo-subtle uppercase tracking-wider mb-1">
-									Package
+									{t`Package`}
 								</h4>
 								<code className="text-xs bg-kumo-tint px-2 py-0.5 rounded">{plugin.package}</code>
 							</div>
@@ -449,19 +453,19 @@ function PluginCard({
 						<div className="grid grid-cols-2 gap-4 text-xs">
 							{plugin.installedAt && (
 								<div>
-									<span className="text-kumo-subtle">Installed:</span>{" "}
+									<span className="text-kumo-subtle">{t`Installed:`}</span>{" "}
 									{new Date(plugin.installedAt).toLocaleDateString()}
 								</div>
 							)}
 							{plugin.activatedAt && (
 								<div>
-									<span className="text-kumo-subtle">Last enabled:</span>{" "}
+									<span className="text-kumo-subtle">{t`Last enabled:`}</span>{" "}
 									{new Date(plugin.activatedAt).toLocaleDateString()}
 								</div>
 							)}
 							{plugin.deactivatedAt && !plugin.enabled && (
 								<div>
-									<span className="text-kumo-subtle">Disabled:</span>{" "}
+									<span className="text-kumo-subtle">{t`Disabled:`}</span>{" "}
 									{new Date(plugin.deactivatedAt).toLocaleDateString()}
 								</div>
 							)}
@@ -477,7 +481,7 @@ function PluginCard({
 									disabled={uninstallMutation.isPending}
 								>
 									<Trash className="mr-2 h-4 w-4" />
-									Uninstall
+									{t`Uninstall`}
 								</Button>
 							</div>
 						)}
@@ -538,6 +542,7 @@ export function UninstallConfirmDialog({
 	onConfirm,
 	onCancel,
 }: UninstallConfirmDialogProps) {
+	const { t } = useLingui();
 	const [deleteData, setDeleteData] = React.useState(false);
 
 	return (
@@ -545,14 +550,14 @@ export function UninstallConfirmDialog({
 			className="fixed inset-0 z-50 flex items-center justify-center"
 			role="dialog"
 			aria-modal="true"
-			aria-label="Uninstall confirmation"
+			aria-label={t`Uninstall confirmation`}
 		>
 			<div className="absolute inset-0 bg-black/50" onClick={() => !isPending && onCancel()} />
 			<div className="relative w-full max-w-sm rounded-lg border bg-kumo-base shadow-lg">
 				<div className="p-6 space-y-4">
-					<h2 className="text-lg font-semibold">Uninstall {pluginName}?</h2>
+					<h2 className="text-lg font-semibold">{t`Uninstall ${pluginName}?`}</h2>
 					<p className="text-sm text-kumo-subtle">
-						This will remove the plugin and its bundle from your site.
+						{t`This will remove the plugin and its bundle from your site.`}
 					</p>
 					<label className="flex items-center gap-2 text-sm">
 						<input
@@ -561,16 +566,16 @@ export function UninstallConfirmDialog({
 							onChange={(e) => setDeleteData(e.target.checked)}
 							className="rounded border"
 						/>
-						Also delete plugin storage data
+						{t`Also delete plugin storage data`}
 					</label>
 					<DialogError message={error} />
 				</div>
 				<div className="flex justify-end gap-3 border-t px-6 py-4">
 					<Button variant="ghost" onClick={onCancel} disabled={isPending}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 					<Button variant="destructive" onClick={() => onConfirm(deleteData)} disabled={isPending}>
-						{isPending ? "Uninstalling..." : "Uninstall"}
+						{isPending ? t`Uninstalling...` : t`Uninstall`}
 					</Button>
 				</div>
 			</div>

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -1,4 +1,6 @@
 import { Badge, Button, Dialog, Input, Label, Switch } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowRight,
 	MagnifyingGlass,
@@ -46,6 +48,7 @@ function RedirectFormDialog({
 	/** Pre-fill source for create mode (e.g. from 404 list) */
 	defaultSource?: string;
 }) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const isEdit = !!redirect;
 
@@ -96,22 +99,22 @@ function RedirectFormDialog({
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<div>
 						<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-							{isEdit ? "Edit Redirect" : "New Redirect"}
+							{isEdit ? t`Edit Redirect` : t`New Redirect`}
 						</Dialog.Title>
 						<p className="text-sm text-kumo-subtle mt-1">
 							{isEdit
-								? "Update this redirect rule."
-								: "Use [param] or [...rest] in paths for pattern matching."}
+								? t`Update this redirect rule.`
+								: t`Use [param] or [...rest] in paths for pattern matching.`}
 						</p>
 					</div>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
@@ -122,7 +125,7 @@ function RedirectFormDialog({
 
 				<form onSubmit={handleSubmit} className="space-y-4">
 					<Input
-						label="Source path"
+						label={t`Source path`}
 						placeholder="/old-page or /blog/[slug]"
 						value={source}
 						onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSource(e.target.value)}
@@ -130,7 +133,7 @@ function RedirectFormDialog({
 					/>
 
 					<Input
-						label="Destination path"
+						label={t`Destination path`}
 						placeholder="/new-page or /articles/[slug]"
 						value={destination}
 						onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDestination(e.target.value)}
@@ -139,22 +142,22 @@ function RedirectFormDialog({
 
 					<div className="grid grid-cols-2 gap-4">
 						<div>
-							<Label htmlFor="redirect-type">Status code</Label>
+							<Label htmlFor="redirect-type">{t`Status code`}</Label>
 							<select
 								id="redirect-type"
 								value={type}
 								onChange={(e) => setType(e.target.value)}
 								className="flex h-10 w-full rounded-md border border-kumo-line bg-kumo-base px-3 py-2 text-sm"
 							>
-								<option value="301">301 Permanent</option>
-								<option value="302">302 Temporary</option>
-								<option value="307">307 Temporary (Strict)</option>
-								<option value="308">308 Permanent (Strict)</option>
+								<option value="301">{t`301 Permanent`}</option>
+								<option value="302">{t`302 Temporary`}</option>
+								<option value="307">{t`307 Temporary (Strict)`}</option>
+								<option value="308">{t`308 Permanent (Strict)`}</option>
 							</select>
 						</div>
 
 						<Input
-							label="Group (optional)"
+							label={t`Group (optional)`}
 							placeholder="e.g. import, blog"
 							value={groupName}
 							onChange={(e: React.ChangeEvent<HTMLInputElement>) => setGroupName(e.target.value)}
@@ -163,23 +166,23 @@ function RedirectFormDialog({
 
 					<div className="flex items-center gap-2">
 						<Switch checked={enabled} onCheckedChange={setEnabled} id="redirect-enabled" />
-						<Label htmlFor="redirect-enabled">Enabled</Label>
+						<Label htmlFor="redirect-enabled">{t`Enabled`}</Label>
 					</div>
 
 					<DialogError message={getMutationError(mutation.error)} />
 
 					<div className="flex justify-end gap-2">
 						<Button type="button" variant="outline" onClick={onClose}>
-							Cancel
+							{t`Cancel`}
 						</Button>
 						<Button type="submit" disabled={mutation.isPending}>
 							{mutation.isPending
 								? isEdit
-									? "Saving..."
-									: "Creating..."
+									? t`Saving...`
+									: t`Creating...`
 								: isEdit
-									? "Save"
-									: "Create"}
+									? t`Save`
+									: t`Create`}
 						</Button>
 					</div>
 				</form>
@@ -199,16 +202,20 @@ function NotFoundPanel({
 	items: NotFoundSummary[];
 	onCreateRedirect: (path: string) => void;
 }) {
+	const { t } = useLingui();
+
 	if (items.length === 0) {
-		return <p className="text-sm text-kumo-subtle py-4 text-center">No 404 errors recorded yet.</p>;
+		return (
+			<p className="text-sm text-kumo-subtle py-4 text-center">{t`No 404 errors recorded yet.`}</p>
+		);
 	}
 
 	return (
 		<div className="border rounded-lg">
 			<div className="flex items-center gap-4 py-2 px-4 border-b bg-kumo-tint/50 text-sm font-medium text-kumo-subtle">
-				<div className="flex-1">Path</div>
-				<div className="w-16 text-right">Hits</div>
-				<div className="w-32">Last seen</div>
+				<div className="flex-1">{t`Path`}</div>
+				<div className="w-16 text-right">{t`Hits`}</div>
+				<div className="w-32">{t`Last seen`}</div>
 				<div className="w-8" />
 			</div>
 			{items.map((item) => (
@@ -228,8 +235,8 @@ function NotFoundPanel({
 						<button
 							onClick={() => onCreateRedirect(item.path)}
 							className="text-kumo-subtle hover:text-kumo-default"
-							title="Create redirect for this path"
-							aria-label={`Create redirect for ${item.path}`}
+							title={t`Create redirect for this path`}
+							aria-label={t`Create redirect for ${item.path}`}
 						>
 							<ArrowsLeftRight size={14} />
 						</button>
@@ -247,6 +254,7 @@ function NotFoundPanel({
 type TabKey = "redirects" | "404s";
 
 export function Redirects() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [tab, setTab] = useState<TabKey>("redirects");
 	const [search, setSearch] = useState("");
@@ -322,11 +330,11 @@ export function Redirects() {
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-3xl font-bold">Redirects</h1>
-					<p className="text-kumo-subtle">Manage URL redirects and view 404 errors.</p>
+					<h1 className="text-3xl font-bold">{t`Redirects`}</h1>
+					<p className="text-kumo-subtle">{t`Manage URL redirects and view 404 errors.`}</p>
 				</div>
 				<Button icon={<Plus />} onClick={() => setShowCreate(true)}>
-					New Redirect
+					{t`New Redirect`}
 				</Button>
 			</div>
 
@@ -341,7 +349,7 @@ export function Redirects() {
 							: "border-transparent text-kumo-subtle hover:text-kumo-default",
 					)}
 				>
-					Redirects
+					{t`Redirects`}
 					{redirectsQuery.data && (
 						<Badge variant="secondary" className="ml-2">
 							{redirectsQuery.data.items.length}
@@ -358,7 +366,7 @@ export function Redirects() {
 							: "border-transparent text-kumo-subtle hover:text-kumo-default",
 					)}
 				>
-					404 Errors
+					{t`404 Errors`}
 				</button>
 			</div>
 
@@ -373,7 +381,7 @@ export function Redirects() {
 								size={16}
 							/>
 							<Input
-								placeholder="Search source or destination..."
+								placeholder={t`Search source or destination...`}
 								className="pl-10"
 								value={search}
 								onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
@@ -384,18 +392,18 @@ export function Redirects() {
 							onChange={(e) => setFilterEnabled(e.target.value)}
 							className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 text-sm"
 						>
-							<option value="all">All statuses</option>
-							<option value="true">Enabled</option>
-							<option value="false">Disabled</option>
+							<option value="all">{t`All statuses`}</option>
+							<option value="true">{t`Enabled`}</option>
+							<option value="false">{t`Disabled`}</option>
 						</select>
 						<select
 							value={filterAuto}
 							onChange={(e) => setFilterAuto(e.target.value)}
 							className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 text-sm"
 						>
-							<option value="all">All types</option>
-							<option value="false">Manual</option>
-							<option value="true">Auto (slug change)</option>
+							<option value="all">{t`All types`}</option>
+							<option value="false">{t`Manual`}</option>
+							<option value="true">{t`Auto (slug change)`}</option>
 						</select>
 					</div>
 
@@ -412,11 +420,13 @@ export function Redirects() {
 								aria-hidden="true"
 							/>
 							<div>
-								<p className="text-sm font-medium text-kumo-warning">Redirect loop detected</p>
+								<p className="text-sm font-medium text-kumo-warning">{t`Redirect loop detected`}</p>
 								<p className="mt-1 text-sm text-kumo-subtle">
-									{loopRedirectIds.size}{" "}
-									{loopRedirectIds.size === 1 ? "redirect is" : "redirects are"} part of a loop.
-									Visitors hitting these paths will see an error.
+									{plural(loopRedirectIds.size, {
+										one: "# redirect is part of a loop.",
+										other: "# redirects are part of a loop.",
+									})}{" "}
+									{t`Visitors hitting these paths will see an error.`}
 								</p>
 							</div>
 						</div>
@@ -424,22 +434,22 @@ export function Redirects() {
 
 					{/* Redirect list */}
 					{redirectsQuery.isLoading ? (
-						<div className="py-12 text-center text-kumo-subtle">Loading redirects...</div>
+						<div className="py-12 text-center text-kumo-subtle">{t`Loading redirects...`}</div>
 					) : redirects.length === 0 ? (
 						<div className="py-12 text-center text-kumo-subtle">
 							<ArrowsLeftRight size={48} className="mx-auto mb-4 opacity-30" />
-							<p className="text-lg font-medium">No redirects yet</p>
-							<p className="text-sm mt-1">Create redirect rules to manage URL changes.</p>
+							<p className="text-lg font-medium">{t`No redirects yet`}</p>
+							<p className="text-sm mt-1">{t`Create redirect rules to manage URL changes.`}</p>
 						</div>
 					) : (
 						<div className="border rounded-lg">
 							<div className="flex items-center gap-4 py-2 px-4 border-b bg-kumo-tint/50 text-sm font-medium text-kumo-subtle">
-								<div className="flex-1">Source</div>
+								<div className="flex-1">{t`Source`}</div>
 								<div className="w-8 text-center" />
-								<div className="flex-1">Destination</div>
-								<div className="w-14 text-center">Code</div>
-								<div className="w-16 text-right">Hits</div>
-								<div className="w-20 text-center">Status</div>
+								<div className="flex-1">{t`Destination`}</div>
+								<div className="w-14 text-center">{t`Code`}</div>
+								<div className="w-16 text-right">{t`Hits`}</div>
+								<div className="w-20 text-center">{t`Status`}</div>
 								<div className="w-20" />
 							</div>
 							{redirects.map((r) => (
@@ -472,39 +482,39 @@ export function Redirects() {
 													enabled: checked,
 												})
 											}
-											aria-label={r.enabled ? "Disable redirect" : "Enable redirect"}
+											aria-label={r.enabled ? t`Disable redirect` : t`Enable redirect`}
 										/>
 									</div>
 									<div className="w-20 flex items-center justify-end gap-1">
 										{loopRedirectIds.has(r.id) && (
-											<span title="Part of a redirect loop" className="mr-1 inline-flex">
+											<span title={t`Part of a redirect loop`} className="mr-1 inline-flex">
 												<WarningCircle
 													size={14}
 													weight="fill"
 													className="text-kumo-warning"
 													role="img"
-													aria-label="Part of a redirect loop"
+													aria-label={t`Part of a redirect loop`}
 												/>
 											</span>
 										)}
 										{r.auto && (
 											<Badge variant="outline" className="mr-1 text-xs">
-												auto
+												{t`auto`}
 											</Badge>
 										)}
 										<button
 											onClick={() => setEditRedirect(r)}
 											className="p-1 text-kumo-subtle hover:text-kumo-default"
-											title="Edit redirect"
-											aria-label={`Edit redirect ${r.source}`}
+											title={t`Edit redirect`}
+											aria-label={t`Edit redirect ${r.source}`}
 										>
 											<PencilSimple size={14} />
 										</button>
 										<button
 											onClick={() => setDeleteId(r.id)}
 											className="p-1 text-kumo-subtle hover:text-kumo-danger"
-											title="Delete redirect"
-											aria-label={`Delete redirect ${r.source}`}
+											title={t`Delete redirect`}
+											aria-label={t`Delete redirect ${r.source}`}
 										>
 											<Trash size={14} />
 										</button>
@@ -544,10 +554,10 @@ export function Redirects() {
 					setDeleteId(null);
 					deleteMutation.reset();
 				}}
-				title="Delete Redirect?"
-				description="This redirect rule will be permanently removed."
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				title={t`Delete Redirect?`}
+				description={t`This redirect rule will be permanently removed.`}
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={deleteMutation.isPending}
 				error={deleteMutation.error}
 				onConfirm={() => deleteId && deleteMutation.mutate(deleteId)}

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -15,6 +15,7 @@ import {
 	arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, Trash, DotsSixVertical, CaretDown, CaretRight } from "@phosphor-icons/react";
 import * as React from "react";
@@ -127,7 +128,7 @@ export function RepeaterField({
 					{label}
 					{items.length > 0 && (
 						<span className="ml-2 text-kumo-subtle font-normal">
-							({items.length} {t`items`})
+							{plural(items.length, { one: "(# item)", other: "(# items)" })}
 						</span>
 					)}
 				</label>

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -15,6 +15,7 @@ import {
 	arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useLingui } from "@lingui/react/macro";
 import { Plus, Trash, DotsSixVertical, CaretDown, CaretRight } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -61,6 +62,7 @@ export function RepeaterField({
 	minItems = 0,
 	maxItems,
 }: RepeaterFieldProps) {
+	const { t } = useLingui();
 	const rawItems = Array.isArray(value) ? value : [];
 	const [items, setItems] = React.useState<RepeaterItem[]>(() => ensureKeys(rawItems));
 	const [collapsedItems, setCollapsedItems] = React.useState<Set<string>>(new Set());
@@ -124,19 +126,21 @@ export function RepeaterField({
 				<label htmlFor={id} className="text-sm font-medium">
 					{label}
 					{items.length > 0 && (
-						<span className="ml-2 text-kumo-subtle font-normal">({items.length} items)</span>
+						<span className="ml-2 text-kumo-subtle font-normal">
+							({items.length} {t`items`})
+						</span>
 					)}
 				</label>
 				{canAdd && (
 					<Button variant="outline" size="sm" icon={<Plus />} onClick={handleAdd}>
-						Add Item
+						{t`Add Item`}
 					</Button>
 				)}
 			</div>
 
 			{items.length === 0 ? (
 				<div className="border-2 border-dashed rounded-lg p-6 text-center text-kumo-subtle">
-					<p className="text-sm">No items yet</p>
+					<p className="text-sm">{t`No items yet`}</p>
 					{canAdd && (
 						<Button
 							variant="outline"
@@ -145,7 +149,7 @@ export function RepeaterField({
 							icon={<Plus />}
 							onClick={handleAdd}
 						>
-							Add First Item
+							{t`Add First Item`}
 						</Button>
 					)}
 				</div>
@@ -197,6 +201,7 @@ function SortableRepeaterItem({
 	onRemove,
 	onChange,
 }: SortableRepeaterItemProps) {
+	const { t } = useLingui();
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
 		id: item._key,
 	});
@@ -209,7 +214,7 @@ function SortableRepeaterItem({
 	// Use the first text sub-field as the item summary label
 	const summaryField = subFields.find((sf) => sf.type === "string" || sf.type === "text");
 	const summaryValue = summaryField ? (item[summaryField.slug] as string) || "" : "";
-	const summaryLabel = summaryValue || `Item ${index + 1}`;
+	const summaryLabel = summaryValue || t`Item ${index + 1}`;
 
 	return (
 		<div
@@ -245,7 +250,7 @@ function SortableRepeaterItem({
 							e.stopPropagation();
 							onRemove();
 						}}
-						aria-label={`Remove item ${index + 1}`}
+						aria-label={t`Remove item ${index + 1}`}
 					>
 						<Trash className="h-3.5 w-3.5 text-kumo-danger" />
 					</Button>
@@ -276,6 +281,7 @@ interface SubFieldInputProps {
 }
 
 function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
+	const { t } = useLingui();
 	switch (subField.type) {
 		case "string":
 			return (
@@ -339,7 +345,7 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 						onChange={(e) => onChange(e.target.value)}
 						required={subField.required}
 					>
-						<option value="">Select...</option>
+						<option value="">{t`Select...`}</option>
 						{subField.options?.map((opt) => (
 							<option key={opt} value={opt}>
 								{opt}

--- a/packages/admin/src/components/RevisionHistory.tsx
+++ b/packages/admin/src/components/RevisionHistory.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, Loader, Toast } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	ClockCounterClockwise,
@@ -333,7 +334,10 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 		<div className="space-y-2">
 			<div className="flex items-center justify-between">
 				<div className="text-xs font-medium text-kumo-subtle">
-					{t`${changedCount} change${changedCount === 1 ? "" : "s"} from next revision`}
+					{plural(changedCount, {
+						one: "# change from next revision",
+						other: "# changes from next revision",
+					})}
 				</div>
 				{unchangedCount > 0 && (
 					<button
@@ -341,7 +345,9 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 						onClick={() => setShowUnchanged(!showUnchanged)}
 						className="text-xs text-kumo-brand hover:underline"
 					>
-						{showUnchanged ? t`Hide` : t`Show`} {unchangedCount} {t`unchanged`}
+						{showUnchanged
+							? plural(unchangedCount, { one: "Hide # unchanged", other: "Hide # unchanged" })
+							: plural(unchangedCount, { one: "Show # unchanged", other: "Show # unchanged" })}
 					</button>
 				)}
 			</div>

--- a/packages/admin/src/components/RevisionHistory.tsx
+++ b/packages/admin/src/components/RevisionHistory.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, Loader, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ClockCounterClockwise,
 	ArrowCounterClockwise,
@@ -98,6 +99,7 @@ function formatFullDate(dateString: string): string {
  * with ability to restore previous versions.
  */
 export function RevisionHistory({ collection, entryId, onRestored }: RevisionHistoryProps) {
+	const { t } = useLingui();
 	const [isExpanded, setIsExpanded] = React.useState(false);
 	const [selectedRevision, setSelectedRevision] = React.useState<Revision | null>(null);
 	const [restoreTarget, setRestoreTarget] = React.useState<Revision | null>(null);
@@ -124,13 +126,13 @@ export function RevisionHistory({ collection, entryId, onRestored }: RevisionHis
 			setRestoreTarget(null);
 			onRestored?.();
 			toastManager.add({
-				title: "Revision restored",
-				description: "Content has been updated to the selected revision.",
+				title: t`Revision restored`,
+				description: t`Content has been updated to the selected revision.`,
 			});
 		},
 		onError: (err: Error) => {
 			toastManager.add({
-				title: "Restore failed",
+				title: t`Restore failed`,
 				description: err.message,
 				type: "error",
 			});
@@ -155,7 +157,7 @@ export function RevisionHistory({ collection, entryId, onRestored }: RevisionHis
 				>
 					<div className="flex items-center gap-2">
 						<ClockCounterClockwise className="h-4 w-4 text-kumo-subtle" />
-						<span className="font-semibold">Revisions</span>
+						<span className="font-semibold">{t`Revisions`}</span>
 						{total > 0 && <span className="text-xs text-kumo-subtle">({total})</span>}
 					</div>
 					{isExpanded ? (
@@ -174,10 +176,10 @@ export function RevisionHistory({ collection, entryId, onRestored }: RevisionHis
 							</div>
 						) : error ? (
 							<div className="py-4 text-center text-sm text-kumo-danger">
-								Failed to load revisions
+								{t`Failed to load revisions`}
 							</div>
 						) : revisions.length === 0 ? (
-							<div className="py-4 text-center text-sm text-kumo-subtle">No revisions yet</div>
+							<div className="py-4 text-center text-sm text-kumo-subtle">{t`No revisions yet`}</div>
 						) : (
 							<div className="space-y-1 pt-2">
 								{revisions.map((revision, index) => (
@@ -208,14 +210,14 @@ export function RevisionHistory({ collection, entryId, onRestored }: RevisionHis
 					setRestoreTarget(null);
 					restoreMutation.reset();
 				}}
-				title="Restore Revision?"
+				title={t`Restore Revision?`}
 				description={
 					restoreTarget
-						? `Restore this version from ${formatFullDate(restoreTarget.createdAt)}? This will update the current content to this revision's data.`
+						? t`Restore this version from ${formatFullDate(restoreTarget.createdAt)}? This will update the current content to this revision's data.`
 						: ""
 				}
-				confirmLabel="Restore"
-				pendingLabel="Restoring..."
+				confirmLabel={t`Restore`}
+				pendingLabel={t`Restoring...`}
 				variant="primary"
 				isPending={restoreMutation.isPending}
 				error={restoreMutation.error}
@@ -247,6 +249,7 @@ function RevisionItem({
 	onRestore,
 	onSelect,
 }: RevisionItemProps) {
+	const { t } = useLingui();
 	return (
 		<div
 			className={`rounded-md border p-3 transition-colors ${
@@ -257,7 +260,7 @@ function RevisionItem({
 				<button type="button" onClick={onSelect} className="flex-1 text-left">
 					<div className="flex items-center gap-2">
 						<span className="text-sm font-medium">{formatRelativeTime(revision.createdAt)}</span>
-						{isLatest && <Badge variant="outline">Current</Badge>}
+						{isLatest && <Badge variant="outline">{t`Current`}</Badge>}
 					</div>
 					<div className="text-xs text-kumo-subtle mt-0.5">
 						{formatFullDate(revision.createdAt)}
@@ -274,8 +277,8 @@ function RevisionItem({
 						}}
 						disabled={isRestoring}
 						className="shrink-0"
-						title="Restore this version"
-						aria-label="Restore this version"
+						title={t`Restore this version`}
+						aria-label={t`Restore this version`}
 					>
 						{isRestoring ? <Loader size="sm" /> : <ArrowCounterClockwise className="h-4 w-4" />}
 					</Button>
@@ -289,7 +292,7 @@ function RevisionItem({
 						<RevisionDiffView older={revision.data} newer={compareRevision.data} />
 					) : (
 						<>
-							<div className="text-xs font-medium text-kumo-subtle mb-2">Content snapshot:</div>
+							<div className="text-xs font-medium text-kumo-subtle mb-2">{t`Content snapshot:`}</div>
 							<pre className="text-xs bg-kumo-tint p-2 rounded overflow-auto max-h-48">
 								{JSON.stringify(revision.data, null, 2)}
 							</pre>
@@ -311,6 +314,7 @@ interface RevisionDiffViewProps {
 }
 
 function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
+	const { t } = useLingui();
 	const [showUnchanged, setShowUnchanged] = React.useState(false);
 	const diffs = React.useMemo(() => computeFieldDiff(older, newer), [older, newer]);
 
@@ -318,7 +322,9 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 	const unchangedCount = diffs.length - changedCount;
 
 	if (diffs.length === 0) {
-		return <div className="text-xs text-kumo-subtle text-center py-2">No fields to compare</div>;
+		return (
+			<div className="text-xs text-kumo-subtle text-center py-2">{t`No fields to compare`}</div>
+		);
 	}
 
 	const visibleDiffs = showUnchanged ? diffs : diffs.filter((d) => d.kind !== "unchanged");
@@ -327,7 +333,7 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 		<div className="space-y-2">
 			<div className="flex items-center justify-between">
 				<div className="text-xs font-medium text-kumo-subtle">
-					{changedCount} change{changedCount === 1 ? "" : "s"} from next revision
+					{t`${changedCount} change${changedCount === 1 ? "" : "s"} from next revision`}
 				</div>
 				{unchangedCount > 0 && (
 					<button
@@ -335,7 +341,7 @@ function RevisionDiffView({ older, newer }: RevisionDiffViewProps) {
 						onClick={() => setShowUnchanged(!showUnchanged)}
 						className="text-xs text-kumo-brand hover:underline"
 					>
-						{showUnchanged ? "Hide" : "Show"} {unchangedCount} unchanged
+						{showUnchanged ? t`Hide` : t`Show`} {unchangedCount} {t`unchanged`}
 					</button>
 				)}
 			</div>

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { ArrowLeft } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
@@ -16,6 +17,7 @@ import { PortableTextEditor } from "./PortableTextEditor";
 import { SaveButton } from "./SaveButton";
 
 export function SectionEditor() {
+	const { t } = useLingui();
 	const { slug } = useParams({ from: "/_admin/sections/$slug" });
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
@@ -36,7 +38,7 @@ export function SectionEditor() {
 		onSuccess: (updated) => {
 			void queryClient.invalidateQueries({ queryKey: ["sections"] });
 			void queryClient.invalidateQueries({ queryKey: ["sections", slug] });
-			toastManager.add({ title: "Section saved" });
+			toastManager.add({ title: t`Section saved` });
 			// If slug changed, navigate to new URL
 			if (updated.slug !== slug) {
 				void navigate({ to: "/sections/$slug", params: { slug: updated.slug } });
@@ -44,7 +46,7 @@ export function SectionEditor() {
 		},
 		onError: (mutationError: Error) => {
 			toastManager.add({
-				title: "Error saving section",
+				title: t`Error saving section`,
 				description: mutationError.message,
 				type: "error",
 			});
@@ -64,15 +66,15 @@ export function SectionEditor() {
 			<div className="space-y-6">
 				<div className="flex items-center gap-4">
 					<Link to="/sections">
-						<Button variant="ghost" shape="square" aria-label="Back to sections">
+						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
 							<ArrowLeft className="h-5 w-5" />
 						</Button>
 					</Link>
-					<h1 className="text-2xl font-bold">Section Not Found</h1>
+					<h1 className="text-2xl font-bold">{t`Section Not Found`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
 					<p className="text-kumo-subtle">
-						{error ? error.message : `Section "${slug}" could not be found.`}
+						{error ? error.message : t`Section "${slug}" could not be found.`}
 					</p>
 				</div>
 			</div>
@@ -96,6 +98,7 @@ interface SectionEditorFormProps {
 }
 
 function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps) {
+	const { t } = useLingui();
 	const [title, setTitle] = React.useState(section.title);
 	const [sectionSlug, setSectionSlug] = React.useState(section.slug);
 	const [slugTouched, setSlugTouched] = React.useState(true); // Existing sections have touched slugs
@@ -148,14 +151,14 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 			<div className="flex items-center justify-between">
 				<div className="flex items-center gap-4">
 					<Link to="/sections">
-						<Button variant="ghost" shape="square" aria-label="Back to sections">
+						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
 							<ArrowLeft className="h-5 w-5" />
 						</Button>
 					</Link>
 					<div>
 						<h1 className="text-2xl font-bold">{section.title}</h1>
 						<p className="text-sm text-kumo-subtle">
-							{section.source === "theme" ? "Theme Section" : "Custom Section"} &middot;{" "}
+							{section.source === "theme" ? t`Theme Section` : t`Custom Section`} &middot;{" "}
 							{section.slug}
 						</p>
 					</div>
@@ -168,7 +171,7 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 				<div className="col-span-8 space-y-6">
 					{/* Content editor */}
 					<div className="rounded-lg border bg-kumo-base p-6">
-						<Label className="text-lg font-semibold mb-4 block">Content</Label>
+						<Label className="text-lg font-semibold mb-4 block">{t`Content`}</Label>
 						<PortableTextEditor
 							value={content as Parameters<typeof PortableTextEditor>[0]["value"]}
 							onChange={(value) => setContent(value as unknown[])}
@@ -180,18 +183,18 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 				<div className="col-span-4 space-y-6">
 					{/* Metadata */}
 					<div className="rounded-lg border bg-kumo-base p-6 space-y-4">
-						<h2 className="text-lg font-semibold">Section Details</h2>
+						<h2 className="text-lg font-semibold">{t`Section Details`}</h2>
 
 						<Input
-							label="Title"
+							label={t`Title`}
 							value={title}
 							onChange={(e) => setTitle(e.target.value)}
-							placeholder="Section title"
+							placeholder={t`Section title`}
 						/>
 
 						<div>
 							<Input
-								label="Slug"
+								label={t`Slug`}
 								value={sectionSlug}
 								onChange={(e) => {
 									setSectionSlug(e.target.value);
@@ -201,44 +204,45 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 								pattern="[a-z0-9-]+"
 							/>
 							<p className="text-xs text-kumo-subtle mt-1">
-								Used to identify this section. Lowercase letters, numbers, and hyphens only.
+								{t`Used to identify this section. Lowercase letters, numbers, and hyphens only.`}
 							</p>
 						</div>
 
 						<InputArea
-							label="Description"
+							label={t`Description`}
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
-							placeholder="Describe what this section is for..."
+							placeholder={t`Describe what this section is for...`}
 							rows={3}
 						/>
 
 						<div>
 							<Input
-								label="Keywords"
+								label={t`Keywords`}
 								value={keywords}
 								onChange={(e) => setKeywords(e.target.value)}
 								placeholder="hero, banner, cta"
 							/>
-							<p className="text-xs text-kumo-subtle mt-1">Comma-separated keywords for search.</p>
+							<p className="text-xs text-kumo-subtle mt-1">{t`Comma-separated keywords for search.`}</p>
 						</div>
 					</div>
 
 					{/* Source info */}
 					<div className="rounded-lg border bg-kumo-base p-6">
-						<h2 className="text-lg font-semibold mb-2">Source</h2>
+						<h2 className="text-lg font-semibold mb-2">{t`Source`}</h2>
 						<p className="text-sm text-kumo-subtle">
 							{section.source === "theme" && (
 								<>
-									This section is provided by the theme. Editing will create a custom copy that
-									overrides the theme version.
+									{t`This section is provided by the theme. Editing will create a custom copy that overrides the theme version.`}
 								</>
 							)}
-							{section.source === "user" && <>This is a custom section.</>}
-							{section.source === "import" && <>This section was imported from another system.</>}
+							{section.source === "user" && <>{t`This is a custom section.`}</>}
+							{section.source === "import" && (
+								<>{t`This section was imported from another system.`}</>
+							)}
 						</p>
 						{section.themeId && (
-							<p className="text-xs text-kumo-subtle mt-2">Theme ID: {section.themeId}</p>
+							<p className="text-xs text-kumo-subtle mt-2">{t`Theme ID: ${section.themeId}`}</p>
 						)}
 					</div>
 				</div>

--- a/packages/admin/src/components/SectionPickerModal.tsx
+++ b/packages/admin/src/components/SectionPickerModal.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Dialog, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { MagnifyingGlass, Stack, FolderOpen } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -21,6 +22,7 @@ interface SectionPickerModalProps {
 }
 
 export function SectionPickerModal({ open, onOpenChange, onSelect }: SectionPickerModalProps) {
+	const { t } = useLingui();
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const debouncedSearch = useDebouncedValue(searchQuery, 300);
 
@@ -52,20 +54,20 @@ export function SectionPickerModal({ open, onOpenChange, onSelect }: SectionPick
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight flex items-center gap-2">
 						<Stack className="h-5 w-5" />
-						Insert Section
+						{t`Insert Section`}
 					</Dialog.Title>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
-								<span className="sr-only">Close</span>
+								<span className="sr-only">{t`Close`}</span>
 							</Button>
 						)}
 					/>
@@ -76,7 +78,7 @@ export function SectionPickerModal({ open, onOpenChange, onSelect }: SectionPick
 					<div className="relative flex-1">
 						<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 						<Input
-							placeholder="Search sections..."
+							placeholder={t`Search sections...`}
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 							className="pl-10"
@@ -89,22 +91,22 @@ export function SectionPickerModal({ open, onOpenChange, onSelect }: SectionPick
 				<div className="flex-1 overflow-y-auto py-4">
 					{sectionsLoading ? (
 						<div className="flex items-center justify-center h-32">
-							<div className="text-kumo-subtle">Loading sections...</div>
+							<div className="text-kumo-subtle">{t`Loading sections...`}</div>
 						</div>
 					) : sections.length === 0 ? (
 						<div className="flex flex-col items-center justify-center h-32 text-center">
 							{searchQuery ? (
 								<>
 									<MagnifyingGlass className="h-8 w-8 text-kumo-subtle mb-2" />
-									<p className="text-kumo-subtle">No sections found</p>
-									<p className="text-sm text-kumo-subtle">Try adjusting your search</p>
+									<p className="text-kumo-subtle">{t`No sections found`}</p>
+									<p className="text-sm text-kumo-subtle">{t`Try adjusting your search`}</p>
 								</>
 							) : (
 								<>
 									<FolderOpen className="h-8 w-8 text-kumo-subtle mb-2" />
-									<p className="text-kumo-subtle">No sections available</p>
+									<p className="text-kumo-subtle">{t`No sections available`}</p>
 									<p className="text-sm text-kumo-subtle">
-										Create sections in the Sections library to use them here
+										{t`Create sections in the Sections library to use them here`}
 									</p>
 								</>
 							)}
@@ -125,7 +127,7 @@ export function SectionPickerModal({ open, onOpenChange, onSelect }: SectionPick
 				{/* Footer */}
 				<div className="flex justify-end gap-2 pt-4 border-t">
 					<Button variant="outline" onClick={() => onOpenChange(false)}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 				</div>
 			</Dialog>

--- a/packages/admin/src/components/Sections.tsx
+++ b/packages/admin/src/components/Sections.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Dialog, Input, InputArea, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	Plus,
 	MagnifyingGlass,
@@ -45,6 +46,7 @@ const sourceLabels: Record<SectionSource, string> = {
 };
 
 export function Sections() {
+	const { t } = useLingui();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
@@ -86,7 +88,7 @@ export function Sections() {
 		onSuccess: (section) => {
 			void queryClient.invalidateQueries({ queryKey: ["sections"] });
 			setIsCreateOpen(false);
-			toastManager.add({ title: "Section created" });
+			toastManager.add({ title: t`Section created` });
 			// Navigate to edit the new section
 			void navigate({ to: "/sections/$slug", params: { slug: section.slug } });
 		},
@@ -100,7 +102,7 @@ export function Sections() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["sections"] });
 			setDeleteSlug(null);
-			toastManager.add({ title: "Section deleted" });
+			toastManager.add({ title: t`Section deleted` });
 		},
 	});
 
@@ -117,7 +119,7 @@ export function Sections() {
 
 	const handleCopySlug = (slug: string) => {
 		void navigator.clipboard.writeText(slug);
-		toastManager.add({ title: "Slug copied to clipboard" });
+		toastManager.add({ title: t`Slug copied to clipboard` });
 	};
 
 	const sectionToDelete = sections.find((s) => s.slug === deleteSlug);
@@ -127,43 +129,43 @@ export function Sections() {
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<h1 className="text-3xl font-bold">Sections</h1>
+					<h1 className="text-3xl font-bold">{t`Sections`}</h1>
 					<p className="text-kumo-subtle">
-						Reusable content blocks you can insert into any content
+						{t`Reusable content blocks you can insert into any content`}
 					</p>
 				</div>
 				<Dialog.Root open={isCreateOpen} onOpenChange={setIsCreateOpen}>
 					<Dialog.Trigger
 						render={(props) => (
 							<Button {...props} icon={<Plus />}>
-								New Section
+								{t`New Section`}
 							</Button>
 						)}
 					/>
 					<Dialog className="p-6" size="lg">
 						<div className="flex items-start justify-between gap-4 mb-4">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								Create Section
+								{t`Create Section`}
 							</Dialog.Title>
 							<Dialog.Close
-								aria-label="Close"
+								aria-label={t`Close`}
 								render={(props) => (
 									<Button
 										{...props}
 										variant="ghost"
 										shape="square"
-										aria-label="Close"
+										aria-label={t`Close`}
 										className="absolute right-4 top-4"
 									>
 										<X className="h-4 w-4" />
-										<span className="sr-only">Close</span>
+										<span className="sr-only">{t`Close`}</span>
 									</Button>
 								)}
 							/>
 						</div>
 						<form onSubmit={handleCreate} className="space-y-4">
 							<Input
-								label="Title"
+								label={t`Title`}
 								value={createTitle}
 								onChange={(e) => {
 									const title = e.target.value;
@@ -177,7 +179,7 @@ export function Sections() {
 							/>
 							<div>
 								<Input
-									label="Slug"
+									label={t`Slug`}
 									value={createSlug}
 									onChange={(e) => {
 										setCreateSlug(e.target.value);
@@ -186,14 +188,14 @@ export function Sections() {
 									required
 									placeholder="hero-banner"
 									pattern="[a-z0-9-]+"
-									title="Lowercase letters, numbers, and hyphens only"
+									title={t`Lowercase letters, numbers, and hyphens only`}
 								/>
 								<p className="text-xs text-kumo-subtle mt-1">
-									Used to identify this section. Lowercase letters, numbers, and hyphens only.
+									{t`Used to identify this section. Lowercase letters, numbers, and hyphens only.`}
 								</p>
 							</div>
 							<InputArea
-								label="Description"
+								label={t`Description`}
 								value={createDescription}
 								onChange={(e) => setCreateDescription(e.target.value)}
 								placeholder="A full-width hero banner with heading, text, and CTA button"
@@ -202,10 +204,10 @@ export function Sections() {
 							<DialogError message={createError || getMutationError(createMutation.error)} />
 							<div className="flex justify-end gap-2">
 								<Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}>
-									Cancel
+									{t`Cancel`}
 								</Button>
 								<Button type="submit" disabled={createMutation.isPending}>
-									{createMutation.isPending ? "Creating..." : "Create"}
+									{createMutation.isPending ? t`Creating...` : t`Create`}
 								</Button>
 							</div>
 						</form>
@@ -219,7 +221,7 @@ export function Sections() {
 				<div className="relative flex-1 max-w-md">
 					<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 					<Input
-						placeholder="Search sections..."
+						placeholder={t`Search sections...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						className="pl-10"
@@ -235,35 +237,35 @@ export function Sections() {
 					}}
 					className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-kumo-ring focus:ring-offset-2"
 				>
-					<option value="">All Sources</option>
-					<option value="theme">Theme</option>
-					<option value="user">Custom</option>
-					<option value="import">Imported</option>
+					<option value="">{t`All Sources`}</option>
+					<option value="theme">{t`Theme`}</option>
+					<option value="user">{t`Custom`}</option>
+					<option value="import">{t`Imported`}</option>
 				</select>
 			</div>
 
 			{/* Section Grid */}
 			{sectionsLoading ? (
 				<div className="flex items-center justify-center h-64">
-					<div className="text-kumo-subtle">Loading sections...</div>
+					<div className="text-kumo-subtle">{t`Loading sections...`}</div>
 				</div>
 			) : sections.length === 0 ? (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					{searchQuery || selectedSource ? (
 						<>
 							<MagnifyingGlass className="mx-auto h-12 w-12 text-kumo-subtle" />
-							<h3 className="mt-4 text-lg font-semibold">No sections found</h3>
-							<p className="mt-2 text-kumo-subtle">Try adjusting your search or filters.</p>
+							<h3 className="mt-4 text-lg font-semibold">{t`No sections found`}</h3>
+							<p className="mt-2 text-kumo-subtle">{t`Try adjusting your search or filters.`}</p>
 						</>
 					) : (
 						<>
 							<FolderOpen className="mx-auto h-12 w-12 text-kumo-subtle" />
-							<h3 className="mt-4 text-lg font-semibold">No sections yet</h3>
+							<h3 className="mt-4 text-lg font-semibold">{t`No sections yet`}</h3>
 							<p className="mt-2 text-kumo-subtle">
-								Create your first reusable content section to get started.
+								{t`Create your first reusable content section to get started.`}
 							</p>
 							<Button className="mt-4" icon={<Plus />} onClick={() => setIsCreateOpen(true)}>
-								Create Section
+								{t`Create Section`}
 							</Button>
 						</>
 					)}
@@ -289,21 +291,20 @@ export function Sections() {
 					setDeleteSlug(null);
 					deleteMutation.reset();
 				}}
-				title="Delete Section?"
+				title={t`Delete Section?`}
 				description={
 					sectionToDelete?.source === "theme" ? (
 						<>
-							Theme-provided sections cannot be deleted. Edit the section to create a custom copy,
-							then delete that.
+							{t`Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that.`}
 						</>
 					) : (
 						<>
-							This will permanently delete "{sectionToDelete?.title}". This action cannot be undone.
+							{t`This will permanently delete "${sectionToDelete?.title}". This action cannot be undone.`}
 						</>
 					)
 				}
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={deleteMutation.isPending}
 				error={deleteMutation.error}
 				onConfirm={() => deleteSlug && deleteMutation.mutate(deleteSlug)}
@@ -323,6 +324,7 @@ function SectionCard({
 	onDelete: () => void;
 	onCopySlug: () => void;
 }) {
+	const { t } = useLingui();
 	const SourceIcon = sourceIcons[section.source];
 
 	return (
@@ -336,7 +338,7 @@ function SectionCard({
 						className="w-full h-full object-cover"
 					/>
 				) : (
-					<div className="text-kumo-subtle text-sm">No preview</div>
+					<div className="text-kumo-subtle text-sm">{t`No preview`}</div>
 				)}
 			</div>
 
@@ -385,14 +387,14 @@ function SectionCard({
 						onClick={onEdit}
 						className="flex-1"
 					>
-						Edit
+						{t`Edit`}
 					</Button>
 					<Button
 						variant="ghost"
 						size="sm"
 						onClick={onCopySlug}
-						title="Copy slug"
-						aria-label={`Copy ${section.slug} to clipboard`}
+						title={t`Copy slug`}
+						aria-label={t`Copy ${section.slug} to clipboard`}
 					>
 						<Copy className="h-4 w-4" />
 					</Button>
@@ -400,8 +402,8 @@ function SectionCard({
 						variant="ghost"
 						size="sm"
 						onClick={onDelete}
-						title={section.source === "theme" ? "Cannot delete theme sections" : "Delete"}
-						aria-label={`Delete ${section.title}`}
+						title={section.source === "theme" ? t`Cannot delete theme sections` : t`Delete`}
+						aria-label={t`Delete ${section.title}`}
 						disabled={section.source === "theme"}
 					>
 						<Trash className="h-4 w-4" />

--- a/packages/admin/src/components/SeoImageField.tsx
+++ b/packages/admin/src/components/SeoImageField.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Button, Label } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Image as ImageIcon, X } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -19,6 +20,7 @@ export interface SeoImageFieldProps {
 }
 
 export function SeoImageField({ seo, onChange }: SeoImageFieldProps) {
+	const { t } = useLingui();
 	const [pickerOpen, setPickerOpen] = React.useState(false);
 	const imageUrl = seo?.image || null;
 
@@ -36,13 +38,13 @@ export function SeoImageField({ seo, onChange }: SeoImageFieldProps) {
 
 	return (
 		<div>
-			<Label>OG Image</Label>
+			<Label>{t`OG Image`}</Label>
 			{imageUrl ? (
 				<div className="mt-2 relative group">
 					<img src={imageUrl} alt="" className="max-h-48 rounded-lg border object-cover" />
 					<div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity flex gap-1">
 						<Button type="button" size="sm" variant="secondary" onClick={() => setPickerOpen(true)}>
-							Change
+							{t`Change`}
 						</Button>
 						<Button
 							type="button"
@@ -50,7 +52,7 @@ export function SeoImageField({ seo, onChange }: SeoImageFieldProps) {
 							variant="destructive"
 							className="h-8 w-8"
 							onClick={handleRemove}
-							aria-label="Remove image"
+							aria-label={t`Remove image`}
 						>
 							<X className="h-4 w-4" />
 						</Button>
@@ -65,19 +67,19 @@ export function SeoImageField({ seo, onChange }: SeoImageFieldProps) {
 				>
 					<div className="flex flex-col items-center gap-2 text-kumo-subtle">
 						<ImageIcon className="h-8 w-8" />
-						<span>Select OG image</span>
+						<span>{t`Select OG image`}</span>
 					</div>
 				</Button>
 			)}
 			<p className="text-xs text-kumo-subtle mt-1">
-				Image shown when this page is shared on social media
+				{t`Image shown when this page is shared on social media`}
 			</p>
 			<MediaPickerModal
 				open={pickerOpen}
 				onOpenChange={setPickerOpen}
 				onSelect={handleSelect}
 				mimeTypeFilter="image/"
-				title="Select OG Image"
+				title={t`Select OG Image`}
 			/>
 		</div>
 	);

--- a/packages/admin/src/components/SeoPanel.tsx
+++ b/packages/admin/src/components/SeoPanel.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Input, InputArea, Label, Switch } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 import type { ContentSeo, ContentSeoInput } from "../lib/api";
@@ -20,6 +21,7 @@ export interface SeoPanelProps {
  * Compact SEO metadata editor for the content sidebar.
  */
 export function SeoPanel({ seo, onChange }: SeoPanelProps) {
+	const { t } = useLingui();
 	const [title, setTitle] = React.useState(seo?.title ?? "");
 	const [description, setDescription] = React.useState(seo?.description ?? "");
 	const [canonical, setCanonical] = React.useState(seo?.canonical ?? "");
@@ -46,8 +48,8 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 	return (
 		<div className="space-y-3">
 			<Input
-				label="SEO Title"
-				description="Overrides the page title in search engine results"
+				label={t`SEO Title`}
+				description={t`Overrides the page title in search engine results`}
 				value={title}
 				onChange={(e) => {
 					setTitle(e.target.value);
@@ -57,11 +59,11 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 
 			<div>
 				<InputArea
-					label="Meta Description"
+					label={t`Meta Description`}
 					description={
 						description
-							? `${description.length}/160 characters`
-							: "Brief summary shown below the title in search results"
+							? t`${description.length}/160 characters`
+							: t`Brief summary shown below the title in search results`
 					}
 					value={description}
 					onChange={(e) => {
@@ -73,8 +75,8 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 			</div>
 
 			<Input
-				label="Canonical URL"
-				description="Points search engines to the original version of this page, if it's duplicated from another URL"
+				label={t`Canonical URL`}
+				description={t`Points search engines to the original version of this page, if it's duplicated from another URL`}
 				value={canonical}
 				onChange={(e) => {
 					setCanonical(e.target.value);
@@ -84,8 +86,8 @@ export function SeoPanel({ seo, onChange }: SeoPanelProps) {
 
 			<div className="flex items-center justify-between pt-1">
 				<div>
-					<Label>Hide from search engines</Label>
-					<p className="text-xs text-kumo-subtle">Add noindex meta tag</p>
+					<Label>{t`Hide from search engines`}</Label>
+					<p className="text-xs text-kumo-subtle">{t`Add noindex meta tag`}</p>
 				</div>
 				<Switch
 					checked={noIndex}

--- a/packages/admin/src/components/SetupWizard.tsx
+++ b/packages/admin/src/components/SetupWizard.tsx
@@ -11,6 +11,8 @@
  */
 
 import { Button, Checkbox, Input, Loader } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
@@ -111,6 +113,7 @@ interface SiteStepProps {
 }
 
 function SiteStep({ seedInfo, onNext, isLoading, error }: SiteStepProps) {
+	const { t } = useLingui();
 	const [title, setTitle] = React.useState("");
 	const [tagline, setTagline] = React.useState("");
 	const [includeContent, setIncludeContent] = React.useState(true);
@@ -119,7 +122,7 @@ function SiteStep({ seedInfo, onNext, isLoading, error }: SiteStepProps) {
 	const validate = (): boolean => {
 		const newErrors: Record<string, string> = {};
 		if (!title.trim()) {
-			newErrors.title = "Site title is required";
+			newErrors.title = t`Site title is required`;
 		}
 		setErrors(newErrors);
 		return Object.keys(newErrors).length === 0;
@@ -135,29 +138,29 @@ function SiteStep({ seedInfo, onNext, isLoading, error }: SiteStepProps) {
 		<form onSubmit={handleSubmit} className="space-y-6">
 			<div className="space-y-4">
 				<Input
-					label="Site Title"
+					label={t`Site Title`}
 					type="text"
 					value={title}
 					onChange={(e) => setTitle(e.target.value)}
-					placeholder="My Awesome Blog"
+					placeholder={t`My Awesome Blog`}
 					className={errors.title ? "border-kumo-danger" : ""}
 					disabled={isLoading}
 				/>
 				{errors.title && <p className="text-sm text-kumo-danger mt-1">{errors.title}</p>}
 
 				<Input
-					label="Tagline"
+					label={t`Tagline`}
 					type="text"
 					value={tagline}
 					onChange={(e) => setTagline(e.target.value)}
-					placeholder="Thoughts, tutorials, and more"
+					placeholder={t`Thoughts, tutorials, and more`}
 					disabled={isLoading}
 				/>
 			</div>
 
 			{seedInfo?.hasContent && (
 				<Checkbox
-					label="Include sample content (recommended for new sites)"
+					label={t`Include sample content (recommended for new sites)`}
 					checked={includeContent}
 					onCheckedChange={(checked) => setIncludeContent(checked)}
 					disabled={isLoading}
@@ -169,13 +172,13 @@ function SiteStep({ seedInfo, onNext, isLoading, error }: SiteStepProps) {
 			)}
 
 			<Button type="submit" className="w-full justify-center" loading={isLoading} variant="primary">
-				{isLoading ? <>Setting up...</> : "Continue →"}
+				{isLoading ? <>{t`Setting up...`}</> : t`Continue →`}
 			</Button>
 
 			{seedInfo && (
 				<p className="text-xs text-kumo-subtle text-center">
-					Template: {seedInfo.name} ({seedInfo.collections} collection
-					{seedInfo.collections !== 1 ? "s" : ""})
+					{t`Template:`} {seedInfo.name} (
+					{plural(seedInfo.collections, { one: "# collection", other: "# collections" })})
 				</p>
 			)}
 		</form>
@@ -190,6 +193,7 @@ interface AdminStepProps {
 }
 
 function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
+	const { t } = useLingui();
 	const [email, setEmail] = React.useState("");
 	const [name, setName] = React.useState("");
 	const [errors, setErrors] = React.useState<Record<string, string>>({});
@@ -197,9 +201,9 @@ function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
 	const validate = (): boolean => {
 		const newErrors: Record<string, string> = {};
 		if (!email.trim()) {
-			newErrors.email = "Email is required";
+			newErrors.email = t`Email is required`;
 		} else if (!email.includes("@")) {
-			newErrors.email = "Please enter a valid email";
+			newErrors.email = t`Please enter a valid email`;
 		}
 		setErrors(newErrors);
 		return Object.keys(newErrors).length === 0;
@@ -215,11 +219,11 @@ function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
 		<form onSubmit={handleSubmit} className="space-y-6">
 			<div className="space-y-4">
 				<Input
-					label="Your Email"
+					label={t`Your Email`}
 					type="email"
 					value={email}
 					onChange={(e) => setEmail(e.target.value)}
-					placeholder="you@example.com"
+					placeholder={t`you@example.com`}
 					className={errors.email ? "border-kumo-danger" : ""}
 					disabled={isLoading}
 					autoComplete="email"
@@ -227,11 +231,11 @@ function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
 				{errors.email && <p className="text-sm text-kumo-danger mt-1">{errors.email}</p>}
 
 				<Input
-					label="Your Name"
+					label={t`Your Name`}
 					type="text"
 					value={name}
 					onChange={(e) => setName(e.target.value)}
-					placeholder="Jane Doe"
+					placeholder={t`Jane Doe`}
 					disabled={isLoading}
 					autoComplete="name"
 				/>
@@ -243,7 +247,7 @@ function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
 
 			<div className="flex gap-3">
 				<Button type="button" variant="outline" onClick={onBack} disabled={isLoading}>
-					← Back
+					{t`← Back`}
 				</Button>
 				<Button
 					type="submit"
@@ -251,7 +255,7 @@ function AdminStep({ onNext, onBack, isLoading, error }: AdminStepProps) {
 					loading={isLoading}
 					variant="primary"
 				>
-					{isLoading ? <>Preparing...</> : "Continue →"}
+					{isLoading ? <>{t`Preparing...`}</> : t`Continue →`}
 				</Button>
 			</div>
 		</form>
@@ -269,6 +273,7 @@ function handlePasskeySuccess() {
 }
 
 function PasskeyStep({ adminData, onBack }: PasskeyStepProps) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-6">
 			<div className="text-center">
@@ -287,10 +292,9 @@ function PasskeyStep({ adminData, onBack }: PasskeyStepProps) {
 						/>
 					</svg>
 				</div>
-				<h3 className="text-lg font-medium">Set up your passkey</h3>
+				<h3 className="text-lg font-medium">{t`Set up your passkey`}</h3>
 				<p className="text-sm text-kumo-subtle mt-1">
-					Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or
-					security key to sign in.
+					{t`Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in.`}
 				</p>
 			</div>
 
@@ -298,12 +302,12 @@ function PasskeyStep({ adminData, onBack }: PasskeyStepProps) {
 				optionsEndpoint="/_emdash/api/setup/admin"
 				verifyEndpoint="/_emdash/api/setup/admin/verify"
 				onSuccess={handlePasskeySuccess}
-				buttonText="Create Passkey"
+				buttonText={t`Create Passkey`}
 				additionalData={{ ...adminData }}
 			/>
 
 			<Button type="button" variant="ghost" onClick={onBack} className="w-full">
-				← Back
+				{t`← Back`}
 			</Button>
 		</div>
 	);
@@ -319,13 +323,14 @@ interface StepIndicatorProps {
 }
 
 function StepIndicator({ currentStep, useAccessAuth }: StepIndicatorProps) {
+	const { t } = useLingui();
 	// In Access mode, only show the site step
 	const steps = useAccessAuth
-		? ([{ key: "site", label: "Site Settings" }] as const)
+		? ([{ key: "site", label: t`Site Settings` }] as const)
 		: ([
-				{ key: "site", label: "Site" },
-				{ key: "admin", label: "Account" },
-				{ key: "passkey", label: "Passkey" },
+				{ key: "site", label: t`Site` },
+				{ key: "admin", label: t`Account` },
+				{ key: "passkey", label: t`Passkey` },
 			] as const);
 
 	const currentIndex = steps.findIndex((s) => s.key === currentStep);
@@ -451,13 +456,15 @@ export function SetupWizard() {
 		return null;
 	}
 
+	const { t } = useLingui();
+
 	// Loading state
 	if (statusLoading) {
 		return (
 			<div className="min-h-screen flex items-center justify-center bg-kumo-base">
 				<div className="text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Loading setup...</p>
+					<p className="mt-4 text-kumo-subtle">{t`Loading setup...`}</p>
 				</div>
 			</div>
 		);
@@ -468,9 +475,9 @@ export function SetupWizard() {
 		return (
 			<div className="min-h-screen flex items-center justify-center bg-kumo-base">
 				<div className="text-center">
-					<h1 className="text-xl font-bold text-kumo-danger">Error</h1>
+					<h1 className="text-xl font-bold text-kumo-danger">{t`Error`}</h1>
 					<p className="mt-2 text-kumo-subtle">
-						{statusError instanceof Error ? statusError.message : "Failed to load setup"}
+						{statusError instanceof Error ? statusError.message : t`Failed to load setup`}
 					</p>
 				</div>
 			</div>
@@ -484,12 +491,12 @@ export function SetupWizard() {
 				<div className="text-center mb-6">
 					<LogoLockup className="h-10 mx-auto mb-2" />
 					<h1 className="text-2xl font-semibold text-kumo-default">
-						{currentStep === "site" && "Set up your site"}
-						{currentStep === "admin" && "Create your account"}
-						{currentStep === "passkey" && "Secure your account"}
+						{currentStep === "site" && t`Set up your site`}
+						{currentStep === "admin" && t`Create your account`}
+						{currentStep === "passkey" && t`Secure your account`}
 					</h1>
 					{useAccessAuth && currentStep === "site" && (
-						<p className="text-sm text-kumo-subtle mt-2">You're signed in via Cloudflare Access</p>
+						<p className="text-sm text-kumo-subtle mt-2">{t`You're signed in via Cloudflare Access`}</p>
 					)}
 				</div>
 

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Button, Input, Loader } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -35,6 +36,7 @@ interface EmailStepProps {
 }
 
 function EmailStep({ onSubmit, isLoading, error }: EmailStepProps) {
+	const { t } = useLingui();
 	const [email, setEmail] = React.useState("");
 	const [validationError, setValidationError] = React.useState<string | null>(null);
 
@@ -43,12 +45,12 @@ function EmailStep({ onSubmit, isLoading, error }: EmailStepProps) {
 		setValidationError(null);
 
 		if (!email.trim()) {
-			setValidationError("Email is required");
+			setValidationError(t`Email is required`);
 			return;
 		}
 
 		if (!email.includes("@") || !email.includes(".")) {
-			setValidationError("Please enter a valid email address");
+			setValidationError(t`Please enter a valid email address`);
 			return;
 		}
 
@@ -60,11 +62,11 @@ function EmailStep({ onSubmit, isLoading, error }: EmailStepProps) {
 			<div className="space-y-4">
 				<div>
 					<Input
-						label="Email address"
+						label={t`Email address`}
 						type="email"
 						value={email}
 						onChange={(e) => setEmail(e.target.value)}
-						placeholder="you@company.com"
+						placeholder={t`you@company.com`}
 						className={validationError ? "border-kumo-danger" : ""}
 						disabled={isLoading}
 						autoComplete="email"
@@ -82,15 +84,15 @@ function EmailStep({ onSubmit, isLoading, error }: EmailStepProps) {
 				{isLoading ? (
 					<>
 						<Loader size="sm" />
-						Sending...
+						{t`Sending...`}
 					</>
 				) : (
-					"Continue"
+					t`Continue`
 				)}
 			</Button>
 
 			<p className="text-xs text-kumo-subtle text-center">
-				Only email addresses from allowed domains can sign up.
+				{t`Only email addresses from allowed domains can sign up.`}
 			</p>
 		</form>
 	);
@@ -104,6 +106,7 @@ interface CheckEmailStepProps {
 }
 
 function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckEmailStepProps) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-6 text-center">
 			<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-kumo-brand/10 mx-auto">
@@ -123,20 +126,20 @@ function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckE
 			</div>
 
 			<div>
-				<h2 className="text-xl font-semibold">Check your email</h2>
+				<h2 className="text-xl font-semibold">{t`Check your email`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					We've sent a verification link to{" "}
+					{t`We've sent a verification link to`}{" "}
 					<span className="font-medium text-kumo-default">{email}</span>
 				</p>
 			</div>
 
 			<div className="text-sm text-kumo-subtle">
-				<p>Click the link in the email to continue setting up your account.</p>
-				<p className="mt-2">The link will expire in 15 minutes.</p>
+				<p>{t`Click the link in the email to continue setting up your account.`}</p>
+				<p className="mt-2">{t`The link will expire in 15 minutes.`}</p>
 			</div>
 
 			<div className="pt-4 border-t">
-				<p className="text-sm text-kumo-subtle mb-2">Didn't receive the email?</p>
+				<p className="text-sm text-kumo-subtle mb-2">{t`Didn't receive the email?`}</p>
 				<Button
 					variant="outline"
 					size="sm"
@@ -144,10 +147,10 @@ function CheckEmailStep({ email, onResend, isResending, resendCooldown }: CheckE
 					disabled={isResending || resendCooldown > 0}
 				>
 					{isResending
-						? "Sending..."
+						? t`Sending...`
 						: resendCooldown > 0
-							? `Resend in ${resendCooldown}s`
-							: "Resend email"}
+							? t`Resend in ${resendCooldown}s`
+							: t`Resend email`}
 				</Button>
 			</div>
 		</div>
@@ -166,6 +169,7 @@ function handleSignupSuccess() {
 }
 
 function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
+	const { t } = useLingui();
 	const [name, setName] = React.useState("");
 
 	return (
@@ -181,39 +185,38 @@ function VerifyStep({ verifyResult, token, onBack: _onBack }: VerifyStepProps) {
 						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
 					</svg>
 				</div>
-				<h2 className="text-xl font-semibold">Email verified!</h2>
+				<h2 className="text-xl font-semibold">{t`Email verified!`}</h2>
 				<p className="text-kumo-subtle mt-2">
-					You'll be signing up as{" "}
+					{t`You'll be signing up as`}{" "}
 					<span className="font-medium text-kumo-default">{verifyResult.roleName}</span>
 				</p>
 			</div>
 
 			{/* Email display (read-only) */}
-			<Input label="Email" value={verifyResult.email} disabled className="bg-kumo-tint" />
+			<Input label={t`Email`} value={verifyResult.email} disabled className="bg-kumo-tint" />
 
 			{/* Name input (optional) */}
 			<Input
-				label="Your name (optional)"
+				label={t`Your name (optional)`}
 				type="text"
 				value={name}
 				onChange={(e) => setName(e.target.value)}
-				placeholder="Jane Doe"
+				placeholder={t`Jane Doe`}
 				autoComplete="name"
 			/>
 
 			{/* Passkey registration */}
 			<div className="pt-4 border-t">
-				<h3 className="text-sm font-medium mb-3">Create your passkey</h3>
+				<h3 className="text-sm font-medium mb-3">{t`Create your passkey`}</h3>
 				<p className="text-sm text-kumo-subtle mb-4">
-					Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or
-					security key.
+					{t`Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key.`}
 				</p>
 
 				<PasskeyRegistration
 					optionsEndpoint="/_emdash/api/setup/admin"
 					verifyEndpoint="/_emdash/api/auth/signup/complete"
 					onSuccess={handleSignupSuccess}
-					buttonText="Create Account"
+					buttonText={t`Create Account`}
 					additionalData={{ token, name: name || undefined }}
 				/>
 			</div>
@@ -228,6 +231,7 @@ interface ErrorStepProps {
 }
 
 function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-6 text-center">
 			<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-kumo-danger/10 mx-auto">
@@ -249,12 +253,12 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 			<div>
 				<h2 className="text-xl font-semibold text-kumo-danger">
 					{code === "token_expired"
-						? "Link expired"
+						? t`Link expired`
 						: code === "invalid_token"
-							? "Invalid link"
+							? t`Invalid link`
 							: code === "user_exists"
-								? "Account exists"
-								: "Something went wrong"}
+								? t`Account exists`
+								: t`Something went wrong`}
 				</h2>
 				<p className="text-kumo-subtle mt-2">{message}</p>
 			</div>
@@ -262,18 +266,18 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 			<div className="space-y-2">
 				{code === "user_exists" ? (
 					<Link to="/login">
-						<Button className="w-full">Sign in instead</Button>
+						<Button className="w-full">{t`Sign in instead`}</Button>
 					</Link>
 				) : (
 					onRetry && (
 						<Button onClick={onRetry} className="w-full">
-							Request a new link
+							{t`Request a new link`}
 						</Button>
 					)
 				)}
 				<Link to="/login">
 					<Button variant="ghost" className="w-full">
-						Back to login
+						{t`Back to login`}
 					</Button>
 				</Link>
 			</div>
@@ -372,13 +376,15 @@ export function SignupPage() {
 		window.history.replaceState({}, "", window.location.pathname);
 	};
 
+	const { t } = useLingui();
+
 	// Loading state for token verification
 	if (isLoading && token) {
 		return (
 			<div className="min-h-screen flex items-center justify-center bg-kumo-base">
 				<div className="text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Verifying your link...</p>
+					<p className="mt-4 text-kumo-subtle">{t`Verifying your link...`}</p>
 				</div>
 			</div>
 		);
@@ -391,10 +397,10 @@ export function SignupPage() {
 				<div className="text-center mb-8">
 					<LogoLockup className="h-10 mx-auto mb-2" />
 					<h1 className="text-2xl font-semibold text-kumo-default">
-						{step === "email" && "Create an account"}
-						{step === "check-email" && "Check your email"}
-						{step === "verify" && "Complete signup"}
-						{step === "error" && "Oops!"}
+						{step === "email" && t`Create an account`}
+						{step === "check-email" && t`Check your email`}
+						{step === "verify" && t`Complete signup`}
+						{step === "error" && t`Oops!`}
 					</h1>
 				</div>
 
@@ -429,9 +435,9 @@ export function SignupPage() {
 				{/* Login link */}
 				{step === "email" && (
 					<p className="text-center mt-6 text-sm text-kumo-subtle">
-						Already have an account?{" "}
+						{t`Already have an account?`}{" "}
 						<Link to="/login" className="text-kumo-brand hover:underline font-medium">
-							Sign in
+							{t`Sign in`}
 						</Link>
 					</p>
 				)}

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Checkbox, Dialog, Input, InputArea, Select, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Plus, Pencil, Trash, X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -54,6 +55,7 @@ function TermRow({
 	onEdit: (term: TaxonomyTerm) => void;
 	onDelete: (term: TaxonomyTerm) => void;
 }) {
+	const { t } = useLingui();
 	return (
 		<>
 			<div className="flex items-center gap-4 py-2 px-4 border-b hover:bg-kumo-tint/50">
@@ -66,7 +68,7 @@ function TermRow({
 					<Button
 						variant="ghost"
 						size="sm"
-						aria-label={`Edit ${term.label}`}
+						aria-label={t`Edit ${term.label}`}
 						onClick={() => onEdit(term)}
 					>
 						<Pencil className="w-4 h-4" />
@@ -74,7 +76,7 @@ function TermRow({
 					<Button
 						variant="ghost"
 						size="sm"
-						aria-label={`Delete ${term.label}`}
+						aria-label={t`Delete ${term.label}`}
 						onClick={() => onDelete(term)}
 					>
 						<Trash className="w-4 h-4" />
@@ -112,6 +114,7 @@ function TermFormDialog({
 	term?: TaxonomyTerm;
 	allTerms: TaxonomyTerm[];
 }) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [label, setLabel] = React.useState(term?.label || "");
 	const [slug, setSlug] = React.useState(term?.slug || "");
@@ -190,7 +193,7 @@ function TermFormDialog({
 	// Flatten terms for parent selector (exclude current term and its children)
 	const flatTerms = flattenTerms(allTerms);
 	const availableParents = term
-		? flatTerms.filter((t) => t.id !== term.id && t.parentId !== term.id)
+		? flatTerms.filter((item) => item.id !== term.id && item.parentId !== term.id)
 		: flatTerms;
 
 	return (
@@ -208,26 +211,26 @@ function TermFormDialog({
 					<div className="flex items-start justify-between gap-4 mb-4">
 						<div className="flex flex-col space-y-1.5">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								{term ? "Edit" : "Add"} {taxonomyDef.labelSingular || "Term"}
+								{term ? t`Edit` : t`Add`} {taxonomyDef.labelSingular || t`Term`}
 							</Dialog.Title>
 							<Dialog.Description className="text-sm text-kumo-subtle">
 								{term
-									? `Update the ${taxonomyDef.labelSingular?.toLowerCase() || "term"} details`
-									: `Create a new ${taxonomyDef.labelSingular?.toLowerCase() || "term"}`}
+									? t`Update the ${taxonomyDef.labelSingular?.toLowerCase() || "term"} details`
+									: t`Create a new ${taxonomyDef.labelSingular?.toLowerCase() || "term"}`}
 							</Dialog.Description>
 						</div>
 						<Dialog.Close
-							aria-label="Close"
+							aria-label={t`Close`}
 							render={(props) => (
 								<Button
 									{...props}
 									variant="ghost"
 									shape="square"
-									aria-label="Close"
+									aria-label={t`Close`}
 									className="absolute right-4 top-4"
 								>
 									<X className="h-4 w-4" />
-									<span className="sr-only">Close</span>
+									<span className="sr-only">{t`Close`}</span>
 								</Button>
 							)}
 						/>
@@ -235,7 +238,7 @@ function TermFormDialog({
 
 					<div className="space-y-4 py-4">
 						<Input
-							label="Name"
+							label={t`Name`}
 							value={label}
 							onChange={(e) => setLabel(e.target.value)}
 							placeholder="News"
@@ -244,7 +247,7 @@ function TermFormDialog({
 
 						<div>
 							<Input
-								label="Slug"
+								label={t`Slug`}
 								value={slug}
 								onChange={(e) => {
 									setSlug(e.target.value);
@@ -254,34 +257,36 @@ function TermFormDialog({
 								required
 							/>
 							<p className="text-sm text-kumo-subtle mt-1">
-								Auto-generated from name (you can edit)
+								{t`Auto-generated from name (you can edit)`}
 							</p>
 						</div>
 
 						{taxonomyDef.hierarchical && (
 							<Select
-								label="Parent"
+								label={t`Parent`}
 								value={parentId}
 								onValueChange={(v) => setParentId(v ?? "")}
 								items={{
-									"": "None (top level)",
-									...Object.fromEntries(availableParents.map((t) => [t.id, t.label])),
+									"": t`None (top level)`,
+									...Object.fromEntries(
+										availableParents.map((parentTerm) => [parentTerm.id, parentTerm.label]),
+									),
 								}}
 							>
-								<Select.Option value="">None (top level)</Select.Option>
-								{availableParents.map((t) => (
-									<Select.Option key={t.id} value={t.id}>
-										{t.label}
+								<Select.Option value="">{t`None (top level)`}</Select.Option>
+								{availableParents.map((parentTerm) => (
+									<Select.Option key={parentTerm.id} value={parentTerm.id}>
+										{parentTerm.label}
 									</Select.Option>
 								))}
 							</Select>
 						)}
 
 						<InputArea
-							label="Description (optional)"
+							label={t`Description (optional)`}
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
-							placeholder="Optional description"
+							placeholder={t`Optional description`}
 							rows={3}
 						/>
 
@@ -296,14 +301,14 @@ function TermFormDialog({
 
 					<div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
 						<Button type="button" variant="outline" onClick={onClose}>
-							Cancel
+							{t`Cancel`}
 						</Button>
 						<Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
 							{createMutation.isPending || updateMutation.isPending
-								? "Saving..."
+								? t`Saving...`
 								: term
-									? "Update"
-									: "Create"}
+									? t`Update`
+									: t`Create`}
 						</Button>
 					</div>
 				</form>
@@ -324,6 +329,7 @@ function CreateTaxonomyDialog({
 	onClose: () => void;
 	onCreated: () => void;
 }) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [name, setName] = React.useState("");
 	const [label, setLabel] = React.useState("");
@@ -381,13 +387,13 @@ function CreateTaxonomyDialog({
 		setError(null);
 
 		if (!name || !label) {
-			setError("Name and label are required");
+			setError(t`Name and label are required`);
 			return;
 		}
 
 		if (!TAXONOMY_NAME_PATTERN.test(name)) {
 			setError(
-				"Name must start with a letter and contain only lowercase letters, numbers, and underscores",
+				t`Name must start with a letter and contain only lowercase letters, numbers, and underscores`,
 			);
 			return;
 		}
@@ -421,24 +427,24 @@ function CreateTaxonomyDialog({
 					<div className="flex items-start justify-between gap-4 mb-4">
 						<div className="flex flex-col space-y-1.5">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								Create Taxonomy
+								{t`Create Taxonomy`}
 							</Dialog.Title>
 							<Dialog.Description className="text-sm text-kumo-subtle">
-								Define a new taxonomy for classifying content
+								{t`Define a new taxonomy for classifying content`}
 							</Dialog.Description>
 						</div>
 						<Dialog.Close
-							aria-label="Close"
+							aria-label={t`Close`}
 							render={(props) => (
 								<Button
 									{...props}
 									variant="ghost"
 									shape="square"
-									aria-label="Close"
+									aria-label={t`Close`}
 									className="absolute right-4 top-4"
 								>
 									<X className="h-4 w-4" />
-									<span className="sr-only">Close</span>
+									<span className="sr-only">{t`Close`}</span>
 								</Button>
 							)}
 						/>
@@ -446,7 +452,7 @@ function CreateTaxonomyDialog({
 
 					<div className="space-y-4 py-4">
 						<Input
-							label="Label"
+							label={t`Label`}
 							value={label}
 							onChange={(e) => setLabel(e.target.value)}
 							placeholder="Genres"
@@ -455,7 +461,7 @@ function CreateTaxonomyDialog({
 
 						<div>
 							<Input
-								label="Name"
+								label={t`Name`}
 								value={name}
 								onChange={(e) => {
 									setName(e.target.value);
@@ -464,24 +470,24 @@ function CreateTaxonomyDialog({
 								placeholder="genre"
 								required
 								pattern="[a-z][a-z0-9_]*"
-								title="Lowercase letters, numbers, and underscores only, starting with a letter"
+								title={t`Lowercase letters, numbers, and underscores only, starting with a letter`}
 							/>
 							<p className="text-xs text-kumo-subtle mt-1">
-								Used as the identifier. Lowercase letters, numbers, and underscores only.
+								{t`Used as the identifier. Lowercase letters, numbers, and underscores only.`}
 							</p>
 						</div>
 
 						<Checkbox
-							label="Hierarchical (like categories, with parent/child relationships)"
+							label={t`Hierarchical (like categories, with parent/child relationships)`}
 							checked={hierarchical}
 							onCheckedChange={(checked) => setHierarchical(checked)}
 						/>
 
 						{collectionEntries.length > 0 && (
 							<div>
-								<label className="text-sm font-medium">Collections</label>
+								<label className="text-sm font-medium">{t`Collections`}</label>
 								<p className="text-xs text-kumo-subtle mb-2">
-									Which content types can use this taxonomy
+									{t`Which content types can use this taxonomy`}
 								</p>
 								<div className="border rounded-md p-2 space-y-1">
 									{collectionEntries.map(({ slug, label: collLabel }) => (
@@ -514,10 +520,10 @@ function CreateTaxonomyDialog({
 								onClose();
 							}}
 						>
-							Cancel
+							{t`Cancel`}
 						</Button>
 						<Button type="submit" disabled={createMutation.isPending}>
-							{createMutation.isPending ? "Creating..." : "Create Taxonomy"}
+							{createMutation.isPending ? t`Creating...` : t`Create Taxonomy`}
 						</Button>
 					</div>
 				</form>
@@ -530,6 +536,7 @@ function CreateTaxonomyDialog({
  * Main TaxonomyManager component
  */
 export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
 	const [formOpen, setFormOpen] = React.useState(false);
@@ -554,7 +561,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 				queryKey: ["taxonomy-terms", taxonomyName],
 			});
 			setDeleteTarget(null);
-			toastManager.add({ title: "Term deleted" });
+			toastManager.add({ title: t`Term deleted` });
 		},
 	});
 
@@ -573,11 +580,15 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 	};
 
 	if (defLoading) {
-		return <div>Loading...</div>;
+		return <div>{t`Loading...`}</div>;
 	}
 
 	if (!taxonomyDef) {
-		return <div>Taxonomy not found: {taxonomyName}</div>;
+		return (
+			<div>
+				{t`Taxonomy not found:`} {taxonomyName}
+			</div>
+		);
 	}
 
 	const flatTerms = flattenTerms(terms);
@@ -588,31 +599,31 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 				<div>
 					<h1 className="text-3xl font-bold">{taxonomyDef.label}</h1>
 					<p className="text-kumo-subtle mt-1">
-						Manage {taxonomyDef.label.toLowerCase()} for {taxonomyDef.collections.join(", ")}
+						{t`Manage ${taxonomyDef.label.toLowerCase()} for ${taxonomyDef.collections.join(", ")}`}
 					</p>
 				</div>
 				<div className="flex gap-2">
 					<Button variant="outline" icon={<Plus />} onClick={() => setCreateTaxonomyOpen(true)}>
-						New Taxonomy
+						{t`New Taxonomy`}
 					</Button>
 					<Button icon={<Plus />} onClick={() => setFormOpen(true)}>
-						Add {taxonomyDef.labelSingular || "Term"}
+						{t`Add`} {taxonomyDef.labelSingular || t`Term`}
 					</Button>
 				</div>
 			</div>
 
 			<div className="border rounded-lg">
 				<div className="flex items-center gap-4 py-2 px-4 border-b bg-kumo-tint/50 font-medium">
-					<div className="flex-1">Name</div>
-					<div className="w-16 text-center">Count</div>
-					<div className="w-24 text-center">Actions</div>
+					<div className="flex-1">{t`Name`}</div>
+					<div className="w-16 text-center">{t`Count`}</div>
+					<div className="w-24 text-center">{t`Actions`}</div>
 				</div>
 
 				{termsLoading ? (
-					<div className="p-8 text-center text-kumo-subtle">Loading terms...</div>
+					<div className="p-8 text-center text-kumo-subtle">{t`Loading terms...`}</div>
 				) : terms.length === 0 ? (
 					<div className="p-8 text-center text-kumo-subtle">
-						No {taxonomyDef.label.toLowerCase()} yet. Create one to get started.
+						{t`No ${taxonomyDef.label.toLowerCase()} yet. Create one to get started.`}
 					</div>
 				) : (
 					<div>
@@ -638,12 +649,12 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 					setDeleteTarget(null);
 					deleteMutation.reset();
 				}}
-				title={`Delete ${taxonomyDef.labelSingular || "Term"}?`}
+				title={t`Delete ${taxonomyDef.labelSingular || "Term"}?`}
 				description={
-					<>This will permanently delete "{deleteTarget?.label}" and remove it from all content.</>
+					<>{t`This will permanently delete "${deleteTarget?.label}" and remove it from all content.`}</>
 				}
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={deleteMutation.isPending}
 				error={deleteMutation.error}
 				onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget)}
@@ -654,7 +665,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 				onClose={() => setCreateTaxonomyOpen(false)}
 				onCreated={() => {
 					setCreateTaxonomyOpen(false);
-					toastManager.add({ title: "Taxonomy created" });
+					toastManager.add({ title: t`Taxonomy created` });
 				}}
 			/>
 		</div>

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Input, Label } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -150,14 +151,18 @@ function TagInput({
 	onRemove: (termId: string) => void;
 	label: string;
 }) {
+	const { t } = useLingui();
 	const [input, setInput] = React.useState("");
 
-	const selectedTerms = terms.filter((t) => selectedIds.has(t.id));
+	const selectedTerms = terms.filter((term) => selectedIds.has(term.id));
 
 	const suggestions = React.useMemo(() => {
 		if (!input) return [];
 		return terms
-			.filter((t) => t.label.toLowerCase().includes(input.toLowerCase()) && !selectedIds.has(t.id))
+			.filter(
+				(term) =>
+					term.label.toLowerCase().includes(input.toLowerCase()) && !selectedIds.has(term.id),
+			)
 			.slice(0, 5);
 	}, [input, terms, selectedIds]);
 
@@ -181,7 +186,7 @@ function TagInput({
 								type="button"
 								onClick={() => onRemove(term.id)}
 								className="hover:text-kumo-danger"
-								aria-label={`Remove ${term.label}`}
+								aria-label={t`Remove ${term.label}`}
 							>
 								<X className="w-3 h-3" />
 							</button>
@@ -195,8 +200,8 @@ function TagInput({
 				<Input
 					value={input}
 					onChange={(e) => setInput(e.target.value)}
-					placeholder="Add tags..."
-					aria-label={`Add ${label}`}
+					placeholder={t`Add tags...`}
+					aria-label={t`Add ${label}`}
 					className="text-sm"
 				/>
 
@@ -234,6 +239,7 @@ function TaxonomySection({
 	entryId?: string;
 	onChange?: (termIds: string[]) => void;
 }) {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 
 	const { data: terms = [] } = useQuery({
@@ -266,7 +272,7 @@ function TaxonomySection({
 
 	// Sync selected IDs from entry terms
 	React.useEffect(() => {
-		setSelectedIds(new Set(entryTerms.map((t) => t.id)));
+		setSelectedIds(new Set(entryTerms.map((term) => term.id)));
 	}, [entryTerms]);
 
 	const handleToggle = (termId: string) => {
@@ -301,7 +307,9 @@ function TaxonomySection({
 			<Label className="text-sm font-medium">{taxonomy.label}</Label>
 
 			{terms.length === 0 ? (
-				<p className="text-sm text-kumo-subtle">No {taxonomy.label.toLowerCase()} available.</p>
+				<p className="text-sm text-kumo-subtle">
+					{t`No ${taxonomy.label.toLowerCase()} available.`}
+				</p>
 			) : taxonomy.hierarchical ? (
 				<div className="border rounded-md p-2 max-h-64 overflow-y-auto">
 					{terms.map((term) => (
@@ -330,13 +338,14 @@ function TaxonomySection({
  * Main TaxonomySidebar component
  */
 export function TaxonomySidebar({ collection, entryId, onChange }: TaxonomySidebarProps) {
+	const { t } = useLingui();
 	const { data: taxonomies = [] } = useQuery({
 		queryKey: ["taxonomy-defs"],
 		queryFn: fetchTaxonomyDefs,
 	});
 
 	// Filter to taxonomies that apply to this collection
-	const applicableTaxonomies = taxonomies.filter((t) => t.collections.includes(collection));
+	const applicableTaxonomies = taxonomies.filter((tax) => tax.collections.includes(collection));
 
 	if (applicableTaxonomies.length === 0) {
 		return null;
@@ -345,7 +354,7 @@ export function TaxonomySidebar({ collection, entryId, onChange }: TaxonomySideb
 	return (
 		<div className="space-y-6">
 			<div>
-				<h3 className="font-semibold mb-4">Taxonomies</h3>
+				<h3 className="font-semibold mb-4">{t`Taxonomies`}</h3>
 				<div className="space-y-4">
 					{applicableTaxonomies.map((taxonomy) => (
 						<TaxonomySection

--- a/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
 	Palette,
@@ -41,6 +42,7 @@ function isSortOption(value: string): value is SortOption {
 }
 
 export function ThemeMarketplaceBrowse() {
+	const { t } = useLingui();
 	const [searchQuery, setSearchQuery] = React.useState("");
 	const [sort, setSort] = React.useState<SortOption>("updated");
 	const [debouncedQuery, setDebouncedQuery] = React.useState("");
@@ -70,9 +72,9 @@ export function ThemeMarketplaceBrowse() {
 		<div className="space-y-6">
 			{/* Header */}
 			<div>
-				<h1 className="text-3xl font-bold">Themes</h1>
+				<h1 className="text-3xl font-bold">{t`Themes`}</h1>
 				<p className="mt-1 text-kumo-subtle">
-					Browse themes and preview them with your own content.
+					{t`Browse themes and preview them with your own content.`}
 				</p>
 			</div>
 
@@ -82,7 +84,7 @@ export function ThemeMarketplaceBrowse() {
 					<MagnifyingGlass className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
 					<input
 						type="search"
-						placeholder="Search themes..."
+						placeholder={t`Search themes...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						className="w-full rounded-md border bg-kumo-base px-3 py-2 pl-9 text-sm placeholder:text-kumo-subtle focus:outline-none focus:ring-2 focus:ring-kumo-ring"
@@ -95,7 +97,7 @@ export function ThemeMarketplaceBrowse() {
 						if (isSortOption(v)) setSort(v);
 					}}
 					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
-					aria-label="Sort themes"
+					aria-label={t`Sort themes`}
 				>
 					{Object.entries(SORT_LABELS).map(([value, label]) => (
 						<option key={value} value={value}>
@@ -109,13 +111,13 @@ export function ThemeMarketplaceBrowse() {
 			{error && (
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">
 					<Warning className="mx-auto h-8 w-8 text-kumo-danger" />
-					<h3 className="mt-3 font-medium text-kumo-danger">Unable to reach marketplace</h3>
+					<h3 className="mt-3 font-medium text-kumo-danger">{t`Unable to reach marketplace`}</h3>
 					<p className="mt-1 text-sm text-kumo-subtle">
-						{error instanceof Error ? error.message : "An error occurred"}
+						{error instanceof Error ? error.message : t`An error occurred`}
 					</p>
 					<Button variant="ghost" className="mt-4" onClick={() => void refetch()}>
 						<ArrowsClockwise className="mr-2 h-4 w-4" />
-						Retry
+						{t`Retry`}
 					</Button>
 				</div>
 			)}
@@ -142,11 +144,11 @@ export function ThemeMarketplaceBrowse() {
 					{themes.length === 0 ? (
 						<div className="rounded-lg border bg-kumo-base p-8 text-center">
 							<Palette className="mx-auto h-12 w-12 text-kumo-subtle" />
-							<h3 className="mt-4 text-lg font-medium">No themes found</h3>
+							<h3 className="mt-4 text-lg font-medium">{t`No themes found`}</h3>
 							<p className="mt-2 text-sm text-kumo-subtle">
 								{debouncedQuery
-									? `No results for "${debouncedQuery}". Try a different search term.`
-									: "The theme marketplace is empty. Check back later."}
+									? t`No results for "${debouncedQuery}". Try a different search term.`
+									: t`The theme marketplace is empty. Check back later.`}
 							</p>
 						</div>
 					) : (
@@ -163,7 +165,7 @@ export function ThemeMarketplaceBrowse() {
 										onClick={() => void fetchNextPage()}
 										disabled={isFetchingNextPage}
 									>
-										{isFetchingNextPage ? "Loading..." : "Load more"}
+										{isFetchingNextPage ? t`Loading...` : t`Load more`}
 									</Button>
 								</div>
 							)}
@@ -180,6 +182,7 @@ export function ThemeMarketplaceBrowse() {
 // ---------------------------------------------------------------------------
 
 function ThemeCard({ theme }: { theme: ThemeSummary }) {
+	const { t } = useLingui();
 	const thumbnailUrl = theme.thumbnailUrl
 		? `/_emdash/api/admin/themes/marketplace/${encodeURIComponent(theme.id)}/thumbnail`
 		: null;
@@ -202,7 +205,7 @@ function ThemeCard({ theme }: { theme: ThemeSummary }) {
 				{thumbnailUrl ? (
 					<img
 						src={thumbnailUrl}
-						alt={`${theme.name} preview`}
+						alt={t`${theme.name} preview`}
 						className="aspect-video w-full object-cover bg-kumo-tint"
 						loading="lazy"
 					/>
@@ -244,7 +247,7 @@ function ThemeCard({ theme }: { theme: ThemeSummary }) {
 						disabled={previewMutation.isPending}
 					>
 						<Eye className="mr-1.5 h-3.5 w-3.5" />
-						{previewMutation.isPending ? "Loading..." : "Try with my data"}
+						{previewMutation.isPending ? t`Loading...` : t`Try with my data`}
 					</Button>
 
 					{theme.demoUrl && (
@@ -254,7 +257,7 @@ function ThemeCard({ theme }: { theme: ThemeSummary }) {
 							onClick={() => window.open(theme.demoUrl!, "_blank", "noopener")}
 						>
 							<ArrowSquareOut className="mr-1.5 h-3.5 w-3.5" />
-							Demo
+							{t`Demo`}
 						</Button>
 					)}
 				</div>
@@ -263,7 +266,7 @@ function ThemeCard({ theme }: { theme: ThemeSummary }) {
 					<p className="mt-2 text-xs text-kumo-danger">
 						{previewMutation.error instanceof Error
 							? previewMutation.error.message
-							: "Failed to generate preview"}
+							: t`Failed to generate preview`}
 					</p>
 				)}
 			</div>

--- a/packages/admin/src/components/ThemeMarketplaceDetail.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceDetail.tsx
@@ -9,6 +9,7 @@
  */
 
 import { Badge, Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowLeft,
 	ArrowSquareOut,
@@ -42,6 +43,7 @@ export interface ThemeMarketplaceDetailProps {
 }
 
 export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps) {
+	const { t } = useLingui();
 	const [lightboxIndex, setLightboxIndex] = React.useState<number | null>(null);
 
 	const {
@@ -83,12 +85,12 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 					className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 				>
 					<ArrowLeft className="h-4 w-4" />
-					Back to Themes
+					{t`Back to Themes`}
 				</Link>
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">
-					<h3 className="font-medium text-kumo-danger">Failed to load theme</h3>
+					<h3 className="font-medium text-kumo-danger">{t`Failed to load theme`}</h3>
 					<p className="mt-1 text-sm text-kumo-subtle">
-						{error instanceof Error ? error.message : "Theme not found"}
+						{error instanceof Error ? error.message : t`Theme not found`}
 					</p>
 				</div>
 			</div>
@@ -107,7 +109,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 				className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 			>
 				<ArrowLeft className="h-4 w-4" />
-				Back to Themes
+				{t`Back to Themes`}
 			</Link>
 
 			{/* Header */}
@@ -140,7 +142,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 						disabled={previewMutation.isPending}
 					>
 						<Eye className="mr-2 h-4 w-4" />
-						{previewMutation.isPending ? "Loading..." : "Try with my data"}
+						{previewMutation.isPending ? t`Loading...` : t`Try with my data`}
 					</Button>
 					{theme.demoUrl && isSafeUrl(theme.demoUrl) && (
 						<Button
@@ -148,7 +150,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 							onClick={() => window.open(theme.demoUrl!, "_blank", "noopener")}
 						>
 							<ArrowSquareOut className="mr-2 h-4 w-4" />
-							Demo
+							{t`Demo`}
 						</Button>
 					)}
 				</div>
@@ -158,14 +160,14 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 				<div className="rounded-md border border-kumo-danger/50 bg-kumo-danger/10 p-3 text-sm text-kumo-danger">
 					{previewMutation.error instanceof Error
 						? previewMutation.error.message
-						: "Failed to generate preview URL"}
+						: t`Failed to generate preview URL`}
 				</div>
 			)}
 
 			{/* Screenshot gallery */}
 			{theme.screenshotCount > 0 && (
 				<div>
-					<h2 className="text-lg font-semibold mb-3">Screenshots</h2>
+					<h2 className="text-lg font-semibold mb-3">{t`Screenshots`}</h2>
 					<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 						{theme.screenshotUrls.map((url, i) => (
 							<button
@@ -175,7 +177,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 							>
 								<img
 									src={url}
-									alt={`Screenshot ${i + 1}`}
+									alt={t`Screenshot ${i + 1}`}
 									className="aspect-video w-full object-cover"
 									loading="lazy"
 								/>
@@ -190,7 +192,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 				{/* Keywords */}
 				{theme.keywords.length > 0 && (
 					<div>
-						<h3 className="text-sm font-medium text-kumo-subtle mb-2">Keywords</h3>
+						<h3 className="text-sm font-medium text-kumo-subtle mb-2">{t`Keywords`}</h3>
 						<div className="flex flex-wrap gap-1">
 							{theme.keywords.map((kw) => (
 								<Badge key={kw} variant="secondary">
@@ -204,14 +206,14 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 				{/* License */}
 				{theme.license && (
 					<div>
-						<h3 className="text-sm font-medium text-kumo-subtle mb-2">License</h3>
+						<h3 className="text-sm font-medium text-kumo-subtle mb-2">{t`License`}</h3>
 						<p className="text-sm">{theme.license}</p>
 					</div>
 				)}
 
 				{/* Links */}
 				<div>
-					<h3 className="text-sm font-medium text-kumo-subtle mb-2">Links</h3>
+					<h3 className="text-sm font-medium text-kumo-subtle mb-2">{t`Links`}</h3>
 					<div className="flex flex-col gap-1.5">
 						{theme.repositoryUrl && isSafeUrl(theme.repositoryUrl) && (
 							<a
@@ -221,7 +223,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 								className="inline-flex items-center gap-1.5 text-sm text-kumo-brand hover:underline"
 							>
 								<GithubLogo className="h-4 w-4" />
-								Repository
+								{t`Repository`}
 							</a>
 						)}
 						{theme.homepageUrl && isSafeUrl(theme.homepageUrl) && (
@@ -232,7 +234,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 								className="inline-flex items-center gap-1.5 text-sm text-kumo-brand hover:underline"
 							>
 								<Globe className="h-4 w-4" />
-								Homepage
+								{t`Homepage`}
 							</a>
 						)}
 					</div>
@@ -274,6 +276,7 @@ function Lightbox({
 	onPrev: () => void;
 	onNext: () => void;
 }) {
+	const { t } = useLingui();
 	React.useEffect(() => {
 		function onKeyDown(e: KeyboardEvent) {
 			if (e.key === "Escape") onClose();
@@ -293,12 +296,12 @@ function Lightbox({
 			onClick={onClose}
 		>
 			<div className="relative max-h-[90vh] max-w-[90vw]" onClick={(e) => e.stopPropagation()}>
-				<img src={url} alt={`Screenshot ${index + 1}`} className="max-h-[85vh] rounded-lg" />
+				<img src={url} alt={t`Screenshot ${index + 1}`} className="max-h-[85vh] rounded-lg" />
 
 				<button
 					onClick={onClose}
 					className="absolute -top-3 -right-3 rounded-full bg-kumo-base p-1.5 shadow-lg hover:bg-kumo-tint"
-					aria-label="Close"
+					aria-label={t`Close`}
 				>
 					<X className="h-4 w-4" />
 				</button>
@@ -308,14 +311,14 @@ function Lightbox({
 						<button
 							onClick={onPrev}
 							className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-kumo-base/80 p-2 shadow hover:bg-kumo-base"
-							aria-label="Previous"
+							aria-label={t`Previous`}
 						>
 							<CaretLeft className="h-5 w-5" />
 						</button>
 						<button
 							onClick={onNext}
 							className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-kumo-base/80 p-2 shadow hover:bg-kumo-base"
-							aria-label="Next"
+							aria-label={t`Next`}
 						>
 							<CaretRight className="h-5 w-5" />
 						</button>

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -1,4 +1,6 @@
 import { Badge, Button, Input, LinkButton, Loader, buttonVariants } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import {
 	Upload,
 	Check,
@@ -598,12 +600,14 @@ export function WordPressImport() {
 	// Check if we're using the plugin source
 	const isPluginSource = importSource?.type === "wordpress-plugin";
 
+	const { t } = useLingui();
+
 	return (
 		<div className="space-y-6">
 			<div>
-				<h1 className="text-2xl font-bold">Import from WordPress</h1>
+				<h1 className="text-2xl font-bold">{t`Import from WordPress`}</h1>
 				<p className="text-kumo-subtle mt-1">
-					Import posts, pages, and custom post types from WordPress.
+					{t`Import posts, pages, and custom post types from WordPress.`}
 				</p>
 			</div>
 
@@ -685,7 +689,7 @@ export function WordPressImport() {
 			{step === "probing" && (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Checking {urlInput}...</p>
+					<p className="mt-4 text-kumo-subtle">{t`Checking ${urlInput}...`}</p>
 				</div>
 			)}
 
@@ -719,8 +723,8 @@ export function WordPressImport() {
 			{step === "analyzing-plugin" && (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Analyzing WordPress site...</p>
-					<p className="text-sm text-kumo-subtle">Fetching content from the EmDash Exporter API.</p>
+					<p className="mt-4 text-kumo-subtle">{t`Analyzing WordPress site...`}</p>
+					<p className="text-sm text-kumo-subtle">{t`Fetching content from the EmDash Exporter API.`}</p>
 				</div>
 			)}
 
@@ -796,7 +800,7 @@ export function WordPressImport() {
 			{step === "preparing" && (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Creating collections and fields...</p>
+					<p className="mt-4 text-kumo-subtle">{t`Creating collections and fields...`}</p>
 				</div>
 			)}
 
@@ -804,8 +808,8 @@ export function WordPressImport() {
 			{step === "importing" && (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Importing content...</p>
-					<p className="text-sm text-kumo-subtle">This may take a while for large exports.</p>
+					<p className="mt-4 text-kumo-subtle">{t`Importing content...`}</p>
+					<p className="text-sm text-kumo-subtle">{t`This may take a while for large exports.`}</p>
 				</div>
 			)}
 
@@ -828,7 +832,7 @@ export function WordPressImport() {
 			{step === "rewriting" && (
 				<div className="rounded-lg border bg-kumo-base p-12 text-center">
 					<Loader />
-					<p className="mt-4 text-kumo-subtle">Updating content URLs...</p>
+					<p className="mt-4 text-kumo-subtle">{t`Updating content URLs...`}</p>
 				</div>
 			)}
 
@@ -898,6 +902,7 @@ function ChooseStep({
 	onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	onDrop: (e: React.DragEvent) => void;
 }) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-6">
 			{/* URL input - primary path */}
@@ -907,9 +912,9 @@ function ChooseStep({
 						<Globe className="h-6 w-6 text-blue-600 dark:text-blue-400" />
 					</div>
 					<div className="flex-1">
-						<h3 className="text-lg font-medium">Enter your WordPress site URL</h3>
+						<h3 className="text-lg font-medium">{t`Enter your WordPress site URL`}</h3>
 						<p className="text-kumo-subtle mt-1">
-							We'll check what import options are available for your site.
+							{t`We'll check what import options are available for your site.`}
 						</p>
 						<form onSubmit={onProbeUrl} className="mt-4 flex gap-2">
 							<Input
@@ -920,7 +925,7 @@ function ChooseStep({
 								className="flex-1"
 							/>
 							<Button type="submit" disabled={!urlInput.trim()}>
-								Check Site
+								{t`Check Site`}
 							</Button>
 						</form>
 					</div>
@@ -932,7 +937,7 @@ function ChooseStep({
 					<div className="w-full border-t" />
 				</div>
 				<div className="relative flex justify-center text-xs uppercase">
-					<span className="bg-kumo-base px-2 text-kumo-subtle">or upload directly</span>
+					<span className="bg-kumo-base px-2 text-kumo-subtle">{t`or upload directly`}</span>
 				</div>
 			</div>
 
@@ -943,11 +948,13 @@ function ChooseStep({
 				onDrop={onDrop}
 			>
 				<Upload className="mx-auto h-10 w-10 text-kumo-subtle" />
-				<h3 className="mt-3 text-sm font-medium">Upload WordPress export file</h3>
-				<p className="mt-1 text-sm text-kumo-subtle">Drag and drop or click to browse (.xml)</p>
+				<h3 className="mt-3 text-sm font-medium">{t`Upload WordPress export file`}</h3>
+				<p className="mt-1 text-sm text-kumo-subtle">{t`Drag and drop or click to browse (.xml)`}</p>
 				<label className="mt-3 inline-block">
 					<input type="file" accept=".xml" className="sr-only" onChange={onFileSelect} />
-					<span className={buttonVariants({ variant: "outline", size: "sm" })}>Browse Files</span>
+					<span
+						className={buttonVariants({ variant: "outline", size: "sm" })}
+					>{t`Browse Files`}</span>
 				</label>
 			</div>
 		</div>
@@ -993,18 +1000,19 @@ const FEATURE_COMPARISON: FeatureComparisonItem[] = [
 ];
 
 function FeatureComparison() {
+	const { t } = useLingui();
 	return (
 		<div className="rounded-lg border bg-kumo-base overflow-hidden">
 			<div className="border-b p-4 bg-kumo-tint/30">
-				<h3 className="font-medium text-sm">Import Capabilities</h3>
+				<h3 className="font-medium text-sm">{t`Import Capabilities`}</h3>
 			</div>
 			<div className="overflow-x-auto">
 				<table className="w-full text-sm">
 					<thead>
 						<tr className="border-b bg-kumo-tint/20">
-							<th className="text-left p-3 font-medium">Feature</th>
-							<th className="text-center p-3 font-medium whitespace-nowrap">WXR File</th>
-							<th className="text-center p-3 font-medium whitespace-nowrap">Plugin</th>
+							<th className="text-left p-3 font-medium">{t`Feature`}</th>
+							<th className="text-center p-3 font-medium whitespace-nowrap">{t`WXR File`}</th>
+							<th className="text-center p-3 font-medium whitespace-nowrap">{t`Plugin`}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -1026,8 +1034,9 @@ function FeatureComparison() {
 				<div className="flex items-start gap-2 text-sm">
 					<Sparkle className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
 					<p className="text-blue-800 dark:text-blue-200">
-						For the best import experience, install the{" "}
-						<span className="font-medium">EmDash Exporter</span> plugin on your WordPress site.
+						{t`For the best import experience, install the`}{" "}
+						<span className="font-medium">{t`EmDash Exporter`}</span>{" "}
+						{t`plugin on your WordPress site.`}
 					</p>
 				</div>
 			</div>
@@ -1071,6 +1080,7 @@ function ProbeResultStep({
 	onPluginManualAuth: () => void;
 	onReset: () => void;
 }) {
+	const { t } = useLingui();
 	const bestMatch = result.bestMatch;
 	const hasPlugin = bestMatch?.sourceId === "wordpress-plugin";
 
@@ -1081,30 +1091,29 @@ function ProbeResultStep({
 					<div className="flex items-start gap-4">
 						<Warning className="h-6 w-6 text-orange-500 flex-shrink-0" />
 						<div>
-							<h3 className="font-medium">Couldn't detect WordPress</h3>
+							<h3 className="font-medium">{t`Couldn't detect WordPress`}</h3>
 							<p className="mt-1 text-sm text-kumo-subtle">
-								We couldn't connect to a WordPress site at {result.url}. This could mean the site
-								isn't WordPress, the REST API is disabled, or the site isn't accessible.
+								{t`We couldn't connect to a WordPress site at ${result.url}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible.`}
 							</p>
 						</div>
 					</div>
 				</div>
 
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<h3 className="font-medium">Export from WordPress manually</h3>
+					<h3 className="font-medium">{t`Export from WordPress manually`}</h3>
 					<ol className="mt-3 space-y-2 text-sm text-kumo-subtle">
-						<li>1. Log into your WordPress admin dashboard</li>
+						<li>{t`1. Log into your WordPress admin dashboard`}</li>
 						<li>
-							2. Go to <strong>Tools → Export</strong>
+							{t`2. Go to`} <strong>{t`Tools → Export`}</strong>
 						</li>
-						<li>3. Select "All content"</li>
-						<li>4. Click "Download Export File"</li>
-						<li>5. Upload the file here</li>
+						<li>{t`3. Select "All content"`}</li>
+						<li>{t`4. Click "Download Export File"`}</li>
+						<li>{t`5. Upload the file here`}</li>
 					</ol>
 					<div className="mt-4 flex gap-2">
-						<Button onClick={onUploadFile}>Upload Export File</Button>
+						<Button onClick={onUploadFile}>{t`Upload Export File`}</Button>
 						<Button variant="outline" onClick={onReset}>
-							Try Another URL
+							{t`Try Another URL`}
 						</Button>
 					</div>
 				</div>
@@ -1121,12 +1130,12 @@ function ProbeResultStep({
 					<Check className="h-6 w-6 text-green-500 flex-shrink-0" />
 					<div>
 						<h3 className="font-medium">
-							{bestMatch?.detected.siteTitle || "WordPress site"} detected
+							{t`${bestMatch?.detected.siteTitle || "WordPress site"} detected`}
 						</h3>
 						<p className="mt-1 text-sm text-kumo-subtle">
 							{hasPlugin
-								? "EmDash Exporter plugin detected! You can import directly."
-								: "This is a WordPress site."}
+								? t`EmDash Exporter plugin detected! You can import directly.`
+								: t`This is a WordPress site.`}
 						</p>
 					</div>
 				</div>
@@ -1135,24 +1144,24 @@ function ProbeResultStep({
 			{/* Preview counts if available */}
 			{bestMatch?.preview && (
 				<div className="rounded-lg border bg-kumo-base p-4">
-					<h4 className="text-sm font-medium mb-3">Content found:</h4>
+					<h4 className="text-sm font-medium mb-3">{t`Content found:`}</h4>
 					<div className="grid grid-cols-3 gap-4 text-center">
 						{bestMatch.preview.posts !== undefined && (
 							<div>
 								<p className="text-2xl font-bold">{bestMatch.preview.posts}</p>
-								<p className="text-xs text-kumo-subtle">Posts</p>
+								<p className="text-xs text-kumo-subtle">{t`Posts`}</p>
 							</div>
 						)}
 						{bestMatch.preview.pages !== undefined && (
 							<div>
 								<p className="text-2xl font-bold">{bestMatch.preview.pages}</p>
-								<p className="text-xs text-kumo-subtle">Pages</p>
+								<p className="text-xs text-kumo-subtle">{t`Pages`}</p>
 							</div>
 						)}
 						{bestMatch.preview.media !== undefined && (
 							<div>
 								<p className="text-2xl font-bold">{bestMatch.preview.media}</p>
-								<p className="text-xs text-kumo-subtle">Media</p>
+								<p className="text-xs text-kumo-subtle">{t`Media`}</p>
 							</div>
 						)}
 					</div>
@@ -1182,24 +1191,23 @@ function ProbeResultStep({
 							</svg>
 						</div>
 						<div className="flex-1">
-							<h3 className="font-medium">Import via EmDash Exporter</h3>
+							<h3 className="font-medium">{t`Import via EmDash Exporter`}</h3>
 							<p className="mt-1 text-sm text-kumo-subtle">
-								Import all content directly including drafts, custom post types, ACF fields, and SEO
-								data. No file download needed.
+								{t`Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed.`}
 							</p>
 							<p className="mt-2 text-xs text-kumo-subtle">
-								You'll be redirected to WordPress to authorize the connection.
+								{t`You'll be redirected to WordPress to authorize the connection.`}
 							</p>
 							<div className="mt-3 flex items-center gap-3">
 								<Button icon={<ArrowSquareOut />} onClick={onPluginConnect}>
-									Connect with WordPress
+									{t`Connect with WordPress`}
 								</Button>
 								<button
 									type="button"
 									className="text-xs text-kumo-subtle hover:text-kumo-default underline"
 									onClick={onPluginManualAuth}
 								>
-									Enter credentials manually
+									{t`Enter credentials manually`}
 								</button>
 							</div>
 						</div>
@@ -1210,24 +1218,24 @@ function ProbeResultStep({
 			{/* File upload fallback */}
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<h3 className="font-medium">
-					{hasPlugin ? "Or upload an export file" : "Upload an export file"}
+					{hasPlugin ? t`Or upload an export file` : t`Upload an export file`}
 				</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{hasPlugin
-						? "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+						? t`Alternatively, you can export from WordPress (Tools → Export) and upload the file.`
 						: bestMatch?.capabilities.privateContent
-							? "Export your content from WordPress to import everything including drafts."
-							: "For a complete import including drafts and all content, export from WordPress."}
+							? t`Export your content from WordPress to import everything including drafts.`
+							: t`For a complete import including drafts and all content, export from WordPress.`}
 				</p>
 				{bestMatch?.suggestedAction.type === "upload" && (
 					<p className="mt-2 text-sm text-kumo-subtle">{bestMatch.suggestedAction.instructions}</p>
 				)}
 				<div className="mt-4 flex gap-2">
 					<Button variant={hasPlugin ? "outline" : "primary"} onClick={onUploadFile}>
-						Upload Export File
+						{t`Upload Export File`}
 					</Button>
 					<Button variant="outline" onClick={onReset}>
-						Try Another URL
+						{t`Try Another URL`}
 					</Button>
 				</div>
 			</div>
@@ -1256,6 +1264,7 @@ function PluginAuthStep({
 	onBack: () => void;
 	error: string | null;
 }) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-6">
 			<div className="rounded-lg border bg-kumo-base p-6">
@@ -1275,9 +1284,9 @@ function PluginAuthStep({
 						</svg>
 					</div>
 					<div className="flex-1">
-						<h3 className="text-lg font-medium">Connect to {siteTitle || "WordPress"}</h3>
+						<h3 className="text-lg font-medium">{t`Connect to ${siteTitle || "WordPress"}`}</h3>
 						<p className="text-kumo-subtle mt-1">
-							Enter your WordPress credentials to import content directly.
+							{t`Enter your WordPress credentials to import content directly.`}
 						</p>
 					</div>
 				</div>
@@ -1294,7 +1303,7 @@ function PluginAuthStep({
 				<form onSubmit={onSubmit} className="mt-6 space-y-4">
 					<div>
 						<label htmlFor="wp-username" className="block text-sm font-medium mb-1">
-							WordPress Username
+							{t`WordPress Username`}
 						</label>
 						<Input
 							id="wp-username"
@@ -1308,7 +1317,7 @@ function PluginAuthStep({
 
 					<div>
 						<label htmlFor="wp-password" className="block text-sm font-medium mb-1">
-							Application Password
+							{t`Application Password`}
 						</label>
 						<Input
 							id="wp-password"
@@ -1319,16 +1328,16 @@ function PluginAuthStep({
 							autoComplete="current-password"
 						/>
 						<p className="mt-1 text-xs text-kumo-subtle">
-							Create one in WordPress: Users → Profile → Application Passwords
+							{t`Create one in WordPress: Users → Profile → Application Passwords`}
 						</p>
 					</div>
 
 					<div className="flex gap-2 pt-2">
 						<Button type="submit" disabled={!username.trim() || !password.trim()}>
-							Connect & Analyze
+							{t`Connect & Analyze`}
 						</Button>
 						<Button type="button" variant="outline" onClick={onBack}>
-							Back
+							{t`Back`}
 						</Button>
 					</div>
 				</form>
@@ -1338,13 +1347,13 @@ function PluginAuthStep({
 				<div className="flex gap-3">
 					<ArrowSquareOut className="h-5 w-5 text-blue-500 flex-shrink-0" />
 					<div className="text-sm">
-						<p className="font-medium">How to create an Application Password</p>
+						<p className="font-medium">{t`How to create an Application Password`}</p>
 						<ol className="mt-2 space-y-1 text-kumo-subtle">
-							<li>1. Log into your WordPress admin</li>
-							<li>2. Go to Users → Profile</li>
-							<li>3. Scroll to "Application Passwords"</li>
-							<li>4. Enter "EmDash" and click "Add New"</li>
-							<li>5. Copy the generated password</li>
+							<li>{t`1. Log into your WordPress admin`}</li>
+							<li>{t`2. Go to Users → Profile`}</li>
+							<li>{t`3. Scroll to "Application Passwords"`}</li>
+							<li>{t`4. Enter "EmDash" and click "Add New"`}</li>
+							<li>{t`5. Copy the generated password`}</li>
 						</ol>
 						<a
 							href={`${siteUrl}/wp-admin/profile.php#application-passwords-section`}
@@ -1352,7 +1361,7 @@ function PluginAuthStep({
 							rel="noopener noreferrer"
 							className="mt-2 inline-flex items-center gap-1 text-blue-600 hover:underline"
 						>
-							Open WordPress Profile
+							{t`Open WordPress Profile`}
 							<ArrowSquareOut className="h-3 w-3" />
 						</a>
 					</div>
@@ -1377,6 +1386,7 @@ function UploadStep({
 	onRetry: () => void;
 	onBack?: () => void;
 }) {
+	const { t } = useLingui();
 	return (
 		<div className="space-y-4">
 			<div
@@ -1392,33 +1402,33 @@ function UploadStep({
 				{isLoading ? (
 					<div className="space-y-4">
 						<Loader />
-						<p className="text-kumo-subtle">Analyzing export file...</p>
+						<p className="text-kumo-subtle">{t`Analyzing export file...`}</p>
 					</div>
 				) : error ? (
 					<div className="space-y-4">
 						<Warning className="mx-auto h-12 w-12 text-kumo-danger" />
 						<p className="text-kumo-danger">{error.message}</p>
 						<Button variant="outline" onClick={onRetry}>
-							Try Again
+							{t`Try Again`}
 						</Button>
 					</div>
 				) : (
 					<>
 						<Upload className="mx-auto h-12 w-12 text-kumo-subtle" />
-						<h3 className="mt-4 text-lg font-medium">Drop your WordPress export file here</h3>
+						<h3 className="mt-4 text-lg font-medium">{t`Drop your WordPress export file here`}</h3>
 						<p className="mt-2 text-sm text-kumo-subtle">
-							Or click to browse. Accepts .xml files exported from WordPress.
+							{t`Or click to browse. Accepts .xml files exported from WordPress.`}
 						</p>
 						<label className="mt-4 inline-block">
 							<input type="file" accept=".xml" className="sr-only" onChange={onFileSelect} />
-							<span className={buttonVariants({ variant: "outline" })}>Browse Files</span>
+							<span className={buttonVariants({ variant: "outline" })}>{t`Browse Files`}</span>
 						</label>
 					</>
 				)}
 			</div>
 			{onBack && !isLoading && !error && (
 				<Button variant="ghost" onClick={onBack}>
-					← Back
+					{t`← Back`}
 				</Button>
 			)}
 		</div>
@@ -1497,6 +1507,7 @@ function ReviewStep({
 	onImportLogoChange: (value: boolean) => void;
 	onImportSeoChange: (value: boolean) => void;
 }) {
+	const { t } = useLingui();
 	const navMenus = getNavMenus(analysis);
 	const hasMenus = navMenus && navMenus.length > 0;
 
@@ -1515,7 +1526,7 @@ function ReviewStep({
 						<WarningCircle className="h-5 w-5 text-kumo-danger flex-shrink-0" />
 						<div>
 							<p className="font-medium text-kumo-danger">
-								{prepareError ? "Schema preparation failed" : "Import failed"}
+								{prepareError ? t`Schema preparation failed` : t`Import failed`}
 							</p>
 							<p className="mt-1 text-sm text-kumo-danger/90 font-mono">
 								{prepareError || importError}
@@ -1530,7 +1541,7 @@ function ReviewStep({
 					<div className="flex gap-3">
 						<WarningCircle className="h-5 w-5 text-kumo-danger flex-shrink-0" />
 						<div>
-							<p className="font-medium text-kumo-danger">Failed to create some collections</p>
+							<p className="font-medium text-kumo-danger">{t`Failed to create some collections`}</p>
 							<ul className="mt-2 text-sm space-y-1">
 								{prepareResult.errors.map((err, i) => (
 									<li key={i}>
@@ -1547,8 +1558,8 @@ function ReviewStep({
 			{/* Post type list */}
 			<div className="rounded-lg border bg-kumo-base">
 				<div className="border-b p-4">
-					<h3 className="font-medium">Content to Import</h3>
-					<p className="text-sm text-kumo-subtle mt-1">Select which content types to import.</p>
+					<h3 className="font-medium">{t`Content to Import`}</h3>
+					<p className="text-sm text-kumo-subtle mt-1">{t`Select which content types to import.`}</p>
 				</div>
 				<div className="divide-y">
 					{analysis.postTypes.map((pt) => (
@@ -1568,8 +1579,8 @@ function ReviewStep({
 			{hasMenus && (
 				<div className="rounded-lg border bg-kumo-base">
 					<div className="border-b p-4">
-						<h3 className="font-medium">Structure</h3>
-						<p className="text-sm text-kumo-subtle mt-1">Additional data to import.</p>
+						<h3 className="font-medium">{t`Structure`}</h3>
+						<p className="text-sm text-kumo-subtle mt-1">{t`Additional data to import.`}</p>
 					</div>
 					<div className="divide-y">
 						{/* Menus */}
@@ -1581,12 +1592,12 @@ function ReviewStep({
 										checked={importMenus}
 										onChange={(e) => onImportMenusChange(e.target.checked)}
 										className="h-4 w-4 rounded border-gray-300"
-										aria-label="Import navigation menus"
+										aria-label={t`Import navigation menus`}
 									/>
 									<div className="flex items-center gap-2">
 										<List className="h-4 w-4 text-kumo-subtle" />
 										<div>
-											<p className="font-medium">Menus ({navMenus.length})</p>
+											<p className="font-medium">{t`Menus (${navMenus.length})`}</p>
 											<p className="text-sm text-kumo-subtle">
 												{navMenus.map((m) => m.name).join(", ")}
 											</p>
@@ -1605,10 +1616,10 @@ function ReviewStep({
 										checked={true}
 										disabled
 										className="h-4 w-4 rounded border-gray-300"
-										aria-label="Categories will be imported"
+										aria-label={t`Categories will be imported`}
 									/>
 									<div>
-										<p className="font-medium">Categories ({analysis.categories})</p>
+										<p className="font-medium">{t`Categories (${analysis.categories})`}</p>
 									</div>
 								</div>
 							</div>
@@ -1623,10 +1634,10 @@ function ReviewStep({
 										checked={true}
 										disabled
 										className="h-4 w-4 rounded border-gray-300"
-										aria-label="Tags will be imported"
+										aria-label={t`Tags will be imported`}
 									/>
 									<div>
-										<p className="font-medium">Tags ({analysis.tags})</p>
+										<p className="font-medium">{t`Tags (${analysis.tags})`}</p>
 									</div>
 								</div>
 							</div>
@@ -1641,10 +1652,10 @@ function ReviewStep({
 					<div className="border-b p-4">
 						<div className="flex items-center gap-2">
 							<Gear className="h-4 w-4 text-kumo-subtle" />
-							<h3 className="font-medium">Settings</h3>
+							<h3 className="font-medium">{t`Settings`}</h3>
 						</div>
 						<p className="text-sm text-kumo-subtle mt-1">
-							Import site configuration from WordPress.
+							{t`Import site configuration from WordPress.`}
 						</p>
 					</div>
 					<div className="divide-y">
@@ -1656,10 +1667,10 @@ function ReviewStep({
 									checked={importSiteTitle}
 									onChange={(e) => onImportSiteTitleChange(e.target.checked)}
 									className="h-4 w-4 rounded border-gray-300"
-									aria-label="Import site title and tagline"
+									aria-label={t`Import site title and tagline`}
 								/>
 								<div>
-									<p className="font-medium">Site title & tagline</p>
+									<p className="font-medium">{t`Site title & tagline`}</p>
 								</div>
 							</div>
 						</div>
@@ -1672,10 +1683,10 @@ function ReviewStep({
 									checked={importLogo}
 									onChange={(e) => onImportLogoChange(e.target.checked)}
 									className="h-4 w-4 rounded border-gray-300"
-									aria-label="Import logo and favicon"
+									aria-label={t`Import logo and favicon`}
 								/>
 								<div>
-									<p className="font-medium">Logo & favicon</p>
+									<p className="font-medium">{t`Logo & favicon`}</p>
 								</div>
 							</div>
 						</div>
@@ -1688,12 +1699,12 @@ function ReviewStep({
 									checked={importSeo}
 									onChange={(e) => onImportSeoChange(e.target.checked)}
 									className="h-4 w-4 rounded border-gray-300"
-									aria-label="Import SEO settings"
+									aria-label={t`Import SEO settings`}
 								/>
 								<div>
-									<p className="font-medium">SEO settings (Yoast)</p>
+									<p className="font-medium">{t`SEO settings (Yoast)`}</p>
 									<p className="text-sm text-kumo-subtle">
-										Meta titles, descriptions, and social images
+										{t`Meta titles, descriptions, and social images`}
 									</p>
 								</div>
 							</div>
@@ -1707,9 +1718,9 @@ function ReviewStep({
 					<div className="flex gap-3">
 						<WarningCircle className="h-5 w-5 text-kumo-danger flex-shrink-0" />
 						<div>
-							<p className="font-medium text-kumo-danger">Some content types cannot be imported</p>
+							<p className="font-medium text-kumo-danger">{t`Some content types cannot be imported`}</p>
 							<p className="text-sm text-kumo-subtle mt-1">
-								The existing collection has fields with incompatible types.
+								{t`The existing collection has fields with incompatible types.`}
 							</p>
 						</div>
 					</div>
@@ -1721,33 +1732,39 @@ function ReviewStep({
 					<div className="flex gap-3">
 						<Database className="h-5 w-5 text-blue-500 flex-shrink-0" />
 						<div className="space-y-2">
-							<p className="font-medium">What will happen when you import</p>
+							<p className="font-medium">{t`What will happen when you import`}</p>
 							<ul className="text-sm text-kumo-subtle space-y-1">
 								{needsNewCollections > 0 && (
 									<li className="flex items-center gap-2">
 										<Plus className="h-4 w-4" />
-										{needsNewCollections} new collection
-										{needsNewCollections > 1 ? "s" : ""} will be created
+										{plural(needsNewCollections, {
+											one: "# new collection will be created",
+											other: "# new collections will be created",
+										})}
 									</li>
 								)}
 								{needsNewFields > 0 && (
 									<li className="flex items-center gap-2">
 										<Plus className="h-4 w-4" />
-										Fields will be added to {needsNewFields} existing collection
-										{needsNewFields > 1 ? "s" : ""}
+										{plural(needsNewFields, {
+											one: "Fields will be added to # existing collection",
+											other: "Fields will be added to # existing collections",
+										})}
 									</li>
 								)}
 								<li className="flex items-center gap-2">
 									<FileText className="h-4 w-4" />
-									{analysis.postTypes
+									{t`${analysis.postTypes
 										.filter((pt) => selections[pt.name]?.enabled)
-										.reduce((sum, pt) => sum + pt.count, 0)}{" "}
-									items will be imported
+										.reduce((sum, pt) => sum + pt.count, 0)} items will be imported`}
 								</li>
 								{hasMenus && importMenus && (
 									<li className="flex items-center gap-2">
 										<List className="h-4 w-4" />
-										{navMenus.length} menu{navMenus.length > 1 ? "s" : ""} will be imported
+										{plural(navMenus.length, {
+											one: "# menu will be imported",
+											other: "# menus will be imported",
+										})}
 									</li>
 								)}
 							</ul>
@@ -1758,12 +1775,12 @@ function ReviewStep({
 
 			<div className="flex gap-3">
 				<Button variant="outline" onClick={onReset}>
-					Cancel
+					{t`Cancel`}
 				</Button>
 				<Button onClick={onStartImport} disabled={selectedCount === 0}>
 					{needsNewCollections > 0 || needsNewFields > 0
-						? "Create Schema & Import"
-						: "Start Import"}
+						? t`Create Schema & Import`
+						: t`Start Import`}
 				</Button>
 			</div>
 		</div>
@@ -1783,6 +1800,7 @@ function PostTypeRow({
 	onToggleExpand: () => void;
 	onToggleEnabled: (enabled: boolean) => void;
 }) {
+	const { t } = useLingui();
 	const { schemaStatus } = postType;
 	const canImport = schemaStatus.canImport;
 	const isNew = !schemaStatus.exists;
@@ -1800,7 +1818,7 @@ function PostTypeRow({
 						disabled={!canImport}
 						onChange={(e) => onToggleEnabled(e.target.checked)}
 						className="h-4 w-4 rounded border-gray-300"
-						aria-label={`Import ${postType.name}`}
+						aria-label={t`Import ${postType.name}`}
 					/>
 					<button
 						onClick={onToggleExpand}
@@ -1815,20 +1833,20 @@ function PostTypeRow({
 						<div>
 							<p className="font-medium">{postType.name}</p>
 							<p className="text-sm text-kumo-subtle">
-								{postType.count} items → {postType.suggestedCollection}
+								{t`${postType.count} items → ${postType.suggestedCollection}`}
 							</p>
 						</div>
 					</button>
 				</div>
 				<div className="flex items-center gap-2">
 					{!canImport ? (
-						<Badge variant="destructive">Incompatible</Badge>
+						<Badge variant="destructive">{t`Incompatible`}</Badge>
 					) : isNew ? (
-						<Badge variant="secondary">New collection</Badge>
+						<Badge variant="secondary">{t`New collection`}</Badge>
 					) : hasMissingFields ? (
-						<Badge variant="secondary">Add fields</Badge>
+						<Badge variant="secondary">{t`Add fields`}</Badge>
 					) : (
-						<Badge>Ready</Badge>
+						<Badge>{t`Ready`}</Badge>
 					)}
 				</div>
 			</div>
@@ -1841,7 +1859,7 @@ function PostTypeRow({
 							{schemaStatus.reason}
 						</div>
 					)}
-					<p className="font-medium mb-2">Required fields:</p>
+					<p className="font-medium mb-2">{t`Required fields:`}</p>
 					<div className="space-y-1">
 						{postType.requiredFields.map((field) => {
 							const status = schemaStatus.fieldStatus[field.slug];
@@ -1852,15 +1870,15 @@ function PostTypeRow({
 									</span>
 									{status?.status === "compatible" ? (
 										<span className="text-green-600 dark:text-green-400">
-											<Check className="inline h-3 w-3" /> Exists
+											<Check className="inline h-3 w-3" /> {t`Exists`}
 										</span>
 									) : status?.status === "missing" ? (
 										<span className="text-blue-600 dark:text-blue-400">
-											<Plus className="inline h-3 w-3" /> Will create
+											<Plus className="inline h-3 w-3" /> {t`Will create`}
 										</span>
 									) : status?.status === "type_mismatch" ? (
 										<span className="text-red-600 dark:text-red-400">
-											<X className="inline h-3 w-3" /> Type mismatch ({status.existingType})
+											<X className="inline h-3 w-3" /> {t`Type mismatch (${status.existingType})`}
 										</span>
 									) : null}
 								</div>
@@ -1884,6 +1902,7 @@ function MediaStep({
 	onImport: () => void;
 	onSkip: () => void;
 }) {
+	const { t } = useLingui();
 	const byType = attachments.items.reduce(
 		(acc, att) => {
 			const type = att.mimeType?.split("/")[0] || "other";
@@ -1901,9 +1920,9 @@ function MediaStep({
 						<Image className="h-6 w-6 text-blue-600 dark:text-blue-400" />
 					</div>
 					<div className="flex-1">
-						<h3 className="text-lg font-medium">Import Media Files</h3>
+						<h3 className="text-lg font-medium">{t`Import Media Files`}</h3>
 						<p className="text-kumo-subtle mt-1">
-							Your WordPress export contains {attachments.count} media files.
+							{t`Your WordPress export contains ${attachments.count} media files.`}
 						</p>
 					</div>
 				</div>
@@ -1913,7 +1932,7 @@ function MediaStep({
 						{Object.entries(byType).map(([type, count]) => (
 							<div key={type}>
 								<p className="text-kumo-subtle capitalize">{type}</p>
-								<p className="font-medium">{count} files</p>
+								<p className="font-medium">{plural(count, { one: "# file", other: "# files" })}</p>
 							</div>
 						))}
 					</div>
@@ -1932,11 +1951,11 @@ function MediaStep({
 					<div className="flex gap-3">
 						<DownloadSimple className="h-5 w-5 text-blue-500 flex-shrink-0" />
 						<div className="text-sm">
-							<p className="font-medium">What happens when you import:</p>
+							<p className="font-medium">{t`What happens when you import:`}</p>
 							<ul className="mt-1 space-y-1 text-kumo-subtle">
-								<li>• Files are downloaded from your WordPress site</li>
-								<li>• Uploaded to your EmDash media storage</li>
-								<li>• URLs in your content are updated automatically</li>
+								<li>{t`• Files are downloaded from your WordPress site`}</li>
+								<li>{t`• Uploaded to your EmDash media storage`}</li>
+								<li>{t`• URLs in your content are updated automatically`}</li>
 							</ul>
 						</div>
 					</div>
@@ -1945,10 +1964,10 @@ function MediaStep({
 
 			<div className="flex gap-3">
 				<Button variant="outline" onClick={onSkip}>
-					Skip Media Import
+					{t`Skip Media Import`}
 				</Button>
 				<Button icon={<DownloadSimple />} onClick={onImport}>
-					Import Media
+					{t`Import Media`}
 				</Button>
 			</div>
 		</div>
@@ -1962,15 +1981,16 @@ function MediaProgressStep({
 	progress: MediaImportProgress | null;
 	total: number;
 }) {
+	const { t } = useLingui();
 	const current = progress?.current ?? 0;
 	const percentage = total > 0 ? Math.round((current / total) * 100) : 0;
 
 	const statusLabels: Record<MediaImportProgress["status"], string> = {
-		downloading: "Downloading",
-		uploading: "Uploading",
-		done: "Done",
-		skipped: "Skipped",
-		failed: "Failed",
+		downloading: t`Downloading`,
+		uploading: t`Uploading`,
+		done: t`Done`,
+		skipped: t`Skipped`,
+		failed: t`Failed`,
 	};
 
 	return (
@@ -1979,13 +1999,11 @@ function MediaProgressStep({
 				<Loader size="lg" />
 				<p className="text-sm font-medium mt-2">{percentage}%</p>
 
-				<h3 className="mt-6 text-lg font-medium">Importing Media</h3>
+				<h3 className="mt-6 text-lg font-medium">{t`Importing Media`}</h3>
 
 				<div className="w-full max-w-md mt-4">
 					<div className="flex justify-between text-sm text-kumo-subtle mb-1">
-						<span>
-							{current} of {total}
-						</span>
+						<span>{t`${current} of ${total}`}</span>
 						<span>{percentage}%</span>
 					</div>
 					<div className="h-2 bg-kumo-tint rounded-full overflow-hidden">
@@ -2000,7 +2018,7 @@ function MediaProgressStep({
 					<div className="mt-4 p-3 rounded-lg bg-kumo-tint/50 w-full max-w-md">
 						<div className="flex items-center justify-between text-sm">
 							<span className="font-medium truncate max-w-[70%]">
-								{progress.filename || `File ${progress.current}`}
+								{progress.filename || t`File ${progress.current}`}
 							</span>
 							<span
 								className={cn(
@@ -2026,7 +2044,7 @@ function MediaProgressStep({
 
 				{!progress && (
 					<p className="mt-4 text-sm text-kumo-subtle">
-						Preparing to download files from WordPress...
+						{t`Preparing to download files from WordPress...`}
 					</p>
 				)}
 			</div>
@@ -2056,22 +2074,43 @@ function CompleteStep({
 	const wasMediaOnlyImport =
 		result.imported === 0 && result.skipped > 0 && mediaResult && mediaResult.imported.length > 0;
 
+	const { t } = useLingui();
+
 	const getSummaryMessage = () => {
 		const parts: string[] = [];
 		if (result.imported > 0) {
-			parts.push(`${result.imported} content items imported`);
+			parts.push(
+				plural(result.imported, {
+					one: "# content item imported",
+					other: "# content items imported",
+				}),
+			);
 		}
 		if (result.skipped > 0 && result.imported > 0) {
-			parts.push(`${result.skipped} skipped (already exist)`);
+			parts.push(
+				plural(result.skipped, {
+					one: "# skipped (already exists)",
+					other: "# skipped (already exist)",
+				}),
+			);
 		}
 		if (mediaResult && mediaResult.imported.length > 0) {
-			parts.push(`${mediaResult.imported.length} media files imported`);
+			parts.push(
+				plural(mediaResult.imported.length, {
+					one: "# media file imported",
+					other: "# media files imported",
+				}),
+			);
 		}
 		if (hasContentErrors) {
-			parts.push(`${result.errors.length} content errors`);
+			parts.push(
+				plural(result.errors.length, { one: "# content error", other: "# content errors" }),
+			);
 		}
 		if (hasMediaErrors) {
-			parts.push(`${mediaResult.failed.length} media errors`);
+			parts.push(
+				plural(mediaResult.failed.length, { one: "# media error", other: "# media errors" }),
+			);
 		}
 		return parts.join(" · ");
 	};
@@ -2094,35 +2133,37 @@ function CompleteStep({
 				<h3 className="mt-4 text-lg font-medium">
 					{overallSuccess
 						? wasMediaOnlyImport
-							? "Media Import Complete"
-							: "Import Complete"
-						: "Import Completed with Errors"}
+							? t`Media Import Complete`
+							: t`Import Complete`
+						: t`Import Completed with Errors`}
 				</h3>
 				<p className="mt-2 text-kumo-subtle">{getSummaryMessage()}</p>
 				{wasMediaOnlyImport && (
 					<p className="text-sm text-kumo-subtle mt-1">
-						Content was skipped because it already exists
+						{t`Content was skipped because it already exists`}
 					</p>
 				)}
-				{skippedMedia && <p className="text-sm text-kumo-subtle mt-1">Media import was skipped</p>}
+				{skippedMedia && (
+					<p className="text-sm text-kumo-subtle mt-1">{t`Media import was skipped`}</p>
+				)}
 			</div>
 
 			{prepareResult &&
 				(prepareResult.collectionsCreated.length > 0 || prepareResult.fieldsCreated.length > 0) && (
 					<div className="rounded-lg border bg-kumo-base">
 						<div className="border-b p-4">
-							<h3 className="font-medium">Schema Changes</h3>
+							<h3 className="font-medium">{t`Schema Changes`}</h3>
 						</div>
 						<div className="p-4 space-y-2 text-sm">
 							{prepareResult.collectionsCreated.length > 0 && (
 								<p>
-									<strong>Collections created:</strong>{" "}
+									<strong>{t`Collections created:`}</strong>{" "}
 									{prepareResult.collectionsCreated.join(", ")}
 								</p>
 							)}
 							{prepareResult.fieldsCreated.length > 0 && (
 								<p>
-									<strong>Fields created:</strong>{" "}
+									<strong>{t`Fields created:`}</strong>{" "}
 									{prepareResult.fieldsCreated.map((f) => `${f.collection}.${f.field}`).join(", ")}
 								</p>
 							)}
@@ -2133,13 +2174,15 @@ function CompleteStep({
 			{Object.keys(result.byCollection).length > 0 && (
 				<div className="rounded-lg border bg-kumo-base">
 					<div className="border-b p-4">
-						<h3 className="font-medium">Imported by Collection</h3>
+						<h3 className="font-medium">{t`Imported by Collection`}</h3>
 					</div>
 					<div className="divide-y">
 						{Object.entries(result.byCollection).map(([collection, count]) => (
 							<div key={collection} className="flex items-center justify-between p-4">
 								<span className="font-medium">{collection}</span>
-								<span className="text-kumo-subtle">{count} items</span>
+								<span className="text-kumo-subtle">
+									{plural(count, { one: "# item", other: "# items" })}
+								</span>
 							</div>
 						))}
 					</div>
@@ -2149,16 +2192,16 @@ function CompleteStep({
 			{mediaResult && mediaResult.imported.length > 0 && (
 				<div className="rounded-lg border bg-kumo-base">
 					<div className="border-b p-4">
-						<h3 className="font-medium">Media Import</h3>
+						<h3 className="font-medium">{t`Media Import`}</h3>
 					</div>
 					<div className="p-4 space-y-2 text-sm">
 						<p>
-							<strong>{mediaResult.imported.length}</strong> files imported
+							<strong>{mediaResult.imported.length}</strong> {t`files imported`}
 						</p>
 						{rewriteResult && rewriteResult.updated > 0 && (
 							<p>
-								<strong>{rewriteResult.urlsRewritten}</strong> image URLs updated in{" "}
-								<strong>{rewriteResult.updated}</strong> content items
+								<strong>{rewriteResult.urlsRewritten}</strong> {t`image URLs updated in`}{" "}
+								<strong>{rewriteResult.updated}</strong> {t`content items`}
 							</p>
 						)}
 					</div>
@@ -2169,7 +2212,7 @@ function CompleteStep({
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10">
 					<div className="border-b border-kumo-danger/50 p-4">
 						<h3 className="font-medium text-kumo-danger">
-							Content Errors ({result.errors.length})
+							{t`Content Errors (${result.errors.length})`}
 						</h3>
 					</div>
 					<div className="divide-y divide-destructive/20 max-h-64 overflow-y-auto">
@@ -2187,7 +2230,7 @@ function CompleteStep({
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10">
 					<div className="border-b border-kumo-danger/50 p-4">
 						<h3 className="font-medium text-kumo-danger">
-							Media Errors ({mediaResult.failed.length})
+							{t`Media Errors (${mediaResult.failed.length})`}
 						</h3>
 					</div>
 					<div className="divide-y divide-destructive/20 max-h-64 overflow-y-auto">
@@ -2203,9 +2246,9 @@ function CompleteStep({
 
 			<div className="flex gap-3">
 				<Button variant="outline" onClick={onReset}>
-					Import Another File
+					{t`Import Another File`}
 				</Button>
-				<LinkButton href="/_emdash/admin">Go to Dashboard</LinkButton>
+				<LinkButton href="/_emdash/admin">{t`Go to Dashboard`}</LinkButton>
 			</div>
 		</div>
 	);
@@ -2228,6 +2271,7 @@ function AuthorMappingStep({
 	onContinue: () => void;
 	onBack: () => void;
 }) {
+	const { t } = useLingui();
 	// Count matched vs unmatched
 	const matchedCount = authorMappings.filter((m) => m.emdashUserId !== null).length;
 	const totalCount = authorMappings.length;
@@ -2240,15 +2284,14 @@ function AuthorMappingStep({
 						<User className="h-6 w-6 text-blue-600 dark:text-blue-400" />
 					</div>
 					<div>
-						<h3 className="text-lg font-medium">Map Authors</h3>
+						<h3 className="text-lg font-medium">{t`Map Authors`}</h3>
 						<p className="text-kumo-subtle mt-1">
-							Assign WordPress authors to EmDash users. Posts will be attributed to the selected
-							user.
+							{t`Assign WordPress authors to EmDash users. Posts will be attributed to the selected user.`}
 						</p>
 						{matchedCount > 0 && (
 							<p className="text-sm text-green-600 dark:text-green-400 mt-2">
 								<Check className="inline h-4 w-4 mr-1" />
-								{matchedCount} of {totalCount} authors matched by email
+								{t`${matchedCount} of ${totalCount} authors matched by email`}
 							</p>
 						)}
 					</div>
@@ -2258,9 +2301,9 @@ function AuthorMappingStep({
 			<div className="rounded-lg border bg-kumo-base">
 				<div className="border-b p-4">
 					<div className="flex items-center justify-between">
-						<h3 className="font-medium">Author Mapping</h3>
+						<h3 className="font-medium">{t`Author Mapping`}</h3>
 						<span className="text-sm text-kumo-subtle">
-							{matchedCount} of {totalCount} assigned
+							{t`${matchedCount} of ${totalCount} assigned`}
 						</span>
 					</div>
 				</div>
@@ -2272,7 +2315,9 @@ function AuthorMappingStep({
 								<p className="text-sm text-kumo-subtle">
 									{mapping.wpEmail || mapping.wpLogin}
 									{mapping.postCount > 0 && (
-										<span className="ml-2">• {mapping.postCount} posts</span>
+										<span className="ml-2">
+											• {plural(mapping.postCount, { one: "# post", other: "# posts" })}
+										</span>
 									)}
 								</p>
 							</div>
@@ -2283,7 +2328,7 @@ function AuthorMappingStep({
 									onChange={(e) => onMappingChange(mapping.wpLogin, e.target.value || null)}
 									className="w-48 px-3 py-2 rounded-md border bg-kumo-base text-sm"
 								>
-									<option value="">Leave unassigned</option>
+									<option value="">{t`Leave unassigned`}</option>
 									{emdashUsers.map((user) => (
 										<option key={user.id} value={user.id}>
 											{user.name || user.email}
@@ -2301,10 +2346,9 @@ function AuthorMappingStep({
 					<div className="flex gap-3">
 						<Warning className="h-5 w-5 text-yellow-500 flex-shrink-0" />
 						<div>
-							<p className="font-medium">No EmDash users found</p>
+							<p className="font-medium">{t`No EmDash users found`}</p>
 							<p className="text-sm text-kumo-subtle mt-1">
-								All imported content will be unassigned. You can reassign authors later from the
-								content editor.
+								{t`All imported content will be unassigned. You can reassign authors later from the content editor.`}
 							</p>
 						</div>
 					</div>
@@ -2313,9 +2357,9 @@ function AuthorMappingStep({
 
 			<div className="flex gap-3">
 				<Button variant="outline" onClick={onBack}>
-					Back
+					{t`Back`}
 				</Button>
-				<Button onClick={onContinue}>Continue Import</Button>
+				<Button onClick={onContinue}>{t`Continue Import`}</Button>
 			</div>
 		</div>
 	);

--- a/packages/admin/src/components/auth/PasskeyLogin.tsx
+++ b/packages/admin/src/components/auth/PasskeyLogin.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 import { apiFetch, parseApiResponse } from "../../lib/api/client";
@@ -129,8 +130,10 @@ export function PasskeyLogin({
 	onSuccess,
 	onError,
 	showEmailInput = false,
-	buttonText = "Sign in with Passkey",
+	buttonText,
 }: PasskeyLoginProps) {
+	const { t } = useLingui();
+	const resolvedButtonText = buttonText ?? t`Sign in with Passkey`;
 	const [state, setState] = React.useState<LoginState>({ status: "idle" });
 	const [email, setEmail] = React.useState("");
 	const [supportsConditional, setSupportsConditional] = React.useState(false);
@@ -152,15 +155,15 @@ export function PasskeyLogin({
 				setState({
 					status: "error",
 					message: insecureContext
-						? "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-						: "WebAuthn is not supported in this browser",
+						? t`Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context.`
+						: t`WebAuthn is not supported in this browser`,
 				});
 				return;
 			}
 
 			try {
 				// Step 1: Get authentication options from server
-				setState({ status: "loading", message: "Preparing..." });
+				setState({ status: "loading", message: t`Preparing...` });
 
 				const optionsResponse = await apiFetch(optionsEndpoint, {
 					method: "POST",
@@ -174,7 +177,7 @@ export function PasskeyLogin({
 				const { options } = optionsData;
 
 				// Step 2: Get assertion from browser
-				setState({ status: "loading", message: "Waiting for passkey..." });
+				setState({ status: "loading", message: t`Waiting for passkey...` });
 
 				// Convert options to the format expected by the browser
 				const publicKeyOptions: PublicKeyCredentialRequestOptions = {
@@ -207,7 +210,7 @@ export function PasskeyLogin({
 				}
 
 				// Step 3: Send credential to server for verification
-				setState({ status: "loading", message: "Verifying..." });
+				setState({ status: "loading", message: t`Verifying...` });
 
 				// navigator.credentials.get() with publicKey returns PublicKeyCredential
 				const credential = rawCredential as PublicKeyCredential;
@@ -257,23 +260,23 @@ export function PasskeyLogin({
 				if (error instanceof DOMException) {
 					switch (error.name) {
 						case "NotAllowedError":
-							userMessage = "Authentication was cancelled or timed out. Please try again.";
+							userMessage = t`Authentication was cancelled or timed out. Please try again.`;
 							break;
 						case "InvalidStateError":
-							userMessage = "No matching passkey found for this account.";
+							userMessage = t`No matching passkey found for this account.`;
 							break;
 						case "NotSupportedError":
-							userMessage = "Your device doesn't support the required security features.";
+							userMessage = t`Your device doesn't support the required security features.`;
 							break;
 						case "SecurityError":
-							userMessage = "Security error. Make sure you're on a secure connection.";
+							userMessage = t`Security error. Make sure you're on a secure connection.`;
 							break;
 						case "AbortError":
 							// User cancelled - don't show error
 							setState({ status: "idle" });
 							return;
 						default:
-							userMessage = `Authentication error: ${error.message}`;
+							userMessage = t`Authentication error: ${error.message}`;
 					}
 				}
 
@@ -290,26 +293,29 @@ export function PasskeyLogin({
 			supportsConditional,
 			onSuccess,
 			onError,
+			t,
 		],
 	);
 
 	if (!isSupported) {
 		return (
 			<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-4">
-				<h3 className="font-medium text-kumo-danger">Passkeys Not Available Here</h3>
+				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
 						<>
-							Passkeys require a <strong className="text-kumo-default">secure context</strong>: use{" "}
-							<strong className="text-kumo-default">HTTPS</strong>, or open the admin at{" "}
-							<strong className="text-kumo-default">http://localhost</strong> (with your dev port).
-							Plain <code className="text-xs">http://</code> on a custom hostname is not treated as
-							secure, even on loopback.
+							{t`Passkeys require a`}{" "}
+							<strong className="text-kumo-default">{t`secure context`}</strong>
+							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
+							{t`, or open the admin at`}{" "}
+							<strong className="text-kumo-default">http://localhost</strong>{" "}
+							{t`(with your dev port).`}
+							{t`Plain`} <code className="text-xs">http://</code>{" "}
+							{t`on a custom hostname is not treated as secure, even on loopback.`}
 						</>
 					) : (
 						<>
-							Your browser doesn't support passkeys. Please use a modern browser like Chrome,
-							Safari, Firefox, or Edge.
+							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}
 						</>
 					)}
 				</p>
@@ -323,16 +329,16 @@ export function PasskeyLogin({
 			{showEmailInput && (
 				<div>
 					<Input
-						label="Email (optional)"
+						label={t`Email (optional)`}
 						type="email"
 						value={email}
 						onChange={(e) => setEmail(e.target.value)}
-						placeholder="you@example.com"
+						placeholder={t`you@example.com`}
 						disabled={state.status === "loading"}
 						autoComplete="username webauthn"
 					/>
 					<p className="mt-1 text-xs text-kumo-subtle">
-						Leave blank to use a discoverable passkey.
+						{t`Leave blank to use a discoverable passkey.`}
 					</p>
 				</div>
 			)}
@@ -352,12 +358,12 @@ export function PasskeyLogin({
 				className="w-full justify-center"
 				variant="primary"
 			>
-				{state.status === "loading" ? <>{state.message}</> : buttonText}
+				{state.status === "loading" ? <>{state.message}</> : resolvedButtonText}
 			</Button>
 
 			{/* Help text */}
 			<p className="text-xs text-kumo-subtle text-center">
-				Use your device's biometric authentication, security key, or PIN to sign in.
+				{t`Use your device's biometric authentication, security key, or PIN to sign in.`}
 			</p>
 		</div>
 	);

--- a/packages/admin/src/components/auth/PasskeyRegistration.tsx
+++ b/packages/admin/src/components/auth/PasskeyRegistration.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 import { apiFetch, parseApiResponse } from "../../lib/api/client";
@@ -137,10 +138,12 @@ export function PasskeyRegistration({
 	verifyEndpoint,
 	onSuccess,
 	onError,
-	buttonText = "Register Passkey",
+	buttonText,
 	showNameInput = false,
 	additionalData = EMPTY_DATA,
 }: PasskeyRegistrationProps) {
+	const { t } = useLingui();
+	const resolvedButtonText = buttonText ?? t`Register Passkey`;
 	const [state, setState] = React.useState<RegistrationState>({
 		status: "idle",
 	});
@@ -157,14 +160,14 @@ export function PasskeyRegistration({
 		if (!isSupported) {
 			setState({
 				status: "error",
-				message: "WebAuthn is not supported in this browser",
+				message: t`WebAuthn is not supported in this browser`,
 			});
 			return;
 		}
 
 		try {
 			// Step 1: Get registration options from server
-			setState({ status: "loading", message: "Preparing registration..." });
+			setState({ status: "loading", message: t`Preparing registration...` });
 
 			const optionsResponse = await apiFetch(optionsEndpoint, {
 				method: "POST",
@@ -178,7 +181,7 @@ export function PasskeyRegistration({
 			const { options } = optionsData;
 
 			// Step 2: Create credential with browser
-			setState({ status: "loading", message: "Waiting for passkey..." });
+			setState({ status: "loading", message: t`Waiting for passkey...` });
 
 			// Convert options to the format expected by the browser
 			const publicKeyOptions: PublicKeyCredentialCreationOptions = {
@@ -209,7 +212,7 @@ export function PasskeyRegistration({
 			}
 
 			// Step 3: Send credential to server for verification
-			setState({ status: "loading", message: "Verifying..." });
+			setState({ status: "loading", message: t`Verifying...` });
 
 			// navigator.credentials.create() with publicKey returns PublicKeyCredential
 			const credential = rawCredential as PublicKeyCredential;
@@ -260,19 +263,19 @@ export function PasskeyRegistration({
 			if (error instanceof DOMException) {
 				switch (error.name) {
 					case "NotAllowedError":
-						userMessage = "Registration was cancelled or timed out. Please try again.";
+						userMessage = t`Registration was cancelled or timed out. Please try again.`;
 						break;
 					case "InvalidStateError":
-						userMessage = "This passkey is already registered on this device.";
+						userMessage = t`This passkey is already registered on this device.`;
 						break;
 					case "NotSupportedError":
-						userMessage = "Your device doesn't support the required security features.";
+						userMessage = t`Your device doesn't support the required security features.`;
 						break;
 					case "SecurityError":
-						userMessage = "Security error. Make sure you're on a secure connection.";
+						userMessage = t`Security error. Make sure you're on a secure connection.`;
 						break;
 					default:
-						userMessage = `Authentication error: ${error.message}`;
+						userMessage = t`Authentication error: ${error.message}`;
 				}
 			}
 
@@ -287,26 +290,29 @@ export function PasskeyRegistration({
 		passkeyName,
 		onSuccess,
 		onError,
+		t,
 	]);
 
 	// Not usable (insecure origin vs missing API — browser hides WebAuthn the same way)
 	if (!isSupported) {
 		return (
 			<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-4">
-				<h3 className="font-medium text-kumo-danger">Passkeys Not Available Here</h3>
+				<h3 className="font-medium text-kumo-danger">{t`Passkeys Not Available Here`}</h3>
 				<p className="mt-1 text-sm text-kumo-subtle">
 					{insecureContext ? (
 						<>
-							Passkeys require a <strong className="text-kumo-default">secure context</strong>: use{" "}
-							<strong className="text-kumo-default">HTTPS</strong>, or open the admin at{" "}
-							<strong className="text-kumo-default">http://localhost</strong> (with your dev port).
-							Plain <code className="text-xs">http://</code> on a custom hostname is not treated as
-							secure, even on loopback.
+							{t`Passkeys require a`}{" "}
+							<strong className="text-kumo-default">{t`secure context`}</strong>
+							{t`: use`} <strong className="text-kumo-default">HTTPS</strong>
+							{t`, or open the admin at`}{" "}
+							<strong className="text-kumo-default">http://localhost</strong>{" "}
+							{t`(with your dev port).`}
+							{t`Plain`} <code className="text-xs">http://</code>{" "}
+							{t`on a custom hostname is not treated as secure, even on loopback.`}
 						</>
 					) : (
 						<>
-							Your browser doesn't support passkeys. Please use a modern browser like Chrome,
-							Safari, Firefox, or Edge.
+							{t`Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge.`}
 						</>
 					)}
 				</p>
@@ -320,15 +326,15 @@ export function PasskeyRegistration({
 			{showNameInput && (
 				<div>
 					<Input
-						label="Passkey Name (optional)"
+						label={t`Passkey Name (optional)`}
 						type="text"
 						value={passkeyName}
 						onChange={(e) => setPasskeyName(e.target.value)}
-						placeholder="e.g., MacBook Pro, iPhone"
+						placeholder={t`e.g., MacBook Pro, iPhone`}
 						disabled={state.status === "loading"}
 					/>
 					<p className="mt-1 text-xs text-kumo-subtle">
-						Give this passkey a name to help you identify it later.
+						{t`Give this passkey a name to help you identify it later.`}
 					</p>
 				</div>
 			)}
@@ -343,7 +349,7 @@ export function PasskeyRegistration({
 			{/* Success message */}
 			{state.status === "success" && (
 				<div className="rounded-lg bg-green-500/10 p-4 text-sm text-green-700 dark:text-green-400">
-					Passkey registered successfully!
+					{t`Passkey registered successfully!`}
 				</div>
 			)}
 
@@ -355,12 +361,12 @@ export function PasskeyRegistration({
 				className="w-full justify-center"
 				variant="primary"
 			>
-				{state.status === "loading" ? <>{state.message}</> : buttonText}
+				{state.status === "loading" ? <>{state.message}</> : resolvedButtonText}
 			</Button>
 
 			{/* Help text */}
 			<p className="text-xs text-kumo-subtle text-center">
-				You'll be prompted to use your device's biometric authentication, security key, or PIN.
+				{t`You'll be prompted to use your device's biometric authentication, security key, or PIN.`}
 			</p>
 		</div>
 	);

--- a/packages/admin/src/components/comments/CommentDetail.tsx
+++ b/packages/admin/src/components/comments/CommentDetail.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Badge, Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { X, Check, Trash, Warning, UserCircle, EnvelopeSimple } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -29,6 +30,8 @@ export function CommentDetail({
 	isAdmin,
 	isStatusPending,
 }: CommentDetailProps) {
+	const { t } = useLingui();
+
 	// Close on Escape
 	React.useEffect(() => {
 		const handler = (e: KeyboardEvent) => {
@@ -52,8 +55,8 @@ export function CommentDetail({
 			<div className="fixed inset-y-0 right-0 z-50 w-full max-w-lg overflow-y-auto bg-kumo-base border-l shadow-lg">
 				{/* Header */}
 				<div className="flex items-center justify-between border-b px-6 py-4">
-					<h2 className="text-lg font-semibold">Comment Detail</h2>
-					<Button variant="ghost" shape="square" onClick={onClose} aria-label="Close">
+					<h2 className="text-lg font-semibold">{t`Comment Detail`}</h2>
+					<Button variant="ghost" shape="square" onClick={onClose} aria-label={t`Close`}>
 						<X className="h-5 w-5" />
 					</Button>
 				</div>
@@ -71,13 +74,13 @@ export function CommentDetail({
 					{/* Author info */}
 					<div className="rounded-lg border p-4 space-y-3">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
-							Author
+							{t`Author`}
 						</h3>
 						<div className="space-y-2">
 							<div className="flex items-center gap-2">
 								<UserCircle className="h-4 w-4 text-kumo-subtle" />
 								<span className="font-medium">{comment.authorName}</span>
-								{comment.authorUserId && <Badge variant="secondary">Registered user</Badge>}
+								{comment.authorUserId && <Badge variant="secondary">{t`Registered user`}</Badge>}
 							</div>
 							<div className="flex items-center gap-2">
 								<EnvelopeSimple className="h-4 w-4 text-kumo-subtle" />
@@ -89,7 +92,7 @@ export function CommentDetail({
 					{/* Comment body */}
 					<div className="rounded-lg border p-4 space-y-3">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
-							Comment
+							{t`Comment`}
 						</h3>
 						<p className="text-sm whitespace-pre-wrap break-words">{comment.body}</p>
 					</div>
@@ -97,21 +100,21 @@ export function CommentDetail({
 					{/* Content reference */}
 					<div className="rounded-lg border p-4 space-y-2">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
-							Content
+							{t`Content`}
 						</h3>
 						<p className="text-sm">
-							<span className="text-kumo-subtle">Collection:</span>{" "}
+							<span className="text-kumo-subtle">{t`Collection:`}</span>{" "}
 							<span className="font-medium">{comment.collection}</span>
 						</p>
 						<p className="text-sm">
-							<span className="text-kumo-subtle">Content ID:</span>{" "}
+							<span className="text-kumo-subtle">{t`Content ID:`}</span>{" "}
 							<code className="bg-kumo-tint px-1.5 py-0.5 rounded text-xs">
 								{comment.contentId}
 							</code>
 						</p>
 						{comment.parentId && (
 							<p className="text-sm">
-								<span className="text-kumo-subtle">Reply to:</span>{" "}
+								<span className="text-kumo-subtle">{t`Reply to:`}</span>{" "}
 								<code className="bg-kumo-tint px-1.5 py-0.5 rounded text-xs">
 									{comment.parentId}
 								</code>
@@ -123,7 +126,7 @@ export function CommentDetail({
 					{comment.moderationMetadata && Object.keys(comment.moderationMetadata).length > 0 && (
 						<div className="rounded-lg border p-4 space-y-3">
 							<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
-								Moderation Signals
+								{t`Moderation Signals`}
 							</h3>
 							<pre className="text-xs bg-kumo-tint rounded p-3 overflow-x-auto">
 								{JSON.stringify(comment.moderationMetadata, null, 2)}
@@ -142,7 +145,7 @@ export function CommentDetail({
 								disabled={isStatusPending}
 								className="flex-1"
 							>
-								Approve
+								{t`Approve`}
 							</Button>
 						)}
 						{comment.status !== "spam" && (
@@ -153,7 +156,7 @@ export function CommentDetail({
 								disabled={isStatusPending}
 								className="flex-1"
 							>
-								Spam
+								{t`Spam`}
 							</Button>
 						)}
 						{comment.status !== "trash" && (
@@ -164,7 +167,7 @@ export function CommentDetail({
 								disabled={isStatusPending}
 								className="flex-1"
 							>
-								Trash
+								{t`Trash`}
 							</Button>
 						)}
 					</div>
@@ -176,7 +179,7 @@ export function CommentDetail({
 							disabled={isStatusPending}
 							className="w-full"
 						>
-							Delete Permanently
+							{t`Delete Permanently`}
 						</Button>
 					)}
 				</div>
@@ -186,6 +189,15 @@ export function CommentDetail({
 }
 
 export function CommentStatusBadge({ status }: { status: CommentStatus }) {
+	const { t } = useLingui();
+
+	const labels: Record<CommentStatus, string> = {
+		approved: t`approved`,
+		pending: t`pending`,
+		spam: t`spam`,
+		trash: t`trash`,
+	};
+
 	return (
 		<span
 			className={cn(
@@ -198,7 +210,7 @@ export function CommentStatusBadge({ status }: { status: CommentStatus }) {
 				status === "trash" && "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",
 			)}
 		>
-			{status}
+			{labels[status]}
 		</span>
 	);
 }

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -6,6 +6,8 @@
  */
 
 import { Badge, Button, Checkbox, Input, Select, Tabs } from "@cloudflare/kumo";
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
 	Check,
@@ -80,6 +82,8 @@ export function CommentInbox({
 	deleteError,
 	onDeleteErrorReset,
 }: CommentInboxProps) {
+	const { t } = useLingui();
+
 	// Selection state
 	const [selected, setSelected] = React.useState<Set<string>>(new Set());
 	const [detailComment, setDetailComment] = React.useState<AdminComment | null>(null);
@@ -133,7 +137,7 @@ export function CommentInbox({
 	};
 
 	// Collection filter items
-	const collectionItems: Record<string, string> = { "": "All collections" };
+	const collectionItems: Record<string, string> = { "": t`All collections` };
 	for (const [slug, config] of Object.entries(collections)) {
 		collectionItems[slug] = config.label;
 	}
@@ -146,8 +150,12 @@ export function CommentInbox({
 			<div className="flex items-center justify-between">
 				<div className="flex items-center gap-3">
 					<ChatCircle className="h-6 w-6" />
-					<h1 className="text-2xl font-bold">Comments</h1>
-					{total > 0 && <span className="text-sm text-kumo-subtle">{total} total</span>}
+					<h1 className="text-2xl font-bold">{t`Comments`}</h1>
+					{total > 0 && (
+						<span className="text-sm text-kumo-subtle">
+							{plural(total, { one: "# total", other: "# total" })}
+						</span>
+					)}
 				</div>
 			</div>
 
@@ -158,8 +166,8 @@ export function CommentInbox({
 					<MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 					<Input
 						type="search"
-						placeholder="Search comments..."
-						aria-label="Search comments"
+						placeholder={t`Search comments...`}
+						aria-label={t`Search comments`}
 						value={searchQuery}
 						onChange={(e) => onSearchChange(e.target.value)}
 						className="pl-9"
@@ -173,7 +181,7 @@ export function CommentInbox({
 							value={collectionFilter}
 							onValueChange={(v) => onCollectionFilterChange(v ?? "")}
 							items={collectionItems}
-							aria-label="Filter by collection"
+							aria-label={t`Filter by collection`}
 						/>
 					</div>
 				)}
@@ -193,17 +201,17 @@ export function CommentInbox({
 						value: "pending",
 						label: (
 							<span className="flex items-center gap-2">
-								Pending
+								{t`Pending`}
 								{counts.pending > 0 && <Badge variant="secondary">{counts.pending}</Badge>}
 							</span>
 						),
 					},
-					{ value: "approved", label: "Approved" },
+					{ value: "approved", label: t`Approved` },
 					{
 						value: "spam",
 						label: (
 							<span className="flex items-center gap-2">
-								Spam
+								{t`Spam`}
 								{counts.spam > 0 && <Badge variant="secondary">{counts.spam}</Badge>}
 							</span>
 						),
@@ -212,7 +220,7 @@ export function CommentInbox({
 						value: "trash",
 						label: (
 							<span className="flex items-center gap-2">
-								Trash
+								{t`Trash`}
 								{counts.trash > 0 && <Badge variant="secondary">{counts.trash}</Badge>}
 							</span>
 						),
@@ -223,7 +231,9 @@ export function CommentInbox({
 			{/* Bulk action bar */}
 			{selected.size > 0 && (
 				<div className="flex items-center gap-3 rounded-lg border bg-kumo-tint/50 px-4 py-2">
-					<span className="text-sm font-medium">{selected.size} selected</span>
+					<span className="text-sm font-medium">
+						{plural(selected.size, { one: "# selected", other: "# selected" })}
+					</span>
 					<div className="flex gap-2 ml-auto">
 						{activeStatus !== "approved" && (
 							<Button
@@ -231,7 +241,7 @@ export function CommentInbox({
 								icon={<Check className="h-3.5 w-3.5" />}
 								onClick={() => handleBulk("approve")}
 							>
-								Approve
+								{t`Approve`}
 							</Button>
 						)}
 						{activeStatus !== "spam" && (
@@ -241,7 +251,7 @@ export function CommentInbox({
 								icon={<Warning className="h-3.5 w-3.5" />}
 								onClick={() => handleBulk("spam")}
 							>
-								Spam
+								{t`Spam`}
 							</Button>
 						)}
 						{activeStatus !== "trash" && (
@@ -251,7 +261,7 @@ export function CommentInbox({
 								icon={<Trash className="h-3.5 w-3.5" />}
 								onClick={() => handleBulk("trash")}
 							>
-								Trash
+								{t`Trash`}
 							</Button>
 						)}
 						{isAdmin && (
@@ -261,7 +271,7 @@ export function CommentInbox({
 								icon={<Trash className="h-3.5 w-3.5" />}
 								onClick={() => handleBulk("delete")}
 							>
-								Delete
+								{t`Delete`}
 							</Button>
 						)}
 					</div>
@@ -277,23 +287,23 @@ export function CommentInbox({
 								<Checkbox
 									checked={allOnPageSelected}
 									onChange={toggleAll}
-									aria-label="Select all"
+									aria-label={t`Select all`}
 								/>
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Author
+								{t`Author`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Comment
+								{t`Comment`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Content
+								{t`Content`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-left text-sm font-medium">
-								Date
+								{t`Date`}
 							</th>
 							<th scope="col" className="px-4 py-3 text-right text-sm font-medium">
-								Actions
+								{t`Actions`}
 							</th>
 						</tr>
 					</thead>
@@ -301,7 +311,7 @@ export function CommentInbox({
 						{isLoading && comments.length === 0 ? (
 							<tr>
 								<td colSpan={6} className="px-4 py-8 text-center text-kumo-subtle">
-									Loading comments...
+									{t`Loading comments...`}
 								</td>
 							</tr>
 						) : paginatedComments.length === 0 ? (
@@ -338,7 +348,7 @@ export function CommentInbox({
 			{(totalPages > 1 || nextCursor) && (
 				<div className="flex items-center justify-between">
 					<span className="text-sm text-kumo-subtle">
-						{comments.length} {comments.length === 1 ? "comment" : "comments"}
+						{plural(comments.length, { one: "# comment", other: "# comments" })}
 					</span>
 					<div className="flex items-center gap-2">
 						<Button
@@ -346,7 +356,7 @@ export function CommentInbox({
 							shape="square"
 							disabled={page === 0}
 							onClick={() => setPage(page - 1)}
-							aria-label="Previous page"
+							aria-label={t`Previous page`}
 						>
 							<CaretLeft className="h-4 w-4" />
 						</Button>
@@ -365,7 +375,7 @@ export function CommentInbox({
 									setPage(page + 1);
 								}
 							}}
-							aria-label="Next page"
+							aria-label={t`Next page`}
 						>
 							<CaretRight className="h-4 w-4" />
 						</Button>
@@ -399,10 +409,10 @@ export function CommentInbox({
 					setDeleteId(null);
 					onDeleteErrorReset();
 				}}
-				title="Delete Comment?"
-				description="This will permanently delete this comment. This action cannot be undone."
-				confirmLabel="Delete"
-				pendingLabel="Deleting..."
+				title={t`Delete Comment?`}
+				description={t`This will permanently delete this comment. This action cannot be undone.`}
+				confirmLabel={t`Delete`}
+				pendingLabel={t`Deleting...`}
 				isPending={isStatusPending}
 				error={deleteError}
 				onConfirm={() => {
@@ -440,6 +450,7 @@ function CommentRow({
 	isAdmin,
 	isStatusPending,
 }: CommentRowProps) {
+	const { t } = useLingui();
 	const date = new Date(comment.createdAt);
 	const excerpt = comment.body.length > 120 ? comment.body.slice(0, 120) + "..." : comment.body;
 
@@ -449,7 +460,7 @@ function CommentRow({
 				<Checkbox
 					checked={isSelected}
 					onChange={onToggle}
-					aria-label={`Select comment by ${comment.authorName}`}
+					aria-label={t`Select comment by ${comment.authorName}`}
 				/>
 			</td>
 			<td className="px-4 py-3">
@@ -482,7 +493,7 @@ function CommentRow({
 							variant="ghost"
 							shape="square"
 							size="sm"
-							aria-label="Approve"
+							aria-label={t`Approve`}
 							onClick={() => onStatusChange(comment.id, "approved")}
 							disabled={isStatusPending}
 						>
@@ -494,7 +505,7 @@ function CommentRow({
 							variant="ghost"
 							shape="square"
 							size="sm"
-							aria-label="Mark as spam"
+							aria-label={t`Mark as spam`}
 							onClick={() => onStatusChange(comment.id, "spam")}
 							disabled={isStatusPending}
 						>
@@ -506,7 +517,7 @@ function CommentRow({
 							variant="ghost"
 							shape="square"
 							size="sm"
-							aria-label="Trash"
+							aria-label={t`Trash`}
 							onClick={() => onStatusChange(comment.id, "trash")}
 							disabled={isStatusPending}
 						>
@@ -518,7 +529,7 @@ function CommentRow({
 							variant="ghost"
 							shape="square"
 							size="sm"
-							aria-label="Delete permanently"
+							aria-label={t`Delete permanently`}
 							onClick={() => onDelete(comment.id)}
 							disabled={isStatusPending}
 						>
@@ -532,15 +543,17 @@ function CommentRow({
 }
 
 function EmptyState({ status, hasSearch }: { status: CommentStatus; hasSearch: boolean }) {
+	const { t } = useLingui();
+
 	if (hasSearch) {
-		return <p>No comments match your search.</p>;
+		return <p>{t`No comments match your search.`}</p>;
 	}
 
 	const messages: Record<CommentStatus, string> = {
-		pending: "No comments awaiting moderation.",
-		approved: "No approved comments yet.",
-		spam: "No spam comments.",
-		trash: "Trash is empty.",
+		pending: t`No comments awaiting moderation.`,
+		approved: t`No approved comments yet.`,
+		spam: t`No spam comments.`,
+		trash: t`Trash is empty.`,
 	};
 
 	return <p>{messages[status]}</p>;

--- a/packages/admin/src/components/editor/DocumentOutline.tsx
+++ b/packages/admin/src/components/editor/DocumentOutline.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { CaretDown, CaretRight, List } from "@phosphor-icons/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
@@ -113,6 +114,7 @@ export interface DocumentOutlineProps {
  * Document outline component showing heading tree structure
  */
 export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
+	const { t } = useLingui();
 	const [isExpanded, setIsExpanded] = React.useState(true);
 	const [headings, setHeadings] = React.useState<HeadingItem[]>([]);
 	const [currentPos, setCurrentPos] = React.useState(0);
@@ -175,7 +177,7 @@ export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
 			>
 				<span className="flex items-center gap-2">
 					<List className="h-4 w-4" />
-					<span className="font-semibold">Outline</span>
+					<span className="font-semibold">{t`Outline`}</span>
 				</span>
 				{isExpanded ? <CaretDown className="h-4 w-4" /> : <CaretRight className="h-4 w-4" />}
 			</Button>
@@ -183,7 +185,7 @@ export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
 			{isExpanded && (
 				<div className="space-y-0.5">
 					{headings.length === 0 ? (
-						<p className="text-sm text-kumo-subtle px-2 py-1">No headings in document</p>
+						<p className="text-sm text-kumo-subtle px-2 py-1">{t`No headings in document`}</p>
 					) : (
 						headings.map((heading) => {
 							const isCurrent = currentHeading?.key === heading.key;

--- a/packages/admin/src/components/editor/ImageDetailPanel.tsx
+++ b/packages/admin/src/components/editor/ImageDetailPanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Input, InputArea, Label, LinkButton } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	X,
 	ArrowSquareOut,
@@ -61,6 +62,7 @@ export function ImageDetailPanel({
 	onClose,
 	inline = false,
 }: ImageDetailPanelProps) {
+	const { t } = useLingui();
 	// Form state
 	const [alt, setAlt] = React.useState(attributes.alt ?? "");
 	const [caption, setCaption] = React.useState(attributes.caption ?? "");
@@ -170,10 +172,10 @@ export function ImageDetailPanel({
 			<ConfirmDialog
 				open={showDeleteConfirm}
 				onClose={() => setShowDeleteConfirm(false)}
-				title="Remove Image?"
-				description="Remove this image from the document?"
-				confirmLabel="Remove"
-				pendingLabel="Removing..."
+				title={t`Remove Image?`}
+				description={t`Remove this image from the document?`}
+				confirmLabel={t`Remove`}
+				pendingLabel={t`Removing...`}
 				isPending={false}
 				error={null}
 				onConfirm={() => {
@@ -186,7 +188,7 @@ export function ImageDetailPanel({
 				onOpenChange={setShowMediaPicker}
 				onSelect={handleMediaSelect}
 				mimeTypeFilter="image/"
-				title="Replace Image"
+				title={t`Replace Image`}
 			/>
 		</>
 	);
@@ -198,11 +200,11 @@ export function ImageDetailPanel({
 				<div className="flex items-center justify-between p-4 border-b">
 					<div className="flex items-center gap-2">
 						<SlidersHorizontal className="h-4 w-4 text-kumo-subtle" />
-						<h3 className="text-sm font-semibold">Image Settings</h3>
+						<h3 className="text-sm font-semibold">{t`Image Settings`}</h3>
 					</div>
-					<Button variant="ghost" shape="square" aria-label="Close" onClick={onClose}>
+					<Button variant="ghost" shape="square" aria-label={t`Close`} onClick={onClose}>
 						<X className="h-4 w-4" />
-						<span className="sr-only">Close</span>
+						<span className="sr-only">{t`Close`}</span>
 					</Button>
 				</div>
 
@@ -221,7 +223,7 @@ export function ImageDetailPanel({
 								icon={<ImageSquare />}
 								onClick={() => setShowMediaPicker(true)}
 							>
-								Replace Image
+								{t`Replace Image`}
 							</Button>
 						</div>
 					</div>
@@ -230,7 +232,7 @@ export function ImageDetailPanel({
 					{(attributes.width || attributes.height) && (
 						<div className="flex items-center gap-2 text-sm mt-3">
 							<Ruler className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">Original:</span>
+							<span className="text-kumo-subtle">{t`Original:`}</span>
 							<span>
 								{attributes.width} × {attributes.height}
 							</span>
@@ -242,20 +244,20 @@ export function ImageDetailPanel({
 				{attributes.width && attributes.height && (
 					<div className="p-4 border-b space-y-3">
 						<div className="flex items-center justify-between">
-							<Label>Display Size</Label>
+							<Label>{t`Display Size`}</Label>
 							<Button
 								variant="ghost"
 								size="sm"
 								onClick={handleResetDimensions}
 								className="h-auto py-1 px-2 text-xs"
 							>
-								Reset to original
+								{t`Reset to original`}
 							</Button>
 						</div>
 						<div className="flex items-center gap-2">
 							<div className="flex-1">
 								<Input
-									label="Width"
+									label={t`Width`}
 									type="number"
 									value={displayWidth ?? ""}
 									onChange={(e) => handleWidthChange(e.target.value)}
@@ -266,8 +268,8 @@ export function ImageDetailPanel({
 								shape="square"
 								className="mt-5"
 								onClick={() => setLockAspectRatio(!lockAspectRatio)}
-								title={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
-								aria-label={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
+								title={lockAspectRatio ? t`Unlock aspect ratio` : t`Lock aspect ratio`}
+								aria-label={lockAspectRatio ? t`Unlock aspect ratio` : t`Lock aspect ratio`}
 							>
 								{lockAspectRatio ? (
 									<LinkSimple className="h-4 w-4" />
@@ -277,7 +279,7 @@ export function ImageDetailPanel({
 							</Button>
 							<div className="flex-1">
 								<Input
-									label="Height"
+									label={t`Height`}
 									type="number"
 									value={displayHeight ?? ""}
 									onChange={(e) => handleHeightChange(e.target.value)}
@@ -285,7 +287,7 @@ export function ImageDetailPanel({
 							</div>
 						</div>
 						<p className="text-xs text-kumo-subtle">
-							Set a custom display size for this image instance.
+							{t`Set a custom display size for this image instance.`}
 						</p>
 					</div>
 				)}
@@ -293,34 +295,34 @@ export function ImageDetailPanel({
 				{/* Editable Fields */}
 				<div className="p-4 space-y-4">
 					<Input
-						label="Alt Text"
+						label={t`Alt Text`}
 						value={alt}
 						onChange={(e) => setAlt(e.target.value)}
-						placeholder="Describe this image for accessibility"
-						description="Required for accessibility. Describes the image for screen readers."
+						placeholder={t`Describe this image for accessibility`}
+						description={t`Required for accessibility. Describes the image for screen readers.`}
 					/>
 
 					<InputArea
-						label="Caption"
+						label={t`Caption`}
 						value={caption}
 						onChange={(e) => setCaption(e.target.value)}
-						placeholder="Optional caption displayed below the image"
-						description="Displayed below the image as a visible caption."
+						placeholder={t`Optional caption displayed below the image`}
+						description={t`Displayed below the image as a visible caption.`}
 						rows={2}
 					/>
 
 					<Input
-						label="Title (Tooltip)"
+						label={t`Title (Tooltip)`}
 						value={title}
 						onChange={(e) => setTitle(e.target.value)}
-						placeholder="Optional tooltip on hover"
-						description="Shown when hovering over the image."
+						placeholder={t`Optional tooltip on hover`}
+						description={t`Shown when hovering over the image.`}
 					/>
 
 					{/* Source URL - only show for external images (no mediaId) */}
 					{!attributes.mediaId && attributes.src && (
 						<div>
-							<Label>Source</Label>
+							<Label>{t`Source`}</Label>
 							<div className="mt-1.5 flex gap-2">
 								<Input value={attributes.src} readOnly className="text-xs font-mono flex-1" />
 								<LinkButton
@@ -328,8 +330,8 @@ export function ImageDetailPanel({
 									shape="square"
 									href={attributes.src}
 									external
-									title="Open in new tab"
-									aria-label="Open in new tab"
+									title={t`Open in new tab`}
+									aria-label={t`Open in new tab`}
 								>
 									<ArrowSquareOut className="h-4 w-4" />
 								</LinkButton>
@@ -341,10 +343,10 @@ export function ImageDetailPanel({
 				{/* Actions */}
 				<div className="p-4 border-t flex items-center justify-between gap-2">
 					<Button variant="destructive" size="sm" onClick={handleDelete}>
-						Remove Image
+						{t`Remove Image`}
 					</Button>
 					<Button size="sm" onClick={handleSave} disabled={!hasChanges}>
-						Save
+						{t`Save`}
 					</Button>
 				</div>
 
@@ -359,11 +361,11 @@ export function ImageDetailPanel({
 			<div className="flex items-center justify-between border-b p-4">
 				<div className="flex items-center gap-2">
 					<SlidersHorizontal className="h-4 w-4 text-kumo-subtle" />
-					<h2 className="font-semibold">Image Settings</h2>
+					<h2 className="font-semibold">{t`Image Settings`}</h2>
 				</div>
-				<Button variant="ghost" shape="square" aria-label="Close" onClick={onClose}>
+				<Button variant="ghost" shape="square" aria-label={t`Close`} onClick={onClose}>
 					<X className="h-4 w-4" />
-					<span className="sr-only">Close</span>
+					<span className="sr-only">{t`Close`}</span>
 				</Button>
 			</div>
 
@@ -384,7 +386,7 @@ export function ImageDetailPanel({
 								icon={<ImageSquare />}
 								onClick={() => setShowMediaPicker(true)}
 							>
-								Replace Image
+								{t`Replace Image`}
 							</Button>
 						</div>
 					</div>
@@ -395,7 +397,7 @@ export function ImageDetailPanel({
 					<div className="p-4 border-b">
 						<div className="flex items-center gap-2 text-sm">
 							<Ruler className="h-4 w-4 text-kumo-subtle" />
-							<span className="text-kumo-subtle">Original:</span>
+							<span className="text-kumo-subtle">{t`Original:`}</span>
 							<span>
 								{attributes.width} × {attributes.height}
 							</span>
@@ -407,20 +409,20 @@ export function ImageDetailPanel({
 				{attributes.width && attributes.height && (
 					<div className="p-4 border-b space-y-3">
 						<div className="flex items-center justify-between">
-							<Label>Display Size</Label>
+							<Label>{t`Display Size`}</Label>
 							<Button
 								variant="ghost"
 								size="sm"
 								onClick={handleResetDimensions}
 								className="h-auto py-1 px-2 text-xs"
 							>
-								Reset to original
+								{t`Reset to original`}
 							</Button>
 						</div>
 						<div className="flex items-center gap-2">
 							<div className="flex-1">
 								<Input
-									label="Width"
+									label={t`Width`}
 									type="number"
 									value={displayWidth ?? ""}
 									onChange={(e) => handleWidthChange(e.target.value)}
@@ -431,8 +433,8 @@ export function ImageDetailPanel({
 								shape="square"
 								className="mt-5"
 								onClick={() => setLockAspectRatio(!lockAspectRatio)}
-								title={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
-								aria-label={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
+								title={lockAspectRatio ? t`Unlock aspect ratio` : t`Lock aspect ratio`}
+								aria-label={lockAspectRatio ? t`Unlock aspect ratio` : t`Lock aspect ratio`}
 							>
 								{lockAspectRatio ? (
 									<LinkSimple className="h-4 w-4" />
@@ -442,7 +444,7 @@ export function ImageDetailPanel({
 							</Button>
 							<div className="flex-1">
 								<Input
-									label="Height"
+									label={t`Height`}
 									type="number"
 									value={displayHeight ?? ""}
 									onChange={(e) => handleHeightChange(e.target.value)}
@@ -450,7 +452,7 @@ export function ImageDetailPanel({
 							</div>
 						</div>
 						<p className="text-xs text-kumo-subtle">
-							Set a custom display size for this image instance.
+							{t`Set a custom display size for this image instance.`}
 						</p>
 					</div>
 				)}
@@ -458,34 +460,34 @@ export function ImageDetailPanel({
 				{/* Editable Fields */}
 				<div className="p-4 space-y-4">
 					<Input
-						label="Alt Text"
+						label={t`Alt Text`}
 						value={alt}
 						onChange={(e) => setAlt(e.target.value)}
-						placeholder="Describe this image for accessibility"
-						description="Required for accessibility. Describes the image for screen readers."
+						placeholder={t`Describe this image for accessibility`}
+						description={t`Required for accessibility. Describes the image for screen readers.`}
 					/>
 
 					<InputArea
-						label="Caption"
+						label={t`Caption`}
 						value={caption}
 						onChange={(e) => setCaption(e.target.value)}
-						placeholder="Optional caption displayed below the image"
-						description="Displayed below the image as a visible caption."
+						placeholder={t`Optional caption displayed below the image`}
+						description={t`Displayed below the image as a visible caption.`}
 						rows={2}
 					/>
 
 					<Input
-						label="Title (Tooltip)"
+						label={t`Title (Tooltip)`}
 						value={title}
 						onChange={(e) => setTitle(e.target.value)}
-						placeholder="Optional tooltip on hover"
-						description="Shown when hovering over the image."
+						placeholder={t`Optional tooltip on hover`}
+						description={t`Shown when hovering over the image.`}
 					/>
 
 					{/* Source URL - only show for external images (no mediaId) */}
 					{!attributes.mediaId && attributes.src && (
 						<div>
-							<Label>Source</Label>
+							<Label>{t`Source`}</Label>
 							<div className="mt-1.5 flex gap-2">
 								<Input value={attributes.src} readOnly className="text-xs font-mono flex-1" />
 								<LinkButton
@@ -493,8 +495,8 @@ export function ImageDetailPanel({
 									shape="square"
 									href={attributes.src}
 									external
-									title="Open in new tab"
-									aria-label="Open in new tab"
+									title={t`Open in new tab`}
+									aria-label={t`Open in new tab`}
 								>
 									<ArrowSquareOut className="h-4 w-4" />
 								</LinkButton>
@@ -507,14 +509,14 @@ export function ImageDetailPanel({
 			{/* Footer */}
 			<div className="p-4 border-t flex items-center justify-between gap-2">
 				<Button variant="destructive" size="sm" onClick={handleDelete}>
-					Remove Image
+					{t`Remove Image`}
 				</Button>
 				<div className="flex gap-2">
 					<Button variant="outline" size="sm" onClick={onClose}>
-						Cancel
+						{t`Cancel`}
 					</Button>
 					<Button size="sm" onClick={handleSave} disabled={!hasChanges}>
-						Save
+						{t`Save`}
 					</Button>
 				</div>
 			</div>

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Dialog, Input, Select, Switch } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	Globe,
 	Plus,
@@ -32,6 +33,7 @@ import {
 import { useAllowedDomainsRolesConfig } from "./useAllowedDomainsRolesConfig.js";
 
 export function AllowedDomainsSettings() {
+	const { t } = useLingui();
 	const { getRoleLabel, signupRoles, signupRoleItems } = useAllowedDomainsRolesConfig();
 	const queryClient = useQueryClient();
 	const [isAddingDomain, setIsAddingDomain] = React.useState(false);
@@ -81,12 +83,12 @@ export function AllowedDomainsSettings() {
 			setIsAddingDomain(false);
 			setNewDomain("");
 			setNewRole(30);
-			setSaveStatus({ type: "success", message: "Domain added successfully" });
+			setSaveStatus({ type: "success", message: t`Domain added successfully` });
 		},
 		onError: (mutationError) => {
 			setSaveStatus({
 				type: "error",
-				message: mutationError instanceof Error ? mutationError.message : "Failed to add domain",
+				message: mutationError instanceof Error ? mutationError.message : t`Failed to add domain`,
 			});
 		},
 	});
@@ -103,12 +105,13 @@ export function AllowedDomainsSettings() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["allowed-domains"] });
 			setEditingDomain(null);
-			setSaveStatus({ type: "success", message: "Domain updated" });
+			setSaveStatus({ type: "success", message: t`Domain updated` });
 		},
 		onError: (mutationError) => {
 			setSaveStatus({
 				type: "error",
-				message: mutationError instanceof Error ? mutationError.message : "Failed to update domain",
+				message:
+					mutationError instanceof Error ? mutationError.message : t`Failed to update domain`,
 			});
 		},
 	});
@@ -119,12 +122,13 @@ export function AllowedDomainsSettings() {
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["allowed-domains"] });
 			setDeletingDomain(null);
-			setSaveStatus({ type: "success", message: "Domain removed" });
+			setSaveStatus({ type: "success", message: t`Domain removed` });
 		},
 		onError: (mutationError) => {
 			setSaveStatus({
 				type: "error",
-				message: mutationError instanceof Error ? mutationError.message : "Failed to remove domain",
+				message:
+					mutationError instanceof Error ? mutationError.message : t`Failed to remove domain`,
 			});
 		},
 	});
@@ -161,11 +165,11 @@ export function AllowedDomainsSettings() {
 	const settingsHeader = (
 		<div className="flex items-center gap-3">
 			<Link to="/settings">
-				<Button variant="ghost" shape="square" aria-label="Back to settings">
+				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 					<ArrowLeft className="h-4 w-4" />
 				</Button>
 			</Link>
-			<h1 className="text-2xl font-bold">Self-Signup Domains</h1>
+			<h1 className="text-2xl font-bold">{t`Self-Signup Domains`}</h1>
 		</div>
 	);
 
@@ -174,7 +178,7 @@ export function AllowedDomainsSettings() {
 			<div className="space-y-6">
 				{settingsHeader}
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<p className="text-kumo-subtle">Loading...</p>
+					<p className="text-kumo-subtle">{t`Loading...`}</p>
 				</div>
 			</div>
 		);
@@ -190,8 +194,7 @@ export function AllowedDomainsSettings() {
 						<Info className="h-5 w-5 text-kumo-subtle mt-0.5 flex-shrink-0" />
 						<div className="space-y-2">
 							<p className="text-kumo-subtle">
-								User access is managed by an external provider ({manifest?.authMode}). Self-signup
-								domain settings are not available when using external authentication.
+								{t`User access is managed by an external provider (${manifest?.authMode}). Self-signup domain settings are not available when using external authentication.`}
 							</p>
 						</div>
 					</div>
@@ -206,7 +209,7 @@ export function AllowedDomainsSettings() {
 				{settingsHeader}
 				<div className="rounded-lg border bg-kumo-base p-6">
 					<p className="text-kumo-danger">
-						{error instanceof Error ? error.message : "Failed to load allowed domains"}
+						{error instanceof Error ? error.message : t`Failed to load allowed domains`}
 					</p>
 				</div>
 			</div>
@@ -239,12 +242,11 @@ export function AllowedDomainsSettings() {
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-center gap-2 mb-4">
 					<Globe className="h-5 w-5 text-kumo-subtle" />
-					<h2 className="text-lg font-semibold">Allowed Domains</h2>
+					<h2 className="text-lg font-semibold">{t`Allowed Domains`}</h2>
 				</div>
 
 				<p className="text-sm text-kumo-subtle mb-6">
-					Users with email addresses from these domains can sign up without an invite. They will be
-					assigned the specified role automatically.
+					{t`Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically.`}
 				</p>
 
 				{/* Domain list */}
@@ -266,7 +268,7 @@ export function AllowedDomainsSettings() {
 									<div>
 										<div className="font-medium">{domain.domain}</div>
 										<div className="text-sm text-kumo-subtle">
-											Default role: {getRoleLabel(domain.defaultRole)}
+											{t`Default role:`} {getRoleLabel(domain.defaultRole)}
 										</div>
 									</div>
 								</div>
@@ -276,7 +278,7 @@ export function AllowedDomainsSettings() {
 										shape="square"
 										onClick={() => setEditingDomain(domain)}
 										disabled={updateMutation.isPending}
-										aria-label={`Edit ${domain.domain}`}
+										aria-label={t`Edit ${domain.domain}`}
 									>
 										<Pencil className="h-4 w-4" />
 									</Button>
@@ -285,7 +287,7 @@ export function AllowedDomainsSettings() {
 										shape="square"
 										onClick={() => setDeletingDomain(domain.domain)}
 										disabled={deleteMutation.isPending}
-										aria-label={`Delete ${domain.domain}`}
+										aria-label={t`Delete ${domain.domain}`}
 									>
 										<Trash className="h-4 w-4 text-kumo-danger" />
 									</Button>
@@ -295,7 +297,7 @@ export function AllowedDomainsSettings() {
 					</div>
 				) : (
 					<div className="rounded-lg border border-dashed p-6 text-center text-kumo-subtle">
-						No domains configured. Users must be invited individually.
+						{t`No domains configured. Users must be invited individually.`}
 					</div>
 				)}
 
@@ -304,7 +306,7 @@ export function AllowedDomainsSettings() {
 					{isAddingDomain ? (
 						<div className="space-y-4">
 							<div className="flex items-center justify-between">
-								<h3 className="font-medium">Add an allowed domain</h3>
+								<h3 className="font-medium">{t`Add an allowed domain`}</h3>
 								<Button
 									variant="ghost"
 									size="sm"
@@ -313,13 +315,13 @@ export function AllowedDomainsSettings() {
 										setNewDomain("");
 									}}
 								>
-									Cancel
+									{t`Cancel`}
 								</Button>
 							</div>
 							<div className="grid gap-4 sm:grid-cols-2">
 								<div className="space-y-2">
 									<Input
-										label="Domain"
+										label={t`Domain`}
 										placeholder="example.com"
 										value={newDomain}
 										onChange={(e) => setNewDomain(e.target.value)}
@@ -327,7 +329,7 @@ export function AllowedDomainsSettings() {
 								</div>
 								<div className="space-y-2">
 									<Select
-										label="Default Role"
+										label={t`Default Role`}
 										value={String(newRole)}
 										onValueChange={(v) => v !== null && setNewRole(Number(v))}
 										items={signupRoleItems}
@@ -344,12 +346,12 @@ export function AllowedDomainsSettings() {
 								onClick={handleAddDomain}
 								disabled={!newDomain.trim() || createMutation.isPending}
 							>
-								{createMutation.isPending ? "Adding..." : "Add Domain"}
+								{createMutation.isPending ? t`Adding...` : t`Add Domain`}
 							</Button>
 						</div>
 					) : (
 						<Button onClick={() => setIsAddingDomain(true)} icon={<Plus />}>
-							Add Domain
+							{t`Add Domain`}
 						</Button>
 					)}
 				</div>
@@ -364,24 +366,24 @@ export function AllowedDomainsSettings() {
 					<div className="flex items-start justify-between gap-4 mb-4">
 						<div className="flex flex-col space-y-1.5">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								Edit Domain
+								{t`Edit Domain`}
 							</Dialog.Title>
 							<Dialog.Description className="text-sm text-kumo-subtle">
-								Update settings for {editingDomain?.domain}
+								{t`Update settings for ${editingDomain?.domain}`}
 							</Dialog.Description>
 						</div>
 						<Dialog.Close
-							aria-label="Close"
+							aria-label={t`Close`}
 							render={(props) => (
 								<Button
 									{...props}
 									variant="ghost"
 									shape="square"
-									aria-label="Close"
+									aria-label={t`Close`}
 									className="absolute right-4 top-4"
 								>
 									<X className="h-4 w-4" />
-									<span className="sr-only">Close</span>
+									<span className="sr-only">{t`Close`}</span>
 								</Button>
 							)}
 						/>
@@ -389,7 +391,7 @@ export function AllowedDomainsSettings() {
 					<div className="space-y-4 py-4">
 						<div className="space-y-2">
 							<Select
-								label="Default Role"
+								label={t`Default Role`}
 								value={String(editingDomain?.defaultRole ?? 30)}
 								onValueChange={(v) =>
 									v !== null && editingDomain && handleUpdateRole(editingDomain.domain, Number(v))
@@ -414,23 +416,23 @@ export function AllowedDomainsSettings() {
 				disablePointerDismissal
 			>
 				<Dialog className="p-6" size="sm">
-					<Dialog.Title className="text-lg font-semibold">Remove Domain?</Dialog.Title>
+					<Dialog.Title className="text-lg font-semibold">{t`Remove Domain?`}</Dialog.Title>
 					<Dialog.Description className="text-kumo-subtle">
-						Users from <strong>{deletingDomain}</strong> will no longer be able to sign up without
-						an invite. Existing users are not affected.
+						{t`Users from`} <strong>{deletingDomain}</strong>{" "}
+						{t`will no longer be able to sign up without an invite. Existing users are not affected.`}
 					</Dialog.Description>
 					<div className="mt-6 flex justify-end gap-2">
 						<Dialog.Close
 							render={(p) => (
 								<Button {...p} variant="secondary">
-									Cancel
+									{t`Cancel`}
 								</Button>
 							)}
 						/>
 						<Dialog.Close
 							render={(p) => (
 								<Button {...p} variant="destructive" onClick={handleDelete}>
-									Remove Domain
+									{t`Remove Domain`}
 								</Button>
 							)}
 						/>

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Input, Loader } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowLeft,
 	CheckCircle,
@@ -26,6 +27,7 @@ import {
 import { getMutationError } from "../DialogError.js";
 
 export function EmailSettings() {
+	const { t } = useLingui();
 	const [testEmail, setTestEmail] = React.useState("");
 	const [status, setStatus] = React.useState<{
 		type: "success" | "error";
@@ -57,7 +59,7 @@ export function EmailSettings() {
 		onError: (error) => {
 			setStatus({
 				type: "error",
-				message: getMutationError(error) || "Failed to send test email",
+				message: getMutationError(error) || t`Failed to send test email`,
 			});
 		},
 	});
@@ -81,15 +83,15 @@ export function EmailSettings() {
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label="Back to settings">
+						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 							<ArrowLeft className="h-4 w-4" />
 						</Button>
 					</Link>
-					<h1 className="text-2xl font-bold">Email Settings</h1>
+					<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
 				</div>
 				<div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200">
 					<WarningCircle className="h-4 w-4 flex-shrink-0" />
-					{getMutationError(fetchError) || "Failed to load email settings"}
+					{getMutationError(fetchError) || t`Failed to load email settings`}
 				</div>
 			</div>
 		);
@@ -100,11 +102,11 @@ export function EmailSettings() {
 			{/* Header */}
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label="Back to settings">
+					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 				</Link>
-				<h1 className="text-2xl font-bold">Email Settings</h1>
+				<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
 			</div>
 
 			{/* Status banner */}
@@ -129,7 +131,7 @@ export function EmailSettings() {
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-center gap-2 mb-4">
 					<Envelope className="h-5 w-5 text-kumo-subtle" />
-					<h2 className="text-lg font-semibold">Email Pipeline</h2>
+					<h2 className="text-lg font-semibold">{t`Email Pipeline`}</h2>
 				</div>
 
 				<PipelineStatus settings={settings} />
@@ -140,24 +142,24 @@ export function EmailSettings() {
 				<div className="rounded-lg border bg-kumo-base p-6">
 					<div className="flex items-center gap-2 mb-4">
 						<PaperPlaneTilt className="h-5 w-5 text-kumo-subtle" />
-						<h2 className="text-lg font-semibold">Send Test Email</h2>
+						<h2 className="text-lg font-semibold">{t`Send Test Email`}</h2>
 					</div>
 					<p className="text-sm text-kumo-subtle mb-4">
-						Send a test email through the full pipeline to verify your email configuration.
+						{t`Send a test email through the full pipeline to verify your email configuration.`}
 					</p>
 					<form onSubmit={handleTestSubmit} className="flex items-end gap-3">
 						<div className="flex-1">
 							<Input
-								label="Recipient email"
+								label={t`Recipient email`}
 								type="email"
 								value={testEmail}
 								onChange={(e) => setTestEmail(e.target.value)}
-								placeholder="test@example.com"
+								placeholder={t`test@example.com`}
 								required
 							/>
 						</div>
 						<Button type="submit" disabled={testMutation.isPending || !testEmail}>
-							{testMutation.isPending ? "Sending..." : "Send Test"}
+							{testMutation.isPending ? t`Sending...` : t`Send Test`}
 						</Button>
 					</form>
 				</div>
@@ -171,6 +173,8 @@ export function EmailSettings() {
 // =============================================================================
 
 function PipelineStatus({ settings }: { settings: EmailSettingsData | undefined }) {
+	const { t } = useLingui();
+
 	if (!settings) return null;
 
 	if (!settings.available) {
@@ -180,14 +184,13 @@ function PipelineStatus({ settings }: { settings: EmailSettingsData | undefined 
 					<WarningCircle className="h-5 w-5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
 					<div>
 						<p className="text-sm font-medium text-amber-800 dark:text-amber-200">
-							No email provider configured
+							{t`No email provider configured`}
 						</p>
 						<p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
-							Install and activate an email provider plugin to enable email features like
-							invitations, magic links, and password recovery.
+							{t`Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery.`}
 						</p>
 						<p className="text-sm text-amber-700 dark:text-amber-300 mt-2">
-							Without an email provider, invite links must be shared manually.
+							{t`Without an email provider, invite links must be shared manually.`}
 						</p>
 					</div>
 				</div>
@@ -202,10 +205,10 @@ function PipelineStatus({ settings }: { settings: EmailSettingsData | undefined 
 				<CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
 				<div>
 					<p className="text-sm font-medium text-green-800 dark:text-green-200">
-						Email provider active
+						{t`Email provider active`}
 					</p>
 					<p className="text-sm text-green-700 dark:text-green-300">
-						Provider:{" "}
+						{t`Provider:`}{" "}
 						<code className="rounded bg-green-100 dark:bg-green-900/40 px-1.5 py-0.5 text-xs">
 							{settings.selectedProviderId || "default"}
 						</code>
@@ -218,16 +221,16 @@ function PipelineStatus({ settings }: { settings: EmailSettingsData | undefined 
 				<div className="p-3 rounded-md bg-kumo-tint/50 border">
 					<div className="flex items-center gap-2 mb-2">
 						<PlugsConnected className="h-4 w-4 text-kumo-subtle" />
-						<p className="text-sm font-medium">Email Middleware</p>
+						<p className="text-sm font-medium">{t`Email Middleware`}</p>
 					</div>
 					{settings.middleware.beforeSend.length > 0 && (
 						<p className="text-sm text-kumo-subtle">
-							Before send: {settings.middleware.beforeSend.join(", ")}
+							{t`Before send:`} {settings.middleware.beforeSend.join(", ")}
 						</p>
 					)}
 					{settings.middleware.afterSend.length > 0 && (
 						<p className="text-sm text-kumo-subtle">
-							After send: {settings.middleware.afterSend.join(", ")}
+							{t`After send:`} {settings.middleware.afterSend.join(", ")}
 						</p>
 					)}
 				</div>
@@ -236,7 +239,7 @@ function PipelineStatus({ settings }: { settings: EmailSettingsData | undefined 
 			{/* Available providers (if multiple) */}
 			{settings.providers.length > 1 && (
 				<div className="p-3 rounded-md bg-kumo-tint/50 border">
-					<p className="text-sm font-medium mb-1">Available Providers</p>
+					<p className="text-sm font-medium mb-1">{t`Available Providers`}</p>
 					<p className="text-sm text-kumo-subtle">
 						{settings.providers.map((p) => p.pluginId).join(", ")}
 					</p>

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button, Input, Label } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowLeft,
 	FloppyDisk,
@@ -22,6 +23,7 @@ import { fetchSettings, updateSettings, type SiteSettings, type MediaItem } from
 import { MediaPickerModal } from "../MediaPickerModal";
 
 export function GeneralSettings() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 
 	const { data: settings, isLoading } = useQuery({
@@ -54,12 +56,12 @@ export function GeneralSettings() {
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: "Settings saved successfully" });
+			setSaveStatus({ type: "success", message: t`Settings saved successfully` });
 		},
 		onError: (error) => {
 			setSaveStatus({
 				type: "error",
-				message: error instanceof Error ? error.message : "Failed to save settings",
+				message: error instanceof Error ? error.message : t`Failed to save settings`,
 			});
 		},
 	});
@@ -102,14 +104,14 @@ export function GeneralSettings() {
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label="Back to settings">
+						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 							<ArrowLeft className="h-4 w-4" />
 						</Button>
 					</Link>
-					<h1 className="text-2xl font-bold">General Settings</h1>
+					<h1 className="text-2xl font-bold">{t`General Settings`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<p className="text-kumo-subtle">Loading settings...</p>
+					<p className="text-kumo-subtle">{t`Loading settings...`}</p>
 				</div>
 			</div>
 		);
@@ -120,11 +122,11 @@ export function GeneralSettings() {
 			{/* Header */}
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label="Back to settings">
+					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 				</Link>
-				<h1 className="text-2xl font-bold">General Settings</h1>
+				<h1 className="text-2xl font-bold">{t`General Settings`}</h1>
 			</div>
 
 			{/* Status banner */}
@@ -148,36 +150,36 @@ export function GeneralSettings() {
 			<form onSubmit={handleSubmit} className="space-y-6">
 				{/* Site Identity */}
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<h2 className="mb-4 text-lg font-semibold">Site Identity</h2>
+					<h2 className="mb-4 text-lg font-semibold">{t`Site Identity`}</h2>
 					<div className="space-y-4">
 						<Input
-							label="Site Title"
+							label={t`Site Title`}
 							value={formData.title || ""}
 							onChange={(e) => handleChange("title", e.target.value)}
-							description="The name of your site, used in the header and metadata"
+							description={t`The name of your site, used in the header and metadata`}
 						/>
 						<Input
-							label="Tagline"
+							label={t`Tagline`}
 							value={formData.tagline || ""}
 							onChange={(e) => handleChange("tagline", e.target.value)}
-							description="A short description of your site"
+							description={t`A short description of your site`}
 						/>
 						<Input
-							label="Site URL"
+							label={t`Site URL`}
 							type="url"
 							value={formData.url || ""}
 							onChange={(e) => handleChange("url", e.target.value)}
-							description="The public URL of your site (used for canonical links and sitemaps)"
+							description={t`The public URL of your site (used for canonical links and sitemaps)`}
 						/>
 
 						{/* Logo Picker */}
 						<div>
-							<Label>Logo</Label>
+							<Label>{t`Logo`}</Label>
 							{formData.logo?.url ? (
 								<div className="mt-2 space-y-2">
 									<img
 										src={formData.logo.url}
-										alt={formData.logo.alt || "Logo"}
+										alt={formData.logo.alt || t`Logo`}
 										className="h-16 rounded border bg-kumo-tint object-contain p-2"
 									/>
 									<div className="flex gap-2">
@@ -188,7 +190,7 @@ export function GeneralSettings() {
 											icon={<Upload />}
 											onClick={() => setLogoPickerOpen(true)}
 										>
-											Change Logo
+											{t`Change Logo`}
 										</Button>
 										<Button
 											type="button"
@@ -197,7 +199,7 @@ export function GeneralSettings() {
 											icon={<X />}
 											onClick={handleLogoRemove}
 										>
-											Remove
+											{t`Remove`}
 										</Button>
 									</div>
 								</div>
@@ -209,19 +211,19 @@ export function GeneralSettings() {
 									onClick={() => setLogoPickerOpen(true)}
 									className="mt-2"
 								>
-									Select Logo
+									{t`Select Logo`}
 								</Button>
 							)}
 						</div>
 
 						{/* Favicon Picker */}
 						<div>
-							<Label>Favicon</Label>
+							<Label>{t`Favicon`}</Label>
 							{formData.favicon?.url ? (
 								<div className="mt-2 space-y-2">
 									<img
 										src={formData.favicon.url}
-										alt="Favicon"
+										alt={t`Favicon`}
 										className="h-8 w-8 rounded border bg-kumo-tint object-contain p-1"
 									/>
 									<div className="flex gap-2">
@@ -232,7 +234,7 @@ export function GeneralSettings() {
 											icon={<Upload />}
 											onClick={() => setFaviconPickerOpen(true)}
 										>
-											Change Favicon
+											{t`Change Favicon`}
 										</Button>
 										<Button
 											type="button"
@@ -241,7 +243,7 @@ export function GeneralSettings() {
 											icon={<X />}
 											onClick={handleFaviconRemove}
 										>
-											Remove
+											{t`Remove`}
 										</Button>
 									</div>
 								</div>
@@ -253,7 +255,7 @@ export function GeneralSettings() {
 									onClick={() => setFaviconPickerOpen(true)}
 									className="mt-2"
 								>
-									Select Favicon
+									{t`Select Favicon`}
 								</Button>
 							)}
 						</div>
@@ -262,28 +264,28 @@ export function GeneralSettings() {
 
 				{/* Reading Settings */}
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<h2 className="mb-4 text-lg font-semibold">Reading</h2>
+					<h2 className="mb-4 text-lg font-semibold">{t`Reading`}</h2>
 					<div className="space-y-4">
 						<Input
-							label="Posts Per Page"
+							label={t`Posts Per Page`}
 							type="number"
 							value={formData.postsPerPage || 10}
 							onChange={(e) => handleChange("postsPerPage", parseInt(e.target.value, 10))}
 							min={1}
 							max={100}
-							description="Number of posts to show per page on list views"
+							description={t`Number of posts to show per page on list views`}
 						/>
 						<Input
-							label="Date Format"
+							label={t`Date Format`}
 							value={formData.dateFormat || "MMMM d, yyyy"}
 							onChange={(e) => handleChange("dateFormat", e.target.value)}
 							description={`Example: ${formData.dateFormat || "MMMM d, yyyy"} → January 23, 2026`}
 						/>
 						<Input
-							label="Timezone"
+							label={t`Timezone`}
 							value={formData.timezone || "UTC"}
 							onChange={(e) => handleChange("timezone", e.target.value)}
-							description="Timezone for displaying dates (e.g., America/New_York)"
+							description={t`Timezone for displaying dates (e.g., America/New_York)`}
 						/>
 					</div>
 				</div>
@@ -291,7 +293,7 @@ export function GeneralSettings() {
 				{/* Save Button */}
 				<div className="flex justify-end">
 					<Button type="submit" disabled={saveMutation.isPending} icon={<FloppyDisk />}>
-						{saveMutation.isPending ? "Saving..." : "Save Settings"}
+						{saveMutation.isPending ? t`Saving...` : t`Save Settings`}
 					</Button>
 				</div>
 			</form>
@@ -302,14 +304,14 @@ export function GeneralSettings() {
 				onOpenChange={setLogoPickerOpen}
 				onSelect={handleLogoSelect}
 				mimeTypeFilter="image/"
-				title="Select Logo"
+				title={t`Select Logo`}
 			/>
 			<MediaPickerModal
 				open={faviconPickerOpen}
 				onOpenChange={setFaviconPickerOpen}
 				onSelect={handleFaviconSelect}
 				mimeTypeFilter="image/"
-				title="Select Favicon"
+				title={t`Select Favicon`}
 			/>
 		</div>
 	);

--- a/packages/admin/src/components/settings/PasskeyItem.tsx
+++ b/packages/admin/src/components/settings/PasskeyItem.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Pencil, Trash, Check, X, DeviceMobile, Cloud } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -16,10 +17,6 @@ export interface PasskeyItemProps {
 	onDelete: (id: string) => Promise<void>;
 	isDeleting?: boolean;
 	isRenaming?: boolean;
-}
-
-function formatDeviceType(type: "singleDevice" | "multiDevice"): string {
-	return type === "multiDevice" ? "Synced passkey" : "Device-bound passkey";
 }
 
 function formatRelativeTime(dateString: string): string {
@@ -56,6 +53,7 @@ export function PasskeyItem({
 	isDeleting,
 	isRenaming,
 }: PasskeyItemProps) {
+	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
 	const [editName, setEditName] = React.useState(passkey.name || "");
 	const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
@@ -98,9 +96,12 @@ export function PasskeyItem({
 			await onDelete(passkey.id);
 			setShowDeleteDialog(false);
 		} catch (err) {
-			setDeleteError(err instanceof Error ? err.message : "Failed to remove passkey");
+			setDeleteError(err instanceof Error ? err.message : t`Failed to remove passkey`);
 		}
 	};
+
+	const deviceTypeLabel =
+		passkey.deviceType === "multiDevice" ? t`Synced passkey` : t`Device-bound passkey`;
 
 	return (
 		<li className="flex items-center justify-between p-4 border rounded-lg bg-kumo-base">
@@ -125,7 +126,7 @@ export function PasskeyItem({
 								onChange={(e) => setEditName(e.target.value)}
 								onKeyDown={handleKeyDown}
 								className="h-8 w-48"
-								placeholder="Passkey name"
+								placeholder={t`Passkey name`}
 								disabled={isRenaming}
 							/>
 							<Button
@@ -133,7 +134,7 @@ export function PasskeyItem({
 								variant="ghost"
 								onClick={handleSave}
 								disabled={isRenaming}
-								aria-label="Save name"
+								aria-label={t`Save name`}
 							>
 								<Check className="h-4 w-4" />
 							</Button>
@@ -142,22 +143,22 @@ export function PasskeyItem({
 								variant="ghost"
 								onClick={handleCancel}
 								disabled={isRenaming}
-								aria-label="Cancel rename"
+								aria-label={t`Cancel rename`}
 							>
 								<X className="h-4 w-4" />
 							</Button>
 						</div>
 					) : (
-						<div className="font-medium">{passkey.name || "Unnamed passkey"}</div>
+						<div className="font-medium">{passkey.name || t`Unnamed passkey`}</div>
 					)}
 					<div className="text-sm text-kumo-subtle">
-						{formatDeviceType(passkey.deviceType)}
+						{deviceTypeLabel}
 						{passkey.backedUp && (
-							<span className="text-green-600 dark:text-green-400"> (synced)</span>
+							<span className="text-green-600 dark:text-green-400"> {t`(synced)`}</span>
 						)}
 					</div>
 					<div className="text-xs text-kumo-subtle mt-1">
-						Last used {formatRelativeTime(passkey.lastUsedAt)}
+						{t`Last used`} {formatRelativeTime(passkey.lastUsedAt)}
 					</div>
 				</div>
 			</div>
@@ -172,8 +173,8 @@ export function PasskeyItem({
 							setEditName(passkey.name || "");
 							setIsEditing(true);
 						}}
-						title="Rename"
-						aria-label={`Rename ${passkey.name || "passkey"}`}
+						title={t`Rename`}
+						aria-label={t`Rename ${passkey.name || "passkey"}`}
 					>
 						<Pencil className="h-4 w-4" />
 					</Button>
@@ -183,8 +184,8 @@ export function PasskeyItem({
 							size="sm"
 							onClick={() => setShowDeleteDialog(true)}
 							className="text-kumo-danger hover:text-kumo-danger"
-							title="Remove"
-							aria-label={`Remove ${passkey.name || "passkey"}`}
+							title={t`Remove`}
+							aria-label={t`Remove ${passkey.name || "passkey"}`}
 						>
 							<Trash className="h-4 w-4" />
 						</Button>
@@ -199,10 +200,10 @@ export function PasskeyItem({
 					setShowDeleteDialog(false);
 					setDeleteError(null);
 				}}
-				title="Remove passkey?"
-				description={`You won't be able to use "${passkey.name || "this passkey"}" to sign in anymore. This action cannot be undone.`}
-				confirmLabel="Remove"
-				pendingLabel="Removing..."
+				title={t`Remove passkey?`}
+				description={t`You won't be able to use "${passkey.name || "this passkey"}" to sign in anymore. This action cannot be undone.`}
+				confirmLabel={t`Remove`}
+				pendingLabel={t`Removing...`}
 				isPending={!!isDeleting}
 				error={deleteError}
 				onConfirm={handleDelete}

--- a/packages/admin/src/components/settings/PasskeyItem.tsx
+++ b/packages/admin/src/components/settings/PasskeyItem.tsx
@@ -174,7 +174,7 @@ export function PasskeyItem({
 							setIsEditing(true);
 						}}
 						title={t`Rename`}
-						aria-label={t`Rename ${passkey.name || "passkey"}`}
+						aria-label={passkey.name ? t`Rename ${passkey.name}` : t`Rename passkey`}
 					>
 						<Pencil className="h-4 w-4" />
 					</Button>
@@ -185,7 +185,7 @@ export function PasskeyItem({
 							onClick={() => setShowDeleteDialog(true)}
 							className="text-kumo-danger hover:text-kumo-danger"
 							title={t`Remove`}
-							aria-label={t`Remove ${passkey.name || "passkey"}`}
+							aria-label={passkey.name ? t`Remove ${passkey.name}` : t`Remove passkey`}
 						>
 							<Trash className="h-4 w-4" />
 						</Button>
@@ -201,7 +201,11 @@ export function PasskeyItem({
 					setDeleteError(null);
 				}}
 				title={t`Remove passkey?`}
-				description={t`You won't be able to use "${passkey.name || "this passkey"}" to sign in anymore. This action cannot be undone.`}
+				description={
+					passkey.name
+						? t`You won't be able to use "${passkey.name}" to sign in anymore. This action cannot be undone.`
+						: t`You won't be able to use this passkey to sign in anymore. This action cannot be undone.`
+				}
 				confirmLabel={t`Remove`}
 				pendingLabel={t`Removing...`}
 				isPending={!!isDeleting}

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Button } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Shield, Plus, CheckCircle, WarningCircle, ArrowLeft, Info } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
@@ -16,6 +17,7 @@ import { PasskeyRegistration } from "../auth/PasskeyRegistration";
 import { PasskeyList } from "./PasskeyList";
 
 export function SecuritySettings() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 	const [isAdding, setIsAdding] = React.useState(false);
 	const [saveStatus, setSaveStatus] = React.useState<{
@@ -55,13 +57,13 @@ export function SecuritySettings() {
 		mutationFn: ({ id, name }: { id: string; name: string }) => renamePasskey(id, name),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			setSaveStatus({ type: "success", message: "Passkey renamed" });
+			setSaveStatus({ type: "success", message: t`Passkey renamed` });
 		},
 		onError: (mutationError) => {
 			setSaveStatus({
 				type: "error",
 				message:
-					mutationError instanceof Error ? mutationError.message : "Failed to rename passkey",
+					mutationError instanceof Error ? mutationError.message : t`Failed to rename passkey`,
 			});
 		},
 	});
@@ -71,13 +73,13 @@ export function SecuritySettings() {
 		mutationFn: (id: string) => deletePasskey(id),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			setSaveStatus({ type: "success", message: "Passkey removed" });
+			setSaveStatus({ type: "success", message: t`Passkey removed` });
 		},
 		onError: (mutationError) => {
 			setSaveStatus({
 				type: "error",
 				message:
-					mutationError instanceof Error ? mutationError.message : "Failed to remove passkey",
+					mutationError instanceof Error ? mutationError.message : t`Failed to remove passkey`,
 			});
 		},
 	});
@@ -93,17 +95,17 @@ export function SecuritySettings() {
 	const handleAddSuccess = () => {
 		void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
 		setIsAdding(false);
-		setSaveStatus({ type: "success", message: "Passkey added successfully" });
+		setSaveStatus({ type: "success", message: t`Passkey added successfully` });
 	};
 
 	const settingsHeader = (
 		<div className="flex items-center gap-3">
 			<Link to="/settings">
-				<Button variant="ghost" shape="square" aria-label="Back to settings">
+				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 					<ArrowLeft className="h-4 w-4" />
 				</Button>
 			</Link>
-			<h1 className="text-2xl font-bold">Security Settings</h1>
+			<h1 className="text-2xl font-bold">{t`Security Settings`}</h1>
 		</div>
 	);
 
@@ -112,7 +114,7 @@ export function SecuritySettings() {
 			<div className="space-y-6">
 				{settingsHeader}
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<p className="text-kumo-subtle">Loading...</p>
+					<p className="text-kumo-subtle">{t`Loading...`}</p>
 				</div>
 			</div>
 		);
@@ -128,8 +130,7 @@ export function SecuritySettings() {
 						<Info className="h-5 w-5 text-kumo-subtle mt-0.5 flex-shrink-0" />
 						<div className="space-y-2">
 							<p className="text-kumo-subtle">
-								Authentication is managed by an external provider ({manifest?.authMode}). Passkey
-								settings are not available when using external authentication.
+								{t`Authentication is managed by an external provider (${manifest?.authMode}). Passkey settings are not available when using external authentication.`}
 							</p>
 						</div>
 					</div>
@@ -144,7 +145,7 @@ export function SecuritySettings() {
 				{settingsHeader}
 				<div className="rounded-lg border bg-kumo-base p-6">
 					<p className="text-kumo-danger">
-						{error instanceof Error ? error.message : "Failed to load passkeys"}
+						{error instanceof Error ? error.message : t`Failed to load passkeys`}
 					</p>
 				</div>
 			</div>
@@ -177,12 +178,11 @@ export function SecuritySettings() {
 			<div className="rounded-lg border bg-kumo-base p-6">
 				<div className="flex items-center gap-2 mb-4">
 					<Shield className="h-5 w-5 text-kumo-subtle" />
-					<h2 className="text-lg font-semibold">Passkeys</h2>
+					<h2 className="text-lg font-semibold">{t`Passkeys`}</h2>
 				</div>
 
 				<p className="text-sm text-kumo-subtle mb-6">
-					Passkeys are a secure, passwordless way to sign in to your account. You can register
-					multiple passkeys for different devices.
+					{t`Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices.`}
 				</p>
 
 				{/* Passkey list */}
@@ -196,7 +196,7 @@ export function SecuritySettings() {
 					/>
 				) : (
 					<div className="rounded-lg border border-dashed p-6 text-center text-kumo-subtle">
-						No passkeys registered yet.
+						{t`No passkeys registered yet.`}
 					</div>
 				)}
 
@@ -205,9 +205,9 @@ export function SecuritySettings() {
 					{isAdding ? (
 						<div className="space-y-4">
 							<div className="flex items-center justify-between">
-								<h3 className="font-medium">Add a new passkey</h3>
+								<h3 className="font-medium">{t`Add a new passkey`}</h3>
 								<Button variant="ghost" size="sm" onClick={() => setIsAdding(false)}>
-									Cancel
+									{t`Cancel`}
 								</Button>
 							</div>
 							<PasskeyRegistration
@@ -221,12 +221,12 @@ export function SecuritySettings() {
 									})
 								}
 								showNameInput
-								buttonText="Register Passkey"
+								buttonText={t`Register Passkey`}
 							/>
 						</div>
 					) : (
 						<Button onClick={() => setIsAdding(true)} icon={<Plus />}>
-							Add Passkey
+							{t`Add Passkey`}
 						</Button>
 					)}
 				</div>

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Input, InputArea } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowLeft,
 	FloppyDisk,
@@ -19,6 +20,7 @@ import * as React from "react";
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
 
 export function SeoSettings() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 
 	const { data: settings, isLoading } = useQuery({
@@ -48,12 +50,12 @@ export function SeoSettings() {
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: "SEO settings saved" });
+			setSaveStatus({ type: "success", message: t`SEO settings saved` });
 		},
 		onError: (error) => {
 			setSaveStatus({
 				type: "error",
-				message: error instanceof Error ? error.message : "Failed to save settings",
+				message: error instanceof Error ? error.message : t`Failed to save settings`,
 			});
 		},
 	});
@@ -78,14 +80,14 @@ export function SeoSettings() {
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label="Back to settings">
+						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 							<ArrowLeft className="h-4 w-4" />
 						</Button>
 					</Link>
-					<h1 className="text-2xl font-bold">SEO Settings</h1>
+					<h1 className="text-2xl font-bold">{t`SEO Settings`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<p className="text-kumo-subtle">Loading settings...</p>
+					<p className="text-kumo-subtle">{t`Loading settings...`}</p>
 				</div>
 			</div>
 		);
@@ -96,11 +98,11 @@ export function SeoSettings() {
 			{/* Header */}
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label="Back to settings">
+					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 				</Link>
-				<h1 className="text-2xl font-bold">SEO Settings</h1>
+				<h1 className="text-2xl font-bold">{t`SEO Settings`}</h1>
 			</div>
 
 			{/* Status banner */}
@@ -125,33 +127,33 @@ export function SeoSettings() {
 				<div className="rounded-lg border bg-kumo-base p-6">
 					<div className="flex items-center gap-2 mb-4">
 						<MagnifyingGlass className="h-5 w-5 text-kumo-subtle" />
-						<h2 className="text-lg font-semibold">Search Engine Optimization</h2>
+						<h2 className="text-lg font-semibold">{t`Search Engine Optimization`}</h2>
 					</div>
 					<div className="space-y-4">
 						<Input
-							label="Title Separator"
+							label={t`Title Separator`}
 							value={formData.seo?.titleSeparator || "|"}
 							onChange={(e) => handleSeoChange("titleSeparator", e.target.value)}
-							description='Character between page title and site name (e.g., "My Post | My Site")'
+							description={t`Character between page title and site name (e.g., "My Post | My Site")`}
 						/>
 						<Input
-							label="Google Verification"
+							label={t`Google Verification`}
 							value={formData.seo?.googleVerification || ""}
 							onChange={(e) => handleSeoChange("googleVerification", e.target.value)}
-							description="Meta tag content for Google Search Console verification"
+							description={t`Meta tag content for Google Search Console verification`}
 						/>
 						<Input
-							label="Bing Verification"
+							label={t`Bing Verification`}
 							value={formData.seo?.bingVerification || ""}
 							onChange={(e) => handleSeoChange("bingVerification", e.target.value)}
-							description="Meta tag content for Bing Webmaster Tools verification"
+							description={t`Meta tag content for Bing Webmaster Tools verification`}
 						/>
 						<InputArea
 							label="robots.txt"
 							value={formData.seo?.robotsTxt || ""}
 							onChange={(e) => handleSeoChange("robotsTxt", e.target.value)}
 							rows={5}
-							description="Custom robots.txt content. Leave empty to use the default."
+							description={t`Custom robots.txt content. Leave empty to use the default.`}
 						/>
 					</div>
 				</div>
@@ -159,7 +161,7 @@ export function SeoSettings() {
 				{/* Save Button */}
 				<div className="flex justify-end">
 					<Button type="submit" disabled={saveMutation.isPending} icon={<FloppyDisk />}>
-						{saveMutation.isPending ? "Saving..." : "Save SEO Settings"}
+						{saveMutation.isPending ? t`Saving...` : t`Save SEO Settings`}
 					</Button>
 				</div>
 			</form>

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { ArrowLeft, FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
@@ -13,6 +14,7 @@ import * as React from "react";
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
 
 export function SocialSettings() {
+	const { t } = useLingui();
 	const queryClient = useQueryClient();
 
 	const { data: settings, isLoading } = useQuery({
@@ -42,12 +44,12 @@ export function SocialSettings() {
 		mutationFn: (data: Partial<SiteSettings>) => updateSettings(data),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["settings"] });
-			setSaveStatus({ type: "success", message: "Social links saved" });
+			setSaveStatus({ type: "success", message: t`Social links saved` });
 		},
 		onError: (error) => {
 			setSaveStatus({
 				type: "error",
-				message: error instanceof Error ? error.message : "Failed to save settings",
+				message: error instanceof Error ? error.message : t`Failed to save settings`,
 			});
 		},
 	});
@@ -72,14 +74,14 @@ export function SocialSettings() {
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label="Back to settings">
+						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 							<ArrowLeft className="h-4 w-4" />
 						</Button>
 					</Link>
-					<h1 className="text-2xl font-bold">Social Links</h1>
+					<h1 className="text-2xl font-bold">{t`Social Links`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<p className="text-kumo-subtle">Loading settings...</p>
+					<p className="text-kumo-subtle">{t`Loading settings...`}</p>
 				</div>
 			</div>
 		);
@@ -90,11 +92,11 @@ export function SocialSettings() {
 			{/* Header */}
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label="Back to settings">
+					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
 						<ArrowLeft className="h-4 w-4" />
 					</Button>
 				</Link>
-				<h1 className="text-2xl font-bold">Social Links</h1>
+				<h1 className="text-2xl font-bold">{t`Social Links`}</h1>
 			</div>
 
 			{/* Status banner */}
@@ -117,47 +119,46 @@ export function SocialSettings() {
 
 			<form onSubmit={handleSubmit} className="space-y-6">
 				<div className="rounded-lg border bg-kumo-base p-6">
-					<h2 className="mb-4 text-lg font-semibold">Social Profiles</h2>
+					<h2 className="mb-4 text-lg font-semibold">{t`Social Profiles`}</h2>
 					<p className="text-sm text-kumo-subtle mb-6">
-						Add your social media profiles. These are available to your site's theme and can be
-						displayed in headers, footers, or author bios.
+						{t`Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios.`}
 					</p>
 					<div className="space-y-4">
 						<Input
-							label="Twitter"
+							label={t`Twitter`}
 							value={formData.social?.twitter || ""}
 							onChange={(e) => handleSocialChange("twitter", e.target.value)}
-							description="Your Twitter/X handle (e.g., @username)"
+							description={t`Your Twitter/X handle (e.g., @username)`}
 						/>
 						<Input
-							label="GitHub"
+							label={t`GitHub`}
 							value={formData.social?.github || ""}
 							onChange={(e) => handleSocialChange("github", e.target.value)}
-							description="Your GitHub username"
+							description={t`Your GitHub username`}
 						/>
 						<Input
-							label="Facebook"
+							label={t`Facebook`}
 							value={formData.social?.facebook || ""}
 							onChange={(e) => handleSocialChange("facebook", e.target.value)}
-							description="Your Facebook page or profile username"
+							description={t`Your Facebook page or profile username`}
 						/>
 						<Input
-							label="Instagram"
+							label={t`Instagram`}
 							value={formData.social?.instagram || ""}
 							onChange={(e) => handleSocialChange("instagram", e.target.value)}
-							description="Your Instagram username"
+							description={t`Your Instagram username`}
 						/>
 						<Input
-							label="LinkedIn"
+							label={t`LinkedIn`}
 							value={formData.social?.linkedin || ""}
 							onChange={(e) => handleSocialChange("linkedin", e.target.value)}
-							description="Your LinkedIn profile username"
+							description={t`Your LinkedIn profile username`}
 						/>
 						<Input
-							label="YouTube"
+							label={t`YouTube`}
 							value={formData.social?.youtube || ""}
 							onChange={(e) => handleSocialChange("youtube", e.target.value)}
-							description="Your YouTube channel ID or handle"
+							description={t`Your YouTube channel ID or handle`}
 						/>
 					</div>
 				</div>
@@ -165,7 +166,7 @@ export function SocialSettings() {
 				{/* Save Button */}
 				<div className="flex justify-end">
 					<Button type="submit" disabled={saveMutation.isPending} icon={<FloppyDisk />}>
-						{saveMutation.isPending ? "Saving..." : "Save Social Links"}
+						{saveMutation.isPending ? t`Saving...` : t`Save Social Links`}
 					</Button>
 				</div>
 			</form>

--- a/packages/admin/src/components/users/InviteUserModal.tsx
+++ b/packages/admin/src/components/users/InviteUserModal.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, Input, Select } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import { Check, Copy, X } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -25,6 +26,7 @@ export function InviteUserModal({
 	onOpenChange,
 	onInvite,
 }: InviteUserModalProps) {
+	const { t } = useLingui();
 	const { roles, roleLabels } = useRolesConfig();
 	const [email, setEmail] = React.useState("");
 	const [role, setRole] = React.useState(30); // Default to Author
@@ -74,26 +76,26 @@ export function InviteUserModal({
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<div className="flex flex-col space-y-1.5">
 						<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-							{inviteUrl ? "Invite Link Created" : "Invite User"}
+							{inviteUrl ? t`Invite Link Created` : t`Invite User`}
 						</Dialog.Title>
 						<Dialog.Description className="text-sm text-kumo-subtle">
 							{inviteUrl
-								? "No email provider configured. Share this link manually."
-								: "Send an invitation email to a new team member."}
+								? t`No email provider configured. Share this link manually.`
+								: t`Send an invitation email to a new team member.`}
 						</Dialog.Description>
 					</div>
 					<Dialog.Close
-						aria-label="Close"
+						aria-label={t`Close`}
 						render={(props) => (
 							<Button
 								{...props}
 								variant="ghost"
 								shape="square"
-								aria-label="Close"
+								aria-label={t`Close`}
 								className="absolute right-4 top-4"
 							>
 								<X className="h-4 w-4" />
-								<span className="sr-only">Close</span>
+								<span className="sr-only">{t`Close`}</span>
 							</Button>
 						)}
 					/>
@@ -104,10 +106,10 @@ export function InviteUserModal({
 					<div className="py-4 space-y-4">
 						<div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4">
 							<p className="text-sm text-amber-800 dark:text-amber-200 font-medium">
-								Share this link with the invited user
+								{t`Share this link with the invited user`}
 							</p>
 							<p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-								This link expires in 7 days and can only be used once.
+								{t`This link expires in 7 days and can only be used once.`}
 							</p>
 						</div>
 
@@ -119,7 +121,7 @@ export function InviteUserModal({
 								variant="ghost"
 								shape="square"
 								onClick={handleCopyUrl}
-								aria-label="Copy invite link"
+								aria-label={t`Copy invite link`}
 							>
 								{copied ? (
 									<Check className="h-4 w-4 text-green-600" />
@@ -129,17 +131,17 @@ export function InviteUserModal({
 							</Button>
 						</div>
 						{copied && (
-							<p className="text-xs text-green-600 dark:text-green-400">Copied to clipboard</p>
+							<p className="text-xs text-green-600 dark:text-green-400">{t`Copied to clipboard`}</p>
 						)}
 						{copyError && (
 							<p className="text-xs text-amber-600 dark:text-amber-400">
-								Could not copy automatically. Please select the URL above and copy manually.
+								{t`Could not copy automatically. Please select the URL above and copy manually.`}
 							</p>
 						)}
 
 						<div className="flex justify-end">
 							<Button type="button" onClick={() => onOpenChange(false)}>
-								Done
+								{t`Done`}
 							</Button>
 						</div>
 					</div>
@@ -149,11 +151,11 @@ export function InviteUserModal({
 						<div className="grid gap-4 py-4">
 							{/* Email */}
 							<Input
-								label="Email address"
+								label={t`Email address`}
 								type="email"
 								value={email}
 								onChange={(e) => setEmail(e.target.value)}
-								placeholder="colleague@example.com"
+								placeholder={t`colleague@example.com`}
 								required
 								autoComplete="off"
 							/>
@@ -161,7 +163,7 @@ export function InviteUserModal({
 							{/* Role */}
 							<div className="grid gap-2">
 								<Select
-									label="Role"
+									label={t`Role`}
 									value={role.toString()}
 									onValueChange={(v) => v !== null && setRole(parseInt(v, 10))}
 									items={roleLabels}
@@ -176,7 +178,7 @@ export function InviteUserModal({
 									))}
 								</Select>
 								<p className="text-xs text-kumo-subtle">
-									The invited user will have this role once they complete registration.
+									{t`The invited user will have this role once they complete registration.`}
 								</p>
 							</div>
 
@@ -195,10 +197,10 @@ export function InviteUserModal({
 								onClick={() => onOpenChange(false)}
 								disabled={isSending}
 							>
-								Cancel
+								{t`Cancel`}
 							</Button>
 							<Button type="submit" disabled={isSending || !email}>
-								{isSending ? "Sending..." : "Send Invite"}
+								{isSending ? t`Sending...` : t`Send Invite`}
 							</Button>
 						</div>
 					</form>

--- a/packages/admin/src/components/users/UserDetail.tsx
+++ b/packages/admin/src/components/users/UserDetail.tsx
@@ -1,4 +1,5 @@
 import { Button, Input, Select } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import {
 	X,
 	Key,
@@ -49,6 +50,7 @@ export function UserDetail({
 	onEnable,
 	onSendRecovery,
 }: UserDetailProps) {
+	const { t } = useLingui();
 	const { roles, roleLabels, getRoleLabel } = useRolesConfig();
 	const [name, setName] = React.useState(user?.name ?? "");
 	const [email, setEmail] = React.useState(user?.email ?? "");
@@ -123,9 +125,9 @@ export function UserDetail({
 				{/* Header */}
 				<div className="flex items-center justify-between border-b px-6 py-4">
 					<h2 id="user-detail-title" className="text-lg font-semibold">
-						User Details
+						{t`User Details`}
 					</h2>
-					<Button variant="ghost" shape="square" onClick={onClose} aria-label="Close panel">
+					<Button variant="ghost" shape="square" onClick={onClose} aria-label={t`Close panel`}>
 						<X className="h-5 w-5" aria-hidden="true" />
 					</Button>
 				</div>
@@ -151,17 +153,17 @@ export function UserDetail({
 								)}
 								<div className="flex-1 min-w-0 space-y-3">
 									<Input
-										label="Name"
+										label={t`Name`}
 										value={name}
 										onChange={(e) => setName(e.target.value)}
-										placeholder="Enter name"
+										placeholder={t`Enter name`}
 									/>
 									<Input
-										label="Email"
+										label={t`Email`}
 										type="email"
 										value={email}
 										onChange={(e) => setEmail(e.target.value)}
-										placeholder="Enter email"
+										placeholder={t`Enter email`}
 										required
 									/>
 								</div>
@@ -172,17 +174,19 @@ export function UserDetail({
 								{isSelf ? (
 									<div className="flex-1">
 										<Input
-											label="Role"
+											label={t`Role`}
 											value={getRoleLabel(role)}
 											disabled
 											className="cursor-not-allowed"
 										/>
-										<p className="text-xs text-kumo-subtle mt-1">You cannot change your own role</p>
+										<p className="text-xs text-kumo-subtle mt-1">
+											{t`You cannot change your own role`}
+										</p>
 									</div>
 								) : (
 									<div className="flex-1">
 										<Select
-											label="Role"
+											label={t`Role`}
 											value={role.toString()}
 											onValueChange={(v) => v !== null && setRole(parseInt(v, 10))}
 											items={roleLabels}
@@ -202,12 +206,12 @@ export function UserDetail({
 									{user.disabled ? (
 										<span className="inline-flex items-center gap-1 text-sm text-kumo-danger">
 											<Prohibit className="h-3.5 w-3.5" aria-hidden="true" />
-											Disabled
+											{t`Disabled`}
 										</span>
 									) : (
 										<span className="inline-flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
 											<CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
-											Active
+											{t`Active`}
 										</span>
 									)}
 								</div>
@@ -217,25 +221,25 @@ export function UserDetail({
 							<div className="grid gap-4">
 								{/* Timestamps */}
 								<div className="rounded-lg border p-4">
-									<h4 className="text-sm font-medium text-kumo-subtle mb-3">Account Info</h4>
+									<h4 className="text-sm font-medium text-kumo-subtle mb-3">{t`Account Info`}</h4>
 									<div className="space-y-2 text-sm">
 										<div className="flex justify-between">
-											<span className="text-kumo-subtle">Created</span>
+											<span className="text-kumo-subtle">{t`Created`}</span>
 											<span>{new Date(user.createdAt).toLocaleDateString()}</span>
 										</div>
 										<div className="flex justify-between">
-											<span className="text-kumo-subtle">Last updated</span>
+											<span className="text-kumo-subtle">{t`Last updated`}</span>
 											<span>{new Date(user.updatedAt).toLocaleDateString()}</span>
 										</div>
 										<div className="flex justify-between">
-											<span className="text-kumo-subtle">Last login</span>
+											<span className="text-kumo-subtle">{t`Last login`}</span>
 											<span>
-												{user.lastLogin ? new Date(user.lastLogin).toLocaleDateString() : "Never"}
+												{user.lastLogin ? new Date(user.lastLogin).toLocaleDateString() : t`Never`}
 											</span>
 										</div>
 										<div className="flex justify-between">
-											<span className="text-kumo-subtle">Email verified</span>
-											<span>{user.emailVerified ? "Yes" : "No"}</span>
+											<span className="text-kumo-subtle">{t`Email verified`}</span>
+											<span>{user.emailVerified ? t`Yes` : t`No`}</span>
 										</div>
 									</div>
 								</div>
@@ -244,24 +248,24 @@ export function UserDetail({
 								<div className="rounded-lg border p-4">
 									<h4 className="text-sm font-medium text-kumo-subtle mb-3 flex items-center gap-2">
 										<Key className="h-4 w-4" aria-hidden="true" />
-										Passkeys ({user.credentials.length})
+										{t`Passkeys (${user.credentials.length})`}
 									</h4>
 									{user.credentials.length === 0 ? (
-										<p className="text-sm text-kumo-subtle">No passkeys registered</p>
+										<p className="text-sm text-kumo-subtle">{t`No passkeys registered`}</p>
 									) : (
 										<div className="space-y-2">
 											{user.credentials.map((cred) => (
 												<div key={cred.id} className="flex justify-between text-sm">
 													<div>
-														<div>{cred.name || "Unnamed passkey"}</div>
+														<div>{cred.name || t`Unnamed passkey`}</div>
 														<div className="text-xs text-kumo-subtle">
-															{cred.deviceType === "multiDevice" ? "Synced" : "Device-bound"}
+															{cred.deviceType === "multiDevice" ? t`Synced` : t`Device-bound`}
 														</div>
 													</div>
 													<div className="text-right text-kumo-subtle">
-														<div>Created {new Date(cred.createdAt).toLocaleDateString()}</div>
+														<div>{t`Created ${new Date(cred.createdAt).toLocaleDateString()}`}</div>
 														<div className="text-xs">
-															Last used {new Date(cred.lastUsedAt).toLocaleDateString()}
+															{t`Last used ${new Date(cred.lastUsedAt).toLocaleDateString()}`}
 														</div>
 													</div>
 												</div>
@@ -275,7 +279,7 @@ export function UserDetail({
 									<div className="rounded-lg border p-4">
 										<h4 className="text-sm font-medium text-kumo-subtle mb-3 flex items-center gap-2">
 											<ArrowSquareOut className="h-4 w-4" aria-hidden="true" />
-											Linked Accounts ({user.oauthAccounts.length})
+											{t`Linked Accounts (${user.oauthAccounts.length})`}
 										</h4>
 										<div className="space-y-2">
 											{user.oauthAccounts.map((account, i) => (
@@ -285,7 +289,7 @@ export function UserDetail({
 												>
 													<span className="capitalize">{account.provider}</span>
 													<span className="text-kumo-subtle">
-														Connected {new Date(account.createdAt).toLocaleDateString()}
+														{t`Connected ${new Date(account.createdAt).toLocaleDateString()}`}
 													</span>
 												</div>
 											))}
@@ -295,7 +299,7 @@ export function UserDetail({
 							</div>
 						</form>
 					) : (
-						<div className="text-center text-kumo-subtle py-8">User not found</div>
+						<div className="text-center text-kumo-subtle py-8">{t`User not found`}</div>
 					)}
 				</div>
 
@@ -310,7 +314,7 @@ export function UserDetail({
 								disabled={!isDirty || isSaving}
 								icon={<FloppyDisk />}
 							>
-								{isSaving ? "Saving..." : "Save Changes"}
+								{isSaving ? t`Saving...` : t`Save Changes`}
 							</Button>
 							{!isSelf && (
 								<Button
@@ -318,7 +322,7 @@ export function UserDetail({
 									onClick={user.disabled ? onEnable : onDisable}
 									icon={user.disabled ? <CheckCircle /> : <Prohibit />}
 								>
-									{user.disabled ? "Enable" : "Disable"}
+									{user.disabled ? t`Enable` : t`Disable`}
 								</Button>
 							)}
 						</div>
@@ -331,11 +335,11 @@ export function UserDetail({
 									disabled={isSendingRecovery}
 									icon={<Envelope />}
 								>
-									{isSendingRecovery ? "Sending..." : "Send Recovery Link"}
+									{isSendingRecovery ? t`Sending...` : t`Send Recovery Link`}
 								</Button>
 								{recoverySent && (
 									<p className="text-xs text-green-600 dark:text-green-400 text-center">
-										Recovery link sent to {user.email}
+										{t`Recovery link sent to ${user.email}`}
 									</p>
 								)}
 								{recoveryError && (

--- a/packages/admin/src/locales/ar/messages.po
+++ b/packages/admin/src/locales/ar/messages.po
@@ -22,14 +22,107 @@ msgstr ""
 msgid " (default)"
 msgstr " الافتراضي"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -44,6 +137,94 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — بدون ترجمة"
@@ -51,6 +232,44 @@ msgstr "{label} — بدون ترجمة"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — عرض الترجمة"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -60,13 +279,96 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr "1 سنة"
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
 msgstr "30 يوم"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -76,17 +378,138 @@ msgstr "7 أيام"
 msgid "90 days"
 msgstr "90 يوم"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -103,8 +526,24 @@ msgstr ""
 msgid "Administrator"
 msgstr "مسؤول"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -116,31 +555,183 @@ msgstr "جميع المَحليات"
 msgid "All roles"
 msgstr "جميع الأدوار"
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "السماح للمستخدمين من نطاقات معينة بالتسجيل"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "رموز API"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "كمسؤول، يمكنك دعوة مستخدمين آخرين من منطقة \"المستخدمين\"."
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "خلل في المصادقة: {error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "مؤلف"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
 msgid "Back to {collectionLabel} list"
@@ -148,12 +739,72 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "العودة إلى تسجيل الدخول"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
 msgstr "العودة إلى الإعدادات"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -181,6 +832,8 @@ msgstr "يمكنه نشر محتواه الخاص"
 msgid "Can view content"
 msgstr "يمكنه عرض المحتوى"
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -188,51 +841,264 @@ msgstr "يمكنه عرض المحتوى"
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
 msgstr "إلغاء"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "الفئات"
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "يرجى تفقد بريدك الإلكتروني"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "إختر لغة التحكم المفضلة لديك"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "إضغط على الرابط في الرسالة لتسجيل الدخول."
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
 msgstr "إغلاق"
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
 msgid "Code Block"
 msgstr "كتلة كود"
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "تأكيد"
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "محتوى"
@@ -241,18 +1107,65 @@ msgstr "محتوى"
 msgid "Content Block"
 msgstr "كتلة محتوى"
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr "قراءة المحتوى"
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "أنواع المحتوى"
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
 msgstr "كتابة المحتوى"
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -260,8 +1173,22 @@ msgid "Contributor"
 msgstr "مساهم"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
 msgstr "تم النسخ إلى الحافظة"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
@@ -271,7 +1198,27 @@ msgstr "قم بنسخ هذا الرمز الآن — لن يظهر لاحقًا"
 msgid "Copy token"
 msgstr "نسخ الرمز"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -279,38 +1226,122 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr "إنشاء قائمة نقطية"
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "إنشاء قائمة مرقمة"
 
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
 msgstr "إنشاء رمز جديد"
 
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
 msgstr "إنشاء رمز وصول شخصي للوصول إلى API برمجيًا"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr "إنشاء رمز"
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "إنشاء، تحديث، حذف المحتوى"
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr "تم إنشاء {0}"
 
@@ -323,13 +1354,37 @@ msgstr "تم الإنشاء في"
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr "جاري الإنشاء..."
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -341,16 +1396,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "لوحة المعلومات"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -359,8 +1510,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -386,6 +1651,20 @@ msgstr "عرض قائمة تنقل"
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -394,12 +1673,37 @@ msgstr ""
 msgid "Divider"
 msgstr "فاصل"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "ليس لديك حساب؟ قم ب<0>التسجيل</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -407,6 +1711,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -419,6 +1724,14 @@ msgstr "مسودة، منشورة، أو مؤرشفة"
 msgid "Drafts"
 msgstr "المسودات"
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -427,9 +1740,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr "على سبيل المثال، خط CI/CD"
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -444,18 +1774,85 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "محرر"
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "عنوان البريد الإلكتروني"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr ""
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -466,25 +1863,101 @@ msgstr "تضمين {0}"
 msgid "Embeds"
 msgstr "المضمنات"
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
 msgstr "تفعيل البحث النصي الكامل على هذه المجموعة"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
+msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1123
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -496,8 +1969,108 @@ msgstr "ينتهي في {0}"
 msgid "Expiry"
 msgstr "الإنتهاء"
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -505,8 +2078,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr "فشل في إرسال الرابط السحري"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -521,9 +2177,38 @@ msgstr "وصول التحكم الكامل"
 msgid "General"
 msgstr "عام"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
 msgstr "بدء الاستخدام"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -540,9 +2225,48 @@ msgstr "عنوان 2"
 msgid "Heading 3"
 msgstr "عنوان 3"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
 msgstr "إخفاء الرمز"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -552,14 +2276,134 @@ msgstr "المعرف"
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "إذا كان يوجد حساب لـ <0>{email}</0>، قمنا بإرسال رابط تسجيل دخول."
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
 msgstr "صورة"
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "إستيراد"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -581,6 +2425,111 @@ msgstr "إدراج قسم قابل لإعادة الاستخدام"
 msgid "Insert an image"
 msgstr "إدراج صورة"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -590,10 +2539,48 @@ msgstr "اللغة"
 msgid "Large section heading"
 msgstr "عنوان قسم كبير"
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
 msgstr "آخر استخدام في {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -603,8 +2590,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -612,8 +2630,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "جاري التحميل..."
@@ -623,28 +2696,129 @@ msgstr "جاري التحميل..."
 msgid "Locale"
 msgstr "المَحلية"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "إدارة مفاتيح مرورك والمصادقة"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr "وسائط"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr "مكتبة الوسائط"
 
@@ -664,10 +2838,85 @@ msgstr "عنوان قسم متوسط"
 msgid "Menu"
 msgstr "قائمة"
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "القوائم"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -681,6 +2930,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -692,20 +2945,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "التنقل"
 
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "علامة تبوب جديدة"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -713,9 +3057,27 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "لا يوجد رموز API بعد. قم بإنشاء واحدة للبدء."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
 msgid "No bylines selected."
@@ -725,17 +3087,138 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "بدون إنتهاء"
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "لا يوجد نتائج"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
@@ -745,25 +3228,253 @@ msgstr ""
 msgid "No results found"
 msgstr "لم يتم العثور على نتائج"
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
 msgstr "قائمة مرقمة"
 
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "أو المواصلة مع"
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "فقرة"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -778,14 +3489,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "الإضافات"
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr "معاينة"
 
@@ -797,8 +3590,21 @@ msgstr "معاينة المحتوى قبل النشر"
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -815,8 +3621,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -844,27 +3656,238 @@ msgstr "قراءة مدخلات المحتوى"
 msgid "Read media files"
 msgstr "قراءة ملفات الوسائط"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr "التعديلات"
 
@@ -880,9 +3903,28 @@ msgstr "إبطال؟"
 msgid "Revoking..."
 msgstr "جاري الإبطال..."
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
 msgstr "محتوى نصي منسق"
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -892,14 +3934,46 @@ msgstr "الدور {role}"
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "حفظ المحتوى كمسودة قبل النشر"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -908,7 +3982,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -937,6 +4020,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr "قراءة المخطط"
@@ -954,6 +4045,33 @@ msgstr "النطاقات"
 msgid "Scopes: {0}"
 msgstr "النطاقات: {0}"
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr "بحث"
@@ -968,53 +4086,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "تحسين محركات البحث والتحقق"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr "البحث في الصفحات والمحتوى..."
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr "قسم"
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "أقسام"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "الأمن"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
 msgstr "إعدادات الأمن"
 
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
 msgstr ""
 
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "نطاقات التسجيل الذاتي"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "إرسال رابط سحري"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "جاري الإرسال..."
 
@@ -1023,16 +4333,83 @@ msgstr "جاري الإرسال..."
 msgid "SEO"
 msgstr "تحسين محركات البحث"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "الإعدادات"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "عرض الرمز"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
@@ -1046,61 +4423,312 @@ msgstr "تسجيل الدخول بالبريد الإلكتروني"
 msgid "Sign in with email link"
 msgstr "تسجيل الدخول برابط البريد الإلكتروني"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "تسجيل الدخول بمفتاح مرور"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "هوية الموقع، الشعار، أيقونة المتصفح، وإعدادات القراءة"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
 msgstr "الاسم اللطيف"
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
 msgstr "عنوان قسم صغير"
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "روابط وسائل التواصل"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "روابط الملفات الشخصية في وسائل التواصل الاجتماعي"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
 msgstr "الحالة"
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "مشترك"
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "الوسوم"
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "ستنتهي صلاحية الرابط بعد 15 دقيقة."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1108,22 +4736,107 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "للإغلاق"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -1143,6 +4856,10 @@ msgstr "تم إنشاء الرمز: {0}"
 msgid "Token Name"
 msgstr "اسم الرمز"
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr "تتبع تاريخ المحتوى"
@@ -1155,6 +4872,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1163,9 +4888,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1180,8 +4990,24 @@ msgstr "غير معروف"
 msgid "Unknown role"
 msgstr "دور غير معروف"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1196,6 +5022,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "تم التحديث في"
@@ -1205,29 +5058,152 @@ msgstr "تم التحديث في"
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "رفع وحذف الوسائط"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
 msgstr "معرف مناسب للروابط"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "قم باستخدام مفتاح المرور المسجل الخاص بك لتسجيل الدخول بشكل آمن."
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1235,9 +5211,48 @@ msgstr ""
 msgid "Users"
 msgstr "المستخدمين"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "عرض حالة مزود البريد الإلكتروني وإرسال رسائل تجريبية."
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1247,9 +5262,44 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "سنقوم بإرسال رابط إليك لتسجيل الدخول بدون كلمة مرور."
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1258,6 +5308,14 @@ msgstr "أهلا بك في EmDash، {firstName}!"
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
 msgstr "أهلا بك في EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -1271,10 +5329,52 @@ msgstr "متى تم تحديث المُدخل في آخر مرة"
 msgid "When the entry was published"
 msgstr "متى تم نشر المُدخل"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "عناصر واجهة المستخدم"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -1288,14 +5388,103 @@ msgstr "يمكنك إدارة المحتوى، الوسائط، القوائم،
 msgid "You can view and contribute to the site."
 msgstr "يمكنك العرض والمساهمة في الموقع."
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "لديك الصلاحية المطلقة لإدارة هذا الموقع، بما في ذلك المستخدمين، الإعدادات، وكامل المحتوى."
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr "تم إنشاء حسابك بنجاح."
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
 msgstr "دورك"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/ar/messages.po
+++ b/packages/admin/src/locales/ar/messages.po
@@ -26,8 +26,8 @@ msgstr " الافتراضي"
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -42,7 +42,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -53,6 +53,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -81,7 +88,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -103,6 +110,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -175,7 +187,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -198,8 +209,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -208,9 +219,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -277,6 +287,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -405,7 +423,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -463,11 +481,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -534,7 +552,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -598,7 +616,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -645,7 +663,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -719,7 +737,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -789,7 +807,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -845,7 +863,7 @@ msgstr "يمكنه عرض المحتوى"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -970,9 +988,9 @@ msgstr "إضغط على الرابط في الرسالة لتسجيل الدخو
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1011,7 +1029,7 @@ msgstr "إغلاق"
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1116,7 +1134,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1132,7 +1150,7 @@ msgstr ""
 msgid "Content Read"
 msgstr "قراءة المحتوى"
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1141,7 +1159,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "أنواع المحتوى"
@@ -1202,7 +1220,7 @@ msgstr "نسخ الرمز"
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1318,7 +1336,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1371,7 +1389,7 @@ msgstr "جاري الإنشاء..."
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1396,7 +1414,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1438,13 +1456,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1464,7 +1482,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1485,7 +1503,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1532,7 +1550,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1756,7 +1774,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1981,7 +1999,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2042,7 +2060,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2099,7 +2117,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2149,7 +2167,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2230,10 +2248,6 @@ msgstr "عنوان 3"
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2251,6 +2265,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2263,7 +2281,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2294,7 +2316,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2400,8 +2422,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2425,7 +2447,7 @@ msgstr "إدراج قسم قابل لإعادة الاستخدام"
 msgid "Insert an image"
 msgstr "إدراج صورة"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2449,7 +2471,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2485,7 +2507,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2499,11 +2521,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2620,7 +2637,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2630,7 +2647,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2680,7 +2697,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2771,7 +2788,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2965,7 +2982,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -3002,7 +3019,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3103,7 +3120,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3131,7 +3148,7 @@ msgstr ""
 msgid "No expiry"
 msgstr "بدون إنتهاء"
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3139,7 +3156,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3157,12 +3174,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3195,7 +3212,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3215,7 +3232,7 @@ msgstr ""
 msgid "No results"
 msgstr "لا يوجد نتائج"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3228,7 +3245,7 @@ msgstr ""
 msgid "No results found"
 msgstr "لم يتم العثور على نتائج"
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3330,7 +3347,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3393,7 +3410,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3506,7 +3523,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3603,6 +3620,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3695,7 +3716,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3717,11 +3738,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3751,8 +3772,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3768,7 +3793,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3776,9 +3801,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3839,7 +3868,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3847,29 +3876,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3882,12 +3911,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr "التعديلات"
 
@@ -4106,7 +4135,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr "تحسين محركات البحث والتحقق"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4114,7 +4143,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr "البحث في الصفحات والمحتوى..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4132,7 +4161,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4195,11 +4224,11 @@ msgstr "الأمن"
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4211,7 +4240,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4261,6 +4290,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4278,11 +4311,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4390,10 +4423,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "عرض الرمز"
@@ -4494,7 +4523,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4537,7 +4566,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4545,7 +4574,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4669,7 +4698,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4682,7 +4711,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr "ستنتهي صلاحية الرابط بعد 15 دقيقة."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4897,7 +4926,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4942,7 +4971,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4950,10 +4979,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5006,7 +5031,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5067,7 +5092,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5075,7 +5100,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5088,7 +5113,7 @@ msgstr "رفع وحذف الوسائط"
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5100,7 +5125,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5140,7 +5165,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5271,7 +5296,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5396,9 +5421,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "لديك الصلاحية المطلقة لإدارة هذا الموقع، بما في ذلك المستخدمين، الإعدادات، وكامل المحتوى."
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -18,14 +18,107 @@ msgstr ""
 msgid " (default)"
 msgstr " (Standard)"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -40,6 +133,94 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — keine Übersetzung"
@@ -47,6 +228,44 @@ msgstr "{label} — keine Übersetzung"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — Übersetzung anzeigen"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -56,12 +275,95 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
@@ -72,17 +374,138 @@ msgstr ""
 msgid "90 days"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -99,8 +522,24 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -112,30 +551,182 @@ msgstr "Alle Sprachen"
 msgid "All roles"
 msgstr ""
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "Benutzern von bestimmten Domains die Registrierung erlauben"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "API-Tokens"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "Authentifizierungsfehler: {error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
@@ -144,11 +735,71 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "Zurück zur Anmeldung"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
@@ -177,6 +828,8 @@ msgstr ""
 msgid "Can view content"
 msgstr ""
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,33 +837,179 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr ""
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "Wählen Sie Ihre bevorzugte Admin-Sprache"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "Klicken Sie auf den Link in der E-Mail, um sich anzumelden."
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
@@ -218,17 +1017,84 @@ msgstr ""
 msgid "Code Block"
 msgstr ""
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr ""
@@ -237,17 +1103,64 @@ msgstr ""
 msgid "Content Block"
 msgstr ""
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
@@ -256,7 +1169,21 @@ msgid "Contributor"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
+msgstr ""
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
@@ -267,7 +1194,27 @@ msgstr ""
 msgid "Copy token"
 msgstr ""
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -275,16 +1222,46 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:110
@@ -292,21 +1269,75 @@ msgstr ""
 msgid "Create personal access tokens for programmatic API access"
 msgstr "Persönliche Zugangstokens für programmatischen API-Zugriff erstellen"
 
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr ""
 
@@ -319,13 +1350,37 @@ msgstr ""
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -355,8 +1506,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -382,6 +1647,20 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -390,12 +1669,37 @@ msgstr ""
 msgid "Divider"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "Noch kein Konto? <0>Registrieren</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -403,6 +1707,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -415,6 +1720,14 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -423,9 +1736,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -440,18 +1770,85 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "E-Mail"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "E-Mail-Adresse"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr ""
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -462,8 +1859,33 @@ msgstr ""
 msgid "Embeds"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
 msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
@@ -471,16 +1893,67 @@ msgstr ""
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -492,8 +1965,108 @@ msgstr ""
 msgid "Expiry"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -501,8 +2074,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr "Magic Link konnte nicht gesendet werden"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -517,8 +2173,37 @@ msgstr ""
 msgid "General"
 msgstr "Allgemein"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
@@ -536,8 +2221,47 @@ msgstr ""
 msgid "Heading 3"
 msgstr ""
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
@@ -548,13 +2272,133 @@ msgstr ""
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "Falls ein Konto für <0>{email}</0> existiert, haben wir einen Anmeldelink gesendet."
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
+msgstr ""
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
 msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
@@ -577,6 +2421,111 @@ msgstr ""
 msgid "Insert an image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,9 +2535,47 @@ msgstr "Sprache"
 msgid "Large section heading"
 msgstr ""
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -599,8 +2586,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -608,8 +2626,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr ""
@@ -619,28 +2692,129 @@ msgstr ""
 msgid "Locale"
 msgstr "Sprache"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "Passkeys und Authentifizierung verwalten"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr ""
 
@@ -660,9 +2834,84 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
@@ -677,6 +2926,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,20 +2941,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -709,8 +3053,26 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
@@ -721,16 +3083,137 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
 msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
@@ -741,25 +3224,253 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "Oder fortfahren mit"
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -774,14 +3485,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr ""
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr ""
 
@@ -793,8 +3586,21 @@ msgstr ""
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -811,8 +3617,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -840,27 +3652,238 @@ msgstr ""
 msgid "Read media files"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr ""
 
@@ -876,8 +3899,27 @@ msgstr ""
 msgid "Revoking..."
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
@@ -888,13 +3930,45 @@ msgstr ""
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
@@ -904,7 +3978,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -933,6 +4016,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr ""
@@ -950,6 +4041,33 @@ msgstr ""
 msgid "Scopes: {0}"
 msgstr ""
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr ""
@@ -964,53 +4082,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "Suchmaschinenoptimierung und Verifizierung"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
 msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "Sicherheit"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
+msgstr ""
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "Selbstregistrierungs-Domains"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "Magic Link senden"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "Wird gesendet..."
 
@@ -1019,15 +4329,82 @@ msgstr "Wird gesendet..."
 msgid "SEO"
 msgstr "SEO"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "Einstellungen"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
@@ -1042,19 +4419,88 @@ msgstr "Mit E-Mail anmelden"
 msgid "Sign in with email link"
 msgstr "Mit E-Mail-Link anmelden"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "Mit Passkey anmelden"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "Website-Identität, Logo, Favicon und Leseeinstellungen"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
 msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
@@ -1062,17 +4508,84 @@ msgid "Small section heading"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "Soziale Netzwerke"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "Links zu Social-Media-Profilen"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
@@ -1080,23 +4593,138 @@ msgstr ""
 msgid "Subscriber"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr ""
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "Der Link ist 15 Minuten gültig."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1104,21 +4732,106 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
@@ -1139,6 +4852,10 @@ msgstr ""
 msgid "Token Name"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr ""
@@ -1151,6 +4868,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1159,9 +4884,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1176,8 +4986,24 @@ msgstr ""
 msgid "Unknown role"
 msgstr ""
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1192,6 +5018,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr ""
@@ -1201,29 +5054,152 @@ msgstr ""
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
 msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "Verwenden Sie Ihren registrierten Passkey, um sich sicher anzumelden."
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1231,9 +5207,48 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "E-Mail-Anbieter-Status anzeigen und Test-E-Mails senden"
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1243,9 +5258,44 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "Wir senden Ihnen einen Link, um sich ohne Passwort anzumelden."
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1253,6 +5303,14 @@ msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
@@ -1267,9 +5325,51 @@ msgstr ""
 msgid "When the entry was published"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
@@ -1284,14 +5384,103 @@ msgstr ""
 msgid "You can view and contribute to the site."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr ""
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
 msgstr ""

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -22,8 +22,8 @@ msgstr " (Standard)"
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -49,6 +49,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -99,6 +106,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -171,7 +183,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -194,8 +205,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -204,9 +215,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -273,6 +283,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -401,7 +419,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -530,7 +548,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -594,7 +612,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -715,7 +733,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -785,7 +803,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -841,7 +859,7 @@ msgstr ""
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr "Klicken Sie auf den Link in der E-Mail, um sich anzumelden."
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr ""
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1112,7 +1130,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1128,7 +1146,7 @@ msgstr ""
 msgid "Content Read"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr ""
@@ -1198,7 +1216,7 @@ msgstr ""
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1367,7 +1385,7 @@ msgstr ""
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2038,7 +2056,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2145,7 +2163,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2226,10 +2244,6 @@ msgstr ""
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2247,6 +2261,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2259,7 +2277,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2290,7 +2312,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2396,8 +2418,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2421,7 +2443,7 @@ msgstr ""
 msgid "Insert an image"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2445,7 +2467,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2495,11 +2517,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2626,7 +2643,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2676,7 +2693,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3099,7 +3116,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3127,7 +3144,7 @@ msgstr ""
 msgid "No expiry"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3135,7 +3152,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3211,7 +3228,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3224,7 +3241,7 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3326,7 +3343,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3389,7 +3406,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3599,6 +3616,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3691,7 +3712,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3713,11 +3734,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,8 +3768,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3772,9 +3797,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3835,7 +3864,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3843,29 +3872,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3878,12 +3907,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr ""
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr "Suchmaschinenoptimierung und Verifizierung"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4110,7 +4139,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4191,11 +4220,11 @@ msgstr "Sicherheit"
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4257,6 +4286,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4386,10 +4419,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr ""
@@ -4490,7 +4519,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4541,7 +4570,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4678,7 +4707,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr "Der Link ist 15 Minuten gültig."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4938,7 +4967,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4946,10 +4975,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5002,7 +5027,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5063,7 +5088,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5071,7 +5096,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5084,7 +5109,7 @@ msgstr ""
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5096,7 +5121,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5267,7 +5292,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5392,9 +5417,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr ""
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369

--- a/packages/admin/src/locales/en/messages.po
+++ b/packages/admin/src/locales/en/messages.po
@@ -18,15 +18,108 @@ msgstr ""
 msgid " (default)"
 msgstr " (default)"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr " (opens in new window)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr " (selected)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", or open the admin at"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": use"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr "(from {0})"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(synced)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(with your dev port)."
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# collection} other {# collections}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# comment} other {# comments}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# content error} other {# content errors}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# content item imported} other {# content items imported}}"
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# item} other {# items}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# media error} other {# media errors}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# media file imported} other {# media files imported}}"
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
 msgstr "{0, plural, one {# media file} other {# media files}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# post} other {# posts}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# selected} other {# selected}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:128
@@ -40,6 +133,94 @@ msgstr "{0, plural, one {# user} other {# users}}"
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr "{0, plural, one {#{1} item} other {#{2} items}}"
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr "{0} detected"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr "{0} has been deactivated"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr "{0} has been removed"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr "{0} installs"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr "{0} is now active"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr "{0} items → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr "{0} items will be imported"
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr "{0} permission{1}"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr "{0} plugins"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr "{0} preview"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr "{0} updated to v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr "{0}/160 characters"
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr "{changedCount} change{0} from next revision"
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# file} other {# files}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# item} other {# items}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr "{current} of {total}"
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — no translation"
@@ -47,6 +228,44 @@ msgstr "{label} — no translation"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — view translation"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} of {totalCount} assigned"
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} of {totalCount} authors matched by email"
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} is requesting additional permissions:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} requires the following permissions:"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# total} other {# total}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {File uploaded} other {# files uploaded}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Upload failed} other {All # uploads failed}}"
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -56,13 +275,96 @@ msgstr "{totalDrafts, plural, one {# draft} other {# drafts}}"
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} uploaded, {failed} failed"
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Files are downloaded from your WordPress site"
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Uploaded to your EmDash media storage"
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr "• URLs in your content are updated automatically"
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr "← Back"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr "1 year"
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr "1. Log into your WordPress admin"
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Log into your WordPress admin dashboard"
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr "2. Go to"
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr "2. Go to Users → Profile"
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Scroll to \"Application Passwords\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr "3. Select \"All content\""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
 msgstr "30 days"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr "301 Permanent"
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr "302 Temporary"
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr "307 Temporary (Strict)"
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanent (Strict)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr "4. Click \"Download Export File\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Enter \"EmDash\" and click \"Add New\""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr "404 Errors"
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr "5. Copy the generated password"
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
+msgstr "5. Upload the file here"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -72,18 +374,139 @@ msgstr "7 days"
 msgid "90 days"
 msgstr "90 days"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr "A short description of your site"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr "Accept & Install"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr "Accept & Update"
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr "Account"
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr "Account exists"
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr "Account Info"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr "Actions"
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr "Active"
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
 msgstr "Add"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr "Add {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr "Add a new passkey"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr "Add an allowed domain"
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Add at least one sub-field to define the repeater structure."
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr "Add Content"
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr "Add Custom Link"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr "Add Domain"
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr "Add Field"
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr "Add fields"
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr "Add First Item"
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr "Add Item"
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
+msgstr "Add links to build your navigation menu"
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
 msgstr "Add New"
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr "Add noindex meta tag"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr "Add Passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Add plugins to your astro.config.mjs to extend EmDash functionality."
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr "Add Sub-Field"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr "Add tags..."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr "Adding..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
+msgstr "Additional data to import."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:402
@@ -99,9 +522,25 @@ msgstr "Admin navigation"
 msgid "Administrator"
 msgstr "Administrator"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr "After send:"
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
 msgstr "All"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr "All capabilities"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr "All collections"
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "All imported content will be unassigned. You can reassign authors later from the content editor."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
@@ -112,31 +551,183 @@ msgstr "All locales"
 msgid "All roles"
 msgstr "All roles"
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "All Sources"
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr "All statuses"
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr "All types"
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "Allow users from specific domains to sign up"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr "Allowed Domains"
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr "Already have an account?"
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr "Also delete plugin storage data"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr "Alt Text"
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr "Alt text set"
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr "An error occurred"
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr "Analyzing export file..."
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr "Analyzing WordPress site..."
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "API Tokens"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr "Application Password"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr "Approve"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "approved"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr "Approved"
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr "Arbitrary JSON data"
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
 msgstr "archived"
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "As an administrator, you can invite other users from the Users section."
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Authentication error: {0}"
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "Authentication error: {error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Authentication was cancelled or timed out. Please try again."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "Author"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr "Author Mapping"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Authorization denied"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Authorize"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Authorize Device"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Authorizing..."
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr "auto"
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr "Auto (slug change)"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr "Auto-generated from name (you can edit)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr "Available media"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr "Available Providers"
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
+msgstr "Back"
 
 #: packages/admin/src/components/ContentEditor.tsx:485
 msgid "Back to {collectionLabel} list"
@@ -144,12 +735,72 @@ msgstr "Back to {collectionLabel} list"
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "Back to login"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr "Back to marketplace"
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr "Back to sections"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
 msgstr "Back to settings"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr "Back to Themes"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr "Before send:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr "Bing Verification"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr "Boolean"
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr "Brief summary shown below the title in search results"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr "Browse and install plugins to extend your site."
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr "Browse Files"
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr "Browse the"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
+msgstr "Browse themes and preview them with your own content."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -177,6 +828,8 @@ msgstr "Can publish own content"
 msgid "Can view content"
 msgstr "Can view content"
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,51 +837,264 @@ msgstr "Can view content"
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
 msgstr "Cancel"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Cancel rename"
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr "Cannot delete theme sections"
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr "Canonical URL"
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr "Capabilities"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr "Capability consent"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
+msgstr "Caption"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "Categories"
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr "Categories ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr "Categories will be imported"
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr "Change"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr "Change Favicon"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr "Change Logo"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Character between page title and site name (e.g., \"My Post | My Site\")"
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr "Check for updates"
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr "Check Site"
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "Check your email"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr "Checking {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Checking authentication..."
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "Choose your preferred admin language"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Click the link in the email to continue setting up your account."
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "Click the link in the email to sign in."
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
 msgstr "Close"
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr "Close panel"
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
+msgstr "Code"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
 msgid "Code Block"
 msgstr "Code Block"
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr "Collapse"
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr "Collapse details"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr "colleague@example.com"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Collection:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr "Collections"
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr "Collections created:"
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr "Comma-separated keywords for search."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr "Comment"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Comment Detail"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
 msgstr "Comments"
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr "Complete signup"
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
+msgstr "Configure Field"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "Confirm"
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr "Connect & Analyze"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr "Connect to {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr "Connect with WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr "Connected {0}"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "Content"
@@ -237,18 +1103,65 @@ msgstr "Content"
 msgid "Content Block"
 msgstr "Content Block"
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr "Content Errors ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr "Content found:"
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr "Content has been updated to the selected revision."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "Content ID:"
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr "content items"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr "Content Read"
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr "Content snapshot:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr "Content to Import"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Content Types"
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr "Content was skipped because it already exists"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
 msgstr "Content Write"
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr "Continue"
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr "Continue →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
+msgstr "Continue Import"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -256,8 +1169,22 @@ msgid "Contributor"
 msgstr "Contributor"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
 msgstr "Copied to clipboard"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr "Copy {0} to clipboard"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Copy invite link"
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
+msgstr "Copy slug"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
@@ -267,7 +1194,27 @@ msgstr "Copy this token now — it won't be shown again."
 msgid "Copy token"
 msgstr "Copy token"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Could not copy automatically. Please select the URL above and copy manually."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr "Could not load image from URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr "Couldn't detect WordPress"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr "Count"
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr "Create"
 
@@ -275,38 +1222,122 @@ msgstr "Create"
 msgid "Create a bullet list"
 msgstr "Create a bullet list"
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr "Create a new {0}"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "Create a numbered list"
+
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr "Create Account"
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
+msgstr "Create an account"
 
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
 msgstr "Create byline"
 
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr "Create Menu"
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
+msgstr "Create New Menu"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
 msgstr "Create New Token"
+
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Create one in WordPress: Users → Profile → Application Passwords"
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
+msgstr "Create Passkey"
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
 msgstr "Create personal access tokens for programmatic API access"
 
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr "Create redirect for {0}"
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr "Create redirect for this path"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr "Create redirect rules to manage URL changes."
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr "Create Schema & Import"
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr "Create Section"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Create sections in the Sections library to use them here"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr "Create Taxonomy"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr "Create Token"
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr "Create your account"
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr "Create your first navigation menu to get started"
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
 msgstr "Create your first one"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr "Create your first reusable content section to get started."
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
+msgstr "Create your passkey"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "Create, update, delete content"
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr "Created"
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr "Created {0}"
 
@@ -319,14 +1350,38 @@ msgstr "Created At"
 msgid "Created: {0}"
 msgstr "Created: {0}"
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr "Creating collections and fields..."
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr "Creating..."
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
 msgstr "current"
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr "Current"
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr "Custom"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Custom robots.txt content. Leave empty to use the default."
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
+msgstr "Custom Section"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr "Dark"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "Dashboard"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr "Date"
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr "Date & Time"
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr "Date and time picker"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr "Date Format"
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr "Decimal number"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr "Default Role"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr "Default role:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr "Define a new taxonomy for classifying content"
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr "Define the structure of your content"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr "Delete"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Delete \"{0}\"? This cannot be undone."
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr "Delete {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr "Delete {0} menu"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr "Delete {0}?"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr "Delete Comment?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr "Delete Content Type?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr "Delete Media?"
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr "Delete Menu"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr "Delete permanently"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr "Delete Permanently"
@@ -355,9 +1506,123 @@ msgstr "Delete Permanently"
 msgid "Delete Permanently?"
 msgstr "Delete Permanently?"
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr "Delete redirect"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr "Delete redirect {0}"
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr "Delete Redirect?"
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr "Delete Section?"
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
 msgstr "Deleted"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr "Deleting..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr "Demo"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Deny"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr "Describe this image for accessibility"
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr "Describe what this section is for..."
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr "Description"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr "Description (optional)"
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr "Destination"
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr "Destination path"
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr "details"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Device authorized"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Device code"
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr "Device-bound"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Device-bound passkey"
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr "Didn't receive the email?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr "Dimensions:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr "Disable"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr "Disable plugin"
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr "Disable redirect"
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr "Disabled"
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
+msgstr "Disabled:"
 
 #: packages/admin/src/components/ContentEditor.tsx:558
 #: packages/admin/src/components/ContentEditor.tsx:580
@@ -382,6 +1647,20 @@ msgstr "Display a navigation menu"
 msgid "Display name"
 msgstr "Display name"
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr "Display name for admin interface"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr "Display Size"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr "Displayed below the image as a visible caption."
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr "Distraction-free mode (⌘⇧\\)"
@@ -390,19 +1669,45 @@ msgstr "Distraction-free mode (⌘⇧\\)"
 msgid "Divider"
 msgstr "Divider"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr "Domain"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr "Domain added successfully"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr "Domain removed"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr "Domain updated"
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "Don't have an account? <0>Sign up</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr "Done"
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
 msgstr "Down"
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
+msgstr "Downloading"
 
 #: packages/admin/src/components/ContentList.tsx:553
 msgid "draft"
 msgstr "draft"
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr "Draft"
 
@@ -415,6 +1720,14 @@ msgstr "draft, published, or archived"
 msgid "Drafts"
 msgstr "Drafts"
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Drag and drop or click to browse (.xml)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr "Drop your WordPress export file here"
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr "Duplicate {title}"
@@ -423,10 +1736,27 @@ msgstr "Duplicate {title}"
 msgid "e.g., CI/CD Pipeline"
 msgstr "e.g., CI/CD Pipeline"
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "e.g., MacBook Pro, iPhone"
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
 msgstr "Edit"
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
+msgstr "Edit {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "Edit {collectionLabel}"
@@ -440,18 +1770,85 @@ msgstr "Edit {title}"
 msgid "Edit byline"
 msgstr "Edit byline"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr "Edit Domain"
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr "Edit Field"
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr "Edit Menu Item"
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr "Edit menu items"
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr "Edit redirect"
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr "Edit Redirect"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr "Edit redirect {0}"
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "Editor"
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "Email"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr "Email (optional)"
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "Email address"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr "Email is required"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr "Email Middleware"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr "Email Pipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr "Email provider active"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr "Email Settings"
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr "Email verified"
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr "Email verified!"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -462,26 +1859,102 @@ msgstr "Embed a {0}"
 msgid "Embeds"
 msgstr "Embeds"
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "EmDash Exporter plugin detected! You can import directly."
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr "Enable"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
 msgstr "Enable full-text search on this collection"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr "Enable plugin"
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr "Enable redirect"
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
+msgstr "Enabled"
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1123
 msgid "Enter {0}..."
 msgstr "Enter {0}..."
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Enter a URL (https://…) or a relative path (/…)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr "Enter credentials manually"
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
 msgstr "Enter distraction-free mode"
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
+msgstr "Enter email"
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr "Enter markdown content..."
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr "Enter name"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Enter the code from your terminal"
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Enter your WordPress credentials to import content directly."
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr "Enter your WordPress site URL"
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr "Error"
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr "Error saving section"
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr "Exists"
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
 msgstr "Exit distraction-free mode"
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr "Expand"
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
+msgstr "Expand details"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:280
@@ -492,18 +1965,201 @@ msgstr "Expires {0}"
 msgid "Expiry"
 msgstr "Expiry"
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr "Export from WordPress manually"
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Export your content from WordPress to import everything including drafts."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr "Fail"
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr "Failed"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr "Failed security audit"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr "Failed to add domain"
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
 msgstr "Failed to create byline"
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr "Failed to create some collections"
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr "Failed to disable plugin"
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr "Failed to enable plugin"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr "Failed to generate preview"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr "Failed to generate preview URL"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr "Failed to load allowed domains"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr "Failed to load email settings"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr "Failed to load passkeys"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr "Failed to load plugin"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr "Failed to load plugins: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr "Failed to load revisions"
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr "Failed to load setup"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr "Failed to load theme"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr "Failed to remove domain"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr "Failed to remove passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr "Failed to rename passkey"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
+msgstr "Failed to save settings"
 
 #: packages/admin/src/components/LoginPage.tsx:127
 #: packages/admin/src/components/LoginPage.tsx:132
 msgid "Failed to send magic link"
 msgstr "Failed to send magic link"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr "Failed to send test email"
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
 msgstr "Failed to update byline"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr "Failed to update domain"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr "Feature"
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr "Features"
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Fetching content from the EmDash Exporter API."
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr "Field label"
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr "Field Label"
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr "Field slugs cannot be changed after creation"
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr "Fields created:"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr "File"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr "File {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr "File from media library"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr "Filename"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr "Filename cannot be changed after upload"
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr "files imported"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr "Filter by capability"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr "Filter by collection"
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "For a complete import including drafts and all content, export from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
+msgstr "For the best import experience, install the"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -517,9 +2173,38 @@ msgstr "Full admin access"
 msgid "General"
 msgstr "General"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr "General Settings"
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
 msgstr "Get Started"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Give this passkey a name to help you identify it later."
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr "Go to Dashboard"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr "Google Verification"
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr "Grid view"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
+msgstr "Group (optional)"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -536,9 +2221,48 @@ msgstr "Heading 2"
 msgid "Heading 3"
 msgstr "Heading 3"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr "Height"
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr "Hide"
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr "Hide from search engines"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
 msgstr "Hide token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Hierarchical (like categories, with parent/child relationships)"
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr "Hits"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr "Homepage"
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr "Hooks"
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr "How to create an Application Password"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
+msgstr "Icon blurred due to image audit"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -548,14 +2272,134 @@ msgstr "ID"
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
 msgstr "Image"
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr "Image from media library"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr "Image Settings"
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr "Image shown when this page is shared on social media"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr "Image URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
+msgstr "image URLs updated in"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "Import"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr "Import {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr "Import Another File"
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr "Import Capabilities"
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr "Import Complete"
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr "Import Completed with Errors"
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr "Import failed"
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr "Import from WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr "Import logo and favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr "Import Media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr "Import Media Files"
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr "Import navigation menus"
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Import posts, pages, and custom post types from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr "Import SEO settings"
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr "Import site configuration from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr "Import site title and tagline"
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr "Import via EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr "Imported"
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr "Imported by Collection"
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr "Importing content..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr "Importing Media"
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr "Include sample content (recommended for new sites)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr "Incompatible"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
+msgstr "Insert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -577,6 +2421,111 @@ msgstr "Insert a reusable section"
 msgid "Insert an image"
 msgstr "Insert an image"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr "Insert from URL"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Insert Section"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr "Install"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr "Install blocked"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr "Installed"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr "Installed from marketplace (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr "Installed:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr "Installing..."
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr "Integer"
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr "Invalid link"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Invite Link Created"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr "Invite User"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr "Item {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr "Item added"
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr "Item deleted"
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr "Item updated"
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr "items"
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr "Jane Doe"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr "Keywords"
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr "Label"
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,10 +2535,48 @@ msgstr "Language"
 msgid "Large section heading"
 msgstr "Large section heading"
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr "Last enabled:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr "Last login"
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr "Last seen"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr "Last updated"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr "Last used"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
 msgstr "Last used {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Leave blank to use a discoverable passkey."
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr "Leave unassigned"
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr "Library"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
+msgstr "License"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -599,17 +2586,103 @@ msgstr "light"
 msgid "Light"
 msgstr "Light"
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr "Link expired"
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr "Link to another content item"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr "Linked Accounts ({0})"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr "Links"
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr "List view"
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
 msgstr "Live View"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
+msgstr "Load more"
 
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 msgid "Load More"
 msgstr "Load More"
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr "Loading collections..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr "Loading comments..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr "Loading content..."
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr "Loading menu..."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr "Loading menus..."
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr "Loading plugins..."
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr "Loading redirects..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr "Loading sections..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr "Loading settings..."
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr "Loading setup..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr "Loading terms..."
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "Loading..."
@@ -619,28 +2692,129 @@ msgstr "Loading..."
 msgid "Locale"
 msgstr "Locale"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr "Lock aspect ratio"
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
 msgstr "Log out"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr "Logo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr "Logo & favicon"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr "Long Text"
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Lowercase letters, numbers, and hyphens only"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Lowercase letters, numbers, and underscores only, starting with a letter"
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr "Manage"
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr "Manage {0} for {1}"
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Manage installed plugins. Enable or disable plugins to control their functionality."
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr "Manage navigation menus for your site"
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Manage URL redirects and view 404 errors."
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "Manage your passkeys and authentication"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr "Manual"
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr "Map Authors"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr "Mark as spam"
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr "marketplace"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr "Marketplace"
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr "Max Items"
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr "Max Length"
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr "Max Value"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr "Media"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr "Media Details"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr "Media Errors ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr "Media Import"
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr "Media Import Complete"
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr "Media import was skipped"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr "Media Library"
 
@@ -660,10 +2834,85 @@ msgstr "Medium section heading"
 msgid "Menu"
 msgstr "Menu"
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr "Menu \"{0}\" has been created."
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr "Menu created"
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr "Menu deleted"
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr "Menu item has been added."
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr "Menu item has been deleted."
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr "Menu item has been updated."
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr "Menu not found"
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr "Menu order has been updated."
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "Menus"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr "Menus ({0})"
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr "Meta Description"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Meta tag content for Bing Webmaster Tools verification"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Meta tag content for Google Search Console verification"
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr "Meta titles, descriptions, and social images"
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr "Min Items"
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr "Min Length"
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr "Min Value"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Moderation Signals"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
+msgstr "Modified"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -677,6 +2926,10 @@ msgstr "Move \"{title}\" to trash? You can restore it later."
 msgid "Move {title} to trash"
 msgstr "Move {title} to trash"
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr "Move down"
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,30 +2941,139 @@ msgstr "Move to Trash"
 msgid "Move to Trash?"
 msgstr "Move to Trash?"
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr "Move up"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr "Multi Select"
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr "Multi-line plain text"
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr "Multiple choices from options"
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr "My Awesome Blog"
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr "Name"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr "Name and label are required"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "Navigation"
+
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr "Never"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr "NEW"
 
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
 msgstr "New {collectionLabel}"
 
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr "New collection"
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr "New Content Type"
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr "New Redirect"
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
+msgstr "New Section"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "new tab"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr "New Taxonomy"
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr "New window"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr "Next"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
 msgstr "Next page"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr "Next screenshot"
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr "No"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
+msgstr "No {0} available."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:212
 msgid "No {0} yet."
 msgstr "No {0} yet."
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr "No {0} yet. Create one to get started."
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr "No 404 errors recorded yet."
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr "No alt text"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "No API tokens yet. Create one to get started."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
+msgstr "No approved comments yet."
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
 msgid "No bylines selected."
@@ -721,17 +3083,138 @@ msgstr "No bylines selected."
 msgid "No collections configured"
 msgstr "No collections configured"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr "No comments awaiting moderation."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr "No comments match your search."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr "No content found"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr "No content in this collection"
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr "No content types yet."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr "No detailed description available."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr "No domains configured. Users must be invited individually."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr "No email provider configured"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "No email provider configured. Share this link manually."
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr "No EmDash users found"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "No expiry"
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr "No fields to compare"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr "No headings in document"
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr "No items yet"
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr "No limit"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr "No matching passkey found for this account."
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr "No maximum"
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr "No media available from this provider"
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr "No media found"
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr "No media yet"
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr "No menu items yet"
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr "No menus yet"
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr "No minimum"
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr "No passkeys registered"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr "No passkeys registered yet."
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr "No plugins configured"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "No plugins found"
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
+msgstr "No preview"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr "No recent activity"
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr "No redirects yet"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "No results"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "No results for \"{debouncedQuery}\". Try a different search term."
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
@@ -741,26 +3224,254 @@ msgstr "No results for \"{searchQuery}\""
 msgid "No results found"
 msgstr "No results found"
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr "No revisions yet"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "No sections available"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr "No sections found"
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr "No sections yet"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr "No spam comments."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr "No themes found"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr "None (top level)"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr "Number"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr "Number of posts to show per page on list views"
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
 msgstr "Numbered List"
 
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr "OG Image"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "on a custom hostname is not treated as secure, even on loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Only authorize codes you recognize."
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Only email addresses from allowed domains can sign up."
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Only lowercase letters, numbers, and hyphens"
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr "Oops!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr "Open in new tab"
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr "Open WordPress Profile"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr "Optional caption displayed below the image"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr "Optional caption for display"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr "Optional description"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr "Optional tooltip on hover"
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr "Options (one per line)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr "or choose from library"
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Or click to browse. Accepts .xml files exported from WordPress."
+
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "Or continue with"
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr "Or upload an export file"
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr "or upload directly"
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr "Order saved"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr "Original:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr "Outline"
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr "Overrides the page title in search engine results"
 
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
 msgstr "Ownership"
 
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr "Package"
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
+msgstr "Pages"
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "Paragraph"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr "Parent"
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr "Part of a redirect loop"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr "Pass"
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr "Passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr "Passkey added successfully"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Passkey name"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Passkey Name (optional)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey registered successfully!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr "Passkey removed"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr "Passkey renamed"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr "Passkeys"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr "Passkeys ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passkeys Not Available Here"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passkeys require a"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr "Path"
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr "Pattern (Regex)"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
 msgstr "pending"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
+msgstr "Pending"
 
 #: packages/admin/src/components/ContentEditor.tsx:726
 msgid "Pending changes"
@@ -774,14 +3485,96 @@ msgstr "Permanently delete \"{title}\"? This cannot be undone."
 msgid "Permanently delete {title}"
 msgstr "Permanently delete {title}"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr "Permissions"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Plain"
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr "Please enter a valid email"
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr "Please enter a valid email address"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr "Please enter a valid URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr "Plugin"
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr "Plugin disabled"
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr "Plugin enabled"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr "Plugin not found"
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr "plugin on your WordPress site."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr "Plugin Permissions"
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr "Plugin uninstalled"
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr "Plugin updated"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "Plugins"
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Points search engines to the original version of this page, if it's duplicated from another URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr "Posts"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr "Posts Per Page"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Preparing registration..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr "Preparing to download files from WordPress..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr "Preparing..."
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr "Preview"
 
@@ -793,9 +3586,22 @@ msgstr "Preview content before publishing"
 msgid "Preview draft"
 msgstr "Preview draft"
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr "Previous"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
 msgstr "Previous page"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr "Previous screenshot"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
+msgstr "Provider:"
 
 #: packages/admin/src/components/ContentEditor.tsx:602
 #: packages/admin/src/components/ContentEditor.tsx:707
@@ -811,9 +3617,15 @@ msgid "published"
 msgstr "published"
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
 msgstr "Published"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
+msgstr "Published {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
 msgid "Published At"
@@ -840,27 +3652,238 @@ msgstr "Read content entries"
 msgid "Read media files"
 msgstr "Read media files"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr "Reading"
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr "Ready"
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr "Recent Activity"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr "Recipient email"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr "Recovery link sent to {0}"
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr "Redirect loop detected"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Redirecting to login..."
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr "Redirects"
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr "Reference"
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr "Register"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr "Register Passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Registered user"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "Registration was cancelled or timed out. Please try again."
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr "Remove"
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr "Remove {0}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr "Remove Domain"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr "Remove Domain?"
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
 msgstr "Remove image"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr "Remove Image"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr "Remove Image?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr "Remove item {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr "Remove passkey?"
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr "Remove sub-field"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr "Remove this image from the document?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr "Removing..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr "Rename"
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr "Rename {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr "Repeater"
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr "Repeating group of fields"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr "Replace Image"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Reply to:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr "Repository"
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr "Request a new link"
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr "Required"
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr "Required fields:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Required for accessibility. Describes the image for screen readers."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr "Requires EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr "Resend email"
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr "Resend in {resendCooldown}s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr "Reset to original"
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
+msgstr "Restore"
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr "Restore {title}"
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr "Restore failed"
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr "Restore Revision?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr "Restore this version"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Restore this version from {0}? This will update the current content to this revision's data."
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr "Restoring..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr "Retry"
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Reusable content blocks you can insert into any content"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr "Review New Permissions"
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr "Revision restored"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr "Revisions"
 
@@ -876,9 +3899,28 @@ msgstr "Revoke?"
 msgid "Revoking..."
 msgstr "Revoking..."
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr "Rich Text"
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
 msgstr "Rich text content"
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr "Rich text editor"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr "Risk score: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
+msgstr "Role"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -888,14 +3930,46 @@ msgstr "Role {role}"
 msgid "Role label"
 msgstr "Role label"
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr "Same window"
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
 msgstr "Save"
 
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
+msgstr "Save Changes"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "Save content as draft before publishing"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Save name"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr "Save SEO Settings"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr "Save Settings"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
+msgstr "Save Social Links"
 
 #: packages/admin/src/components/ContentEditor.tsx:522
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -904,7 +3978,16 @@ msgstr "Saved"
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr "Saving..."
 
@@ -933,6 +4016,14 @@ msgstr "Scheduled"
 msgid "Scheduled for: {0}"
 msgstr "Scheduled for: {0}"
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr "Schema Changes"
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr "Schema preparation failed"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr "Schema Read"
@@ -950,6 +4041,33 @@ msgstr "Scopes"
 msgid "Scopes: {0}"
 msgstr "Scopes: {0}"
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr "Screenshot {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr "Screenshot {0} of {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr "Screenshot blurred due to image audit"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr "Screenshot viewer"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr "Screenshots"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr "Search"
@@ -964,53 +4082,245 @@ msgstr "Search {0}"
 msgid "Search {0}..."
 msgstr "Search {0}..."
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr "Search comments"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr "Search comments..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Search content..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr "Search Engine Optimization"
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "Search engine optimization and verification"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr "Search media"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr "Search pages and content..."
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr "Search plugins..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr "Search sections..."
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr "Search source or destination..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr "Search themes..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr "Search..."
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr "Searchable"
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr "Section"
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr "Section \"{slug}\" could not be found."
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr "Section created"
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr "Section deleted"
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr "Section Details"
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr "Section Not Found"
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr "Section saved"
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr "Section title"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "Sections"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "secure context"
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
+msgstr "Secure your account"
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "Security"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr "Security Audit"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr "Security audit failed"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr "Security audit flagged concerns"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "Security audit flagged potential concerns with this plugin."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "Security audit flagged this plugin as potentially unsafe."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr "Security audit passed"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Security error. Make sure you're on a secure connection."
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
 msgstr "Security Settings"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
+msgstr "Select"
 
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
 msgstr "Select {label}"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
+msgstr "Select all"
+
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
 msgstr "Select byline..."
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr "Select comment by {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Select Content"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr "Select Favicon"
 
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr "Select image"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr "Select Logo"
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr "Select OG image"
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr "Select OG Image"
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr "Select which content types to import."
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr "Select..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr "Selected:"
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "Self-Signup Domains"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Send a test email through the full pipeline to verify your email configuration."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Send an invitation email to a new team member."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr "Send Invite"
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "Send magic link"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr "Send Recovery Link"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr "Send Test"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr "Send Test Email"
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "Sending..."
 
@@ -1019,16 +4329,83 @@ msgstr "Sending..."
 msgid "SEO"
 msgstr "SEO"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr "SEO Settings"
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr "SEO settings (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr "SEO settings saved"
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr "SEO Title"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr "Set a custom display size for this image instance."
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr "Set up your passkey"
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr "Set up your site"
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr "Setting up..."
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "Settings"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr "Settings saved successfully"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Share this link with the invited user"
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr "Short Text"
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr "Show"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Show token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr "Shown when hovering over the image."
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr "Sign in"
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Sign in instead"
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
@@ -1042,61 +4419,312 @@ msgstr "Sign in with email"
 msgid "Sign in with email link"
 msgstr "Sign in with email link"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "Sign in with Passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Signed in as {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr "Single choice from options"
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr "Single line text input"
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr "Site"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr "Site Identity"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "Site identity, logo, favicon, and reading preferences"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr "Site Settings"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr "Site Title"
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr "Site title & tagline"
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr "Site title is required"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr "Site URL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr "Size"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr "Size:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr "Skip Media Import"
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr "Skipped"
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
 msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
+msgstr "Slug copied to clipboard"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
 msgstr "Small section heading"
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "Social Links"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr "Social links saved"
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "Social media profile links"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr "Social Profiles"
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr "Some content types cannot be imported"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr "Something went wrong"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr "Sort plugins"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr "Sort themes"
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr "Source"
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr "Source path"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "spam"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr "Spam"
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr "Start Import"
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
 msgstr "Status"
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr "Status code"
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr "Structure"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
+msgstr "Sub-Fields"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "Subscriber"
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr "Synced"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Synced passkey"
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
 msgstr "System ({resolvedLabel})"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
+msgstr "Tagline"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "Tags"
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr "Tags ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr "Tags will be imported"
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr "Target"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr "Taxonomies"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr "Taxonomy created"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr "Taxonomy not found:"
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr "Template:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr "Term"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr "Term deleted"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "The device will not be granted access."
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr "The existing collection has fields with incompatible types."
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr "The invited user will have this role once they complete registration."
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "The link will expire in 15 minutes."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "The marketplace is empty. Check back later for new plugins."
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr "The menu has been deleted."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr "The name of your site, used in the header and metadata"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "The public URL of your site (used for canonical links and sitemaps)"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr "The theme marketplace is empty. Check back later."
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr "Theme"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr "Theme ID: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr "Theme not found"
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr "Theme Section"
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr "Theme: {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr "Themes"
 
@@ -1104,22 +4732,107 @@ msgstr "Themes"
 msgid "This field is required"
 msgstr "This field is required"
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr "This is a custom section."
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr "This is a WordPress site."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "This link expires in 7 days and can only be used once."
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr "This may take a while for large exports."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "This passkey is already registered on this device."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr "This plugin requires no special permissions."
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr "This redirect rule will be permanently removed."
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr "This section was imported from another system."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "This will grant CLI access with your permissions."
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
 msgstr "This will move the item to trash. You can restore it later from the trash."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "This will permanently delete \"{0}\" and remove it from all content."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "This will permanently delete \"{0}\". This action cannot be undone."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "This will permanently delete this comment. This action cannot be undone."
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "This will remove the plugin and its bundle from your site."
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr "This will revert to the published version. Your draft changes will be lost."
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr "Thoughts, tutorials, and more"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr "Timezone"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Timezone for displaying dates (e.g., America/New_York)"
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
 msgstr "Title"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr "Title (Tooltip)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
+msgstr "Title Separator"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "to close"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "to install plugins, or add them to your astro.config.mjs."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -1139,6 +4852,10 @@ msgstr "Token created: {0}"
 msgid "Token Name"
 msgstr "Token Name"
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr "Tools → Export"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr "Track content history"
@@ -1151,6 +4868,14 @@ msgstr "Translate"
 msgid "Translations"
 msgstr "Translations"
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "trash"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr "Trash"
@@ -1159,10 +4884,95 @@ msgstr "Trash"
 msgid "Trash is empty"
 msgstr "Trash is empty"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr "Trash is empty."
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr "True/false toggle"
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr "Try a different search term"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Try adjusting your search"
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr "Try adjusting your search or filters."
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr "Try Again"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Try another code"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr "Try Another URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr "Try with my data"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr "Type"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr "Type mismatch ({0})"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr "Unable to reach marketplace"
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
 msgstr "Unassigned"
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr "unchanged"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr "Uninstall"
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr "Uninstall {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr "Uninstall confirmation"
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr "Uninstalling..."
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
+msgstr "Unique"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "Unique identifier (ULID)"
@@ -1176,9 +4986,25 @@ msgstr "Unknown"
 msgid "Unknown role"
 msgstr "Unknown role"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr "Unlock aspect ratio"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr "Unnamed passkey"
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
 msgstr "Unpublish"
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
+msgstr "Unregistered Content Tables Found"
 
 #: packages/admin/src/components/ContentEditor.tsx:741
 msgid "Unschedule"
@@ -1192,6 +5018,33 @@ msgstr "Untitled"
 msgid "Up"
 msgstr "Up"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr "Update"
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr "Update Field"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr "Update settings for {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr "Update the {0} details"
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr "Update this redirect rule."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr "Update to v{0}"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "Updated At"
@@ -1201,39 +5054,201 @@ msgstr "Updated At"
 msgid "Updated: {0}"
 msgstr "Updated: {0}"
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr "Updating content URLs..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr "Updating..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr "Upload"
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr "Upload an export file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr "Upload an image to get started"
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "Upload and delete media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr "Upload Export File"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr "Upload failed: {uploadError}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr "Upload files"
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr "Upload Files"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr "Upload Image"
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr "Upload images, videos, and documents to get started."
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr "Upload Media"
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr "Upload media to get started"
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr "Upload to {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr "Upload WordPress export file"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr "Uploaded:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr "Uploading"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr "Uploading {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr "Uploading..."
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr "URL"
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
 msgstr "URL-friendly identifier"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Use [param] or [...rest] in paths for pattern matching."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Use your device's biometric authentication, security key, or PIN to sign in."
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "Use your registered passkey to sign in securely."
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Used as the identifier. Lowercase letters, numbers, and underscores only."
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr "Used as the main visual for this post on listing pages and at the top of the post"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr "Used by screen readers and when image fails to load"
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
 msgstr "User"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr "User Details"
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
+msgstr "User not found"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
 #: packages/admin/src/components/Sidebar.tsx:206
 msgid "Users"
 msgstr "Users"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr "Users from"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr "v{0} available"
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr "Validation"
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr "Verifying your link..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Verifying..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr "Version"
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "View email provider status and send test emails"
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr "View in Marketplace"
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr "View mode"
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1243,9 +5258,44 @@ msgstr "View published {title}"
 msgid "View Site"
 msgstr "View Site"
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr "Visitors hitting these paths will see an error."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "Waiting for passkey..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr "Warn"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr "We'll check what import options are available for your site."
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "We'll send you a link to sign in without a password."
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr "We've sent a verification link to"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn is not supported in this browser"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr "Website"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1254,6 +5304,14 @@ msgstr "Welcome to EmDash, {firstName}!"
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
 msgstr "Welcome to EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr "What happens when you import:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
+msgstr "What will happen when you import"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -1267,10 +5325,52 @@ msgstr "When the entry was last modified"
 msgid "When the entry was published"
 msgstr "When the entry was published"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr "Which content types can use this taxonomy"
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr "Whole number"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "Widgets"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr "Width"
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr "Will create"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "will no longer be able to sign up without an invite. Existing users are not affected."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Without an email provider, invite links must be shared manually."
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr "WordPress Username"
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr "WXR File"
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr "Yes"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "You can close this page and return to your terminal."
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -1284,14 +5384,103 @@ msgstr "You can manage content, media, menus, and taxonomies."
 msgid "You can view and contribute to the site."
 msgstr "You can view and contribute to the site."
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr "You cannot change your own role"
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "You have full access to manage this site, including users, settings, and all content."
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "You'll be redirected to WordPress to authorize the connection."
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr "You'll be signing up as"
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr "You're signed in via Cloudflare Access"
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr "you@company.com"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
+msgstr "you@example.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr "Your account has been created successfully."
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Your device doesn't support the required security features."
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr "Your Email"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr "Your Facebook page or profile username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr "Your GitHub username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr "Your Instagram username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr "Your LinkedIn profile username"
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr "Your Name"
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr "Your name (optional)"
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
 msgstr "Your Role"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Your Twitter/X handle (e.g., @username)"
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr "Your WordPress export contains {0} media files."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr "Your YouTube channel ID or handle"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
+msgstr "YouTube"

--- a/packages/admin/src/locales/en/messages.po
+++ b/packages/admin/src/locales/en/messages.po
@@ -22,8 +22,8 @@ msgstr " (default)"
 msgid " (opens in new window)"
 msgstr " (opens in new window)"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr " (selected)"
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ": use"
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr "(from {0})"
 
@@ -50,6 +50,13 @@ msgstr "(synced)"
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
 msgstr "(with your dev port)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# item)} other {(# items)}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:181
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr "{0, plural, one {# item} other {# items}}"
 
@@ -100,6 +107,11 @@ msgstr "{0, plural, one {# media file} other {# media files}}"
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
 msgstr "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# permission} other {# permissions}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2319
@@ -171,7 +183,6 @@ msgstr "{0} items will be imported"
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr "{0} permission{1}"
@@ -194,8 +205,8 @@ msgstr "{0} updated to v{1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr "{0}{1}"
 
@@ -204,10 +215,9 @@ msgstr "{0}{1}"
 msgid "{0}/160 characters"
 msgstr "{0}/160 characters"
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
-msgstr "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
 msgid "{count, plural, one {# file} other {# files}}"
@@ -274,6 +284,14 @@ msgstr "{totalDrafts, plural, one {# draft} other {# drafts}}"
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
 #: packages/admin/src/components/MediaLibrary.tsx:186
@@ -401,7 +419,7 @@ msgstr "Account Info"
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr "Add Field"
 msgid "Add fields"
 msgstr "Add fields"
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr "Add First Item"
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr "Add Item"
 
@@ -530,7 +548,7 @@ msgstr "After send:"
 msgid "All"
 msgstr "All"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr "All capabilities"
 
@@ -594,7 +612,7 @@ msgstr "Alt text set"
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr "archived"
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 
@@ -715,7 +733,7 @@ msgstr "Auto (slug change)"
 msgid "Auto-generated from name (you can edit)"
 msgstr "Auto-generated from name (you can edit)"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr "Available media"
 
@@ -785,7 +803,7 @@ msgstr "Boolean"
 msgid "Brief summary shown below the title in search results"
 msgstr "Brief summary shown below the title in search results"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr "Browse and install plugins to extend your site."
 
@@ -841,7 +859,7 @@ msgstr "Can view content"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr "Click the link in the email to sign in."
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr "Close"
 msgid "Close panel"
 msgstr "Close panel"
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr "Code"
@@ -1112,7 +1130,7 @@ msgstr "Content Errors ({0})"
 msgid "Content found:"
 msgstr "Content found:"
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr "Content has been updated to the selected revision."
 
@@ -1128,7 +1146,7 @@ msgstr "content items"
 msgid "Content Read"
 msgstr "Content Read"
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr "Content snapshot:"
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr "Content to Import"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Content Types"
@@ -1198,7 +1216,7 @@ msgstr "Copy token"
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr "Could not copy automatically. Please select the URL above and copy manually."
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr "Could not load image from URL"
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr "Create your first navigation menu to get started"
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr "Create your first one"
 
@@ -1367,7 +1385,7 @@ msgstr "Creating..."
 msgid "current"
 msgstr "current"
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr "Current"
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr "Dark"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr "Default role:"
 msgid "Define a new taxonomy for classifying content"
 msgstr "Define a new taxonomy for classifying content"
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr "Define the structure of your content"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr "Delete \"{0}\"? This cannot be undone."
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr "Delete {0}?"
 msgid "Delete Comment?"
 msgstr "Delete Comment?"
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr "Delete Content Type?"
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr "Deleted"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr "Edit"
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr "Export your content from WordPress to import everything including drafts
 msgid "Facebook"
 msgstr "Facebook"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr "Fail"
 
@@ -2038,7 +2056,7 @@ msgstr "Failed to load plugin"
 msgid "Failed to load plugins: {0}"
 msgstr "Failed to load plugins: {0}"
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr "Failed to load revisions"
 
@@ -2095,7 +2113,7 @@ msgstr "Favicon"
 msgid "Feature"
 msgstr "Feature"
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr "Features"
 
@@ -2145,7 +2163,7 @@ msgstr "Filename cannot be changed after upload"
 msgid "files imported"
 msgstr "files imported"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr "Filter by capability"
 
@@ -2226,10 +2244,6 @@ msgstr "Heading 3"
 msgid "Height"
 msgstr "Height"
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr "Hide"
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr "Hide from search engines"
@@ -2247,6 +2261,10 @@ msgstr "Hierarchical (like categories, with parent/child relationships)"
 msgid "Hits"
 msgstr "Hits"
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr "Home"
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr "Homepage"
@@ -2259,7 +2277,11 @@ msgstr "Hooks"
 msgid "How to create an Application Password"
 msgstr "How to create an Application Password"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr "https://example.com or /about"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr "Icon blurred due to image audit"
@@ -2290,7 +2312,7 @@ msgstr "Image Settings"
 msgid "Image shown when this page is shared on social media"
 msgstr "Image shown when this page is shared on social media"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr "Image URL"
 
@@ -2396,8 +2418,8 @@ msgstr "Include sample content (recommended for new sites)"
 msgid "Incompatible"
 msgstr "Incompatible"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr "Insert"
 
@@ -2421,7 +2443,7 @@ msgstr "Insert a reusable section"
 msgid "Insert an image"
 msgstr "Insert an image"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr "Insert from URL"
 
@@ -2445,7 +2467,7 @@ msgstr "Install and activate an email provider plugin to enable email features l
 msgid "Install blocked"
 msgstr "Install blocked"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr "Installed"
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr "Invite User"
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr "Item {0}"
 
@@ -2496,11 +2518,6 @@ msgstr "Item deleted"
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
 msgstr "Item updated"
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
-msgstr "items"
 
 #: packages/admin/src/components/SetupWizard.tsx:238
 #: packages/admin/src/components/SignupPage.tsx:204
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr "Live View"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr "Load more"
@@ -2626,7 +2643,7 @@ msgstr "Load more"
 msgid "Load More"
 msgstr "Load More"
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr "Loading collections..."
 
@@ -2676,7 +2693,7 @@ msgstr "Loading terms..."
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr "Mark as spam"
 msgid "marketplace"
 msgstr "marketplace"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr "Multiple choices from options"
 msgid "My Awesome Blog"
 msgstr "My Awesome Blog"
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr "New {collectionLabel}"
 msgid "New collection"
 msgstr "New collection"
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr "New Content Type"
 
@@ -3099,7 +3116,7 @@ msgstr "No content found"
 msgid "No content in this collection"
 msgstr "No content in this collection"
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr "No content types yet."
 
@@ -3127,7 +3144,7 @@ msgstr "No EmDash users found"
 msgid "No expiry"
 msgstr "No expiry"
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr "No fields to compare"
 
@@ -3135,7 +3152,7 @@ msgstr "No fields to compare"
 msgid "No headings in document"
 msgstr "No headings in document"
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr "No items yet"
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr "No maximum"
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr "No media available from this provider"
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr "No media found"
 
@@ -3191,7 +3208,7 @@ msgstr "No passkeys registered yet."
 msgid "No plugins configured"
 msgstr "No plugins configured"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr "No plugins found"
 
@@ -3211,7 +3228,7 @@ msgstr "No redirects yet"
 msgid "No results"
 msgstr "No results"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr "No results for \"{debouncedQuery}\". Try a different search term."
@@ -3224,7 +3241,7 @@ msgstr "No results for \"{searchQuery}\""
 msgid "No results found"
 msgstr "No results found"
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr "No revisions yet"
 
@@ -3326,7 +3343,7 @@ msgstr "Optional tooltip on hover"
 msgid "Options (one per line)"
 msgstr "Options (one per line)"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr "or choose from library"
 
@@ -3389,7 +3406,7 @@ msgstr "Parent"
 msgid "Part of a redirect loop"
 msgstr "Part of a redirect loop"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr "Pass"
 
@@ -3502,7 +3519,7 @@ msgstr "Please enter a valid email"
 msgid "Please enter a valid email address"
 msgstr "Please enter a valid email address"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr "Please enter a valid URL"
 
@@ -3599,6 +3616,10 @@ msgstr "Previous page"
 msgid "Previous screenshot"
 msgstr "Previous screenshot"
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr "Primary Navigation"
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr "Provider:"
@@ -3691,7 +3712,7 @@ msgstr "Redirects"
 msgid "Reference"
 msgstr "Reference"
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr "Register"
 
@@ -3713,11 +3734,11 @@ msgstr "Registration was cancelled or timed out. Please try again."
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr "Remove"
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,9 +3768,13 @@ msgid "Remove Image?"
 msgstr "Remove Image?"
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
 msgstr "Remove item {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr "Remove passkey"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
 msgid "Remove passkey?"
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr "Remove this image from the document?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr "Removing..."
 
@@ -3772,10 +3797,14 @@ msgstr "Removing..."
 msgid "Rename"
 msgstr "Rename"
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
 msgstr "Rename {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr "Rename passkey"
 
 #: packages/admin/src/components/FieldEditor.tsx:229
 msgid "Repeater"
@@ -3835,7 +3864,7 @@ msgstr "Resend in {resendCooldown}s"
 msgid "Reset to original"
 msgstr "Reset to original"
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr "Restore"
 
@@ -3843,29 +3872,29 @@ msgstr "Restore"
 msgid "Restore {title}"
 msgstr "Restore {title}"
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr "Restore failed"
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr "Restore Revision?"
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr "Restore this version"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr "Restore this version from {0}? This will update the current content to this revision's data."
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr "Restoring..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr "Retry"
@@ -3878,12 +3907,12 @@ msgstr "Reusable content blocks you can insert into any content"
 msgid "Review New Permissions"
 msgstr "Review New Permissions"
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr "Revision restored"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr "Revisions"
 
@@ -4102,7 +4131,7 @@ msgstr "Search Engine Optimization"
 msgid "Search engine optimization and verification"
 msgstr "Search engine optimization and verification"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr "Search media"
 
@@ -4110,7 +4139,7 @@ msgstr "Search media"
 msgid "Search pages and content..."
 msgstr "Search pages and content..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr "Search plugins..."
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr "Search themes..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr "Search..."
 
@@ -4191,11 +4220,11 @@ msgstr "Security"
 msgid "Security Audit"
 msgstr "Security Audit"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr "Security audit failed"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr "Security audit flagged concerns"
 
@@ -4207,7 +4236,7 @@ msgstr "Security audit flagged potential concerns with this plugin."
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr "Security audit flagged this plugin as potentially unsafe."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr "Security audit passed"
 
@@ -4257,6 +4286,10 @@ msgstr "Select Favicon"
 msgid "Select image"
 msgstr "Select image"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr "Select Image"
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr "Select OG Image"
 msgid "Select which content types to import."
 msgstr "Select which content types to import."
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr "Select..."
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr "Selected:"
 
@@ -4386,10 +4419,6 @@ msgstr "Share this link with the invited user"
 msgid "Short Text"
 msgstr "Short Text"
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr "Show"
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Show token"
@@ -4490,7 +4519,7 @@ msgstr "Skipped"
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr "Some content types cannot be imported"
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr "Sort plugins"
 
@@ -4541,7 +4570,7 @@ msgstr "Sort plugins"
 msgid "Sort themes"
 msgstr "Sort themes"
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr "The device will not be granted access."
 msgid "The existing collection has fields with incompatible types."
 msgstr "The existing collection has fields with incompatible types."
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 
@@ -4678,7 +4707,7 @@ msgstr "The invited user will have this role once they complete registration."
 msgid "The link will expire in 15 minutes."
 msgstr "The link will expire in 15 minutes."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr "The marketplace is empty. Check back later for new plugins."
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr "True/false toggle"
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr "Try a different search term"
 
@@ -4938,7 +4967,7 @@ msgstr "Type"
 msgid "Type mismatch ({0})"
 msgstr "Type mismatch ({0})"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr "Unable to reach marketplace"
@@ -4947,10 +4976,6 @@ msgstr "Unable to reach marketplace"
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
 msgstr "Unassigned"
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
-msgstr "unchanged"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
 #: packages/admin/src/components/PluginManager.tsx:484
@@ -5002,7 +5027,7 @@ msgstr "Unnamed passkey"
 msgid "Unpublish"
 msgstr "Unpublish"
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr "Unregistered Content Tables Found"
 
@@ -5063,7 +5088,7 @@ msgstr "Updating content URLs..."
 msgid "Updating..."
 msgstr "Updating..."
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr "Upload"
 
@@ -5071,7 +5096,7 @@ msgstr "Upload"
 msgid "Upload an export file"
 msgstr "Upload an export file"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr "Upload an image to get started"
 
@@ -5084,7 +5109,7 @@ msgstr "Upload and delete media"
 msgid "Upload Export File"
 msgstr "Upload Export File"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr "Upload failed: {uploadError}"
 
@@ -5096,7 +5121,7 @@ msgstr "Upload files"
 msgid "Upload Files"
 msgstr "Upload Files"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr "Upload Image"
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr "Uploading {0}/{1}..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr "Uploading..."
 
@@ -5267,7 +5292,7 @@ msgstr "Visitors hitting these paths will see an error."
 msgid "Waiting for passkey..."
 msgstr "Waiting for passkey..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr "Warn"
 
@@ -5392,10 +5417,14 @@ msgstr "You cannot change your own role"
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "You have full access to manage this site, including users, settings, and all content."
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
 msgstr "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -18,14 +18,107 @@ msgstr ""
 msgid " (default)"
 msgstr " (par défaut)"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -40,6 +133,94 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — aucune traduction"
@@ -47,6 +228,44 @@ msgstr "{label} — aucune traduction"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — voir la traduction"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -56,13 +275,96 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr "1 an"
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
 msgstr "30 jours"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -72,17 +374,138 @@ msgstr "7 jours"
 msgid "90 days"
 msgstr "90 jours"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -99,8 +522,24 @@ msgstr ""
 msgid "Administrator"
 msgstr "Administrateur"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -112,31 +551,183 @@ msgstr "Toutes les langues"
 msgid "All roles"
 msgstr "Tous les rôles"
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "Autoriser les utilisateurs de domaines spécifiques à s'inscrire"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "Tokens d'API"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "En tant qu'administrateur, vous pouvez inviter d'autres utilisateurs depuis la section Utilisateurs."
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "Erreur d'authentification : {error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "Auteur"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
 msgid "Back to {collectionLabel} list"
@@ -144,12 +735,72 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "Retour à la connexion"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
 msgstr "Retour aux paramètres"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -177,6 +828,8 @@ msgstr "Peut publier son propre contenu"
 msgid "Can view content"
 msgstr "Peut consulter le contenu"
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,51 +837,264 @@ msgstr "Peut consulter le contenu"
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
 msgstr "Annuler"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "Catégories"
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "Vérifiez votre e-mail"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "Choisissez votre langue d'administration préférée"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "Cliquez sur le lien dans l'e-mail pour vous connecter."
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
 msgstr "Fermer"
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
 msgid "Code Block"
 msgstr "Bloc de code"
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "Confirmer"
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "Contenu"
@@ -237,18 +1103,65 @@ msgstr "Contenu"
 msgid "Content Block"
 msgstr "Bloc de contenu"
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr "Lecture du contenu"
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Types de contenu"
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
 msgstr "Écriture du contenu"
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -256,8 +1169,22 @@ msgid "Contributor"
 msgstr "Contributeur"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
@@ -267,7 +1194,27 @@ msgstr "Copiez ce token maintenant — il ne sera plus affiché."
 msgid "Copy token"
 msgstr "Copier le token"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -275,38 +1222,122 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr "Créer une liste à puces"
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "Créer une liste numérotée"
 
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
 msgstr "Créer un nouveau token"
 
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
 msgstr "Créez des tokens d'accès personnels pour un accès programmatique à l'API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr "Créer un token"
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "Créer, modifier, supprimer du contenu"
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr "Créé le {0}"
 
@@ -319,13 +1350,37 @@ msgstr "Créé le"
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr "Création en cours..."
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "Dashboard"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -355,8 +1506,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -382,6 +1647,20 @@ msgstr "Afficher un menu de navigation"
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -390,12 +1669,37 @@ msgstr ""
 msgid "Divider"
 msgstr "Séparateur"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "Pas encore de compte ? <0>S'inscrire</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -403,6 +1707,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -415,6 +1720,14 @@ msgstr "brouillon, publié ou archivé"
 msgid "Drafts"
 msgstr "Brouillons"
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -423,9 +1736,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr "ex. : pipeline CI/CD"
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -440,18 +1770,85 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "Éditeur"
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "E-mail"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "Adresse e-mail"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr ""
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -462,25 +1859,101 @@ msgstr "Insérer un {0}"
 msgid "Embeds"
 msgstr "Embeds"
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
 msgstr "Permettre la recherche dans le contenu de cette collection"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
+msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1123
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -492,8 +1965,108 @@ msgstr "Expire le {0}"
 msgid "Expiry"
 msgstr "Expiration"
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -501,8 +2074,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr "Échec de l'envoi du lien de connexion"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -517,9 +2173,38 @@ msgstr "Accès administrateur complet"
 msgid "General"
 msgstr "Général"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
 msgstr "Commencer"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -536,9 +2221,48 @@ msgstr "Titre 2"
 msgid "Heading 3"
 msgstr "Titre 3"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
 msgstr "Masquer le token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -548,14 +2272,134 @@ msgstr "ID"
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "Si un compte existe pour <0>{email}</0>, nous vous avons envoyé un lien de connexion."
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
 msgstr "Image"
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "Importer"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -577,6 +2421,111 @@ msgstr "Insérer une section réutilisable"
 msgid "Insert an image"
 msgstr "Insérer une image"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,10 +2535,48 @@ msgstr "Langue"
 msgid "Large section heading"
 msgstr "Titre principal"
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
 msgstr "Dernière utilisation le {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -599,8 +2586,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -608,8 +2626,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "Chargement..."
@@ -619,28 +2692,129 @@ msgstr "Chargement..."
 msgid "Locale"
 msgstr "Langue"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "Gérez vos clés d'accès et votre authentification"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr "Médias"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr "Médiathèque"
 
@@ -660,10 +2834,85 @@ msgstr "Titre secondaire"
 msgid "Menu"
 msgstr "Menu"
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "Menus"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -677,6 +2926,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,20 +2941,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "Navigation"
 
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "nouvel onglet"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -709,9 +3053,27 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "Aucun token d'API pour l'instant. Créez-en un pour commencer."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
 msgid "No bylines selected."
@@ -721,17 +3083,138 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "Sans expiration"
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "Aucun résultat"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
@@ -741,25 +3224,253 @@ msgstr ""
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
 msgstr "Liste numérotée"
 
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "Ou se connecter avec"
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "Paragraphe"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -774,14 +3485,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "Plugins"
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr "Aperçu"
 
@@ -793,8 +3586,21 @@ msgstr "Prévisualiser le contenu avant publication"
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -811,8 +3617,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -840,27 +3652,238 @@ msgstr "Lire les entrées de contenu"
 msgid "Read media files"
 msgstr "Lire les fichiers médias"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr "Révisions"
 
@@ -876,9 +3899,28 @@ msgstr "Révoquer ?"
 msgid "Revoking..."
 msgstr "Révocation en cours..."
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
 msgstr "Texte enrichi"
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -888,14 +3930,46 @@ msgstr "Rôle {role}"
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "Enregistrer le contenu en brouillon avant publication"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -904,7 +3978,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -933,6 +4016,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr "Lecture du schéma"
@@ -950,6 +4041,33 @@ msgstr "Scopes"
 msgid "Scopes: {0}"
 msgstr "Scopes : {0}"
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr "Recherche"
@@ -964,53 +4082,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "Optimisation et vérification pour les moteurs de recherche"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr "Rechercher des pages et du contenu..."
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr "Section"
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "Sections"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "Sécurité"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
 msgstr "Paramètres de sécurité"
 
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
 msgstr ""
 
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "Domaines d'inscription autorisés"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "Envoyer un lien de connexion"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "Envoi en cours..."
 
@@ -1019,16 +4329,83 @@ msgstr "Envoi en cours..."
 msgid "SEO"
 msgstr "SEO"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "Paramètres"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Afficher le token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
@@ -1042,61 +4419,312 @@ msgstr "Se connecter avec un e-mail"
 msgid "Sign in with email link"
 msgstr "Se connecter avec un lien par e-mail"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "Se connecter avec une clé d'accès"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "Identité du site, logo, favicon et préférences de lecture"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
 msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
 msgstr "Petit titre"
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "Liens sociaux"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "Liens vers les profils de réseaux sociaux"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
 msgstr "Statut"
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "Abonné"
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "Tags"
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "Le lien expirera dans 15 minutes."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1104,22 +4732,107 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "pour fermer"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -1139,6 +4852,10 @@ msgstr "Token créé : {0}"
 msgid "Token Name"
 msgstr "Nom du token"
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr "Suivre l'historique du contenu"
@@ -1151,6 +4868,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1159,9 +4884,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1176,8 +4986,24 @@ msgstr "Inconnu"
 msgid "Unknown role"
 msgstr "Rôle inconnu"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1192,6 +5018,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "Modifié le"
@@ -1201,29 +5054,152 @@ msgstr "Modifié le"
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "Téléverser et supprimer des médias"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
 msgstr "Identifiant adapté aux URL"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "Utilisez votre clé d'accès enregistrée pour vous connecter en toute sécurité."
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1231,9 +5207,48 @@ msgstr ""
 msgid "Users"
 msgstr "Utilisateurs"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "Consulter l'état du fournisseur d'e-mail et envoyer un e-mail de test"
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1243,9 +5258,44 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "Nous vous enverrons un lien pour vous connecter sans mot de passe."
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1254,6 +5304,14 @@ msgstr "Bienvenue sur EmDash, {firstName} !"
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
 msgstr "Bienvenue sur EmDash !"
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -1267,10 +5325,52 @@ msgstr "Date de dernière modification de l'entrée"
 msgid "When the entry was published"
 msgstr "Date de publication de l'entrée"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "Widgets"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -1284,14 +5384,103 @@ msgstr "Vous pouvez gérer le contenu, les médias, les menus et les taxonomies.
 msgid "You can view and contribute to the site."
 msgstr "Vous pouvez consulter le site et y contribuer."
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "Vous avez un accès complet pour gérer ce site, y compris les utilisateurs, les paramètres et tout le contenu."
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr "Votre compte a bien été créé."
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
 msgstr "Votre rôle"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -22,8 +22,8 @@ msgstr " (par défaut)"
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -49,6 +49,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -99,6 +106,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -171,7 +183,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -194,8 +205,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -204,9 +215,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -273,6 +283,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -401,7 +419,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -530,7 +548,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -594,7 +612,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -715,7 +733,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -785,7 +803,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -841,7 +859,7 @@ msgstr "Peut consulter le contenu"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr "Cliquez sur le lien dans l'e-mail pour vous connecter."
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr "Fermer"
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1112,7 +1130,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1128,7 +1146,7 @@ msgstr ""
 msgid "Content Read"
 msgstr "Lecture du contenu"
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Types de contenu"
@@ -1198,7 +1216,7 @@ msgstr "Copier le token"
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1367,7 +1385,7 @@ msgstr "Création en cours..."
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2038,7 +2056,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2145,7 +2163,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2226,10 +2244,6 @@ msgstr "Titre 3"
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2247,6 +2261,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2259,7 +2277,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2290,7 +2312,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2396,8 +2418,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2421,7 +2443,7 @@ msgstr "Insérer une section réutilisable"
 msgid "Insert an image"
 msgstr "Insérer une image"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2445,7 +2467,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2495,11 +2517,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2626,7 +2643,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2676,7 +2693,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3099,7 +3116,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3127,7 +3144,7 @@ msgstr ""
 msgid "No expiry"
 msgstr "Sans expiration"
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3135,7 +3152,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3211,7 +3228,7 @@ msgstr ""
 msgid "No results"
 msgstr "Aucun résultat"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3224,7 +3241,7 @@ msgstr ""
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3326,7 +3343,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3389,7 +3406,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3599,6 +3616,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3691,7 +3712,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3713,11 +3734,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,8 +3768,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3772,9 +3797,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3835,7 +3864,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3843,29 +3872,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3878,12 +3907,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr "Révisions"
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr "Optimisation et vérification pour les moteurs de recherche"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4110,7 +4139,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr "Rechercher des pages et du contenu..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4191,11 +4220,11 @@ msgstr "Sécurité"
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4257,6 +4286,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4386,10 +4419,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Afficher le token"
@@ -4490,7 +4519,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4541,7 +4570,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4678,7 +4707,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr "Le lien expirera dans 15 minutes."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4938,7 +4967,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4946,10 +4975,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5002,7 +5027,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5063,7 +5088,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5071,7 +5096,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5084,7 +5109,7 @@ msgstr "Téléverser et supprimer des médias"
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5096,7 +5121,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5267,7 +5292,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5392,9 +5417,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "Vous avez un accès complet pour gérer ce site, y compris les utilisateurs, les paramètres et tout le contenu."
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369

--- a/packages/admin/src/locales/pseudo/messages.po
+++ b/packages/admin/src/locales/pseudo/messages.po
@@ -18,14 +18,107 @@ msgstr ""
 msgid " (default)"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -40,12 +133,138 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
 msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
@@ -56,12 +275,95 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
@@ -72,17 +374,138 @@ msgstr ""
 msgid "90 days"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -99,8 +522,24 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -112,8 +551,62 @@ msgstr ""
 msgid "All roles"
 msgstr ""
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
@@ -121,21 +614,119 @@ msgstr ""
 msgid "API Tokens"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr ""
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
@@ -144,11 +735,71 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
@@ -177,6 +828,8 @@ msgstr ""
 msgid "Can view content"
 msgstr ""
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,33 +837,179 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr ""
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
@@ -218,17 +1017,84 @@ msgstr ""
 msgid "Code Block"
 msgstr ""
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr ""
@@ -237,17 +1103,64 @@ msgstr ""
 msgid "Content Block"
 msgstr ""
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
@@ -256,7 +1169,21 @@ msgid "Contributor"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
+msgstr ""
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
@@ -267,7 +1194,27 @@ msgstr ""
 msgid "Copy token"
 msgstr ""
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -275,16 +1222,46 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:110
@@ -292,21 +1269,75 @@ msgstr ""
 msgid "Create personal access tokens for programmatic API access"
 msgstr ""
 
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr ""
 
@@ -319,13 +1350,37 @@ msgstr ""
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -355,8 +1506,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -382,6 +1647,20 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -390,12 +1669,37 @@ msgstr ""
 msgid "Divider"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr ""
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -403,6 +1707,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -415,6 +1720,14 @@ msgstr ""
 msgid "Drafts"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -423,9 +1736,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -440,17 +1770,84 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
 msgstr ""
 
 #. placeholder {0}: block.label
@@ -462,8 +1859,33 @@ msgstr ""
 msgid "Embeds"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
 msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
@@ -471,16 +1893,67 @@ msgstr ""
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -492,8 +1965,108 @@ msgstr ""
 msgid "Expiry"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -501,8 +2074,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -517,8 +2173,37 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
@@ -536,8 +2221,47 @@ msgstr ""
 msgid "Heading 3"
 msgstr ""
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
@@ -548,13 +2272,133 @@ msgstr ""
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
+msgstr ""
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
 msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
@@ -577,6 +2421,111 @@ msgstr ""
 msgid "Insert an image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,9 +2535,47 @@ msgstr ""
 msgid "Large section heading"
 msgstr ""
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -599,8 +2586,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -608,8 +2626,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr ""
@@ -619,28 +2692,129 @@ msgstr ""
 msgid "Locale"
 msgstr ""
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr ""
 
@@ -660,9 +2834,84 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
@@ -677,6 +2926,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,20 +2941,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -709,8 +3053,26 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
@@ -721,16 +3083,137 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
 msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
@@ -741,25 +3224,253 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -774,14 +3485,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr ""
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr ""
 
@@ -793,8 +3586,21 @@ msgstr ""
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -811,8 +3617,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -840,27 +3652,238 @@ msgstr ""
 msgid "Read media files"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr ""
 
@@ -876,8 +3899,27 @@ msgstr ""
 msgid "Revoking..."
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
@@ -888,13 +3930,45 @@ msgstr ""
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
@@ -904,7 +3978,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -933,6 +4016,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr ""
@@ -950,6 +4041,33 @@ msgstr ""
 msgid "Scopes: {0}"
 msgstr ""
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr ""
@@ -964,53 +4082,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr ""
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
+msgstr ""
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr ""
 
@@ -1019,15 +4329,82 @@ msgstr ""
 msgid "SEO"
 msgstr ""
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
@@ -1042,19 +4419,88 @@ msgstr ""
 msgid "Sign in with email link"
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
 msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
@@ -1062,17 +4508,84 @@ msgid "Small section heading"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
 msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr ""
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
@@ -1080,16 +4593,130 @@ msgstr ""
 msgid "Subscriber"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr ""
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
@@ -1097,6 +4724,7 @@ msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1104,21 +4732,106 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
@@ -1139,6 +4852,10 @@ msgstr ""
 msgid "Token Name"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr ""
@@ -1151,6 +4868,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1159,9 +4884,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1176,8 +4986,24 @@ msgstr ""
 msgid "Unknown role"
 msgstr ""
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1192,6 +5018,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr ""
@@ -1201,29 +5054,152 @@ msgstr ""
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
 msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1231,8 +5207,47 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
@@ -1243,8 +5258,43 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
@@ -1253,6 +5303,14 @@ msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
@@ -1267,9 +5325,51 @@ msgstr ""
 msgid "When the entry was published"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
@@ -1284,14 +5384,103 @@ msgstr ""
 msgid "You can view and contribute to the site."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr ""
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr ""
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
 msgstr ""

--- a/packages/admin/src/locales/pseudo/messages.po
+++ b/packages/admin/src/locales/pseudo/messages.po
@@ -22,8 +22,8 @@ msgstr ""
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -49,6 +49,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -99,6 +106,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -171,7 +183,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -194,8 +205,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -204,9 +215,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -273,6 +283,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -401,7 +419,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -530,7 +548,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -594,7 +612,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -715,7 +733,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -785,7 +803,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -841,7 +859,7 @@ msgstr ""
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr ""
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr ""
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1112,7 +1130,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1128,7 +1146,7 @@ msgstr ""
 msgid "Content Read"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr ""
@@ -1198,7 +1216,7 @@ msgstr ""
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1367,7 +1385,7 @@ msgstr ""
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2038,7 +2056,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2145,7 +2163,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2226,10 +2244,6 @@ msgstr ""
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2247,6 +2261,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2259,7 +2277,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2290,7 +2312,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2396,8 +2418,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2421,7 +2443,7 @@ msgstr ""
 msgid "Insert an image"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2445,7 +2467,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2495,11 +2517,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2626,7 +2643,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2676,7 +2693,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3099,7 +3116,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3127,7 +3144,7 @@ msgstr ""
 msgid "No expiry"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3135,7 +3152,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3211,7 +3228,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3224,7 +3241,7 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3326,7 +3343,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3389,7 +3406,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3599,6 +3616,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3691,7 +3712,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3713,11 +3734,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,8 +3768,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3772,9 +3797,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3835,7 +3864,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3843,29 +3872,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3878,12 +3907,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr ""
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4110,7 +4139,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4191,11 +4220,11 @@ msgstr ""
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4257,6 +4286,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4386,10 +4419,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr ""
@@ -4490,7 +4519,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4541,7 +4570,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4678,7 +4707,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4938,7 +4967,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4946,10 +4975,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5002,7 +5027,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5063,7 +5088,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5071,7 +5096,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5084,7 +5109,7 @@ msgstr ""
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5096,7 +5121,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5267,7 +5292,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5392,9 +5417,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr ""
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369

--- a/packages/admin/src/locales/pt-BR/messages.po
+++ b/packages/admin/src/locales/pt-BR/messages.po
@@ -22,8 +22,8 @@ msgstr " (padrão)"
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -49,6 +49,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -99,6 +106,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -171,7 +183,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -194,8 +205,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -204,9 +215,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -273,6 +283,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -401,7 +419,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -530,7 +548,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -594,7 +612,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -715,7 +733,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -785,7 +803,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -841,7 +859,7 @@ msgstr "Pode visualizar conteúdo"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr "Clique no link no e-mail para entrar."
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr "Fechar"
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1112,7 +1130,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1128,7 +1146,7 @@ msgstr ""
 msgid "Content Read"
 msgstr "Leitura de conteúdo"
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Tipos de conteúdo"
@@ -1198,7 +1216,7 @@ msgstr "Copiar token"
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1367,7 +1385,7 @@ msgstr "Criando..."
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2038,7 +2056,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2145,7 +2163,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2226,10 +2244,6 @@ msgstr "Título 3"
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2247,6 +2261,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2259,7 +2277,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2290,7 +2312,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2396,8 +2418,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2421,7 +2443,7 @@ msgstr "Inserir uma seção reutilizável"
 msgid "Insert an image"
 msgstr "Inserir uma imagem"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2445,7 +2467,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2495,11 +2517,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2626,7 +2643,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2676,7 +2693,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3099,7 +3116,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3127,7 +3144,7 @@ msgstr ""
 msgid "No expiry"
 msgstr "Sem expiração"
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3135,7 +3152,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3211,7 +3228,7 @@ msgstr ""
 msgid "No results"
 msgstr "Nenhum resultado"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3224,7 +3241,7 @@ msgstr ""
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3326,7 +3343,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3389,7 +3406,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3599,6 +3616,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3691,7 +3712,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3713,11 +3734,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,8 +3768,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3772,9 +3797,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3835,7 +3864,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3843,29 +3872,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3878,12 +3907,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr "Revisões"
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr "Otimização e verificação para mecanismos de pesquisa"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4110,7 +4139,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr "Pesquisar páginas e conteúdo..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4191,11 +4220,11 @@ msgstr "Segurança"
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4257,6 +4286,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4386,10 +4419,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Exibir token"
@@ -4490,7 +4519,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4541,7 +4570,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4678,7 +4707,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr "O link expirará em 15 minutos."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4938,7 +4967,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4946,10 +4975,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5002,7 +5027,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5063,7 +5088,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5071,7 +5096,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5084,7 +5109,7 @@ msgstr "Enviar e excluir mídia"
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5096,7 +5121,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5267,7 +5292,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5392,9 +5417,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "Você tem acesso completo para gerenciar este site, incluindo usuários, configurações e todo o conteúdo."
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369

--- a/packages/admin/src/locales/pt-BR/messages.po
+++ b/packages/admin/src/locales/pt-BR/messages.po
@@ -18,14 +18,107 @@ msgstr ""
 msgid " (default)"
 msgstr " (padrão)"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -40,6 +133,94 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — sem tradução"
@@ -47,6 +228,44 @@ msgstr "{label} — sem tradução"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — ver tradução"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -56,13 +275,96 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr "1 ano"
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
 msgstr "30 dias"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -72,17 +374,138 @@ msgstr "7 dias"
 msgid "90 days"
 msgstr "90 dias"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -99,8 +522,24 @@ msgstr ""
 msgid "Administrator"
 msgstr "Administrador"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -112,31 +551,183 @@ msgstr "Todas as localizações"
 msgid "All roles"
 msgstr "Todas as funções"
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "Permitir que usuários de domínios específicos se cadastrem"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "Tokens de API"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "Como administrador, você pode convidar outros usuários na seção Usuários."
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "Erro de autenticação: {error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "Autor"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
 msgid "Back to {collectionLabel} list"
@@ -144,12 +735,72 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "Voltar ao login"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
 msgstr "Voltar às configurações"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -177,6 +828,8 @@ msgstr "Pode publicar seu próprio conteúdo"
 msgid "Can view content"
 msgstr "Pode visualizar conteúdo"
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,51 +837,264 @@ msgstr "Pode visualizar conteúdo"
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "Categorias"
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "Verifique seu e-mail"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "Escolha o idioma preferido do painel"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "Clique no link no e-mail para entrar."
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
 msgstr "Fechar"
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
 msgid "Code Block"
 msgstr "Bloco de código"
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "Confirmar"
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "Conteúdo"
@@ -237,18 +1103,65 @@ msgstr "Conteúdo"
 msgid "Content Block"
 msgstr "Bloco de conteúdo"
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr "Leitura de conteúdo"
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "Tipos de conteúdo"
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
 msgstr "Escrita de conteúdo"
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -256,8 +1169,22 @@ msgid "Contributor"
 msgstr "Colaborador"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
@@ -267,7 +1194,27 @@ msgstr "Copie este token agora — ele não será exibido novamente."
 msgid "Copy token"
 msgstr "Copiar token"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -275,38 +1222,122 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr "Criar uma lista com marcadores"
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "Criar uma lista numerada"
 
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
 msgstr "Criar novo token"
 
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
 msgstr "Crie tokens de acesso pessoal para acesso programático à API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr "Criar token"
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "Criar, atualizar, excluir conteúdo"
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr "Criado em {0}"
 
@@ -319,13 +1350,37 @@ msgstr "Criado em"
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr "Criando..."
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "Painel"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -355,8 +1506,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -382,6 +1647,20 @@ msgstr "Exibir um menu de navegação"
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -390,12 +1669,37 @@ msgstr ""
 msgid "Divider"
 msgstr "Divisor"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "Não tem uma conta? <0>Cadastre-se</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -403,6 +1707,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -415,6 +1720,14 @@ msgstr "rascunho, publicado ou arquivado"
 msgid "Drafts"
 msgstr "Rascunhos"
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -423,9 +1736,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr "ex.: Pipeline CI/CD"
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -440,18 +1770,85 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "Editor"
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "E-mail"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "Endereço de e-mail"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr ""
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -462,25 +1859,101 @@ msgstr "Incorporar um {0}"
 msgid "Embeds"
 msgstr "Incorporações"
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
 msgstr "Ativar pesquisa de texto completo nesta coleção"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
+msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1123
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -492,8 +1965,108 @@ msgstr "Expira em {0}"
 msgid "Expiry"
 msgstr "Expiração"
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -501,8 +2074,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr "Falha ao enviar link mágico"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -517,9 +2173,38 @@ msgstr "Acesso administrativo completo"
 msgid "General"
 msgstr "Geral"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
 msgstr "Começar"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -536,9 +2221,48 @@ msgstr "Título 2"
 msgid "Heading 3"
 msgstr "Título 3"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
 msgstr "Ocultar token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -548,14 +2272,134 @@ msgstr "ID"
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "Se existir uma conta para <0>{email}</0>, enviamos um link de acesso."
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
 msgstr "Imagem"
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "Importar"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -577,6 +2421,111 @@ msgstr "Inserir uma seção reutilizável"
 msgid "Insert an image"
 msgstr "Inserir uma imagem"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,10 +2535,48 @@ msgstr "Idioma"
 msgid "Large section heading"
 msgstr "Título de seção grande"
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
 msgstr "Último uso em {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -599,8 +2586,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -608,8 +2626,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "Carregando..."
@@ -619,28 +2692,129 @@ msgstr "Carregando..."
 msgid "Locale"
 msgstr "Localização"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "Gerencie suas chaves de acesso e autenticação"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr "Mídia"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr "Biblioteca de mídia"
 
@@ -660,10 +2834,85 @@ msgstr "Título de seção médio"
 msgid "Menu"
 msgstr "Menu"
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "Menus"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -677,6 +2926,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,20 +2941,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "Navegação"
 
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "nova aba"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -709,9 +3053,27 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "Nenhum token de API ainda. Crie um para começar."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
 msgid "No bylines selected."
@@ -721,17 +3083,138 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "Sem expiração"
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "Nenhum resultado"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
@@ -741,25 +3224,253 @@ msgstr ""
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
 msgstr "Lista numerada"
 
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "Ou continue com"
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "Parágrafo"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -774,14 +3485,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "Plugins"
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr "Pré-visualização"
 
@@ -793,8 +3586,21 @@ msgstr "Pré-visualizar conteúdo antes de publicar"
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -811,8 +3617,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -840,27 +3652,238 @@ msgstr "Ler entradas de conteúdo"
 msgid "Read media files"
 msgstr "Ler arquivos de mídia"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr "Revisões"
 
@@ -876,9 +3899,28 @@ msgstr "Revogar?"
 msgid "Revoking..."
 msgstr "Revogando..."
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
 msgstr "Conteúdo de texto rico"
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -888,14 +3930,46 @@ msgstr "Função {role}"
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "Salvar conteúdo como rascunho antes de publicar"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -904,7 +3978,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -933,6 +4016,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr "Leitura de esquema"
@@ -950,6 +4041,33 @@ msgstr "Escopos"
 msgid "Scopes: {0}"
 msgstr "Escopos: {0}"
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr "Pesquisa"
@@ -964,53 +4082,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "Otimização e verificação para mecanismos de pesquisa"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr "Pesquisar páginas e conteúdo..."
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr "Seção"
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "Seções"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "Segurança"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
 msgstr "Configurações de segurança"
 
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
 msgstr ""
 
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "Domínios de auto-cadastro"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "Enviar link mágico"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "Enviando..."
 
@@ -1019,16 +4329,83 @@ msgstr "Enviando..."
 msgid "SEO"
 msgstr "SEO"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "Configurações"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "Exibir token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
@@ -1042,61 +4419,312 @@ msgstr "Entrar com e-mail"
 msgid "Sign in with email link"
 msgstr "Entrar com link de e-mail"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "Entrar com chave de acesso"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "Identidade do site, logo, favicon e preferências de leitura"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
 msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
 msgstr "Título de seção pequeno"
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "Links sociais"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "Links de perfis em redes sociais"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
 msgstr "Status"
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "Assinante"
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "Tags"
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "O link expirará em 15 minutos."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1104,22 +4732,107 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "para fechar"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -1139,6 +4852,10 @@ msgstr "Token criado: {0}"
 msgid "Token Name"
 msgstr "Nome do token"
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr "Rastrear histórico de conteúdo"
@@ -1151,6 +4868,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1159,9 +4884,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1176,8 +4986,24 @@ msgstr "Desconhecido"
 msgid "Unknown role"
 msgstr "Função desconhecida"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1192,6 +5018,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "Atualizado em"
@@ -1201,29 +5054,152 @@ msgstr "Atualizado em"
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "Enviar e excluir mídia"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
 msgstr "Identificador amigável para URL"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "Use sua chave de acesso cadastrada para entrar com segurança."
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1231,9 +5207,48 @@ msgstr ""
 msgid "Users"
 msgstr "Usuários"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "Verificar status do provedor de e-mail e enviar e-mails de teste"
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1243,9 +5258,44 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "Enviaremos um link para você entrar sem senha."
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1254,6 +5304,14 @@ msgstr "Boas-vindas ao EmDash, {firstName}!"
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
 msgstr "Boas-vindas ao EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -1267,10 +5325,52 @@ msgstr "Quando a entrada foi modificada pela última vez"
 msgid "When the entry was published"
 msgstr "Quando a entrada foi publicada"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "Widgets"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -1284,14 +5384,103 @@ msgstr "Você pode gerenciar conteúdo, mídia, menus e taxonomias."
 msgid "You can view and contribute to the site."
 msgstr "Você pode visualizar e contribuir com o site."
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "Você tem acesso completo para gerenciar este site, incluindo usuários, configurações e todo o conteúdo."
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr "Sua conta foi criada com sucesso."
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
 msgstr "Sua função"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -18,14 +18,107 @@ msgstr ""
 msgid " (default)"
 msgstr "（默认）"
 
+#: packages/admin/src/components/MenuEditor.tsx:344
+msgid " (opens in new window)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid " (selected)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ""
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "(from {0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:351
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2107
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2083
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
 msgstr ""
 
+#. placeholder {0}: items.length
+#: packages/admin/src/components/MediaPickerModal.tsx:448
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2112
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2099
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1764
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2319
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:425
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:235
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2091
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
 msgstr ""
 
 #. placeholder {0}: stats.userCount
@@ -40,6 +133,94 @@ msgstr ""
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
 msgstr ""
 
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1133
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:260
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:213
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1836
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:348
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:165
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:247
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:633
+#: packages/admin/src/components/MediaPickerModal.tsx:715
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: description.length
+#: packages/admin/src/components/SeoPanel.tsx:65
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: changedCount === 1 ? "" : "s"
+#: packages/admin/src/components/RevisionHistory.tsx:336
+msgid "{changedCount} change{0} from next revision"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1935
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2184
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2006
+msgid "{current} of {total}"
+msgstr ""
+
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
 msgstr "{label} — 无翻译"
@@ -47,6 +228,44 @@ msgstr "{label} — 无翻译"
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
 msgstr "{label} — 查看翻译"
+
+#: packages/admin/src/components/WordPressImport.tsx:2306
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2294
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1740
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1749
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:156
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -56,13 +275,96 @@ msgstr ""
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1956
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1957
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1958
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:250
+#: packages/admin/src/components/SetupWizard.tsx:310
+#: packages/admin/src/components/WordPressImport.tsx:1431
+msgid "← Back"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
 msgstr "1 年"
 
+#: packages/admin/src/components/WordPressImport.tsx:1352
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1353
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1354
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1109
+msgid "3. Select \"All content\""
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
 msgstr "30 天"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:154
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:155
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1110
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1355
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:369
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1356
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1111
+msgid "5. Upload the file here"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -72,17 +374,138 @@ msgstr "7 天"
 msgid "90 days"
 msgstr "90 天"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:332
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:260
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:224
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
+#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:214
+msgid "Active"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1488
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:204
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:208
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:536
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:234
+#: packages/admin/src/components/MenuEditor.tsx:323
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:246
+#: packages/admin/src/components/MenuEditor.tsx:253
+#: packages/admin/src/components/MenuEditor.tsx:326
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1847
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:152
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:136
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:316
+msgid "Add links to build your navigation menu"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:90
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:229
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:530
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:203
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:124
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:297
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1583
+msgid "Additional data to import."
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
@@ -99,8 +522,24 @@ msgstr ""
 msgid "Administrator"
 msgstr "管理员"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "After send:"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:140
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2351
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
 msgstr ""
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
@@ -112,31 +551,183 @@ msgstr "所有语言"
 msgid "All roles"
 msgstr "所有角色"
 
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:395
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:404
+msgid "All types"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
 msgstr "允许来自特定域的用户注册"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:438
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:569
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:203
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1225
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/PluginManager.tsx:90
+#: packages/admin/src/components/PluginManager.tsx:109
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1405
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:726
+msgid "Analyzing WordPress site..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
 msgstr "API 令牌"
 
+#: packages/admin/src/components/WordPressImport.tsx:1320
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:244
+#: packages/admin/src/components/comments/CommentInbox.tsx:496
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:209
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:218
+msgid "Arbitrary JSON data"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:144
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:208
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
 msgstr "作为管理员，您可以从\"用户\"部分邀请其他用户。"
 
+#: packages/admin/src/components/WordPressImport.tsx:2289
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
 msgstr "认证错误：{error}"
 
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:133
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:294
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
 msgstr "作者"
+
+#: packages/admin/src/components/WordPressImport.tsx:2304
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:406
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:260
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:512
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:242
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:218
+#: packages/admin/src/components/WordPressImport.tsx:1340
+#: packages/admin/src/components/WordPressImport.tsx:2360
+msgid "Back"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:485
 msgid "Back to {collectionLabel} list"
@@ -144,12 +735,72 @@ msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
+#: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
 msgstr "返回登录"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:125
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:402
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:69
+#: packages/admin/src/components/SectionEditor.tsx:154
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
+#: packages/admin/src/components/settings/EmailSettings.tsx:86
+#: packages/admin/src/components/settings/EmailSettings.tsx:105
+#: packages/admin/src/components/settings/GeneralSettings.tsx:107
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:83
+#: packages/admin/src/components/settings/SeoSettings.tsx:101
+#: packages/admin/src/components/settings/SocialSettings.tsx:77
+#: packages/admin/src/components/settings/SocialSettings.tsx:95
 msgid "Back to settings"
 msgstr "返回设置"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:228
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:146
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+#: packages/admin/src/components/FieldEditor.tsx:576
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:66
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:957
+#: packages/admin/src/components/WordPressImport.tsx:1424
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Browse themes and preview them with your own content."
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -177,6 +828,8 @@ msgstr "可以发布自己的内容"
 msgid "Can view content"
 msgstr "可以查看内容"
 
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
 #: packages/admin/src/components/ContentEditor.tsx:573
 #: packages/admin/src/components/ContentEditor.tsx:777
 #: packages/admin/src/components/ContentEditor.tsx:829
@@ -184,51 +837,264 @@ msgstr "可以查看内容"
 #: packages/admin/src/components/ContentEditor.tsx:1644
 #: packages/admin/src/components/ContentList.tsx:445
 #: packages/admin/src/components/ContentList.tsx:516
+#: packages/admin/src/components/ContentPickerModal.tsx:253
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/FieldEditor.tsx:635
+#: packages/admin/src/components/MediaDetailPanel.tsx:235
+#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MenuEditor.tsx:294
+#: packages/admin/src/components/MenuEditor.tsx:439
+#: packages/admin/src/components/MenuList.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:575
+#: packages/admin/src/components/Redirects.tsx:176
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:207
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:318
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:428
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:318
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:446
+#: packages/admin/src/components/settings/SecuritySettings.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:304
+#: packages/admin/src/components/TaxonomyManager.tsx:523
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/WordPressImport.tsx:1778
 msgid "Cancel"
 msgstr "取消"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:405
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:78
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:414
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:211
+msgid "Caption"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
 msgstr "分类"
 
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1622
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1619
+msgid "Categories will be imported"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1348
+#: packages/admin/src/components/FieldEditor.tsx:383
+#: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:137
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:154
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:928
+msgid "Check Site"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:158
+#: packages/admin/src/components/SignupPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
 msgstr "查看您的邮箱"
+
+#: packages/admin/src/components/WordPressImport.tsx:692
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
 msgstr "选择您的首选管理语言"
 
+#: packages/admin/src/components/SignupPage.tsx:137
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
 msgstr "点击邮件中的链接即可登录。"
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:326
+#: packages/admin/src/components/FieldEditor.tsx:332
+#: packages/admin/src/components/FieldEditor.tsx:336
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:447
+#: packages/admin/src/components/MediaDetailPanel.tsx:132
+#: packages/admin/src/components/MediaDetailPanel.tsx:134
+#: packages/admin/src/components/MediaPickerModal.tsx:348
+#: packages/admin/src/components/MediaPickerModal.tsx:354
+#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MenuEditor.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:262
+#: packages/admin/src/components/MenuEditor.tsx:266
+#: packages/admin/src/components/MenuEditor.tsx:398
+#: packages/admin/src/components/MenuEditor.tsx:404
+#: packages/admin/src/components/MenuEditor.tsx:408
+#: packages/admin/src/components/MenuList.tsx:107
+#: packages/admin/src/components/MenuList.tsx:113
+#: packages/admin/src/components/MenuList.tsx:117
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:151
+#: packages/admin/src/components/Sections.tsx:157
+#: packages/admin/src/components/Sections.tsx:161
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:376
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:382
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:386
+#: packages/admin/src/components/TaxonomyManager.tsx:223
+#: packages/admin/src/components/TaxonomyManager.tsx:229
+#: packages/admin/src/components/TaxonomyManager.tsx:233
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+#: packages/admin/src/components/TaxonomyManager.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:447
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:304
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
 #: packages/admin/src/components/WelcomeModal.tsx:54
 msgid "Close"
 msgstr "关闭"
+
+#: packages/admin/src/components/users/UserDetail.tsx:130
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/Redirects.tsx:450
+msgid "Code"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
 msgid "Code Block"
 msgstr "代码块"
 
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:488
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2160
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:226
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:297
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Configure Field"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
 msgstr "确认"
 
+#: packages/admin/src/components/WordPressImport.tsx:1337
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1287
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:292
+msgid "Connected {0}"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:300
 #: packages/admin/src/components/Dashboard.tsx:164
 #: packages/admin/src/components/PortableTextEditor.tsx:1431
+#: packages/admin/src/components/SectionEditor.tsx:174
 #: packages/admin/src/components/Sidebar.tsx:376
 msgid "Content"
 msgstr "内容"
@@ -237,18 +1103,65 @@ msgstr "内容"
 msgid "Content Block"
 msgstr "内容块"
 
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2215
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2204
+msgid "content items"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
 msgstr "内容读取"
 
+#: packages/admin/src/components/RevisionHistory.tsx:295
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1561
+msgid "Content to Import"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:38
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "内容类型"
 
+#: packages/admin/src/components/WordPressImport.tsx:2143
+msgid "Content was skipped because it already exists"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
 msgstr "内容写入"
+
+#: packages/admin/src/components/SignupPage.tsx:90
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2362
+msgid "Continue Import"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -256,8 +1169,22 @@ msgid "Contributor"
 msgstr "贡献者"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
 msgstr "已复制到剪贴板"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:397
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:396
+msgid "Copy slug"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
@@ -267,7 +1194,27 @@ msgstr "立即复制此令牌 — 它将不再显示。"
 msgid "Copy token"
 msgstr "复制令牌"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:307
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1094
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:618
+msgid "Count"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:185
+#: packages/admin/src/components/Sections.tsx:210
+#: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
 msgstr ""
 
@@ -275,38 +1222,122 @@ msgstr ""
 msgid "Create a bullet list"
 msgstr "创建无序列表"
 
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:219
+msgid "Create a new {0}"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
 msgstr "创建有序列表"
 
+#: packages/admin/src/components/SignupPage.tsx:219
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Create an account"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1563
 msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:97
+#: packages/admin/src/components/MenuList.tsx:160
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Create New Menu"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
 msgstr "创建新令牌"
 
+#: packages/admin/src/components/WordPressImport.tsx:1331
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:305
+msgid "Create Passkey"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
 msgstr "创建个人访问令牌以通过程序访问 API"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:239
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1782
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:148
+#: packages/admin/src/components/Sections.tsx:268
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:430
+#: packages/admin/src/components/TaxonomyManager.tsx:526
+msgid "Create Taxonomy"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
 msgstr "创建令牌"
 
+#: packages/admin/src/components/SetupWizard.tsx:495
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:158
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:121
 msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:210
+msgid "Create your passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
 msgstr "创建、更新、删除内容"
 
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:290
+#: packages/admin/src/components/users/UserDetail.tsx:266
 msgid "Created {0}"
 msgstr "创建于 {0}"
 
@@ -319,13 +1350,37 @@ msgstr "创建时间"
 msgid "Created: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:803
+msgid "Creating collections and fields..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1615
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/Redirects.tsx:182
+#: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
+#: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Creating..."
 msgstr "创建中..."
 
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:263
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:242
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:156
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Custom Section"
 msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
@@ -337,16 +1392,112 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:245
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
 msgid "Dashboard"
 msgstr "仪表板"
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:175
+#: packages/admin/src/components/FieldEditor.tsx:577
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:176
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:158
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:433
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:39
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:274
+#: packages/admin/src/components/comments/CommentInbox.tsx:414
+#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuEditor.tsx:372
+#: packages/admin/src/components/MenuList.tsx:209
+#: packages/admin/src/components/Redirects.tsx:559
+#: packages/admin/src/components/Sections.tsx:306
+#: packages/admin/src/components/Sections.tsx:405
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/Sections.tsx:406
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
+#: packages/admin/src/components/TaxonomyManager.tsx:79
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:191
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:652
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:412
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:141
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:207
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:532
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
 msgstr ""
@@ -355,8 +1506,122 @@ msgstr ""
 msgid "Delete Permanently?"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:516
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:517
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:557
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:294
+msgid "Delete Section?"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:415
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/MediaDetailPanel.tsx:231
+#: packages/admin/src/components/MediaDetailPanel.tsx:257
+#: packages/admin/src/components/MenuList.tsx:210
+#: packages/admin/src/components/Redirects.tsx:560
+#: packages/admin/src/components/Sections.tsx:307
+#: packages/admin/src/components/TaxonomyManager.tsx:657
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:215
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:212
+#: packages/admin/src/components/Sections.tsx:198
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:286
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:449
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:142
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:177
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:308
+#: packages/admin/src/components/Redirects.tsx:397
+#: packages/admin/src/components/users/UserDetail.tsx:209
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:468
+msgid "Disabled:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:558
@@ -382,6 +1647,20 @@ msgstr "显示导航菜单"
 msgid "Display name"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:138
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:534
 msgid "Distraction-free mode (⌘⇧\\)"
 msgstr ""
@@ -390,12 +1669,37 @@ msgstr ""
 msgid "Divider"
 msgstr "分隔线"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
+msgid "Domain updated"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
 msgstr "还没有账号？<0>立即注册</0>"
 
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1991
+msgid "Done"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1509
 msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1989
+msgid "Downloading"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:553
@@ -403,6 +1707,7 @@ msgid "draft"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:728
+#: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
 msgstr ""
 
@@ -415,6 +1720,14 @@ msgstr "草稿、已发布或已归档"
 msgid "Drafts"
 msgstr "草稿"
 
+#: packages/admin/src/components/WordPressImport.tsx:952
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1418
+msgid "Drop your WordPress export file here"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
 msgstr ""
@@ -423,9 +1736,26 @@ msgstr ""
 msgid "e.g., CI/CD Pipeline"
 msgstr "例如：CI/CD 流水线"
 
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:909
 #: packages/admin/src/components/ContentEditor.tsx:1518
+#: packages/admin/src/components/MenuEditor.tsx:367
+#: packages/admin/src/components/MenuList.tsx:185
+#: packages/admin/src/components/Sections.tsx:390
+#: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: term.label
+#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
+#: packages/admin/src/components/TaxonomyManager.tsx:71
+msgid "Edit {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:502
@@ -440,18 +1770,85 @@ msgstr ""
 msgid "Edit byline"
 msgstr ""
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:323
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:395
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:225
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:508
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Edit redirect {0}"
+msgstr ""
+
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "编辑"
 
 #: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:196
+#: packages/admin/src/components/users/UserDetail.tsx:162
 msgid "Email"
 msgstr "邮箱"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:183
+#: packages/admin/src/components/SignupPage.tsx:65
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
 msgstr "邮箱地址"
+
+#: packages/admin/src/components/SetupWizard.tsx:204
+#: packages/admin/src/components/SignupPage.tsx:48
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:134
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:208
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:90
+#: packages/admin/src/components/settings/EmailSettings.tsx:109
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:241
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:188
+msgid "Email verified!"
+msgstr ""
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
@@ -462,25 +1859,101 @@ msgstr "嵌入 {0}"
 msgid "Embeds"
 msgstr "嵌入"
 
+#: packages/admin/src/components/WordPressImport.tsx:1038
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1137
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:325
+msgid "Enable"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
 msgstr "在此集合上启用全文搜索"
+
+#: packages/admin/src/components/PluginManager.tsx:389
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:485
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:169
+#: packages/admin/src/components/Redirects.tsx:396
+msgid "Enabled"
+msgstr ""
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1123
 msgid "Enter {0}..."
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:279
+#: packages/admin/src/components/MenuEditor.tsx:423
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1210
+msgid "Enter credentials manually"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:533
 msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:166
+msgid "Enter email"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1144
 msgid "Enter markdown content..."
 msgstr ""
 
+#: packages/admin/src/components/users/UserDetail.tsx:159
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1289
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:915
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:83
+#: packages/admin/src/components/MenuEditor.tsx:122
+#: packages/admin/src/components/SetupWizard.tsx:478
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:49
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1873
+msgid "Exists"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:496
 msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Expand details"
 msgstr ""
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
@@ -492,8 +1965,108 @@ msgstr "过期于 {0}"
 msgid "Expiry"
 msgstr "过期时间"
 
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1227
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:140
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1993
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:198
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
+msgid "Failed to add domain"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1609
 msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1544
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:108
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:89
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:94
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:148
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:120
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:179
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:480
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Failed to load theme"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:64
+#: packages/admin/src/components/settings/SeoSettings.tsx:58
+#: packages/admin/src/components/settings/SocialSettings.tsx:52
+msgid "Failed to save settings"
 msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:127
@@ -501,8 +2074,91 @@ msgstr ""
 msgid "Failed to send magic link"
 msgstr "发送免密登录链接失败"
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:62
+msgid "Failed to send test email"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1659
 msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1013
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:102
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:727
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:559
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:395
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:407
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2166
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:2021
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:206
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:193
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:197
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2199
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:184
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1228
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1037
+msgid "For the best import experience, install the"
 msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
@@ -517,9 +2173,38 @@ msgstr "完全管理员访问权限"
 msgid "General"
 msgstr "常规"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:111
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
 msgstr "开始使用"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:134
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2251
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:140
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "Group (optional)"
+msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -536,9 +2221,48 @@ msgstr "标题 2"
 msgid "Heading 3"
 msgstr "标题 3"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Hide"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:89
+msgid "Hide from search engines"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
 msgstr "隐藏令牌"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:481
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+#: packages/admin/src/components/Redirects.tsx:451
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:339
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1350
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:152
+msgid "Icon blurred due to image audit"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -548,14 +2272,134 @@ msgstr "ID"
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
 msgstr "如果存在与 <0>{email}</0> 关联的账号，我们已发送登录链接。"
 
+#: packages/admin/src/components/FieldEditor.tsx:199
 #: packages/admin/src/components/PortableTextEditor.tsx:1413
 msgid "Image"
 msgstr "图片"
+
+#: packages/admin/src/components/FieldEditor.tsx:200
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:373
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2203
+msgid "image URLs updated in"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
 msgid "Import"
 msgstr "导入"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1821
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1196
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2249
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1007
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2137
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2138
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:608
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1686
+msgid "Import logo and favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1970
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1923
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1595
+msgid "Import navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:610
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1702
+msgid "Import SEO settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1658
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1670
+msgid "Import site title and tagline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1194
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:243
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:811
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2002
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:163
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1843
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:384
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+msgid "Insert"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -577,6 +2421,111 @@ msgstr "插入可复用区块"
 msgid "Insert an image"
 msgstr "插入图片"
 
+#: packages/admin/src/components/MediaPickerModal.tsx:366
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:146
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:190
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:196
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:183
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:437
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+#: packages/admin/src/components/FieldEditor.tsx:575
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:258
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite User"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:217
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:77
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:102
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:68
+#: packages/admin/src/components/RepeaterField.tsx:130
+msgid "items"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:238
+#: packages/admin/src/components/SignupPage.tsx:204
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:304
+#: packages/admin/src/components/SectionEditor.tsx:221
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:392
+#: packages/admin/src/components/FieldEditor.tsx:545
+#: packages/admin/src/components/MenuEditor.tsx:272
+#: packages/admin/src/components/MenuEditor.tsx:415
+#: packages/admin/src/components/MenuList.tsx:137
+#: packages/admin/src/components/TaxonomyManager.tsx:455
+msgid "Label"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
@@ -586,10 +2535,48 @@ msgstr "语言"
 msgid "Large section heading"
 msgstr "大章节标题"
 
+#: packages/admin/src/components/PluginManager.tsx:462
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:218
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:285
+#: packages/admin/src/components/users/UserDetail.tsx:268
 msgid "Last used {0}"
 msgstr "最后使用于 {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2331
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
+msgid "License"
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -599,8 +2586,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: packages/admin/src/components/SignupPage.tsx:256
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:212
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:282
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:152
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:241
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+msgid "Load more"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:290
@@ -608,8 +2626,63 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
+#: packages/admin/src/components/ContentTypeList.tsx:113
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:314
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:169
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:198
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:126
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:437
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:250
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:114
+#: packages/admin/src/components/settings/SeoSettings.tsx:90
+#: packages/admin/src/components/settings/SocialSettings.tsx:84
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:467
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+msgid "Loading terms..."
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
+#: packages/admin/src/components/ContentPickerModal.tsx:238
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
+#: packages/admin/src/components/settings/SecuritySettings.tsx:117
+#: packages/admin/src/components/TaxonomyManager.tsx:583
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
 msgstr "加载中..."
@@ -619,28 +2692,129 @@ msgstr "加载中..."
 msgid "Locale"
 msgstr "语言区域"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1689
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+#: packages/admin/src/components/FieldEditor.tsx:573
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:191
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:473
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:390
 msgid "Manage"
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:602
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:85
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:334
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
 msgstr "管理您的通行密钥和认证"
 
+#: packages/admin/src/components/Redirects.tsx:405
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2287
+msgid "Map Authors"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:508
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:196
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/PluginManager.tsx:161
+#: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:620
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:462
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:492
+msgid "Max Value"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
+#: packages/admin/src/components/WordPressImport.tsx:1164
 msgid "Media"
 msgstr "媒体"
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2233
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2195
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2136
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2147
+msgid "Media import was skipped"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
 msgstr "媒体库"
 
@@ -660,10 +2834,85 @@ msgstr "中章节标题"
 msgid "Menu"
 msgstr "菜单"
 
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:40
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:39
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:65
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:78
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:103
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:206
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:117
+msgid "Menu order has been updated."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Menus"
 msgstr "菜单"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1600
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:62
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:149
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:143
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1707
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:613
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:455
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:485
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:216
+msgid "Modified"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -677,6 +2926,10 @@ msgstr ""
 msgid "Move {title} to trash"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:360
+msgid "Move down"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:814
 #: packages/admin/src/components/ContentEditor.tsx:836
 #: packages/admin/src/components/ContentList.tsx:452
@@ -688,20 +2941,111 @@ msgstr ""
 msgid "Move to Trash?"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:351
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:152
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:188
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:145
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/MenuList.tsx:125
+#: packages/admin/src/components/TaxonomyManager.tsx:241
+#: packages/admin/src/components/TaxonomyManager.tsx:464
+#: packages/admin/src/components/TaxonomyManager.tsx:617
+#: packages/admin/src/components/users/UserDetail.tsx:156
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
 msgstr "导航"
 
+#: packages/admin/src/components/users/UserDetail.tsx:237
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:502
 msgid "New {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1845
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:43
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:337
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:141
+msgid "New Section"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
 msgstr "新标签页"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:607
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:289
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:474
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:311
+msgid "No {0} available."
 msgstr ""
 
 #. placeholder {0}: collectionLabel.toLowerCase()
@@ -709,9 +3053,27 @@ msgstr ""
 msgid "No {0} yet."
 msgstr ""
 
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:209
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
 msgstr "暂无 API 令牌。创建一个以开始使用。"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:554
+msgid "No approved comments yet."
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1550
 msgid "No bylines selected."
@@ -721,17 +3083,138 @@ msgstr ""
 msgid "No collections configured"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:553
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:176
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:182
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:119
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:275
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:187
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2349
+msgid "No EmDash users found"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
 msgstr "永不过期"
+
+#: packages/admin/src/components/RevisionHistory.tsx:326
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:188
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:143
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:624
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:466
+#: packages/admin/src/components/FieldEditor.tsx:496
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:490
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:315
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:157
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:459
+#: packages/admin/src/components/FieldEditor.tsx:489
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:199
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:341
+msgid "No preview"
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:441
+msgid "No redirects yet"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
 msgstr "无结果"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
@@ -741,25 +3224,253 @@ msgstr ""
 msgid "No results found"
 msgstr "未找到结果"
 
+#: packages/admin/src/components/RevisionHistory.tsx:182
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:257
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:263
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:555
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:270
+#: packages/admin/src/components/TaxonomyManager.tsx:276
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+#: packages/admin/src/components/FieldEditor.tsx:574
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
 msgid "Numbered List"
 msgstr "有序列表"
 
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:95
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:130
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:403
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:214
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:289
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:396
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1420
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
 msgstr "或继续使用"
 
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:940
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:116
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:180
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:52
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:851
 msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:446
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:327
+#: packages/admin/src/components/WordPressImport.tsx:1158
+msgid "Pages"
 msgstr ""
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
 msgstr "段落"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:266
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:490
+#: packages/admin/src/components/Redirects.tsx:496
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:333
+msgid "Passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:251
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:185
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:212
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:297
+msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:471
+msgid "Pattern (Regex)"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:204
+msgid "Pending"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:726
@@ -774,14 +3485,96 @@ msgstr ""
 msgid "Permanently delete {title}"
 msgstr ""
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:284
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:206
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:53
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:283
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1015
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:102
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:83
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:122
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1039
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:246
+msgid "Plugin updated"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:125
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Plugins"
 msgstr "插件"
 
+#: packages/admin/src/components/SeoPanel.tsx:79
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1152
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2047
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:258
+msgid "Preparing..."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:547
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
+#: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
 msgstr "预览"
 
@@ -793,8 +3586,21 @@ msgstr "发布前预览内容"
 msgid "Preview draft"
 msgstr ""
 
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:456
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:211
+msgid "Provider:"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:602
@@ -811,8 +3617,14 @@ msgid "published"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:722
+#: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:337
+msgid "Published {0}"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
@@ -840,27 +3652,238 @@ msgstr "读取内容条目"
 msgid "Read media files"
 msgstr "读取媒体文件"
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1849
+msgid "Ready"
+msgstr ""
+
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
 msgstr ""
 
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:342
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:423
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+#: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
 msgstr ""
 
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:77
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:224
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1527
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:205
 msgid "Remove"
 msgstr ""
 
+#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:189
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
+msgid "Remove Domain?"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1356
+#: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/RepeaterField.tsx:253
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:604
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name || "passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:230
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:274
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:422
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1862
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:335
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:152
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:219
+msgid "Restore"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
 msgstr ""
 
+#: packages/admin/src/components/RevisionHistory.tsx:135
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:213
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:280
+#: packages/admin/src/components/RevisionHistory.tsx:281
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:216
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:134
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:129
+msgid "Revision restored"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
+#: packages/admin/src/components/RevisionHistory.tsx:160
 msgid "Revisions"
 msgstr "修订版本"
 
@@ -876,9 +3899,28 @@ msgstr "撤销？"
 msgid "Revoking..."
 msgstr "撤销中..."
 
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Rich Text"
+msgstr ""
+
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
 msgstr "富文本内容"
+
+#: packages/admin/src/components/FieldEditor.tsx:194
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:322
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:177
+#: packages/admin/src/components/users/UserDetail.tsx:189
+msgid "Role"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -888,14 +3930,46 @@ msgstr "角色 {role}"
 msgid "Role label"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:286
+#: packages/admin/src/components/MenuEditor.tsx:288
+#: packages/admin/src/components/MenuEditor.tsx:431
+#: packages/admin/src/components/MenuEditor.tsx:433
+msgid "Same window"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:317
+msgid "Save Changes"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
 msgstr "发布前将内容保存为草稿"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+msgid "Save Social Links"
+msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:522
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -904,7 +3978,16 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:517
 #: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/FieldEditor.tsx:646
+#: packages/admin/src/components/MediaDetailPanel.tsx:242
+#: packages/admin/src/components/MenuEditor.tsx:442
+#: packages/admin/src/components/Redirects.tsx:181
 #: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:164
+#: packages/admin/src/components/settings/SocialSettings.tsx:169
+#: packages/admin/src/components/TaxonomyManager.tsx:308
+#: packages/admin/src/components/users/UserDetail.tsx:317
 msgid "Saving..."
 msgstr ""
 
@@ -933,6 +4016,14 @@ msgstr ""
 msgid "Scheduled for: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:2155
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1529
+msgid "Schema preparation failed"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
 msgstr "模式读取"
@@ -950,6 +4041,33 @@ msgstr "权限范围"
 msgid "Scopes: {0}"
 msgstr "权限范围：{0}"
 
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:254
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:257
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:442
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
+msgid "Screenshots"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
 msgstr "搜索"
@@ -964,53 +4082,245 @@ msgstr ""
 msgid "Search {0}..."
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:170
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:169
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "Search Engine Optimization"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
 msgstr "搜索引擎优化和验证"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:440
+msgid "Search media"
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
 msgstr "搜索页面和内容..."
 
+#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:224
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:384
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:439
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:444
+msgid "Searchable"
+msgstr ""
+
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
 msgstr "区块"
 
+#: packages/admin/src/components/SectionEditor.tsx:77
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:91
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:105
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:186
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:41
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:192
+msgid "Section title"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:132
 #: packages/admin/src/components/Sidebar.tsx:193
 msgid "Sections"
 msgstr "区块"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:496
+msgid "Secure your account"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
 msgstr "安全"
 
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:318
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:108
 msgid "Security Settings"
 msgstr "安全设置"
 
+#: packages/admin/src/components/FieldEditor.tsx:181
+#: packages/admin/src/components/FieldEditor.tsx:578
+msgid "Select"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1380
 msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Select all"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:1471
 msgid "Select byline..."
 msgstr ""
 
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:463
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1371
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1562
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:348
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:570
+msgid "Selected:"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
 msgstr "自助注册域"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
 msgstr "发送免密登录链接"
 
+#: packages/admin/src/components/users/UserDetail.tsx:338
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:145
+msgid "Send Test Email"
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:206
+#: packages/admin/src/components/settings/EmailSettings.tsx:162
+#: packages/admin/src/components/SignupPage.tsx:87
+#: packages/admin/src/components/SignupPage.tsx:150
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:338
 msgid "Sending..."
 msgstr "发送中..."
 
@@ -1019,16 +4329,83 @@ msgstr "发送中..."
 msgid "SEO"
 msgstr "SEO"
 
+#: packages/admin/src/components/settings/SeoSettings.tsx:87
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1705
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:51
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:295
+msgid "Set up your passkey"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:494
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:175
+msgid "Setting up..."
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/PluginManager.tsx:380
 #: packages/admin/src/components/Settings.tsx:62
 #: packages/admin/src/components/Sidebar.tsx:224
+#: packages/admin/src/components/WordPressImport.tsx:1655
 msgid "Settings"
 msgstr "设置"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:59
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:145
+#: packages/admin/src/components/FieldEditor.tsx:572
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "Show"
+msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "显示令牌"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:440
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
@@ -1042,61 +4419,312 @@ msgstr "使用邮箱登录"
 msgid "Sign in with email link"
 msgstr "使用邮箱链接登录"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
 msgid "Sign in with Passkey"
 msgstr "使用通行密钥登录"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:182
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:146
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:331
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
 msgstr "网站标识、徽标、网站图标和阅读偏好"
 
+#: packages/admin/src/components/SetupWizard.tsx:329
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:141
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1673
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:125
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:171
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1967
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1992
+msgid "Skipped"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:710
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
+#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/FieldEditor.tsx:223
+#: packages/admin/src/components/FieldEditor.tsx:399
+#: packages/admin/src/components/SectionEditor.tsx:197
+#: packages/admin/src/components/Sections.tsx:182
+#: packages/admin/src/components/TaxonomyManager.tsx:250
 msgid "Slug"
 msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:122
+msgid "Slug copied to clipboard"
+msgstr ""
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
 msgstr "小章节标题"
 
 #: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
 msgid "Social Links"
 msgstr "社交链接"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:47
+msgid "Social links saved"
+msgstr ""
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
 msgstr "社交媒体个人资料链接"
 
+#: packages/admin/src/components/settings/SocialSettings.tsx:122
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1721
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/PluginManager.tsx:434
+#: packages/admin/src/components/Redirects.tsx:447
+#: packages/admin/src/components/SectionEditor.tsx:232
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:214
+#: packages/admin/src/components/comments/CommentInbox.tsx:254
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1783
+msgid "Start Import"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:716
 #: packages/admin/src/components/ContentList.tsx:193
 #: packages/admin/src/components/ContentTypeEditor.tsx:115
+#: packages/admin/src/components/Redirects.tsx:452
 msgid "Status"
 msgstr "状态"
+
+#: packages/admin/src/components/Redirects.tsx:145
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1582
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid "Sub-Fields"
+msgstr ""
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
 msgstr "订阅者"
 
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:152
+msgid "Tagline"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
 msgstr "标签"
 
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1640
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1637
+msgid "Tags will be imported"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/MenuEditor.tsx:428
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:357
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:668
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:589
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:180
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:214
+#: packages/admin/src/components/TaxonomyManager.tsx:610
+msgid "Term"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:157
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1723
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:57
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:170
+#: packages/admin/src/components/SignupPage.tsx:138
 msgid "The link will expire in 15 minutes."
 msgstr "链接将在 15 分钟后过期。"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:56
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:241
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:245
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:161
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:298
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
 msgstr ""
 
 #: packages/admin/src/components/Sidebar.tsx:218
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
 msgstr ""
 
@@ -1104,22 +4732,107 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1138
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:287
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:558
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:236
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:241
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:823
 msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:302
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:413
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:560
+msgid "This will remove the plugin and its bundle from your site."
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:567
 msgid "This will revert to the published version. Your draft changes will be lost."
 msgstr ""
 
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
+#: packages/admin/src/components/SectionEditor.tsx:189
+#: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:134
+msgid "Title Separator"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "关闭"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -1139,6 +4852,10 @@ msgstr "令牌已创建：{0}"
 msgid "Token Name"
 msgstr "令牌名称"
 
+#: packages/admin/src/components/WordPressImport.tsx:1107
+msgid "Tools → Export"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
 msgstr "跟踪内容历史"
@@ -1151,6 +4868,14 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:223
+#: packages/admin/src/components/comments/CommentInbox.tsx:264
+#: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
 msgstr ""
@@ -1159,9 +4884,94 @@ msgstr ""
 msgid "Trash is empty"
 msgstr ""
 
+#: packages/admin/src/components/comments/CommentInbox.tsx:556
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:170
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:493
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:258
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1412
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+#: packages/admin/src/components/WordPressImport.tsx:1238
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:562
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1881
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+msgid "Unable to reach marketplace"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:344
+msgid "unchanged"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:190
+#: packages/admin/src/components/PluginManager.tsx:484
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:558
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:553
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:578
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:431
+msgid "Unique"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
@@ -1176,8 +4986,24 @@ msgstr "未知"
 msgid "Unknown role"
 msgstr "未知角色"
 
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Unnamed passkey"
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:54
+msgid "Unregistered Content Tables Found"
 msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:741
@@ -1192,6 +5018,33 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
+#: packages/admin/src/components/TaxonomyManager.tsx:310
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:646
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
+msgid "Update settings for {0}"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:218
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Update to v{0}"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
 msgstr "更新时间"
@@ -1201,29 +5054,152 @@ msgstr "更新时间"
 msgid "Updated: {0}"
 msgstr ""
 
+#: packages/admin/src/components/WordPressImport.tsx:835
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:363
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1221
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "Upload an image to get started"
+msgstr ""
+
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
 msgstr "上传和删除媒体"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+#: packages/admin/src/components/WordPressImport.tsx:1235
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
 msgstr ""
 
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:951
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:185
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1990
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:274
+#: packages/admin/src/components/MenuEditor.tsx:418
+msgid "URL"
+msgstr ""
+
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/FieldEditor.tsx:224
 msgid "URL-friendly identifier"
 msgstr "URL 友好的标识符"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
 msgstr "使用您注册的通行密钥安全登录。"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
 #: packages/admin/src/components/ContentEditor.tsx:1219
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
 msgstr ""
 
+#: packages/admin/src/components/MediaDetailPanel.tsx:207
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:207
+#: packages/admin/src/components/Sections.tsx:194
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:128
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:302
+msgid "User not found"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
@@ -1231,9 +5207,48 @@ msgstr ""
 msgid "Users"
 msgstr "用户"
 
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:312
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:452
+#: packages/admin/src/components/FieldEditor.tsx:482
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:387
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:331
+msgid "Version"
+msgstr ""
+
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
 msgstr "查看邮件提供商状态并发送测试邮件"
+
+#: packages/admin/src/components/PluginManager.tsx:371
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
@@ -1243,9 +5258,44 @@ msgstr ""
 msgid "View Site"
 msgstr ""
 
+#: packages/admin/src/components/Redirects.tsx:429
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1096
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:917
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
 msgstr "我们将向您发送一个无需密码即可登录的链接。"
+
+#: packages/admin/src/components/SignupPage.tsx:131
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:236
+msgid "Website"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -1254,6 +5304,14 @@ msgstr "欢迎使用 EmDash，{firstName}！"
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
 msgstr "欢迎使用 EmDash！"
+
+#: packages/admin/src/components/WordPressImport.tsx:1954
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1735
+msgid "What will happen when you import"
+msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -1267,10 +5325,52 @@ msgstr "条目最后修改时间"
 msgid "When the entry was published"
 msgstr "条目发布时间"
 
+#: packages/admin/src/components/TaxonomyManager.tsx:490
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:164
+msgid "Whole number"
+msgstr ""
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:333
 #: packages/admin/src/components/Sidebar.tsx:192
 msgid "Widgets"
 msgstr "小部件"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1877
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:193
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1306
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1014
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:242
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -1284,14 +5384,103 @@ msgstr "您可以管理内容、媒体、菜单和分类法。"
 msgid "You can view and contribute to the site."
 msgstr "您可以查看和贡献网站内容。"
 
+#: packages/admin/src/components/users/UserDetail.tsx:183
+msgid "You cannot change your own role"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "您拥有完全访问权限来管理此网站，包括用户、设置和所有内容。"
+
+#. placeholder {0}: passkey.name || "this passkey"
+#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1199
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:190
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:499
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:69
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:226
+msgid "you@example.com"
+msgstr ""
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
 msgstr "您的账号已成功创建。"
 
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:222
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:143
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:137
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:149
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:155
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:234
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:200
+msgid "Your name (optional)"
+msgstr ""
+
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
 msgstr "您的角色"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:131
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1925
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:161
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:158
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -22,8 +22,8 @@ msgstr "（默认）"
 msgid " (opens in new window)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
 msgstr ""
 
@@ -38,7 +38,7 @@ msgid ": use"
 msgstr ""
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
-#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
 msgstr ""
 
@@ -49,6 +49,13 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:131
+msgid "{0, plural, one {(# item)} other {(# items)}}"
 msgstr ""
 
 #. placeholder {0}: seedInfo.collections
@@ -77,7 +84,7 @@ msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matchi
 msgstr ""
 
 #. placeholder {0}: items.length
-#: packages/admin/src/components/MediaPickerModal.tsx:448
+#: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
 msgstr ""
 
@@ -99,6 +106,11 @@ msgstr ""
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:289
+msgid "{0, plural, one {# permission} other {# permissions}}"
 msgstr ""
 
 #. placeholder {0}: mapping.postCount
@@ -171,7 +183,6 @@ msgstr ""
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
-#: packages/admin/src/components/MarketplaceBrowse.tsx:288
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
 msgstr ""
@@ -194,8 +205,8 @@ msgstr ""
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
-#: packages/admin/src/components/MediaPickerModal.tsx:633
-#: packages/admin/src/components/MediaPickerModal.tsx:715
+#: packages/admin/src/components/MediaPickerModal.tsx:634
+#: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
 msgstr ""
 
@@ -204,9 +215,8 @@ msgstr ""
 msgid "{0}/160 characters"
 msgstr ""
 
-#. placeholder {0}: changedCount === 1 ? "" : "s"
-#: packages/admin/src/components/RevisionHistory.tsx:336
-msgid "{changedCount} change{0} from next revision"
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
 msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
@@ -273,6 +283,14 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
@@ -401,7 +419,7 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
 #: packages/admin/src/components/ContentList.tsx:309
-#: packages/admin/src/components/ContentTypeList.tsx:105
+#: packages/admin/src/components/ContentTypeList.tsx:106
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
@@ -459,11 +477,11 @@ msgstr ""
 msgid "Add fields"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:152
+#: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:136
+#: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
 msgstr ""
 
@@ -530,7 +548,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:107
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
 msgstr ""
 
@@ -594,7 +612,7 @@ msgstr ""
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:137
+#: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
@@ -641,7 +659,7 @@ msgid "archived"
 msgstr ""
 
 #. placeholder {0}: deleteTarget.label
-#: packages/admin/src/components/ContentTypeList.tsx:144
+#: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
 msgstr ""
 
@@ -715,7 +733,7 @@ msgstr ""
 msgid "Auto-generated from name (you can edit)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:512
+#: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
 msgstr ""
 
@@ -785,7 +803,7 @@ msgstr ""
 msgid "Brief summary shown below the title in search results"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:86
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
 msgstr ""
 
@@ -841,7 +859,7 @@ msgstr "可以查看内容"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
 #: packages/admin/src/components/FieldEditor.tsx:635
 #: packages/admin/src/components/MediaDetailPanel.tsx:235
-#: packages/admin/src/components/MediaPickerModal.tsx:580
+#: packages/admin/src/components/MediaPickerModal.tsx:581
 #: packages/admin/src/components/MenuEditor.tsx:294
 #: packages/admin/src/components/MenuEditor.tsx:439
 #: packages/admin/src/components/MenuList.tsx:143
@@ -966,9 +984,9 @@ msgstr "点击邮件中的链接即可登录。"
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:447
 #: packages/admin/src/components/MediaDetailPanel.tsx:132
 #: packages/admin/src/components/MediaDetailPanel.tsx:134
-#: packages/admin/src/components/MediaPickerModal.tsx:348
-#: packages/admin/src/components/MediaPickerModal.tsx:354
-#: packages/admin/src/components/MediaPickerModal.tsx:358
+#: packages/admin/src/components/MediaPickerModal.tsx:349
+#: packages/admin/src/components/MediaPickerModal.tsx:355
+#: packages/admin/src/components/MediaPickerModal.tsx:359
 #: packages/admin/src/components/MenuEditor.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:262
 #: packages/admin/src/components/MenuEditor.tsx:266
@@ -1007,7 +1025,7 @@ msgstr "关闭"
 msgid "Close panel"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:243
+#: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
 msgstr ""
@@ -1112,7 +1130,7 @@ msgstr ""
 msgid "Content found:"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:130
+#: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
 msgstr ""
 
@@ -1128,7 +1146,7 @@ msgstr ""
 msgid "Content Read"
 msgstr "内容读取"
 
-#: packages/admin/src/components/RevisionHistory.tsx:295
+#: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgid "Content to Import"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
-#: packages/admin/src/components/ContentTypeList.tsx:38
+#: packages/admin/src/components/ContentTypeList.tsx:39
 #: packages/admin/src/components/Sidebar.tsx:205
 msgid "Content Types"
 msgstr "内容类型"
@@ -1198,7 +1216,7 @@ msgstr "复制令牌"
 msgid "Could not copy automatically. Please select the URL above and copy manually."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:307
+#: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
 msgstr ""
 
@@ -1314,7 +1332,7 @@ msgid "Create your first navigation menu to get started"
 msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:219
-#: packages/admin/src/components/ContentTypeList.tsx:121
+#: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
 msgstr ""
 
@@ -1367,7 +1385,7 @@ msgstr "创建中..."
 msgid "current"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:263
+#: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
 msgstr ""
 
@@ -1392,7 +1410,7 @@ msgid "Dark"
 msgstr ""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
-#: packages/admin/src/components/ContentTypeList.tsx:245
+#: packages/admin/src/components/ContentTypeList.tsx:246
 #: packages/admin/src/components/Dashboard.tsx:42
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:365
@@ -1434,13 +1452,13 @@ msgstr ""
 msgid "Define a new taxonomy for classifying content"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:39
+#: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
-#: packages/admin/src/components/ContentTypeList.tsx:147
+#: packages/admin/src/components/ContentTypeList.tsx:148
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:256
 #: packages/admin/src/components/MenuEditor.tsx:372
@@ -1460,7 +1478,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: section.title
-#: packages/admin/src/components/ContentTypeList.tsx:228
+#: packages/admin/src/components/ContentTypeList.tsx:229
 #: packages/admin/src/components/Sections.tsx:406
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
@@ -1481,7 +1499,7 @@ msgstr ""
 msgid "Delete Comment?"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:141
+#: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
 msgstr ""
 
@@ -1528,7 +1546,7 @@ msgid "Deleted"
 msgstr ""
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
-#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/ContentTypeList.tsx:149
 #: packages/admin/src/components/MediaDetailPanel.tsx:231
 #: packages/admin/src/components/MediaDetailPanel.tsx:257
 #: packages/admin/src/components/MenuList.tsx:210
@@ -1752,7 +1770,7 @@ msgstr ""
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
 #. placeholder {0}: term.label
-#: packages/admin/src/components/ContentTypeList.tsx:219
+#: packages/admin/src/components/ContentTypeList.tsx:220
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
@@ -1977,7 +1995,7 @@ msgstr ""
 msgid "Facebook"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+#: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
 msgstr ""
 
@@ -2038,7 +2056,7 @@ msgstr ""
 msgid "Failed to load plugins: {0}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:179
+#: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "Feature"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:102
+#: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
 msgstr ""
 
@@ -2145,7 +2163,7 @@ msgstr ""
 msgid "files imported"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:105
+#: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
 msgstr ""
 
@@ -2226,10 +2244,6 @@ msgstr "标题 3"
 msgid "Height"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Hide"
-msgstr ""
-
 #: packages/admin/src/components/SeoPanel.tsx:89
 msgid "Hide from search engines"
 msgstr ""
@@ -2247,6 +2261,10 @@ msgstr ""
 msgid "Hits"
 msgstr ""
 
+#: packages/admin/src/components/MenuEditor.tsx:272
+msgid "Home"
+msgstr ""
+
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
 msgstr ""
@@ -2259,7 +2277,11 @@ msgstr ""
 msgid "How to create an Application Password"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:280
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
 msgstr ""
@@ -2290,7 +2312,7 @@ msgstr ""
 msgid "Image shown when this page is shared on social media"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:373
+#: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
 msgstr ""
 
@@ -2396,8 +2418,8 @@ msgstr ""
 msgid "Incompatible"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:384
-#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MediaPickerModal.tsx:385
+#: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
 msgstr ""
 
@@ -2421,7 +2443,7 @@ msgstr "插入可复用区块"
 msgid "Insert an image"
 msgstr "插入图片"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
 msgstr ""
 
@@ -2445,7 +2467,7 @@ msgstr ""
 msgid "Install blocked"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
 msgstr ""
@@ -2481,7 +2503,7 @@ msgid "Invite User"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:217
+#: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
 msgstr ""
 
@@ -2495,11 +2517,6 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
-
-#: packages/admin/src/components/ContentTypeList.tsx:68
-#: packages/admin/src/components/RepeaterField.tsx:130
-msgid "items"
 msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:238
@@ -2616,7 +2633,7 @@ msgid "Live View"
 msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
 msgstr ""
@@ -2626,7 +2643,7 @@ msgstr ""
 msgid "Load More"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:113
+#: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
 msgstr ""
 
@@ -2676,7 +2693,7 @@ msgstr ""
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 #: packages/admin/src/components/ContentPickerModal.tsx:238
-#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:181
 #: packages/admin/src/components/settings/SecuritySettings.tsx:117
 #: packages/admin/src/components/TaxonomyManager.tsx:583
@@ -2767,7 +2784,7 @@ msgstr ""
 msgid "marketplace"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:85
+#: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -2961,7 +2978,7 @@ msgstr ""
 msgid "My Awesome Blog"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:93
+#: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
 #: packages/admin/src/components/TaxonomyManager.tsx:241
 #: packages/admin/src/components/TaxonomyManager.tsx:464
@@ -2998,7 +3015,7 @@ msgstr ""
 msgid "New collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:43
+#: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
 msgstr ""
 
@@ -3099,7 +3116,7 @@ msgstr ""
 msgid "No content in this collection"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:119
+#: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
 msgstr ""
 
@@ -3127,7 +3144,7 @@ msgstr ""
 msgid "No expiry"
 msgstr "永不过期"
 
-#: packages/admin/src/components/RevisionHistory.tsx:326
+#: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
 msgstr ""
 
@@ -3135,7 +3152,7 @@ msgstr ""
 msgid "No headings in document"
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:143
+#: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
 msgstr ""
 
@@ -3153,12 +3170,12 @@ msgid "No maximum"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
-#: packages/admin/src/components/MediaPickerModal.tsx:496
+#: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
-#: packages/admin/src/components/MediaPickerModal.tsx:490
+#: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
 msgstr ""
 
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "No plugins configured"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+#: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
 msgstr ""
 
@@ -3211,7 +3228,7 @@ msgstr ""
 msgid "No results"
 msgstr "无结果"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
 msgstr ""
@@ -3224,7 +3241,7 @@ msgstr ""
 msgid "No results found"
 msgstr "未找到结果"
 
-#: packages/admin/src/components/RevisionHistory.tsx:182
+#: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
 msgstr ""
 
@@ -3326,7 +3343,7 @@ msgstr ""
 msgid "Options (one per line)"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:396
+#: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
 msgstr ""
 
@@ -3389,7 +3406,7 @@ msgstr ""
 msgid "Part of a redirect loop"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+#: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
 msgstr ""
 
@@ -3502,7 +3519,7 @@ msgstr ""
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:283
+#: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
 msgstr ""
 
@@ -3599,6 +3616,10 @@ msgstr ""
 msgid "Previous screenshot"
 msgstr ""
 
+#: packages/admin/src/components/MenuList.tsx:137
+msgid "Primary Navigation"
+msgstr ""
+
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
 msgstr ""
@@ -3691,7 +3712,7 @@ msgstr ""
 msgid "Reference"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:77
+#: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
 msgstr ""
 
@@ -3713,11 +3734,11 @@ msgstr ""
 #: packages/admin/src/components/settings/GeneralSettings.tsx:202
 #: packages/admin/src/components/settings/GeneralSettings.tsx:246
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
-#: packages/admin/src/components/settings/PasskeyItem.tsx:205
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
@@ -3747,8 +3768,12 @@ msgid "Remove Image?"
 msgstr ""
 
 #. placeholder {0}: index + 1
-#: packages/admin/src/components/RepeaterField.tsx:253
+#: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
 msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
@@ -3764,7 +3789,7 @@ msgid "Remove this image from the document?"
 msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
-#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
 msgstr ""
 
@@ -3772,9 +3797,13 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#. placeholder {0}: passkey.name || "passkey"
+#. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
 msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -3835,7 +3864,7 @@ msgstr ""
 msgid "Reset to original"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:219
+#: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
 msgstr ""
 
@@ -3843,29 +3872,29 @@ msgstr ""
 msgid "Restore {title}"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:135
+#: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:213
+#: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:280
 #: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
 msgstr ""
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
-#: packages/admin/src/components/RevisionHistory.tsx:216
+#: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:220
+#: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
 msgstr ""
@@ -3878,12 +3907,12 @@ msgstr ""
 msgid "Review New Permissions"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:129
+#: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
 msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
-#: packages/admin/src/components/RevisionHistory.tsx:160
+#: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
 msgstr "修订版本"
 
@@ -4102,7 +4131,7 @@ msgstr ""
 msgid "Search engine optimization and verification"
 msgstr "搜索引擎优化和验证"
 
-#: packages/admin/src/components/MediaPickerModal.tsx:440
+#: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
 msgstr ""
 
@@ -4110,7 +4139,7 @@ msgstr ""
 msgid "Search pages and content..."
 msgstr "搜索页面和内容..."
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:95
+#: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
 msgstr ""
 
@@ -4128,7 +4157,7 @@ msgid "Search themes..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
-#: packages/admin/src/components/MediaPickerModal.tsx:439
+#: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
 msgstr ""
 
@@ -4191,11 +4220,11 @@ msgstr "安全"
 msgid "Security Audit"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:337
+#: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:327
+#: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
 msgstr ""
 
@@ -4207,7 +4236,7 @@ msgstr ""
 msgid "Security audit flagged this plugin as potentially unsafe."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:316
+#: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
 msgstr ""
 
@@ -4257,6 +4286,10 @@ msgstr ""
 msgid "Select image"
 msgstr ""
 
+#: packages/admin/src/components/MediaPickerModal.tsx:71
+msgid "Select Image"
+msgstr ""
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
@@ -4274,11 +4307,11 @@ msgstr ""
 msgid "Select which content types to import."
 msgstr ""
 
-#: packages/admin/src/components/RepeaterField.tsx:348
+#: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:570
+#: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
 msgstr ""
 
@@ -4386,10 +4419,6 @@ msgstr ""
 msgid "Short Text"
 msgstr ""
 
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "Show"
-msgstr ""
-
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
 msgstr "显示令牌"
@@ -4490,7 +4519,7 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1574
 #: packages/admin/src/components/ContentEditor.tsx:1636
 #: packages/admin/src/components/ContentTypeEditor.tsx:109
-#: packages/admin/src/components/ContentTypeList.tsx:96
+#: packages/admin/src/components/ContentTypeList.tsx:97
 #: packages/admin/src/components/FieldEditor.tsx:223
 #: packages/admin/src/components/FieldEditor.tsx:399
 #: packages/admin/src/components/SectionEditor.tsx:197
@@ -4533,7 +4562,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:121
+#: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
 msgstr ""
 
@@ -4541,7 +4570,7 @@ msgstr ""
 msgid "Sort themes"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:99
+#: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:225
@@ -4665,7 +4694,7 @@ msgstr ""
 msgid "The existing collection has fields with incompatible types."
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:57
+#: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
 msgstr ""
 
@@ -4678,7 +4707,7 @@ msgstr ""
 msgid "The link will expire in 15 minutes."
 msgstr "链接将在 15 分钟后过期。"
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+#: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
 msgstr ""
 
@@ -4893,7 +4922,7 @@ msgid "True/false toggle"
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
-#: packages/admin/src/components/MediaPickerModal.tsx:493
+#: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
 msgstr ""
 
@@ -4938,7 +4967,7 @@ msgstr ""
 msgid "Type mismatch ({0})"
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:135
+#: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
 msgstr ""
@@ -4946,10 +4975,6 @@ msgstr ""
 #: packages/admin/src/components/ContentEditor.tsx:1679
 #: packages/admin/src/components/ContentEditor.tsx:1694
 msgid "Unassigned"
-msgstr ""
-
-#: packages/admin/src/components/RevisionHistory.tsx:344
-msgid "unchanged"
 msgstr ""
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
@@ -5002,7 +5027,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: packages/admin/src/components/ContentTypeList.tsx:54
+#: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
 msgstr ""
 
@@ -5063,7 +5088,7 @@ msgstr ""
 msgid "Updating..."
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
 msgstr ""
 
@@ -5071,7 +5096,7 @@ msgstr ""
 msgid "Upload an export file"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:495
+#: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
 msgstr ""
 
@@ -5084,7 +5109,7 @@ msgstr "上传和删除媒体"
 msgid "Upload Export File"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
 msgstr ""
 
@@ -5096,7 +5121,7 @@ msgstr ""
 msgid "Upload Files"
 msgstr ""
 
-#: packages/admin/src/components/MediaPickerModal.tsx:504
+#: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
 msgstr ""
 
@@ -5136,7 +5161,7 @@ msgid "Uploading {0}/{1}..."
 msgstr ""
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
-#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
 msgstr ""
 
@@ -5267,7 +5292,7 @@ msgstr ""
 msgid "Waiting for passkey..."
 msgstr ""
 
-#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+#: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
 msgstr ""
 
@@ -5392,9 +5417,13 @@ msgstr ""
 msgid "You have full access to manage this site, including users, settings, and all content."
 msgstr "您拥有完全访问权限来管理此网站，包括用户、设置和所有内容。"
 
-#. placeholder {0}: passkey.name || "this passkey"
-#: packages/admin/src/components/settings/PasskeyItem.tsx:204
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
 msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369


### PR DESCRIPTION
## What does this PR do?

Completes i18n coverage of the admin UI. Every user-visible string in every admin component is now wrapped with Lingui's `t\`...\`` macro and will appear translated when a locale catalog covers it.

This is part 2 of the i18n rollout (part 1 was #521).

**Catalog growth: 296 → 1,216 message IDs (+920)**

**Components covered:**
- Media: MediaLibrary, MediaDetailPanel, MediaPickerModal
- Menus: MenuList, MenuEditor
- Structure: Sections, SectionEditor, SectionPickerModal, Redirects
- Taxonomies: TaxonomyManager, TaxonomySidebar
- Content types: ContentTypeList, FieldEditor
- Plugins: PluginManager, MarketplaceBrowse, MarketplacePluginDetail, ThemeMarketplaceBrowse, ThemeMarketplaceDetail, CapabilityConsentDialog
- Content management: RevisionHistory, RepeaterField, ConfirmDialog, ContentPickerModal
- SEO: SeoPanel, SeoImageField, editor/ImageDetailPanel, editor/DocumentOutline
- Settings: AllowedDomainsSettings, PasskeyItem, SeoSettings, SocialSettings
- One-time flows: WordPressImport, SetupWizard, SignupPage, DeviceAuthorizePage
- Auth: PasskeyLogin, PasskeyRegistration

**Patterns used:**
- `t\`...\`` tagged template for inline strings
- `plural(count, { one: "# item", other: "# items" })` for count-based strings
- Each sub-component has its own `useLingui()` call
- User-generated content (names, slugs, body text) left unwrapped

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code