### PR TITLE
fix: reduce cold-start D1 queries from 159 to ~25

### DIFF
--- a/.changeset/wide-flies-think.md
+++ b/.changeset/wide-flies-think.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes cold-start query explosion (159 -> ~25 queries) by short-circuiting migrations when all are applied, fixing FTS triggers to exclude soft-deleted content, and preventing false-positive FTS index rebuilds on every startup.

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -1,4 +1,4 @@
-import { type Kysely, type Migration, type MigrationProvider, Migrator } from "kysely";
+import { type Kysely, type Migration, type MigrationProvider, Migrator, sql } from "kysely";
 
 import type { Database } from "../types.js";
 // Import migrations statically for bundling
@@ -122,9 +122,30 @@ export async function getMigrationStatus(db: Kysely<Database>): Promise<Migratio
 }
 
 /**
- * Run all pending migrations
+ * Run all pending migrations.
+ *
+ * Includes a fast-path: if the migration table already exists and contains
+ * exactly MIGRATION_COUNT rows, all migrations have been applied and we can
+ * skip the Kysely Migrator entirely. This avoids the expensive
+ * `pragma_table_info` introspection that Kysely runs for every table in the
+ * database (twice!) just to check if the migration tables exist.
+ * On D1 with ~57 tables, that's ~116 queries saved per init.
  */
 export async function runMigrations(db: Kysely<Database>): Promise<{ applied: string[] }> {
+	// Fast path: check if all migrations are already applied.
+	// A single cheap query vs the Migrator's full schema introspection.
+	try {
+		const result = await sql<{ count: number }>`
+			SELECT COUNT(*) as count FROM ${sql.ref(MIGRATION_TABLE)}
+		`.execute(db);
+		if (result.rows[0]?.count === MIGRATION_COUNT) {
+			return { applied: [] };
+		}
+	} catch {
+		// Table doesn't exist yet (first run). Fall through to the Migrator
+		// which will create it.
+	}
+
 	const migrator = new Migrator({
 		db,
 		provider: new StaticMigrationProvider(),

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -100,7 +100,12 @@ export class FTSManager {
 	}
 
 	/**
-	 * Create triggers to keep FTS table in sync with content table
+	 * Create triggers to keep FTS table in sync with content table.
+	 *
+	 * The insert and update triggers only add rows to the FTS index when
+	 * `deleted_at IS NULL`. This keeps soft-deleted content out of the
+	 * search index and ensures the FTS row count matches the non-deleted
+	 * content count (which `verifyAndRepairIndex` relies on).
 	 */
 	private async createTriggers(collectionSlug: string, searchableFields: string[]): Promise<void> {
 		this.validateInputs(collectionSlug, searchableFields);
@@ -109,11 +114,12 @@ export class FTSManager {
 		const fieldList = searchableFields.join(", ");
 		const newFieldList = searchableFields.map((f) => `NEW.${f}`).join(", ");
 
-		// Insert trigger
+		// Insert trigger - only index non-deleted content
 		await sql
 			.raw(`
 			CREATE TRIGGER IF NOT EXISTS "${ftsTable}_insert" 
 			AFTER INSERT ON "${contentTable}" 
+			WHEN NEW.deleted_at IS NULL
 			BEGIN
 				INSERT INTO "${ftsTable}"(rowid, id, locale, ${fieldList})
 				VALUES (NEW.rowid, NEW.id, NEW.locale, ${newFieldList});
@@ -121,7 +127,9 @@ export class FTSManager {
 		`)
 			.execute(this.db);
 
-		// Update trigger - delete old, insert new
+		// Update trigger - always remove the old FTS row, only re-insert
+		// if the row is not soft-deleted. This handles both content edits
+		// and soft-delete operations (UPDATE SET deleted_at = ...).
 		await sql
 			.raw(`
 			CREATE TRIGGER IF NOT EXISTS "${ftsTable}_update" 
@@ -129,7 +137,8 @@ export class FTSManager {
 			BEGIN
 				DELETE FROM "${ftsTable}" WHERE rowid = OLD.rowid;
 				INSERT INTO "${ftsTable}"(rowid, id, locale, ${fieldList})
-				VALUES (NEW.rowid, NEW.id, NEW.locale, ${newFieldList});
+				SELECT NEW.rowid, NEW.id, NEW.locale, ${newFieldList}
+				WHERE NEW.deleted_at IS NULL;
 			END
 		`)
 			.execute(this.db);
@@ -291,9 +300,12 @@ export class FTSManager {
 	}
 
 	/**
-	 * Enable search for a collection
+	 * Enable search for a collection.
 	 *
-	 * Creates the FTS table and triggers, and populates from existing content.
+	 * Uses rebuildIndex to ensure a clean state -- drop any existing FTS
+	 * table/triggers, recreate them, and populate from content. This avoids
+	 * duplicate rows when triggers have already populated the index (e.g.
+	 * during seeding where content is inserted before search is enabled).
 	 */
 	async enableSearch(
 		collectionSlug: string,
@@ -312,11 +324,8 @@ export class FTSManager {
 			);
 		}
 
-		// Create FTS table
-		await this.createFtsTable(collectionSlug, searchableFields, options?.weights);
-
-		// Populate from existing content
-		await this.populateFromContent(collectionSlug, searchableFields);
+		// Rebuild from scratch to ensure clean state (no duplicate rows)
+		await this.rebuildIndex(collectionSlug, searchableFields, options?.weights);
 
 		// Update search config
 		await this.setSearchConfig(collectionSlug, {


### PR DESCRIPTION
## What does this PR do?

Fixes a cold-start query explosion where every Worker cold start on D1 executes 159+ queries and takes 3s+ to load. Reduces to ~25 queries.

A user reported 150+ D1 queries per pageload. Root cause analysis of the query log revealed three compounding issues:

1. **Kysely Migrator introspects the entire schema twice** (~116 queries on D1). The Migrator calls `pragma_table_info()` for every table in the database -- twice -- just to check if two migration tables exist. On D1 (which can't use cross-joins with pragma functions), each check is a separate query per table.

2. **FTS triggers keep soft-deleted content in the search index**, causing a count mismatch between the FTS and content tables. `verifyAndRepairAll()` at startup detects the mismatch and triggers a full DROP/CREATE/INSERT rebuild for every search-enabled collection -- on every cold start.

3. **`enableSearch()` double-populates the FTS index** during seeding. Triggers insert rows during content creation, then `enableSearch()` does a second bulk INSERT, doubling the row count and guaranteeing a mismatch on the next startup.

### Changes

**Migration short-circuit** (`runner.ts`): Before creating the Kysely Migrator, do a single `SELECT COUNT(*) FROM _emdash_migrations`. If the count matches the known migration count, all migrations are applied -- skip the Migrator entirely. Saves ~116 queries on D1.

**FTS trigger fix** (`fts-manager.ts`): The INSERT trigger now has `WHEN NEW.deleted_at IS NULL`. The UPDATE trigger uses a conditional INSERT (`INSERT ... SELECT ... WHERE NEW.deleted_at IS NULL`) so soft-deleted content is removed from the FTS index instead of being re-inserted. This keeps FTS and content counts in sync, preventing false-positive rebuilds.

**enableSearch() uses rebuildIndex** (`fts-manager.ts`): Instead of `createFtsTable()` + `populateFromContent()` (which appends to existing trigger-populated rows), uses `rebuildIndex()` which drops and recreates cleanly.

### Before vs After (D1, 3 search-enabled collections, ~57 tables)

| Category | Before | After |
|----------|--------|-------|
| Migration check | ~116 queries | 1 query |
| FTS verification | ~90 queries (3 full rebuilds) | ~6 queries (3 count checks) |
| Other init queries | ~10 queries | ~10 queries |
| Page content queries | ~8 queries | ~8 queries |
| **Total** | **~159 queries** | **~25 queries** |

## Type of change

- [x] Bug fix
- [x] Performance improvement

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code