### PR TITLE
fix: support built plugin entrypoints

### DIFF
--- a/.changeset/fix-plugin-bundle-built-entries.md
+++ b/.changeset/fix-plugin-bundle-built-entries.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes plugin bundling for built JavaScript entrypoints so marketplace validation works with packaged plugin exports.

--- a/lunaria.config.ts
+++ b/lunaria.config.ts
@@ -1,6 +1,25 @@
 import { defineConfig } from "@lunariajs/core/config";
 
-import { SOURCE_LOCALE, TARGET_LOCALES } from "./packages/admin/src/locales/locales.js";
+import {
+	SOURCE_LOCALE,
+	TARGET_LOCALES,
+	type LocaleDefinition,
+} from "./packages/admin/src/locales/locales.js";
+
+type LunariaLocale = { label: string; lang: string };
+
+function toNonEmptyLunariaLocales(
+	locales: LocaleDefinition[],
+): [LunariaLocale, ...LunariaLocale[]] {
+	const [first, ...rest] = locales.map((l) => ({
+		label: l.label,
+		lang: l.code,
+	}));
+	if (!first) throw new Error("Lunaria requires at least one target locale");
+	return [first, ...rest];
+}
+
+const locales = toNonEmptyLunariaLocales(TARGET_LOCALES);
 
 export default defineConfig({
 	repository: {
@@ -11,10 +30,7 @@ export default defineConfig({
 		label: SOURCE_LOCALE.label,
 		lang: SOURCE_LOCALE.code,
 	},
-	locales: TARGET_LOCALES.map((l) => ({
-		label: l.label,
-		lang: l.code,
-	})) as [{ label: string; lang: string }, ...{ label: string; lang: string }[]],
+	locales,
 	files: [
 		{
 			include: ["packages/admin/src/locales/en/messages.po"],

--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 			babel: {
 				plugins: ["@lingui/babel-plugin-lingui-macro"],
 			},
-		}) as Plugin[],
+		}),
 	],
 	test: {
 		globals: true,

--- a/packages/core/src/api/handlers/redirects.ts
+++ b/packages/core/src/api/handlers/redirects.ts
@@ -318,7 +318,7 @@ export async function handleRedirectDelete(
 function loopError(loopPath: string[]): ApiResult<never> {
 	const hops = loopPath
 		.slice(0, -1)
-		.map((p, i) => `${p} \u2192 ${loopPath[i + 1]!}`)
+		.map((p, i) => `${p} \u2192 ${loopPath[i + 1]}`)
 		.join("\n");
 	return {
 		success: false,

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -305,7 +305,7 @@ export function createViteConfig(
 			// In dev mode with source alias, compile Lingui macros on the fly
 			// and redirect locale .mjs imports to dist/.
 			// In production, macros are pre-compiled by tsdown in the admin package.
-			...(useSource ? [linguiMacroPlugin(adminSourcePath!, adminDistPath)] : []),
+			...(useSource ? [linguiMacroPlugin(adminSourcePath, adminDistPath)] : []),
 		] as NonNullable<AstroConfig["vite"]>["plugins"],
 		// Handle native modules for SSR.
 		// On Node: external keeps native addons out of the SSR bundle.

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -14,6 +14,10 @@ import { contentListQuery, contentCreateBody } from "#api/schemas.js";
 
 export const prerender = false;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
 	const denied = requirePerm(user, "content:read");
@@ -53,14 +57,8 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 				mapErrorStatus(source.error?.code),
 			);
 		}
-		const sourceData =
-			source.data && typeof source.data === "object"
-				? (source.data as Record<string, unknown>)
-				: undefined;
-		const sourceItem =
-			sourceData?.item && typeof sourceData.item === "object"
-				? (sourceData.item as Record<string, unknown>)
-				: sourceData;
+		const sourceData = isRecord(source.data) ? source.data : undefined;
+		const sourceItem = isRecord(sourceData?.item) ? sourceData.item : sourceData;
 		const sourceAuthor = typeof sourceItem?.authorId === "string" ? sourceItem.authorId : "";
 		const translationDenied = requireOwnerPerm(
 			user,

--- a/packages/core/src/cli/commands/bundle-utils.ts
+++ b/packages/core/src/cli/commands/bundle-utils.ts
@@ -7,7 +7,7 @@
 
 import { createWriteStream } from "node:fs";
 import { readdir, stat, access } from "node:fs/promises";
-import { resolve, join } from "node:path";
+import { basename, resolve, join } from "node:path";
 import { pipeline } from "node:stream/promises";
 
 import { imageSize } from "image-size";
@@ -36,6 +36,7 @@ const LEADING_DOT_SLASH_RE = /^\.\//;
 const DIST_PREFIX_RE = /^dist\//;
 const MJS_EXT_RE = /\.m?js$/;
 const TS_TO_TSX_RE = /\.ts$/;
+const BUILD_OUTPUT_ENTRY_EXT_RE = /\.(?:[cm]?js|tsx?)$/;
 
 /** Node.js built-in modules that shouldn't appear in sandbox code */
 const NODE_BUILTINS = new Set([
@@ -173,6 +174,14 @@ export function findNodeBuiltinImports(code: string): string[] {
 }
 
 // ── Path resolution ──────────────────────────────────────────────────────────
+
+/**
+ * Get the base name tsdown uses for an entry output.
+ * Handles both source entries (`index.ts`) and built package exports (`index.mjs`).
+ */
+export function getBuildOutputBaseName(entry: string): string {
+	return basename(entry).replace(BUILD_OUTPUT_ENTRY_EXT_RE, "");
+}
 
 /**
  * Find a build output file by base name, checking common extensions.

--- a/packages/core/src/cli/commands/bundle.ts
+++ b/packages/core/src/cli/commands/bundle.ts
@@ -15,7 +15,7 @@
 
 import { createHash } from "node:crypto";
 import { readFile, stat, mkdir, writeFile, rm, copyFile, symlink, readdir } from "node:fs/promises";
-import { resolve, join, extname, basename } from "node:path";
+import { resolve, join, extname } from "node:path";
 
 import { defineCommand } from "citty";
 import consola from "consola";
@@ -27,6 +27,7 @@ import {
 	extractManifest,
 	findNodeBuiltinImports,
 	findBuildOutput,
+	getBuildOutputBaseName,
 	findSourceExports,
 	resolveSourceEntry,
 	calculateDirectorySize,
@@ -38,7 +39,6 @@ import {
 	ICON_SIZE,
 } from "./bundle-utils.js";
 
-const TS_EXT_RE = /\.tsx?$/;
 const SLASH_RE = /\//g;
 const LEADING_AT_RE = /^@/;
 const emdash_SCOPE_RE = /^@emdash-cms\//;
@@ -188,7 +188,7 @@ export const bundleCommand = defineCommand({
 			}
 
 			// Import the built module to get the resolved plugin
-			const mainBaseName = basename(mainEntry).replace(TS_EXT_RE, "");
+			const mainBaseName = getBuildOutputBaseName(mainEntry);
 			const mainOutputPath = await findBuildOutput(mainOutDir, mainBaseName);
 
 			if (!mainOutputPath) {
@@ -261,7 +261,7 @@ export const bundleCommand = defineCommand({
 									alias: { emdash: join(probeShimDir, "emdash.mjs") },
 									treeshake: true,
 								});
-								const backendBaseName = basename(backendEntry).replace(TS_EXT_RE, "");
+								const backendBaseName = getBuildOutputBaseName(backendEntry);
 								const backendProbePath = await findBuildOutput(backendProbeDir, backendBaseName);
 								if (backendProbePath) {
 									const backendModule = (await import(backendProbePath)) as Record<string, unknown>;
@@ -380,7 +380,7 @@ export const bundleCommand = defineCommand({
 					treeshake: true,
 				});
 
-				const backendBaseName = basename(backendEntry).replace(TS_EXT_RE, "");
+				const backendBaseName = getBuildOutputBaseName(backendEntry);
 				const backendOutputPath = await findBuildOutput(join(tmpDir, "backend"), backendBaseName);
 
 				if (backendOutputPath) {
@@ -411,7 +411,7 @@ export const bundleCommand = defineCommand({
 					treeshake: true,
 				});
 
-				const adminBaseName = basename(adminEntry).replace(TS_EXT_RE, "");
+				const adminBaseName = getBuildOutputBaseName(adminEntry);
 				const adminOutputPath = await findBuildOutput(join(tmpDir, "admin"), adminBaseName);
 
 				if (adminOutputPath) {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -61,6 +61,12 @@ const VALID_LINK_REL = new Set([
 	"site.standard.document",
 ]);
 
+function parseStringArray(value: string): string[] {
+	const parsed: unknown = JSON.parse(value);
+	if (!Array.isArray(parsed)) return [];
+	return parsed.filter((item): item is string => typeof item === "string");
+}
+
 /**
  * Runtime validation for sandboxed plugin metadata contributions.
  * Sandboxed plugins return `unknown` across the RPC boundary — we must
@@ -1330,7 +1336,7 @@ export class EmDashRuntime {
 				label: row.label,
 				labelSingular: row.label_singular ?? undefined,
 				hierarchical: row.hierarchical === 1,
-				collections: row.collections ? (JSON.parse(row.collections) as string[]).toSorted() : [],
+				collections: row.collections ? parseStringArray(row.collections).toSorted() : [],
 			}));
 		} catch (error) {
 			console.debug("EmDash: Could not load taxonomy definitions:", error);

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -426,7 +426,7 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 			// Edit mode (authenticated editors) has collection-wide draft access.
 			if (isPreviewMode && !isEditMode) {
 				const dbId = entryDatabaseId(baseEntry);
-				if (preview!.id !== dbId && preview!.id !== id) {
+				if (preview.id !== dbId && preview.id !== id) {
 					// Token doesn't match — serve only if publicly visible, without draft access
 					if (isVisible(baseEntry)) {
 						return successResult(wrapEntry(baseEntry), {

--- a/packages/core/src/storage/s3.ts
+++ b/packages/core/src/storage/s3.ts
@@ -131,7 +131,8 @@ export class S3Storage implements Storage {
 		this.publicUrl = config.publicUrl;
 		this.endpoint = config.endpoint;
 
-		this.client = new S3Client({
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- S3ClientConfig requires credentials in types, but the SDK supports environment/default provider resolution.
+		const clientConfig = {
 			endpoint: config.endpoint,
 			region: config.region || "auto",
 			...(config.accessKeyId && config.secretAccessKey
@@ -144,7 +145,9 @@ export class S3Storage implements Storage {
 				: {}),
 			// Required for R2 and some S3-compatible services
 			forcePathStyle: true,
-		} as ConstructorParameters<typeof S3Client>[0]);
+		} as ConstructorParameters<typeof S3Client>[0];
+
+		this.client = new S3Client(clientConfig);
 	}
 
 	async upload(options: {

--- a/packages/core/tests/unit/cli/bundle-utils.test.ts
+++ b/packages/core/tests/unit/cli/bundle-utils.test.ts
@@ -21,6 +21,7 @@ import {
 	resolveSourceEntry,
 	findNodeBuiltinImports,
 	findBuildOutput,
+	getBuildOutputBaseName,
 	findSourceExports,
 } from "../../../src/cli/commands/bundle-utils.js";
 import type { ResolvedPlugin } from "../../../src/plugins/types.js";
@@ -246,6 +247,16 @@ describe("resolveSourceEntry", () => {
 	it("returns undefined when nothing matches", async () => {
 		const result = await resolveSourceEntry(tempDir, "./dist/missing.mjs");
 		expect(result).toBeUndefined();
+	});
+});
+
+describe("getBuildOutputBaseName", () => {
+	it("strips source and built entry extensions", () => {
+		expect(getBuildOutputBaseName("/tmp/plugin/src/index.ts")).toBe("index");
+		expect(getBuildOutputBaseName("/tmp/plugin/src/admin.tsx")).toBe("admin");
+		expect(getBuildOutputBaseName("/tmp/plugin/dist/index.mjs")).toBe("index");
+		expect(getBuildOutputBaseName("/tmp/plugin/dist/sandbox-entry.js")).toBe("sandbox-entry");
+		expect(getBuildOutputBaseName("/tmp/plugin/dist/worker.cjs")).toBe("worker");
 	});
 });
 

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -3,7 +3,16 @@ import { readFileSync } from "node:fs";
 
 import { defineConfig } from "tsdown";
 
-const pkg = JSON.parse(readFileSync("package.json", "utf-8")) as { version: string };
+function readPackageVersion(): string {
+	const parsed: unknown = JSON.parse(readFileSync("package.json", "utf-8"));
+	if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+		const { version } = parsed;
+		if (typeof version === "string") return version;
+	}
+	throw new Error("package.json is missing a string version");
+}
+
+const version = readPackageVersion();
 const commit = (() => {
 	try {
 		return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
@@ -58,7 +67,7 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	define: {
-		__EMDASH_VERSION__: JSON.stringify(pkg.version),
+		__EMDASH_VERSION__: JSON.stringify(version),
 		__EMDASH_COMMIT__: JSON.stringify(commit),
 	},
 	// Externalize native modules, dialect-specific packages, and internal shared modules


### PR DESCRIPTION
## What does this PR do?

Fixes plugin bundling when a plugin manifest points at built JavaScript entrypoints such as `dist/index.mjs`, `dist/sandbox-entry.js`, or `dist/worker.cjs`.

The bundle command previously derived tsdown output names by stripping only `.ts` / `.tsx`, so built JS entrypoints kept their extension in the base name and the CLI could miss the generated output. This adds a shared `getBuildOutputBaseName()` helper for source and built entrypoints, uses it for main/backend/admin bundle outputs, and adds unit coverage for `.ts`, `.tsx`, `.mjs`, `.js`, and `.cjs` entries.

Scope note: this branch is based directly on `origin/main` and includes a second commit with the current type-aware lint baseline fixes that were already present in #184, solely so this PR passes independently against `main`. It does not include the PortableText plugin-block changes from #184. If maintainers prefer to merge baseline cleanup elsewhere first, this draft can be rebased to drop that support commit.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable; no admin UI strings changed)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — bug fix, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Not visual.

Validation run locally:

- `pnpm --silent lint:quick` → passed
- `pnpm --silent lint:json | jq '.diagnostics | length'` → `0`
- `pnpm format` → passed
- `pnpm typecheck` → passed
- `pnpm --filter emdash test -- tests/unit/cli/bundle-utils.test.ts` → passed (`135` files / `2353` tests; this command runs the core package vitest suite under the current config)
