### PR TITLE
fix(core): render Table cell content through Portable Text pipeline

### DIFF
--- a/.changeset/table-mark-rendering.md
+++ b/.changeset/table-mark-rendering.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Table block to render inline marks (bold, italic, code, links, etc.) through the Portable Text pipeline instead of stripping them to plain text. Links are sanitized via `sanitizeHref()`. Table styles now use CSS custom properties with fallbacks.

--- a/packages/core/src/components/Table.astro
+++ b/packages/core/src/components/Table.astro
@@ -2,8 +2,13 @@
 /**
  * Portable Text Table block component
  *
- * Renders tables from WordPress imports.
+ * Renders tables from content imports. Cell content is rendered through the
+ * standard Portable Text pipeline so all marks (bold, italic, links, etc.) are
+ * handled by the registered mark components -- including `sanitizeHref` for links.
  */
+import { PortableText } from "astro-portabletext";
+import { emdashMarkComponents } from "./marks.js";
+
 export interface Props {
 	node: {
 		_type: "table";
@@ -32,6 +37,8 @@ export interface Props {
 	};
 }
 
+const markComponents = { mark: emdashMarkComponents };
+
 const { node } = Astro.props;
 const rows = node?.rows ?? [];
 
@@ -39,45 +46,65 @@ if (!rows.length) {
 	return null;
 }
 
-// Helper to render cell content as text (simplified - doesn't handle marks)
-function renderCellText(
-	content: Array<{ text: string; marks?: string[] }>,
-): string {
-	return content.map((span) => span.text).join("");
+/**
+ * Wrap a table cell's inline content as a Portable Text block so it can be
+ * rendered through the standard pipeline (marks, markDefs, etc.).
+ */
+function cellToBlock(cell: Props["node"]["rows"][number]["cells"][number]) {
+	return [
+		{
+			_type: "block" as const,
+			_key: cell._key,
+			children: cell.content,
+			markDefs: cell.markDefs ?? [],
+		},
+	];
 }
+
+const hasHeader = node?.hasHeaderRow;
+const headerRow = hasHeader ? rows[0] : null;
+const bodyRows = hasHeader ? rows.slice(1) : rows;
 ---
 
-{() => {
-	const hasHeader = node?.hasHeaderRow;
-	const headerRow = hasHeader ? rows[0] : null;
-	const bodyRows = hasHeader ? rows.slice(1) : rows;
-
-	return (
-		<div class="emdash-table-wrapper">
-			<table class="emdash-table">
-				{headerRow && (
-					<thead>
-						<tr>
-							{headerRow.cells.map((cell) => (
-								<th>{renderCellText(cell.content)}</th>
-							))}
-						</tr>
-					</thead>
-				)}
-				<tbody>
-					{bodyRows.map((row) => (
-						<tr>
-							{row.cells.map((cell) => {
-								const CellTag = cell.isHeader ? "th" : "td";
-								return <CellTag>{renderCellText(cell.content)}</CellTag>;
-							})}
-						</tr>
-					))}
-				</tbody>
-			</table>
-		</div>
-	);
-}}
+<div class="emdash-table-wrapper">
+	<table class="emdash-table">
+		{
+			headerRow && (
+				<thead>
+					<tr>
+						{headerRow.cells.map((cell) => (
+							<th>
+								<PortableText
+									value={cellToBlock(cell)}
+									components={markComponents}
+								/>
+							</th>
+						))}
+					</tr>
+				</thead>
+			)
+		}
+		<tbody>
+			{
+				bodyRows.map((row) => (
+					<tr>
+						{row.cells.map((cell) => {
+							const CellTag = cell.isHeader ? "th" : "td";
+							return (
+								<CellTag>
+									<PortableText
+										value={cellToBlock(cell)}
+										components={markComponents}
+									/>
+								</CellTag>
+							);
+						})}
+					</tr>
+				))
+			}
+		</tbody>
+	</table>
+</div>
 
 <style>
 	.emdash-table-wrapper {
@@ -91,18 +118,23 @@ function renderCellText(
 	}
 	.emdash-table th,
 	.emdash-table td {
-		border: 1px solid #ddd;
+		border: 1px solid var(--color-border, #ddd);
 		padding: 0.75rem;
 		text-align: left;
 	}
+	/* Remove default block margins inside cells */
+	.emdash-table th :global(p),
+	.emdash-table td :global(p) {
+		margin: 0;
+	}
 	.emdash-table th {
-		background: #f5f5f5;
+		background: var(--color-surface, #f5f5f5);
 		font-weight: 600;
 	}
 	.emdash-table tbody tr:nth-child(even) {
-		background: #fafafa;
+		background: var(--color-bg-subtle, #fafafa);
 	}
 	.emdash-table tbody tr:hover {
-		background: #f0f0f0;
+		background: var(--color-surface, #f0f0f0);
 	}
 </style>

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -69,11 +69,7 @@ import GalleryComponent from "./Gallery.astro";
 import HtmlBlockComponent from "./HtmlBlock.astro";
 // Pre-configured components object for PortableText
 import ImageComponent from "./Image.astro";
-import LinkMark from "./marks/Link.astro";
-import StrikeThroughMark from "./marks/StrikeThrough.astro";
-import SubscriptMark from "./marks/Subscript.astro";
-import SuperscriptMark from "./marks/Superscript.astro";
-import UnderlineMark from "./marks/Underline.astro";
+import { emdashMarkComponents } from "./marks.js";
 import PullquoteComponent from "./Pullquote.astro";
 import TableComponent from "./Table.astro";
 
@@ -101,13 +97,7 @@ export const emdashComponents = {
 		file: FileComponent,
 		pullquote: PullquoteComponent,
 	},
-	mark: {
-		superscript: SuperscriptMark,
-		subscript: SubscriptMark,
-		underline: UnderlineMark,
-		"strike-through": StrikeThroughMark,
-		link: LinkMark,
-	},
+	mark: emdashMarkComponents,
 };
 
 // Public page contribution components

--- a/packages/core/src/components/marks.ts
+++ b/packages/core/src/components/marks.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared mark component map for Portable Text rendering.
+ *
+ * Used by both the top-level `emdashComponents` config and individual block
+ * components (e.g. Table) that render nested inline content through the PT
+ * pipeline.
+ */
+import LinkMark from "./marks/Link.astro";
+import StrikeThroughMark from "./marks/StrikeThrough.astro";
+import SubscriptMark from "./marks/Subscript.astro";
+import SuperscriptMark from "./marks/Superscript.astro";
+import UnderlineMark from "./marks/Underline.astro";
+
+export const emdashMarkComponents = {
+	superscript: SuperscriptMark,
+	subscript: SubscriptMark,
+	underline: UnderlineMark,
+	"strike-through": StrikeThroughMark,
+	link: LinkMark,
+};


### PR DESCRIPTION
## What does this PR do?

The Table block component was rendering cell content as plain text, stripping all marks. This rewrites it to render cells through the `astro-portabletext` pipeline with EmDash's mark components, so all marks work (bold, italic, code, underline, strikethrough, superscript, subscript, links) and links go through `sanitizeHref()`. Also switches table styles to CSS properties, making it compatible with dark mode.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion (internal gchat)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Testing

Added a test page to the simple demo with hardcoded PT table data covering all mark types and a `javascript:` href XSS attempt. All marks rendered correctly and the XSS link was sanitized to `#`.