### PR TITLE
fix: use @layer to ensure theme.css overrides win over Base.astro defaults

### DIFF
--- a/templates/blog-cloudflare/src/layouts/Base.astro
+++ b/templates/blog-cloudflare/src/layouts/Base.astro
@@ -343,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -493,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 

--- a/templates/blog-cloudflare/src/styles/theme.css
+++ b/templates/blog-cloudflare/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/templates/blog/src/layouts/Base.astro
+++ b/templates/blog/src/layouts/Base.astro
@@ -343,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -493,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 

--- a/templates/blog/src/styles/theme.css
+++ b/templates/blog/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/theme.css";
 
 interface Props {
 	title?: string;
@@ -212,81 +213,104 @@ const pageCtx = createPublicPageContext({
 		</script>
 
 		<style is:global>
-			*,
-			*::before,
-			*::after {
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			:root {
-				/* Colors - Playful/Bold palette */
-				--color-bg: #ffffff;
-				--color-text: #0f172a;
-				--color-muted: #64748b;
-				--color-border: #e2e8f0;
-				--color-surface: #f8fafc;
-				--color-primary: #6366f1;
-				--color-primary-dark: #4f46e5;
-				--color-primary-light: #818cf8;
-				--color-accent: #f472b6;
-				--color-accent-light: #f9a8d4;
-				--color-success: #22c55e;
-				--color-warning: #f59e0b;
+			@layer base {
+				*,
+				*::before,
+				*::after {
+					box-sizing: border-box;
+					margin: 0;
+					padding: 0;
+				}
 
-				/* Typography */
-				--font-mono: ui-monospace, "SF Mono", monospace;
+				:root {
+					/* Colors - Playful/Bold palette */
+					--color-bg: #ffffff;
+					--color-text: #0f172a;
+					--color-muted: #64748b;
+					--color-border: #e2e8f0;
+					--color-surface: #f8fafc;
+					--color-primary: #6366f1;
+					--color-primary-dark: #4f46e5;
+					--color-primary-light: #818cf8;
+					--color-accent: #f472b6;
+					--color-accent-light: #f9a8d4;
+					--color-success: #22c55e;
+					--color-warning: #f59e0b;
 
-				--font-size-xs: 0.75rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
-				--font-size-6xl: 4.5rem;
+					/* Typography */
+					--font-mono: ui-monospace, "SF Mono", monospace;
 
-				/* Spacing */
-				--spacing-xs: 0.25rem;
-				--spacing-sm: 0.5rem;
-				--spacing-md: 1rem;
-				--spacing-lg: 1.5rem;
-				--spacing-xl: 2rem;
-				--spacing-2xl: 3rem;
-				--spacing-3xl: 4rem;
-				--spacing-4xl: 6rem;
-				--spacing-5xl: 8rem;
+					--font-size-xs: 0.75rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
+					--font-size-6xl: 4.5rem;
 
-				/* Layout */
-				--max-width: 720px;
-				--wide-width: 1200px;
-				--radius-sm: 6px;
-				--radius: 10px;
-				--radius-lg: 16px;
-				--radius-full: 9999px;
+					/* Spacing */
+					--spacing-xs: 0.25rem;
+					--spacing-sm: 0.5rem;
+					--spacing-md: 1rem;
+					--spacing-lg: 1.5rem;
+					--spacing-xl: 2rem;
+					--spacing-2xl: 3rem;
+					--spacing-3xl: 4rem;
+					--spacing-4xl: 6rem;
+					--spacing-5xl: 8rem;
 
-				/* Transitions */
-				--transition-fast: 150ms ease;
-				--transition-base: 200ms ease;
-				--transition-slow: 300ms ease;
+					/* Layout */
+					--max-width: 720px;
+					--wide-width: 1200px;
+					--radius-sm: 6px;
+					--radius: 10px;
+					--radius-lg: 16px;
+					--radius-full: 9999px;
 
-				/* Shadows */
-				--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-				--shadow:
-					0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-				--shadow-lg:
-					0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-				--shadow-xl:
-					0 20px 25px -5px rgba(0, 0, 0, 0.1),
-					0 8px 10px -6px rgba(0, 0, 0, 0.1);
-			}
+					/* Transitions */
+					--transition-fast: 150ms ease;
+					--transition-base: 200ms ease;
+					--transition-slow: 300ms ease;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+					--shadow:
+						0 4px 6px -1px rgba(0, 0, 0, 0.1),
+						0 2px 4px -2px rgba(0, 0, 0, 0.1);
+					--shadow-lg:
+						0 10px 15px -3px rgba(0, 0, 0, 0.1),
+						0 4px 6px -4px rgba(0, 0, 0, 0.1);
+					--shadow-xl:
+						0 20px 25px -5px rgba(0, 0, 0, 0.1),
+						0 8px 10px -6px rgba(0, 0, 0, 0.1);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0f172a;
+						--color-text: #f1f5f9;
+						--color-muted: #94a3b8;
+						--color-border: #334155;
+						--color-surface: #1e293b;
+						--color-primary: #818cf8;
+						--color-primary-dark: #6366f1;
+						--color-primary-light: #a5b4fc;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0f172a;
 					--color-text: #f1f5f9;
 					--color-muted: #94a3b8;
@@ -296,141 +320,129 @@ const pageCtx = createPublicPageContext({
 					--color-primary-dark: #6366f1;
 					--color-primary-light: #a5b4fc;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0f172a;
-				--color-text: #f1f5f9;
-				--color-muted: #94a3b8;
-				--color-border: #334155;
-				--color-surface: #1e293b;
-				--color-primary: #818cf8;
-				--color-primary-dark: #6366f1;
-				--color-primary-light: #a5b4fc;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: 1.6;
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: 1.6;
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				min-height: 100vh;
-			}
+				a {
+					color: currentColor;
+					text-decoration: none;
+				}
 
-			a {
-				color: currentColor;
-				text-decoration: none;
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-weight: 700;
+					line-height: 1.2;
+					letter-spacing: -0.02em;
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-weight: 700;
-				line-height: 1.2;
-				letter-spacing: -0.02em;
-			}
+				h1 {
+					font-size: var(--font-size-5xl);
+				}
+				h2 {
+					font-size: var(--font-size-3xl);
+				}
+				h3 {
+					font-size: var(--font-size-2xl);
+				}
+				h4 {
+					font-size: var(--font-size-xl);
+				}
 
-			h1 {
-				font-size: var(--font-size-5xl);
-			}
-			h2 {
-				font-size: var(--font-size-3xl);
-			}
-			h3 {
-				font-size: var(--font-size-2xl);
-			}
-			h4 {
-				font-size: var(--font-size-xl);
-			}
+				/* Utility classes */
+				.container {
+					max-width: var(--wide-width);
+					margin: 0 auto;
+					padding: 0 var(--spacing-lg);
+				}
 
-			/* Utility classes */
-			.container {
-				max-width: var(--wide-width);
-				margin: 0 auto;
-				padding: 0 var(--spacing-lg);
-			}
+				.section {
+					padding: var(--spacing-5xl) 0;
+				}
 
-			.section {
-				padding: var(--spacing-5xl) 0;
-			}
+				.btn {
+					display: inline-flex;
+					align-items: center;
+					justify-content: center;
+					gap: var(--spacing-sm);
+					padding: var(--spacing-sm) var(--spacing-lg);
+					font-family: inherit;
+					font-size: var(--font-size-sm);
+					font-weight: 600;
+					border-radius: var(--radius);
+					cursor: pointer;
+					transition:
+						background var(--transition-fast),
+						transform var(--transition-fast),
+						box-shadow var(--transition-fast);
+				}
 
-			.btn {
-				display: inline-flex;
-				align-items: center;
-				justify-content: center;
-				gap: var(--spacing-sm);
-				padding: var(--spacing-sm) var(--spacing-lg);
-				font-family: inherit;
-				font-size: var(--font-size-sm);
-				font-weight: 600;
-				border-radius: var(--radius);
-				cursor: pointer;
-				transition:
-					background var(--transition-fast),
-					transform var(--transition-fast),
-					box-shadow var(--transition-fast);
-			}
+				.btn:hover {
+					transform: translateY(-1px);
+				}
 
-			.btn:hover {
-				transform: translateY(-1px);
-			}
+				.btn:active {
+					transform: translateY(0);
+				}
 
-			.btn:active {
-				transform: translateY(0);
-			}
+				.btn-primary {
+					color: white;
+					background: linear-gradient(
+						135deg,
+						var(--color-primary-dark),
+						var(--color-accent)
+					);
+					border: none;
+					transition:
+						background 0.3s ease,
+						box-shadow 0.3s ease;
+				}
 
-			.btn-primary {
-				color: white;
-				background: linear-gradient(
-					135deg,
-					var(--color-primary-dark),
-					var(--color-accent)
-				);
-				border: none;
-				transition:
-					background 0.3s ease,
-					box-shadow 0.3s ease;
-			}
+				.btn-primary:hover {
+					background: linear-gradient(
+						135deg,
+						var(--color-primary),
+						var(--color-accent)
+					);
+					box-shadow: var(--shadow-lg);
+				}
 
-			.btn-primary:hover {
-				background: linear-gradient(
-					135deg,
-					var(--color-primary),
-					var(--color-accent)
-				);
-				box-shadow: var(--shadow-lg);
-			}
+				.btn-secondary {
+					color: var(--color-text);
+					background: transparent;
+					border: 1px solid var(--color-border);
+				}
 
-			.btn-secondary {
-				color: var(--color-text);
-				background: transparent;
-				border: 1px solid var(--color-border);
-			}
+				.btn-secondary:hover {
+					background: var(--color-surface);
+					border-color: var(--color-muted);
+				}
 
-			.btn-secondary:hover {
-				background: var(--color-surface);
-				border-color: var(--color-muted);
-			}
-
-			.btn-lg {
-				padding: var(--spacing-md) var(--spacing-xl);
-				font-size: var(--font-size-base);
+				.btn-lg {
+					padding: var(--spacing-md) var(--spacing-xl);
+					font-size: var(--font-size-base);
+				}
 			}
 		</style>
 

--- a/templates/marketing-cloudflare/src/styles/theme.css
+++ b/templates/marketing-cloudflare/src/styles/theme.css
@@ -1,0 +1,80 @@
+/*
+  theme.css -- override any :root variable here to retheme the site.
+
+  This is the only file you need to edit to customize the site's visual
+  appearance. All defaults are listed below as comments. Uncomment and
+  change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
+
+  Note: this template defines explicit dark mode colors in Base.astro.
+  Overriding light-mode --color-* variables here won't affect dark mode.
+  To customize dark mode, also override --color-* variables inside a
+  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+*/
+
+:root {
+	/* --- Colors ---
+	--color-bg: #ffffff;
+	--color-text: #0f172a;
+	--color-muted: #64748b;
+	--color-border: #e2e8f0;
+	--color-surface: #f8fafc;
+	--color-primary: #6366f1;
+	--color-primary-dark: #4f46e5;
+	--color-primary-light: #818cf8;
+	--color-accent: #f472b6;
+	--color-accent-light: #f9a8d4;
+	--color-success: #22c55e;
+	--color-warning: #f59e0b;
+	*/
+
+	/* --- Typography ---
+	--font-mono: ui-monospace, "SF Mono", monospace;
+	--font-size-xs: 0.75rem;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1rem;
+	--font-size-lg: 1.125rem;
+	--font-size-xl: 1.25rem;
+	--font-size-2xl: 1.5rem;
+	--font-size-3xl: 2rem;
+	--font-size-4xl: 2.5rem;
+	--font-size-5xl: 3.5rem;
+	--font-size-6xl: 4.5rem;
+	*/
+
+	/* --- Spacing ---
+	--spacing-xs: 0.25rem;
+	--spacing-sm: 0.5rem;
+	--spacing-md: 1rem;
+	--spacing-lg: 1.5rem;
+	--spacing-xl: 2rem;
+	--spacing-2xl: 3rem;
+	--spacing-3xl: 4rem;
+	--spacing-4xl: 6rem;
+	--spacing-5xl: 8rem;
+	*/
+
+	/* --- Layout ---
+	--max-width: 720px;
+	--wide-width: 1200px;
+	--radius-sm: 6px;
+	--radius: 10px;
+	--radius-lg: 16px;
+	--radius-full: 9999px;
+	*/
+
+	/* --- Transitions ---
+	--transition-fast: 150ms ease;
+	--transition-base: 200ms ease;
+	--transition-slow: 300ms ease;
+	*/
+
+	/* --- Shadows ---
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+	--shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+	--shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+	--shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+	*/
+}

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/theme.css";
 
 interface Props {
 	title?: string;
@@ -212,81 +213,104 @@ const pageCtx = createPublicPageContext({
 		</script>
 
 		<style is:global>
-			*,
-			*::before,
-			*::after {
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			:root {
-				/* Colors - Playful/Bold palette */
-				--color-bg: #ffffff;
-				--color-text: #0f172a;
-				--color-muted: #64748b;
-				--color-border: #e2e8f0;
-				--color-surface: #f8fafc;
-				--color-primary: #6366f1;
-				--color-primary-dark: #4f46e5;
-				--color-primary-light: #818cf8;
-				--color-accent: #f472b6;
-				--color-accent-light: #f9a8d4;
-				--color-success: #22c55e;
-				--color-warning: #f59e0b;
+			@layer base {
+				*,
+				*::before,
+				*::after {
+					box-sizing: border-box;
+					margin: 0;
+					padding: 0;
+				}
 
-				/* Typography */
-				--font-mono: ui-monospace, "SF Mono", monospace;
+				:root {
+					/* Colors - Playful/Bold palette */
+					--color-bg: #ffffff;
+					--color-text: #0f172a;
+					--color-muted: #64748b;
+					--color-border: #e2e8f0;
+					--color-surface: #f8fafc;
+					--color-primary: #6366f1;
+					--color-primary-dark: #4f46e5;
+					--color-primary-light: #818cf8;
+					--color-accent: #f472b6;
+					--color-accent-light: #f9a8d4;
+					--color-success: #22c55e;
+					--color-warning: #f59e0b;
 
-				--font-size-xs: 0.75rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
-				--font-size-6xl: 4.5rem;
+					/* Typography */
+					--font-mono: ui-monospace, "SF Mono", monospace;
 
-				/* Spacing */
-				--spacing-xs: 0.25rem;
-				--spacing-sm: 0.5rem;
-				--spacing-md: 1rem;
-				--spacing-lg: 1.5rem;
-				--spacing-xl: 2rem;
-				--spacing-2xl: 3rem;
-				--spacing-3xl: 4rem;
-				--spacing-4xl: 6rem;
-				--spacing-5xl: 8rem;
+					--font-size-xs: 0.75rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
+					--font-size-6xl: 4.5rem;
 
-				/* Layout */
-				--max-width: 720px;
-				--wide-width: 1200px;
-				--radius-sm: 6px;
-				--radius: 10px;
-				--radius-lg: 16px;
-				--radius-full: 9999px;
+					/* Spacing */
+					--spacing-xs: 0.25rem;
+					--spacing-sm: 0.5rem;
+					--spacing-md: 1rem;
+					--spacing-lg: 1.5rem;
+					--spacing-xl: 2rem;
+					--spacing-2xl: 3rem;
+					--spacing-3xl: 4rem;
+					--spacing-4xl: 6rem;
+					--spacing-5xl: 8rem;
 
-				/* Transitions */
-				--transition-fast: 150ms ease;
-				--transition-base: 200ms ease;
-				--transition-slow: 300ms ease;
+					/* Layout */
+					--max-width: 720px;
+					--wide-width: 1200px;
+					--radius-sm: 6px;
+					--radius: 10px;
+					--radius-lg: 16px;
+					--radius-full: 9999px;
 
-				/* Shadows */
-				--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-				--shadow:
-					0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-				--shadow-lg:
-					0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-				--shadow-xl:
-					0 20px 25px -5px rgba(0, 0, 0, 0.1),
-					0 8px 10px -6px rgba(0, 0, 0, 0.1);
-			}
+					/* Transitions */
+					--transition-fast: 150ms ease;
+					--transition-base: 200ms ease;
+					--transition-slow: 300ms ease;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+					--shadow:
+						0 4px 6px -1px rgba(0, 0, 0, 0.1),
+						0 2px 4px -2px rgba(0, 0, 0, 0.1);
+					--shadow-lg:
+						0 10px 15px -3px rgba(0, 0, 0, 0.1),
+						0 4px 6px -4px rgba(0, 0, 0, 0.1);
+					--shadow-xl:
+						0 20px 25px -5px rgba(0, 0, 0, 0.1),
+						0 8px 10px -6px rgba(0, 0, 0, 0.1);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0f172a;
+						--color-text: #f1f5f9;
+						--color-muted: #94a3b8;
+						--color-border: #334155;
+						--color-surface: #1e293b;
+						--color-primary: #818cf8;
+						--color-primary-dark: #6366f1;
+						--color-primary-light: #a5b4fc;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0f172a;
 					--color-text: #f1f5f9;
 					--color-muted: #94a3b8;
@@ -296,141 +320,129 @@ const pageCtx = createPublicPageContext({
 					--color-primary-dark: #6366f1;
 					--color-primary-light: #a5b4fc;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0f172a;
-				--color-text: #f1f5f9;
-				--color-muted: #94a3b8;
-				--color-border: #334155;
-				--color-surface: #1e293b;
-				--color-primary: #818cf8;
-				--color-primary-dark: #6366f1;
-				--color-primary-light: #a5b4fc;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: 1.6;
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: 1.6;
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				min-height: 100vh;
-			}
+				a {
+					color: currentColor;
+					text-decoration: none;
+				}
 
-			a {
-				color: currentColor;
-				text-decoration: none;
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-weight: 700;
+					line-height: 1.2;
+					letter-spacing: -0.02em;
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-weight: 700;
-				line-height: 1.2;
-				letter-spacing: -0.02em;
-			}
+				h1 {
+					font-size: var(--font-size-5xl);
+				}
+				h2 {
+					font-size: var(--font-size-3xl);
+				}
+				h3 {
+					font-size: var(--font-size-2xl);
+				}
+				h4 {
+					font-size: var(--font-size-xl);
+				}
 
-			h1 {
-				font-size: var(--font-size-5xl);
-			}
-			h2 {
-				font-size: var(--font-size-3xl);
-			}
-			h3 {
-				font-size: var(--font-size-2xl);
-			}
-			h4 {
-				font-size: var(--font-size-xl);
-			}
+				/* Utility classes */
+				.container {
+					max-width: var(--wide-width);
+					margin: 0 auto;
+					padding: 0 var(--spacing-lg);
+				}
 
-			/* Utility classes */
-			.container {
-				max-width: var(--wide-width);
-				margin: 0 auto;
-				padding: 0 var(--spacing-lg);
-			}
+				.section {
+					padding: var(--spacing-5xl) 0;
+				}
 
-			.section {
-				padding: var(--spacing-5xl) 0;
-			}
+				.btn {
+					display: inline-flex;
+					align-items: center;
+					justify-content: center;
+					gap: var(--spacing-sm);
+					padding: var(--spacing-sm) var(--spacing-lg);
+					font-family: inherit;
+					font-size: var(--font-size-sm);
+					font-weight: 600;
+					border-radius: var(--radius);
+					cursor: pointer;
+					transition:
+						background var(--transition-fast),
+						transform var(--transition-fast),
+						box-shadow var(--transition-fast);
+				}
 
-			.btn {
-				display: inline-flex;
-				align-items: center;
-				justify-content: center;
-				gap: var(--spacing-sm);
-				padding: var(--spacing-sm) var(--spacing-lg);
-				font-family: inherit;
-				font-size: var(--font-size-sm);
-				font-weight: 600;
-				border-radius: var(--radius);
-				cursor: pointer;
-				transition:
-					background var(--transition-fast),
-					transform var(--transition-fast),
-					box-shadow var(--transition-fast);
-			}
+				.btn:hover {
+					transform: translateY(-1px);
+				}
 
-			.btn:hover {
-				transform: translateY(-1px);
-			}
+				.btn:active {
+					transform: translateY(0);
+				}
 
-			.btn:active {
-				transform: translateY(0);
-			}
+				.btn-primary {
+					color: white;
+					background: linear-gradient(
+						135deg,
+						var(--color-primary-dark),
+						var(--color-accent)
+					);
+					border: none;
+					transition:
+						background 0.3s ease,
+						box-shadow 0.3s ease;
+				}
 
-			.btn-primary {
-				color: white;
-				background: linear-gradient(
-					135deg,
-					var(--color-primary-dark),
-					var(--color-accent)
-				);
-				border: none;
-				transition:
-					background 0.3s ease,
-					box-shadow 0.3s ease;
-			}
+				.btn-primary:hover {
+					background: linear-gradient(
+						135deg,
+						var(--color-primary),
+						var(--color-accent)
+					);
+					box-shadow: var(--shadow-lg);
+				}
 
-			.btn-primary:hover {
-				background: linear-gradient(
-					135deg,
-					var(--color-primary),
-					var(--color-accent)
-				);
-				box-shadow: var(--shadow-lg);
-			}
+				.btn-secondary {
+					color: var(--color-text);
+					background: transparent;
+					border: 1px solid var(--color-border);
+				}
 
-			.btn-secondary {
-				color: var(--color-text);
-				background: transparent;
-				border: 1px solid var(--color-border);
-			}
+				.btn-secondary:hover {
+					background: var(--color-surface);
+					border-color: var(--color-muted);
+				}
 
-			.btn-secondary:hover {
-				background: var(--color-surface);
-				border-color: var(--color-muted);
-			}
-
-			.btn-lg {
-				padding: var(--spacing-md) var(--spacing-xl);
-				font-size: var(--font-size-base);
+				.btn-lg {
+					padding: var(--spacing-md) var(--spacing-xl);
+					font-size: var(--font-size-base);
+				}
 			}
 		</style>
 

--- a/templates/marketing/src/styles/theme.css
+++ b/templates/marketing/src/styles/theme.css
@@ -1,0 +1,80 @@
+/*
+  theme.css -- override any :root variable here to retheme the site.
+
+  This is the only file you need to edit to customize the site's visual
+  appearance. All defaults are listed below as comments. Uncomment and
+  change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
+
+  Note: this template defines explicit dark mode colors in Base.astro.
+  Overriding light-mode --color-* variables here won't affect dark mode.
+  To customize dark mode, also override --color-* variables inside a
+  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+*/
+
+:root {
+	/* --- Colors ---
+	--color-bg: #ffffff;
+	--color-text: #0f172a;
+	--color-muted: #64748b;
+	--color-border: #e2e8f0;
+	--color-surface: #f8fafc;
+	--color-primary: #6366f1;
+	--color-primary-dark: #4f46e5;
+	--color-primary-light: #818cf8;
+	--color-accent: #f472b6;
+	--color-accent-light: #f9a8d4;
+	--color-success: #22c55e;
+	--color-warning: #f59e0b;
+	*/
+
+	/* --- Typography ---
+	--font-mono: ui-monospace, "SF Mono", monospace;
+	--font-size-xs: 0.75rem;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1rem;
+	--font-size-lg: 1.125rem;
+	--font-size-xl: 1.25rem;
+	--font-size-2xl: 1.5rem;
+	--font-size-3xl: 2rem;
+	--font-size-4xl: 2.5rem;
+	--font-size-5xl: 3.5rem;
+	--font-size-6xl: 4.5rem;
+	*/
+
+	/* --- Spacing ---
+	--spacing-xs: 0.25rem;
+	--spacing-sm: 0.5rem;
+	--spacing-md: 1rem;
+	--spacing-lg: 1.5rem;
+	--spacing-xl: 2rem;
+	--spacing-2xl: 3rem;
+	--spacing-3xl: 4rem;
+	--spacing-4xl: 6rem;
+	--spacing-5xl: 8rem;
+	*/
+
+	/* --- Layout ---
+	--max-width: 720px;
+	--wide-width: 1200px;
+	--radius-sm: 6px;
+	--radius: 10px;
+	--radius-lg: 16px;
+	--radius-full: 9999px;
+	*/
+
+	/* --- Transitions ---
+	--transition-fast: 150ms ease;
+	--transition-base: 200ms ease;
+	--transition-slow: 300ms ease;
+	*/
+
+	/* --- Shadows ---
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+	--shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+	--shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+	--shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+	*/
+}

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/theme.css";
 
 interface Props {
 	title?: string;
@@ -187,60 +188,80 @@ const pageCtx = createPublicPageContext({
 		</script>
 
 		<style is:global>
-			*,
-			*::before,
-			*::after {
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			:root {
-				/* Colors - Elegant/Minimal palette */
-				--color-bg: #fafafa;
-				--color-text: #1a1a1a;
-				--color-muted: #6b7280;
-				--color-border: #e5e7eb;
-				--color-surface: #ffffff;
-				--color-accent: #7c3aed;
-				--color-accent-muted: #a78bfa;
+			@layer base {
+				*,
+				*::before,
+				*::after {
+					box-sizing: border-box;
+					margin: 0;
+					padding: 0;
+				}
 
-				/* Typography */
-				--font-sans: system-ui, -apple-system, sans-serif;
-				--font-mono: ui-monospace, monospace;
+				:root {
+					/* Colors - Elegant/Minimal palette */
+					--color-bg: #fafafa;
+					--color-text: #1a1a1a;
+					--color-muted: #6b7280;
+					--color-border: #e5e7eb;
+					--color-surface: #ffffff;
+					--color-accent: #7c3aed;
+					--color-accent-muted: #a78bfa;
 
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1.0625rem;
-				--font-size-lg: 1.25rem;
-				--font-size-xl: 1.5rem;
-				--font-size-2xl: 2rem;
-				--font-size-3xl: 2.75rem;
-				--font-size-4xl: 3.5rem;
+					/* Typography */
+					--font-sans: system-ui, -apple-system, sans-serif;
+					--font-mono: ui-monospace, monospace;
 
-				/* Spacing */
-				--spacing-xs: 0.25rem;
-				--spacing-sm: 0.5rem;
-				--spacing-md: 1rem;
-				--spacing-lg: 1.5rem;
-				--spacing-xl: 2rem;
-				--spacing-2xl: 3rem;
-				--spacing-3xl: 4rem;
-				--spacing-4xl: 6rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1.0625rem;
+					--font-size-lg: 1.25rem;
+					--font-size-xl: 1.5rem;
+					--font-size-2xl: 2rem;
+					--font-size-3xl: 2.75rem;
+					--font-size-4xl: 3.5rem;
 
-				/* Layout */
-				--max-width: 720px;
-				--wide-width: 1200px;
-				--radius: 4px;
+					/* Spacing */
+					--spacing-xs: 0.25rem;
+					--spacing-sm: 0.5rem;
+					--spacing-md: 1rem;
+					--spacing-lg: 1.5rem;
+					--spacing-xl: 2rem;
+					--spacing-2xl: 3rem;
+					--spacing-3xl: 4rem;
+					--spacing-4xl: 6rem;
 
-				/* Transitions */
-				--transition-fast: 150ms ease;
-				--transition-base: 200ms ease;
-				--transition-slow: 300ms ease;
-			}
+					/* Layout */
+					--max-width: 720px;
+					--wide-width: 1200px;
+					--radius: 4px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Transitions */
+					--transition-fast: 150ms ease;
+					--transition-base: 200ms ease;
+					--transition-slow: 300ms ease;
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0a0a0a;
+						--color-text: #f5f5f5;
+						--color-muted: #a1a1aa;
+						--color-border: #27272a;
+						--color-surface: #18181b;
+						--color-accent: #a78bfa;
+						--color-accent-muted: #7c3aed;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0a0a0a;
 					--color-text: #f5f5f5;
 					--color-muted: #a1a1aa;
@@ -249,62 +270,51 @@ const pageCtx = createPublicPageContext({
 					--color-accent: #a78bfa;
 					--color-accent-muted: #7c3aed;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0a0a0a;
-				--color-text: #f5f5f5;
-				--color-muted: #a1a1aa;
-				--color-border: #27272a;
-				--color-surface: #18181b;
-				--color-accent: #a78bfa;
-				--color-accent-muted: #7c3aed;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: 1.6;
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: 1.6;
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				min-height: 100vh;
-			}
+				a {
+					color: currentColor;
+				}
 
-			a {
-				color: currentColor;
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4 {
+					font-family: var(--font-serif);
+					font-weight: 500;
+					line-height: 1.2;
+				}
 
-			h1,
-			h2,
-			h3,
-			h4 {
-				font-family: var(--font-serif);
-				font-weight: 500;
-				line-height: 1.2;
-			}
+				h1 {
+					font-size: var(--font-size-4xl);
+				}
 
-			h1 {
-				font-size: var(--font-size-4xl);
-			}
+				h2 {
+					font-size: var(--font-size-2xl);
+				}
 
-			h2 {
-				font-size: var(--font-size-2xl);
-			}
-
-			h3 {
-				font-size: var(--font-size-xl);
+				h3 {
+					font-size: var(--font-size-xl);
+				}
 			}
 		</style>
 

--- a/templates/portfolio-cloudflare/src/styles/theme.css
+++ b/templates/portfolio-cloudflare/src/styles/theme.css
@@ -1,0 +1,62 @@
+/*
+  theme.css -- override any :root variable here to retheme the site.
+
+  This is the only file you need to edit to customize the site's visual
+  appearance. All defaults are listed below as comments. Uncomment and
+  change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
+
+  Note: this template defines explicit dark mode colors in Base.astro.
+  Overriding light-mode --color-* variables here won't affect dark mode.
+  To customize dark mode, also override --color-* variables inside a
+  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+*/
+
+:root {
+	/* --- Colors ---
+	--color-bg: #fafafa;
+	--color-text: #1a1a1a;
+	--color-muted: #6b7280;
+	--color-border: #e5e7eb;
+	--color-surface: #ffffff;
+	--color-accent: #7c3aed;
+	--color-accent-muted: #a78bfa;
+	*/
+
+	/* --- Typography ---
+	--font-sans: system-ui, -apple-system, sans-serif;
+	--font-mono: ui-monospace, monospace;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1.0625rem;
+	--font-size-lg: 1.25rem;
+	--font-size-xl: 1.5rem;
+	--font-size-2xl: 2rem;
+	--font-size-3xl: 2.75rem;
+	--font-size-4xl: 3.5rem;
+	*/
+
+	/* --- Spacing ---
+	--spacing-xs: 0.25rem;
+	--spacing-sm: 0.5rem;
+	--spacing-md: 1rem;
+	--spacing-lg: 1.5rem;
+	--spacing-xl: 2rem;
+	--spacing-2xl: 3rem;
+	--spacing-3xl: 4rem;
+	--spacing-4xl: 6rem;
+	*/
+
+	/* --- Layout ---
+	--max-width: 720px;
+	--wide-width: 1200px;
+	--radius: 4px;
+	*/
+
+	/* --- Transitions ---
+	--transition-fast: 150ms ease;
+	--transition-base: 200ms ease;
+	--transition-slow: 300ms ease;
+	*/
+}

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { getMenu, getSiteSettings } from "emdash";
 import { EmDashHead } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
 import { Font } from "astro:assets";
+import "../styles/theme.css";
 
 interface Props {
 	title?: string;
@@ -187,60 +188,80 @@ const pageCtx = createPublicPageContext({
 		</script>
 
 		<style is:global>
-			*,
-			*::before,
-			*::after {
-				box-sizing: border-box;
-				margin: 0;
-				padding: 0;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			:root {
-				/* Colors - Elegant/Minimal palette */
-				--color-bg: #fafafa;
-				--color-text: #1a1a1a;
-				--color-muted: #6b7280;
-				--color-border: #e5e7eb;
-				--color-surface: #ffffff;
-				--color-accent: #7c3aed;
-				--color-accent-muted: #a78bfa;
+			@layer base {
+				*,
+				*::before,
+				*::after {
+					box-sizing: border-box;
+					margin: 0;
+					padding: 0;
+				}
 
-				/* Typography */
-				--font-sans: system-ui, -apple-system, sans-serif;
-				--font-mono: ui-monospace, monospace;
+				:root {
+					/* Colors - Elegant/Minimal palette */
+					--color-bg: #fafafa;
+					--color-text: #1a1a1a;
+					--color-muted: #6b7280;
+					--color-border: #e5e7eb;
+					--color-surface: #ffffff;
+					--color-accent: #7c3aed;
+					--color-accent-muted: #a78bfa;
 
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1.0625rem;
-				--font-size-lg: 1.25rem;
-				--font-size-xl: 1.5rem;
-				--font-size-2xl: 2rem;
-				--font-size-3xl: 2.75rem;
-				--font-size-4xl: 3.5rem;
+					/* Typography */
+					--font-sans: system-ui, -apple-system, sans-serif;
+					--font-mono: ui-monospace, monospace;
 
-				/* Spacing */
-				--spacing-xs: 0.25rem;
-				--spacing-sm: 0.5rem;
-				--spacing-md: 1rem;
-				--spacing-lg: 1.5rem;
-				--spacing-xl: 2rem;
-				--spacing-2xl: 3rem;
-				--spacing-3xl: 4rem;
-				--spacing-4xl: 6rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1.0625rem;
+					--font-size-lg: 1.25rem;
+					--font-size-xl: 1.5rem;
+					--font-size-2xl: 2rem;
+					--font-size-3xl: 2.75rem;
+					--font-size-4xl: 3.5rem;
 
-				/* Layout */
-				--max-width: 720px;
-				--wide-width: 1200px;
-				--radius: 4px;
+					/* Spacing */
+					--spacing-xs: 0.25rem;
+					--spacing-sm: 0.5rem;
+					--spacing-md: 1rem;
+					--spacing-lg: 1.5rem;
+					--spacing-xl: 2rem;
+					--spacing-2xl: 3rem;
+					--spacing-3xl: 4rem;
+					--spacing-4xl: 6rem;
 
-				/* Transitions */
-				--transition-fast: 150ms ease;
-				--transition-base: 200ms ease;
-				--transition-slow: 300ms ease;
-			}
+					/* Layout */
+					--max-width: 720px;
+					--wide-width: 1200px;
+					--radius: 4px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Transitions */
+					--transition-fast: 150ms ease;
+					--transition-base: 200ms ease;
+					--transition-slow: 300ms ease;
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0a0a0a;
+						--color-text: #f5f5f5;
+						--color-muted: #a1a1aa;
+						--color-border: #27272a;
+						--color-surface: #18181b;
+						--color-accent: #a78bfa;
+						--color-accent-muted: #7c3aed;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0a0a0a;
 					--color-text: #f5f5f5;
 					--color-muted: #a1a1aa;
@@ -249,62 +270,51 @@ const pageCtx = createPublicPageContext({
 					--color-accent: #a78bfa;
 					--color-accent-muted: #7c3aed;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0a0a0a;
-				--color-text: #f5f5f5;
-				--color-muted: #a1a1aa;
-				--color-border: #27272a;
-				--color-surface: #18181b;
-				--color-accent: #a78bfa;
-				--color-accent-muted: #7c3aed;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: 1.6;
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: 1.6;
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				min-height: 100vh;
-			}
+				a {
+					color: currentColor;
+				}
 
-			a {
-				color: currentColor;
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4 {
+					font-family: var(--font-serif);
+					font-weight: 500;
+					line-height: 1.2;
+				}
 
-			h1,
-			h2,
-			h3,
-			h4 {
-				font-family: var(--font-serif);
-				font-weight: 500;
-				line-height: 1.2;
-			}
+				h1 {
+					font-size: var(--font-size-4xl);
+				}
 
-			h1 {
-				font-size: var(--font-size-4xl);
-			}
+				h2 {
+					font-size: var(--font-size-2xl);
+				}
 
-			h2 {
-				font-size: var(--font-size-2xl);
-			}
-
-			h3 {
-				font-size: var(--font-size-xl);
+				h3 {
+					font-size: var(--font-size-xl);
+				}
 			}
 		</style>
 

--- a/templates/portfolio/src/styles/theme.css
+++ b/templates/portfolio/src/styles/theme.css
@@ -1,0 +1,62 @@
+/*
+  theme.css -- override any :root variable here to retheme the site.
+
+  This is the only file you need to edit to customize the site's visual
+  appearance. All defaults are listed below as comments. Uncomment and
+  change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
+
+  Note: this template defines explicit dark mode colors in Base.astro.
+  Overriding light-mode --color-* variables here won't affect dark mode.
+  To customize dark mode, also override --color-* variables inside a
+  @media (prefers-color-scheme: dark) block and/or in the :root.dark rule.
+*/
+
+:root {
+	/* --- Colors ---
+	--color-bg: #fafafa;
+	--color-text: #1a1a1a;
+	--color-muted: #6b7280;
+	--color-border: #e5e7eb;
+	--color-surface: #ffffff;
+	--color-accent: #7c3aed;
+	--color-accent-muted: #a78bfa;
+	*/
+
+	/* --- Typography ---
+	--font-sans: system-ui, -apple-system, sans-serif;
+	--font-mono: ui-monospace, monospace;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1.0625rem;
+	--font-size-lg: 1.25rem;
+	--font-size-xl: 1.5rem;
+	--font-size-2xl: 2rem;
+	--font-size-3xl: 2.75rem;
+	--font-size-4xl: 3.5rem;
+	*/
+
+	/* --- Spacing ---
+	--spacing-xs: 0.25rem;
+	--spacing-sm: 0.5rem;
+	--spacing-md: 1rem;
+	--spacing-lg: 1.5rem;
+	--spacing-xl: 2rem;
+	--spacing-2xl: 3rem;
+	--spacing-3xl: 4rem;
+	--spacing-4xl: 6rem;
+	*/
+
+	/* --- Layout ---
+	--max-width: 720px;
+	--wide-width: 1200px;
+	--radius: 4px;
+	*/
+
+	/* --- Transitions ---
+	--transition-fast: 150ms ease;
+	--transition-base: 200ms ease;
+	--transition-slow: 300ms ease;
+	*/
+}


### PR DESCRIPTION
## What does this PR do?

Fixes theme.css overrides being silently ignored in the blog template, and adds the same theme.css customization support to marketing and portfolio templates.

Astro's CSS pipeline injects ESM-imported CSS (`import "../styles/theme.css"`) into the `<head>` **before** `<style is:global>` blocks. Both target `:root` with identical specificity, so the later declaration (the defaults in Base.astro) always wins. The user's overrides in `theme.css` were dead code.

The fix wraps all default styles in `@layer base`. CSS custom properties declared in a named layer have lower cascade priority than unlayered declarations, regardless of source order. Since `theme.css` is unlayered, its `:root` overrides now always win.

Also removes a debug `--color-bg: #ff0000` that was left in the blog template's theme.css.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Templates affected

- **blog / blog-cloudflare** -- fixed existing broken theme.css override, wrapped globals in `@layer base`
- **marketing / marketing-cloudflare** -- added `src/styles/theme.css` (45 variables), wrapped globals in `@layer base`
- **portfolio / portfolio-cloudflare** -- added `src/styles/theme.css` (30 variables), wrapped globals in `@layer base`
- **starter** -- not changed (has no CSS system)