### PR TITLE
feat(plugins): expand ContentItem fields and fire afterDelete hooks

### DIFF
--- a/.changeset/plugin-content-api.md
+++ b/.changeset/plugin-content-api.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `slug`, `status`, and `publishedAt` to the `ContentItem` type returned by the plugin content access API. Exports `ContentPublishStateChangeEvent` type. Fires `afterDelete` hooks on permanent content deletion.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1614,7 +1614,7 @@ export class EmDashRuntime {
 
 		// Run afterDelete hooks (fire-and-forget)
 		if (result.success) {
-			this.runAfterDeleteHooks(id, collection);
+			this.runAfterDeleteHooks(id, collection, false);
 		}
 
 		return result;
@@ -1636,7 +1636,14 @@ export class EmDashRuntime {
 	}
 
 	async handleContentPermanentDelete(collection: string, id: string) {
-		return handleContentPermanentDelete(this.db, collection, id);
+		const result = await handleContentPermanentDelete(this.db, collection, id);
+
+		// Run afterDelete hooks so plugins (e.g. AI Search) can clean up
+		if (result.success) {
+			this.runAfterDeleteHooks(id, collection, true);
+		}
+
+		return result;
 	}
 
 	async handleContentCountTrashed(collection: string) {
@@ -2011,11 +2018,11 @@ export class EmDashRuntime {
 		}
 	}
 
-	private runAfterDeleteHooks(id: string, collection: string): void {
+	private runAfterDeleteHooks(id: string, collection: string, permanent: boolean): void {
 		// Trusted plugins
 		if (this.hooks.hasHooks("content:afterDelete")) {
 			this.hooks
-				.runContentAfterDelete(id, collection)
+				.runContentAfterDelete(id, collection, permanent)
 				.catch((err) => console.error("EmDash afterDelete hook error:", err));
 		}
 
@@ -2025,7 +2032,7 @@ export class EmDashRuntime {
 			if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
 
 			plugin
-				.invokeHook("content:afterDelete", { id, collection })
+				.invokeHook("content:afterDelete", { id, collection, permanent })
 				.catch((err) =>
 					console.error(`EmDash: Sandboxed plugin ${pluginId} afterDelete error:`, err),
 				);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -213,6 +213,8 @@ export type {
 	ResolvedHook,
 	ResolvedPluginHooks,
 	ContentHookEvent,
+	ContentDeleteEvent,
+	ContentPublishStateChangeEvent,
 	MediaUploadEvent,
 	HookResult,
 	PluginRoute,

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -202,9 +202,12 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 			const result: ContentItem = {
 				id: item.id,
 				type: item.type,
+				slug: item.slug,
+				status: item.status,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
+				publishedAt: item.publishedAt,
 			};
 
 			if (await seoRepo.isEnabled(collection)) {
@@ -237,9 +240,12 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 			const items: ContentItem[] = result.items.map((item) => ({
 				id: item.id,
 				type: item.type,
+				slug: item.slug,
+				status: item.status,
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
+				publishedAt: item.publishedAt,
 			}));
 
 			if (items.length > 0 && (await seoRepo.isEnabled(collection))) {
@@ -294,9 +300,12 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 				const result: ContentItem = {
 					id: item.id,
 					type: item.type,
+					slug: item.slug,
+					status: item.status,
 					data: item.data,
 					createdAt: item.createdAt,
 					updatedAt: item.updatedAt,
+					publishedAt: item.publishedAt,
 				};
 
 				if (hasSeo) {
@@ -336,9 +345,12 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 				const result: ContentItem = {
 					id: item.id,
 					type: item.type,
+					slug: item.slug,
+					status: item.status,
 					data: item.data,
 					createdAt: item.createdAt,
 					updatedAt: item.updatedAt,
+					publishedAt: item.publishedAt,
 				};
 
 				if (hasSeo) {

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -561,7 +561,7 @@ export class HookPipeline {
 
 		for (const hook of hooks) {
 			const { handler } = hook;
-			const event: ContentDeleteEvent = { id, collection };
+			const event: ContentDeleteEvent = { id, collection, permanent: false };
 			const ctx = this.getContext(hook.pluginId);
 			const start = Date.now();
 
@@ -597,13 +597,17 @@ export class HookPipeline {
 	/**
 	 * Run content:afterDelete hooks
 	 */
-	async runContentAfterDelete(id: string, collection: string): Promise<HookResult<void>[]> {
+	async runContentAfterDelete(
+		id: string,
+		collection: string,
+		permanent: boolean,
+	): Promise<HookResult<void>[]> {
 		const hooks = this.getTypedHooks("content:afterDelete");
 		const results: HookResult<void>[] = [];
 
 		for (const hook of hooks) {
 			const { handler } = hook;
-			const event: ContentDeleteEvent = { id, collection };
+			const event: ContentDeleteEvent = { id, collection, permanent };
 			const ctx = this.getContext(hook.pluginId);
 			const start = Date.now();
 

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -121,6 +121,7 @@ export type {
 	ResolvedPluginHooks,
 	ContentHookEvent,
 	ContentDeleteEvent,
+	ContentPublishStateChangeEvent,
 	MediaUploadEvent,
 	MediaAfterUploadEvent,
 	LifecycleEvent,

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -333,9 +333,13 @@ export class PluginManager {
 	/**
 	 * Run content:afterDelete hooks across all active plugins
 	 */
-	async runContentAfterDelete(id: string, collection: string): Promise<HookResult<void>[]> {
+	async runContentAfterDelete(
+		id: string,
+		collection: string,
+		permanent: boolean,
+	): Promise<HookResult<void>[]> {
 		this.ensureInitialized();
-		return this.hookPipeline!.runContentAfterDelete(id, collection);
+		return this.hookPipeline!.runContentAfterDelete(id, collection, permanent);
 	}
 
 	/**

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -195,6 +195,8 @@ export interface ContentItemSeoInput {
 export interface ContentItem {
 	id: string;
 	type: string;
+	slug: string | null;
+	status: string;
 	data: Record<string, unknown>;
 	/**
 	 * SEO metadata, populated when the collection has SEO enabled
@@ -203,6 +205,7 @@ export interface ContentItem {
 	seo?: ContentItemSeo;
 	createdAt: string;
 	updatedAt: string;
+	publishedAt: string | null;
 }
 
 /**
@@ -702,6 +705,8 @@ export interface ContentHookEvent {
 export interface ContentDeleteEvent {
 	id: string;
 	collection: string;
+	/** `true` when the content is permanently deleted (not just trashed). */
+	permanent: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Adds `slug`, `status`, and `publishedAt` to the `ContentItem` type returned by the plugin content access API (`ctx.content.get()`, `ctx.content.list()`, `ctx.content.create()`, `ctx.content.update()`). These columns were preexisting.

Also exports the `ContentPublishStateChangeEvent` type and fires `afterDelete` hooks on permanent content deletion (previously only fired on soft delete/trash), adding a field in this event to distinguish between permanent and soft deletes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a changeset (if this PR changes a published package)
- [x] New features link to an approved Discussion (internal gchat)

## AI-generated code disclosure

- [x] This PR includes AI-generated code