### PR TITLE
fix: use aggregate expression in HAVING for PostgreSQL compatibility

### DIFF
--- a/.changeset/fix-having-postgres.md
+++ b/.changeset/fix-having-postgres.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes revision pruning crash on PostgreSQL by replacing column alias in HAVING clause with the aggregate expression.

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -121,11 +121,11 @@ export async function runSystemCleanup(
  * them down to REVISION_KEEP_COUNT.
  */
 async function pruneExcessiveRevisions(db: Kysely<Database>): Promise<number> {
-	const entries = await sql<{ collection: string; entry_id: string; cnt: number }>`
-		SELECT collection, entry_id, COUNT(*) as cnt
+	const entries = await sql<{ collection: string; entry_id: string }>`
+		SELECT collection, entry_id
 		FROM revisions
 		GROUP BY collection, entry_id
-		HAVING cnt > ${REVISION_PRUNE_THRESHOLD}
+		HAVING COUNT(*) > ${REVISION_PRUNE_THRESHOLD}
 	`.execute(db);
 
 	if (entries.rows.length === 0) return 0;


### PR DESCRIPTION
## What does this PR do?

Fixes a runtime crash in revision pruning (`cleanup.ts`) when using PostgreSQL. The `HAVING cnt > N` clause references a SELECT alias, which SQLite allows but PostgreSQL rejects per SQL standard (`column "cnt" does not exist`).

The fix replaces `HAVING cnt >` with `HAVING COUNT(*) >` and removes the unused `cnt` alias from the SELECT list since no downstream code references it.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Error on PostgreSQL before fix:
```
[cleanup] Failed to prune revisions: error: column "cnt" does not exist
  severity: 'ERROR',
  code: '42703',
  routine: 'errorMissingColumn'
```