### PR TITLE
feat(plugins): add locale to ContentItem

### DIFF
--- a/.changeset/content-item-locale.md
+++ b/.changeset/content-item-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `locale` to the `ContentItem` type returned by the plugin content access API. Follow-up to #536 — plugins that build i18n URLs from content records need the locale to pick the right URL prefix, otherwise multilingual content is emitted at default-locale URLs.

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -207,6 +207,7 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
+				locale: item.locale,
 				publishedAt: item.publishedAt,
 			};
 
@@ -245,6 +246,7 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 				data: item.data,
 				createdAt: item.createdAt,
 				updatedAt: item.updatedAt,
+				locale: item.locale,
 				publishedAt: item.publishedAt,
 			}));
 
@@ -305,6 +307,7 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 					data: item.data,
 					createdAt: item.createdAt,
 					updatedAt: item.updatedAt,
+					locale: item.locale,
 					publishedAt: item.publishedAt,
 				};
 
@@ -350,6 +353,7 @@ export function createContentAccessWithWrite(db: Kysely<Database>): ContentAcces
 					data: item.data,
 					createdAt: item.createdAt,
 					updatedAt: item.updatedAt,
+					locale: item.locale,
 					publishedAt: item.publishedAt,
 				};
 

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -197,6 +197,7 @@ export interface ContentItem {
 	type: string;
 	slug: string | null;
 	status: string;
+	locale: string | null;
 	data: Record<string, unknown>;
 	/**
 	 * SEO metadata, populated when the collection has SEO enabled


### PR DESCRIPTION
## What does this PR do?

Adds `locale` to the plugin-facing `ContentItem` type. Follow-up to #536, which added `slug`/`status`/`publishedAt` but left `locale` out.

**Why:** plugins that build i18n URLs from content records (sitemaps, llms.txt, schema maps, alternate-language link graphs, etc.) need the locale to pick the correct URL prefix. Without it they fall back to the default locale and emit wrong URLs on multilingual sites — the failure is silent on single-locale sites (the locale always equals the default) and only surfaces when someone enables i18n.

The internal `ContentRepository` entity already carries `locale` (it's a real column on every `ec_*` table). This PR just plumbs it through the public API, matching the pattern #536 established for the other system fields.

Discussion: [#530](https://github.com/emdash-cms/emdash/discussions/530) — maintainer explicitly invited PRs in a comment on that thread.

## Type of change

- [x] Feature (additive to `ContentItem` — purely expanding the returned shape, no behavior change for existing consumers)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes (core)
- [x] `pnpm format` run
- [x] Changeset added (`emdash` minor)
- [ ] Tests — #536 shipped without new tests for the same surface; following precedent. Happy to add a context.ts unit test if reviewers want one.

## AI-generated code disclosure

- [x] This PR includes AI-generated code

---

Sibling PR coming for `ContentListOptions.where.status` — the second piece of [#530](https://github.com/emdash-cms/emdash/discussions/530) that #536 didn't cover. Keeping it separate since it's a query-API change rather than a shape expansion.