### PR TITLE
feat(plugins): add where filter to ContentListOptions

### DIFF
--- a/.changeset/content-list-where-status.md
+++ b/.changeset/content-list-where-status.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds `where: { status?, locale? }` to `ContentListOptions`, letting plugins narrow `ContentAccess.list()` results at the database layer instead of filtering the returned array. The underlying repository already supports these filters — this PR only exposes them through the plugin-facing type.

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -235,6 +235,7 @@ export function createContentAccess(db: Kysely<Database>): ContentAccess {
 				limit: options?.limit ?? 50,
 				cursor: options?.cursor,
 				orderBy,
+				where: options?.where,
 			});
 
 			const items: ContentItem[] = result.items.map((item) => ({

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -208,13 +208,6 @@ export interface ContentItem {
 	publishedAt: string | null;
 }
 
-/**
- * Filters applied at the database layer to `ContentAccess.list()`.
- *
- * Applied via SQL `WHERE` clauses, so they narrow the result set before
- * pagination — unlike filtering the returned array in userland, which
- * would still pay for pulling every row across the boundary.
- */
 export interface ContentListWhere {
 	/** Exact match on `status` (e.g. `"published"`, `"draft"`). */
 	status?: string;

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -209,12 +209,27 @@ export interface ContentItem {
 }
 
 /**
+ * Filters applied at the database layer to `ContentAccess.list()`.
+ *
+ * Applied via SQL `WHERE` clauses, so they narrow the result set before
+ * pagination — unlike filtering the returned array in userland, which
+ * would still pay for pulling every row across the boundary.
+ */
+export interface ContentListWhere {
+	/** Exact match on `status` (e.g. `"published"`, `"draft"`). */
+	status?: string;
+	/** Exact match on `locale` (e.g. `"en"`, `"fr-CA"`). */
+	locale?: string;
+}
+
+/**
  * Content list options
  */
 export interface ContentListOptions {
 	limit?: number;
 	cursor?: string;
 	orderBy?: Record<string, "asc" | "desc">;
+	where?: ContentListWhere;
 }
 
 /**

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -130,6 +130,79 @@ describe("Capability Enforcement Integration (v2)", () => {
 				expect(result.hasMore).toBe(false);
 			});
 
+			it("narrows list results by where.status", async () => {
+				const access = createContentAccess(db);
+				const result = await access.list("posts", { where: { status: "published" } });
+
+				expect(result.items).toHaveLength(1);
+				expect(result.items[0]!.id).toBe("post-1");
+				expect(result.items[0]!.status).toBe("published");
+			});
+
+			it("narrows list results by where.locale", async () => {
+				await sql`
+					INSERT INTO ec_posts (id, slug, status, title, content, locale, translation_group)
+					VALUES ('post-3', 'bonjour', 'published', 'Bonjour', 'Contenu', 'fr', 'post-3')
+				`.execute(db);
+				const access = createContentAccess(db);
+				const result = await access.list("posts", { where: { locale: "fr" } });
+
+				expect(result.items).toHaveLength(1);
+				expect(result.items[0]!.id).toBe("post-3");
+			});
+
+			it("combines where.status and where.locale", async () => {
+				await sql`
+					INSERT INTO ec_posts (id, slug, status, title, content, locale, translation_group)
+					VALUES
+						('post-3', 'bonjour',  'published', 'Bonjour',  'Contenu', 'fr', 'post-3'),
+						('post-4', 'brouillon', 'draft',    'Brouillon', 'WIP',     'fr', 'post-4')
+				`.execute(db);
+				const access = createContentAccess(db);
+				const result = await access.list("posts", {
+					where: { status: "published", locale: "fr" },
+				});
+
+				expect(result.items).toHaveLength(1);
+				expect(result.items[0]!.id).toBe("post-3");
+			});
+
+			it("paginates consistently with where filters", async () => {
+				// Three more published posts so the total published count is 4.
+				// A limit of 2 should yield two pages: [2, 2] — never drafts.
+				await sql`
+					INSERT INTO ec_posts (id, slug, status, title, content, locale, translation_group)
+					VALUES
+						('post-3', 'a', 'published', 'A', 'a', 'en', 'post-3'),
+						('post-4', 'b', 'published', 'B', 'b', 'en', 'post-4'),
+						('post-5', 'c', 'published', 'C', 'c', 'en', 'post-5')
+				`.execute(db);
+				const access = createContentAccess(db);
+
+				const page1 = await access.list("posts", {
+					limit: 2,
+					where: { status: "published" },
+				});
+				expect(page1.items).toHaveLength(2);
+				expect(page1.hasMore).toBe(true);
+				for (const item of page1.items) expect(item.status).toBe("published");
+
+				const page2 = await access.list("posts", {
+					limit: 2,
+					cursor: page1.cursor,
+					where: { status: "published" },
+				});
+				expect(page2.items).toHaveLength(2);
+				expect(page2.hasMore).toBe(false);
+				for (const item of page2.items) expect(item.status).toBe("published");
+
+				// No overlap between pages
+				const ids = new Set([...page1.items, ...page2.items].map((i) => i.id));
+				expect(ids.size).toBe(4);
+				// Drafts never surface
+				expect(ids.has("post-2")).toBe(false);
+			});
+
 			it("returns null for non-existent content", async () => {
 				const access = createContentAccess(db);
 				const post = await access.get("posts", "non-existent");


### PR DESCRIPTION
## What does this PR do?

Adds `where: { status?, locale? }` to the plugin-facing `ContentListOptions`, letting plugins narrow `ContentAccess.list()` results at the database layer instead of pulling every row and filtering in userland.

The underlying `ContentRepository.findMany` already accepts `where.status` / `where.locale` / `where.authorId` ([`packages/core/src/database/repositories/types.ts:66`](https://github.com/emdash-cms/emdash/blob/main/packages/core/src/database/repositories/types.ts#L66)) — this PR only plumbs the commonly-needed subset through the public API. `authorId` is left out for now since no current ask requires it; easy follow-up if someone needs it.

**Why:** today, a plugin that wants "published items only" has to pull every row (drafts, trashed, everything), filter in memory, and discard most of them. On a site with thousands of drafts this is wasteful and paginates wrong (the cursor counts pre-filter rows). A `where.status` filter pushes the narrowing into the SQL query, which is what the repository was designed to do.

Discussion: [#530](https://github.com/emdash-cms/emdash/discussions/530). Companion PR #539 handles the `locale` field addition to `ContentItem`.

## Type of change

- [x] Feature (additive — new optional field on an existing options type, no behavior change for consumers that don't pass it)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes (core)
- [x] `pnpm format` run
- [x] Changeset added (`emdash` minor)
- [ ] Tests — following the precedent set by #536 (no new tests for the same plugin API surface). Happy to add one if reviewers prefer.

## AI-generated code disclosure

- [x] This PR includes AI-generated code