### PR TITLE
fix(cloudflare): provide emdash shim module to Worker Loader

### DIFF
--- a/.changeset/poor-rings-sniff.md
+++ b/.changeset/poor-rings-sniff.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes sandboxed plugin loading in Worker Loader by providing an `emdash` shim module

--- a/packages/cloudflare/src/sandbox/runner.ts
+++ b/packages/cloudflare/src/sandbox/runner.ts
@@ -26,6 +26,8 @@ import { setEmailSendCallback } from "./bridge.js";
 import type { WorkerLoader, WorkerStub, PluginBridgeBinding, WorkerLoaderLimits } from "./types.js";
 import { generatePluginWrapper } from "./wrapper.js";
 
+const EMDASH_SHIM = "export const definePlugin = (d) => d;\n";
+
 /**
  * Default resource limits for sandboxed plugins.
  *
@@ -248,11 +250,12 @@ class CloudflareSandboxedPlugin implements SandboxedPlugin {
 		// Get a fresh stub with the new bridge binding.
 		// Worker Loader caches the isolate but the stub/bindings are per-call.
 		return this.loader.get(this.id, () => ({
-			compatibilityDate: "2025-01-01",
+			compatibilityDate: "2026-04-01",
 			mainModule: "plugin.js",
 			modules: {
 				"plugin.js": { js: this.wrapperCode! },
 				"sandbox-plugin.js": { js: this.code },
+				emdash: { js: EMDASH_SHIM },
 			},
 			// Block direct network access - plugins must use ctx.http via bridge
 			globalOutbound: null,


### PR DESCRIPTION
## What does this PR do?

Sandboxed plugins built from npm packages (via Astro build) retain `import { definePlugin } from "emdash"` in their dist files because `emdash` is an external peer dependency. The CLI `bundle` command already aliases this to a shim during tsdown bundling, but the Astro build path embeds the dist file verbatim into `virtual:emdash/sandboxed-plugins`. When the Worker Loader runs `sandbox-plugin.js`, it fails with `No such module "emdash"`.

This adds an `"emdash"` shim module to the Worker Loader's `modules` config so the import resolves at runtime. `definePlugin` for standard-format plugins is an identity function.

Also bumps `compatibilityDate` to `2026-04-01`.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code