### PR TITLE
fix(blocks-playground): use fileURLToPath to handle spaces in directory paths

### DIFF
--- a/packages/blocks/playground/vite.config.ts
+++ b/packages/blocks/playground/vite.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -7,7 +9,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			// Resolve @emdash-cms/blocks from source for HMR
-			"@emdash-cms/blocks": new URL("../src/index.ts", import.meta.url).pathname,
+			"@emdash-cms/blocks": fileURLToPath(new URL("../src/index.ts", import.meta.url)),
 		},
 	},
 });


### PR DESCRIPTION
## What does this PR do?

`new URL(...).pathname` returns a URL-encoded path — spaces in directory names become `%20`. The blocks playground `vite.config.ts` used this to alias `@emdash-cms/blocks` to its source, which breaks when the project is cloned into a path with spaces (e.g. `Local Sites`). Vite can't resolve the `%20`-encoded path and the build fails with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`.

Replacing `.pathname` with `fileURLToPath()` from `node:url` correctly decodes the path to its filesystem representation.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation
- [ ] I have added a changeset (demo/tooling-only change, no published package affected)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Before: `pnpm build` fails with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` when project path contains spaces.

After: `pnpm build` completes successfully.