### PR TITLE
fix(cloudflare): disable FK enforcement during DO table cleanup

### DIFF
--- a/packages/cloudflare/src/db/do-class.ts
+++ b/packages/cloudflare/src/db/do-class.ts
@@ -202,21 +202,33 @@ export class EmDashPreviewDB extends DurableObject {
 	/**
 	 * Drop all user tables in the DO's SQLite database.
 	 * Preserves SQLite and Cloudflare internal tables.
+	 *
+	 * Disables foreign key enforcement before dropping to avoid cascade
+	 * errors when tables are dropped in an order that violates FK
+	 * dependencies (e.g. parent before child).
 	 */
 	private dropAllTables(): void {
-		const tables = [
-			...this.ctx.storage.sql.exec(
-				"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%'",
-			),
-		];
-		for (const row of tables) {
-			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- SqlStorageCursor yields loosely-typed rows
-			const name = String(row.name as string);
-			if (!SAFE_IDENTIFIER.test(name)) {
-				// Skip tables with unsafe names rather than interpolating them
-				continue;
+		// Disable FK enforcement so DROP order doesn't matter.
+		// Cloudflare DO SQLite enforces foreign keys by default.
+		this.ctx.storage.sql.exec("PRAGMA foreign_keys = OFF");
+
+		try {
+			const tables = [
+				...this.ctx.storage.sql.exec(
+					"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%'",
+				),
+			];
+			for (const row of tables) {
+				// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- SqlStorageCursor yields loosely-typed rows
+				const name = String(row.name as string);
+				if (!SAFE_IDENTIFIER.test(name)) {
+					// Skip tables with unsafe names rather than interpolating them
+					continue;
+				}
+				this.ctx.storage.sql.exec(`DROP TABLE IF EXISTS "${name}"`);
 			}
-			this.ctx.storage.sql.exec(`DROP TABLE IF EXISTS "${name}"`);
+		} finally {
+			this.ctx.storage.sql.exec("PRAGMA foreign_keys = ON");
 		}
 	}
 

--- a/packages/cloudflare/src/db/do-class.ts
+++ b/packages/cloudflare/src/db/do-class.ts
@@ -205,7 +205,8 @@ export class EmDashPreviewDB extends DurableObject {
 	 *
 	 * Disables foreign key enforcement before dropping to avoid cascade
 	 * errors when tables are dropped in an order that violates FK
-	 * dependencies (e.g. parent before child).
+	 * dependencies (e.g. child dropped first, then parent's implicit
+	 * CASCADE delete references the already-dropped child table).
 	 */
 	private dropAllTables(): void {
 		// Disable FK enforcement so DROP order doesn't matter.


### PR DESCRIPTION
## What does this PR do?

Fixes `no such table: main._emdash_menus: SQLITE_ERROR` errors in the playground worker's alarm handler.

Cloudflare DO SQLite enforces `PRAGMA foreign_keys = ON` by default. When the TTL alarm fires and `dropAllTables()` iterates tables from `sqlite_master`, the alphabetical drop order can violate FK dependencies. For example, `_emdash_menu_items` (child) sorts before `_emdash_menus` (parent) -- when the parent is dropped, SQLite's implicit `DELETE FROM` triggers a CASCADE to the already-dropped child table, producing the "no such table" error.

The fix disables FK enforcement before the drop loop and re-enables it in a `finally` block. This is the standard SQLite pattern for schema operations that interact with FKs.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code