### PR TITLE
fix(core): /search/suggest crash from double-star FTS5 prefix (#547)

### DIFF
--- a/.changeset/shy-keys-check.md
+++ b/.changeset/shy-keys-check.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `/_emdash/api/search/suggest` 500 error. `getSuggestions` no longer double-appends the FTS5 prefix operator `*` on top of the one `escapeQuery` already adds, so autocomplete queries like `?q=des` now return results instead of raising `SqliteError: fts5: syntax error near "*"`.

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -275,9 +275,10 @@ export async function getSuggestions(
 		const ftsTable = ftsManager.getFtsTableName(collection);
 		const contentTable = ftsManager.getContentTableName(collection);
 
-		// Use prefix search for autocomplete
-		const prefixQuery = `${escapeQuery(query)}*`;
-		if (!prefixQuery || prefixQuery === "*") {
+		// Use prefix search for autocomplete. `escapeQuery` already appends `*`
+		// to each term for prefix matching, so we must not append another one.
+		const prefixQuery = escapeQuery(query);
+		if (!prefixQuery) {
 			continue;
 		}
 

--- a/packages/core/tests/integration/search/suggest.test.ts
+++ b/packages/core/tests/integration/search/suggest.test.ts
@@ -1,0 +1,57 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { FTSManager } from "../../../src/search/fts-manager.js";
+import { getSuggestions } from "../../../src/search/query.js";
+import { createPostFixture } from "../../utils/fixtures.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("getSuggestions (Integration)", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		const ftsManager = new FTSManager(db);
+		await registry.updateField("post", "title", { searchable: true });
+		await ftsManager.enableSearch("post");
+
+		await repo.create(
+			createPostFixture({
+				slug: "designing-things",
+				status: "published",
+				data: { title: "Designing things" },
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("returns matching suggestions for a plain prefix query", async () => {
+		const suggestions = await getSuggestions(db, "des", {
+			collections: ["post"],
+		});
+
+		expect(suggestions).toHaveLength(1);
+		expect(suggestions[0]).toMatchObject({
+			collection: "post",
+			title: "Designing things",
+		});
+	});
+
+	it("returns empty array for a non-matching query", async () => {
+		const suggestions = await getSuggestions(db, "zzz", {
+			collections: ["post"],
+		});
+
+		expect(suggestions).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the `/_emdash/api/search/suggest` 500 error filed in #547. `getSuggestions` in `packages/core/src/search/query.ts` was appending `*` on top of the `*` that `escapeQuery` already appends to each term, producing invalid FTS5 like `"des"**` and raising `SqliteError: fts5: syntax error near "*"` on every request.

```diff
-		// Use prefix search for autocomplete
-		const prefixQuery = `${escapeQuery(query)}*`;
-		if (!prefixQuery || prefixQuery === "*") {
+		// Use prefix search for autocomplete. `escapeQuery` already appends `*`
+		// to each term for prefix matching, so we must not append another one.
+		const prefixQuery = escapeQuery(query);
+		if (!prefixQuery) {
 			continue;
 		}
```

`escapeQuery` returns `"des"*` for `"des"` (line 395 in the same file), so simply passing its output to `MATCH` is the correct thing to do. The `prefixQuery === "*"` guard is no longer reachable now that the literal `*` is gone, so the check is simplified to `!prefixQuery`.

A regression test is added at `packages/core/tests/integration/search/suggest.test.ts`:
- `returns matching suggestions for a plain prefix query` — reproduces the crash on `main`, passes after the fix.
- `returns empty array for a non-matching query` — guards against the returned shape regressing.

Closes #547. Follow-up to PR #424 (where I intentionally kept this out of scope per AGENTS.md).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (baseline on `main` is 11 pre-existing diagnostics in unrelated files; this PR does not add any)
- [x] `pnpm test` passes (new suggest tests green; the one pre-existing failure in `tests/integration/plugins/capabilities.test.ts "does not throw for any host"` reproduces on pristine `main` too and is unrelated to this change — verified by checking out `origin/main` and running the same test)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A — no UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion (N/A — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Before (`main` at `82c6345`):

```console
$ pnpm vitest run tests/integration/search/suggest.test.ts
FAIL  tests/integration/search/suggest.test.ts > getSuggestions (Integration) > returns matching suggestions for a plain prefix query
SqliteError: fts5: syntax error near "*"
 ❯ getSuggestions src/search/query.ts:284:19
Tests  2 failed (2)
```

After this PR:

```console
$ pnpm vitest run tests/integration/search/suggest.test.ts
✓ tests/integration/search/suggest.test.ts (2 tests) 52ms
Tests  2 passed (2)
```
