### PR TITLE
fix(admin): use dropdown for login page language selector

### DIFF
--- a/.changeset/forty-facts-deny.md
+++ b/.changeset/forty-facts-deny.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Replaces the horizontal language-switch button bar on the admin login page with a dropdown, so the selector stays usable as more locales are added.

--- a/packages/admin/src/components/LoginPage.tsx
+++ b/packages/admin/src/components/LoginPage.tsx
@@ -13,7 +13,7 @@
  * redirects to the admin dashboard since authentication is handled externally.
  */
 
-import { Button, Input, Loader } from "@cloudflare/kumo";
+import { Button, Input, Loader, Select } from "@cloudflare/kumo";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
@@ -366,22 +366,14 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 
 				{/* Language selector — only shown when multiple locales are available */}
 				{SUPPORTED_LOCALES.length > 1 && (
-					<div className="mt-6 flex justify-center gap-2 text-xs text-kumo-subtle">
-						{SUPPORTED_LOCALES.map((l, i) => (
-							<React.Fragment key={l.code}>
-								{i > 0 && <span>·</span>}
-								<button
-									onClick={() => setLocale(l.code)}
-									className={
-										l.code === locale
-											? "font-medium text-kumo-default"
-											: "hover:text-kumo-default transition-colors"
-									}
-								>
-									{l.label}
-								</button>
-							</React.Fragment>
-						))}
+					<div className="mt-6 flex justify-center">
+						<Select
+							aria-label={t`Language`}
+							className="w-48"
+							value={locale}
+							onValueChange={(v) => v && setLocale(v)}
+							items={Object.fromEntries(SUPPORTED_LOCALES.map((l) => [l.code, l.label]))}
+						/>
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## What does this PR do?

The login page's language selector rendered every supported locale as an inline button with dot separators. That worked when there were three locales; with the current nine (and more coming) it wraps awkwardly and is hard to scan. This PR swaps it for the same kumo `Select` dropdown already used for the language setting in Settings, so the affordance is consistent and scales.

Also bumps `@cloudflare/kumo` to the workspace catalog (`^1.18.0`) so `@emdash-cms/admin` and `@emdash-cms/blocks` share a single version and pick up the `Select` component.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Verified `pnpm --filter @emdash-cms/admin typecheck` and `pnpm lint:quick` clean on the touched file.