### PR TITLE
fix(admin): document outline shows headings on initial load

### DIFF
--- a/.changeset/fix-document-outline.md
+++ b/.changeset/fix-document-outline.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fix document outline not showing headings on initial load. The outline now defers initial extraction to next tick (so TipTap finishes hydrating) and also listens for transaction events to catch programmatic content changes.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -228,8 +228,17 @@ export function ContentEditor({
 			[],
 	);
 
-	// Track portableText editor for document outline
+	// Track portableText editor for document outline — use a ref to
+	// ensure only the first portableText field claims the slot even when
+	// multiple PT fields render in the same pass.
 	const [portableTextEditor, setPortableTextEditor] = React.useState<Editor | null>(null);
+	const ptEditorClaimedRef = React.useRef(false);
+	const handlePTEditorReady = React.useCallback((editor: Editor) => {
+		if (!ptEditorClaimedRef.current) {
+			ptEditorClaimedRef.current = true;
+			setPortableTextEditor(editor);
+		}
+	}, []);
 
 	// Block sidebar state – when a block (e.g. image) requests sidebar space, this holds
 	// the panel data. When non-null the sidebar shows the block panel instead of the
@@ -672,7 +681,7 @@ export function ContentEditor({
 										value={formData[name]}
 										onChange={handleFieldChange}
 										onEditorReady={
-											field.kind === "portableText" ? setPortableTextEditor : undefined
+											field.kind === "portableText" && name === "content" ? setPortableTextEditor : undefined
 										}
 										minimal={isDistractionFree}
 										pluginBlocks={pluginBlocks}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -681,7 +681,9 @@ export function ContentEditor({
 										value={formData[name]}
 										onChange={handleFieldChange}
 										onEditorReady={
-											field.kind === "portableText" && name === "content" ? setPortableTextEditor : undefined
+											field.kind === "portableText" && name === "content"
+												? setPortableTextEditor
+												: undefined
 										}
 										minimal={isDistractionFree}
 										pluginBlocks={pluginBlocks}


### PR DESCRIPTION
## Summary

The document outline panel in the content editor always shows "No headings in document" when first loading a post that has h2/h3 headings.

## Root cause

`extractHeadings()` runs synchronously in a `useEffect` when the editor instance becomes available. However, TipTap's `useEditor` hook returns the editor before the initial `content` prop has been fully hydrated into the ProseMirror document. The initial extraction finds an empty document, and since TipTap doesn't fire an `update` event for the initial content load, the outline never refreshes.

## Fix

Two changes in `DocumentOutline.tsx`:

1. **Defer initial extraction** to next tick via `setTimeout(fn, 0)` so TipTap has finished hydrating the document
2. **Add `transaction` listener** alongside the existing `update` listener to catch programmatic content replacements (e.g. draft restore, undo) that don't fire `update`

## Test plan

- [ ] Open a post with h2/h3 headings - outline should show them immediately
- [ ] Edit a heading - outline should update
- [ ] Create a new empty post - outline should show "No headings in document"
- [ ] Add a heading to empty post - outline should update

## Related

Discovered while testing with posts that have h2 headings in Portable Text content. The headings render correctly on the published page but the admin outline panel was always empty.