### PR TITLE
feat: extensions — custom admin pages with sidebar navigation

### DIFF
--- a/.changeset/extensions-feature.md
+++ b/.changeset/extensions-feature.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds extensions — custom admin pages with sidebar navigation. Extensions are Astro pages in `src/extensions/{name}/` with full access to database and storage. Registered via `extensions` config in emdash().

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -16,6 +16,8 @@ import {
 	Users,
 	Stack,
 	ArrowsLeftRight,
+	Rocket,
+	Globe,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
@@ -59,6 +61,12 @@ export interface SidebarNavProps {
 		version?: string;
 		commit?: string;
 		marketplace?: string;
+		extensions?: Array<{
+			label: string;
+			icon?: string;
+			group?: string;
+			url: string;
+		}>;
 	};
 }
 
@@ -166,8 +174,6 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 		enabled: userRole >= ROLE_EDITOR,
 	});
 
-	// --- Build nav item groups ---
-
 	const contentItems: NavItem[] = [{ to: "/", label: t`Dashboard`, icon: SquaresFour }];
 	for (const [name, config] of Object.entries(manifest.collections)) {
 		contentItems.push({
@@ -223,6 +229,29 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 		{ to: "/import/wordpress", label: t`Import`, icon: Upload, minRole: ROLE_ADMIN },
 		{ to: "/settings", label: t`Settings`, icon: Gear, minRole: ROLE_ADMIN },
 	);
+
+	const EXTENSION_ICONS: Record<string, React.ElementType> = {
+		rocket: Rocket,
+		upload: Upload,
+		database: Database,
+		gear: Gear,
+		list: List,
+		globe: Globe,
+	};
+
+	for (const ext of manifest.extensions ?? []) {
+		const slug = ext.url.replace("/_emdash/ext/", "");
+		const item: NavItem = {
+			to: "/ext/$name",
+			params: { name: slug },
+			label: ext.label,
+			icon: EXTENSION_ICONS[ext.icon ?? ""] ?? Upload,
+			minRole: ROLE_ADMIN,
+		};
+		if (ext.group === "content") contentItems.push(item);
+		else if (ext.group === "admin") adminItems.push(item);
+		else manageItems.push(item);
+	}
 
 	const pluginItems: NavItem[] = [];
 	for (const [pluginId, config] of Object.entries(manifest.plugins)) {

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1619,7 +1619,23 @@ const notFoundRoute = createRoute({
 	component: () => <NotFoundPage />,
 });
 
-// Create route tree with admin routes under layout and setup route separate
+function ExtensionPage() {
+	const { name } = useParams({ from: "/_admin/ext/$name" });
+	if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) return <NotFoundPage />;
+	return (
+		<iframe
+			src={`/_emdash/ext/${name}`}
+			style={{ width: "100%", height: "100%", border: "none", minHeight: "calc(100vh - 64px)" }}
+		/>
+	);
+}
+
+const extensionRoute = createRoute({
+	getParentRoute: () => adminLayoutRoute,
+	path: "/ext/$name",
+	component: ExtensionPage,
+});
+
 const adminRoutes = adminLayoutRoute.addChildren([
 	dashboardRoute,
 	contentListRoute,
@@ -1654,6 +1670,7 @@ const adminRoutes = adminLayoutRoute.addChildren([
 	apiTokenSettingsRoute,
 	emailSettingsRoute,
 	wordpressImportRoute,
+	extensionRoute,
 	notFoundRoute,
 ]);
 

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1619,9 +1619,11 @@ const notFoundRoute = createRoute({
 	component: () => <NotFoundPage />,
 });
 
+const VALID_EXT_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 function ExtensionPage() {
 	const { name } = useParams({ from: "/_admin/ext/$name" });
-	if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) return <NotFoundPage />;
+	if (!VALID_EXT_SLUG.test(name)) return <NotFoundPage />;
 	return (
 		<iframe
 			src={`/_emdash/ext/${name}`}

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -21,6 +21,7 @@ import { createViteConfig } from "./vite-config.js";
 // Re-export runtime types and functions
 export type {
 	EmDashConfig,
+	ExtensionDescriptor,
 	PluginDescriptor,
 	SandboxedPluginDescriptor,
 	ResolvedPlugin,
@@ -37,6 +38,8 @@ const DEFAULT_STORAGE = local({
 const dim = (s: string) => `\x1b[2m${s}\x1b[22m`;
 const bold = (s: string) => `\x1b[1m${s}\x1b[22m`;
 const cyan = (s: string) => `\x1b[36m${s}\x1b[39m`;
+
+const VALID_EXTENSION_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /** Print the EmDash startup banner */
 function printBanner(_logger: AstroIntegrationLogger): void {
@@ -158,6 +161,12 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 		auth: resolvedConfig.auth,
 		marketplace: resolvedConfig.marketplace,
 		siteUrl: resolvedConfig.siteUrl,
+		extensions: resolvedConfig.extensions?.map((ext) => ({
+			label: ext.label,
+			icon: ext.icon,
+			group: ext.group || "manage",
+			url: "/_emdash/ext/" + ext.name,
+		})),
 	};
 
 	// Determine auth mode for route injection
@@ -167,7 +176,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 	return {
 		name: "emdash",
 		hooks: {
-			"astro:config:setup": ({
+			"astro:config:setup": async ({
 				injectRoute,
 				addMiddleware,
 				logger,
@@ -231,6 +240,66 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				// Inject MCP endpoint (always on — bearer-token-only, no cost if unused)
 				if (resolvedConfig.mcp !== false) {
 					injectMcpRoute(injectRoute);
+				}
+
+				if (resolvedConfig.extensions?.length) {
+					const { resolve: resolvePath } = await import("node:path");
+					const { existsSync } = await import("node:fs");
+					const projectRoot = process.cwd();
+					const seenNames = new Set<string>();
+
+					for (const ext of resolvedConfig.extensions) {
+						if (!VALID_EXTENSION_SLUG.test(ext.name)) {
+							logger.warn(
+								`Skipping extension "${ext.name}": name must be lowercase alphanumeric with hyphens`,
+							);
+							continue;
+						}
+
+						if (seenNames.has(ext.name)) {
+							logger.warn(`Skipping duplicate extension "${ext.name}"`);
+							continue;
+						}
+						seenNames.add(ext.name);
+
+						const dir = resolvePath(projectRoot, "src", "extensions", ext.name);
+						if (!dir.startsWith(projectRoot)) {
+							logger.warn(
+								`Skipping extension "${ext.name}": resolved path escapes project directory`,
+							);
+							continue;
+						}
+
+						const pagePath = resolvePath(dir, "page.astro");
+						if (!existsSync(pagePath)) {
+							logger.warn(`Skipping extension "${ext.name}": missing page.astro in ${dir}`);
+							continue;
+						}
+
+						injectRoute({
+							pattern: "/_emdash/ext/" + ext.name,
+							entrypoint: pagePath,
+							prerender: false,
+						});
+
+						const integrationPath = resolvePath(dir, "integration.ts");
+						if (existsSync(integrationPath)) {
+							const mod = await import(integrationPath);
+							const setupFn = mod.default || Object.values(mod)[0];
+							if (typeof setupFn === "function") {
+								const integration = setupFn();
+								if (integration?.hooks?.["astro:config:setup"]) {
+									await integration.hooks["astro:config:setup"]({
+										injectRoute,
+										updateConfig,
+										config: astroConfig,
+										command,
+										logger,
+									});
+								}
+							}
+						}
+					}
 				}
 
 				// In playground mode, inject the playground middleware FIRST.

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -125,6 +125,13 @@ export interface PluginDescriptor<TOptions = Record<string, unknown>> {
 export type SandboxedPluginDescriptor<TOptions = Record<string, unknown>> =
 	PluginDescriptor<TOptions>;
 
+export interface ExtensionDescriptor {
+	name: string;
+	label: string;
+	icon?: string;
+	group?: "content" | "manage" | "admin";
+}
+
 export interface EmDashConfig {
 	/**
 	 * Database configuration
@@ -255,6 +262,13 @@ export interface EmDashConfig {
 	 * ```
 	 */
 	marketplace?: string;
+
+	/**
+	 * Admin sidebar extensions — custom pages rendered inline.
+	 * Each extension adds a nav item to the specified sidebar group
+	 * and renders the Astro page file in an iframe.
+	 */
+	extensions?: ExtensionDescriptor[];
 
 	/**
 	 * Public browser-facing origin for the site.

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -37,7 +37,8 @@ export const GET: APIRoute = async ({ locals }) => {
 		}
 	}
 
-	const extensions = (emdash?.config as Record<string, unknown>)?.extensions as EmDashManifest["extensions"];
+	const extensions = (emdash?.config as Record<string, unknown>)
+		?.extensions as EmDashManifest["extensions"];
 
 	const manifest: EmDashManifest = emdashManifest
 		? {

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -37,11 +37,14 @@ export const GET: APIRoute = async ({ locals }) => {
 		}
 	}
 
+	const extensions = (emdash?.config as Record<string, unknown>)?.extensions as EmDashManifest["extensions"];
+
 	const manifest: EmDashManifest = emdashManifest
 		? {
 				...emdashManifest,
 				authMode: authMode.type === "external" ? authMode.providerType : "passkey",
 				signupEnabled,
+				extensions,
 			}
 		: {
 				version: VERSION,
@@ -52,6 +55,7 @@ export const GET: APIRoute = async ({ locals }) => {
 				taxonomies: [],
 				authMode: "passkey",
 				signupEnabled,
+				extensions,
 			};
 
 	return Response.json(

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -38,9 +38,10 @@ export const GET: APIRoute = async ({ locals }) => {
 	}
 
 	const config = emdash?.config;
-	const extensions: EmDashManifest["extensions"] = config && "extensions" in config
-		? (config.extensions as EmDashManifest["extensions"])
-		: undefined;
+	const extensions: EmDashManifest["extensions"] =
+		config && "extensions" in config
+			? (config.extensions as EmDashManifest["extensions"])
+			: undefined;
 
 	const manifest: EmDashManifest = emdashManifest
 		? {

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -37,8 +37,10 @@ export const GET: APIRoute = async ({ locals }) => {
 		}
 	}
 
-	const extensions = (emdash?.config as Record<string, unknown>)
-		?.extensions as EmDashManifest["extensions"];
+	const config = emdash?.config;
+	const extensions: EmDashManifest["extensions"] = config && "extensions" in config
+		? (config.extensions as EmDashManifest["extensions"])
+		: undefined;
 
 	const manifest: EmDashManifest = emdashManifest
 		? {

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -142,6 +142,12 @@ export interface EmDashManifest {
 	 * When true, the admin UI can show marketplace browse/install features.
 	 */
 	marketplace?: boolean;
+	extensions?: Array<{
+		label: string;
+		icon?: string;
+		group?: string;
+		url: string;
+	}>;
 }
 
 /**

--- a/skills/creating-extensions/SKILL.md
+++ b/skills/creating-extensions/SKILL.md
@@ -9,15 +9,15 @@ Extensions are Astro pages that appear in the admin sidebar with full access to 
 
 ## When to Use Extensions vs Plugins
 
-| Need | Use |
-|------|-----|
-| Send email, react to content changes, webhooks | Plugin |
-| Simple settings page with form fields | Plugin |
-| Query all database tables directly | Extension |
-| Upload files to R2 storage | Extension |
-| Custom analytics dashboard | Extension |
-| Bulk import/export tool | Extension |
-| Deploy trigger with custom UI | Extension |
+| Need                                           | Use       |
+| ---------------------------------------------- | --------- |
+| Send email, react to content changes, webhooks | Plugin    |
+| Simple settings page with form fields          | Plugin    |
+| Query all database tables directly             | Extension |
+| Upload files to R2 storage                     | Extension |
+| Custom analytics dashboard                     | Extension |
+| Bulk import/export tool                        | Extension |
+| Deploy trigger with custom UI                  | Extension |
 
 **Rule:** If the plugin `ctx` API is enough, use a plugin. If you need `db` or `storage` directly, use an extension.
 
@@ -59,10 +59,8 @@ const db = emdash?.db;
 
 ```ts
 emdash({
-	extensions: [
-		{ name: "my-tool", label: "My Tool", icon: "rocket", group: "manage" },
-	],
-})
+	extensions: [{ name: "my-tool", label: "My Tool", icon: "rocket", group: "manage" }],
+});
 ```
 
 ### 4. Build and deploy
@@ -82,24 +80,24 @@ The extension appears in the admin sidebar under the specified group.
 
 ### Available Icons
 
-| Name | Icon |
-|------|------|
-| `rocket` | Rocket |
-| `upload` | Upload |
+| Name       | Icon     |
+| ---------- | -------- |
+| `rocket`   | Rocket   |
+| `upload`   | Upload   |
 | `database` | Database |
-| `gear` | Gear |
-| `list` | List |
-| `globe` | Globe |
+| `gear`     | Gear     |
+| `list`     | List     |
+| `globe`    | Globe    |
 
 Unrecognized names fall back to Upload.
 
 ### Sidebar Groups
 
-| Group | Appears alongside |
-|-------|------------------|
-| `content` | Posts, Pages, Media |
-| `manage` | Menus, Tags, Bylines |
-| `admin` | Users, Plugins, Settings |
+| Group     | Appears alongside        |
+| --------- | ------------------------ |
+| `content` | Posts, Pages, Media      |
+| `manage`  | Menus, Tags, Bylines     |
+| `admin`   | Users, Plugins, Settings |
 
 ## What Extensions Can Access
 
@@ -112,7 +110,11 @@ const posts = await db.selectFrom("ec_posts").selectAll().execute();
 
 // Storage (R2/S3)
 const storage = (Astro.locals as any).emdash?.storage;
-await storage.upload({ key: "exports/data.json", body: jsonBytes, contentType: "application/json" });
+await storage.upload({
+	key: "exports/data.json",
+	body: jsonBytes,
+	contentType: "application/json",
+});
 
 // Authenticated user
 const user = (Astro.locals as any).user;
@@ -251,4 +253,3 @@ Extensions can include inline JavaScript for client-side behavior:
 - Extensions must check auth themselves (`user.role < 50`)
 - The emdash middleware chain (auth, CSRF) runs before the extension page
 - Extensions run as trusted code (same as any Astro page in the project)
-

--- a/skills/creating-extensions/SKILL.md
+++ b/skills/creating-extensions/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: creating-extensions
+description: Create EmDash extensions — custom admin pages with full database and storage access. Use this skill when asked to build admin tools, dashboards, export pages, or any feature that needs direct database queries or R2 storage access from the admin sidebar.
+---
+
+# Creating EmDash Extensions
+
+Extensions are Astro pages that appear in the admin sidebar with full access to the database, storage, and authenticated user. They fill the gap between plugins (sandboxed, limited API) and custom Astro pages (no sidebar integration).
+
+## When to Use Extensions vs Plugins
+
+| Need | Use |
+|------|-----|
+| Send email, react to content changes, webhooks | Plugin |
+| Simple settings page with form fields | Plugin |
+| Query all database tables directly | Extension |
+| Upload files to R2 storage | Extension |
+| Custom analytics dashboard | Extension |
+| Bulk import/export tool | Extension |
+| Deploy trigger with custom UI | Extension |
+
+**Rule:** If the plugin `ctx` API is enough, use a plugin. If you need `db` or `storage` directly, use an extension.
+
+## Quick Start
+
+### 1. Create the extension folder
+
+```
+src/extensions/my-tool/
+	page.astro
+```
+
+### 2. Write the page
+
+```astro
+---
+export const prerender = false;
+
+const user = (Astro.locals as any).user;
+if (!user) return Astro.redirect("/_emdash/admin");
+if (user.role < 50) return new Response("Forbidden", { status: 403 });
+
+const emdash = (Astro.locals as any).emdash;
+const db = emdash?.db;
+---
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>My Tool</title>
+</head>
+<body>
+	<h1>My Tool</h1>
+	<p>Extension is working.</p>
+</body>
+</html>
+```
+
+### 3. Register in astro.config.mjs
+
+```ts
+emdash({
+	extensions: [
+		{ name: "my-tool", label: "My Tool", icon: "rocket", group: "manage" },
+	],
+})
+```
+
+### 4. Build and deploy
+
+The extension appears in the admin sidebar under the specified group.
+
+## Extension Descriptor
+
+```ts
+{
+	name: string;       // Slug: lowercase, hyphens, no special chars
+	label: string;      // Display name in sidebar
+	icon?: string;      // Phosphor icon name (default: "upload")
+	group?: string;     // Sidebar group: "content" | "manage" | "admin" (default: "manage")
+}
+```
+
+### Available Icons
+
+| Name | Icon |
+|------|------|
+| `rocket` | Rocket |
+| `upload` | Upload |
+| `database` | Database |
+| `gear` | Gear |
+| `list` | List |
+| `globe` | Globe |
+
+Unrecognized names fall back to Upload.
+
+### Sidebar Groups
+
+| Group | Appears alongside |
+|-------|------------------|
+| `content` | Posts, Pages, Media |
+| `manage` | Menus, Tags, Bylines |
+| `admin` | Users, Plugins, Settings |
+
+## What Extensions Can Access
+
+The page runs as a standard Astro page with full access to:
+
+```ts
+// Database (Kysely instance)
+const db = (Astro.locals as any).emdash?.db;
+const posts = await db.selectFrom("ec_posts").selectAll().execute();
+
+// Storage (R2/S3)
+const storage = (Astro.locals as any).emdash?.storage;
+await storage.upload({ key: "exports/data.json", body: jsonBytes, contentType: "application/json" });
+
+// Authenticated user
+const user = (Astro.locals as any).user;
+// user.role: 50 = admin, 40 = editor, 30 = author, 20 = contributor
+
+// Request
+const url = Astro.url;
+const method = Astro.request.method;
+const formData = await Astro.request.formData();
+```
+
+## File Structure
+
+```
+src/extensions/
+	my-tool/
+		page.astro            # Required — the page rendered in the admin
+		integration.ts        # Optional — build-time setup (Vite aliases, extra routes)
+		helper.ts             # Optional — any helper files the page imports
+```
+
+### page.astro (Required)
+
+The main page. Must have `export const prerender = false;`. Should check auth:
+
+```astro
+---
+export const prerender = false;
+const user = (Astro.locals as any).user;
+if (!user) return Astro.redirect("/_emdash/admin");
+if (user.role < 50) return new Response("Forbidden", { status: 403 });
+---
+```
+
+### integration.ts (Optional)
+
+Build-time setup. Only needed if the page imports something Vite can't resolve (like emdash internal modules). Returns an Astro integration:
+
+```ts
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { AstroIntegration } from "astro";
+
+export function myToolSetup(): AstroIntegration {
+	return {
+		name: "my-tool-setup",
+		hooks: {
+			"astro:config:setup": ({ updateConfig }) => {
+				const require = createRequire(path.join(process.cwd(), "package.json"));
+				const emdashRoot = require.resolve("emdash").replace(/[/\\]dist[/\\].*$/, "");
+				updateConfig({
+					vite: {
+						resolve: {
+							alias: {
+								"my-custom-alias": path.join(emdashRoot, "src/some/internal/module.ts"),
+							},
+						},
+					},
+				});
+			},
+		},
+	};
+}
+```
+
+Most extensions don't need this. Only use it when importing emdash internals that aren't publicly exported.
+
+## How It Works
+
+1. emdash reads `extensions` from config at build time
+2. Validates each name against `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`
+3. Resolves `src/extensions/{name}/page.astro` and injects a route at `/_emdash/ext/{name}`
+4. If `integration.ts` exists, imports and runs its setup hook
+5. Serializes extension metadata (label, icon, group, URL) into the manifest
+6. The admin sidebar reads extensions from the manifest and adds nav items
+7. Clicking an extension navigates to a TanStack Router route that renders an iframe
+8. The iframe loads the Astro page at `/_emdash/ext/{name}`
+
+## Handling Form Submissions
+
+Extensions support POST requests for form handling:
+
+```astro
+---
+export const prerender = false;
+
+const user = (Astro.locals as any).user;
+if (!user) return Astro.redirect("/_emdash/admin");
+
+let result = null;
+
+if (Astro.request.method === "POST") {
+	const formData = await Astro.request.formData();
+	const name = formData.get("name") as string;
+	// process the form...
+	result = { success: true };
+}
+---
+<html>
+<body>
+	{result?.success && <p>Done!</p>}
+	<form method="POST">
+		<input name="name" type="text" />
+		<button type="submit">Submit</button>
+	</form>
+</body>
+</html>
+```
+
+## Client-Side JavaScript
+
+Extensions can include inline JavaScript for client-side behavior:
+
+```astro
+<button id="my-btn">Click me</button>
+<div id="status"></div>
+
+<script is:inline>
+(function() {
+	document.getElementById("my-btn").addEventListener("click", function() {
+		document.getElementById("status").textContent = "Clicked!";
+		fetch("https://api.example.com/trigger", { method: "POST" })
+			.then(function(res) {
+				document.getElementById("status").textContent = res.ok ? "Done!" : "Failed";
+			});
+	});
+})();
+</script>
+```
+
+## Security
+
+- Extension names are validated against a strict slug regex
+- Resolved paths are checked to not escape the project root
+- The iframe route validates the slug client-side before constructing the src URL
+- Extensions must check auth themselves (`user.role < 50`)
+- The emdash middleware chain (auth, CSRF) runs before the extension page
+- Extensions run as trusted code (same as any Astro page in the project)
+


### PR DESCRIPTION
# Extensions: Custom Admin Pages

## Why

Plugins run in a constrained environment -- they interact with the CMS through hooks and a scoped API. Some use cases need direct database access, full Astro rendering, or custom server-side logic that does not fit the plugin model. Examples: static site export, analytics dashboards, bulk content tools, deployment management.

Extensions fill this gap. They are first-class Astro pages that live inside the project, have full access to Astro.locals (database, storage, auth), and appear as sidebar items in the admin UI.

## Developer Experience

### Configuration

```ts
// astro.config.mjs
emdash({
  extensions: [
    { name: "static-deploy", label: "Static Export", icon: "rocket", group: "manage" },
    { name: "analytics", label: "Analytics", icon: "globe", group: "content" },
    { name: "bulk-ops", label: "Bulk Operations", icon: "database", group: "admin" },
  ],
})
```

### File Structure

```
src/
  extensions/
    static-deploy/
      page.astro          # Required -- the extension page
      integration.ts      # Optional -- inject additional routes or config
    analytics/
      page.astro
```

### Extension Page

A standard Astro page with full access to the CMS runtime:

```astro
---
export const prerender = false;
const user = (Astro.locals as any).user;
if (!user) return Astro.redirect("/_emdash/admin");

const { emdash } = Astro.locals;
const posts = await emdash.db.selectFrom("ec_posts").selectAll().execute();
---
<html>
<body>
  <h1>My Extension</h1>
  <p>Found {posts.length} posts.</p>
</body>
</html>
```

## Sidebar Integration

Each extension appears in one of three sidebar groups based on the `group` field:

| Group | Description | Default |
|-------|-------------|---------|
| `content` | Alongside collections and media | |
| `manage` | With comments, menus, redirects | Yes |
| `admin` | With users, plugins, settings | |

The admin UI renders a TanStack Router route at `/ext/$name` that loads the extension page in an iframe pointing to `/_emdash/ext/{name}`. This keeps the sidebar and header chrome visible while the extension has full control over its content area.

## How It Works

1. At build time, the integration validates each extension name against `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`, resolves `src/extensions/{name}/page.astro`, and calls `injectRoute` to register it at `/_emdash/ext/{name}`.

2. The serialized extension metadata (label, icon, group, URL) is baked into the virtual config module and included in the manifest response.

3. The admin sidebar reads extensions from the manifest and adds nav items to the appropriate group. Clicking an extension navigates to the TanStack Router route, which renders the iframe.

4. If `integration.ts` exists, it is dynamically imported at build time and can inject additional routes or modify the Astro config.

## Security

- **Slug validation**: Extension names must match `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`. No dots, slashes, or special characters.
- **Path traversal protection**: The resolved directory is checked with `startsWith(projectRoot)` to prevent escaping the project root.
- **Client-side validation**: The iframe route validates the slug before constructing the src URL.
- **Duplicate detection**: Duplicate extension names are rejected with a warning.
- **Auth**: Extension pages handle their own auth checks (same as any Astro page). The middleware chain (auth, CSRF) runs before the extension page.

## Icon Mapping

Extensions specify icons by name. Currently supported:

| Icon name | Phosphor icon |
|-----------|--------------|
| `rocket` | Rocket |
| `upload` | Upload |
| `database` | Database |
| `gear` | Gear |
| `list` | List |
| `globe` | Globe |

Falls back to Upload if the icon name is not recognized.

## Extensions vs Plugins

| | Extensions | Plugins |
|---|-----------|---------|
| **Access** | Full Astro locals (db, storage, auth) | Scoped API via hooks |
| **UI** | Full Astro page (HTML, any framework) | Block Kit or React components |
| **Location** | Project source (src/extensions/) | npm package |
| **Sandboxing** | None (trusted, same as your own pages) | Optional (V8 isolate) |
| **Distribution** | Not distributable | Publishable to marketplace |
| **Use case** | Site-specific tools, dashboards, admin pages | Reusable functionality |

Use extensions when you need full server-side control for site-specific tooling. Use plugins when building reusable functionality that other sites can install.