### PR TITLE
i18n(fr): translate all the missing admin UI keys

### DIFF
--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -828,7 +828,7 @@ msgstr "Liste à puces"
 #: packages/admin/src/components/ContentEditor.tsx:892
 #: packages/admin/src/components/Sidebar.tsx:201
 msgid "Bylines"
-msgstr "Signatures"
+msgstr "Auteurs"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -922,19 +922,19 @@ msgstr "Les catégories seront importées"
 #: packages/admin/src/components/FieldEditor.tsx:383
 #: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
-msgstr "Changer"
+msgstr "Modifier"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:237
 msgid "Change Favicon"
-msgstr "Changer de favicon"
+msgstr "Modifier le favicon"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:193
 msgid "Change Logo"
-msgstr "Changer de logo"
+msgstr "Modifier le logo"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:137
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr "Caractère entre le titre de la page et le nom du site (par exemple, « Mon article | Mon site »)"
+msgstr "Caractère entre le titre de la page et le nom du site (p. ex. « Mon article | Mon site »)"
 
 #: packages/admin/src/components/PluginManager.tsx:154
 msgid "Check for updates"
@@ -960,7 +960,7 @@ msgstr "En cours de vérification de l'authentification..."
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
-msgstr "Choisissez votre langue d'administration préférée"
+msgstr "Choisir votre langue d'administration préférée"
 
 #: packages/admin/src/components/SignupPage.tsx:137
 msgid "Click the link in the email to continue setting up your account."
@@ -1259,7 +1259,7 @@ msgstr "Créer un compte"
 
 #: packages/admin/src/components/ContentEditor.tsx:1675
 msgid "Create byline"
-msgstr "Créer une signature"
+msgstr "Créer un auteur"
 
 #: packages/admin/src/components/MenuList.tsx:97
 #: packages/admin/src/components/MenuList.tsx:160
@@ -1786,7 +1786,7 @@ msgstr "Modifier {title}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1737
 msgid "Edit byline"
-msgstr "Modifier la signature"
+msgstr "Modifier l'auteur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
 msgid "Edit Domain"
@@ -1841,7 +1841,7 @@ msgstr "Adresse e-mail"
 #: packages/admin/src/components/SetupWizard.tsx:204
 #: packages/admin/src/components/SignupPage.tsx:48
 msgid "Email is required"
-msgstr "L'e-mail est requis"
+msgstr "L'e-mail est obligatoire"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:224
 msgid "Email Middleware"
@@ -1849,7 +1849,7 @@ msgstr "Middleware de messagerie"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:134
 msgid "Email Pipeline"
-msgstr "Chaîne de messagerie"
+msgstr "Pipeline de messagerie"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:208
 msgid "Email provider active"
@@ -2013,7 +2013,7 @@ msgstr "Échec de l'ajout du domaine"
 
 #: packages/admin/src/components/ContentEditor.tsx:1721
 msgid "Failed to create byline"
-msgstr "Échec de la création de la signature"
+msgstr "Échec de la création de l'auteur"
 
 #: packages/admin/src/components/WordPressImport.tsx:1544
 msgid "Failed to create some collections"
@@ -2098,7 +2098,7 @@ msgstr "Échec de l'envoi de l'e-mail de test"
 
 #: packages/admin/src/components/ContentEditor.tsx:1771
 msgid "Failed to update byline"
-msgstr "Échec de la mise à jour de la signature"
+msgstr "Échec de la mise à jour de l'auteur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
 msgid "Failed to update domain"
@@ -2376,7 +2376,7 @@ msgstr "Importer les menus de navigation"
 
 #: packages/admin/src/components/WordPressImport.tsx:610
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr "Importez des articles, des pages et des types de publications personnalisés depuis WordPress."
+msgstr "Importer des articles, des pages et des types de publications personnalisés depuis WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1702
 msgid "Import SEO settings"
@@ -2545,7 +2545,7 @@ msgstr "Mots-clés"
 #: packages/admin/src/components/MenuList.tsx:137
 #: packages/admin/src/components/TaxonomyManager.tsx:455
 msgid "Label"
-msgstr "Étiquette"
+msgstr "Libellé"
 
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
@@ -2754,11 +2754,11 @@ msgstr "Gérer"
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:602
 msgid "Manage {0} for {1}"
-msgstr "Gérer {0} pour {1}"
+msgstr "Gérer les {0} pour les {1}"
 
 #: packages/admin/src/components/PluginManager.tsx:170
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr "Gérer les modules d'extension installés. Activez ou désactivez les modules d'extension pour contrôler leurs fonctionnalités."
+msgstr "Gérer les modules d'extension installés. Activer ou désactiver les modules d'extension pour contrôler leurs fonctionnalités."
 
 #: packages/admin/src/components/MenuList.tsx:85
 msgid "Manage navigation menus for your site"
@@ -2766,11 +2766,11 @@ msgstr "Gérer les menus de navigation de votre site"
 
 #: packages/admin/src/components/Redirects.tsx:334
 msgid "Manage URL redirects and view 404 errors."
-msgstr "Gérez les redirections d'URL et affichez les erreurs 404."
+msgstr "Gérer les redirections d'URL et afficher les erreurs 404."
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
-msgstr "Gérez vos clés d'accès et votre authentification"
+msgstr "Gérer vos clés d'accès et votre authentification"
 
 #: packages/admin/src/components/Redirects.tsx:405
 msgid "Manual"
@@ -2905,11 +2905,11 @@ msgstr "Méta description"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:149
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr "Contenu des balises méta pour la vérification des outils pour les webmasters Bing"
+msgstr "Contenu des balises méta pour la vérification avec les outils pour les webmasters de Bing"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:143
 msgid "Meta tag content for Google Search Console verification"
-msgstr "Contenu des balises méta pour la vérification de la console de recherche Google"
+msgstr "Contenu des balises méta pour la vérification avec la console de recherche de Google"
 
 #: packages/admin/src/components/WordPressImport.tsx:1707
 msgid "Meta titles, descriptions, and social images"
@@ -2993,7 +2993,7 @@ msgstr "Nom"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:390
 msgid "Name and label are required"
-msgstr "Le nom et l'étiquette sont requis"
+msgstr "Le nom et le libellé sont requis"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:396
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
@@ -3030,7 +3030,7 @@ msgstr "Nouvelle redirection"
 
 #: packages/admin/src/components/Sections.tsx:141
 msgid "New Section"
-msgstr "Nouvelle rubrique"
+msgstr "Nouvelle section"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
@@ -3098,7 +3098,7 @@ msgstr "Aucun commentaire approuvé pour l'instant."
 
 #: packages/admin/src/components/ContentEditor.tsx:1662
 msgid "No bylines selected."
-msgstr "Aucune signature sélectionnée."
+msgstr "Aucun auteur sélectionnée."
 
 #: packages/admin/src/components/Dashboard.tsx:172
 msgid "No collections configured"
@@ -3218,7 +3218,7 @@ msgstr "Aucun module d'extension trouvé"
 
 #: packages/admin/src/components/Sections.tsx:341
 msgid "No preview"
-msgstr "Pas d'aperçu"
+msgstr "Aucun aperçu"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
@@ -3332,7 +3332,7 @@ msgstr "Légende facultative affichée sous l'image"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:213
 msgid "Optional caption for display"
-msgstr "Légende facultative pour l'affichage"
+msgstr "Légende facultative à afficher"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:289
 msgid "Optional description"
@@ -3378,7 +3378,7 @@ msgstr "Original :"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:180
 msgid "Outline"
-msgstr "Contour"
+msgstr "Plan"
 
 #: packages/admin/src/components/SeoPanel.tsx:152
 msgid "Overrides the page title in search engine results"
@@ -3658,7 +3658,7 @@ msgstr "Publié le"
 
 #: packages/admin/src/components/ContentEditor.tsx:1670
 msgid "Quick create byline"
-msgstr "Création rapide d'une signature"
+msgstr "Création rapide d'un auteur"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:85
 #: packages/admin/src/components/PortableTextEditor.tsx:749
@@ -3679,7 +3679,7 @@ msgstr "Lire les fichiers multimédias"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:267
 msgid "Reading"
-msgstr "En lisant"
+msgstr "Lecture"
 
 #: packages/admin/src/components/WordPressImport.tsx:1849
 msgid "Ready"
@@ -3961,7 +3961,7 @@ msgstr "Rôle {role}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1644
 msgid "Role label"
-msgstr "Étiquette de rôle"
+msgstr "Libellé du rôle"
 
 #: packages/admin/src/components/MenuEditor.tsx:286
 #: packages/admin/src/components/MenuEditor.tsx:288
@@ -4179,7 +4179,7 @@ msgstr "La section « {slug} » est introuvable."
 
 #: packages/admin/src/components/Sections.tsx:91
 msgid "Section created"
-msgstr "Rubrique créée"
+msgstr "Section créée"
 
 #: packages/admin/src/components/Sections.tsx:105
 msgid "Section deleted"
@@ -4187,7 +4187,7 @@ msgstr "Section supprimée"
 
 #: packages/admin/src/components/SectionEditor.tsx:186
 msgid "Section Details"
-msgstr "Détails des sections"
+msgstr "Détails de la section"
 
 #: packages/admin/src/components/SectionEditor.tsx:73
 msgid "Section Not Found"
@@ -4270,7 +4270,7 @@ msgstr "Tout sélectionner"
 
 #: packages/admin/src/components/ContentEditor.tsx:1583
 msgid "Select byline..."
-msgstr "Sélectionner la signature..."
+msgstr "Sélectionner l'auteur..."
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:463
@@ -4322,15 +4322,15 @@ msgstr "Sélectionné :"
 #: packages/admin/src/components/Settings.tsx:98
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
 msgid "Self-Signup Domains"
-msgstr "Domaines d'inscription autorisés"
+msgstr "Domaines autorisés pour l'inscription"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr "Envoyez un e-mail de test via le processus complet pour vérifier votre configuration de messagerie."
+msgstr "Envoyer un e-mail de test via le processus complet pour vérifier votre configuration de messagerie."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr "Envoyez un e-mail d'invitation à un nouveau membre de l'équipe."
+msgstr "Envoyer un e-mail d'invitation à un nouveau membre de l'équipe."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 msgid "Send Invite"
@@ -4450,7 +4450,7 @@ msgstr "Se connecter avec un e-mail"
 
 #: packages/admin/src/components/LoginPage.tsx:340
 msgid "Sign in with email link"
-msgstr "Se connecter avec un lien par e-mail"
+msgstr "Se connecter avec un lien envoyé par e-mail"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:304
@@ -4497,7 +4497,7 @@ msgstr "Titre et slogan du site"
 
 #: packages/admin/src/components/SetupWizard.tsx:125
 msgid "Site title is required"
-msgstr "Le titre du site est requis"
+msgstr "Le titre du site est obligatoire"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:168
 msgid "Site URL"
@@ -4590,13 +4590,13 @@ msgstr "Chemin source"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr "courrier indésirable"
+msgstr "indésirable"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:214
 #: packages/admin/src/components/comments/CommentInbox.tsx:254
 msgid "Spam"
-msgstr "Courrier indésirable"
+msgstr "Indésirable"
 
 #: packages/admin/src/components/WordPressImport.tsx:1783
 msgid "Start Import"
@@ -4746,7 +4746,7 @@ msgstr "Thème introuvable"
 
 #: packages/admin/src/components/SectionEditor.tsx:161
 msgid "Theme Section"
-msgstr "Section des thèmes"
+msgstr "Section du thème"
 
 #: packages/admin/src/components/Sections.tsx:298
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
@@ -4833,7 +4833,7 @@ msgstr "Cela rétablira la version publiée. Vos modifications en cours seront p
 
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "Thoughts, tutorials, and more"
-msgstr "Réflexions, tutoriels et plus"
+msgstr "Réflexions, tutoriels et bien plus encore"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:285
 msgid "Timezone"
@@ -4841,7 +4841,7 @@ msgstr "Fuseau horaire"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:288
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr "Fuseau horaire pour l'affichage des dates (par exemple, Amérique/New_York)"
+msgstr "Fuseau horaire pour l'affichage des dates (p. ex. Amérique/New_York)"
 
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
@@ -5181,7 +5181,7 @@ msgstr "Identifiant adapté aux URL"
 
 #: packages/admin/src/components/MenuList.tsx:133
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr "Identifiant adapté aux URL (par exemple, « principal », « pied-de-page »)"
+msgstr "Identifiant adapté aux URL (p. ex. « principal », « pied-de-page »)"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
@@ -5503,7 +5503,7 @@ msgstr "Votre rôle"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:131
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "Votre identifiant Twitter/X (par exemple, @username)"
+msgstr "Votre identifiant Twitter/X (p. ex. @username)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1925

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -20,216 +20,216 @@ msgstr " (par défaut)"
 
 #: packages/admin/src/components/MenuEditor.tsx:344
 msgid " (opens in new window)"
-msgstr ""
+msgstr " (ouvre dans une nouvelle fenêtre)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:634
 #: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid " (selected)"
-msgstr ""
+msgstr " (sélectionné)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr ""
+msgstr ", ou ouvrez l'administration sur"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:309
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
 msgid ": use"
-msgstr ""
+msgstr " : utiliser"
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
 #: packages/admin/src/components/MediaPickerModal.tsx:574
 msgid "(from {0})"
-msgstr ""
+msgstr "(à partir de {0})"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:157
 msgid "(synced)"
-msgstr ""
+msgstr "(synchronisé)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
-msgstr ""
+msgstr "(avec votre port de développement)."
 
 #. placeholder {0}: items.length
 #. placeholder {0}: orphan.rowCount
 #: packages/admin/src/components/ContentTypeList.tsx:69
 #: packages/admin/src/components/RepeaterField.tsx:131
 msgid "{0, plural, one {(# item)} other {(# items)}}"
-msgstr ""
+msgstr "{0, plural, one {(# élément)} other {(# éléments)}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr ""
+msgstr "{0, plural, one {# collection} other {# collections}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:351
 msgid "{0, plural, one {# comment} other {# comments}}"
-msgstr ""
+msgstr "{0, plural, one {# commentaire} other {# commentaires}}"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2107
 msgid "{0, plural, one {# content error} other {# content errors}}"
-msgstr ""
+msgstr "{0, plural, one {# erreur liée au contenu} other {# erreurs liées au contenu}}"
 
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2083
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr ""
+msgstr "{0, plural, one {# élément de contenu importé} other {# éléments de contenu importés}}"
 
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:251
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{0, plural, one {# élément correspondant à « {searchQuery} »} other {# éléments correspondant à « {searchQuery} »}}"
 
 #. placeholder {0}: items.length
 #: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "{0, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{0, plural, one {# élément} other {# éléments}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2112
 msgid "{0, plural, one {# media error} other {# media errors}}"
-msgstr ""
+msgstr "{0, plural, one {# erreur liée à un fichier multimédia} other {# erreurs liées aux fichiers multimédias}}"
 
 #. placeholder {0}: mediaResult.imported.length
 #: packages/admin/src/components/WordPressImport.tsx:2099
 msgid "{0, plural, one {# media file imported} other {# media files imported}}"
-msgstr ""
+msgstr "{0, plural, one {# fichier multimédia importé} other {# fichiers multimédias importés}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
-msgstr ""
+msgstr "{0, plural, one {# fichier multimédia} other {# fichiers multimédias}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1764
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
-msgstr ""
+msgstr "{0, plural, one {# menu sera importé} other {# menus seront importés}}"
 
 #. placeholder {0}: plugin.capabilities.length
 #: packages/admin/src/components/MarketplaceBrowse.tsx:289
 msgid "{0, plural, one {# permission} other {# permissions}}"
-msgstr ""
+msgstr "{0, plural, one {# autorisation} other {# autorisations}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2319
 msgid "{0, plural, one {# post} other {# posts}}"
-msgstr ""
+msgstr "{0, plural, one {# article} other {# articles}}"
 
 #. placeholder {0}: loopRedirectIds.size
 #: packages/admin/src/components/Redirects.tsx:425
 msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
-msgstr ""
+msgstr "{0, plural, one {Une redirection fait partie d'une boucle.} other {# redirections font partie d'une boucle.}}"
 
 #. placeholder {0}: selected.size
 #: packages/admin/src/components/comments/CommentInbox.tsx:235
 msgid "{0, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{0, plural, one {# commentaire sélectionné} other {# commentaires sélectionnés}}"
 
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2091
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr ""
+msgstr "{0, plural, one {# élément ignoré (existe déjà)} other {# éléments ignorés (existent déjà)}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:128
 msgid "{0, plural, one {# user} other {# users}}"
-msgstr ""
+msgstr "{0, plural, one {# utilisateur} other {# utilisateurs}}"
 
 #. placeholder {0}: filteredItems.length
 #. placeholder {1}: hasMore ? "+" : ""
 #. placeholder {2}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:255
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
-msgstr ""
+msgstr "{0, plural, one {#{1} élément} other {#{2} éléments}}"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1133
 msgid "{0} detected"
-msgstr ""
+msgstr "{0} détecté"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:103
 msgid "{0} has been deactivated"
-msgstr ""
+msgstr "{0} a été désactivé"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:260
 msgid "{0} has been removed"
-msgstr ""
+msgstr "{0} a été supprimé"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:213
 msgid "{0} installs"
-msgstr ""
+msgstr "{0} installations"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:84
 msgid "{0} is now active"
-msgstr ""
+msgstr "{0} est maintenant actif"
 
 #. placeholder {0}: postType.count
 #. placeholder {1}: postType.suggestedCollection
 #: packages/admin/src/components/WordPressImport.tsx:1836
 msgid "{0} items → {1}"
-msgstr ""
+msgstr "{0} éléments → {1}"
 
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "{0} items will be imported"
-msgstr ""
+msgstr "{0} éléments seront importés"
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
 #: packages/admin/src/components/PluginManager.tsx:348
 msgid "{0} permission{1}"
-msgstr ""
+msgstr "{0} autorisation{1}"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:165
 msgid "{0} plugins"
-msgstr ""
+msgstr "{0} modules d'extension"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:208
 msgid "{0} preview"
-msgstr ""
+msgstr "Aperçu de {0}"
 
 #. placeholder {0}: plugin.name
 #. placeholder {1}: updateInfo?.latest
 #: packages/admin/src/components/PluginManager.tsx:247
 msgid "{0} updated to v{1}"
-msgstr ""
+msgstr "{0} mis à jour vers v{1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
 #: packages/admin/src/components/MediaPickerModal.tsx:634
 #: packages/admin/src/components/MediaPickerModal.tsx:716
 msgid "{0}{1}"
-msgstr ""
+msgstr "{0}{1}"
 
 #. placeholder {0}: draft.description.length
 #: packages/admin/src/components/SeoPanel.tsx:164
 msgid "{0}/160 characters"
-msgstr ""
+msgstr "{0}/160 caractères"
 
 #: packages/admin/src/components/RevisionHistory.tsx:337
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr ""
+msgstr "{changedCount, plural, one {# modification par rapport à la prochaine révision} other {# modifications par rapport à la prochaine révision}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1935
 msgid "{count, plural, one {# file} other {# files}}"
-msgstr ""
+msgstr "{count, plural, one {# fichier} other {# fichiers}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2184
 msgid "{count, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{count, plural, one {# élément} other {# éléments}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2006
 msgid "{current} of {total}"
-msgstr ""
+msgstr "{current} sur {total}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
@@ -241,80 +241,80 @@ msgstr "{label} — voir la traduction"
 
 #: packages/admin/src/components/WordPressImport.tsx:2306
 msgid "{matchedCount} of {totalCount} assigned"
-msgstr ""
+msgstr "{matchedCount} sur {totalCount} attribués"
 
 #: packages/admin/src/components/WordPressImport.tsx:2294
 msgid "{matchedCount} of {totalCount} authors matched by email"
-msgstr ""
+msgstr "{matchedCount} auteurs sur {totalCount} correspondants par e-mail"
 
 #: packages/admin/src/components/WordPressImport.tsx:1740
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr ""
+msgstr "{needsNewCollections, plural, one {Une nouvelle collection sera créée} other {# nouvelles collections seront créées}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1749
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr ""
+msgstr "{needsNewFields, plural, one {Les champs seront ajoutés à la collection existante} other {Les champs seront ajoutés aux # collections existantes}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:76
 msgid "{pluginName} is requesting additional permissions:"
-msgstr ""
+msgstr "{pluginName} demande des autorisations supplémentaires :"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:77
 msgid "{pluginName} requires the following permissions:"
-msgstr ""
+msgstr "{pluginName} nécessite les autorisations suivantes :"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:156
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr ""
+msgstr "{total, plural, one {# au total} other {# au total}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:140
 #: packages/admin/src/components/MediaLibrary.tsx:176
 msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
-msgstr ""
+msgstr "{total, plural, one {Fichier téléversé} other {# fichiers téléversés}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:145
 #: packages/admin/src/components/MediaLibrary.tsx:181
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr ""
+msgstr "{total, plural, one {Échec du téléversement} other {Échec de # téléversements}}"
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {# brouillon} other {# brouillons}}"
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {# contenu programmé} other {# contenus programmés}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:349
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Masquer # champ inchangé} other {Masquer # champs inchangés}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:350
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Afficher # champ inchangé} other {Afficher # champs inchangés}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
 #: packages/admin/src/components/MediaLibrary.tsx:186
 msgid "{uploaded} uploaded, {failed} failed"
-msgstr ""
+msgstr "{uploaded} téléversés, {failed} en échec"
 
 #: packages/admin/src/components/WordPressImport.tsx:1956
 msgid "• Files are downloaded from your WordPress site"
-msgstr ""
+msgstr "• Les fichiers sont téléchargés depuis votre site WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1957
 msgid "• Uploaded to your EmDash media storage"
-msgstr ""
+msgstr "• Téléversé vers votre espace de stockage de fichiers multimédias EmDash"
 
 #: packages/admin/src/components/WordPressImport.tsx:1958
 msgid "• URLs in your content are updated automatically"
-msgstr ""
+msgstr "• Les URL dans votre contenu sont mises à jour automatiquement"
 
 #: packages/admin/src/components/SetupWizard.tsx:250
 #: packages/admin/src/components/SetupWizard.tsx:310
 #: packages/admin/src/components/WordPressImport.tsx:1431
 msgid "← Back"
-msgstr ""
+msgstr "← Retour"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:44
 msgid "1 year"
@@ -322,27 +322,27 @@ msgstr "1 an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1352
 msgid "1. Log into your WordPress admin"
-msgstr ""
+msgstr "1. Connectez-vous à l'administration WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1105
 msgid "1. Log into your WordPress admin dashboard"
-msgstr ""
+msgstr "1. Connectez-vous à votre tableau de bord d'administration WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1107
 msgid "2. Go to"
-msgstr ""
+msgstr "2. Allez à"
 
 #: packages/admin/src/components/WordPressImport.tsx:1353
 msgid "2. Go to Users → Profile"
-msgstr ""
+msgstr "2. Allez dans Utilisateurs → Profil"
 
 #: packages/admin/src/components/WordPressImport.tsx:1354
 msgid "3. Scroll to \"Application Passwords\""
-msgstr ""
+msgstr "3. Faites défiler jusqu'à « Mots de passe d'application »"
 
 #: packages/admin/src/components/WordPressImport.tsx:1109
 msgid "3. Select \"All content\""
-msgstr ""
+msgstr "3. Sélectionnez « Tout le contenu »"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:42
 msgid "30 days"
@@ -350,39 +350,39 @@ msgstr "30 jours"
 
 #: packages/admin/src/components/Redirects.tsx:152
 msgid "301 Permanent"
-msgstr ""
+msgstr "301 Permanent"
 
 #: packages/admin/src/components/Redirects.tsx:153
 msgid "302 Temporary"
-msgstr ""
+msgstr "302 Temporaire"
 
 #: packages/admin/src/components/Redirects.tsx:154
 msgid "307 Temporary (Strict)"
-msgstr ""
+msgstr "307 Temporaire (Strict)"
 
 #: packages/admin/src/components/Redirects.tsx:155
 msgid "308 Permanent (Strict)"
-msgstr ""
+msgstr "308 Permanent (Strict)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1110
 msgid "4. Click \"Download Export File\""
-msgstr ""
+msgstr "4. Cliquez sur « Télécharger le fichier d'exportation »"
 
 #: packages/admin/src/components/WordPressImport.tsx:1355
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr ""
+msgstr "4. Saisissez « EmDash » et cliquez sur « Ajouter »."
 
 #: packages/admin/src/components/Redirects.tsx:369
 msgid "404 Errors"
-msgstr ""
+msgstr "Erreurs 404"
 
 #: packages/admin/src/components/WordPressImport.tsx:1356
 msgid "5. Copy the generated password"
-msgstr ""
+msgstr "5. Copiez le mot de passe généré"
 
 #: packages/admin/src/components/WordPressImport.tsx:1111
 msgid "5. Upload the file here"
-msgstr ""
+msgstr "5. Importez le fichier ici"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:41
 msgid "7 days"
@@ -394,27 +394,27 @@ msgstr "90 jours"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "A short description of your site"
-msgstr ""
+msgstr "Une brève description de votre site"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:148
 msgid "Accept & Install"
-msgstr ""
+msgstr "Accepter et installer"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:147
 msgid "Accept & Update"
-msgstr ""
+msgstr "Accepter et mettre à jour"
 
 #: packages/admin/src/components/SetupWizard.tsx:332
 msgid "Account"
-msgstr ""
+msgstr "Compte"
 
 #: packages/admin/src/components/SignupPage.tsx:260
 msgid "Account exists"
-msgstr ""
+msgstr "Le compte existe"
 
 #: packages/admin/src/components/users/UserDetail.tsx:216
 msgid "Account Info"
-msgstr ""
+msgstr "Informations sur le compte"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:306
 #: packages/admin/src/components/ContentList.tsx:204
@@ -423,108 +423,108 @@ msgstr ""
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:619
 msgid "Actions"
-msgstr ""
+msgstr "Actions"
 
 #: packages/admin/src/components/users/UserDetail.tsx:206
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #: packages/admin/src/components/ContentEditor.tsx:1600
 #: packages/admin/src/components/MenuEditor.tsx:297
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 #: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Add"
-msgstr ""
+msgstr "Ajouter"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:204
 msgid "Add {label}"
-msgstr ""
+msgstr "Ajouter {label}"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:208
 msgid "Add a new passkey"
-msgstr ""
+msgstr "Ajouter une nouvelle clé d'accès"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:309
 msgid "Add an allowed domain"
-msgstr ""
+msgstr "Ajouter un domaine autorisé"
 
 #: packages/admin/src/components/FieldEditor.tsx:536
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr ""
+msgstr "Ajoutez au moins un sous-champ pour définir la structure du répéteur."
 
 #: packages/admin/src/components/MenuEditor.tsx:234
 #: packages/admin/src/components/MenuEditor.tsx:323
 msgid "Add Content"
-msgstr ""
+msgstr "Ajouter du contenu"
 
 #: packages/admin/src/components/MenuEditor.tsx:246
 #: packages/admin/src/components/MenuEditor.tsx:253
 #: packages/admin/src/components/MenuEditor.tsx:326
 msgid "Add Custom Link"
-msgstr ""
+msgstr "Ajouter un lien personnalisé"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:354
 msgid "Add Domain"
-msgstr ""
+msgstr "Ajouter un domaine"
 
 #: packages/admin/src/components/FieldEditor.tsx:323
 #: packages/admin/src/components/FieldEditor.tsx:646
 msgid "Add Field"
-msgstr ""
+msgstr "Ajouter un champ"
 
 #: packages/admin/src/components/WordPressImport.tsx:1847
 msgid "Add fields"
-msgstr ""
+msgstr "Ajouter des champs"
 
 #: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add First Item"
-msgstr ""
+msgstr "Ajouter un premier élément"
 
 #: packages/admin/src/components/RepeaterField.tsx:137
 msgid "Add Item"
-msgstr ""
+msgstr "Ajouter un élément"
 
 #: packages/admin/src/components/MenuEditor.tsx:316
 msgid "Add links to build your navigation menu"
-msgstr ""
+msgstr "Ajoutez des liens pour créer votre menu de navigation"
 
 #: packages/admin/src/components/ContentList.tsx:140
 msgid "Add New"
-msgstr ""
+msgstr "Ajouter"
 
 #: packages/admin/src/components/SeoPanel.tsx:187
 msgid "Add noindex meta tag"
-msgstr ""
+msgstr "Ajouter une balise méta noindex"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:229
 msgid "Add Passkey"
-msgstr ""
+msgstr "Ajouter une clé d'accès"
 
 #: packages/admin/src/components/PluginManager.tsx:201
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr ""
+msgstr "Ajoutez des modules d'extension à votre fichier astro.config.mjs pour étendre les fonctionnalités d'EmDash."
 
 #: packages/admin/src/components/FieldEditor.tsx:530
 msgid "Add Sub-Field"
-msgstr ""
+msgstr "Ajouter un sous-champ"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:203
 msgid "Add tags..."
-msgstr ""
+msgstr "Ajouter des étiquettes..."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:124
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr ""
+msgstr "Ajoutez vos profils de réseaux sociaux. Ceux-ci sont disponibles pour le thème de votre site et peuvent être affichés dans les en-têtes, les pieds de page ou les biographies des auteurs."
 
 #: packages/admin/src/components/MenuEditor.tsx:297
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
 msgid "Adding..."
-msgstr ""
+msgstr "En cours d'ajout..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1583
 msgid "Additional data to import."
-msgstr ""
+msgstr "Données supplémentaires à importer."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
 #: packages/admin/src/components/Sidebar.tsx:426
@@ -534,7 +534,7 @@ msgstr "Admin"
 
 #: packages/admin/src/components/Sidebar.tsx:373
 msgid "Admin navigation"
-msgstr ""
+msgstr "Navigation administrateur"
 
 #: packages/admin/src/components/WelcomeModal.tsx:25
 msgid "Administrator"
@@ -542,23 +542,23 @@ msgstr "Administrateur"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:233
 msgid "After send:"
-msgstr ""
+msgstr "Après l'envoi :"
 
 #: packages/admin/src/components/ContentList.tsx:167
 msgid "All"
-msgstr ""
+msgstr "Tous"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
-msgstr ""
+msgstr "Toutes les capacités"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:140
 msgid "All collections"
-msgstr ""
+msgstr "Toutes les collections"
 
 #: packages/admin/src/components/WordPressImport.tsx:2351
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr ""
+msgstr "Tout le contenu importé ne sera pas attribué. Vous pouvez réaffecter les auteurs ultérieurement à partir de l'éditeur de contenu."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
@@ -571,15 +571,15 @@ msgstr "Tous les rôles"
 
 #: packages/admin/src/components/Sections.tsx:240
 msgid "All Sources"
-msgstr ""
+msgstr "Toutes les sources"
 
 #: packages/admin/src/components/Redirects.tsx:395
 msgid "All statuses"
-msgstr ""
+msgstr "Tous les statuts"
 
 #: packages/admin/src/components/Redirects.tsx:404
 msgid "All types"
-msgstr ""
+msgstr "Tous les types"
 
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
@@ -587,85 +587,85 @@ msgstr "Autoriser les utilisateurs de domaines spécifiques à s'inscrire"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:245
 msgid "Allowed Domains"
-msgstr ""
+msgstr "Domaines autorisés"
 
 #: packages/admin/src/components/SignupPage.tsx:438
 msgid "Already have an account?"
-msgstr ""
+msgstr "Vous avez déjà un compte ?"
 
 #: packages/admin/src/components/PluginManager.tsx:569
 msgid "Also delete plugin storage data"
-msgstr ""
+msgstr "Supprimez également les données de stockage du module d'extension"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
 #: packages/admin/src/components/MediaDetailPanel.tsx:202
 msgid "Alt Text"
-msgstr ""
+msgstr "Texte alternatif"
 
 #: packages/admin/src/components/MediaLibrary.tsx:612
 #: packages/admin/src/components/MediaLibrary.tsx:669
 msgid "Alt text set"
-msgstr ""
+msgstr "Ensemble de texte alternatif"
 
 #: packages/admin/src/components/WordPressImport.tsx:1225
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
-msgstr ""
+msgstr "Alternativement, vous pouvez exporter depuis WordPress (Outils → Exporter) et importer le fichier."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:138
 #: packages/admin/src/components/PluginManager.tsx:90
 #: packages/admin/src/components/PluginManager.tsx:109
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:116
 msgid "An error occurred"
-msgstr ""
+msgstr "Une erreur s'est produite"
 
 #: packages/admin/src/components/WordPressImport.tsx:1405
 msgid "Analyzing export file..."
-msgstr ""
+msgstr "Analyse du fichier d'exportation en cours..."
 
 #: packages/admin/src/components/WordPressImport.tsx:726
 msgid "Analyzing WordPress site..."
-msgstr ""
+msgstr "Analyse du site WordPress en cours..."
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:176
 msgid "API Tokens"
-msgstr "Tokens d'API"
+msgstr "Jetons d'API"
 
 #: packages/admin/src/components/WordPressImport.tsx:1320
 msgid "Application Password"
-msgstr ""
+msgstr "Mot de passe de l'application"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:244
 #: packages/admin/src/components/comments/CommentInbox.tsx:496
 msgid "Approve"
-msgstr ""
+msgstr "Approuver"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:195
 msgid "approved"
-msgstr ""
+msgstr "approuvé"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:209
 msgid "Approved"
-msgstr ""
+msgstr "Approuvé"
 
 #: packages/admin/src/components/FieldEditor.tsx:218
 msgid "Arbitrary JSON data"
-msgstr ""
+msgstr "Données JSON arbitraires"
 
 #: packages/admin/src/components/ContentList.tsx:557
 msgid "archived"
-msgstr ""
+msgstr "archivé"
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir supprimer « {0} » ? Cela supprimera également tout le contenu de cette collection."
 
 #: packages/admin/src/components/MenuList.tsx:208
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-msgstr ""
+msgstr "Êtes-vous sûr de vouloir supprimer ce menu ? Cela supprimera également tous les éléments de menu. Cette action ne peut pas être annulée."
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
@@ -673,13 +673,13 @@ msgstr "En tant qu'administrateur, vous pouvez inviter d'autres utilisateurs dep
 
 #: packages/admin/src/components/WordPressImport.tsx:2289
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr ""
+msgstr "Attribuez des auteurs WordPress aux utilisateurs d'EmDash. Les publications seront attribuées à l'utilisateur sélectionné."
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:279
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
 msgid "Authentication error: {0}"
-msgstr ""
+msgstr "Erreur d'authentification : {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:253
 msgid "Authentication error: {error}"
@@ -688,11 +688,11 @@ msgstr "Erreur d'authentification : {error}"
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:133
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr ""
+msgstr "L'authentification est gérée par un fournisseur externe ({0}). Les paramètres de clé d'accès ne sont pas disponibles lors de l'utilisation de l'authentification externe."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:263
 msgid "Authentication was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "L'authentification a été annulée ou a expiré. Veuillez réessayer."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:77
 #: packages/admin/src/components/comments/CommentInbox.tsx:294
@@ -703,69 +703,69 @@ msgstr "Auteur"
 
 #: packages/admin/src/components/WordPressImport.tsx:2304
 msgid "Author Mapping"
-msgstr ""
+msgstr "Correspondance des auteurs"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:197
 msgid "Authorization denied"
-msgstr ""
+msgstr "Autorisation refusée"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
-msgstr ""
+msgstr "Autoriser"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:176
 msgid "Authorize Device"
-msgstr ""
+msgstr "Autoriser l'appareil"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorizing..."
-msgstr ""
+msgstr "En cours d'autorisation..."
 
 #: packages/admin/src/components/Redirects.tsx:502
 msgid "auto"
-msgstr ""
+msgstr "auto"
 
 #: packages/admin/src/components/Redirects.tsx:406
 msgid "Auto (slug change)"
-msgstr ""
+msgstr "Auto (changement de slug)"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:260
 msgid "Auto-generated from name (you can edit)"
-msgstr ""
+msgstr "Généré automatiquement à partir du nom (vous pouvez le modifier)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:513
 msgid "Available media"
-msgstr ""
+msgstr "Fichiers multimédias disponibles"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:242
 msgid "Available Providers"
-msgstr ""
+msgstr "Fournisseurs disponibles"
 
 #: packages/admin/src/components/MenuEditor.tsx:218
 #: packages/admin/src/components/WordPressImport.tsx:1340
 #: packages/admin/src/components/WordPressImport.tsx:2360
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 #: packages/admin/src/components/ContentEditor.tsx:509
 msgid "Back to {collectionLabel} list"
-msgstr ""
+msgstr "Retour à la liste {collectionLabel}"
 
 #: packages/admin/src/components/LoginPage.tsx:174
 #: packages/admin/src/components/LoginPage.tsx:210
 #: packages/admin/src/components/SignupPage.tsx:280
 msgid "Back to login"
-msgstr "Retour à la connexion"
+msgstr "Retour à la page de connexion"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:125
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:402
 msgid "Back to marketplace"
-msgstr ""
+msgstr "Retour à la place de marché"
 
 #: packages/admin/src/components/SectionEditor.tsx:69
 #: packages/admin/src/components/SectionEditor.tsx:154
 msgid "Back to sections"
-msgstr ""
+msgstr "Retour aux sections"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:168
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:171
@@ -784,41 +784,41 @@ msgstr "Retour aux paramètres"
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:88
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:112
 msgid "Back to Themes"
-msgstr ""
+msgstr "Retour aux thèmes"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:228
 msgid "Before send:"
-msgstr ""
+msgstr "Avant l'envoi :"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:146
 msgid "Bing Verification"
-msgstr ""
+msgstr "Vérification Bing"
 
 #: packages/admin/src/components/FieldEditor.tsx:169
 #: packages/admin/src/components/FieldEditor.tsx:576
 msgid "Boolean"
-msgstr ""
+msgstr "Booléen"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Brief summary shown below the title in search results"
-msgstr ""
+msgstr "Bref résumé affiché sous le titre dans les résultats de recherche"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:87
 msgid "Browse and install plugins to extend your site."
-msgstr ""
+msgstr "Parcourez et installez des modules d'extension pour étendre votre site."
 
 #: packages/admin/src/components/WordPressImport.tsx:957
 #: packages/admin/src/components/WordPressImport.tsx:1424
 msgid "Browse Files"
-msgstr ""
+msgstr "Parcourir les fichiers"
 
 #: packages/admin/src/components/PluginManager.tsx:194
 msgid "Browse the"
-msgstr ""
+msgstr "Parcourez le"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Browse themes and preview them with your own content."
-msgstr ""
+msgstr "Parcourez les thèmes et prévisualisez-les avec votre propre contenu."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:729
@@ -828,7 +828,7 @@ msgstr "Liste à puces"
 #: packages/admin/src/components/ContentEditor.tsx:892
 #: packages/admin/src/components/Sidebar.tsx:201
 msgid "Bylines"
-msgstr ""
+msgstr "Signatures"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -881,29 +881,29 @@ msgstr "Annuler"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
-msgstr ""
+msgstr "Annuler le changement de nom"
 
 #: packages/admin/src/components/Sections.tsx:405
 msgid "Cannot delete theme sections"
-msgstr ""
+msgstr "Impossible de supprimer les sections de thème"
 
 #: packages/admin/src/components/SeoPanel.tsx:176
 msgid "Canonical URL"
-msgstr ""
+msgstr "URL canonique"
 
 #: packages/admin/src/components/PluginManager.tsx:414
 msgid "Capabilities"
-msgstr ""
+msgstr "Capacités"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:62
 msgid "Capability consent"
-msgstr ""
+msgstr "Consentement de capacité"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
 #: packages/admin/src/components/MediaDetailPanel.tsx:210
 msgid "Caption"
-msgstr ""
+msgstr "Légende"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
@@ -912,51 +912,51 @@ msgstr "Catégories"
 #. placeholder {0}: analysis.categories
 #: packages/admin/src/components/WordPressImport.tsx:1622
 msgid "Categories ({0})"
-msgstr ""
+msgstr "Catégories ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1619
 msgid "Categories will be imported"
-msgstr ""
+msgstr "Les catégories seront importées"
 
 #: packages/admin/src/components/ContentEditor.tsx:1460
 #: packages/admin/src/components/FieldEditor.tsx:383
 #: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
-msgstr ""
+msgstr "Changer"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:237
 msgid "Change Favicon"
-msgstr ""
+msgstr "Changer de favicon"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:193
 msgid "Change Logo"
-msgstr ""
+msgstr "Changer de logo"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:137
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr ""
+msgstr "Caractère entre le titre de la page et le nom du site (par exemple, « Mon article | Mon site »)"
 
 #: packages/admin/src/components/PluginManager.tsx:154
 msgid "Check for updates"
-msgstr ""
+msgstr "Vérifier les mises à jour"
 
 #: packages/admin/src/components/WordPressImport.tsx:928
 msgid "Check Site"
-msgstr ""
+msgstr "Vérifier le site"
 
 #: packages/admin/src/components/LoginPage.tsx:158
 #: packages/admin/src/components/SignupPage.tsx:129
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Check your email"
-msgstr "Vérifiez votre e-mail"
+msgstr "Vérifier votre e-mail"
 
 #: packages/admin/src/components/WordPressImport.tsx:692
 msgid "Checking {urlInput}..."
-msgstr ""
+msgstr "En cours de vérification de {urlInput}..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
-msgstr ""
+msgstr "En cours de vérification de l'authentification..."
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
@@ -964,7 +964,7 @@ msgstr "Choisissez votre langue d'administration préférée"
 
 #: packages/admin/src/components/SignupPage.tsx:137
 msgid "Click the link in the email to continue setting up your account."
-msgstr ""
+msgstr "Cliquez sur le lien dans l'e-mail pour continuer la configuration de votre compte."
 
 #: packages/admin/src/components/LoginPage.tsx:169
 msgid "Click the link in the email to sign in."
@@ -1023,12 +1023,12 @@ msgstr "Fermer"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
-msgstr ""
+msgstr "Fermer le panneau"
 
 #: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/Redirects.tsx:450
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:759
@@ -1037,53 +1037,53 @@ msgstr "Bloc de code"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 msgid "Collapse"
-msgstr ""
+msgstr "Réduire"
 
 #: packages/admin/src/components/PluginManager.tsx:395
 msgid "Collapse details"
-msgstr ""
+msgstr "Réduire les détails"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:158
 msgid "colleague@example.com"
-msgstr ""
+msgstr "collegue@exemple.com"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr ""
+msgstr "Collection :"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:488
 msgid "Collections"
-msgstr ""
+msgstr "Collections"
 
 #: packages/admin/src/components/WordPressImport.tsx:2160
 msgid "Collections created:"
-msgstr ""
+msgstr "Collections créées :"
 
 #: packages/admin/src/components/SectionEditor.tsx:226
 msgid "Comma-separated keywords for search."
-msgstr ""
+msgstr "Mots-clés séparés par des virgules pour la recherche."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:95
 #: packages/admin/src/components/comments/CommentInbox.tsx:297
 msgid "Comment"
-msgstr ""
+msgstr "Commentaire"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:58
 msgid "Comment Detail"
-msgstr ""
+msgstr "Détail du commentaire"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:153
 #: packages/admin/src/components/Sidebar.tsx:185
 msgid "Comments"
-msgstr ""
+msgstr "Commentaires"
 
 #: packages/admin/src/components/SignupPage.tsx:402
 msgid "Complete signup"
-msgstr ""
+msgstr "Terminer l'inscription"
 
 #: packages/admin/src/components/FieldEditor.tsx:323
 msgid "Configure Field"
-msgstr ""
+msgstr "Configurer le champ"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Confirm"
@@ -1091,21 +1091,21 @@ msgstr "Confirmer"
 
 #: packages/admin/src/components/WordPressImport.tsx:1337
 msgid "Connect & Analyze"
-msgstr ""
+msgstr "Se connecter et analyser"
 
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1287
 msgid "Connect to {0}"
-msgstr ""
+msgstr "Se connecter à {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1203
 msgid "Connect with WordPress"
-msgstr ""
+msgstr "Se connecter avec WordPress"
 
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr ""
+msgstr "Connecté {0}"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1124,23 +1124,23 @@ msgstr "Bloc de contenu"
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2215
 msgid "Content Errors ({0})"
-msgstr ""
+msgstr "Erreurs liées au contenu ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "Content found:"
-msgstr ""
+msgstr "Contenu trouvé :"
 
 #: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
-msgstr ""
+msgstr "Le contenu a été mis à jour vers la révision sélectionnée."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr ""
+msgstr "ID de contenu :"
 
 #: packages/admin/src/components/WordPressImport.tsx:2204
 msgid "content items"
-msgstr ""
+msgstr "éléments de contenu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:54
 msgid "Content Read"
@@ -1148,11 +1148,11 @@ msgstr "Lecture du contenu"
 
 #: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
-msgstr ""
+msgstr "Instantané du contenu :"
 
 #: packages/admin/src/components/WordPressImport.tsx:1561
 msgid "Content to Import"
-msgstr ""
+msgstr "Contenu à importer"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
 #: packages/admin/src/components/ContentTypeList.tsx:39
@@ -1162,7 +1162,7 @@ msgstr "Types de contenu"
 
 #: packages/admin/src/components/WordPressImport.tsx:2143
 msgid "Content was skipped because it already exists"
-msgstr ""
+msgstr "Le contenu a été ignoré car il existe déjà"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:59
 msgid "Content Write"
@@ -1170,16 +1170,16 @@ msgstr "Écriture du contenu"
 
 #: packages/admin/src/components/SignupPage.tsx:90
 msgid "Continue"
-msgstr ""
+msgstr "Continuer"
 
 #: packages/admin/src/components/SetupWizard.tsx:175
 #: packages/admin/src/components/SetupWizard.tsx:258
 msgid "Continue →"
-msgstr ""
+msgstr "Continuer →"
 
 #: packages/admin/src/components/WordPressImport.tsx:2362
 msgid "Continue Import"
-msgstr ""
+msgstr "Continuer l'importation"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -1194,39 +1194,39 @@ msgstr "Copié dans le presse-papiers"
 #. placeholder {0}: section.slug
 #: packages/admin/src/components/Sections.tsx:397
 msgid "Copy {0} to clipboard"
-msgstr ""
+msgstr "Copier {0} dans le presse-papiers"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:124
 msgid "Copy invite link"
-msgstr ""
+msgstr "Copier le lien d'invitation"
 
 #: packages/admin/src/components/Sections.tsx:396
 msgid "Copy slug"
-msgstr ""
+msgstr "Copier le slug"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:193
 msgid "Copy this token now — it won't be shown again."
-msgstr "Copiez ce token maintenant — il ne sera plus affiché."
+msgstr "Copiez ce jeton maintenant — il ne sera plus affiché."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:211
 msgid "Copy token"
-msgstr "Copier le token"
+msgstr "Copier le jeton"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:138
 msgid "Could not copy automatically. Please select the URL above and copy manually."
-msgstr ""
+msgstr "Impossible de copier automatiquement. Veuillez sélectionner l'URL ci-dessus et copier manuellement."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:308
 msgid "Could not load image from URL"
-msgstr ""
+msgstr "Impossible de charger l'image à partir de l'URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1094
 msgid "Couldn't detect WordPress"
-msgstr ""
+msgstr "Impossible de détecter WordPress"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:618
 msgid "Count"
-msgstr ""
+msgstr "Nombre"
 
 #: packages/admin/src/components/ContentEditor.tsx:1727
 #: packages/admin/src/components/MenuList.tsx:146
@@ -1234,7 +1234,7 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:210
 #: packages/admin/src/components/TaxonomyManager.tsx:311
 msgid "Create"
-msgstr ""
+msgstr "Créer"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:730
 msgid "Create a bullet list"
@@ -1243,7 +1243,7 @@ msgstr "Créer une liste à puces"
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:219
 msgid "Create a new {0}"
-msgstr ""
+msgstr "Créer un nouveau {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:740
 msgid "Create a numbered list"
@@ -1251,98 +1251,98 @@ msgstr "Créer une liste numérotée"
 
 #: packages/admin/src/components/SignupPage.tsx:219
 msgid "Create Account"
-msgstr ""
+msgstr "Créer un compte"
 
 #: packages/admin/src/components/SignupPage.tsx:400
 msgid "Create an account"
-msgstr ""
+msgstr "Créer un compte"
 
 #: packages/admin/src/components/ContentEditor.tsx:1675
 msgid "Create byline"
-msgstr ""
+msgstr "Créer une signature"
 
 #: packages/admin/src/components/MenuList.tsx:97
 #: packages/admin/src/components/MenuList.tsx:160
 msgid "Create Menu"
-msgstr ""
+msgstr "Créer un menu"
 
 #: packages/admin/src/components/MenuList.tsx:104
 msgid "Create New Menu"
-msgstr ""
+msgstr "Créer un nouveau menu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:389
 msgid "Create New Token"
-msgstr "Créer un nouveau token"
+msgstr "Créer un nouveau jeton"
 
 #: packages/admin/src/components/WordPressImport.tsx:1331
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr ""
+msgstr "En créer un dans WordPress : Utilisateurs → Profil → Mots de passe d'application"
 
 #: packages/admin/src/components/SetupWizard.tsx:305
 msgid "Create Passkey"
-msgstr ""
+msgstr "Créer une clé d'accès"
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:178
 msgid "Create personal access tokens for programmatic API access"
-msgstr "Créez des tokens d'accès personnels pour un accès programmatique à l'API"
+msgstr "Créer des jetons d'accès personnels pour un accès programmatique à l'API"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:239
 msgid "Create redirect for {0}"
-msgstr ""
+msgstr "Créer une redirection pour {0}"
 
 #: packages/admin/src/components/Redirects.tsx:238
 msgid "Create redirect for this path"
-msgstr ""
+msgstr "Créer une redirection pour ce chemin"
 
 #: packages/admin/src/components/Redirects.tsx:442
 msgid "Create redirect rules to manage URL changes."
-msgstr ""
+msgstr "Créer des règles de redirection pour gérer les modifications d'URL."
 
 #: packages/admin/src/components/WordPressImport.tsx:1782
 msgid "Create Schema & Import"
-msgstr ""
+msgstr "Créer un schéma et l'importer"
 
 #: packages/admin/src/components/Sections.tsx:148
 #: packages/admin/src/components/Sections.tsx:268
 msgid "Create Section"
-msgstr ""
+msgstr "Créer une section"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:109
 msgid "Create sections in the Sections library to use them here"
-msgstr ""
+msgstr "Créer des sections dans la bibliothèque Sections pour les utiliser ici"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:430
 #: packages/admin/src/components/TaxonomyManager.tsx:526
 msgid "Create Taxonomy"
-msgstr ""
+msgstr "Créer une taxonomie"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:251
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:443
 msgid "Create Token"
-msgstr "Créer un token"
+msgstr "Créer un jeton"
 
 #: packages/admin/src/components/SetupWizard.tsx:495
 msgid "Create your account"
-msgstr ""
+msgstr "Créez votre compte"
 
 #: packages/admin/src/components/MenuList.tsx:158
 msgid "Create your first navigation menu to get started"
-msgstr ""
+msgstr "Créer votre premier menu de navigation pour commencer"
 
 #: packages/admin/src/components/ContentList.tsx:219
 #: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
-msgstr ""
+msgstr "Créer le premier"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "Create your first reusable content section to get started."
-msgstr ""
+msgstr "Créer votre première section de contenu réutilisable pour commencer."
 
 #: packages/admin/src/components/SignupPage.tsx:210
 msgid "Create your passkey"
-msgstr ""
+msgstr "Créer votre clé d'accès"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
@@ -1350,7 +1350,7 @@ msgstr "Créer, modifier, supprimer du contenu"
 
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
-msgstr ""
+msgstr "Créé"
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
@@ -1366,11 +1366,11 @@ msgstr "Créé le"
 #. placeholder {0}: new Date(item.createdAt).toLocaleString()
 #: packages/admin/src/components/ContentEditor.tsx:826
 msgid "Created: {0}"
-msgstr ""
+msgstr "Créé : {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:803
 msgid "Creating collections and fields..."
-msgstr ""
+msgstr "En cours de création de collections et de champs..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1727
 #: packages/admin/src/components/MenuList.tsx:146
@@ -1383,31 +1383,31 @@ msgstr "Création en cours..."
 
 #: packages/admin/src/components/ContentEditor.tsx:929
 msgid "current"
-msgstr ""
+msgstr "actuel"
 
 #: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
-msgstr ""
+msgstr "Actuel"
 
 #: packages/admin/src/components/Sections.tsx:242
 msgid "Custom"
-msgstr ""
+msgstr "Personnalisé"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:156
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr ""
+msgstr "Contenu robots.txt personnalisé. Laissez vide pour utiliser la valeur par défaut."
 
 #: packages/admin/src/components/SectionEditor.tsx:161
 msgid "Custom Section"
-msgstr ""
+msgstr "Section personnalisée"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
-msgstr ""
+msgstr "sombre"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Dark"
-msgstr ""
+msgstr "Sombre"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
 #: packages/admin/src/components/ContentTypeList.tsx:246
@@ -1415,46 +1415,46 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:171
 #: packages/admin/src/components/Sidebar.tsx:389
 msgid "Dashboard"
-msgstr "Dashboard"
+msgstr "Tableau de bord"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:303
 #: packages/admin/src/components/ContentList.tsx:201
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 #: packages/admin/src/components/FieldEditor.tsx:577
 msgid "Date & Time"
-msgstr ""
+msgstr "Date et heure"
 
 #: packages/admin/src/components/FieldEditor.tsx:176
 msgid "Date and time picker"
-msgstr ""
+msgstr "Sélecteur de date et d'heure"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:279
 msgid "Date Format"
-msgstr ""
+msgstr "Format des dates"
 
 #: packages/admin/src/components/FieldEditor.tsx:158
 msgid "Decimal number"
-msgstr ""
+msgstr "Nombre décimal"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:332
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:394
 msgid "Default Role"
-msgstr ""
+msgstr "Rôle par défaut"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:271
 msgid "Default role:"
-msgstr ""
+msgstr "Rôle par défaut :"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:433
 msgid "Define a new taxonomy for classifying content"
-msgstr ""
+msgstr "Définir une nouvelle taxonomie pour classer le contenu"
 
 #: packages/admin/src/components/ContentTypeList.tsx:40
 msgid "Define the structure of your content"
-msgstr ""
+msgstr "Définir la structure de votre contenu"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:274
 #: packages/admin/src/components/comments/CommentInbox.tsx:414
@@ -1468,12 +1468,12 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:405
 #: packages/admin/src/components/TaxonomyManager.tsx:656
 msgid "Delete"
-msgstr ""
+msgstr "Supprimer"
 
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:254
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr ""
+msgstr "Supprimer « {0} » ? Cela ne peut pas être annulé."
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -1483,67 +1483,67 @@ msgstr ""
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:290
 #: packages/admin/src/components/TaxonomyManager.tsx:79
 msgid "Delete {0}"
-msgstr ""
+msgstr "Supprimer {0}"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:191
 msgid "Delete {0} menu"
-msgstr ""
+msgstr "Supprimer le menu {0}"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:652
 msgid "Delete {0}?"
-msgstr ""
+msgstr "Supprimer {0} ?"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:412
 msgid "Delete Comment?"
-msgstr ""
+msgstr "Supprimer le commentaire ?"
 
 #: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
-msgstr ""
+msgstr "Supprimer le type de contenu ?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:253
 msgid "Delete Media?"
-msgstr ""
+msgstr "Supprimer le fichier multimédia ?"
 
 #: packages/admin/src/components/MenuList.tsx:207
 msgid "Delete Menu"
-msgstr ""
+msgstr "Supprimer le menu"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:532
 msgid "Delete permanently"
-msgstr ""
+msgstr "Supprimer définitivement"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:527
 msgid "Delete Permanently"
-msgstr ""
+msgstr "Supprimer définitivement"
 
 #: packages/admin/src/components/ContentList.tsx:507
 msgid "Delete Permanently?"
-msgstr ""
+msgstr "Supprimer définitivement ?"
 
 #: packages/admin/src/components/Redirects.tsx:516
 msgid "Delete redirect"
-msgstr ""
+msgstr "Supprimer la redirection"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:517
 msgid "Delete redirect {0}"
-msgstr ""
+msgstr "Supprimer la redirection {0}"
 
 #: packages/admin/src/components/Redirects.tsx:557
 msgid "Delete Redirect?"
-msgstr ""
+msgstr "Supprimer la redirection ?"
 
 #: packages/admin/src/components/Sections.tsx:294
 msgid "Delete Section?"
-msgstr ""
+msgstr "Supprimer la section ?"
 
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Deleted"
-msgstr ""
+msgstr "Supprimé"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:415
 #: packages/admin/src/components/ContentTypeList.tsx:149
@@ -1554,102 +1554,102 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:307
 #: packages/admin/src/components/TaxonomyManager.tsx:657
 msgid "Deleting..."
-msgstr ""
+msgstr "En cours de suppression..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:260
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:153
 msgid "Demo"
-msgstr ""
+msgstr "Démo"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
-msgstr ""
+msgstr "Refuser"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
 #: packages/admin/src/components/MediaDetailPanel.tsx:205
 msgid "Describe this image for accessibility"
-msgstr ""
+msgstr "Décrivez cette image pour l'accessibilité"
 
 #: packages/admin/src/components/SectionEditor.tsx:215
 msgid "Describe what this section is for..."
-msgstr ""
+msgstr "Décrivez à quoi sert cette section..."
 
 #: packages/admin/src/components/SectionEditor.tsx:212
 #: packages/admin/src/components/Sections.tsx:198
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:286
 msgid "Description (optional)"
-msgstr ""
+msgstr "Description (facultatif)"
 
 #: packages/admin/src/components/Redirects.tsx:449
 msgid "Destination"
-msgstr ""
+msgstr "Destination"
 
 #: packages/admin/src/components/Redirects.tsx:136
 msgid "Destination path"
-msgstr ""
+msgstr "Chemin d'arrivée"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 msgid "details"
-msgstr ""
+msgstr "détails"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:186
 msgid "Device authorized"
-msgstr ""
+msgstr "Appareil autorisé"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:229
 msgid "Device code"
-msgstr ""
+msgstr "Code de l'appareil"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr ""
+msgstr "Lié à l'appareil"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr ""
+msgstr "Clé d'accès liée à l'appareil"
 
 #: packages/admin/src/components/SignupPage.tsx:142
 msgid "Didn't receive the email?"
-msgstr ""
+msgstr "Vous n'avez pas reçu l'e-mail ?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:176
 msgid "Dimensions:"
-msgstr ""
+msgstr "Dimensions :"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
-msgstr ""
+msgstr "Désactiver"
 
 #: packages/admin/src/components/PluginManager.tsx:389
 msgid "Disable plugin"
-msgstr ""
+msgstr "Désactiver le module d'extension"
 
 #: packages/admin/src/components/Redirects.tsx:485
 msgid "Disable redirect"
-msgstr ""
+msgstr "Désactiver la redirection"
 
 #: packages/admin/src/components/PluginManager.tsx:308
 #: packages/admin/src/components/Redirects.tsx:397
 #: packages/admin/src/components/users/UserDetail.tsx:201
 msgid "Disabled"
-msgstr ""
+msgstr "Désactivé"
 
 #: packages/admin/src/components/PluginManager.tsx:468
 msgid "Disabled:"
-msgstr ""
+msgstr "Désactivé :"
 
 #: packages/admin/src/components/ContentEditor.tsx:587
 #: packages/admin/src/components/ContentEditor.tsx:609
 msgid "Discard changes"
-msgstr ""
+msgstr "Ignorer les modifications"
 
 #: packages/admin/src/components/ContentEditor.tsx:593
 msgid "Discard draft changes?"
-msgstr ""
+msgstr "Supprimer les brouillons de modifications ?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:226
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:228
@@ -1663,25 +1663,25 @@ msgstr "Afficher un menu de navigation"
 #: packages/admin/src/components/ContentEditor.tsx:1678
 #: packages/admin/src/components/ContentEditor.tsx:1740
 msgid "Display name"
-msgstr ""
+msgstr "Nom affiché"
 
 #: packages/admin/src/components/MenuList.tsx:138
 msgid "Display name for admin interface"
-msgstr ""
+msgstr "Nom affiché dans l'interface d'administration"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
 msgid "Display Size"
-msgstr ""
+msgstr "Taille d'affichage"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
 msgid "Displayed below the image as a visible caption."
-msgstr ""
+msgstr "Affiché sous l’image sous forme de légende visible."
 
 #: packages/admin/src/components/ContentEditor.tsx:563
 msgid "Distraction-free mode (⌘⇧\\)"
-msgstr ""
+msgstr "Mode sans distraction (⌘⇧\\)"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:769
 msgid "Divider"
@@ -1689,19 +1689,19 @@ msgstr "Séparateur"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:324
 msgid "Domain"
-msgstr ""
+msgstr "Domaine"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:86
 msgid "Domain added successfully"
-msgstr ""
+msgstr "Domaine ajouté avec succès"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:125
 msgid "Domain removed"
-msgstr ""
+msgstr "Domaine supprimé"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:108
 msgid "Domain updated"
-msgstr ""
+msgstr "Domaine mis à jour"
 
 #: packages/admin/src/components/LoginPage.tsx:358
 msgid "Don't have an account? <0>Sign up</0>"
@@ -1710,24 +1710,24 @@ msgstr "Pas encore de compte ? <0>S'inscrire</0>"
 #: packages/admin/src/components/users/InviteUserModal.tsx:144
 #: packages/admin/src/components/WordPressImport.tsx:1991
 msgid "Done"
-msgstr ""
+msgstr "Fait"
 
 #: packages/admin/src/components/ContentEditor.tsx:1621
 msgid "Down"
-msgstr ""
+msgstr "Vers le bas"
 
 #: packages/admin/src/components/WordPressImport.tsx:1989
 msgid "Downloading"
-msgstr ""
+msgstr "Téléchargement"
 
 #: packages/admin/src/components/ContentList.tsx:553
 msgid "draft"
-msgstr ""
+msgstr "brouillon"
 
 #: packages/admin/src/components/ContentEditor.tsx:757
 #: packages/admin/src/components/ContentPickerModal.tsx:217
 msgid "Draft"
-msgstr ""
+msgstr "Brouillon"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:117
 msgid "draft, published, or archived"
@@ -1740,23 +1740,23 @@ msgstr "Brouillons"
 
 #: packages/admin/src/components/WordPressImport.tsx:952
 msgid "Drag and drop or click to browse (.xml)"
-msgstr ""
+msgstr "Glisser-déposer ou cliquer pour parcourir (.xml)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1418
 msgid "Drop your WordPress export file here"
-msgstr ""
+msgstr "Déposer votre fichier d'exportation WordPress ici"
 
 #: packages/admin/src/components/ContentList.tsx:418
 msgid "Duplicate {title}"
-msgstr ""
+msgstr "Dupliquer {title}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:403
 msgid "e.g., CI/CD Pipeline"
-msgstr "ex. : pipeline CI/CD"
+msgstr "p. ex. : pipeline CI/CD"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr ""
+msgstr "p. ex. : MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentEditor.tsx:938
 #: packages/admin/src/components/ContentEditor.tsx:1630
@@ -1765,7 +1765,7 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:390
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 msgid "Edit"
-msgstr ""
+msgstr "Modifier"
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -1774,48 +1774,48 @@ msgstr ""
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:281
 #: packages/admin/src/components/TaxonomyManager.tsx:71
 msgid "Edit {0}"
-msgstr ""
+msgstr "Modifier {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:526
 msgid "Edit {collectionLabel}"
-msgstr ""
+msgstr "Modifier {collectionLabel}"
 
 #: packages/admin/src/components/ContentList.tsx:410
 msgid "Edit {title}"
-msgstr ""
+msgstr "Modifier {title}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1737
 msgid "Edit byline"
-msgstr ""
+msgstr "Modifier la signature"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:369
 msgid "Edit Domain"
-msgstr ""
+msgstr "Modifier le domaine"
 
 #: packages/admin/src/components/FieldEditor.tsx:323
 msgid "Edit Field"
-msgstr ""
+msgstr "Modifier le champ"
 
 #: packages/admin/src/components/MenuEditor.tsx:395
 msgid "Edit Menu Item"
-msgstr ""
+msgstr "Modifier l'élément de menu"
 
 #: packages/admin/src/components/MenuEditor.tsx:225
 msgid "Edit menu items"
-msgstr ""
+msgstr "Modifier les éléments du menu"
 
 #: packages/admin/src/components/Redirects.tsx:508
 msgid "Edit redirect"
-msgstr ""
+msgstr "Modifier la redirection"
 
 #: packages/admin/src/components/Redirects.tsx:102
 msgid "Edit Redirect"
-msgstr ""
+msgstr "Modifier la redirection"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:509
 msgid "Edit redirect {0}"
-msgstr ""
+msgstr "Modifier la redirection {0}"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
@@ -1830,7 +1830,7 @@ msgstr "E-mail"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:332
 msgid "Email (optional)"
-msgstr ""
+msgstr "E-mail (facultatif)"
 
 #: packages/admin/src/components/LoginPage.tsx:183
 #: packages/admin/src/components/SignupPage.tsx:65
@@ -1841,53 +1841,53 @@ msgstr "Adresse e-mail"
 #: packages/admin/src/components/SetupWizard.tsx:204
 #: packages/admin/src/components/SignupPage.tsx:48
 msgid "Email is required"
-msgstr ""
+msgstr "L'e-mail est requis"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:224
 msgid "Email Middleware"
-msgstr ""
+msgstr "Middleware de messagerie"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:134
 msgid "Email Pipeline"
-msgstr ""
+msgstr "Chaîne de messagerie"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:208
 msgid "Email provider active"
-msgstr ""
+msgstr "Fournisseur de messagerie actif"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:90
 #: packages/admin/src/components/settings/EmailSettings.tsx:109
 msgid "Email Settings"
-msgstr ""
+msgstr "Paramètres de messagerie"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
-msgstr ""
+msgstr "E-mail vérifié"
 
 #: packages/admin/src/components/SignupPage.tsx:188
 msgid "Email verified!"
-msgstr ""
+msgstr "E-mail vérifié !"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1443
 msgid "Embed a {0}"
-msgstr "Insérer un {0}"
+msgstr "Intégrer un {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1446
 msgid "Embeds"
-msgstr "Embeds"
+msgstr "Intégrations"
 
 #: packages/admin/src/components/WordPressImport.tsx:1038
 msgid "EmDash Exporter"
-msgstr ""
+msgstr "Exportateur EmDash"
 
 #: packages/admin/src/components/WordPressImport.tsx:1137
 msgid "EmDash Exporter plugin detected! You can import directly."
-msgstr ""
+msgstr "Module d'extension EmDash Exporter détecté ! Vous pouvez importer directement."
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
-msgstr ""
+msgstr "Activer"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:85
 msgid "Enable full-text search on this collection"
@@ -1895,84 +1895,84 @@ msgstr "Permettre la recherche dans le contenu de cette collection"
 
 #: packages/admin/src/components/PluginManager.tsx:389
 msgid "Enable plugin"
-msgstr ""
+msgstr "Activer le module d'extension"
 
 #: packages/admin/src/components/Redirects.tsx:485
 msgid "Enable redirect"
-msgstr ""
+msgstr "Activer la redirection"
 
 #: packages/admin/src/components/Redirects.tsx:169
 #: packages/admin/src/components/Redirects.tsx:396
 msgid "Enabled"
-msgstr ""
+msgstr "Activé"
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1156
 msgid "Enter {0}..."
-msgstr ""
+msgstr "Saisissez {0}..."
 
 #: packages/admin/src/components/MenuEditor.tsx:279
 #: packages/admin/src/components/MenuEditor.tsx:423
 msgid "Enter a URL (https://…) or a relative path (/…)"
-msgstr ""
+msgstr "Saisissez une URL (https://…) ou un chemin relatif (/…)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1210
 msgid "Enter credentials manually"
-msgstr ""
+msgstr "Saisir les informations d'identification manuellement"
 
 #: packages/admin/src/components/ContentEditor.tsx:562
 msgid "Enter distraction-free mode"
-msgstr ""
+msgstr "Passez en mode sans distraction"
 
 #: packages/admin/src/components/users/UserDetail.tsx:158
 msgid "Enter email"
-msgstr ""
+msgstr "Saisissez l'adresse mail"
 
 #: packages/admin/src/components/ContentEditor.tsx:1177
 msgid "Enter markdown content..."
-msgstr ""
+msgstr "Saisissez du contenu Markdown..."
 
 #: packages/admin/src/components/users/UserDetail.tsx:151
 msgid "Enter name"
-msgstr ""
+msgstr "Saisissez le nom"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:177
 msgid "Enter the code from your terminal"
-msgstr ""
+msgstr "Saisissez le code depuis votre terminal"
 
 #: packages/admin/src/components/WordPressImport.tsx:1289
 msgid "Enter your WordPress credentials to import content directly."
-msgstr ""
+msgstr "Saisissez vos informations d'identification WordPress pour importer du contenu directement."
 
 #: packages/admin/src/components/WordPressImport.tsx:915
 msgid "Enter your WordPress site URL"
-msgstr ""
+msgstr "Saisir l'URL de votre site WordPress"
 
 #: packages/admin/src/components/MenuEditor.tsx:83
 #: packages/admin/src/components/MenuEditor.tsx:122
 #: packages/admin/src/components/SetupWizard.tsx:478
 msgid "Error"
-msgstr ""
+msgstr "Erreur"
 
 #: packages/admin/src/components/SectionEditor.tsx:49
 msgid "Error saving section"
-msgstr ""
+msgstr "Erreur lors de l'enregistrement de la section"
 
 #: packages/admin/src/components/WordPressImport.tsx:1873
 msgid "Exists"
-msgstr ""
+msgstr "Existe"
 
 #: packages/admin/src/components/ContentEditor.tsx:520
 msgid "Exit distraction-free mode"
-msgstr ""
+msgstr "Quitter le mode sans distraction"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 msgid "Expand"
-msgstr ""
+msgstr "Développer"
 
 #: packages/admin/src/components/PluginManager.tsx:395
 msgid "Expand details"
-msgstr ""
+msgstr "Développer les détails"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:280
@@ -1985,107 +1985,107 @@ msgstr "Expiration"
 
 #: packages/admin/src/components/WordPressImport.tsx:1103
 msgid "Export from WordPress manually"
-msgstr ""
+msgstr "Exporter manuellement depuis WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1227
 msgid "Export your content from WordPress to import everything including drafts."
-msgstr ""
+msgstr "Exportez votre contenu depuis WordPress pour tout importer, y compris les brouillons."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:140
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:344
 msgid "Fail"
-msgstr ""
+msgstr "Échec"
 
 #: packages/admin/src/components/WordPressImport.tsx:1993
 msgid "Failed"
-msgstr ""
+msgstr "Échec"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:198
 msgid "Failed security audit"
-msgstr ""
+msgstr "Échec de l'audit de sécurité"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:91
 msgid "Failed to add domain"
-msgstr ""
+msgstr "Échec de l'ajout du domaine"
 
 #: packages/admin/src/components/ContentEditor.tsx:1721
 msgid "Failed to create byline"
-msgstr ""
+msgstr "Échec de la création de la signature"
 
 #: packages/admin/src/components/WordPressImport.tsx:1544
 msgid "Failed to create some collections"
-msgstr ""
+msgstr "Échec de la création de certaines collections"
 
 #: packages/admin/src/components/PluginManager.tsx:108
 msgid "Failed to disable plugin"
-msgstr ""
+msgstr "Échec de la désactivation du module d'extension"
 
 #: packages/admin/src/components/PluginManager.tsx:89
 msgid "Failed to enable plugin"
-msgstr ""
+msgstr "Échec de l'activation du module d'extension"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:269
 msgid "Failed to generate preview"
-msgstr ""
+msgstr "Échec de la génération de l'aperçu"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:163
 msgid "Failed to generate preview URL"
-msgstr ""
+msgstr "Échec de la génération de l'URL d'aperçu"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:212
 msgid "Failed to load allowed domains"
-msgstr ""
+msgstr "Échec du chargement des domaines autorisés"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:94
 msgid "Failed to load email settings"
-msgstr ""
+msgstr "Échec du chargement des paramètres de messagerie"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:148
 msgid "Failed to load passkeys"
-msgstr ""
+msgstr "Échec du chargement des clés d'accès"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:120
 msgid "Failed to load plugin"
-msgstr ""
+msgstr "Échec du chargement du module d'extension"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:135
 msgid "Failed to load plugins: {0}"
-msgstr ""
+msgstr "Échec du chargement des modules d'extension : {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
-msgstr ""
+msgstr "Échec du chargement des révisions"
 
 #: packages/admin/src/components/SetupWizard.tsx:480
 msgid "Failed to load setup"
-msgstr ""
+msgstr "Échec du chargement de la configuration"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Failed to load theme"
-msgstr ""
+msgstr "Échec du chargement du thème"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:131
 msgid "Failed to remove domain"
-msgstr ""
+msgstr "Échec de la suppression du domaine"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:99
 #: packages/admin/src/components/settings/SecuritySettings.tsx:82
 msgid "Failed to remove passkey"
-msgstr ""
+msgstr "Échec de la suppression de la clé d'accès"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:66
 msgid "Failed to rename passkey"
-msgstr ""
+msgstr "Échec du renommage de la clé d'accès"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:64
 #: packages/admin/src/components/settings/SeoSettings.tsx:58
 #: packages/admin/src/components/settings/SocialSettings.tsx:52
 msgid "Failed to save settings"
-msgstr ""
+msgstr "Échec de l'enregistrement des paramètres"
 
 #: packages/admin/src/components/LoginPage.tsx:127
 #: packages/admin/src/components/LoginPage.tsx:132
@@ -2094,90 +2094,90 @@ msgstr "Échec de l'envoi du lien de connexion"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:62
 msgid "Failed to send test email"
-msgstr ""
+msgstr "Échec de l'envoi de l'e-mail de test"
 
 #: packages/admin/src/components/ContentEditor.tsx:1771
 msgid "Failed to update byline"
-msgstr ""
+msgstr "Échec de la mise à jour de la signature"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:114
 msgid "Failed to update domain"
-msgstr ""
+msgstr "Échec de la mise à jour du domaine"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:221
 #: packages/admin/src/components/settings/GeneralSettings.tsx:226
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1013
 msgid "Feature"
-msgstr ""
+msgstr "Fonctionnalité"
 
 #: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
-msgstr ""
+msgstr "Fonctionnalités"
 
 #: packages/admin/src/components/WordPressImport.tsx:727
 msgid "Fetching content from the EmDash Exporter API."
-msgstr ""
+msgstr "Récupération de contenu à partir de l'API EmDash Exporter."
 
 #: packages/admin/src/components/FieldEditor.tsx:559
 msgid "Field label"
-msgstr ""
+msgstr "Libellé du champ"
 
 #: packages/admin/src/components/FieldEditor.tsx:395
 msgid "Field Label"
-msgstr ""
+msgstr "Libellé du champ"
 
 #: packages/admin/src/components/FieldEditor.tsx:407
 msgid "Field slugs cannot be changed after creation"
-msgstr ""
+msgstr "Le slug des champs ne peut pas être modifié après la création"
 
 #: packages/admin/src/components/WordPressImport.tsx:2166
 msgid "Fields created:"
-msgstr ""
+msgstr "Champs créés :"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "File"
-msgstr ""
+msgstr "Fichier"
 
 #. placeholder {0}: progress.current
 #: packages/admin/src/components/WordPressImport.tsx:2021
 msgid "File {0}"
-msgstr ""
+msgstr "Fichier {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:206
 msgid "File from media library"
-msgstr ""
+msgstr "Fichier de la médiathèque"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:416
 msgid "Filename"
-msgstr ""
+msgstr "Nom du fichier"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:196
 msgid "Filename cannot be changed after upload"
-msgstr ""
+msgstr "Le nom du fichier ne peut pas être modifié après le téléversement"
 
 #: packages/admin/src/components/WordPressImport.tsx:2199
 msgid "files imported"
-msgstr ""
+msgstr "fichiers importés"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:106
 msgid "Filter by capability"
-msgstr ""
+msgstr "Filtrer par capacité"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:184
 msgid "Filter by collection"
-msgstr ""
+msgstr "Filtrer par collection"
 
 #: packages/admin/src/components/WordPressImport.tsx:1228
 msgid "For a complete import including drafts and all content, export from WordPress."
-msgstr ""
+msgstr "Pour une importation complète incluant les brouillons et tout le contenu, exportez depuis WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1037
 msgid "For the best import experience, install the"
-msgstr ""
+msgstr "Pour une expérience d'importation optimale, installez le"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -2194,7 +2194,7 @@ msgstr "Général"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:111
 #: packages/admin/src/components/settings/GeneralSettings.tsx:129
 msgid "General Settings"
-msgstr ""
+msgstr "Paramètres généraux"
 
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
@@ -2202,27 +2202,27 @@ msgstr "Commencer"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:134
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr ""
+msgstr "Donnez un nom à cette clé d'accès pour vous aider à l'identifier plus tard."
 
 #: packages/admin/src/components/WordPressImport.tsx:2251
 msgid "Go to Dashboard"
-msgstr ""
+msgstr "Aller au tableau de bord"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:140
 msgid "Google Verification"
-msgstr ""
+msgstr "Vérification Google"
 
 #: packages/admin/src/components/MediaLibrary.tsx:232
 msgid "Grid view"
-msgstr ""
+msgstr "Vue en grille"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "Group (optional)"
-msgstr ""
+msgstr "Groupe (facultatif)"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:699
@@ -2242,49 +2242,49 @@ msgstr "Titre 3"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
 msgid "Height"
-msgstr ""
+msgstr "Hauteur"
 
 #: packages/admin/src/components/SeoPanel.tsx:186
 msgid "Hide from search engines"
-msgstr ""
+msgstr "Masquer des moteurs de recherche"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Hide token"
-msgstr "Masquer le token"
+msgstr "Masquer le jeton"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:481
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr ""
+msgstr "Hiérarchique (comme les catégories, avec des relations parent/enfant)"
 
 #: packages/admin/src/components/Redirects.tsx:217
 #: packages/admin/src/components/Redirects.tsx:451
 msgid "Hits"
-msgstr ""
+msgstr "Clics"
 
 #: packages/admin/src/components/MenuEditor.tsx:272
 msgid "Home"
-msgstr ""
+msgstr "Accueil"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:237
 msgid "Homepage"
-msgstr ""
+msgstr "Page d'accueil"
 
 #: packages/admin/src/components/PluginManager.tsx:339
 msgid "Hooks"
-msgstr ""
+msgstr "Hooks"
 
 #: packages/admin/src/components/WordPressImport.tsx:1350
 msgid "How to create an Application Password"
-msgstr ""
+msgstr "Comment créer un mot de passe d'application"
 
 #: packages/admin/src/components/MenuEditor.tsx:280
 msgid "https://example.com or /about"
-msgstr ""
+msgstr "https://example.com ou /about"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:242
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:152
 msgid "Icon blurred due to image audit"
-msgstr ""
+msgstr "Icône floutée en raison de l'audit d'image"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:103
 msgid "ID"
@@ -2301,24 +2301,24 @@ msgstr "Image"
 
 #: packages/admin/src/components/FieldEditor.tsx:200
 msgid "Image from media library"
-msgstr ""
+msgstr "Image de la médiathèque"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
 msgid "Image Settings"
-msgstr ""
+msgstr "Paramètres d'image"
 
 #: packages/admin/src/components/SeoImageField.tsx:75
 msgid "Image shown when this page is shared on social media"
-msgstr ""
+msgstr "Image affichée lorsque cette page est partagée sur les réseaux sociaux"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:374
 msgid "Image URL"
-msgstr ""
+msgstr "URL de l'image"
 
 #: packages/admin/src/components/WordPressImport.tsx:2203
 msgid "image URLs updated in"
-msgstr ""
+msgstr "URL des images mises à jour dans"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:223
@@ -2328,100 +2328,100 @@ msgstr "Importer"
 #. placeholder {0}: postType.name
 #: packages/admin/src/components/WordPressImport.tsx:1821
 msgid "Import {0}"
-msgstr ""
+msgstr "Importer {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1196
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr ""
+msgstr "Importez directement tout le contenu, y compris les brouillons, les types de publication personnalisés, les champs ACF et les données SEO. Aucun téléchargement de fichier n'est nécessaire."
 
 #: packages/admin/src/components/WordPressImport.tsx:2249
 msgid "Import Another File"
-msgstr ""
+msgstr "Importer un autre fichier"
 
 #: packages/admin/src/components/WordPressImport.tsx:1007
 msgid "Import Capabilities"
-msgstr ""
+msgstr "Capacités d'importation"
 
 #: packages/admin/src/components/WordPressImport.tsx:2137
 msgid "Import Complete"
-msgstr ""
+msgstr "Importation terminée"
 
 #: packages/admin/src/components/WordPressImport.tsx:2138
 msgid "Import Completed with Errors"
-msgstr ""
+msgstr "Importation terminée avec des erreurs"
 
 #: packages/admin/src/components/WordPressImport.tsx:1529
 msgid "Import failed"
-msgstr ""
+msgstr "Échec de l'importation"
 
 #: packages/admin/src/components/WordPressImport.tsx:608
 msgid "Import from WordPress"
-msgstr ""
+msgstr "Importer depuis WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1686
 msgid "Import logo and favicon"
-msgstr ""
+msgstr "Importer le logo et le favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1970
 msgid "Import Media"
-msgstr ""
+msgstr "Importer des fichiers multimédias"
 
 #: packages/admin/src/components/WordPressImport.tsx:1923
 msgid "Import Media Files"
-msgstr ""
+msgstr "Importer des fichiers multimédias"
 
 #: packages/admin/src/components/WordPressImport.tsx:1595
 msgid "Import navigation menus"
-msgstr ""
+msgstr "Importer les menus de navigation"
 
 #: packages/admin/src/components/WordPressImport.tsx:610
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr ""
+msgstr "Importez des articles, des pages et des types de publications personnalisés depuis WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1702
 msgid "Import SEO settings"
-msgstr ""
+msgstr "Importer les paramètres SEO"
 
 #: packages/admin/src/components/WordPressImport.tsx:1658
 msgid "Import site configuration from WordPress."
-msgstr ""
+msgstr "Importez la configuration du site depuis WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1670
 msgid "Import site title and tagline"
-msgstr ""
+msgstr "Importer le titre et le slogan du site"
 
 #: packages/admin/src/components/WordPressImport.tsx:1194
 msgid "Import via EmDash Exporter"
-msgstr ""
+msgstr "Importer via l'exportateur EmDash"
 
 #: packages/admin/src/components/Sections.tsx:243
 msgid "Imported"
-msgstr ""
+msgstr "Importé"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "Imported by Collection"
-msgstr ""
+msgstr "Importé par Collection"
 
 #: packages/admin/src/components/WordPressImport.tsx:811
 msgid "Importing content..."
-msgstr ""
+msgstr "En cours d'importation de contenu..."
 
 #: packages/admin/src/components/WordPressImport.tsx:2002
 msgid "Importing Media"
-msgstr ""
+msgstr "Importation de fichiers multimédias"
 
 #: packages/admin/src/components/SetupWizard.tsx:163
 msgid "Include sample content (recommended for new sites)"
-msgstr ""
+msgstr "Inclure un exemple de contenu (recommandé pour les nouveaux sites)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1843
 msgid "Incompatible"
-msgstr ""
+msgstr "Incompatible"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:385
 #: packages/admin/src/components/MediaPickerModal.tsx:584
 msgid "Insert"
-msgstr ""
+msgstr "Insérer"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:750
 msgid "Insert a blockquote"
@@ -2445,98 +2445,98 @@ msgstr "Insérer une image"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:367
 msgid "Insert from URL"
-msgstr ""
+msgstr "Insérer à partir de l'URL"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:57
 msgid "Insert Section"
-msgstr ""
+msgstr "Insérer une section"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:146
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:203
 msgid "Install"
-msgstr ""
+msgstr "Installer"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:190
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr ""
+msgstr "Installez et activez un module d'extension de fournisseur de messagerie pour activer les fonctionnalités de messagerie telles que les invitations, les liens magiques et la récupération de mot de passe."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:196
 msgid "Install blocked"
-msgstr ""
+msgstr "Installation bloquée"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:262
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:183
 msgid "Installed"
-msgstr ""
+msgstr "Installé"
 
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:437
 msgid "Installed from marketplace (v{0})"
-msgstr ""
+msgstr "Installé depuis la place de marché (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "Installed:"
-msgstr ""
+msgstr "Installé :"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:145
 msgid "Installing..."
-msgstr ""
+msgstr "En cours d'installation..."
 
 #: packages/admin/src/components/FieldEditor.tsx:163
 #: packages/admin/src/components/FieldEditor.tsx:575
 msgid "Integer"
-msgstr ""
+msgstr "Entier"
 
 #: packages/admin/src/components/ContentEditor.tsx:1356
 msgid "Invalid JSON"
-msgstr ""
+msgstr "JSON invalide"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Invalid link"
-msgstr ""
+msgstr "Lien invalide"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
-msgstr ""
+msgstr "Lien d'invitation créé"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite User"
-msgstr ""
+msgstr "Inviter un utilisateur"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/RepeaterField.tsx:218
 msgid "Item {0}"
-msgstr ""
+msgstr "Article {0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:65
 msgid "Item added"
-msgstr ""
+msgstr "Article ajouté"
 
 #: packages/admin/src/components/MenuEditor.tsx:77
 msgid "Item deleted"
-msgstr ""
+msgstr "Élément supprimé"
 
 #: packages/admin/src/components/MenuEditor.tsx:102
 msgid "Item updated"
-msgstr ""
+msgstr "Article mis à jour"
 
 #: packages/admin/src/components/SetupWizard.tsx:238
 #: packages/admin/src/components/SignupPage.tsx:204
 msgid "Jane Doe"
-msgstr ""
+msgstr "Jane Doe"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:304
 #: packages/admin/src/components/SectionEditor.tsx:221
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:195
 msgid "Keywords"
-msgstr ""
+msgstr "Mots-clés"
 
 #: packages/admin/src/components/FieldEditor.tsx:392
 #: packages/admin/src/components/FieldEditor.tsx:545
@@ -2545,7 +2545,7 @@ msgstr ""
 #: packages/admin/src/components/MenuList.tsx:137
 #: packages/admin/src/components/TaxonomyManager.tsx:455
 msgid "Label"
-msgstr ""
+msgstr "Étiquette"
 
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
@@ -2558,23 +2558,23 @@ msgstr "Titre principal"
 
 #: packages/admin/src/components/PluginManager.tsx:462
 msgid "Last enabled:"
-msgstr ""
+msgstr "Dernière activation :"
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
-msgstr ""
+msgstr "Dernière connexion"
 
 #: packages/admin/src/components/Redirects.tsx:218
 msgid "Last seen"
-msgstr ""
+msgstr "Vu pour la dernière fois"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
-msgstr ""
+msgstr "Dernière mise à jour"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:161
 msgid "Last used"
-msgstr ""
+msgstr "Dernière utilisation"
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
@@ -2585,114 +2585,114 @@ msgstr "Dernière utilisation le {0}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:341
 msgid "Leave blank to use a discoverable passkey."
-msgstr ""
+msgstr "Laissez vide pour utiliser une clé d'accès détectable."
 
 #: packages/admin/src/components/WordPressImport.tsx:2331
 msgid "Leave unassigned"
-msgstr ""
+msgstr "Laisser non attribué"
 
 #: packages/admin/src/components/MediaLibrary.tsx:314
 msgid "Library"
-msgstr ""
+msgstr "Bibliothèque"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:209
 msgid "License"
-msgstr ""
+msgstr "Licence"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
-msgstr ""
+msgstr "clair"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Light"
-msgstr ""
+msgstr "Clair"
 
 #: packages/admin/src/components/SignupPage.tsx:256
 msgid "Link expired"
-msgstr ""
+msgstr "Lien expiré"
 
 #: packages/admin/src/components/FieldEditor.tsx:212
 msgid "Link to another content item"
-msgstr ""
+msgstr "Lien vers un autre élément de contenu"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr ""
+msgstr "Comptes associés ({0})"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:152
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:216
 msgid "Links"
-msgstr ""
+msgstr "Liens"
 
 #: packages/admin/src/components/MediaLibrary.tsx:241
 msgid "List view"
-msgstr ""
+msgstr "Vue en liste"
 
 #: packages/admin/src/components/ContentEditor.tsx:642
 msgid "Live View"
-msgstr ""
+msgstr "Affichage en direct"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:241
 #: packages/admin/src/components/MarketplaceBrowse.tsx:199
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:168
 msgid "Load more"
-msgstr ""
+msgstr "Charger davantage"
 
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
 msgid "Load More"
-msgstr ""
+msgstr "Charger davantage"
 
 #: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
-msgstr ""
+msgstr "En cours de chargement des collections..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:314
 msgid "Loading comments..."
-msgstr ""
+msgstr "En cours de chargement des commentaires..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:169
 msgid "Loading content..."
-msgstr ""
+msgstr "En cours de chargement du contenu..."
 
 #: packages/admin/src/components/MenuEditor.tsx:198
 msgid "Loading menu..."
-msgstr ""
+msgstr "En cours de chargement du menu..."
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "Loading menus..."
-msgstr ""
+msgstr "En cours de chargement des menus..."
 
 #: packages/admin/src/components/PluginManager.tsx:126
 msgid "Loading plugins..."
-msgstr ""
+msgstr "En cours de chargement des modules d'extension..."
 
 #: packages/admin/src/components/Redirects.tsx:437
 msgid "Loading redirects..."
-msgstr ""
+msgstr "En cours de chargement des redirections..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:94
 #: packages/admin/src/components/Sections.tsx:250
 msgid "Loading sections..."
-msgstr ""
+msgstr "En cours de chargement des rubriques..."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:114
 #: packages/admin/src/components/settings/SeoSettings.tsx:90
 #: packages/admin/src/components/settings/SocialSettings.tsx:84
 msgid "Loading settings..."
-msgstr ""
+msgstr "En cours de chargement des paramètres..."
 
 #: packages/admin/src/components/SetupWizard.tsx:467
 msgid "Loading setup..."
-msgstr ""
+msgstr "En cours de chargement de la configuration..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:623
 msgid "Loading terms..."
-msgstr ""
+msgstr "En cours de chargement des termes..."
 
 #: packages/admin/src/components/ContentList.tsx:290
 #: packages/admin/src/components/ContentList.tsx:338
@@ -2706,7 +2706,7 @@ msgstr ""
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Loading..."
-msgstr "Chargement..."
+msgstr "En cours de chargement..."
 
 #: packages/admin/src/components/ContentList.tsx:197
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
@@ -2718,55 +2718,55 @@ msgstr "Langue"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Lock aspect ratio"
-msgstr ""
+msgstr "Verrouiller le rapport hauteur/largeur"
 
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
-msgstr ""
+msgstr "Se déconnecter"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:177
 #: packages/admin/src/components/settings/GeneralSettings.tsx:182
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1689
 msgid "Logo & favicon"
-msgstr ""
+msgstr "Logo et favicon"
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 #: packages/admin/src/components/FieldEditor.tsx:573
 msgid "Long Text"
-msgstr ""
+msgstr "Texte long"
 
 #: packages/admin/src/components/Sections.tsx:191
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr ""
+msgstr "Lettres minuscules, chiffres et traits d'union uniquement"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:473
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
-msgstr ""
+msgstr "Lettres minuscules, chiffres et traits de soulignement uniquement, commençant par une lettre"
 
 #: packages/admin/src/components/Sidebar.tsx:414
 msgid "Manage"
-msgstr ""
+msgstr "Gérer"
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:602
 msgid "Manage {0} for {1}"
-msgstr ""
+msgstr "Gérer {0} pour {1}"
 
 #: packages/admin/src/components/PluginManager.tsx:170
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr ""
+msgstr "Gérer les modules d'extension installés. Activez ou désactivez les modules d'extension pour contrôler leurs fonctionnalités."
 
 #: packages/admin/src/components/MenuList.tsx:85
 msgid "Manage navigation menus for your site"
-msgstr ""
+msgstr "Gérer les menus de navigation de votre site"
 
 #: packages/admin/src/components/Redirects.tsx:334
 msgid "Manage URL redirects and view 404 errors."
-msgstr ""
+msgstr "Gérez les redirections d'URL et affichez les erreurs 404."
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
@@ -2774,38 +2774,38 @@ msgstr "Gérez vos clés d'accès et votre authentification"
 
 #: packages/admin/src/components/Redirects.tsx:405
 msgid "Manual"
-msgstr ""
+msgstr "Manuel"
 
 #: packages/admin/src/components/WordPressImport.tsx:2287
 msgid "Map Authors"
-msgstr ""
+msgstr "Associer les auteurs"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:508
 msgid "Mark as spam"
-msgstr ""
+msgstr "Marquer comme indésirable"
 
 #: packages/admin/src/components/PluginManager.tsx:196
 msgid "marketplace"
-msgstr ""
+msgstr "place de marché"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:86
 #: packages/admin/src/components/PluginManager.tsx:161
 #: packages/admin/src/components/PluginManager.tsx:309
 #: packages/admin/src/components/Sidebar.tsx:214
 msgid "Marketplace"
-msgstr ""
+msgstr "Place de marché"
 
 #: packages/admin/src/components/FieldEditor.tsx:620
 msgid "Max Items"
-msgstr ""
+msgstr "Nombre maximum d'éléments"
 
 #: packages/admin/src/components/FieldEditor.tsx:462
 msgid "Max Length"
-msgstr ""
+msgstr "Longueur maximale"
 
 #: packages/admin/src/components/FieldEditor.tsx:492
 msgid "Max Value"
-msgstr ""
+msgstr "Valeur maximale"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1417
 #: packages/admin/src/components/Sidebar.tsx:180
@@ -2815,24 +2815,24 @@ msgstr "Médias"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:130
 msgid "Media Details"
-msgstr ""
+msgstr "Détails des fichiers multimédias"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2233
 msgid "Media Errors ({0})"
-msgstr ""
+msgstr "Erreurs liées aux fichiers multimédias ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:2195
 msgid "Media Import"
-msgstr ""
+msgstr "Importation de fichiers multimédias"
 
 #: packages/admin/src/components/WordPressImport.tsx:2136
 msgid "Media Import Complete"
-msgstr ""
+msgstr "Importation des fichiers multimédias terminée"
 
 #: packages/admin/src/components/WordPressImport.tsx:2147
 msgid "Media import was skipped"
-msgstr ""
+msgstr "L'importation des fichiers multimédias a été ignorée"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
 #: packages/admin/src/components/MediaLibrary.tsx:226
@@ -2841,11 +2841,11 @@ msgstr "Médiathèque"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:64
 msgid "Media Read"
-msgstr "Lecture des médias"
+msgstr "Lecture des fichiers multimédias"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:69
 msgid "Media Write"
-msgstr "Écriture des médias"
+msgstr "Écriture des fichiers multimédias"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:710
 msgid "Medium section heading"
@@ -2858,35 +2858,35 @@ msgstr "Menu"
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:40
 msgid "Menu \"{0}\" has been created."
-msgstr ""
+msgstr "Le menu « {0} » a été créé."
 
 #: packages/admin/src/components/MenuList.tsx:39
 msgid "Menu created"
-msgstr ""
+msgstr "Menu créé"
 
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu deleted"
-msgstr ""
+msgstr "Menu supprimé"
 
 #: packages/admin/src/components/MenuEditor.tsx:65
 msgid "Menu item has been added."
-msgstr ""
+msgstr "Un élément de menu a été ajouté."
 
 #: packages/admin/src/components/MenuEditor.tsx:78
 msgid "Menu item has been deleted."
-msgstr ""
+msgstr "L'élément de menu a été supprimé."
 
 #: packages/admin/src/components/MenuEditor.tsx:103
 msgid "Menu item has been updated."
-msgstr ""
+msgstr "L'élément de menu a été mis à jour."
 
 #: packages/admin/src/components/MenuEditor.tsx:206
 msgid "Menu not found"
-msgstr ""
+msgstr "Menu introuvable"
 
 #: packages/admin/src/components/MenuEditor.tsx:117
 msgid "Menu order has been updated."
-msgstr ""
+msgstr "L'ordre des menus a été mis à jour."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
 #: packages/admin/src/components/MenuList.tsx:84
@@ -2897,43 +2897,43 @@ msgstr "Menus"
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1600
 msgid "Menus ({0})"
-msgstr ""
+msgstr "Menus ({0})"
 
 #: packages/admin/src/components/SeoPanel.tsx:161
 msgid "Meta Description"
-msgstr ""
+msgstr "Méta description"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:149
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr ""
+msgstr "Contenu des balises méta pour la vérification des outils pour les webmasters Bing"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:143
 msgid "Meta tag content for Google Search Console verification"
-msgstr ""
+msgstr "Contenu des balises méta pour la vérification de la console de recherche Google"
 
 #: packages/admin/src/components/WordPressImport.tsx:1707
 msgid "Meta titles, descriptions, and social images"
-msgstr ""
+msgstr "Méta titres, descriptions et images sociales"
 
 #: packages/admin/src/components/FieldEditor.tsx:613
 msgid "Min Items"
-msgstr ""
+msgstr "Articles minimum"
 
 #: packages/admin/src/components/FieldEditor.tsx:455
 msgid "Min Length"
-msgstr ""
+msgstr "Longueur minimale"
 
 #: packages/admin/src/components/FieldEditor.tsx:485
 msgid "Min Value"
-msgstr ""
+msgstr "Valeur minimale"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr ""
+msgstr "Signaux de modération"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:216
 msgid "Modified"
-msgstr ""
+msgstr "Modifié"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Modify collection schemas"
@@ -2941,46 +2941,46 @@ msgstr "Modifier les schémas de collections"
 
 #: packages/admin/src/components/ContentList.tsx:439
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr ""
+msgstr "Déplacer « {title} » vers la corbeille ? Vous pourrez le restaurer plus tard."
 
 #: packages/admin/src/components/ContentList.tsx:430
 msgid "Move {title} to trash"
-msgstr ""
+msgstr "Déplacer {title} vers la corbeille"
 
 #: packages/admin/src/components/MenuEditor.tsx:360
 msgid "Move down"
-msgstr ""
+msgstr "Descendre"
 
 #: packages/admin/src/components/ContentEditor.tsx:843
 #: packages/admin/src/components/ContentEditor.tsx:865
 #: packages/admin/src/components/ContentList.tsx:452
 msgid "Move to Trash"
-msgstr ""
+msgstr "Déplacer vers la corbeille"
 
 #: packages/admin/src/components/ContentEditor.tsx:849
 #: packages/admin/src/components/ContentList.tsx:437
 msgid "Move to Trash?"
-msgstr ""
+msgstr "Placer dans la corbeille ?"
 
 #: packages/admin/src/components/MenuEditor.tsx:351
 msgid "Move up"
-msgstr ""
+msgstr "Monter"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Multi Select"
-msgstr ""
+msgstr "Sélection multiple"
 
 #: packages/admin/src/components/FieldEditor.tsx:152
 msgid "Multi-line plain text"
-msgstr ""
+msgstr "Texte brut multiligne"
 
 #: packages/admin/src/components/FieldEditor.tsx:188
 msgid "Multiple choices from options"
-msgstr ""
+msgstr "Plusieurs choix parmi les options"
 
 #: packages/admin/src/components/SetupWizard.tsx:145
 msgid "My Awesome Blog"
-msgstr ""
+msgstr "Mon super blog"
 
 #: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MenuList.tsx:125
@@ -2989,15 +2989,15 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:617
 #: packages/admin/src/components/users/UserDetail.tsx:148
 msgid "Name"
-msgstr ""
+msgstr "Nom"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:390
 msgid "Name and label are required"
-msgstr ""
+msgstr "Le nom et l'étiquette sont requis"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:396
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
-msgstr ""
+msgstr "Le nom doit commencer par une lettre et contenir uniquement des lettres minuscules, des chiffres et des traits de soulignement."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
@@ -3005,32 +3005,32 @@ msgstr "Navigation"
 
 #: packages/admin/src/components/users/UserDetail.tsx:231
 msgid "Never"
-msgstr ""
+msgstr "Jamais"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:103
 msgid "NEW"
-msgstr ""
+msgstr "NOUVEAU"
 
 #: packages/admin/src/components/ContentEditor.tsx:526
 msgid "New {collectionLabel}"
-msgstr ""
+msgstr "Nouveau {collectionLabel}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1845
 msgid "New collection"
-msgstr ""
+msgstr "Nouvelle collection"
 
 #: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
-msgstr ""
+msgstr "Nouveau type de contenu"
 
 #: packages/admin/src/components/Redirects.tsx:102
 #: packages/admin/src/components/Redirects.tsx:337
 msgid "New Redirect"
-msgstr ""
+msgstr "Nouvelle redirection"
 
 #: packages/admin/src/components/Sections.tsx:141
 msgid "New Section"
-msgstr ""
+msgstr "Nouvelle rubrique"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
@@ -3038,111 +3038,111 @@ msgstr "nouvel onglet"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:607
 msgid "New Taxonomy"
-msgstr ""
+msgstr "Nouvelle taxonomie"
 
 #: packages/admin/src/components/MenuEditor.tsx:286
 #: packages/admin/src/components/MenuEditor.tsx:289
 #: packages/admin/src/components/MenuEditor.tsx:431
 #: packages/admin/src/components/MenuEditor.tsx:434
 msgid "New window"
-msgstr ""
+msgstr "Nouvelle fenêtre"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:321
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:378
 #: packages/admin/src/components/ContentList.tsx:278
 msgid "Next page"
-msgstr ""
+msgstr "Page suivante"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:474
 msgid "Next screenshot"
-msgstr ""
+msgstr "Capture d'écran suivante"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "No"
-msgstr ""
+msgstr "Non"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:311
 msgid "No {0} available."
-msgstr ""
+msgstr "Aucun {0} disponible."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:212
 msgid "No {0} yet."
-msgstr ""
+msgstr "Pas encore de {0}."
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:626
 msgid "No {0} yet. Create one to get started."
-msgstr ""
+msgstr "Pas encore de {0}. Créez-en un pour commencer."
 
 #: packages/admin/src/components/Redirects.tsx:209
 msgid "No 404 errors recorded yet."
-msgstr ""
+msgstr "Aucune erreur 404 enregistrée pour le moment."
 
 #: packages/admin/src/components/MediaLibrary.tsx:612
 #: packages/admin/src/components/MediaLibrary.tsx:669
 msgid "No alt text"
-msgstr ""
+msgstr "Aucun texte alternatif"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:263
 msgid "No API tokens yet. Create one to get started."
-msgstr "Aucun token d'API pour l'instant. Créez-en un pour commencer."
+msgstr "Aucun jeton d'API pour l'instant. Créez-en un pour commencer."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:554
 msgid "No approved comments yet."
-msgstr ""
+msgstr "Aucun commentaire approuvé pour l'instant."
 
 #: packages/admin/src/components/ContentEditor.tsx:1662
 msgid "No bylines selected."
-msgstr ""
+msgstr "Aucune signature sélectionnée."
 
 #: packages/admin/src/components/Dashboard.tsx:172
 msgid "No collections configured"
-msgstr ""
+msgstr "Aucune collection configurée"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:553
 msgid "No comments awaiting moderation."
-msgstr ""
+msgstr "Aucun commentaire en attente de modération."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:549
 msgid "No comments match your search."
-msgstr ""
+msgstr "Aucun commentaire ne correspond à votre recherche."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:176
 msgid "No content found"
-msgstr ""
+msgstr "Aucun contenu trouvé"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:182
 msgid "No content in this collection"
-msgstr ""
+msgstr "Aucun contenu dans cette collection"
 
 #: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
-msgstr ""
+msgstr "Aucun type de contenu pour l'instant."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:275
 msgid "No detailed description available."
-msgstr ""
+msgstr "Aucune description détaillée disponible."
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:300
 msgid "No domains configured. Users must be invited individually."
-msgstr ""
+msgstr "Aucun domaine configuré. Les utilisateurs doivent être invités individuellement."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:187
 msgid "No email provider configured"
-msgstr ""
+msgstr "Aucun fournisseur de messagerie configuré"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr ""
+msgstr "Aucun fournisseur de messagerie configuré. Partagez ce lien manuellement."
 
 #: packages/admin/src/components/WordPressImport.tsx:2349
 msgid "No EmDash users found"
-msgstr ""
+msgstr "Aucun utilisateur EmDash trouvé"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:40
 msgid "No expiry"
@@ -3150,83 +3150,83 @@ msgstr "Sans expiration"
 
 #: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
-msgstr ""
+msgstr "Aucun champ à comparer"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:188
 msgid "No headings in document"
-msgstr ""
+msgstr "Aucun titre dans le document"
 
 #: packages/admin/src/components/RepeaterField.tsx:144
 msgid "No items yet"
-msgstr ""
+msgstr "Aucun élément pour l'instant"
 
 #: packages/admin/src/components/FieldEditor.tsx:624
 msgid "No limit"
-msgstr ""
+msgstr "Aucune limite"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
-msgstr ""
+msgstr "Aucune clé d'accès correspondante trouvée pour ce compte."
 
 #: packages/admin/src/components/FieldEditor.tsx:466
 #: packages/admin/src/components/FieldEditor.tsx:496
 msgid "No maximum"
-msgstr ""
+msgstr "Pas de maximum"
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
 #: packages/admin/src/components/MediaPickerModal.tsx:497
 msgid "No media available from this provider"
-msgstr ""
+msgstr "Aucun fichier multimédia disponible auprès de ce fournisseur"
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
 #: packages/admin/src/components/MediaPickerModal.tsx:491
 msgid "No media found"
-msgstr ""
+msgstr "Aucun fichier multimédia trouvé"
 
 #: packages/admin/src/components/MediaLibrary.tsx:352
 msgid "No media yet"
-msgstr ""
+msgstr "Pas encore de fichier multimédia"
 
 #: packages/admin/src/components/MenuEditor.tsx:315
 msgid "No menu items yet"
-msgstr ""
+msgstr "Aucun élément de menu pour l'instant"
 
 #: packages/admin/src/components/MenuList.tsx:157
 msgid "No menus yet"
-msgstr ""
+msgstr "Pas encore de menus"
 
 #: packages/admin/src/components/FieldEditor.tsx:459
 #: packages/admin/src/components/FieldEditor.tsx:489
 msgid "No minimum"
-msgstr ""
+msgstr "Pas de minimum"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
-msgstr ""
+msgstr "Aucune clé d'accès enregistrée"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:199
 msgid "No passkeys registered yet."
-msgstr ""
+msgstr "Aucune clé d'accès enregistrée pour l'instant."
 
 #: packages/admin/src/components/PluginManager.tsx:190
 msgid "No plugins configured"
-msgstr ""
+msgstr "Aucun module d'extension configuré"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:174
 msgid "No plugins found"
-msgstr ""
+msgstr "Aucun module d'extension trouvé"
 
 #: packages/admin/src/components/Sections.tsx:341
 msgid "No preview"
-msgstr ""
+msgstr "Pas d'aperçu"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
-msgstr ""
+msgstr "Aucune activité récente"
 
 #: packages/admin/src/components/Redirects.tsx:441
 msgid "No redirects yet"
-msgstr ""
+msgstr "Aucune redirection pour l'instant"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:940
 msgid "No results"
@@ -3235,11 +3235,11 @@ msgstr "Aucun résultat"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:177
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:150
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr ""
+msgstr "Aucun résultat pour « {debouncedQuery} ». Essayez un autre terme de recherche."
 
 #: packages/admin/src/components/ContentList.tsx:226
 msgid "No results for \"{searchQuery}\""
-msgstr ""
+msgstr "Aucun résultat pour « {searchQuery} »"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:452
 msgid "No results found"
@@ -3247,42 +3247,42 @@ msgstr "Aucun résultat trouvé"
 
 #: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
-msgstr ""
+msgstr "Aucune révision pour l'instant"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:107
 msgid "No sections available"
-msgstr ""
+msgstr "Aucune section disponible"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:101
 #: packages/admin/src/components/Sections.tsx:257
 msgid "No sections found"
-msgstr ""
+msgstr "Aucune section trouvée"
 
 #: packages/admin/src/components/Sections.tsx:263
 msgid "No sections yet"
-msgstr ""
+msgstr "Aucune section pour l'instant"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:555
 msgid "No spam comments."
-msgstr ""
+msgstr "Aucun commentaire indésirable."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:147
 msgid "No themes found"
-msgstr ""
+msgstr "Aucun thème trouvé"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:270
 #: packages/admin/src/components/TaxonomyManager.tsx:276
 msgid "None (top level)"
-msgstr ""
+msgstr "Aucun (niveau supérieur)"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 #: packages/admin/src/components/FieldEditor.tsx:574
 msgid "Number"
-msgstr ""
+msgstr "Nombre"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:276
 msgid "Number of posts to show per page on list views"
-msgstr ""
+msgstr "Nombre d'articles à afficher par page dans les vues de liste"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:739
@@ -3291,69 +3291,69 @@ msgstr "Liste numérotée"
 
 #: packages/admin/src/components/SeoImageField.tsx:41
 msgid "OG Image"
-msgstr ""
+msgstr "Image OG"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:314
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr ""
+msgstr "sur un nom d'hôte personnalisé n'est pas traité comme sécurisé, même en cas de bouclage."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr ""
+msgstr "Autorisez uniquement les codes que vous reconnaissez."
 
 #: packages/admin/src/components/SignupPage.tsx:95
 msgid "Only email addresses from allowed domains can sign up."
-msgstr ""
+msgstr "Seules les adresses e-mail des domaines autorisés peuvent s'inscrire."
 
 #: packages/admin/src/components/MenuList.tsx:130
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr ""
+msgstr "Uniquement les lettres minuscules, les chiffres et les traits d'union"
 
 #: packages/admin/src/components/SignupPage.tsx:403
 msgid "Oops!"
-msgstr ""
+msgstr "Oups !"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
 msgid "Open in new tab"
-msgstr ""
+msgstr "Ouvrir dans un nouvel onglet"
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "Open WordPress Profile"
-msgstr ""
+msgstr "Ouvrir le profil WordPress"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
 msgid "Optional caption displayed below the image"
-msgstr ""
+msgstr "Légende facultative affichée sous l'image"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:213
 msgid "Optional caption for display"
-msgstr ""
+msgstr "Légende facultative pour l'affichage"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:289
 msgid "Optional description"
-msgstr ""
+msgstr "Description facultative"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
 msgid "Optional tooltip on hover"
-msgstr ""
+msgstr "Info-bulle facultative au survol"
 
 #: packages/admin/src/components/FieldEditor.tsx:504
 msgid "Options (one per line)"
-msgstr ""
+msgstr "Options (une par ligne)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:397
 msgid "or choose from library"
-msgstr ""
+msgstr "ou choisissez dans la bibliothèque"
 
 #: packages/admin/src/components/WordPressImport.tsx:1420
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr ""
+msgstr "Ou cliquez pour parcourir. Accepte les fichiers .xml exportés depuis WordPress."
 
 #: packages/admin/src/components/LoginPage.tsx:313
 msgid "Or continue with"
@@ -3361,41 +3361,41 @@ msgstr "Ou se connecter avec"
 
 #: packages/admin/src/components/WordPressImport.tsx:1221
 msgid "Or upload an export file"
-msgstr ""
+msgstr "Ou importer un fichier d'exportation"
 
 #: packages/admin/src/components/WordPressImport.tsx:940
 msgid "or upload directly"
-msgstr ""
+msgstr "ou importer directement"
 
 #: packages/admin/src/components/MenuEditor.tsx:116
 msgid "Order saved"
-msgstr ""
+msgstr "Ordre enregistré"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
 msgid "Original:"
-msgstr ""
+msgstr "Original :"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:180
 msgid "Outline"
-msgstr ""
+msgstr "Contour"
 
 #: packages/admin/src/components/SeoPanel.tsx:152
 msgid "Overrides the page title in search engine results"
-msgstr ""
+msgstr "Remplace le titre de la page dans les résultats des moteurs de recherche"
 
 #: packages/admin/src/components/ContentEditor.tsx:880
 msgid "Ownership"
-msgstr ""
+msgstr "Propriété"
 
 #: packages/admin/src/components/PluginManager.tsx:446
 msgid "Package"
-msgstr ""
+msgstr "Paquet"
 
 #: packages/admin/src/components/PluginManager.tsx:327
 #: packages/admin/src/components/WordPressImport.tsx:1158
 msgid "Pages"
-msgstr ""
+msgstr "Pages"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
@@ -3403,161 +3403,161 @@ msgstr "Paragraphe"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:266
 msgid "Parent"
-msgstr ""
+msgstr "Parent"
 
 #: packages/admin/src/components/Redirects.tsx:490
 #: packages/admin/src/components/Redirects.tsx:496
 msgid "Part of a redirect loop"
-msgstr ""
+msgstr "Partie d'une boucle de redirection"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:323
 msgid "Pass"
-msgstr ""
+msgstr "Passer"
 
 #: packages/admin/src/components/SetupWizard.tsx:333
 msgid "Passkey"
-msgstr ""
+msgstr "Clé d'accès"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:98
 msgid "Passkey added successfully"
-msgstr ""
+msgstr "Clé d'accès ajoutée avec succès"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr ""
+msgstr "Nom de la clé d'accès"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr ""
+msgstr "Nom de la clé d'accès (facultatif)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
-msgstr ""
+msgstr "Mot de passe enregistré avec succès !"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:76
 msgid "Passkey removed"
-msgstr ""
+msgstr "Clé d'accès supprimée"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:60
 msgid "Passkey renamed"
-msgstr ""
+msgstr "Clé d'accès renommée"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:181
 msgid "Passkeys"
-msgstr ""
+msgstr "Clés d'accès"
 
 #. placeholder {0}: user.credentials.length
 #: packages/admin/src/components/users/UserDetail.tsx:245
 msgid "Passkeys ({0})"
-msgstr ""
+msgstr "Clés d'accès ({0})"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:185
 msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
-msgstr ""
+msgstr "Les clés d'accès sont un moyen sécurisé et sans mot de passe de vous connecter à votre compte. Vous pouvez enregistrer plusieurs clés d'accès pour différents appareils."
 
 #: packages/admin/src/components/SignupPage.tsx:212
 msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
-msgstr ""
+msgstr "Les clés d'accès constituent un moyen sécurisé et sans mot de passe de vous connecter à l'aide des données biométriques, du code PIN ou de la clé de sécurité de votre appareil."
 
 #: packages/admin/src/components/SetupWizard.tsx:297
 msgid "Passkeys are more secure than passwords. You'll use your device's biometrics, PIN, or security key to sign in."
-msgstr ""
+msgstr "Les clés d'accès sont plus sécurisées que les mots de passe. Vous utiliserez les données biométriques, le code PIN ou la clé de sécurité de votre appareil pour vous connecter."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:303
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
 msgid "Passkeys Not Available Here"
-msgstr ""
+msgstr "Clés d'accès non disponibles ici"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
 msgid "Passkeys require a"
-msgstr ""
+msgstr "Les clés d'accès nécessitent un"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-msgstr ""
+msgstr "Les clés d'accès nécessitent HTTPS ou http://localhost (avec votre port) ; ce nom d'hôte n'est pas un contexte de navigateur sécurisé."
 
 #: packages/admin/src/components/Redirects.tsx:216
 msgid "Path"
-msgstr ""
+msgstr "Chemin"
 
 #: packages/admin/src/components/FieldEditor.tsx:471
 msgid "Pattern (Regex)"
-msgstr ""
+msgstr "Modèle (expression régulière)"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:576
 msgid "pending"
-msgstr ""
+msgstr "en attente"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:204
 msgid "Pending"
-msgstr ""
+msgstr "En attente"
 
 #: packages/admin/src/components/ContentEditor.tsx:755
 msgid "Pending changes"
-msgstr ""
+msgstr "Modifications en attente"
 
 #: packages/admin/src/components/ContentList.tsx:510
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr ""
+msgstr "Supprimer définitivement « {title} » ? Cela ne peut pas être annulé."
 
 #: packages/admin/src/components/ContentList.tsx:499
 msgid "Permanently delete {title}"
-msgstr ""
+msgstr "Supprimer définitivement {title}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:284
 msgid "Permissions"
-msgstr ""
+msgstr "Autorisations"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:313
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr ""
+msgstr "Un simple"
 
 #: packages/admin/src/components/SetupWizard.tsx:206
 msgid "Please enter a valid email"
-msgstr ""
+msgstr "Veuillez saisir un email valide"
 
 #: packages/admin/src/components/SignupPage.tsx:53
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Veuillez saisir une adresse email valide"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:284
 msgid "Please enter a valid URL"
-msgstr ""
+msgstr "Veuillez saisir une URL valide"
 
 #: packages/admin/src/components/WordPressImport.tsx:1015
 msgid "Plugin"
-msgstr ""
+msgstr "Module d'extension"
 
 #: packages/admin/src/components/PluginManager.tsx:102
 msgid "Plugin disabled"
-msgstr ""
+msgstr "Module d'extension désactivé"
 
 #: packages/admin/src/components/PluginManager.tsx:83
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Module d'extension activé"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:122
 msgid "Plugin not found"
-msgstr ""
+msgstr "Module d'extension introuvable"
 
 #: packages/admin/src/components/WordPressImport.tsx:1039
 msgid "plugin on your WordPress site."
-msgstr ""
+msgstr "module d'extension sur votre site WordPress."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:72
 msgid "Plugin Permissions"
-msgstr ""
+msgstr "Autorisations du module d'extension"
 
 #: packages/admin/src/components/PluginManager.tsx:259
 msgid "Plugin uninstalled"
-msgstr ""
+msgstr "Module d'extension désinstallé"
 
 #: packages/admin/src/components/PluginManager.tsx:246
 msgid "Plugin updated"
-msgstr ""
+msgstr "Module d'extension mis à jour"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:125
@@ -3566,32 +3566,32 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:207
 #: packages/admin/src/components/Sidebar.tsx:438
 msgid "Plugins"
-msgstr "Plugins"
+msgstr "Modules d'extension"
 
 #: packages/admin/src/components/SeoPanel.tsx:177
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
-msgstr ""
+msgstr "Dirige les moteurs de recherche vers la version originale de cette page, si elle est dupliquée à partir d'une autre URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1152
 msgid "Posts"
-msgstr ""
+msgstr "Articles"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:270
 msgid "Posts Per Page"
-msgstr ""
+msgstr "Articles par page"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
-msgstr ""
+msgstr "En cours de préparation de l'inscription..."
 
 #: packages/admin/src/components/WordPressImport.tsx:2047
 msgid "Preparing to download files from WordPress..."
-msgstr ""
+msgstr "En cours de préparation du téléchargement de fichiers depuis WordPress..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:166
 #: packages/admin/src/components/SetupWizard.tsx:258
 msgid "Preparing..."
-msgstr ""
+msgstr "En cours de préparation..."
 
 #: packages/admin/src/components/ContentEditor.tsx:576
 #: packages/admin/src/components/ContentTypeEditor.tsx:79
@@ -3605,52 +3605,52 @@ msgstr "Prévisualiser le contenu avant publication"
 
 #: packages/admin/src/components/ContentEditor.tsx:576
 msgid "Preview draft"
-msgstr ""
+msgstr "Aperçu du brouillon"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:314
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:359
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "Previous page"
-msgstr ""
+msgstr "Page précédente"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:456
 msgid "Previous screenshot"
-msgstr ""
+msgstr "Capture d'écran précédente"
 
 #: packages/admin/src/components/MenuList.tsx:137
 msgid "Primary Navigation"
-msgstr ""
+msgstr "Navigation principale"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:211
 msgid "Provider:"
-msgstr ""
+msgstr "Fournisseur :"
 
 #: packages/admin/src/components/ContentEditor.tsx:631
 #: packages/admin/src/components/ContentEditor.tsx:736
 msgid "Publish"
-msgstr ""
+msgstr "Publier"
 
 #: packages/admin/src/components/ContentEditor.tsx:621
 msgid "Publish changes"
-msgstr ""
+msgstr "Publier les modifications"
 
 #: packages/admin/src/components/ContentList.tsx:551
 msgid "published"
-msgstr ""
+msgstr "publié"
 
 #: packages/admin/src/components/ContentEditor.tsx:751
 #: packages/admin/src/components/ContentPickerModal.tsx:214
 #: packages/admin/src/components/Dashboard.tsx:187
 msgid "Published"
-msgstr ""
+msgstr "Publié"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:337
 msgid "Published {0}"
-msgstr ""
+msgstr "Publié {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:133
 msgid "Published At"
@@ -3658,7 +3658,7 @@ msgstr "Publié le"
 
 #: packages/admin/src/components/ContentEditor.tsx:1670
 msgid "Quick create byline"
-msgstr ""
+msgstr "Création rapide d'une signature"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:85
 #: packages/admin/src/components/PortableTextEditor.tsx:749
@@ -3675,63 +3675,63 @@ msgstr "Lire les entrées de contenu"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
 msgid "Read media files"
-msgstr "Lire les fichiers médias"
+msgstr "Lire les fichiers multimédias"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:267
 msgid "Reading"
-msgstr ""
+msgstr "En lisant"
 
 #: packages/admin/src/components/WordPressImport.tsx:1849
 msgid "Ready"
-msgstr ""
+msgstr "Prêt"
 
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
-msgstr ""
+msgstr "Activité récente"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
 msgid "Recipient email"
-msgstr ""
+msgstr "E-mail du destinataire"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/users/UserDetail.tsx:336
 msgid "Recovery link sent to {0}"
-msgstr ""
+msgstr "Lien de récupération envoyé à {0}"
 
 #: packages/admin/src/components/Redirects.tsx:423
 msgid "Redirect loop detected"
-msgstr ""
+msgstr "Boucle de redirection détectée"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr ""
+msgstr "En cours de redirection vers le formulaire de connexion..."
 
 #: packages/admin/src/components/Redirects.tsx:333
 #: packages/admin/src/components/Redirects.tsx:352
 #: packages/admin/src/components/Sidebar.tsx:191
 msgid "Redirects"
-msgstr ""
+msgstr "Redirections"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "Reference"
-msgstr ""
+msgstr "Référence"
 
 #: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
-msgstr ""
+msgstr "Enregistrer"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
 #: packages/admin/src/components/settings/SecuritySettings.tsx:224
 msgid "Register Passkey"
-msgstr ""
+msgstr "Enregistrer la clé d'accès"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:83
 msgid "Registered user"
-msgstr ""
+msgstr "Utilisateur enregistré"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "L'inscription a été annulée ou a expiré. Veuillez réessayer."
 
 #: packages/admin/src/components/ContentEditor.tsx:1639
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
@@ -3740,180 +3740,180 @@ msgstr ""
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
 #: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
-msgstr ""
+msgstr "Supprimer"
 
 #. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:189
 msgid "Remove {0}"
-msgstr ""
+msgstr "Supprimer {0}"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:435
 msgid "Remove Domain"
-msgstr ""
+msgstr "Supprimer le domaine"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:419
 msgid "Remove Domain?"
-msgstr ""
+msgstr "Supprimer le domaine ?"
 
 #: packages/admin/src/components/ContentEditor.tsx:1468
 #: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
-msgstr ""
+msgstr "Supprimer l'image"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
 msgid "Remove Image"
-msgstr ""
+msgstr "Supprimer l'image"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
 msgid "Remove Image?"
-msgstr ""
+msgstr "Supprimer l'image ?"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/RepeaterField.tsx:254
 msgid "Remove item {0}"
-msgstr ""
+msgstr "Supprimer l'élément {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 msgid "Remove passkey"
-msgstr ""
+msgstr "Supprimer la clé d'accès"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
 msgid "Remove passkey?"
-msgstr ""
+msgstr "Supprimer la clé d'accès ?"
 
 #: packages/admin/src/components/FieldEditor.tsx:604
 msgid "Remove sub-field"
-msgstr ""
+msgstr "Supprimer le sous-champ"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
 msgid "Remove this image from the document?"
-msgstr ""
+msgstr "Supprimer cette image du document ?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
 #: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
-msgstr ""
+msgstr "En cours de suppression..."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:176
 msgid "Rename"
-msgstr ""
+msgstr "Renommer"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
-msgstr ""
+msgstr "Renommer {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename passkey"
-msgstr ""
+msgstr "Renommer la clé d'accès"
 
 #: packages/admin/src/components/FieldEditor.tsx:229
 msgid "Repeater"
-msgstr ""
+msgstr "Répétiteur"
 
 #: packages/admin/src/components/FieldEditor.tsx:230
 msgid "Repeating group of fields"
-msgstr ""
+msgstr "Groupe de champs répétitif"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
 msgid "Replace Image"
-msgstr ""
+msgstr "Remplacer l'image"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr ""
+msgstr "Répondre à :"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:226
 msgid "Repository"
-msgstr ""
+msgstr "Dépôt"
 
 #: packages/admin/src/components/SignupPage.tsx:274
 msgid "Request a new link"
-msgstr ""
+msgstr "Demander un nouveau lien"
 
 #: packages/admin/src/components/FieldEditor.tsx:422
 #: packages/admin/src/components/FieldEditor.tsx:592
 msgid "Required"
-msgstr ""
+msgstr "Obligatoire"
 
 #: packages/admin/src/components/WordPressImport.tsx:1862
 msgid "Required fields:"
-msgstr ""
+msgstr "Champs obligatoires :"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
 msgid "Required for accessibility. Describes the image for screen readers."
-msgstr ""
+msgstr "Nécessaire pour l'accessibilité. Décrit l'image pour les lecteurs d'écran."
 
 #. placeholder {0}: latest.minEmDashVersion
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:335
 msgid "Requires EmDash {0}"
-msgstr ""
+msgstr "Nécessite EmDash {0}"
 
 #: packages/admin/src/components/SignupPage.tsx:153
 msgid "Resend email"
-msgstr ""
+msgstr "Renvoyer l'e-mail"
 
 #: packages/admin/src/components/SignupPage.tsx:152
 msgid "Resend in {resendCooldown}s"
-msgstr ""
+msgstr "Renvoyer dans {resendCooldown} s"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
 msgid "Reset to original"
-msgstr ""
+msgstr "Réinitialiser à la version d'origine"
 
 #: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
-msgstr ""
+msgstr "Restaurer"
 
 #: packages/admin/src/components/ContentList.tsx:487
 msgid "Restore {title}"
-msgstr ""
+msgstr "Restaurer {title}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
-msgstr ""
+msgstr "La restauration a échoué"
 
 #: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
-msgstr ""
+msgstr "Restaurer la révision ?"
 
 #: packages/admin/src/components/RevisionHistory.tsx:281
 #: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
-msgstr ""
+msgstr "Restaurer cette version"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr ""
+msgstr "Restaurer cette version à partir de {0} ? Cela mettra à jour le contenu actuel avec les données de cette révision."
 
 #: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
-msgstr ""
+msgstr "Restauration en cours..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:142
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:120
 msgid "Retry"
-msgstr ""
+msgstr "Réessayer"
 
 #: packages/admin/src/components/Sections.tsx:134
 msgid "Reusable content blocks you can insert into any content"
-msgstr ""
+msgstr "Blocs de contenu réutilisables que vous pouvez insérer dans n'importe quel contenu"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:72
 msgid "Review New Permissions"
-msgstr ""
+msgstr "Examiner les nouvelles autorisations"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
-msgstr ""
+msgstr "Révision restaurée"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:74
 #: packages/admin/src/components/RevisionHistory.tsx:161
@@ -3922,7 +3922,7 @@ msgstr "Révisions"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:326
 msgid "Revoke token"
-msgstr "Révoquer le token"
+msgstr "Révoquer le jeton"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:301
 msgid "Revoke?"
@@ -3934,7 +3934,7 @@ msgstr "Révocation en cours..."
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Rich Text"
-msgstr ""
+msgstr "Texte enrichi"
 
 #: packages/admin/src/components/Widgets.tsx:89
 msgid "Rich text content"
@@ -3942,18 +3942,18 @@ msgstr "Texte enrichi"
 
 #: packages/admin/src/components/FieldEditor.tsx:194
 msgid "Rich text editor"
-msgstr ""
+msgstr "Éditeur de texte enrichi"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:322
 msgid "Risk score: {0}/100"
-msgstr ""
+msgstr "Score de risque : {0}/100"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:166
 #: packages/admin/src/components/users/UserDetail.tsx:169
 #: packages/admin/src/components/users/UserDetail.tsx:181
 msgid "Role"
-msgstr ""
+msgstr "Rôle"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -3961,14 +3961,14 @@ msgstr "Rôle {role}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1644
 msgid "Role label"
-msgstr ""
+msgstr "Étiquette de rôle"
 
 #: packages/admin/src/components/MenuEditor.tsx:286
 #: packages/admin/src/components/MenuEditor.tsx:288
 #: packages/admin/src/components/MenuEditor.tsx:431
 #: packages/admin/src/components/MenuEditor.tsx:433
 msgid "Same window"
-msgstr ""
+msgstr "Même fenêtre"
 
 #: packages/admin/src/components/ContentEditor.tsx:1777
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
@@ -3978,11 +3978,11 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:184
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
-msgstr ""
+msgstr "Enregistrer les modifications"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:70
 msgid "Save content as draft before publishing"
@@ -3990,24 +3990,24 @@ msgstr "Enregistrer le contenu en brouillon avant publication"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:137
 msgid "Save name"
-msgstr ""
+msgstr "Enregistrer le nom"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:164
 msgid "Save SEO Settings"
-msgstr ""
+msgstr "Enregistrer les paramètres SEO"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:296
 msgid "Save Settings"
-msgstr ""
+msgstr "Enregistrer les paramètres"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:169
 msgid "Save Social Links"
-msgstr ""
+msgstr "Enregistrer les liens sociaux"
 
 #: packages/admin/src/components/ContentEditor.tsx:551
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Saved"
-msgstr ""
+msgstr "Enregistré"
 
 #: packages/admin/src/components/ContentEditor.tsx:546
 #: packages/admin/src/components/ContentEditor.tsx:1777
@@ -4022,40 +4022,40 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:308
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Saving..."
-msgstr ""
+msgstr "En cours d'enregistrement..."
 
 #: packages/admin/src/components/ContentEditor.tsx:795
 msgid "Schedule"
-msgstr ""
+msgstr "Programmer"
 
 #: packages/admin/src/components/ContentEditor.tsx:781
 msgid "Schedule for"
-msgstr ""
+msgstr "Programmer pour le"
 
 #: packages/admin/src/components/ContentEditor.tsx:818
 msgid "Schedule for later"
-msgstr ""
+msgstr "Programmer pour plus tard"
 
 #: packages/admin/src/components/ContentList.tsx:555
 msgid "scheduled"
-msgstr ""
+msgstr "programmé"
 
 #: packages/admin/src/components/ContentEditor.tsx:758
 msgid "Scheduled"
-msgstr ""
+msgstr "Programmé"
 
 #. placeholder {0}: formatScheduledDate(item.scheduledAt)
 #: packages/admin/src/components/ContentEditor.tsx:768
 msgid "Scheduled for: {0}"
-msgstr ""
+msgstr "Programmé pour le : {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2155
 msgid "Schema Changes"
-msgstr ""
+msgstr "Modifications du schéma"
 
 #: packages/admin/src/components/WordPressImport.tsx:1529
 msgid "Schema preparation failed"
-msgstr ""
+msgstr "Échec de la préparation du schéma"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:74
 msgid "Schema Read"
@@ -4067,12 +4067,12 @@ msgstr "Écriture du schéma"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:409
 msgid "Scopes"
-msgstr "Scopes"
+msgstr "Champs d'application"
 
 #. placeholder {0}: token.scopes.join(", ")
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:277
 msgid "Scopes: {0}"
-msgstr "Scopes : {0}"
+msgstr "Champs d'application : {0}"
 
 #. placeholder {0}: i + 1
 #. placeholder {0}: index + 1
@@ -4080,26 +4080,26 @@ msgstr "Scopes : {0}"
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:180
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:299
 msgid "Screenshot {0}"
-msgstr ""
+msgstr "Capture d'écran {0}"
 
 #. placeholder {0}: index + 1
 #. placeholder {1}: screenshots.length
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:464
 msgid "Screenshot {0} of {1}"
-msgstr ""
+msgstr "Capture d'écran {0} sur {1}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:257
 msgid "Screenshot blurred due to image audit"
-msgstr ""
+msgstr "Capture d'écran floutée en raison d'un audit d'image"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:442
 msgid "Screenshot viewer"
-msgstr ""
+msgstr "Visionneuse de capture d'écran"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:244
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:170
 msgid "Screenshots"
-msgstr ""
+msgstr "Captures d'écran"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:84
 msgid "Search"
@@ -4108,28 +4108,28 @@ msgstr "Recherche"
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:151
 msgid "Search {0}"
-msgstr ""
+msgstr "Rechercher {0}"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:150
 msgid "Search {0}..."
-msgstr ""
+msgstr "Rechercher {0}..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:170
 msgid "Search comments"
-msgstr ""
+msgstr "Rechercher des commentaires"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:169
 msgid "Search comments..."
-msgstr ""
+msgstr "Rechercher des commentaires..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:141
 msgid "Search content..."
-msgstr ""
+msgstr "Rechercher du contenu..."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:130
 msgid "Search Engine Optimization"
-msgstr ""
+msgstr "Optimisation des moteurs de recherche"
 
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
@@ -4137,7 +4137,7 @@ msgstr "Optimisation et vérification pour les moteurs de recherche"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:441
 msgid "Search media"
-msgstr ""
+msgstr "Rechercher des fichiers multimédias"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
@@ -4145,29 +4145,29 @@ msgstr "Rechercher des pages et du contenu..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:96
 msgid "Search plugins..."
-msgstr ""
+msgstr "Rechercher des modules d'extension..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:81
 #: packages/admin/src/components/Sections.tsx:224
 msgid "Search sections..."
-msgstr ""
+msgstr "Rechercher des sections..."
 
 #: packages/admin/src/components/Redirects.tsx:384
 msgid "Search source or destination..."
-msgstr ""
+msgstr "Rechercher une source ou une destination..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:87
 msgid "Search themes..."
-msgstr ""
+msgstr "Rechercher des thèmes..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
 #: packages/admin/src/components/MediaPickerModal.tsx:440
 msgid "Search..."
-msgstr ""
+msgstr "Recherche..."
 
 #: packages/admin/src/components/FieldEditor.tsx:444
 msgid "Searchable"
-msgstr ""
+msgstr "Interrogeable"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1427
 msgid "Section"
@@ -4175,31 +4175,31 @@ msgstr "Section"
 
 #: packages/admin/src/components/SectionEditor.tsx:77
 msgid "Section \"{slug}\" could not be found."
-msgstr ""
+msgstr "La section « {slug} » est introuvable."
 
 #: packages/admin/src/components/Sections.tsx:91
 msgid "Section created"
-msgstr ""
+msgstr "Rubrique créée"
 
 #: packages/admin/src/components/Sections.tsx:105
 msgid "Section deleted"
-msgstr ""
+msgstr "Section supprimée"
 
 #: packages/admin/src/components/SectionEditor.tsx:186
 msgid "Section Details"
-msgstr ""
+msgstr "Détails des sections"
 
 #: packages/admin/src/components/SectionEditor.tsx:73
 msgid "Section Not Found"
-msgstr ""
+msgstr "Section introuvable"
 
 #: packages/admin/src/components/SectionEditor.tsx:41
 msgid "Section saved"
-msgstr ""
+msgstr "Section enregistrée"
 
 #: packages/admin/src/components/SectionEditor.tsx:192
 msgid "Section title"
-msgstr ""
+msgstr "Titre de la section"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
 #: packages/admin/src/components/Sections.tsx:132
@@ -4210,11 +4210,11 @@ msgstr "Sections"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
 msgid "secure context"
-msgstr ""
+msgstr "contexte sécurisé"
 
 #: packages/admin/src/components/SetupWizard.tsx:496
 msgid "Secure your account"
-msgstr ""
+msgstr "Sécuriser votre compte"
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
@@ -4222,32 +4222,32 @@ msgstr "Sécurité"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:318
 msgid "Security Audit"
-msgstr ""
+msgstr "Audit de sécurité"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:341
 msgid "Security audit failed"
-msgstr ""
+msgstr "Échec de l'audit de sécurité"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:331
 msgid "Security audit flagged concerns"
-msgstr ""
+msgstr "L'audit de sécurité a signalé des problèmes"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:126
 msgid "Security audit flagged potential concerns with this plugin."
-msgstr ""
+msgstr "L'audit de sécurité a signalé des problèmes potentiels avec ce module d'extension."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:127
 msgid "Security audit flagged this plugin as potentially unsafe."
-msgstr ""
+msgstr "L'audit de sécurité a signalé ce module d'extension comme potentiellement dangereux."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:320
 msgid "Security audit passed"
-msgstr ""
+msgstr "Audit de sécurité réussi"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:272
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
 msgid "Security error. Make sure you're on a secure connection."
-msgstr ""
+msgstr "Erreur de sécurité. Assurez-vous que vous êtes sur une connexion sécurisée."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
@@ -4258,66 +4258,66 @@ msgstr "Paramètres de sécurité"
 #: packages/admin/src/components/FieldEditor.tsx:181
 #: packages/admin/src/components/FieldEditor.tsx:578
 msgid "Select"
-msgstr ""
+msgstr "Sélectionner"
 
 #: packages/admin/src/components/ContentEditor.tsx:1492
 msgid "Select {label}"
-msgstr ""
+msgstr "Sélectionner {label}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:290
 msgid "Select all"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: packages/admin/src/components/ContentEditor.tsx:1583
 msgid "Select byline..."
-msgstr ""
+msgstr "Sélectionner la signature..."
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:463
 msgid "Select comment by {0}"
-msgstr ""
+msgstr "Sélectionner le commentaire par {0}"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
-msgstr ""
+msgstr "Sélectionner le contenu"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:258
 #: packages/admin/src/components/settings/GeneralSettings.tsx:314
 msgid "Select Favicon"
-msgstr ""
+msgstr "Sélectionner la favicon"
 
 #: packages/admin/src/components/ContentEditor.tsx:1483
 msgid "Select image"
-msgstr ""
+msgstr "Sélectionner une image"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:71
 msgid "Select Image"
-msgstr ""
+msgstr "Sélectionner une image"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
-msgstr ""
+msgstr "Sélectionner le logo"
 
 #: packages/admin/src/components/SeoImageField.tsx:70
 msgid "Select OG image"
-msgstr ""
+msgstr "Sélectionner l'image OG"
 
 #: packages/admin/src/components/SeoImageField.tsx:82
 msgid "Select OG Image"
-msgstr ""
+msgstr "Sélectionner l'image originale"
 
 #: packages/admin/src/components/WordPressImport.tsx:1562
 msgid "Select which content types to import."
-msgstr ""
+msgstr "Sélectionner les types de contenu à importer."
 
 #: packages/admin/src/components/RepeaterField.tsx:349
 msgid "Select..."
-msgstr ""
+msgstr "Sélectionner..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:571
 msgid "Selected:"
-msgstr ""
+msgstr "Sélectionné :"
 
 #: packages/admin/src/components/Settings.tsx:98
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:172
@@ -4326,15 +4326,15 @@ msgstr "Domaines d'inscription autorisés"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr ""
+msgstr "Envoyez un e-mail de test via le processus complet pour vérifier votre configuration de messagerie."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr ""
+msgstr "Envoyez un e-mail d'invitation à un nouveau membre de l'équipe."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 msgid "Send Invite"
-msgstr ""
+msgstr "Envoyer une invitation"
 
 #: packages/admin/src/components/LoginPage.tsx:206
 msgid "Send magic link"
@@ -4342,15 +4342,15 @@ msgstr "Envoyer un lien de connexion"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
-msgstr ""
+msgstr "Envoyer le lien de récupération"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:162
 msgid "Send Test"
-msgstr ""
+msgstr "Envoyer le test"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:145
 msgid "Send Test Email"
-msgstr ""
+msgstr "Envoyer un e-mail de test"
 
 #: packages/admin/src/components/LoginPage.tsx:206
 #: packages/admin/src/components/settings/EmailSettings.tsx:162
@@ -4369,36 +4369,36 @@ msgstr "SEO"
 #: packages/admin/src/components/settings/SeoSettings.tsx:87
 #: packages/admin/src/components/settings/SeoSettings.tsx:105
 msgid "SEO Settings"
-msgstr ""
+msgstr "Paramètres SEO"
 
 #: packages/admin/src/components/WordPressImport.tsx:1705
 msgid "SEO settings (Yoast)"
-msgstr ""
+msgstr "Paramètres SEO (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:53
 msgid "SEO settings saved"
-msgstr ""
+msgstr "Paramètres SEO enregistrés"
 
 #: packages/admin/src/components/SeoPanel.tsx:151
 msgid "SEO Title"
-msgstr ""
+msgstr "Titre SEO"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
 msgid "Set a custom display size for this image instance."
-msgstr ""
+msgstr "Définissez une taille d'affichage personnalisée pour cette instance d'image."
 
 #: packages/admin/src/components/SetupWizard.tsx:295
 msgid "Set up your passkey"
-msgstr ""
+msgstr "Configurer votre clé d'accès"
 
 #: packages/admin/src/components/SetupWizard.tsx:494
 msgid "Set up your site"
-msgstr ""
+msgstr "Configurer votre site"
 
 #: packages/admin/src/components/SetupWizard.tsx:175
 msgid "Setting up..."
-msgstr ""
+msgstr "Mise en place en cours..."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/Header.tsx:93
@@ -4412,37 +4412,37 @@ msgstr "Paramètres"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:59
 msgid "Settings saved successfully"
-msgstr ""
+msgstr "Paramètres enregistrés avec succès"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr ""
+msgstr "Partager ce lien avec l'utilisateur invité"
 
 #: packages/admin/src/components/FieldEditor.tsx:145
 #: packages/admin/src/components/FieldEditor.tsx:572
 msgid "Short Text"
-msgstr ""
+msgstr "Texte court"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:203
 msgid "Show token"
-msgstr "Afficher le token"
+msgstr "Afficher le jeton"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
 msgid "Shown when hovering over the image."
-msgstr ""
+msgstr "S'affiche lorsque vous survolez l'image."
 
 #: packages/admin/src/components/SignupPage.tsx:440
 msgid "Sign in"
-msgstr ""
+msgstr "Se connecter"
 
 #: packages/admin/src/components/SignupPage.tsx:269
 msgid "Sign in instead"
-msgstr ""
+msgstr "Se connecter"
 
 #: packages/admin/src/components/LoginPage.tsx:283
 msgid "Sign in to your site"
-msgstr "Connectez-vous à votre site"
+msgstr "Se connecter à votre site"
 
 #: packages/admin/src/components/LoginPage.tsx:284
 msgid "Sign in with email"
@@ -4460,23 +4460,23 @@ msgstr "Se connecter avec une clé d'accès"
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr ""
+msgstr "Connecté en tant que {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:182
 msgid "Single choice from options"
-msgstr ""
+msgstr "Choix unique parmi les options"
 
 #: packages/admin/src/components/FieldEditor.tsx:146
 msgid "Single line text input"
-msgstr ""
+msgstr "Champ de texte sur une seule ligne"
 
 #: packages/admin/src/components/SetupWizard.tsx:331
 msgid "Site"
-msgstr ""
+msgstr "Site"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:153
 msgid "Site Identity"
-msgstr ""
+msgstr "Identité du site"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
@@ -4484,40 +4484,40 @@ msgstr "Identité du site, logo, favicon et préférences de lecture"
 
 #: packages/admin/src/components/SetupWizard.tsx:329
 msgid "Site Settings"
-msgstr ""
+msgstr "Paramètres du site"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:156
 #: packages/admin/src/components/SetupWizard.tsx:141
 msgid "Site Title"
-msgstr ""
+msgstr "Titre du site"
 
 #: packages/admin/src/components/WordPressImport.tsx:1673
 msgid "Site title & tagline"
-msgstr ""
+msgstr "Titre et slogan du site"
 
 #: packages/admin/src/components/SetupWizard.tsx:125
 msgid "Site title is required"
-msgstr ""
+msgstr "Le titre du site est requis"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:168
 msgid "Site URL"
-msgstr ""
+msgstr "URL du site"
 
 #: packages/admin/src/components/MediaLibrary.tsx:418
 msgid "Size"
-msgstr ""
+msgstr "Taille"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:170
 msgid "Size:"
-msgstr ""
+msgstr "Taille :"
 
 #: packages/admin/src/components/WordPressImport.tsx:1967
 msgid "Skip Media Import"
-msgstr ""
+msgstr "Ignorer l'importation de fichiers multimédias"
 
 #: packages/admin/src/components/WordPressImport.tsx:1992
 msgid "Skipped"
-msgstr ""
+msgstr "Ignoré"
 
 #: packages/admin/src/components/ContentEditor.tsx:739
 #: packages/admin/src/components/ContentEditor.tsx:1686
@@ -4534,7 +4534,7 @@ msgstr "Slug"
 
 #: packages/admin/src/components/Sections.tsx:122
 msgid "Slug copied to clipboard"
-msgstr ""
+msgstr "Slug copié dans le presse-papiers"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:720
 msgid "Small section heading"
@@ -4548,7 +4548,7 @@ msgstr "Liens sociaux"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:47
 msgid "Social links saved"
-msgstr ""
+msgstr "Liens sociaux enregistrés"
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
@@ -4556,23 +4556,23 @@ msgstr "Liens vers les profils de réseaux sociaux"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:122
 msgid "Social Profiles"
-msgstr ""
+msgstr "Profils sociaux"
 
 #: packages/admin/src/components/WordPressImport.tsx:1721
 msgid "Some content types cannot be imported"
-msgstr ""
+msgstr "Certains types de contenu ne peuvent pas être importés"
 
 #: packages/admin/src/components/SignupPage.tsx:261
 msgid "Something went wrong"
-msgstr ""
+msgstr "Quelque chose s'est mal passé"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:122
 msgid "Sort plugins"
-msgstr ""
+msgstr "Trier les modules d'extension"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:100
 msgid "Sort themes"
-msgstr ""
+msgstr "Trier les thèmes"
 
 #: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
@@ -4582,25 +4582,25 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:447
 #: packages/admin/src/components/SectionEditor.tsx:232
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 #: packages/admin/src/components/Redirects.tsx:128
 msgid "Source path"
-msgstr ""
+msgstr "Chemin source"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr ""
+msgstr "courrier indésirable"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:214
 #: packages/admin/src/components/comments/CommentInbox.tsx:254
 msgid "Spam"
-msgstr ""
+msgstr "Courrier indésirable"
 
 #: packages/admin/src/components/WordPressImport.tsx:1783
 msgid "Start Import"
-msgstr ""
+msgstr "Démarrer l'importation"
 
 #: packages/admin/src/components/ContentEditor.tsx:745
 #: packages/admin/src/components/ContentList.tsx:193
@@ -4611,15 +4611,15 @@ msgstr "Statut"
 
 #: packages/admin/src/components/Redirects.tsx:145
 msgid "Status code"
-msgstr ""
+msgstr "Code d'état"
 
 #: packages/admin/src/components/WordPressImport.tsx:1582
 msgid "Structure"
-msgstr ""
+msgstr "Structure"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid "Sub-Fields"
-msgstr ""
+msgstr "Sous-champs"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
@@ -4628,83 +4628,83 @@ msgstr "Abonné"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
-msgstr ""
+msgstr "Synchronisé"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr ""
+msgstr "Mot de passe synchronisé"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
-msgstr ""
+msgstr "Système ({resolvedLabel})"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:162
 #: packages/admin/src/components/SetupWizard.tsx:152
 msgid "Tagline"
-msgstr ""
+msgstr "Slogan"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
-msgstr "Tags"
+msgstr "Étiquettes"
 
 #. placeholder {0}: analysis.tags
 #: packages/admin/src/components/WordPressImport.tsx:1640
 msgid "Tags ({0})"
-msgstr ""
+msgstr "Étiquettes ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1637
 msgid "Tags will be imported"
-msgstr ""
+msgstr "Les étiquettes seront importées"
 
 #: packages/admin/src/components/MenuEditor.tsx:283
 #: packages/admin/src/components/MenuEditor.tsx:428
 msgid "Target"
-msgstr ""
+msgstr "Cible"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:357
 msgid "Taxonomies"
-msgstr ""
+msgstr "Taxonomies"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:668
 msgid "Taxonomy created"
-msgstr ""
+msgstr "Taxonomie créée"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:589
 msgid "Taxonomy not found:"
-msgstr ""
+msgstr "Taxonomie introuvable :"
 
 #: packages/admin/src/components/SetupWizard.tsx:180
 msgid "Template:"
-msgstr ""
+msgstr "Modèle :"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:214
 #: packages/admin/src/components/TaxonomyManager.tsx:610
 msgid "Term"
-msgstr ""
+msgstr "Terme"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:564
 msgid "Term deleted"
-msgstr ""
+msgstr "Terme supprimé"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:157
 msgid "test@example.com"
-msgstr ""
+msgstr "test@exemple.com"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
-msgstr ""
+msgstr "L'appareil n'aura pas d'autorisation d'accès."
 
 #: packages/admin/src/components/WordPressImport.tsx:1723
 msgid "The existing collection has fields with incompatible types."
-msgstr ""
+msgstr "La collection existante contient des champs avec des types incompatibles."
 
 #: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr ""
+msgstr "Les tableaux suivants contiennent du contenu mais ne sont pas enregistrés en tant que collections. Enregistrez-les pour gérer ce contenu dans l'administration."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
-msgstr ""
+msgstr "L'utilisateur invité aura ce rôle une fois son inscription terminée."
 
 #: packages/admin/src/components/LoginPage.tsx:170
 #: packages/admin/src/components/SignupPage.tsx:138
@@ -4713,151 +4713,151 @@ msgstr "Le lien expirera dans 15 minutes."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:178
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr ""
+msgstr "La place de marché est vide. Revenez plus tard pour de nouveaux modules d'extension."
 
 #: packages/admin/src/components/MenuList.tsx:56
 msgid "The menu has been deleted."
-msgstr ""
+msgstr "Le menu a été supprimé."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:159
 msgid "The name of your site, used in the header and metadata"
-msgstr ""
+msgstr "Le nom de votre site, utilisé dans l'en-tête et les métadonnées"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:172
 msgid "The public URL of your site (used for canonical links and sitemaps)"
-msgstr ""
+msgstr "L'URL publique de votre site (utilisée pour les liens canoniques et les plans de site)"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:151
 msgid "The theme marketplace is empty. Check back later."
-msgstr ""
+msgstr "La place de marché des thèmes est vide. Revenez plus tard."
 
 #: packages/admin/src/components/Sections.tsx:241
 msgid "Theme"
-msgstr ""
+msgstr "Thème"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:245
 msgid "Theme ID: {0}"
-msgstr ""
+msgstr "ID du thème : {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:93
 msgid "Theme not found"
-msgstr ""
+msgstr "Thème introuvable"
 
 #: packages/admin/src/components/SectionEditor.tsx:161
 msgid "Theme Section"
-msgstr ""
+msgstr "Section des thèmes"
 
 #: packages/admin/src/components/Sections.tsx:298
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr ""
+msgstr "Les sections fournies par un thème ne peuvent pas être supprimées. Modifiez la section pour créer une copie personnalisée, puis supprimez-la."
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
-msgstr ""
+msgstr "Thème : {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:218
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:75
 msgid "Themes"
-msgstr ""
+msgstr "Thèmes"
 
 #: packages/admin/src/components/ContentEditor.tsx:1496
 msgid "This field is required"
-msgstr ""
+msgstr "Ce champ est obligatoire"
 
 #: packages/admin/src/components/SectionEditor.tsx:239
 msgid "This is a custom section."
-msgstr ""
+msgstr "Ceci est une section personnalisée."
 
 #: packages/admin/src/components/WordPressImport.tsx:1138
 msgid "This is a WordPress site."
-msgstr ""
+msgstr "Ceci est un site WordPress."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
-msgstr ""
+msgstr "Ce lien expire dans 7 jours et ne peut être utilisé qu'une seule fois."
 
 #: packages/admin/src/components/WordPressImport.tsx:812
 msgid "This may take a while for large exports."
-msgstr ""
+msgstr "Cela peut prendre un certain temps pour les grandes exportations."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
 msgid "This passkey is already registered on this device."
-msgstr ""
+msgstr "Cette clé d'accès est déjà enregistrée sur cet appareil."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:287
 msgid "This plugin requires no special permissions."
-msgstr ""
+msgstr "Ce module d'extension ne nécessite aucune autorisation particulière."
 
 #: packages/admin/src/components/Redirects.tsx:558
 msgid "This redirect rule will be permanently removed."
-msgstr ""
+msgstr "Cette règle de redirection sera définitivement supprimée."
 
 #: packages/admin/src/components/SectionEditor.tsx:236
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr ""
+msgstr "Cette section est fournie par le thème. La modification créera une copie personnalisée qui remplacera la version du thème."
 
 #: packages/admin/src/components/SectionEditor.tsx:241
 msgid "This section was imported from another system."
-msgstr ""
+msgstr "Cette section a été importée d'un autre système."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
-msgstr ""
+msgstr "Cela accordera l'accès à la CLI avec vos autorisations."
 
 #: packages/admin/src/components/ContentEditor.tsx:852
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr ""
+msgstr "Cela déplacera l'élément vers la corbeille. Vous pourrez le restaurer plus tard depuis la corbeille."
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:654
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr ""
+msgstr "Cela supprimera définitivement « {0} » et le supprimera de tout contenu."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:302
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr ""
+msgstr "Cela supprimera définitivement « {0} ». Cette action ne peut pas être annulée."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:413
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr ""
+msgstr "Cela supprimera définitivement ce commentaire. Cette action ne peut pas être annulée."
 
 #: packages/admin/src/components/PluginManager.tsx:560
 msgid "This will remove the plugin and its bundle from your site."
-msgstr ""
+msgstr "Cela supprimera le module d'extension et son paquet de votre site."
 
 #: packages/admin/src/components/ContentEditor.tsx:596
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr ""
+msgstr "Cela rétablira la version publiée. Vos modifications en cours seront perdues."
 
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "Thoughts, tutorials, and more"
-msgstr ""
+msgstr "Réflexions, tutoriels et plus"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:285
 msgid "Timezone"
-msgstr ""
+msgstr "Fuseau horaire"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:288
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr ""
+msgstr "Fuseau horaire pour l'affichage des dates (par exemple, Amérique/New_York)"
 
 #: packages/admin/src/components/ContentList.tsx:190
 #: packages/admin/src/components/ContentList.tsx:303
 #: packages/admin/src/components/SectionEditor.tsx:189
 #: packages/admin/src/components/Sections.tsx:168
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
 msgid "Title (Tooltip)"
-msgstr ""
+msgstr "Titre (info-bulle)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:134
 msgid "Title Separator"
-msgstr ""
+msgstr "Séparateur de titre"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
@@ -4865,7 +4865,7 @@ msgstr "pour fermer"
 
 #: packages/admin/src/components/PluginManager.tsx:198
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr ""
+msgstr "pour installer des modules d'extension, ou ajoutez-les à votre fichier astro.config.mjs."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -4874,20 +4874,20 @@ msgstr "pour sélectionner"
 #: packages/admin/src/components/ThemeToggle.tsx:30
 #: packages/admin/src/components/ThemeToggle.tsx:41
 msgid "Toggle theme (current: {label})"
-msgstr ""
+msgstr "Changer de thème (actuel : {label})"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:190
 msgid "Token created: {0}"
-msgstr "Token créé : {0}"
+msgstr "Jeton créé : {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:400
 msgid "Token Name"
-msgstr "Nom du token"
+msgstr "Nom du jeton"
 
 #: packages/admin/src/components/WordPressImport.tsx:1107
 msgid "Tools → Export"
-msgstr ""
+msgstr "Outils → Exporter"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:75
 msgid "Track content history"
@@ -4895,15 +4895,15 @@ msgstr "Suivre l'historique du contenu"
 
 #: packages/admin/src/components/ContentEditor.tsx:948
 msgid "Translate"
-msgstr ""
+msgstr "Traduire"
 
 #: packages/admin/src/components/ContentEditor.tsx:906
 msgid "Translations"
-msgstr ""
+msgstr "Traductions"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:198
 msgid "trash"
-msgstr ""
+msgstr "corbeille"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:170
 #: packages/admin/src/components/comments/CommentInbox.tsx:223
@@ -4911,97 +4911,97 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:520
 #: packages/admin/src/components/ContentList.tsx:173
 msgid "Trash"
-msgstr ""
+msgstr "Corbeille"
 
 #: packages/admin/src/components/ContentList.tsx:317
 msgid "Trash is empty"
-msgstr ""
+msgstr "La corbeille est vide"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:556
 msgid "Trash is empty."
-msgstr ""
+msgstr "La corbeille est vide."
 
 #: packages/admin/src/components/FieldEditor.tsx:170
 msgid "True/false toggle"
-msgstr ""
+msgstr "Bascule vrai/faux"
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
 #: packages/admin/src/components/MediaPickerModal.tsx:494
 msgid "Try a different search term"
-msgstr ""
+msgstr "Essayer un autre terme de recherche"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 #: packages/admin/src/components/SectionPickerModal.tsx:102
 msgid "Try adjusting your search"
-msgstr ""
+msgstr "Essayez d'ajuster votre recherche"
 
 #: packages/admin/src/components/Sections.tsx:258
 msgid "Try adjusting your search or filters."
-msgstr ""
+msgstr "Essayez d'ajuster votre recherche ou vos filtres."
 
 #: packages/admin/src/components/WordPressImport.tsx:1412
 msgid "Try Again"
-msgstr ""
+msgstr "Essayer à nouveau"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:207
 msgid "Try another code"
-msgstr ""
+msgstr "Essayez un autre code"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 #: packages/admin/src/components/WordPressImport.tsx:1238
 msgid "Try Another URL"
-msgstr ""
+msgstr "Essayez une autre URL"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:250
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:145
 msgid "Try with my data"
-msgstr ""
+msgstr "Essayez avec mes données"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: packages/admin/src/components/FieldEditor.tsx:562
 #: packages/admin/src/components/MediaLibrary.tsx:417
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:1881
 msgid "Type mismatch ({0})"
-msgstr ""
+msgstr "Incompatibilité de type ({0})"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:136
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
 msgid "Unable to reach marketplace"
-msgstr ""
+msgstr "Impossible d'accéder à la place de marché"
 
 #: packages/admin/src/components/ContentEditor.tsx:1791
 #: packages/admin/src/components/ContentEditor.tsx:1806
 msgid "Unassigned"
-msgstr ""
+msgstr "Non attribué"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:190
 #: packages/admin/src/components/PluginManager.tsx:484
 #: packages/admin/src/components/PluginManager.tsx:578
 msgid "Uninstall"
-msgstr ""
+msgstr "Désinstaller"
 
 #: packages/admin/src/components/PluginManager.tsx:558
 msgid "Uninstall {pluginName}?"
-msgstr ""
+msgstr "Désinstaller {pluginName} ?"
 
 #: packages/admin/src/components/PluginManager.tsx:553
 msgid "Uninstall confirmation"
-msgstr ""
+msgstr "Confirmation de désinstallation"
 
 #: packages/admin/src/components/PluginManager.tsx:578
 msgid "Uninstalling..."
-msgstr ""
+msgstr "En cours de désinstallation..."
 
 #: packages/admin/src/components/FieldEditor.tsx:431
 msgid "Unique"
-msgstr ""
+msgstr "Unique"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "Unique identifier (ULID)"
@@ -5020,59 +5020,59 @@ msgstr "Rôle inconnu"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Unlock aspect ratio"
-msgstr ""
+msgstr "Déverrouiller le rapport hauteur/largeur"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
 msgid "Unnamed passkey"
-msgstr ""
+msgstr "Clé d'accès sans nom"
 
 #: packages/admin/src/components/ContentEditor.tsx:625
 msgid "Unpublish"
-msgstr ""
+msgstr "Annuler la publication"
 
 #: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
-msgstr ""
+msgstr "Tables de contenu non enregistrées trouvées"
 
 #: packages/admin/src/components/ContentEditor.tsx:770
 msgid "Unschedule"
-msgstr ""
+msgstr "Déprogrammer"
 
 #: packages/admin/src/components/Dashboard.tsx:249
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
 #: packages/admin/src/components/ContentEditor.tsx:1618
 msgid "Up"
-msgstr ""
+msgstr "En haut"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:310
 msgid "Update"
-msgstr ""
+msgstr "Mise à jour"
 
 #: packages/admin/src/components/FieldEditor.tsx:646
 msgid "Update Field"
-msgstr ""
+msgstr "Champ de mise à jour"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:372
 msgid "Update settings for {0}"
-msgstr ""
+msgstr "Mettre à jour les paramètres pour {0}"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:218
 msgid "Update the {0} details"
-msgstr ""
+msgstr "Mettre à jour les détails de {0}"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Update this redirect rule."
-msgstr ""
+msgstr "Mettez à jour cette règle de redirection."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:363
 msgid "Update to v{0}"
-msgstr ""
+msgstr "Mise à jour vers v{0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:127
 msgid "Updated At"
@@ -5081,98 +5081,98 @@ msgstr "Modifié le"
 #. placeholder {0}: new Date(item.updatedAt).toLocaleString()
 #: packages/admin/src/components/ContentEditor.tsx:827
 msgid "Updated: {0}"
-msgstr ""
+msgstr "Mise à jour : {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:835
 msgid "Updating content URLs..."
-msgstr ""
+msgstr "En cours de mise à jour des URL de contenu..."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:144
 #: packages/admin/src/components/PluginManager.tsx:363
 msgid "Updating..."
-msgstr ""
+msgstr "En cours de mise à jour..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Upload"
-msgstr ""
+msgstr "Téléverser"
 
 #: packages/admin/src/components/WordPressImport.tsx:1221
 msgid "Upload an export file"
-msgstr ""
+msgstr "Importer un fichier d'exportation"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Upload an image to get started"
-msgstr ""
+msgstr "Téléversez une image pour commencer"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Upload and delete media"
-msgstr "Téléverser et supprimer des médias"
+msgstr "Téléverser et supprimer des fichiers multimédias"
 
 #: packages/admin/src/components/WordPressImport.tsx:1114
 #: packages/admin/src/components/WordPressImport.tsx:1235
 msgid "Upload Export File"
-msgstr ""
+msgstr "Importer le fichier d'exportation"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:478
 msgid "Upload failed: {uploadError}"
-msgstr ""
+msgstr "Échec du téléversement : {uploadError}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:323
 msgid "Upload files"
-msgstr ""
+msgstr "Téléverser des fichiers"
 
 #: packages/admin/src/components/MediaLibrary.tsx:357
 msgid "Upload Files"
-msgstr ""
+msgstr "Téléverser des fichiers"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:505
 msgid "Upload Image"
-msgstr ""
+msgstr "Téléverser une image"
 
 #: packages/admin/src/components/MediaLibrary.tsx:354
 msgid "Upload images, videos, and documents to get started."
-msgstr ""
+msgstr "Téléverser des images, des vidéos et des documents pour commencer."
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
-msgstr ""
+msgstr "Téléverser des fichiers multimédias"
 
 #: packages/admin/src/components/MediaLibrary.tsx:368
 msgid "Upload media to get started"
-msgstr ""
+msgstr "Téléversez des fichiers multimédias pour commencer"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:314
 msgid "Upload to {0}"
-msgstr ""
+msgstr "Téléverser vers {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:951
 msgid "Upload WordPress export file"
-msgstr ""
+msgstr "Importez le fichier d'exportation WordPress"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:184
 msgid "Uploaded:"
-msgstr ""
+msgstr "Téléversé :"
 
 #: packages/admin/src/components/WordPressImport.tsx:1990
 msgid "Uploading"
-msgstr ""
+msgstr "Importation"
 
 #. placeholder {0}: uploadState.progress.current
 #. placeholder {1}: uploadState.progress.total
 #: packages/admin/src/components/MediaLibrary.tsx:289
 msgid "Uploading {0}/{1}..."
-msgstr ""
+msgstr "En cours de téléversement {0}/{1}..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
 #: packages/admin/src/components/MediaPickerModal.tsx:462
 msgid "Uploading..."
-msgstr ""
+msgstr "En cours de téléversement..."
 
 #: packages/admin/src/components/MenuEditor.tsx:274
 #: packages/admin/src/components/MenuEditor.tsx:418
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:111
 #: packages/admin/src/components/FieldEditor.tsx:224
@@ -5181,15 +5181,15 @@ msgstr "Identifiant adapté aux URL"
 
 #: packages/admin/src/components/MenuList.tsx:133
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr ""
+msgstr "Identifiant adapté aux URL (par exemple, « principal », « pied-de-page »)"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr ""
+msgstr "Utilisez [param] ou [...rest] dans les chemins pour la correspondance de modèles."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:366
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr ""
+msgstr "Utilisez l'authentification biométrique, la clé de sécurité ou le code PIN de votre appareil pour vous connecter."
 
 #: packages/admin/src/components/LoginPage.tsx:351
 msgid "Use your registered passkey to sign in securely."
@@ -5197,39 +5197,39 @@ msgstr "Utilisez votre clé d'accès enregistrée pour vous connecter en toute s
 
 #: packages/admin/src/components/TaxonomyManager.tsx:476
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
-msgstr ""
+msgstr "Utilisé comme identifiant. Lettres minuscules, chiffres et traits de soulignement uniquement."
 
 #: packages/admin/src/components/ContentEditor.tsx:1252
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
-msgstr ""
+msgstr "Utilisé comme visuel principal de cet article sur les pages contenant des listes et en haut de l'article"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:206
 msgid "Used by screen readers and when image fails to load"
-msgstr ""
+msgstr "Utilisé par les lecteurs d'écran et lorsque l'image ne se charge pas"
 
 #: packages/admin/src/components/SectionEditor.tsx:207
 #: packages/admin/src/components/Sections.tsx:194
 msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
-msgstr ""
+msgstr "Utilisé pour identifier cette section. Lettres minuscules, chiffres et traits d'union uniquement."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 msgid "User"
-msgstr ""
+msgstr "Utilisateur"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:197
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr ""
+msgstr "L'accès des utilisateurs est géré par un fournisseur externe ({0}). Les paramètres de domaine d'inscription automatique ne sont pas disponibles lors de l'utilisation d'une authentification externe."
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr ""
+msgstr "Détails de l'utilisateur"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr ""
+msgstr "Utilisateur introuvable"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
 #: packages/admin/src/components/Sidebar.tsx:206
@@ -5238,34 +5238,34 @@ msgstr "Utilisateurs"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:421
 msgid "Users from"
-msgstr ""
+msgstr "Utilisateurs de"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:249
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr ""
+msgstr "Les utilisateurs disposant d'adresses e-mail utilisant ces domaines peuvent s'inscrire sans invitation. Le rôle spécifié leur sera automatiquement attribué."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:312
 msgid "v{0} available"
-msgstr ""
+msgstr "v{0} disponible"
 
 #: packages/admin/src/components/FieldEditor.tsx:452
 #: packages/admin/src/components/FieldEditor.tsx:482
 msgid "Validation"
-msgstr ""
+msgstr "Validation"
 
 #: packages/admin/src/components/SignupPage.tsx:387
 msgid "Verifying your link..."
-msgstr ""
+msgstr "Vérification de votre lien en cours..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:213
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
 msgid "Verifying..."
-msgstr ""
+msgstr "Vérification en cours..."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:331
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
@@ -5273,41 +5273,41 @@ msgstr "Consulter l'état du fournisseur d'e-mail et envoyer un e-mail de test"
 
 #: packages/admin/src/components/PluginManager.tsx:371
 msgid "View in Marketplace"
-msgstr ""
+msgstr "Afficher dans la place de marché"
 
 #: packages/admin/src/components/MediaLibrary.tsx:227
 msgid "View mode"
-msgstr ""
+msgstr "Mode d'affichage"
 
 #: packages/admin/src/components/ContentList.tsx:401
 msgid "View published {title}"
-msgstr ""
+msgstr "Voir {title} publié"
 
 #: packages/admin/src/components/Header.tsx:51
 msgid "View Site"
-msgstr ""
+msgstr "Voir le site"
 
 #: packages/admin/src/components/Redirects.tsx:429
 msgid "Visitors hitting these paths will see an error."
-msgstr ""
+msgstr "Les visiteurs qui empruntent ces chemins verront une erreur."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
 msgid "Waiting for passkey..."
-msgstr ""
+msgstr "En attente de la clé d'accès..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:334
 msgid "Warn"
-msgstr ""
+msgstr "Avertir"
 
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1096
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr ""
+msgstr "Nous n'avons pas pu nous connecter à un site WordPress à l'adresse {0}. Cela peut signifier que le site n'est pas WordPress, que l'API REST est désactivée ou que le site n'est pas accessible."
 
 #: packages/admin/src/components/WordPressImport.tsx:917
 msgid "We'll check what import options are available for your site."
-msgstr ""
+msgstr "Nous vérifierons quelles options d'importation sont disponibles pour votre site."
 
 #: packages/admin/src/components/LoginPage.tsx:352
 msgid "We'll send you a link to sign in without a password."
@@ -5315,16 +5315,16 @@ msgstr "Nous vous enverrons un lien pour vous connecter sans mot de passe."
 
 #: packages/admin/src/components/SignupPage.tsx:131
 msgid "We've sent a verification link to"
-msgstr ""
+msgstr "Nous avons envoyé un lien de vérification à"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:159
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
 msgid "WebAuthn is not supported in this browser"
-msgstr ""
+msgstr "WebAuthn n'est pas pris en charge dans ce navigateur"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:236
 msgid "Website"
-msgstr ""
+msgstr "Site web"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -5332,15 +5332,15 @@ msgstr "Bienvenue sur EmDash, {firstName} !"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
-msgstr "Bienvenue sur EmDash !"
+msgstr "Bienvenue sur EmDash !"
 
 #: packages/admin/src/components/WordPressImport.tsx:1954
 msgid "What happens when you import:"
-msgstr ""
+msgstr "Ce qu'il se passe lorsque vous importez :"
 
 #: packages/admin/src/components/WordPressImport.tsx:1735
 msgid "What will happen when you import"
-msgstr ""
+msgstr "Ce qu'il se passera lorsque vous importerez"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "When the entry was created"
@@ -5356,11 +5356,11 @@ msgstr "Date de publication de l'entrée"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:490
 msgid "Which content types can use this taxonomy"
-msgstr ""
+msgstr "Quels types de contenu peuvent utiliser cette taxonomie"
 
 #: packages/admin/src/components/FieldEditor.tsx:164
 msgid "Whole number"
-msgstr ""
+msgstr "Nombre entier"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
 #: packages/admin/src/components/PluginManager.tsx:333
@@ -5371,35 +5371,35 @@ msgstr "Widgets"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
 msgid "Width"
-msgstr ""
+msgstr "Largeur"
 
 #: packages/admin/src/components/WordPressImport.tsx:1877
 msgid "Will create"
-msgstr ""
+msgstr "Créera"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:422
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr ""
+msgstr "ne pourra plus s'inscrire sans invitation. Les utilisateurs existants ne sont pas concernés."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:193
 msgid "Without an email provider, invite links must be shared manually."
-msgstr ""
+msgstr "Sans fournisseur de messagerie, les liens d'invitation doivent être partagés manuellement."
 
 #: packages/admin/src/components/WordPressImport.tsx:1306
 msgid "WordPress Username"
-msgstr ""
+msgstr "Nom d'utilisateur WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1014
 msgid "WXR File"
-msgstr ""
+msgstr "Fichier WXR"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "Yes"
-msgstr ""
+msgstr "Oui"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
-msgstr ""
+msgstr "Vous pouvez fermer cette page et revenir à votre terminal."
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -5407,7 +5407,7 @@ msgstr "Vous pouvez créer et modifier votre propre contenu."
 
 #: packages/admin/src/components/WelcomeModal.tsx:42
 msgid "You can manage content, media, menus, and taxonomies."
-msgstr "Vous pouvez gérer le contenu, les médias, les menus et les taxonomies."
+msgstr "Vous pouvez gérer le contenu, les fichiers multimédias, les menus et les taxonomies."
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
@@ -5415,7 +5415,7 @@ msgstr "Vous pouvez consulter le site et y contribuer."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr ""
+msgstr "Vous ne pouvez pas changer votre propre rôle"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
@@ -5424,36 +5424,36 @@ msgstr "Vous avez un accès complet pour gérer ce site, y compris les utilisate
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Vous ne pourrez plus utiliser « {0} » pour vous connecter. Cette action ne peut pas être annulée."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:207
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Vous ne pourrez plus utiliser cette clé d'accès pour vous connecter. Cette action ne peut pas être annulée."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr ""
+msgstr "Vous serez invité à utiliser l'authentification biométrique, la clé de sécurité ou le code PIN de votre appareil."
 
 #: packages/admin/src/components/WordPressImport.tsx:1199
 msgid "You'll be redirected to WordPress to authorize the connection."
-msgstr ""
+msgstr "Vous serez redirigé vers WordPress pour autoriser la connexion."
 
 #: packages/admin/src/components/SignupPage.tsx:190
 msgid "You'll be signing up as"
-msgstr ""
+msgstr "Vous serez inscrit en tant que"
 
 #: packages/admin/src/components/SetupWizard.tsx:499
 msgid "You're signed in via Cloudflare Access"
-msgstr ""
+msgstr "Vous êtes connecté via Cloudflare Access"
 
 #: packages/admin/src/components/SignupPage.tsx:69
 msgid "you@company.com"
-msgstr ""
+msgstr "vous@entreprise.com"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:336
 #: packages/admin/src/components/SetupWizard.tsx:226
 msgid "you@example.com"
-msgstr ""
+msgstr "vous@exemple.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
@@ -5462,40 +5462,40 @@ msgstr "Votre compte a bien été créé."
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:318
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
 msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
-msgstr ""
+msgstr "Votre navigateur ne prend pas en charge les mots de passe. Veuillez utiliser un navigateur moderne comme Chrome, Safari, Firefox ou Edge."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:269
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
 msgid "Your device doesn't support the required security features."
-msgstr ""
+msgstr "Votre appareil ne prend pas en charge les fonctionnalités de sécurité requises."
 
 #: packages/admin/src/components/SetupWizard.tsx:222
 msgid "Your Email"
-msgstr ""
+msgstr "Votre e-mail"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:143
 msgid "Your Facebook page or profile username"
-msgstr ""
+msgstr "Le nom d'utilisateur de votre page Facebook ou de votre profil"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:137
 msgid "Your GitHub username"
-msgstr ""
+msgstr "Le nom d'utilisateur de votre compte GitHub"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:149
 msgid "Your Instagram username"
-msgstr ""
+msgstr "Le nom d'utilisateur de votre compte Instagram"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:155
 msgid "Your LinkedIn profile username"
-msgstr ""
+msgstr "Le nom d'utilisateur de votre compte LinkedIn"
 
 #: packages/admin/src/components/SetupWizard.tsx:234
 msgid "Your Name"
-msgstr ""
+msgstr "Votre nom"
 
 #: packages/admin/src/components/SignupPage.tsx:200
 msgid "Your name (optional)"
-msgstr ""
+msgstr "Votre nom (facultatif)"
 
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
@@ -5503,17 +5503,17 @@ msgstr "Votre rôle"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:131
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr ""
+msgstr "Votre identifiant Twitter/X (par exemple, @username)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1925
 msgid "Your WordPress export contains {0} media files."
-msgstr ""
+msgstr "Votre exportation WordPress contient {0} fichiers multimédias."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:161
 msgid "Your YouTube channel ID or handle"
-msgstr ""
+msgstr "Votre identifiant ou l'identifiant de votre chaîne YouTube"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:158
 msgid "YouTube"
-msgstr ""
+msgstr "YouTube"

--- a/packages/admin/src/locales/fr/messages.po
+++ b/packages/admin/src/locales/fr/messages.po
@@ -20,7 +20,7 @@ msgstr " (par défaut)"
 
 #: packages/admin/src/components/MenuEditor.tsx:344
 msgid " (opens in new window)"
-msgstr " (ouvre dans une nouvelle fenêtre)"
+msgstr " (s'ouvre dans une nouvelle fenêtre)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:634
 #: packages/admin/src/components/MediaPickerModal.tsx:716


### PR DESCRIPTION
## What does this PR do?

Translates into French all the missing keys of the administration interface, and updates a few existing translations:
* "dashboard": this is an English word and we have a valid and commonly used translation for this.
* "token": this is an English word. The [French Wikipedia page](https://fr.wikipedia.org/wiki/Jeton_d%27authentification), the [French CNIL](https://www.cnil.fr/fr/les-jetons-individuels-de-connexion-ou-token-access), the [Grand dictionnaire terminologique from Quebec](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/26560744/jeton) all use "jeton".
* "Scopes" has no meaning in French... Some people might understand what it is, but I doubt this is the case for most. In this context, I think "Champs d'application" is the right translation ("Périmètres" could work too). This is suggested by the [Grand dictionnaire terminologique from Quebec](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/3293099/portee) and, while this is probably AI generated, this is what [Google uses](https://developers.google.com/identity/protocols/oauth2/scopes?hl=fr).
* "Embeds", same here. Because "Intégrer" was used for the verb, I replaced it with "Intégrations" but "Incrustrations" could also work.

There may still be some typos; I haven't been able to proofread some parts (e.g. WordPress importer steps because I don't have a WordPress website). There may also remain inconsistencies between imperative and infinitive (but this is more a matter of fine-tuning than a real problem).

And, some parts could sound odd to French users because of the current limitations. For example:
* `"New {collectionLabel}"` should allow agreement (for example, in French, "new" could be translated as "Nouveau", "Nouvel" or "Nouvelle" depending on the word used for "collectionLabel").
* `"Update the {0} details"` same as above (e.g. "les détails" followed by "du"/"de la"/"des" then `{0}`)
* `"Manage {0} for {1}"` could also be an issue (masculine/feminine, plural/singular)

**Note:** If this is too much to review, happy to split the PR... 😅 

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code

1. I generated the translation using Copilot (I was curious to know how good it was, never done that on Astro docs),
2. I reread/updated each translated strings and checked the context in the components.
3. I checked the demo website before opening this PR.

## Screenshots / test output

```
Catalog statistics for packages/admin/src/locales/{locale}/messages: 
┌─────────────┬─────────────┬─────────┐
│ Language    │ Total count │ Missing │
├─────────────┼─────────────┼─────────┤
│ en (source) │    1224     │    -    │
│ ar          │    1224     │    1    │
│ de          │    1224     │   928   │
│ es-419      │    1224     │    0    │
│ eu          │    1224     │  1046   │
│ fr          │    1224     │    0    │
│ ja          │    1224     │    0    │
│ pt-BR       │    1224     │    1    │
│ zh-CN       │    1224     │    1    │
│ zh-TW       │    1224     │    1    │
└─────────────┴─────────────┴─────────┘
```

<!-- Optional. Include if the change is visual or if you want to show test results. -->
