### PR TITLE
Security: CSP policy allows unsafe inline scripts and styles on admin/API surface

### DIFF
--- a/packages/core/src/astro/middleware/csp.ts
+++ b/packages/core/src/astro/middleware/csp.ts
@@ -13,8 +13,8 @@
 export function buildEmDashCsp(): string {
 	return [
 		"default-src 'self'",
-		"script-src 'self' 'unsafe-inline'",
-		"style-src 'self' 'unsafe-inline'",
+		"script-src 'self'",
+		"style-src 'self'",
 		"connect-src 'self'",
 		"form-action 'self'",
 		"frame-ancestors 'none'",


### PR DESCRIPTION
## Problem

The CSP builder includes `script-src 'unsafe-inline'` and `style-src 'unsafe-inline'` for `/_emdash` routes. If any XSS injection occurs, inline script execution is permitted, substantially reducing CSP's mitigation value.

**Severity**: `medium`
**File**: `packages/core/src/astro/middleware/csp.ts`

## Solution

Move to nonce- or hash-based CSP for scripts/styles and remove `'unsafe-inline'`. If inline styles are unavoidable, keep them scoped and remove unsafe inline scripts first. Add `report-uri`/`report-to` for CSP violation monitoring.

## Changes

- `packages/core/src/astro/middleware/csp.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
