### PR TITLE
fix(core): don't first-time enable FTS from syncSearchState

### DIFF
--- a/.changeset/bright-parks-greet.md
+++ b/.changeset/bright-parks-greet.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes playground initialization crash caused by syncSearchState attempting first-time FTS enablement during field creation.

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -500,14 +500,15 @@ export class SchemaRegistry {
 	}
 
 	/**
-	 * Synchronize FTS state with the collection's current supports and searchable fields.
+	 * Synchronize an existing FTS index with the collection's current state.
 	 *
-	 * Called whenever supports or searchable fields change. Reconciles user intent
-	 * (supports includes "search") with FTS implementation reality.
+	 * Only rebuilds or disables — never first-time enables. First-time FTS
+	 * enablement is handled by the seed's explicit enableSearch call (which
+	 * is try-caught) or the admin UI toggle.
 	 *
-	 * - supports search + has searchable fields → enable or rebuild FTS
-	 * - supports search + no searchable fields  → disable FTS if active
-	 * - does not support search                 → disable FTS if active
+	 * - FTS active + still has search support and searchable fields → rebuild
+	 * - FTS active + lost search support or no searchable fields    → disable
+	 * - FTS not active                                              → no-op
 	 *
 	 * Pass `db` when calling from within a transaction so FTS operations
 	 * participate in the same transaction and are rolled back on failure.

--- a/packages/core/src/schema/registry.ts
+++ b/packages/core/src/schema/registry.ts
@@ -529,13 +529,9 @@ export class SchemaRegistry {
 		const config = await ftsManager.getSearchConfig(collectionSlug);
 		const ftsActive = config?.enabled === true;
 
-		if (wantsSearch && searchableFields.length > 0) {
-			if (ftsActive) {
-				await ftsManager.rebuildIndex(collectionSlug, searchableFields, config?.weights);
-			} else {
-				await ftsManager.enableSearch(collectionSlug, { weights: config?.weights });
-			}
-		} else if (ftsActive) {
+		if (wantsSearch && searchableFields.length > 0 && ftsActive) {
+			await ftsManager.rebuildIndex(collectionSlug, searchableFields, config?.weights);
+		} else if (ftsActive && (!wantsSearch || searchableFields.length === 0)) {
 			await ftsManager.disableSearch(collectionSlug);
 		}
 	}

--- a/packages/core/tests/unit/schema/registry.test.ts
+++ b/packages/core/tests/unit/schema/registry.test.ts
@@ -381,7 +381,7 @@ describe("SchemaRegistry", () => {
 			ftsManager = new FTSManager(db);
 		});
 
-		it("creates FTS table when adding a searchable field to a collection with search support", async () => {
+		it("does not auto-enable FTS when adding a searchable field", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
@@ -395,10 +395,10 @@ describe("SchemaRegistry", () => {
 				searchable: true,
 			});
 
-			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
+			expect(await ftsManager.ftsTableExists("articles")).toBe(false);
 		});
 
-		it("creates FTS table when adding search support to a collection that already has searchable fields", async () => {
+		it("does not auto-enable FTS when adding search support to a collection", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
@@ -411,12 +411,11 @@ describe("SchemaRegistry", () => {
 				searchable: true,
 			});
 
-			// FTS should not exist before enabling search
 			expect(await ftsManager.ftsTableExists("articles")).toBe(false);
 
 			await registry.updateCollection("articles", { supports: ["drafts", "search"] });
 
-			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
+			expect(await ftsManager.ftsTableExists("articles")).toBe(false);
 		});
 
 		it("disables FTS when search support is removed from a collection", async () => {
@@ -431,7 +430,7 @@ describe("SchemaRegistry", () => {
 				type: "string",
 				searchable: true,
 			});
-			// createField auto-syncs; verify FTS is live before testing the disable path
+			await ftsManager.enableSearch("articles");
 			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 
 			await registry.updateCollection("articles", { supports: ["drafts"] });
@@ -451,10 +450,9 @@ describe("SchemaRegistry", () => {
 				type: "string",
 				searchable: true,
 			});
-			// createField auto-syncs; verify FTS is live before adding the second field
+			await ftsManager.enableSearch("articles");
 			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 
-			// Add a second searchable field — FTS table must be rebuilt to include it
 			await registry.createField("articles", {
 				slug: "body",
 				label: "Body",
@@ -462,8 +460,6 @@ describe("SchemaRegistry", () => {
 				searchable: true,
 			});
 
-			// Verify the FTS table was rebuilt to include the body column.
-			// Selecting a non-existent column from the FTS virtual table throws an error.
 			await expect(
 				sql`SELECT body FROM "_emdash_fts_articles" LIMIT 0`.execute(db),
 			).resolves.toBeDefined();
@@ -487,13 +483,10 @@ describe("SchemaRegistry", () => {
 				type: "text",
 				searchable: true,
 			});
-			// FTS is now active with title and body columns in its triggers
+			await ftsManager.enableSearch("articles");
 
-			// Deleting a searchable field must not throw (SQLite rejects dropping a
-			// column still referenced by a trigger)
 			await expect(registry.deleteField("articles", "body")).resolves.toBeUndefined();
 
-			// FTS should be rebuilt around the remaining searchable field
 			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 			await expect(
 				sql`SELECT title FROM "_emdash_fts_articles" LIMIT 0`.execute(db),
@@ -512,7 +505,7 @@ describe("SchemaRegistry", () => {
 				type: "string",
 				searchable: true,
 			});
-			// createField auto-syncs; verify FTS is live before testing collection deletion
+			await ftsManager.enableSearch("articles");
 			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 
 			await registry.deleteCollection("articles");
@@ -532,6 +525,7 @@ describe("SchemaRegistry", () => {
 				type: "string",
 				searchable: true,
 			});
+			await ftsManager.enableSearch("articles");
 			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 
 			await registry.deleteField("articles", "title");
@@ -555,7 +549,7 @@ describe("SchemaRegistry", () => {
 			expect(await ftsManager.ftsTableExists("articles")).toBe(false);
 		});
 
-		it("preserves weights when search support is toggled off then back on", async () => {
+		it("preserves weights in config when search support is toggled off", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
@@ -568,18 +562,12 @@ describe("SchemaRegistry", () => {
 				searchable: true,
 			});
 
-			// Enable FTS with custom weights
 			await ftsManager.enableSearch("articles", { weights: { title: 10 } });
 			const initialConfig = await ftsManager.getSearchConfig("articles");
 			expect(initialConfig?.weights).toEqual({ title: 10 });
 
-			// Toggle search support off — drops FTS table, must preserve weights in config
 			await registry.updateCollection("articles", { supports: ["drafts"] });
 			expect(await ftsManager.ftsTableExists("articles")).toBe(false);
-
-			// Toggle search support back on — must re-enable with the preserved weights
-			await registry.updateCollection("articles", { supports: ["drafts", "search"] });
-			expect(await ftsManager.ftsTableExists("articles")).toBe(true);
 
 			const finalConfig = await ftsManager.getSearchConfig("articles");
 			expect(finalConfig?.weights).toEqual({ title: 10 });
@@ -591,32 +579,7 @@ describe("SchemaRegistry", () => {
 			vi.restoreAllMocks();
 		});
 
-		it("rolls back updateCollection when FTS sync fails", async () => {
-			await registry.createCollection({
-				slug: "articles",
-				label: "Articles",
-				supports: ["drafts"],
-			});
-			await registry.createField("articles", {
-				slug: "title",
-				label: "Title",
-				type: "string",
-				searchable: true,
-			});
-
-			vi.spyOn(FTSManager.prototype, "enableSearch").mockRejectedValueOnce(
-				new Error("FTS sync sabotaged"),
-			);
-
-			await expect(
-				registry.updateCollection("articles", { supports: ["drafts", "search"] }),
-			).rejects.toThrow();
-
-			const collection = await registry.getCollection("articles");
-			expect(collection?.supports).toEqual(["drafts"]);
-		});
-
-		it("rolls back updateField when FTS sync fails", async () => {
+		it("rolls back updateCollection when FTS disable fails", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
@@ -626,22 +589,51 @@ describe("SchemaRegistry", () => {
 				slug: "title",
 				label: "Title",
 				type: "string",
-				searchable: false,
+				searchable: true,
 			});
+			const ftsManager = new FTSManager(db);
+			await ftsManager.enableSearch("articles");
 
-			vi.spyOn(FTSManager.prototype, "enableSearch").mockRejectedValueOnce(
+			vi.spyOn(FTSManager.prototype, "disableSearch").mockRejectedValueOnce(
 				new Error("FTS sync sabotaged"),
 			);
 
 			await expect(
-				registry.updateField("articles", "title", { searchable: true }),
+				registry.updateCollection("articles", { supports: ["drafts"] }),
+			).rejects.toThrow();
+
+			const collection = await registry.getCollection("articles");
+			expect(collection?.supports).toContain("search");
+		});
+
+		it("rolls back updateField when FTS rebuild fails", async () => {
+			await registry.createCollection({
+				slug: "articles",
+				label: "Articles",
+				supports: ["search"],
+			});
+			await registry.createField("articles", {
+				slug: "title",
+				label: "Title",
+				type: "string",
+				searchable: true,
+			});
+			const ftsManager = new FTSManager(db);
+			await ftsManager.enableSearch("articles");
+
+			vi.spyOn(FTSManager.prototype, "disableSearch").mockRejectedValueOnce(
+				new Error("FTS sync sabotaged"),
+			);
+
+			await expect(
+				registry.updateField("articles", "title", { searchable: false }),
 			).rejects.toThrow();
 
 			const field = await registry.getField("articles", "title");
-			expect(field?.searchable).toBe(false);
+			expect(field?.searchable).toBe(true);
 		});
 
-		it("rolls back deleteField when FTS sync fails", async () => {
+		it("rolls back deleteField when FTS rebuild fails", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
@@ -659,6 +651,8 @@ describe("SchemaRegistry", () => {
 				type: "text",
 				searchable: true,
 			});
+			const ftsManager = new FTSManager(db);
+			await ftsManager.enableSearch("articles");
 
 			vi.spyOn(FTSManager.prototype, "rebuildIndex").mockRejectedValueOnce(
 				new Error("FTS sync sabotaged"),
@@ -670,27 +664,35 @@ describe("SchemaRegistry", () => {
 			expect(field).not.toBeNull();
 		});
 
-		it("rolls back createField when FTS sync fails", async () => {
+		it("rolls back createField when FTS rebuild fails", async () => {
 			await registry.createCollection({
 				slug: "articles",
 				label: "Articles",
 				supports: ["search"],
 			});
+			await registry.createField("articles", {
+				slug: "title",
+				label: "Title",
+				type: "string",
+				searchable: true,
+			});
+			const ftsManager = new FTSManager(db);
+			await ftsManager.enableSearch("articles");
 
-			vi.spyOn(FTSManager.prototype, "enableSearch").mockRejectedValueOnce(
+			vi.spyOn(FTSManager.prototype, "rebuildIndex").mockRejectedValueOnce(
 				new Error("FTS sync sabotaged"),
 			);
 
 			await expect(
 				registry.createField("articles", {
-					slug: "title",
-					label: "Title",
-					type: "string",
+					slug: "body",
+					label: "Body",
+					type: "text",
 					searchable: true,
 				}),
 			).rejects.toThrow();
 
-			const field = await registry.getField("articles", "title");
+			const field = await registry.getField("articles", "body");
 			expect(field).toBeNull();
 		});
 	});


### PR DESCRIPTION
## What does this PR do?

Fixes a regression from #465 (`0a61ef4`) that crashes playground initialization.

`syncSearchState` was calling `enableSearch()` when FTS wasn't yet active, which triggered FTS5 operations (drop triggers, create virtual table, etc.) during field creation in the seed. The seed's own `enableSearch` step at the end handles failures gracefully with a try/catch, but the new `createField` → `syncSearchState` path didn't — so any FTS failure during field creation killed the entire playground init.

Now `syncSearchState` only:
- **Rebuilds** an already-active FTS index (when searchable fields change)
- **Disables** an active FTS index (when search support is removed or no searchable fields remain)

First-time FTS enablement stays with the seed's try-caught `enableSearch` call and the admin UI's explicit toggle.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)

## AI-generated code disclosure

- [x] This PR includes AI-generated code