### PR TITLE
Fix: Added the missing "invalid JSON" in the Chinese translation.

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -497,7 +497,7 @@ msgstr "添加新内容"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:440
 msgid "Add new {0}"
-msgstr ""
+msgstr "添加新{0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:187
 msgid "Add noindex meta tag"
@@ -2027,7 +2027,7 @@ msgstr "创建部分合集失败"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:447
 msgid "Failed to create term"
-msgstr ""
+msgstr "创建分类项失败"
 
 #: packages/admin/src/components/PluginManager.tsx:108
 msgid "Failed to disable plugin"
@@ -3025,7 +3025,7 @@ msgstr "新"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:418
 msgid "New {0}"
-msgstr ""
+msgstr "新{0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:526
 msgid "New {collectionLabel}"

--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -2502,7 +2502,7 @@ msgstr "整数"
 
 #: packages/admin/src/components/ContentEditor.tsx:1356
 msgid "Invalid JSON"
-msgstr ""
+msgstr "无效的 JSON"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Invalid link"

--- a/packages/admin/src/locales/zh-TW/messages.po
+++ b/packages/admin/src/locales/zh-TW/messages.po
@@ -2502,7 +2502,7 @@ msgstr "整數"
 
 #: packages/admin/src/components/ContentEditor.tsx:1356
 msgid "Invalid JSON"
-msgstr ""
+msgstr "無效的 JSON"
 
 #: packages/admin/src/components/SignupPage.tsx:258
 msgid "Invalid link"

--- a/packages/admin/src/locales/zh-TW/messages.po
+++ b/packages/admin/src/locales/zh-TW/messages.po
@@ -497,7 +497,7 @@ msgstr "添加新內容"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:440
 msgid "Add new {0}"
-msgstr ""
+msgstr "添加新{0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:187
 msgid "Add noindex meta tag"
@@ -2027,7 +2027,7 @@ msgstr "創建部分合集失敗"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:447
 msgid "Failed to create term"
-msgstr ""
+msgstr "創建分類項失敗"
 
 #: packages/admin/src/components/PluginManager.tsx:108
 msgid "Failed to disable plugin"
@@ -3025,7 +3025,7 @@ msgstr "新"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:418
 msgid "New {0}"
-msgstr ""
+msgstr "新{0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:526
 msgid "New {collectionLabel}"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Added the missing "invalid JSON" in the Chinese translation.
## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
