### PR TITLE
fix(import): surface real error messages in WordPress import failures

### DIFF
--- a/.changeset/surface-wordpress-import-errors.md
+++ b/.changeset/surface-wordpress-import-errors.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes WordPress import error reporting to surface the real exception message instead of a generic "Failed to import item" string, making import failures diagnosable.

--- a/packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts
@@ -332,7 +332,7 @@ async function importContent(
 			console.error(`Import error for "${item.title || "Untitled"}":`, error);
 			result.errors.push({
 				title: item.title || "Untitled",
-				error: "Failed to import item",
+				error: error instanceof Error && error.message ? error.message : "Failed to import item",
 			});
 		}
 	}

--- a/packages/core/src/astro/routes/api/import/wordpress/execute.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/execute.ts
@@ -271,7 +271,7 @@ async function importContent(
 			console.error(`Import error for "${post.title || "Untitled"}":`, error);
 			result.errors.push({
 				title: post.title || "Untitled",
-				error: "Failed to import item",
+				error: error instanceof Error && error.message ? error.message : "Failed to import item",
 			});
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

Surfaces real exception messages in WordPress import errors instead of the generic `"Failed to import item"` string.

### Problem

Both WordPress import paths catch per-item exceptions and replace them with a hardcoded `"Failed to import item"` string before adding them to the result. The actual error message is logged to the server console via `console.error`, but discarded from the API response.

This makes issues like #553 (where all 185 items failed) nearly impossible to diagnose remotely — every error in the admin UI looks identical regardless of root cause.

### Change

Replace the hardcoded string with the actual `error.message`, falling back to `"Failed to import item"` only when no message is available:

```ts
error: error instanceof Error && error.message
    ? error.message
    : "Failed to import item",
```

### Scope

Intentionally narrow. This does **not** fix #553 — it makes #553 (and future import failures) diagnosable so the root cause can be identified from user reports.

### Files

- `packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts`
- `packages/core/src/astro/routes/api/import/wordpress/execute.ts`

Refs #553

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — server-side change only. Error messages that were previously swallowed will now appear in the admin UI's import results.