### PR TITLE
feat: add Noto Sans as default admin UI font with multi-script support

### DIFF
--- a/.changeset/wet-kings-bake.md
+++ b/.changeset/wet-kings-bake.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds Noto Sans as the default admin UI font via the Astro Font API. Fonts are downloaded from Google at build time and self-hosted. The base font covers Latin, Cyrillic, Greek, Devanagari, and Vietnamese. Additional scripts (Arabic, CJK, Hebrew, Thai, etc.) can be added via the new `fonts.scripts` config option. Set `fonts: false` to disable and use system fonts.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -98,6 +98,36 @@ import seoPlugin from "@emdash-cms/plugin-seo";
 plugins: [seoPlugin()];
 ```
 
+### `fonts`
+
+**Optional.** Admin UI font configuration.
+
+By default, EmDash loads [Noto Sans](https://fonts.google.com/noto/specimen/Noto+Sans) via the [Astro Font API](https://docs.astro.build/en/guides/fonts/). Fonts are downloaded from Google at build time and self-hosted, so there are no runtime CDN requests. The base font covers Latin, Cyrillic, Greek, Devanagari, and Vietnamese scripts.
+
+To add support for additional writing systems, pass script names:
+
+```js
+emdash({
+  fonts: {
+    scripts: ["arabic", "japanese"],
+  },
+})
+```
+
+Available scripts: `arabic`, `armenian`, `bengali`, `chinese-simplified`, `chinese-traditional`, `chinese-hongkong`, `devanagari`, `ethiopic`, `georgian`, `gujarati`, `gurmukhi`, `hebrew`, `japanese`, `kannada`, `khmer`, `korean`, `lao`, `malayalam`, `myanmar`, `oriya`, `sinhala`, `tamil`, `telugu`, `thai`, `tibetan`.
+
+Each script maps to the corresponding Noto Sans variant on Google Fonts (e.g. `"arabic"` loads Noto Sans Arabic). All font faces share a single `font-family` name and use `unicode-range` so the browser only downloads the files it needs for the characters on the page.
+
+Set to `false` to disable font injection entirely and use system fonts:
+
+```js
+emdash({
+  fonts: false,
+})
+```
+
+The admin CSS uses the `--font-emdash` CSS variable. This is set automatically by the font configuration above.
+
 ### `auth`
 
 **Optional.** Authentication configuration.

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -72,6 +72,28 @@
 	--text-color-kumo-warning: #dba617;
 }
 
+/**
+ * Admin font stack
+ *
+ * --font-emdash is set by the Astro Font API (Noto Sans by default).
+ * Users can add extra script coverage (Arabic, CJK, etc.) by adding
+ * their own fonts targeting --font-emdash in astro.config.
+ *
+ * Override Tailwind's --font-sans so all font-sans utilities use it.
+ */
+@theme {
+	--font-sans: var(
+		--font-emdash,
+		ui-sans-serif,
+		system-ui,
+		sans-serif,
+		"Apple Color Emoji",
+		"Segoe UI Emoji",
+		"Segoe UI Symbol",
+		"Noto Color Emoji"
+	);
+}
+
 /* Base styles */
 * {
 	border-color: var(--color-kumo-line);

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -76,8 +76,10 @@
  * Admin font stack
  *
  * --font-emdash is set by the Astro Font API (Noto Sans by default).
- * Users can add extra script coverage (Arabic, CJK, etc.) by adding
- * their own fonts targeting --font-emdash in astro.config.
+ * To add extra script coverage (Arabic, CJK, etc.), configure EmDash with
+ * emdash({ fonts: { scripts: [...] } }) rather than adding another font entry
+ * that targets --font-emdash. If you need to supply your own font entry and
+ * CSS variable instead, disable EmDash-managed fonts first with fonts: false.
  *
  * Override Tailwind's --font-sans so all font-sans utilities use it.
  */

--- a/packages/core/src/astro/integration/font-provider.ts
+++ b/packages/core/src/astro/integration/font-provider.ts
@@ -1,0 +1,181 @@
+/**
+ * EmDash Noto Sans font provider
+ *
+ * A custom Astro font provider that wraps Google Fonts to resolve
+ * multiple Noto Sans families (Latin, Arabic, JP, etc.) under a
+ * single logical font entry. This lets all @font-face blocks share
+ * the same font-family name, so the browser picks the right file
+ * per character via unicode-range.
+ *
+ * Without this, registering "Noto Sans" and "Noto Sans Arabic" as
+ * separate font entries on the same cssVariable triggers an Astro
+ * warning and the last entry overwrites the first.
+ */
+
+import { fontProviders } from "astro/config";
+
+/**
+ * All subset names used by Google Fonts CSS responses.
+ * Passed when resolving extra script families so the unifont
+ * provider doesn't filter out any faces.
+ */
+const ALL_GOOGLE_SUBSETS = [
+	"arabic",
+	"armenian",
+	"bengali",
+	"chinese-simplified",
+	"chinese-traditional",
+	"chinese-hongkong",
+	"cyrillic",
+	"cyrillic-ext",
+	"devanagari",
+	"ethiopic",
+	"georgian",
+	"greek",
+	"greek-ext",
+	"gujarati",
+	"gurmukhi",
+	"hebrew",
+	"japanese",
+	"kannada",
+	"khmer",
+	"korean",
+	"lao",
+	"latin",
+	"latin-ext",
+	"malayalam",
+	"math",
+	"myanmar",
+	"oriya",
+	"sinhala",
+	"symbols",
+	"tamil",
+	"telugu",
+	"thai",
+	"tibetan",
+	"vietnamese",
+];
+
+/**
+ * Known Noto Sans script families on Google Fonts.
+ * Maps user-friendly script names to Google Fonts family names.
+ */
+const NOTO_SCRIPT_FAMILIES: Record<string, string> = {
+	arabic: "Noto Sans Arabic",
+	armenian: "Noto Sans Armenian",
+	bengali: "Noto Sans Bengali",
+	"chinese-simplified": "Noto Sans SC",
+	"chinese-traditional": "Noto Sans TC",
+	"chinese-hongkong": "Noto Sans HK",
+	devanagari: "Noto Sans Devanagari",
+	ethiopic: "Noto Sans Ethiopic",
+	georgian: "Noto Sans Georgian",
+	gujarati: "Noto Sans Gujarati",
+	gurmukhi: "Noto Sans Gurmukhi",
+	hebrew: "Noto Sans Hebrew",
+	japanese: "Noto Sans JP",
+	kannada: "Noto Sans Kannada",
+	khmer: "Noto Sans Khmer",
+	korean: "Noto Sans KR",
+	lao: "Noto Sans Lao",
+	malayalam: "Noto Sans Malayalam",
+	myanmar: "Noto Sans Myanmar",
+	oriya: "Noto Sans Oriya",
+	sinhala: "Noto Sans Sinhala",
+	tamil: "Noto Sans Tamil",
+	telugu: "Noto Sans Telugu",
+	thai: "Noto Sans Thai",
+	tibetan: "Noto Sans Tibetan",
+};
+
+export interface NotoSansProviderOptions {
+	/**
+	 * Additional Noto Sans script families to include.
+	 * Use script names like "arabic", "japanese", "chinese-simplified".
+	 *
+	 * @see {@link NOTO_SCRIPT_FAMILIES} for the full list of supported scripts.
+	 */
+	scripts?: string[];
+}
+
+// Use ReturnType to get the provider type without importing it directly.
+// The Astro FontProvider type is not part of the public API surface.
+type GoogleProvider = ReturnType<typeof fontProviders.google>;
+
+/**
+ * Create a font provider that resolves Noto Sans plus additional
+ * script-specific Noto families from Google Fonts, all under one
+ * font-family name.
+ */
+export function notoSans(options?: NotoSansProviderOptions): GoogleProvider {
+	// Create a single Google provider instance to share initialization
+	const googleProvider = fontProviders.google();
+
+	return {
+		name: "emdash-noto",
+		async init(context) {
+			await googleProvider.init?.(context);
+		},
+		async resolveFont(resolveFontOptions) {
+			const { weights, styles, formats } = resolveFontOptions;
+
+			// Resolve the base Noto Sans (Latin, Cyrillic, Greek, etc.)
+			const base = await googleProvider.resolveFont(resolveFontOptions);
+			const baseFonts = base?.fonts ?? [];
+
+			if (!options?.scripts?.length) {
+				return base;
+			}
+
+			// Collect subset names already covered by the base font so we
+			// can filter out duplicate faces from extra script families.
+			// e.g. Noto Sans Arabic includes latin/latin-ext faces that
+			// would otherwise override the base Noto Sans latin faces.
+			const baseSubsets = new Set(baseFonts.map((f) => f.meta?.subset).filter(Boolean));
+
+			// Resolve additional script families
+			const extraFonts = await Promise.all(
+				options.scripts.map(async (script) => {
+					const family = NOTO_SCRIPT_FAMILIES[script];
+					if (!family) {
+						// Silently skip subset names that are already covered
+						// by the base Noto Sans font (latin, cyrillic, etc.)
+						if (ALL_GOOGLE_SUBSETS.includes(script)) {
+							return undefined;
+						}
+						console.warn(
+							`[emdash] Unknown Noto Sans script "${script}". ` +
+								`Available: ${Object.keys(NOTO_SCRIPT_FAMILIES).join(", ")}`,
+						);
+						return undefined;
+					}
+					return googleProvider.resolveFont({
+						familyName: family,
+						weights,
+						styles,
+						// Pass all known subset names so the unifont provider
+						// doesn't filter out any faces. Each script family
+						// only returns faces for its own subsets anyway.
+						subsets: ALL_GOOGLE_SUBSETS,
+						formats,
+						options: undefined,
+					});
+				}),
+			);
+
+			// Merge, dropping faces from extra fonts that duplicate base subsets
+			const extraFaces = extraFonts.flatMap((r) =>
+				(r?.fonts ?? []).filter((f) => !f.meta?.subset || !baseSubsets.has(f.meta.subset)),
+			);
+
+			return {
+				fonts: [...baseFonts, ...extraFaces],
+			};
+		},
+	};
+}
+
+/** Get the list of available Noto Sans script names */
+export function getAvailableNotoScripts(): string[] {
+	return Object.keys(NOTO_SCRIPT_FAMILIES);
+}

--- a/packages/core/src/astro/integration/font-provider.ts
+++ b/packages/core/src/astro/integration/font-provider.ts
@@ -117,8 +117,6 @@ export function notoSans(options?: NotoSansProviderOptions): GoogleProvider {
 			await googleProvider.init?.(context);
 		},
 		async resolveFont(resolveFontOptions) {
-			const { weights, styles, formats } = resolveFontOptions;
-
 			// Resolve the base Noto Sans (Latin, Cyrillic, Greek, etc.)
 			const base = await googleProvider.resolveFont(resolveFontOptions);
 			const baseFonts = base?.fonts ?? [];
@@ -150,15 +148,12 @@ export function notoSans(options?: NotoSansProviderOptions): GoogleProvider {
 						return undefined;
 					}
 					return googleProvider.resolveFont({
+						...resolveFontOptions,
 						familyName: family,
-						weights,
-						styles,
 						// Pass all known subset names so the unifont provider
 						// doesn't filter out any faces. Each script family
 						// only returns faces for its own subsets anyway.
 						subsets: ALL_GOOGLE_SUBSETS,
-						formats,
-						options: undefined,
 					});
 				}),
 			);

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -14,6 +14,7 @@ import type { AstroIntegration, AstroIntegrationLogger } from "astro";
 
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import { local } from "../storage/adapters.js";
+import { notoSans } from "./font-provider.js";
 import { injectCoreRoutes, injectBuiltinAuthRoutes, injectMcpRoute } from "./routes.js";
 import type { EmDashConfig, PluginDescriptor } from "./runtime.js";
 import { createViteConfig } from "./vite-config.js";
@@ -207,8 +208,48 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 						? { allowedDomains: [{ hostname: new URL(resolvedConfig.siteUrl).hostname }] }
 						: {}),
 				};
+
+				// Inject default Noto Sans font for the admin UI.
+				// Uses the Astro Font API so fonts are downloaded at build time
+				// and self-hosted (no runtime CDN requests).
+				//
+				// The admin CSS references var(--font-emdash) with a system font
+				// fallback. Users can add extra script coverage (Arabic, CJK, etc.)
+				// by passing fonts.scripts in the emdash() config. The custom
+				// notoSans provider resolves all script families from Google Fonts
+				// under a single font-family name, so they stack via unicode-range.
+				const fontsConfig = resolvedConfig.fonts;
+				const emdashFonts =
+					fontsConfig === false
+						? []
+						: [
+								{
+									provider: notoSans({
+										scripts: fontsConfig?.scripts,
+									}),
+									name: "Noto Sans",
+									cssVariable: "--font-emdash",
+									weights: ["100 900" as const],
+									styles: ["normal" as const, "italic" as const],
+									subsets: [
+										"latin" as const,
+										"latin-ext" as const,
+										"cyrillic" as const,
+										"cyrillic-ext" as const,
+										"devanagari" as const,
+										"greek" as const,
+										"greek-ext" as const,
+										"vietnamese" as const,
+									],
+									fallbacks: ["ui-sans-serif", "system-ui", "sans-serif"],
+								},
+							];
+
 				updateConfig({
 					security: securityConfig,
+					// fonts is a valid AstroConfig key but may not be in the
+					// type definition for the minimum supported Astro version
+					...({ fonts: emdashFonts } as Record<string, unknown>),
 					vite: createViteConfig(
 						{
 							serializableConfig,

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -322,6 +322,56 @@ export interface EmDashConfig {
 	 * ```
 	 */
 	mediaProviders?: MediaProviderDescriptor[];
+
+	/**
+	 * Admin UI font configuration.
+	 *
+	 * By default, EmDash loads Noto Sans via the Astro Font API, covering
+	 * Latin, Latin Extended, Cyrillic, Cyrillic Extended, Greek, Greek
+	 * Extended, Devanagari, and Vietnamese. Fonts are downloaded from
+	 * Google at build time and self-hosted, so there are no runtime CDN
+	 * requests.
+	 *
+	 * To add support for additional writing systems (Arabic, CJK, etc.),
+	 * pass script names. EmDash resolves the matching Noto Sans variant
+	 * from Google Fonts and merges all script faces under a single
+	 * font-family, so the browser downloads only the glyphs it needs
+	 * via unicode-range.
+	 *
+	 * Set to `false` to disable font injection entirely and use system fonts.
+	 *
+	 * @example
+	 * ```ts
+	 * // Add Arabic and Japanese support
+	 * emdash({
+	 *   fonts: {
+	 *     scripts: ["arabic", "japanese"],
+	 *   },
+	 * })
+	 * ```
+	 *
+	 * @example
+	 * ```ts
+	 * // Disable web fonts entirely (use system fonts)
+	 * emdash({
+	 *   fonts: false,
+	 * })
+	 * ```
+	 */
+	fonts?:
+		| false
+		| {
+				/**
+				 * Additional Noto Sans script families to include.
+				 *
+				 * Available scripts: arabic, armenian, bengali, chinese-simplified,
+				 * chinese-traditional, chinese-hongkong, devanagari, ethiopic,
+				 * georgian, gujarati, gurmukhi, hebrew, japanese, kannada, khmer,
+				 * korean, lao, malayalam, myanmar, oriya, sinhala, tamil, telugu,
+				 * thai, tibetan.
+				 */
+				scripts?: string[];
+		  };
 }
 
 /**

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -9,6 +9,7 @@ import "@emdash-cms/admin/styles.css";
 // Use package-qualified import so Astro generates a proper module URL
 // (relative imports resolve to absolute paths which break client hydration)
 import AdminWrapper from "emdash/routes/PluginRegistry";
+import { Font } from "astro:assets";
 
 export const prerender = false;
 
@@ -24,6 +25,7 @@ const messages = await loadMessages(resolvedLocale);
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<Font cssVariable="--font-emdash" />
 		<link
 			rel="icon"
 			href="data:image/svg+xml,<svg width='75' height='75' viewBox='0 0 75 75' fill='none' xmlns='http://www.w3.org/2000/svg'> <g clip-path='url(%23clip0_50_99)'> <rect x='3' y='3' width='69' height='69' rx='10.518' stroke='url(%23paint0_linear_50_99)' stroke-width='6'/> <rect x='18' y='34' width='39.3661' height='6.56101' fill='url(%23paint1_linear_50_99)'/> </g> <defs> <linearGradient id='paint0_linear_50_99' x1='-42.9996' y1='124' x2='92.4233' y2='-41.7456' gradientUnits='userSpaceOnUse'> <stop stop-color='%230F006B'/> <stop offset='0.0833333' stop-color='%23281A81'/> <stop offset='0.166667' stop-color='%235D0C83'/> <stop offset='0.25' stop-color='%23911475'/> <stop offset='0.333333' stop-color='%23CE2F55'/> <stop offset='0.416667' stop-color='%23FF6633'/> <stop offset='0.5' stop-color='%23F6821F'/> <stop offset='0.583333' stop-color='%23FBAD41'/> <stop offset='0.666667' stop-color='%23FFCD89'/> <stop offset='0.75' stop-color='%23FFE9CB'/> <stop offset='0.833333' stop-color='%23FFF7EC'/> <stop offset='0.916667' stop-color='%23FFF8EE'/> <stop offset='1' stop-color='white'/> </linearGradient> <linearGradient id='paint1_linear_50_99' x1='91.4992' y1='27.4982' x2='28.1217' y2='54.1775' gradientUnits='userSpaceOnUse'> <stop stop-color='white'/> <stop offset='0.129253' stop-color='%23FFF8EE'/> <stop offset='0.617058' stop-color='%23FBAD41'/> <stop offset='0.848019' stop-color='%23F6821F'/> <stop offset='1' stop-color='%23FF6633'/> </linearGradient> <clipPath id='clip0_50_99'> <rect width='75' height='75' fill='white'/> </clipPath> </defs> </svg>"
@@ -63,10 +65,12 @@ const messages = await loadMessages(resolvedLocale);
 					}
 					#emdash-boot-loader p {
 						margin-top: 1rem;
-						font-family:
+						font-family: var(
+							--font-emdash,
+							ui-sans-serif,
 							system-ui,
-							-apple-system,
-							sans-serif;
+							sans-serif
+						);
 						font-size: 0.875rem;
 						color: light-dark(hsl(215.4 16.3% 46.9%), hsl(215 20.2% 65.1%));
 					}


### PR DESCRIPTION
## What does this PR do?

Adds Noto Sans as the default font for the admin UI, loaded via the Astro Font API. Fonts are downloaded from Google at build time and self-hosted, so there are no runtime CDN requests. Users can add additional writing systems (Arabic, CJK, Hebrew, etc.) via a simple config option.

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

## How it works

- A custom Astro font provider (`font-provider.ts`) wraps the Google provider to resolve multiple Noto Sans script families under a single `font-family` name. This is needed because Astro's Font API warns and overwrites when different font names share a cssVariable. The custom provider merges all faces so they stack via `unicode-range`.
- The integration injects Noto Sans with all its native subsets (Latin, Cyrillic, Greek, Devanagari, Vietnamese) via `updateConfig` in `astro:config:setup`.
- The admin CSS overrides Tailwind's `--font-sans` to use `var(--font-emdash, <system fallback>)`.
- The `<Font cssVariable="--font-emdash" />` component is added to the admin route head (without `preload` to avoid downloading all subsets eagerly).

## User-facing API

```ts
// Default: Noto Sans with Latin, Cyrillic, Greek, Devanagari, Vietnamese
emdash()

// Add Arabic
emdash({ fonts: { scripts: ["arabic"] } })

// Add multiple scripts
emdash({ fonts: { scripts: ["arabic", "japanese", "korean"] } })

// System fonts only
emdash({ fonts: false })
```

25 scripts available: arabic, armenian, bengali, chinese-simplified, chinese-traditional, chinese-hongkong, devanagari, ethiopic, georgian, gujarati, gurmukhi, hebrew, japanese, kannada, khmer, korean, lao, malayalam, myanmar, oriya, sinhala, tamil, telugu, thai, tibetan.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/588

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

All 2375 core tests, 549 admin tests, and all other package tests pass.