### PR TITLE
fix(admin): unblock the saving of Content Types settings

### DIFF
--- a/.changeset/spotty-rockets-hunt.md
+++ b/.changeset/spotty-rockets-hunt.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the Save Changes button on the Content Type editor failing silently with a 400 error

--- a/e2e/tests/content-types.spec.ts
+++ b/e2e/tests/content-types.spec.ts
@@ -110,6 +110,41 @@ test.describe("Content Types", () => {
 		});
 	});
 
+	test.describe("Save Content Type Settings", () => {
+		test("toggling a feature and saving persists across reloads", async ({ admin }) => {
+			await admin.goto("/content-types/posts");
+			await admin.waitForShell();
+			await admin.waitForLoading();
+
+			const toggleLabel = admin.page.locator("label", { hasText: "Enable comments" });
+			const saveButton = admin.page.getByRole("button", { name: "Save Changes" });
+
+			// On initial load there are no unsaved changes
+			await expect(saveButton).toBeDisabled();
+
+			// Flip the toggle -- Save should enable
+			await toggleLabel.click();
+			await expect(saveButton).toBeEnabled();
+
+			// Save: the PUT must return 200 and no failure toast should render
+			const savePut = admin.page.waitForResponse(
+				(res) =>
+					res.url().includes("/api/schema/collections/posts") && res.request().method() === "PUT",
+				{ timeout: 10000 },
+			);
+			await saveButton.click();
+			expect((await savePut).status()).toBe(200);
+			await expect(admin.page.getByText("Failed to save")).not.toBeVisible();
+
+			// Reload -- the saved change is reflected server-side, so the editor
+			// loads with no unsaved diff
+			await admin.page.reload();
+			await admin.waitForShell();
+			await admin.waitForLoading();
+			await expect(saveButton).toBeDisabled();
+		});
+	});
+
 	test.describe("Create Content Type", () => {
 		test("creates a new content type and redirects to editor", async ({ admin }) => {
 			await admin.goto("/content-types/new");

--- a/e2e/tests/content-types.spec.ts
+++ b/e2e/tests/content-types.spec.ts
@@ -142,6 +142,23 @@ test.describe("Content Types", () => {
 			await admin.waitForShell();
 			await admin.waitForLoading();
 			await expect(saveButton).toBeDisabled();
+
+			// Restore the original toggle state so the shared DB used by other E2E
+			// tests (e.g. comments.spec.ts) isn't left with commentsEnabled flipped.
+			await toggleLabel.click();
+			await expect(saveButton).toBeEnabled();
+			const restorePut = admin.page.waitForResponse(
+				(res) =>
+					res.url().includes("/api/schema/collections/posts") && res.request().method() === "PUT",
+				{ timeout: 10000 },
+			);
+			await saveButton.click();
+			expect((await restorePut).status()).toBe(200);
+			await expect(admin.page.getByText("Failed to save")).not.toBeVisible();
+			await admin.page.reload();
+			await admin.waitForShell();
+			await admin.waitForLoading();
+			await expect(saveButton).toBeDisabled();
 		});
 	});
 

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -158,7 +158,11 @@ export function ContentTypeEditor({
 	const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? "");
 	const [description, setDescription] = React.useState(collection?.description ?? "");
 	const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? "");
-	const [supports, setSupports] = React.useState<string[]>(collection?.supports ?? ["drafts"]);
+	// SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry
+	// so it isn't sent back on save (the API enum rejects it).
+	const [supports, setSupports] = React.useState<string[]>(
+		(collection?.supports ?? ["drafts"]).filter((s) => s !== "seo"),
+	);
 
 	// SEO state
 	const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false);
@@ -195,7 +199,7 @@ export function ContentTypeEditor({
 			description !== (collection.description ?? "") ||
 			urlPattern !== (collection.urlPattern ?? "") ||
 			JSON.stringify([...supports].toSorted()) !==
-				JSON.stringify([...collection.supports].toSorted()) ||
+				JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) ||
 			hasSeo !== collection.hasSeo ||
 			commentsEnabled !== collection.commentsEnabled ||
 			commentsModeration !== collection.commentsModeration ||

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Loader, Toast } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
 import type { QueryClient } from "@tanstack/react-query";
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -1486,6 +1487,7 @@ function ContentTypesEditPage() {
 	const { slug } = useParams({ from: "/_admin/content-types/$slug" });
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
+	const { t } = useLingui();
 
 	const {
 		data: collection,
@@ -1528,8 +1530,8 @@ function ContentTypesEditPage() {
 		},
 		onError: (mutationError) => {
 			toastManager.add({
-				title: "Failed to save",
-				description: mutationError instanceof Error ? mutationError.message : "An error occurred",
+				title: t`Failed to save`,
+				description: mutationError instanceof Error ? mutationError.message : t`An error occurred`,
 				type: "error",
 			});
 		},

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1485,6 +1485,7 @@ const contentTypesEditRoute = createRoute({
 function ContentTypesEditPage() {
 	const { slug } = useParams({ from: "/_admin/content-types/$slug" });
 	const queryClient = useQueryClient();
+	const toastManager = Toast.useToastManager();
 
 	const {
 		data: collection,
@@ -1524,6 +1525,13 @@ function ContentTypesEditPage() {
 			});
 			void queryClient.invalidateQueries({ queryKey: ["schema", "collections"] });
 			void queryClient.invalidateQueries({ queryKey: ["manifest"] });
+		},
+		onError: (mutationError) => {
+			toastManager.add({
+				title: "Failed to save",
+				description: mutationError instanceof Error ? mutationError.message : "An error occurred",
+				type: "error",
+			});
 		},
 	});
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
Fixes the "Save Changes" button on the Content Type editor failing silently with a 400 error.

This bug affects saving any setting on the Content Type editor (label, description, URL pattern, features, SEO toggle, comments settings), and not just changes to "Enable comments" checkbox.

Closes #98 

### The cause
When we attempt to save the settings of a collection whose `supports` array contains "seo" (seeded into the DB by the demo seed.json files), the API's enum rejects it, because "seo" is not in the [allowed list](https://github.com/emdash-cms/emdash/blob/9295cc199f72c9b9adff236e4a72ba412604493f/packages/core/src/api/schemas/schema.ts#L9). 400 response is returned, and the admin UI silently fails. The save button appears to do nothing.

https://github.com/user-attachments/assets/9084c267-a2b8-4975-b1a7-0e187e48c602

### The fix
I have stripped "seo" out of the supports array, so the Save payload no longer contains the value.

For a more permanent fix, if "seo" is no longer a supported value (since we are now using `hasSeo`), we might want to remove "seo" from the supports column on every row of the `_emdash_collections` table with a one-time migration, and then from the demo seed files too.

I would love to get your opinion on this @MattieTK and @ascorbic.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

https://github.com/user-attachments/assets/fb961633-b14e-4ae0-ac1e-ed51d88e95c7

<!-- Optional. Include if the change is visual or if you want to show test results. -->
