### PR TITLE
fix: route anonymous D1 reads through a session so replicas get used

### DIFF
--- a/.changeset/d1-session-anonymous-reads.md
+++ b/.changeset/d1-session-anonymous-reads.md
@@ -1,0 +1,18 @@
+---
+"emdash": patch
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes D1 read replicas being bypassed for anonymous public page traffic. The middleware fast path now asks the database adapter for a per-request scoped Kysely, so anonymous reads land on the nearest replica instead of the primary-pinned singleton binding.
+
+All D1-specific semantics (Sessions API, constraint selection, bookmark cookie) live in `@emdash-cms/cloudflare/db/d1` behind a single `createRequestScopedDb(opts)` function. Core middleware has no D1-specific logic. Adapters opt in via a new `supportsRequestScope: boolean` flag on `DatabaseDescriptor`; `d1()` sets it to true.
+
+Other fixes in the same change:
+
+- Nested `runWithContext` calls in the request-context middleware now merge the parent context instead of replacing it, so an outer per-request db override is preserved through edit/preview flows.
+- Baseline security headers now forward Astro's cookie symbol across the response clone so `cookies.set()` calls in middleware survive.
+- Any write (authenticated or anonymous) now forces `first-primary`, so an anonymous form/comment POST isn't racing across replicas.
+- The session user is read once per request and reused in both the fast path and the full runtime init (previously read twice on authenticated public-page traffic).
+- Bookmark cookies are validated only for length (≤1024) and absence of control characters — no stricter shape check, so a future D1 bookmark format change won't silently degrade consistency.
+- The `!config` bail-out now still applies baseline security headers.
+- `__ec_d1_bookmark` references aligned to `__em_d1_bookmark` across runtime, docs, and JSDoc.

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 | ---------------- | -------- | -------------------- | ------------------------------------- |
 | `binding`        | `string` | —                    | D1 binding name from `wrangler.jsonc` |
 | `session`        | `string` | `"disabled"`         | Read replication mode (see below)     |
-| `bookmarkCookie` | `string` | `"__ec_d1_bookmark"` | Cookie name for session bookmarks     |
+| `bookmarkCookie` | `string` | `"__em_d1_bookmark"` | Cookie name for session bookmarks     |
 
 ### Setup
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -364,7 +364,7 @@ Cloudflare D1 database. Import from `@emdash-cms/cloudflare`.
 | ---------------- | -------- | -------------------- | --------------------------------------------------- |
 | `binding`        | `string` | —                    | D1 binding name from `wrangler.jsonc`               |
 | `session`        | `string` | `"disabled"`         | Read replication mode: `"disabled"`, `"auto"`, or `"primary-first"` |
-| `bookmarkCookie` | `string` | `"__ec_d1_bookmark"` | Cookie name for session bookmarks                   |
+| `bookmarkCookie` | `string` | `"__em_d1_bookmark"` | Cookie name for session bookmarks                   |
 
 ```js
 // Basic

--- a/infra/demo-blog/wrangler.jsonc
+++ b/infra/demo-blog/wrangler.jsonc
@@ -6,15 +6,13 @@
 	"name": "emdash-demo-blog",
 	"main": "./src/worker.ts",
 	"compatibility_date": "2026-02-24",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
+	"compatibility_flags": ["nodejs_compat"],
 	"routes": [
 		{
 			"pattern": "blog-demo.emdashcms.com",
 			"zone_name": "emdashcms.com",
-			"custom_domain": true
-		}
+			"custom_domain": true,
+		},
 	],
 	"d1_databases": [
 		{
@@ -38,7 +36,7 @@
 	"kv_namespaces": [
 		{
 			"binding": "SESSION",
-			"id": "045dd0600977420992277da020ae2df3"
-		}
-	]
+			"id": "045dd0600977420992277da020ae2df3",
+		},
+	],
 }

--- a/packages/cloudflare/src/cache/runtime.ts
+++ b/packages/cloudflare/src/cache/runtime.ts
@@ -42,7 +42,7 @@ const SWR_REGEX = /stale-while-revalidate=(\d+)/;
 const INTERNAL_HEADERS = [STORED_AT_HEADER, MAX_AGE_HEADER, SWR_HEADER];
 
 /** Default D1 bookmark cookie name (from @emdash-cms/cloudflare d1 config) */
-const DEFAULT_BOOKMARK_COOKIE = "__ec_d1_bookmark";
+const DEFAULT_BOOKMARK_COOKIE = "__em_d1_bookmark";
 
 export interface CloudflareCacheConfig {
 	/**
@@ -55,7 +55,7 @@ export interface CloudflareCacheConfig {
 	 * D1 bookmark cookie name. Responses whose only Set-Cookie is this
 	 * bookmark will have it stripped before caching. Responses with any
 	 * other Set-Cookie headers will not be cached.
-	 * @default "__ec_d1_bookmark"
+	 * @default "__em_d1_bookmark"
 	 */
 	bookmarkCookie?: string;
 

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -1,15 +1,15 @@
 /**
  * Cloudflare D1 runtime adapter - RUNTIME ENTRY
  *
- * Creates a Kysely dialect for D1.
- * Loaded at runtime via virtual module when database queries are needed.
+ * Creates a Kysely dialect for D1 and, when read replication is enabled,
+ * a per-request Kysely bound to a D1 Sessions-API session.
  *
  * This module imports directly from cloudflare:workers to access the D1 binding.
  * Do NOT import this at config time - use { d1 } from "@emdash-cms/cloudflare" instead.
  */
 
 import { env } from "cloudflare:workers";
-import type { DatabaseIntrospector, Dialect, Kysely } from "kysely";
+import { type DatabaseIntrospector, type Dialect, Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
 
 import { D1Introspector } from "./d1-introspector.js";
@@ -21,6 +21,27 @@ interface D1Config {
 	binding: string;
 	session?: "disabled" | "auto" | "primary-first";
 	bookmarkCookie?: string;
+}
+
+const DEFAULT_BOOKMARK_COOKIE = "__em_d1_bookmark";
+
+/**
+ * D1 bookmarks are opaque, minted by Cloudflare. We don't validate the shape
+ * (a tighter regex risks rejecting a format change and silently degrading
+ * read-your-writes), but we do cap length and reject control characters so a
+ * malicious or corrupt cookie can't smuggle anything weird into `withSession`.
+ */
+// D1 bookmarks observed in the wild are ~60 chars, but the format is opaque
+// and future encodings (e.g. signed envelopes) could be longer. Err on the
+// generous side — cookie values max out at ~4 KB anyway.
+const MAX_BOOKMARK_LENGTH = 1024;
+
+function hasControlChars(value: string): boolean {
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i);
+		if (code < 0x20 || code === 0x7f) return true;
+	}
+	return false;
 }
 
 /**
@@ -36,77 +57,136 @@ class EmDashD1Dialect extends D1Dialect {
 }
 
 /**
- * Create a D1 dialect from config
- *
- * @param config - D1 configuration with binding name
+ * Create a D1 dialect from config. Used for the singleton Kysely instance
+ * (no session — queries go through the raw binding).
  */
 export function createDialect(config: D1Config): Dialect {
-	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Worker binding accessed from untyped env object
-	const db = (env as Record<string, unknown>)[config.binding];
-
+	const db = getBinding(config);
 	if (!db) {
+		const example = JSON.stringify(
+			{
+				d1_databases: [
+					{
+						binding: config.binding,
+						database_name: "your-database-name",
+						database_id: "your-database-id",
+					},
+				],
+			},
+			null,
+			2,
+		);
 		throw new Error(
 			`D1 binding "${config.binding}" not found in environment. ` +
-				`Check your wrangler.toml configuration:\n\n` +
-				`[[d1_databases]]\n` +
-				`binding = "${config.binding}"\n` +
-				`database_name = "your-database-name"\n` +
-				`database_id = "your-database-id"`,
+				`Check your wrangler.jsonc configuration:\n\n${example}`,
 		);
 	}
-
-	// Use our custom dialect with D1-compatible introspector
-	// db is unknown from env access; D1Dialect expects D1Database
-	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- D1Database binding from untyped env object
-	return new EmDashD1Dialect({ database: db as D1Database });
+	return new EmDashD1Dialect({ database: db });
 }
 
 // =========================================================================
-// D1 Read Replica Session Helpers
+// D1 Read Replica Session Support
 //
-// These are exported through virtual:emdash/dialect so the middleware
-// can create per-request D1 sessions without importing cloudflare:workers.
+// createRequestScopedDb is called by the core middleware on each request.
+// When sessions are enabled it returns a per-request Kysely bound to a
+// D1 Sessions API session, plus a `commit()` callback that persists the
+// resulting bookmark as a cookie for authenticated users.
 // =========================================================================
 
 /**
- * Whether D1 sessions are enabled in the config.
+ * A cookie interface minimally compatible with Astro's AstroCookies. Declared
+ * here (not imported from astro) so this module stays free of astro types.
  */
-export function isSessionEnabled(config: D1Config): boolean {
+interface CookieJar {
+	get(name: string): { value: string } | undefined;
+	set(name: string, value: string, options: Record<string, unknown>): void;
+}
+
+export interface RequestScopedDbOpts {
+	config: D1Config;
+	isAuthenticated: boolean;
+	isWrite: boolean;
+	cookies: CookieJar;
+	url: URL;
+}
+
+export interface RequestScopedDb {
+	/** Per-request Kysely instance backed by a D1 Sessions API session. */
+	db: Kysely<any>;
+	/**
+	 * Persist any per-request session state (e.g. the resulting D1 bookmark)
+	 * as a cookie. Idempotent; safe to call once after next() returns.
+	 */
+	commit: () => void;
+}
+
+/**
+ * Create a per-request session-backed Kysely, or null when D1 sessions are
+ * disabled or the binding is missing. Core middleware calls this once per
+ * request, stashes `db` in ALS for the duration of next(), then invokes
+ * `commit()` on the response path.
+ */
+export function createRequestScopedDb(opts: RequestScopedDbOpts): RequestScopedDb | null {
+	if (!isSessionEnabled(opts.config)) return null;
+	const binding = getBinding(opts.config);
+	if (!binding || typeof binding.withSession !== "function") return null;
+
+	const cookieName = opts.config.bookmarkCookie ?? DEFAULT_BOOKMARK_COOKIE;
+	const configConstraint =
+		opts.config.session === "primary-first" ? "first-primary" : "first-unconstrained";
+
+	// Any write — authenticated or not (e.g. an anonymous comment POST) — must
+	// hit primary; we don't want a write plus a follow-up read racing across
+	// replicas. Authenticated reads resume from a prior bookmark when the client
+	// sent a valid one. Everything else (anonymous reads — the whole point of
+	// read replicas) uses the config default, typically "first-unconstrained"
+	// for nearest-replica routing.
+	let constraint: string = configConstraint;
+	if (opts.isWrite) {
+		constraint = "first-primary";
+	} else if (opts.isAuthenticated) {
+		const bookmark = opts.cookies.get(cookieName)?.value;
+		if (
+			bookmark &&
+			bookmark.length > 0 &&
+			bookmark.length <= MAX_BOOKMARK_LENGTH &&
+			!hasControlChars(bookmark)
+		) {
+			constraint = bookmark;
+		}
+	}
+
+	const session = binding.withSession(constraint);
+	// kysely-d1 only touches .prepare() and .batch() on the database argument,
+	// both of which D1DatabaseSession implements.
+	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- session is structurally compatible with the subset D1Dialect uses
+	const sessionAsDatabase = session as unknown as D1Database;
+	const db = new Kysely<any>({ dialect: new EmDashD1Dialect({ database: sessionAsDatabase }) });
+
+	return {
+		db,
+		commit() {
+			// Anonymous sessions can't resume across requests, so there's no
+			// value in persisting a bookmark for them.
+			if (!opts.isAuthenticated) return;
+			const newBookmark = session.getBookmark?.();
+			if (!newBookmark) return;
+			opts.cookies.set(cookieName, newBookmark, {
+				path: "/",
+				httpOnly: true,
+				sameSite: "lax",
+				secure: opts.url.protocol === "https:",
+			});
+		},
+	};
+}
+
+function isSessionEnabled(config: D1Config): boolean {
 	return !!config.session && config.session !== "disabled";
 }
 
-/**
- * Get the raw D1 binding for creating sessions.
- * Returns null if sessions are disabled.
- */
-export function getD1Binding(config: D1Config): D1Database | null {
-	if (!isSessionEnabled(config)) return null;
+function getBinding(config: D1Config): D1Database | null {
 	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Worker binding accessed from untyped env object
 	const db = (env as Record<string, unknown>)[config.binding] as D1Database | undefined;
 	return db ?? null;
-}
-
-/**
- * Get the default session constraint for the config's session mode.
- */
-export function getDefaultConstraint(config: D1Config): string {
-	if (config.session === "primary-first") return "first-primary";
-	return "first-unconstrained";
-}
-
-/**
- * Get the cookie name used for storing D1 session bookmarks.
- */
-export function getBookmarkCookieName(config: D1Config): string {
-	return config.bookmarkCookie ?? "__ec_d1_bookmark";
-}
-
-/**
- * Create a Kysely dialect from a D1 session object.
- *
- * D1DatabaseSession has the same `prepare()` / `batch()` interface
- * as D1Database, so we pass it directly to D1Dialect.
- */
-export function createSessionDialect(session: D1Database): Dialect {
-	return new EmDashD1Dialect({ database: session });
 }

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -67,7 +67,7 @@ export interface D1Config {
 	 * Cookie name for storing the session bookmark.
 	 * Only used when session is `"auto"` or `"primary-first"`.
 	 *
-	 * @default "__ec_d1_bookmark"
+	 * @default "__em_d1_bookmark"
 	 */
 	bookmarkCookie?: string;
 }
@@ -163,6 +163,7 @@ export function d1(config: D1Config): DatabaseDescriptor {
 		entrypoint: "@emdash-cms/cloudflare/db/d1",
 		config,
 		type: "sqlite",
+		supportsRequestScope: true,
 	};
 }
 

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -65,62 +65,42 @@ export function generateConfigModule(serializableConfig: Record<string, unknown>
 
 /**
  * Generates the dialect virtual module.
- * Statically imports the configured database dialect and exports the dialect type.
  *
- * For D1 adapters, also re-exports session helpers (isSessionEnabled, getD1Binding,
- * getDefaultConstraint, getBookmarkCookieName, createSessionDialect) used by
- * middleware for per-request read replica sessions.
- *
- * For non-D1 adapters, session exports are no-ops.
+ * Adapters that set `supportsRequestScope: true` on their descriptor are
+ * expected to export `createRequestScopedDb` from their runtime entrypoint;
+ * the generator re-exports it so middleware can ask for a per-request Kysely
+ * (used for D1 Sessions API, bookmark cookies, read-replica routing). Other
+ * adapters get a stub that returns null.
  */
-export function generateDialectModule(
-	dbEntrypoint?: string,
-	dbType?: string,
-	dbConfig?: unknown,
-): string {
-	if (!dbEntrypoint) {
+export function generateDialectModule(opts: {
+	entrypoint?: string;
+	type?: string;
+	supportsRequestScope: boolean;
+}): string {
+	const { entrypoint, supportsRequestScope } = opts;
+	if (!entrypoint) {
 		return [
 			`export const createDialect = undefined;`,
 			`export const dialectType = "sqlite";`,
-			`export const isSessionEnabled = () => false;`,
-			`export const getD1Binding = () => null;`,
-			`export const getDefaultConstraint = () => "first-unconstrained";`,
-			`export const getBookmarkCookieName = () => "";`,
-			`export const createSessionDialect = undefined;`,
+			`export const createRequestScopedDb = (_opts) => null;`,
 		].join("\n");
 	}
-	const type = dbType ?? "sqlite";
+	const type = opts.type ?? "sqlite";
 
-	// Check if the adapter is D1 (has session helpers)
-	const isD1 = dbEntrypoint.includes("cloudflare") && dbEntrypoint.includes("d1");
-
-	// Check if sessions are enabled in the config
-	const sessionMode =
-		isD1 && dbConfig && typeof dbConfig === "object" && "session" in dbConfig
-			? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- runtime-checked above
-				(dbConfig as { session?: string }).session
-			: undefined;
-	const sessionEnabled = !!sessionMode && sessionMode !== "disabled";
-
-	if (isD1 && sessionEnabled) {
+	if (supportsRequestScope) {
 		return `
-import { createDialect as _createDialect } from "${dbEntrypoint}";
-export { isSessionEnabled, getD1Binding, getDefaultConstraint, getBookmarkCookieName, createSessionDialect } from "${dbEntrypoint}";
+import { createDialect as _createDialect } from "${entrypoint}";
+export { createRequestScopedDb } from "${entrypoint}";
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
 `;
 	}
 
-	// Non-D1 or sessions disabled: export no-ops
 	return `
-import { createDialect as _createDialect } from "${dbEntrypoint}";
+import { createDialect as _createDialect } from "${entrypoint}";
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
-export const isSessionEnabled = () => false;
-export const getD1Binding = () => null;
-export const getDefaultConstraint = () => "first-unconstrained";
-export const getBookmarkCookieName = () => "";
-export const createSessionDialect = undefined;
+export const createRequestScopedDb = (_opts) => null;
 `;
 }
 

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -184,11 +184,11 @@ export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 			// Generate a module that statically imports the configured dialect
 			// This allows Vite to properly resolve and bundle it
 			if (id === RESOLVED_VIRTUAL_DIALECT_ID) {
-				return generateDialectModule(
-					resolvedConfig.database?.entrypoint,
-					resolvedConfig.database?.type,
-					resolvedConfig.database?.config,
-				);
+				return generateDialectModule({
+					entrypoint: resolvedConfig.database?.entrypoint,
+					type: resolvedConfig.database?.type,
+					supportsRequestScope: resolvedConfig.database?.supportsRequestScope ?? false,
+				});
 			}
 			// Generate a module that statically imports the configured storage
 			if (id === RESOLVED_VIRTUAL_STORAGE_ID) {

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -6,19 +6,16 @@
  */
 
 import { defineMiddleware } from "astro:middleware";
-import { Kysely } from "kysely";
+import type { Kysely } from "kysely";
 // Import from virtual modules (populated by integration at build time)
 // @ts-ignore - virtual module
 import virtualConfig from "virtual:emdash/config";
 // @ts-ignore - virtual module
 import {
 	createDialect as virtualCreateDialect,
-	isSessionEnabled as virtualIsSessionEnabled,
-	getD1Binding as virtualGetD1Binding,
-	getDefaultConstraint as virtualGetDefaultConstraint,
-	getBookmarkCookieName as virtualGetBookmarkCookieName,
-	createSessionDialect as virtualCreateSessionDialect,
+	createRequestScopedDb as virtualCreateRequestScopedDb,
 } from "virtual:emdash/dialect";
+import type { RequestScopedDbOpts } from "virtual:emdash/dialect";
 // @ts-ignore - virtual module
 import { mediaProviders as virtualMediaProviders } from "virtual:emdash/media-providers";
 // @ts-ignore - virtual module
@@ -43,7 +40,7 @@ import { setI18nConfig } from "../i18n/config.js";
 import type { Database, Storage } from "../index.js";
 import type { SandboxRunner } from "../plugins/sandbox/types.js";
 import type { ResolvedPlugin } from "../plugins/types.js";
-import { runWithContext } from "../request-context.js";
+import { getRequestContext, runWithContext } from "../request-context.js";
 import type { EmDashConfig } from "./integration/runtime.js";
 import type { EmDashHandlers } from "./types.js";
 
@@ -157,11 +154,23 @@ async function getRuntime(config: EmDashConfig): Promise<EmDashRuntime> {
 }
 
 /**
+ * Astro attaches AstroCookies to outgoing responses via a well-known global
+ * symbol. Cloning a Response (`new Response(body, init)`) drops non-header
+ * metadata, so any middleware that wraps the response must explicitly forward
+ * this symbol or `cookies.set()` calls will be silently dropped.
+ */
+const ASTRO_COOKIES_SYMBOL = Symbol.for("astro.cookies");
+
+/**
  * Baseline security headers applied to all responses.
  * Admin routes get additional headers (strict CSP) from auth middleware.
  */
 function setBaselineSecurityHeaders(response: Response): Response {
 	const res = new Response(response.body, response);
+	const astroCookies = Reflect.get(response, ASTRO_COOKIES_SYMBOL);
+	if (astroCookies !== undefined) {
+		Reflect.set(res, ASTRO_COOKIES_SYMBOL, astroCookies);
+	}
 	res.headers.set("X-Content-Type-Options", "nosniff");
 	res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 	res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
@@ -174,6 +183,23 @@ function setBaselineSecurityHeaders(response: Response): Response {
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */
 const PUBLIC_RUNTIME_ROUTES = new Set(["/sitemap.xml", "/robots.txt"]);
 const SITEMAP_COLLECTION_RE = /^\/sitemap-[a-z][a-z0-9_]*\.xml$/;
+
+/**
+ * Ask the configured database adapter for a per-request scoped Kysely. The
+ * adapter encapsulates any per-request semantics (D1 sessions, read-replica
+ * routing, bookmark cookies, etc.); core just forwards the cookie jar and
+ * request flags and wraps next() in ALS if a scope was returned.
+ */
+function createRequestScopedDb(
+	opts: RequestScopedDbOpts,
+): { db: Kysely<Database>; commit: () => void } | null {
+	if (typeof virtualCreateRequestScopedDb !== "function") return null;
+	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- adapter returns Kysely<unknown>; cast to Database since core owns that type
+	const fn = virtualCreateRequestScopedDb as (
+		o: RequestScopedDbOpts,
+	) => { db: Kysely<Database>; commit: () => void } | null;
+	return fn(opts);
+}
 
 export const onRequest = defineMiddleware(async (context, next) => {
 	const { request, locals, cookies } = context;
@@ -195,8 +221,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// available to getDb() and the runtime's db getter via the correct ALS instance.
 	const playgroundDb = locals.__playgroundDb;
 
+	// Read the Astro session user once up-front. Both the anonymous fast path
+	// and the full doInit path need this, and the session store is network-backed
+	// (KV / Durable Object) so we want to avoid re-fetching on the hot path.
+	// Skipped entirely for prerendered requests — they have no session.
+	const sessionUser = context.isPrerendered ? null : await context.session?.get("user");
+
 	if (!isEmDashRoute && !isPublicRuntimeRoute && !hasEditCookie && !hasPreviewToken) {
-		const sessionUser = context.isPrerendered ? null : await context.session?.get("user");
 		if (!sessionUser && !playgroundDb) {
 			// On a fresh deployment the database may be completely empty.
 			// Public pages call getSiteSettings() / getMenu() via getDb(), which
@@ -239,15 +270,33 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				}
 			}
 
-			const response = await next();
-			return setBaselineSecurityHeaders(response);
+			// Even on the anonymous fast path we ask the adapter for a per-request
+			// scoped db. For D1 with read replication this routes anonymous reads
+			// to the nearest replica; for other adapters it's a no-op.
+			const anonScoped = createRequestScopedDb({
+				config: config?.database?.config,
+				isAuthenticated: false,
+				isWrite: request.method !== "GET" && request.method !== "HEAD",
+				cookies,
+				url,
+			});
+			const runAnon = async () => setBaselineSecurityHeaders(await next());
+			if (anonScoped) {
+				const parent = getRequestContext();
+				return runWithContext({ ...parent, db: anonScoped.db }, async () => {
+					const response = await runAnon();
+					anonScoped.commit();
+					return response;
+				});
+			}
+			return runAnon();
 		}
 	}
 
 	const config = getConfig();
 	if (!config) {
 		console.error("EmDash: No configuration found");
-		return next();
+		return setBaselineSecurityHeaders(await next());
 	}
 
 	// In playground mode, wrap the entire runtime init + request handling in
@@ -344,97 +393,25 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			console.error("EmDash middleware error:", error);
 		}
 
-		// =========================================================================
-		// D1 Read Replica Session Management
-		//
-		// When D1 sessions are enabled, we create a per-request D1 session and
-		// Kysely instance. The session is wrapped in ALS so `runtime.db` (a getter)
-		// picks up the per-request instance instead of the singleton.
-		//
-		// After the response, we extract the bookmark from the session and set
-		// it as a cookie for authenticated users (read-your-writes consistency).
-		// =========================================================================
-		const dbConfig = config?.database?.config;
-		const sessionEnabled =
-			dbConfig &&
-			typeof virtualIsSessionEnabled === "function" &&
-			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- virtual module functions are untyped
-			(virtualIsSessionEnabled as (config: unknown) => boolean)(dbConfig);
+		// Ask the adapter for a request-scoped db. When it returns one, we stash
+		// it in ALS so the runtime's db getter and loader's getDb() pick it up,
+		// then call commit() after next() so the adapter can persist any
+		// per-request state (e.g. a D1 bookmark cookie for read-your-writes).
+		const scoped = createRequestScopedDb({
+			config: config?.database?.config,
+			isAuthenticated: !!sessionUser,
+			isWrite: request.method !== "GET" && request.method !== "HEAD",
+			cookies: context.cookies,
+			url,
+		});
 
-		if (
-			sessionEnabled &&
-			typeof virtualGetD1Binding === "function" &&
-			virtualCreateSessionDialect
-		) {
-			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- virtual module functions are untyped
-			const d1Binding = (virtualGetD1Binding as (config: unknown) => unknown)(dbConfig);
-
-			if (d1Binding && typeof d1Binding === "object" && "withSession" in d1Binding) {
-				const isAuthenticated = context.isPrerendered
-					? false
-					: !!(await context.session?.get("user"));
-				const isWrite = request.method !== "GET" && request.method !== "HEAD";
-
-				// Determine session constraint:
-				// - Config says "primary-first" → always "first-primary"
-				// - Authenticated writes → "first-primary" (need to hit primary)
-				// - Authenticated reads with bookmark → resume from bookmark
-				// - Otherwise → "first-unconstrained" (nearest replica)
-				// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- virtual module functions are untyped
-				const configConstraint = (virtualGetDefaultConstraint as (config: unknown) => string)(
-					dbConfig,
-				);
-				// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- virtual module functions are untyped
-				const cookieName = (virtualGetBookmarkCookieName as (config: unknown) => string)(dbConfig);
-
-				let constraint: string = configConstraint;
-				if (isAuthenticated && isWrite) {
-					constraint = "first-primary";
-				} else if (isAuthenticated) {
-					const bookmarkCookie = context.cookies.get(cookieName);
-					if (bookmarkCookie?.value) {
-						constraint = bookmarkCookie.value;
-					}
-				}
-
-				// Create the D1 session and per-request Kysely instance.
-				// D1DatabaseSession has the same prepare()/batch() interface as D1Database,
-				// so createSessionDialect passes it straight to D1Dialect.
-				// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- D1 binding with Sessions API, checked via "withSession" in d1Binding above
-				const withSession = (d1Binding as { withSession: (c: string) => unknown }).withSession;
-				const session = withSession.call(d1Binding, constraint);
-				const sessionDialect =
-					// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- virtual module functions are untyped
-					(virtualCreateSessionDialect as (db: unknown) => import("kysely").Dialect)(session);
-				const sessionDb = new Kysely<Database>({ dialect: sessionDialect });
-
-				// Wrap the request in ALS with the per-request db
-				return runWithContext({ editMode: false, db: sessionDb }, async () => {
-					const response = setBaselineSecurityHeaders(await next());
-
-					// Set bookmark cookie for authenticated users only — they need
-					// read-your-writes consistency across requests. Anonymous visitors
-					// don't write, so they get "first-unconstrained" every time.
-					if (
-						isAuthenticated &&
-						session &&
-						typeof session === "object" &&
-						"getBookmark" in session
-					) {
-						// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- D1DatabaseSession with getBookmark()
-						const getBookmark = (session as { getBookmark: () => string | null }).getBookmark;
-						const newBookmark = getBookmark.call(session);
-						if (newBookmark) {
-							response.headers.append(
-								"Set-Cookie",
-								`${cookieName}=${newBookmark}; Path=/; HttpOnly; SameSite=Lax; Secure`,
-							);
-						}
-					}
-
-					return response;
-				});
-			}
+		if (scoped) {
+			const parent = getRequestContext();
+			return runWithContext({ ...parent, db: scoped.db }, async () => {
+				const response = setBaselineSecurityHeaders(await next());
+				scoped.commit();
+				return response;
+			});
 		}
 
 		const response = await next();

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -13,7 +13,7 @@
 import { defineMiddleware } from "astro:middleware";
 
 import { verifyPreviewToken, parseContentId } from "../../preview/tokens.js";
-import { runWithContext } from "../../request-context.js";
+import { getRequestContext, runWithContext } from "../../request-context.js";
 import { renderToolbar } from "../../visual-editing/toolbar.js";
 
 /**
@@ -90,7 +90,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	const needsContext = hasEditCookie || hasPreviewToken;
 
 	if (needsContext) {
-		return runWithContext({ editMode, preview, locale }, async () => {
+		// Merge with any outer ALS context (e.g. the per-request D1 session db
+		// set by the runtime middleware). `storage.run()` replaces the store
+		// wholesale, so without the spread the outer `db` would be lost and
+		// loaders would fall back to the singleton non-session dialect.
+		const parent = getRequestContext();
+		return runWithContext({ ...parent, editMode, preview, locale }, async () => {
 			let response = await next();
 
 			// Preview responses must not be cached -- draft content could leak past token expiry.

--- a/packages/core/src/db/adapters.ts
+++ b/packages/core/src/db/adapters.ts
@@ -33,6 +33,21 @@ export interface DatabaseDescriptor {
 	entrypoint: string;
 	config: unknown;
 	type: DatabaseDialectType;
+	/**
+	 * When true, the adapter's runtime entrypoint MUST export a named
+	 * `createRequestScopedDb` function matching the signature declared in
+	 * `virtual:emdash/dialect`. The virtual-module generator re-exports it
+	 * by name, so a missing export becomes a build-time bundler error.
+	 *
+	 * The function is called once per request and decides — based on its own
+	 * runtime config (e.g. whether the user opted into D1 sessions) — whether
+	 * to return a per-request Kysely or null. Use this for features like D1
+	 * read-replica sessions, bookmark cookies, or any per-request DB handle.
+	 *
+	 * When false or absent, the generator emits a stub that returns null and
+	 * the middleware takes its default (singleton) path.
+	 */
+	supportsRequestScope?: boolean;
 }
 
 export interface SqliteConfig {

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -21,7 +21,7 @@ declare module "virtual:emdash/config" {
 }
 
 declare module "virtual:emdash/dialect" {
-	import type { Dialect } from "kysely";
+	import type { Dialect, Kysely } from "kysely";
 
 	import type { DatabaseDialectType } from "./db/adapters.js";
 
@@ -29,15 +29,27 @@ declare module "virtual:emdash/dialect" {
 	export const createDialect: ((config: unknown) => Dialect) | undefined;
 	export const dialectType: DatabaseDialectType | undefined;
 
-	// D1 read replica session helpers (no-ops for non-D1 adapters).
-	// Types use `unknown` because the core package doesn't depend on
-	// @cloudflare/workers-types — the actual D1Database types are resolved
-	// at bundle time in the cloudflare adapter.
-	export const isSessionEnabled: (config: unknown) => boolean;
-	export const getD1Binding: (config: unknown) => unknown;
-	export const getDefaultConstraint: (config: unknown) => string;
-	export const getBookmarkCookieName: (config: unknown) => string;
-	export const createSessionDialect: ((database: unknown) => Dialect) | undefined;
+	/**
+	 * Adapter-owned per-request scoping. Returns null when the configured
+	 * adapter has no per-request semantics (non-D1, or D1 with sessions
+	 * disabled). Otherwise returns a request-scoped Kysely and a commit
+	 * callback to persist per-request state.
+	 */
+	export interface RequestScopedDbOpts {
+		config: unknown;
+		isAuthenticated: boolean;
+		isWrite: boolean;
+		cookies: {
+			get(name: string): { value: string } | undefined;
+			set(name: string, value: string, options: Record<string, unknown>): void;
+		};
+		url: URL;
+	}
+	export interface RequestScopedDb {
+		db: Kysely<unknown>;
+		commit: () => void;
+	}
+	export const createRequestScopedDb: (opts: RequestScopedDbOpts) => RequestScopedDb | null;
 }
 
 declare module "virtual:emdash/storage" {

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -26,9 +26,7 @@ describe("generateDialectModule", () => {
 			type: "sqlite",
 			supportsRequestScope: true,
 		});
-		expect(out).toContain(
-			`export { createRequestScopedDb } from "@emdash-cms/cloudflare/db/d1"`,
-		);
+		expect(out).toContain(`export { createRequestScopedDb } from "@emdash-cms/cloudflare/db/d1"`);
 		expect(out).not.toContain("= () => null");
 		expect(out).not.toContain("= (_opts) => null");
 	});

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { generateDialectModule } from "../../../../src/astro/integration/virtual-modules.js";
+
+describe("generateDialectModule", () => {
+	it("emits undefined createDialect and null stub when no entrypoint is configured", () => {
+		const out = generateDialectModule({ supportsRequestScope: false });
+		expect(out).toContain("export const createDialect = undefined");
+		expect(out).toContain("export const createRequestScopedDb = (_opts) => null");
+	});
+
+	it("emits a null stub for adapters that don't support request scoping", () => {
+		const out = generateDialectModule({
+			entrypoint: "some-adapter/dialect",
+			type: "sqlite",
+			supportsRequestScope: false,
+		});
+		expect(out).toContain(`import { createDialect as _createDialect } from "some-adapter/dialect"`);
+		expect(out).toContain("export const createRequestScopedDb = (_opts) => null");
+		expect(out).not.toContain(`export { createRequestScopedDb } from`);
+	});
+
+	it("re-exports createRequestScopedDb from the adapter when supportsRequestScope is true", () => {
+		const out = generateDialectModule({
+			entrypoint: "@emdash-cms/cloudflare/db/d1",
+			type: "sqlite",
+			supportsRequestScope: true,
+		});
+		expect(out).toContain(
+			`export { createRequestScopedDb } from "@emdash-cms/cloudflare/db/d1"`,
+		);
+		expect(out).not.toContain("= () => null");
+		expect(out).not.toContain("= (_opts) => null");
+	});
+
+	it("threads the dialect type through", () => {
+		const out = generateDialectModule({
+			entrypoint: "emdash/db/postgres",
+			type: "postgres",
+			supportsRequestScope: false,
+		});
+		expect(out).toContain(`export const dialectType = "postgres"`);
+	});
+});

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -1,14 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 
 vi.mock("astro:middleware", () => ({
 	defineMiddleware: (handler: unknown) => handler,
+}));
+
+// vi.mock factories are hoisted above normal `const` declarations; use
+// vi.hoisted so the marker object is available both to the mock factory and
+// to assertions below.
+const { DB_CONFIG_MARKER } = vi.hoisted(() => ({
+	DB_CONFIG_MARKER: { binding: "DB", session: "auto" },
 }));
 
 vi.mock(
 	"virtual:emdash/config",
 	() => ({
 		default: {
-			database: { config: {} },
+			database: { config: DB_CONFIG_MARKER },
 			auth: { mode: "none" },
 		},
 	}),
@@ -19,11 +26,7 @@ vi.mock(
 	"virtual:emdash/dialect",
 	() => ({
 		createDialect: vi.fn(),
-		isSessionEnabled: vi.fn().mockReturnValue(false),
-		getD1Binding: vi.fn(),
-		getDefaultConstraint: vi.fn().mockReturnValue("first-unconstrained"),
-		getBookmarkCookieName: vi.fn().mockReturnValue("emdash-bookmark"),
-		createSessionDialect: vi.fn(),
+		createRequestScopedDb: vi.fn().mockReturnValue(null),
 	}),
 	{ virtual: true },
 );
@@ -53,50 +56,45 @@ vi.mock("../../../src/loader.js", () => ({
 	})),
 }));
 
-import { createSessionDialect, getD1Binding, isSessionEnabled } from "virtual:emdash/dialect";
+import { createRequestScopedDb } from "virtual:emdash/dialect";
 
 import onRequest from "../../../src/astro/middleware.js";
+import { getRequestContext } from "../../../src/request-context.js";
 
 describe("astro middleware prerendered routes", () => {
-	it("does not access session on prerendered public runtime routes", async () => {
-		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-		try {
-			vi.mocked(isSessionEnabled).mockReturnValue(true);
-			vi.mocked(getD1Binding).mockReturnValue({
-				withSession: () => {
-					throw new Error("withSession reached");
-				},
-			});
-			vi.mocked(createSessionDialect).mockReturnValue(undefined as never);
-
-			const cookies = {
-				get: vi.fn(() => undefined),
-			};
-
-			const context: Record<string, unknown> = {
-				request: new Request("https://example.com/robots.txt"),
-				url: new URL("https://example.com/robots.txt"),
-				cookies,
-				locals: {},
-				redirect: vi.fn(),
-				isPrerendered: true,
-			};
-
-			Object.defineProperty(context, "session", {
-				get() {
-					throw new Error("session should not be accessed during prerender");
-				},
-			});
-
-			await expect(
-				onRequest(context as Parameters<typeof onRequest>[0], async () => new Response("ok")),
-			).rejects.toThrow("withSession reached");
-		} finally {
-			consoleErrorSpy.mockRestore();
-		}
+	beforeEach(() => {
+		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
 	});
 
-	it("does not access session when prerendering public pages", async () => {
+	it("does not access context.session on prerendered public runtime routes", async () => {
+		const cookies = {
+			get: vi.fn(() => undefined),
+		};
+
+		const context: Record<string, unknown> = {
+			request: new Request("https://example.com/robots.txt"),
+			url: new URL("https://example.com/robots.txt"),
+			cookies,
+			locals: {},
+			redirect: vi.fn(),
+			isPrerendered: true,
+		};
+
+		Object.defineProperty(context, "session", {
+			get() {
+				throw new Error("context.session should not be accessed during prerender");
+			},
+		});
+
+		const response = await onRequest(
+			context as Parameters<typeof onRequest>[0],
+			async () => new Response("ok"),
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("does not access context.session when prerendering public pages", async () => {
 		const cookies = {
 			get: vi.fn(() => undefined),
 		};
@@ -115,7 +113,7 @@ describe("astro middleware prerendered routes", () => {
 
 		Object.defineProperty(context, "session", {
 			get() {
-				throw new Error("session should not be accessed during prerender");
+				throw new Error("context.session should not be accessed during prerender");
 			},
 		});
 
@@ -126,5 +124,93 @@ describe("astro middleware prerendered routes", () => {
 
 		expect(response.status).toBe(200);
 		expect(redirect).not.toHaveBeenCalled();
+	});
+});
+
+describe("astro middleware request-scoped db", () => {
+	beforeEach(() => {
+		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+	});
+
+	it("asks the adapter for a scoped db on anonymous public pages and exposes it via ALS", async () => {
+		const commit = vi.fn();
+		const scopedDb = { _marker: "scoped" };
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: scopedDb as never,
+			commit,
+		});
+
+		const cookies = {
+			get: vi.fn(() => undefined),
+			set: vi.fn(),
+		};
+		const astroSession = {
+			get: vi.fn(async () => null),
+		};
+
+		const context: Record<string, unknown> = {
+			request: new Request("https://example.com/"),
+			url: new URL("https://example.com/"),
+			cookies,
+			locals: {},
+			redirect: vi.fn(),
+			isPrerendered: false,
+			session: astroSession,
+		};
+
+		let dbSeenByNext: unknown;
+		const response = await onRequest(context as Parameters<typeof onRequest>[0], async () => {
+			dbSeenByNext = getRequestContext()?.db;
+			return new Response("ok");
+		});
+
+		expect(response.status).toBe(200);
+		expect(createRequestScopedDb).toHaveBeenCalledTimes(1);
+		const opts = vi.mocked(createRequestScopedDb).mock.calls[0]?.[0];
+		// Opts shape matches the RequestScopedDbOpts contract declared in
+		// virtual-modules.d.ts. The `config` field name must match exactly —
+		// it's what the D1 adapter reads; a rename silently breaks D1 sessions.
+		expect(opts).toMatchObject({
+			config: DB_CONFIG_MARKER,
+			isAuthenticated: false,
+			isWrite: false,
+			cookies,
+		});
+		expect(dbSeenByNext).toBe(scopedDb);
+		expect(commit).toHaveBeenCalledTimes(1);
+		// ALS must be fully torn down after the middleware returns; otherwise
+		// a refactor to enterWith() could silently leak request state into
+		// other async work on the same worker.
+		expect(getRequestContext()).toBeUndefined();
+	});
+
+	it("forces isWrite true for POST requests on public pages", async () => {
+		const commit = vi.fn();
+		vi.mocked(createRequestScopedDb).mockReturnValue({
+			db: { _marker: "scoped" } as never,
+			commit,
+		});
+
+		const cookies = { get: vi.fn(() => undefined), set: vi.fn() };
+		const astroSession = { get: vi.fn(async () => null) };
+
+		const context: Record<string, unknown> = {
+			request: new Request("https://example.com/", { method: "POST" }),
+			url: new URL("https://example.com/"),
+			cookies,
+			locals: {},
+			redirect: vi.fn(),
+			isPrerendered: false,
+			session: astroSession,
+		};
+
+		await onRequest(context as Parameters<typeof onRequest>[0], async () => new Response("ok"));
+
+		const opts = vi.mocked(createRequestScopedDb).mock.calls[0]?.[0];
+		expect(opts).toMatchObject({
+			config: DB_CONFIG_MARKER,
+			isAuthenticated: false,
+			isWrite: true,
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Fixes D1 read replicas being bypassed for anonymous public page traffic — the dominant read path on most sites.

The middleware's anonymous fast path returned before ever reaching the D1 Sessions API block, so `withSession()` was never called for anonymous visitors. Queries went through the singleton D1 binding, which has no session semantics — no replica routing, no bookmark tracking. The feature only worked for authenticated admin traffic.

The middleware now asks the configured database adapter for a per-request scoped Kysely on both the anonymous fast path and the full runtime-init path, and wraps `next()` in ALS so `getDb()` and `runtime.db` pick up the scoped instance.

All D1-specific semantics (Sessions API, constraint selection, bookmark cookie) live in `@emdash-cms/cloudflare/db/d1` behind a single `createRequestScopedDb(opts)` function. Core has no D1 knowledge. Adapters opt in with a new `supportsRequestScope` flag on `DatabaseDescriptor`; `d1()` sets it to true.

Also in this change (caught across seven rounds of adversarial review):

- Nested `runWithContext` in the request-context middleware now merges the parent context. Previously it replaced wholesale, so an outer per-request db override was dropped on edit/preview flows.
- Baseline security headers forward Astro's cookie symbol across the response clone so `cookies.set()` calls in middleware survive.
- Any write (authenticated or anonymous) forces `first-primary` — an anonymous form POST shouldn't race against replicas.
- Session user is read once per request and reused, not read twice on authenticated public-page traffic.
- Bookmark cookie validation relaxed to length-cap (≤1024) + control-char rejection, so a future D1 bookmark format change won't silently degrade consistency.
- `!config` bail-out now still applies baseline security headers.
- `__ec_d1_bookmark` references aligned to `__em_d1_bookmark` across runtime, JSDoc, and docs.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics in touched files)
- [x] `pnpm test` passes (1762 core + 127 cloudflare)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no UI changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

New tests:

- `packages/core/tests/unit/astro/middleware-prerender.test.ts` — asserts the adapter is called with the correct opts shape (regression test for a rename-the-field bug caught by review), asserts the scoped db reaches ALS inside `next()`, asserts POSTs set `isWrite: true`, asserts ALS is cleaned up after the middleware returns.
- `packages/core/tests/unit/astro/integration/virtual-modules.test.ts` — covers all three branches of `generateDialectModule` (no entrypoint, `supportsRequestScope: true`, `supportsRequestScope: false`) and dialect-type threading.

Verification:

- `pnpm --filter emdash vitest run tests/unit` — 1762 passed
- `pnpm --filter @emdash-cms/cloudflare test` — 127 passed
- `pnpm --filter emdash --filter @emdash-cms/cloudflare typecheck` — clean
- `pnpm --silent lint:json | jq '.diagnostics | length'` — 16 (all pre-existing, none in touched files)