### PR TITLE
perf: cache manifest and batch site info queries

### DIFF
--- a/.changeset/manifest-caching.md
+++ b/.changeset/manifest-caching.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Caches the manifest in memory and in the database to eliminate N+1 schema queries per request. Batches site info queries during initialization. Cold starts read 1 cached row instead of rebuilding from scratch.

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/[fieldSlug].ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/[fieldSlug].ts
@@ -57,6 +57,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		fieldSlug,
 		body as UpdateFieldInput,
 	);
+	if (result.success) emdash!.invalidateManifest();
 	return unwrapResult(result);
 };
 
@@ -72,5 +73,6 @@ export const DELETE: APIRoute = async ({ params, locals }) => {
 	if (denied) return denied;
 
 	const result = await handleSchemaFieldDelete(emdash!.db, collectionSlug, fieldSlug);
+	if (result.success) emdash!.invalidateManifest();
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/index.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/index.ts
@@ -48,5 +48,6 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		collectionSlug,
 		body as CreateFieldInput,
 	);
+	if (result.success) emdash!.invalidateManifest();
 	return unwrapResult(result, 201);
 };

--- a/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/reorder.ts
+++ b/packages/core/src/astro/routes/api/schema/collections/[slug]/fields/reorder.ts
@@ -28,5 +28,6 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 	if (isParseError(body)) return body;
 
 	const result = await handleSchemaFieldReorder(emdash!.db, collectionSlug, body.fieldSlugs);
+	if (result.success) emdash!.invalidateManifest();
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/taxonomies/index.ts
+++ b/packages/core/src/astro/routes/api/taxonomies/index.ts
@@ -52,6 +52,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		const result = await handleTaxonomyCreate(emdash.db, body);
+		if (result.success) emdash.invalidateManifest();
 		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create taxonomy", "TAXONOMY_CREATE_ERROR");

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1167,9 +1167,9 @@ export class EmDashRuntime {
 	 * API routes, MCP server, plugin toggle, and taxonomy def changes.
 	 */
 	async getManifest(): Promise<EmDashManifest> {
-		// Playground mode: each session has its own DO database, so the
-		// singleton cache would serve the wrong manifest. Skip caching
-		// entirely when the DB is overridden via ALS.
+		// When the DB is overridden via ALS (playground/DO-preview sessions,
+		// D1 read-replica routing), bypass caching and rebuild against the
+		// request-scoped database handle.
 		if (getRequestContext()?.db) {
 			return this._buildManifest();
 		}
@@ -1184,7 +1184,8 @@ export class EmDashRuntime {
 				cached &&
 				typeof cached === "object" &&
 				"version" in cached &&
-				cached.version === VERSION
+				cached.version === VERSION &&
+				cached.commit === COMMIT
 			) {
 				this._cachedManifest = cached;
 				return cached;
@@ -1193,28 +1194,37 @@ export class EmDashRuntime {
 			// Options table may not exist yet
 		}
 
-		// Full rebuild, then persist
+		// Full rebuild, then persist. Track which promise is current so
+		// an invalidation during the build can't be overwritten.
 		if (!this._manifestPromise) {
-			this._manifestPromise = this._loadManifest();
+			let manifestPromise: Promise<EmDashManifest>;
+			const isCurrentLoad = () => this._manifestPromise === manifestPromise;
+			manifestPromise = this._loadManifest(isCurrentLoad);
+			this._manifestPromise = manifestPromise;
 		}
 		return this._manifestPromise;
 	}
 
-	private async _loadManifest(): Promise<EmDashManifest> {
+	private async _loadManifest(isCurrentLoad: () => boolean): Promise<EmDashManifest> {
 		try {
 			const manifest = await this._buildManifest();
-			this._cachedManifest = manifest;
 
-			try {
-				const options = new OptionsRepository(this.db);
-				await options.set("emdash:manifest_cache", manifest);
-			} catch {
-				// Non-fatal — will just rebuild next time
+			if (isCurrentLoad()) {
+				this._cachedManifest = manifest;
+
+				try {
+					const options = new OptionsRepository(this.db);
+					await options.set("emdash:manifest_cache", manifest);
+				} catch {
+					// Non-fatal — will just rebuild next time
+				}
 			}
 
 			return manifest;
 		} finally {
-			this._manifestPromise = null;
+			if (isCurrentLoad()) {
+				this._manifestPromise = null;
+			}
 		}
 	}
 
@@ -1458,9 +1468,11 @@ export class EmDashRuntime {
 		// DB delete is best-effort for the next cold start.
 		try {
 			const options = new OptionsRepository(this.db);
-			options.delete("emdash:manifest_cache").catch(() => {});
-		} catch {
-			// Non-fatal (db may not be ready)
+			options.delete("emdash:manifest_cache").catch((error) => {
+				console.error("Failed to delete persisted manifest cache", error);
+			});
+		} catch (error) {
+			console.error("Failed to initialize manifest cache invalidation", error);
 		}
 	}
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -286,6 +286,9 @@ export class EmDashRuntime {
 	private enabledPlugins: Set<string>;
 	private pluginStates: Map<string, string>;
 
+	private _cachedManifest: EmDashManifest | null = null;
+	private _manifestPromise: Promise<EmDashManifest> | null = null;
+
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
 		return this._hooks;
@@ -413,6 +416,7 @@ export class EmDashRuntime {
 			this.enabledPlugins.delete(pluginId);
 			await this.rebuildHookPipeline();
 		}
+		this.invalidateManifest();
 	}
 
 	/**
@@ -605,17 +609,19 @@ export class EmDashRuntime {
 			}
 		}
 
-		// Load site info for plugin context extensions
+		// Load site info for plugin context extensions (1 batch query instead of 3)
 		let siteInfo: { siteName?: string; siteUrl?: string; locale?: string } | undefined;
 		try {
 			const optionsRepo = new OptionsRepository(db);
-			const siteName = await optionsRepo.get<string>("emdash:site_title");
-			const siteUrl = await optionsRepo.get<string>("emdash:site_url");
-			const locale = await optionsRepo.get<string>("emdash:locale");
+			const siteOpts = await optionsRepo.getMany<string>([
+				"emdash:site_title",
+				"emdash:site_url",
+				"emdash:locale",
+			]);
 			siteInfo = {
-				siteName: siteName ?? undefined,
-				siteUrl: siteUrl ?? undefined,
-				locale: locale ?? undefined,
+				siteName: siteOpts.get("emdash:site_title") ?? undefined,
+				siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
+				locale: siteOpts.get("emdash:locale") ?? undefined,
 			};
 		} catch {
 			// Options table may not exist yet (pre-setup)
@@ -880,7 +886,18 @@ export class EmDashRuntime {
 			const dialect = deps.createDialect(dbConfig.config);
 			const db = new Kysely<Database>({ dialect });
 
-			await runMigrations(db);
+			const { applied } = await runMigrations(db);
+
+			// If migrations were applied, the schema changed — clear the
+			// DB-persisted manifest cache so getManifest() rebuilds it.
+			if (applied.length > 0) {
+				try {
+					const options = new OptionsRepository(db);
+					await options.delete("emdash:manifest_cache");
+				} catch {
+					// Non-fatal
+				}
+			}
 
 			// Auto-seed schema if no collections exist and setup hasn't run.
 			// This covers first-load on sites that skip the setup wizard.
@@ -1142,9 +1159,69 @@ export class EmDashRuntime {
 	// =========================================================================
 
 	/**
-	 * Build the manifest (rebuilt on each request for freshness)
+	 * Get the manifest, using an in-memory cache with a DB-persisted
+	 * fallback for cold starts. Avoids N+1 schema registry queries
+	 * on every request.
+	 *
+	 * Cache is invalidated by invalidateManifest(), called from schema
+	 * API routes, MCP server, plugin toggle, and taxonomy def changes.
 	 */
 	async getManifest(): Promise<EmDashManifest> {
+		// Playground mode: each session has its own DO database, so the
+		// singleton cache would serve the wrong manifest. Skip caching
+		// entirely when the DB is overridden via ALS.
+		if (getRequestContext()?.db) {
+			return this._buildManifest();
+		}
+
+		if (this._cachedManifest) return this._cachedManifest;
+
+		// DB-persisted cache (1 query instead of N+1 rebuild on cold start)
+		try {
+			const options = new OptionsRepository(this.db);
+			const cached = await options.get<EmDashManifest>("emdash:manifest_cache");
+			if (
+				cached &&
+				typeof cached === "object" &&
+				"version" in cached &&
+				cached.version === VERSION
+			) {
+				this._cachedManifest = cached;
+				return cached;
+			}
+		} catch {
+			// Options table may not exist yet
+		}
+
+		// Full rebuild, then persist
+		if (!this._manifestPromise) {
+			this._manifestPromise = this._loadManifest();
+		}
+		return this._manifestPromise;
+	}
+
+	private async _loadManifest(): Promise<EmDashManifest> {
+		try {
+			const manifest = await this._buildManifest();
+			this._cachedManifest = manifest;
+
+			try {
+				const options = new OptionsRepository(this.db);
+				await options.set("emdash:manifest_cache", manifest);
+			} catch {
+				// Non-fatal — will just rebuild next time
+			}
+
+			return manifest;
+		} finally {
+			this._manifestPromise = null;
+		}
+	}
+
+	/**
+	 * Build the manifest from database (N+1 collection queries).
+	 */
+	private async _buildManifest(): Promise<EmDashManifest> {
 		// Build collections from database.
 		// Use this.db (ALS-aware getter) so playground mode picks up the
 		// per-session DO database instead of the hardcoded singleton.
@@ -1370,11 +1447,21 @@ export class EmDashRuntime {
 
 	/**
 	 * Invalidate cached data derived from the manifest/schema.
-	 * Called when collections are created, updated, or deleted.
+	 * Called when collections, fields, plugins, or taxonomy defs change.
 	 */
 	invalidateManifest(): void {
-		// Invalidate the URL pattern cache used by resolveEmDashPath
+		this._cachedManifest = null;
+		this._manifestPromise = null;
 		invalidateUrlPatternCache();
+		// Delete DB-persisted cache so the next cold start rebuilds.
+		// Fire-and-forget: in-memory is already cleared for this worker,
+		// DB delete is best-effort for the next cold start.
+		try {
+			const options = new OptionsRepository(this.db);
+			options.delete("emdash:manifest_cache").catch(() => {});
+		} catch {
+			// Non-fatal (db may not be ready)
+		}
 	}
 
 	// =========================================================================


### PR DESCRIPTION
## What does this PR do?

Eliminates the N+1 schema registry queries that `getManifest()` runs on every request, and batches 3 sequential options queries into 1 during initialization.

Alternative, simpler approach to #378. Addresses the same discussion: https://github.com/emdash-cms/emdash/discussions/346

### Before
- Every request: N+1 queries (list collections + get fields per collection). 11+ queries on a 10-collection site.
- Every cold start: 3 sequential `options.get()` for site info.

### After
- Warm requests: 0 queries (in-memory cache hit)
- Cold start (cache populated): 1 query (read DB-persisted manifest from options table)
- Cold start (first ever or post-deploy): full rebuild, then cached

### How it works

Two-tier manifest cache in `getManifest()`:
1. **In-memory** — instant, same worker lifetime
2. **DB-persisted** — 1 query on cold start, stored in the options table

`invalidateManifest()` clears both tiers. It was already called from schema API routes and MCP server. This PR also wires it into two previously-uncovered paths:
- `setPluginStatus()` (plugin enable/disable changes manifest)
- Taxonomy definition creation (taxonomy list is in the manifest)

Safety:
- **Playground mode**: skips caching entirely when the DB is overridden via ALS (each playground session has its own DO database)
- **Version check**: DB cache auto-invalidates when the EmDash version changes
- **Post-migration**: DB cache is deleted when migrations are applied
- **Concurrent requests**: deduplicates rebuilds via a shared promise

Also batches 3 sequential `options.get()` calls for site info into 1 `getMany()` query.

## Type of change

- [x] Performance improvement

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Test output

2381 core tests passed, 127 cloudflare tests passed. 0 lint diagnostics introduced (15 pre-existing, unchanged from main).