### PR TITLE
fix(core): serialize widget-area API responses through rowToWidget

### DIFF
--- a/.changeset/widget-api-serialization.md
+++ b/.changeset/widget-api-serialization.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `/_emdash/api/widget-areas/*` endpoints returning raw DB rows (snake_case fields, `content` as a JSON string) instead of the transformed `Widget` shape. Admin UI expects `content` to already be a parsed PortableText array and `componentId`/`componentProps`/`menuName` in camelCase, so expanding a content widget in `/_emdash/admin/widgets` produced an empty editor. All four route handlers (`GET /widget-areas`, `GET /widget-areas/:name`, `POST /widget-areas/:name/widgets`, `PUT /widget-areas/:name/widgets/:id`) now run their results through `rowToWidget`, which was made module-exported.

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -122,6 +122,7 @@ import {
 	reorderWidgetsBody,
 	updateWidgetBody,
 	widgetAreaSchema,
+	widgetAreaWithWidgetsAndCountSchema,
 	widgetAreaWithWidgetsSchema,
 	widgetSchema,
 } from "../schemas/widgets.js";
@@ -1581,7 +1582,9 @@ const widgetPaths = {
 					description: "Widget area list",
 					content: {
 						[JSON_CONTENT]: {
-							schema: successEnvelope(z.object({ items: z.array(widgetAreaSchema) })),
+							schema: successEnvelope(
+								z.object({ items: z.array(widgetAreaWithWidgetsAndCountSchema) }),
+							),
 						},
 					},
 				},

--- a/packages/core/src/api/schemas/widgets.ts
+++ b/packages/core/src/api/schemas/widgets.ts
@@ -60,16 +60,12 @@ export const widgetAreaSchema = z
 export const widgetSchema = z
 	.object({
 		id: z.string(),
-		area_id: z.string(),
-		type: z.string(),
-		title: z.string().nullable(),
-		content: z.string().nullable(),
-		menu_name: z.string().nullable(),
-		component_id: z.string().nullable(),
-		component_props: z.string().nullable(),
-		sort_order: z.number().int(),
-		created_at: z.string(),
-		updated_at: z.string(),
+		type: widgetType,
+		title: z.string().optional(),
+		content: z.array(z.record(z.string(), z.unknown())).optional(),
+		menuName: z.string().optional(),
+		componentId: z.string().optional(),
+		componentProps: z.record(z.string(), z.unknown()).optional(),
 	})
 	.meta({ id: "Widget" });
 
@@ -78,3 +74,9 @@ export const widgetAreaWithWidgetsSchema = widgetAreaSchema
 		widgets: z.array(widgetSchema),
 	})
 	.meta({ id: "WidgetAreaWithWidgets" });
+
+export const widgetAreaWithWidgetsAndCountSchema = widgetAreaWithWidgetsSchema
+	.extend({
+		widgetCount: z.number().int(),
+	})
+	.meta({ id: "WidgetAreaWithWidgetsAndCount" });

--- a/packages/core/src/astro/routes/api/widget-areas/[name].ts
+++ b/packages/core/src/astro/routes/api/widget-areas/[name].ts
@@ -9,6 +9,8 @@ import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
+import { rowToWidget } from "#widgets/index.js";
+import type { WidgetRow } from "#widgets/types.js";
 
 export const prerender = false;
 
@@ -40,13 +42,14 @@ export const GET: APIRoute = async ({ params, locals }) => {
 		const widgets = await db
 			.selectFrom("_emdash_widgets")
 			.selectAll()
+			.$castTo<WidgetRow>()
 			.where("area_id", "=", area.id)
 			.orderBy("sort_order", "asc")
 			.execute();
 
 		return apiSuccess({
 			...area,
-			widgets,
+			widgets: widgets.map((row) => rowToWidget(row)),
 		});
 	} catch (error) {
 		return handleError(error, "Failed to fetch widget area", "WIDGET_AREA_GET_ERROR");

--- a/packages/core/src/astro/routes/api/widget-areas/[name]/widgets.ts
+++ b/packages/core/src/astro/routes/api/widget-areas/[name]/widgets.ts
@@ -11,6 +11,8 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { createWidgetBody } from "#api/schemas.js";
+import { rowToWidget } from "#widgets/index.js";
+import type { WidgetRow } from "#widgets/types.js";
 
 export const prerender = false;
 
@@ -70,10 +72,11 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		const widget = await db
 			.selectFrom("_emdash_widgets")
 			.selectAll()
+			.$castTo<WidgetRow>()
 			.where("id", "=", id)
 			.executeTakeFirstOrThrow();
 
-		return apiSuccess(widget, 201);
+		return apiSuccess(rowToWidget(widget), 201);
 	} catch (error) {
 		return handleError(error, "Failed to create widget", "WIDGET_CREATE_ERROR");
 	}

--- a/packages/core/src/astro/routes/api/widget-areas/[name]/widgets/[id].ts
+++ b/packages/core/src/astro/routes/api/widget-areas/[name]/widgets/[id].ts
@@ -11,6 +11,8 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { updateWidgetBody } from "#api/schemas.js";
+import { rowToWidget } from "#widgets/index.js";
+import type { WidgetRow } from "#widgets/types.js";
 
 export const prerender = false;
 
@@ -73,10 +75,11 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 		const widget = await db
 			.selectFrom("_emdash_widgets")
 			.selectAll()
+			.$castTo<WidgetRow>()
 			.where("id", "=", id)
 			.executeTakeFirstOrThrow();
 
-		return apiSuccess(widget);
+		return apiSuccess(rowToWidget(widget));
 	} catch (error) {
 		return handleError(error, "Failed to update widget", "WIDGET_UPDATE_ERROR");
 	}

--- a/packages/core/src/astro/routes/api/widget-areas/index.ts
+++ b/packages/core/src/astro/routes/api/widget-areas/index.ts
@@ -12,6 +12,8 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { createWidgetAreaBody } from "#api/schemas.js";
+import { rowToWidget } from "#widgets/index.js";
+import type { WidgetRow } from "#widgets/types.js";
 
 export const prerender = false;
 
@@ -35,13 +37,14 @@ export const GET: APIRoute = async ({ locals }) => {
 				const widgets = await db
 					.selectFrom("_emdash_widgets")
 					.selectAll()
+					.$castTo<WidgetRow>()
 					.where("area_id", "=", area.id)
 					.orderBy("sort_order", "asc")
 					.execute();
 
 				return {
 					...area,
-					widgets,
+					widgets: widgets.map((row) => rowToWidget(row)),
 					widgetCount: widgets.length,
 				};
 			}),

--- a/packages/core/src/widgets/index.ts
+++ b/packages/core/src/widgets/index.ts
@@ -125,7 +125,7 @@ export function getWidgetComponents(): WidgetComponentDef[] {
 /**
  * Convert a widget row to the API type
  */
-function rowToWidget(row: WidgetRow): Widget {
+export function rowToWidget(row: WidgetRow): Widget {
 	const widget: Widget = {
 		id: row.id,
 		type: row.type,


### PR DESCRIPTION
## What does this PR do?

The four `/_emdash/api/widget-areas/*` route handlers return raw `_emdash_widgets` rows directly — snake_case columns, and `content` left as a JSON string. The public `Widget` type (and the admin UI that consumes it) expects the camelCase shape with `content` parsed into a PortableText array.

The `rowToWidget` helper that does that transform already exists in `packages/core/src/widgets/index.ts` but is file-local. This PR exports it and runs all four handlers through it:

- `GET    /_emdash/api/widget-areas`
- `GET    /_emdash/api/widget-areas/:name`
- `POST   /_emdash/api/widget-areas/:name/widgets`
- `PUT    /_emdash/api/widget-areas/:name/widgets/:id`

### Reproduction

1. Create a widget area with one content-type widget that has any PortableText content.
2. Open `/_emdash/admin/widgets` and expand that widget.

**Before:** the editor is empty — the UI receives `content` as a string and `componentId`/`componentProps`/`menuName` in snake_case, so nothing binds.
**After:** the editor renders the stored PortableText blocks.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes on unchecked items:

- **Tests:** existing widget-area tests (if any) appear to assert against the raw row shape — happy to add handler-level tests asserting `rowToWidget`'s output shape in a follow-up if maintainers want them in this PR. Did not want to reshape existing fixtures without guidance.
- **i18n:** no user-visible strings changed.

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

`pnpm --filter emdash typecheck`, `pnpm lint`, `pnpm format:check`, and `pnpm --filter emdash test` all pass locally on this branch.