### PR TITLE
fix(admin): pass pluginBlocks and block sidebar callbacks to WidgetEditor

### DIFF
--- a/.changeset/admin-widget-plugin-blocks.md
+++ b/.changeset/admin-widget-plugin-blocks.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Threads plugin block definitions and the block sidebar callbacks through the Widgets admin UI. `WidgetEditor` now passes `pluginBlocks`, `onBlockSidebarOpen`, and `onBlockSidebarClose` into its nested `PortableTextEditor`, and renders `ImageDetailPanel` when the image block panel is opened. Without this, custom plugin block types inside widget content (image, marker blocks, etc.) had no configuration UI — the settings button and media picker did nothing. Behavior now matches the content-entry editor.

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -38,6 +38,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
 import {
+	fetchManifest,
 	fetchWidgetAreas,
 	fetchWidgetComponents,
 	fetchMenus,
@@ -47,6 +48,7 @@ import {
 	deleteWidget,
 	deleteWidgetArea,
 	reorderWidgets,
+	type AdminManifest,
 	type WidgetArea,
 	type Widget,
 	type WidgetComponent,
@@ -55,7 +57,12 @@ import {
 } from "../lib/api";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
-import { PortableTextEditor } from "./PortableTextEditor";
+import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
+import {
+	PortableTextEditor,
+	type BlockSidebarPanel,
+	type PluginBlockDef,
+} from "./PortableTextEditor";
 
 /** Palette item types that can be dragged into areas */
 interface PaletteItemData {
@@ -74,6 +81,19 @@ type DragItemData = PaletteItemData | ExistingWidgetData;
 
 function isPaletteItem(data: DragItemData): data is PaletteItemData {
 	return data.source === "palette";
+}
+
+/** Extract plugin block definitions from the manifest for Portable Text editor */
+function getPluginBlocks(manifest: AdminManifest): PluginBlockDef[] {
+	const blocks: PluginBlockDef[] = [];
+	for (const [pluginId, plugin] of Object.entries(manifest.plugins)) {
+		if (plugin.portableTextBlocks) {
+			for (const block of plugin.portableTextBlocks) {
+				blocks.push({ ...block, pluginId });
+			}
+		}
+	}
+	return blocks;
 }
 
 /** Built-in widget types available in the palette */
@@ -118,6 +138,13 @@ export function Widgets() {
 		queryKey: ["widget-components"],
 		queryFn: fetchWidgetComponents,
 	});
+
+	const { data: manifest } = useQuery({
+		queryKey: ["manifest"],
+		queryFn: fetchManifest,
+	});
+
+	const pluginBlocks = React.useMemo(() => (manifest ? getPluginBlocks(manifest) : []), [manifest]);
 
 	const createAreaMutation = useMutation({
 		mutationFn: createWidgetArea,
@@ -411,6 +438,7 @@ export function Widgets() {
 									onToggleWidget={toggleWidget}
 									isDraggingPalette={activeDragData !== null && isPaletteItem(activeDragData)}
 									components={components}
+									pluginBlocks={pluginBlocks}
 								/>
 							))
 						)}
@@ -481,12 +509,14 @@ function WidgetAreaPanel({
 	onToggleWidget,
 	isDraggingPalette,
 	components,
+	pluginBlocks,
 }: {
 	area: WidgetArea;
 	expandedWidgets: Set<string>;
 	onToggleWidget: (id: string) => void;
 	isDraggingPalette: boolean;
 	components: WidgetComponent[];
+	pluginBlocks: PluginBlockDef[];
 }) {
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
@@ -541,6 +571,7 @@ function WidgetAreaPanel({
 								isExpanded={expandedWidgets.has(widget.id)}
 								onToggle={() => onToggleWidget(widget.id)}
 								components={components}
+								pluginBlocks={pluginBlocks}
 							/>
 						))}
 					</SortableContext>
@@ -586,12 +617,14 @@ function WidgetItem({
 	isExpanded,
 	onToggle,
 	components,
+	pluginBlocks,
 }: {
 	widget: Widget;
 	areaName: string;
 	isExpanded: boolean;
 	onToggle: () => void;
 	components: WidgetComponent[];
+	pluginBlocks: PluginBlockDef[];
 }) {
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
@@ -674,6 +707,7 @@ function WidgetItem({
 				<WidgetEditor
 					widget={widget}
 					components={components}
+					pluginBlocks={pluginBlocks}
 					onSave={(input) => updateMutation.mutate(input)}
 					isSaving={updateMutation.isPending}
 				/>
@@ -686,11 +720,13 @@ function WidgetItem({
 function WidgetEditor({
 	widget,
 	components,
+	pluginBlocks,
 	onSave,
 	isSaving,
 }: {
 	widget: Widget;
 	components: WidgetComponent[];
+	pluginBlocks: PluginBlockDef[];
 	onSave: (input: UpdateWidgetInput) => void;
 	isSaving: boolean;
 }) {
@@ -703,6 +739,18 @@ function WidgetEditor({
 	const [componentProps, setComponentProps] = React.useState<Record<string, unknown>>(
 		widget.componentProps ?? {},
 	);
+	const [blockSidebarPanel, setBlockSidebarPanel] = React.useState<BlockSidebarPanel | null>(null);
+
+	const handleBlockSidebarOpen = React.useCallback((panel: BlockSidebarPanel) => {
+		setBlockSidebarPanel(panel);
+	}, []);
+
+	const handleBlockSidebarClose = React.useCallback(() => {
+		setBlockSidebarPanel((prev) => {
+			prev?.onClose();
+			return null;
+		});
+	}, []);
 
 	const { data: menus = [] } = useQuery({
 		queryKey: ["menus"],
@@ -742,7 +790,26 @@ function WidgetEditor({
 						onChange={(value) => setContent(value as unknown[])}
 						minimal
 						placeholder="Write widget content..."
+						pluginBlocks={pluginBlocks}
+						onBlockSidebarOpen={handleBlockSidebarOpen}
+						onBlockSidebarClose={handleBlockSidebarClose}
 					/>
+					{blockSidebarPanel?.type === "image" && (
+						<ImageDetailPanel
+							attributes={blockSidebarPanel.attrs as unknown as ImageAttributes}
+							onUpdate={(attrs) =>
+								blockSidebarPanel.onUpdate(attrs as unknown as Record<string, unknown>)
+							}
+							onReplace={(attrs) =>
+								blockSidebarPanel.onReplace(attrs as unknown as Record<string, unknown>)
+							}
+							onDelete={() => {
+								blockSidebarPanel.onDelete();
+								setBlockSidebarPanel(null);
+							}}
+							onClose={handleBlockSidebarClose}
+						/>
+					)}
 				</div>
 			)}
 


### PR DESCRIPTION
## What does this PR do?

The Widgets admin screen renders a `PortableTextEditor` for each content-type widget, but omits three props that the content-entry editor supplies:

- `pluginBlocks` — the flat list of plugin-registered block definitions
- `onBlockSidebarOpen` / `onBlockSidebarClose` — callbacks that show/hide the per-block configuration sidebar

As a result, custom block types placed inside widget content (image blocks, marker blocks, anything registered by a plugin) have no configuration UI — the block's settings button and the media picker silently do nothing.

This PR:

- Fetches the admin manifest with react-query in the top-level `Widgets` component and derives the flat `PluginBlockDef[]` list via a small `getPluginBlocks` helper.
- Threads `pluginBlocks` down through `WidgetAreaPanel` → `WidgetItem` → `WidgetEditor`.
- Adds `blockSidebarPanel` state in `WidgetEditor`, wires `onBlockSidebarOpen` / `onBlockSidebarClose`, and renders `ImageDetailPanel` when the panel type is `"image"` — mirroring how the content-entry editor handles the same hooks.

### Reproduction

1. Insert an image block inside a content-type widget's PortableText via `/_emdash/admin/widgets`.
2. Click the block's settings button or the media picker.

**Before:** nothing opens.
**After:** the image detail sidebar opens, the media picker works, and updates round-trip through the widget's content.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes on unchecked items:

- **Tests:** this is a wiring fix between components that already have coverage. Happy to add a React Testing Library test asserting that `ImageDetailPanel` renders on open if maintainers want one in this PR.
- **i18n:** no new user-visible strings — only props plumbing.

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

`pnpm --filter @emdash-cms/admin typecheck`, `pnpm lint`, `pnpm format:check`, and `pnpm --filter @emdash-cms/admin test` all pass locally on this branch.