### PR TITLE
fix(admin): wire block sidebar callbacks + ImageDetailPanel in WidgetEditor

### DIFF
--- a/.changeset/admin-widget-block-sidebar.md
+++ b/.changeset/admin-widget-block-sidebar.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Wires up the block configuration sidebar inside `WidgetEditor`. `PortableTextEditor` now receives `onBlockSidebarOpen`/`onBlockSidebarClose` callbacks that hold the active `BlockSidebarPanel` in local state, and renders `ImageDetailPanel` when the panel type is `"image"` — mirroring the content-entry editor. Without this, clicking a block's settings button or the media picker inside widget content had no visible effect.

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -57,7 +57,12 @@ import {
 import { getPluginBlocks } from "../lib/pluginBlocks";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
-import { PortableTextEditor, type PluginBlockDef } from "./PortableTextEditor";
+import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
+import {
+	PortableTextEditor,
+	type BlockSidebarPanel,
+	type PluginBlockDef,
+} from "./PortableTextEditor";
 
 /** Palette item types that can be dragged into areas */
 interface PaletteItemData {
@@ -721,6 +726,18 @@ function WidgetEditor({
 	const [componentProps, setComponentProps] = React.useState<Record<string, unknown>>(
 		widget.componentProps ?? {},
 	);
+	const [blockSidebarPanel, setBlockSidebarPanel] = React.useState<BlockSidebarPanel | null>(null);
+
+	const handleBlockSidebarOpen = React.useCallback((panel: BlockSidebarPanel) => {
+		setBlockSidebarPanel(panel);
+	}, []);
+
+	const handleBlockSidebarClose = React.useCallback(() => {
+		setBlockSidebarPanel((prev) => {
+			prev?.onClose();
+			return null;
+		});
+	}, []);
 
 	const { data: menus = [] } = useQuery({
 		queryKey: ["menus"],
@@ -761,7 +778,25 @@ function WidgetEditor({
 						minimal
 						placeholder="Write widget content..."
 						pluginBlocks={pluginBlocks}
+						onBlockSidebarOpen={handleBlockSidebarOpen}
+						onBlockSidebarClose={handleBlockSidebarClose}
 					/>
+					{blockSidebarPanel?.type === "image" && (
+						<ImageDetailPanel
+							attributes={blockSidebarPanel.attrs as unknown as ImageAttributes}
+							onUpdate={(attrs) =>
+								blockSidebarPanel.onUpdate(attrs as unknown as Record<string, unknown>)
+							}
+							onReplace={(attrs) =>
+								blockSidebarPanel.onReplace(attrs as unknown as Record<string, unknown>)
+							}
+							onDelete={() => {
+								blockSidebarPanel.onDelete();
+								setBlockSidebarPanel(null);
+							}}
+							onClose={handleBlockSidebarClose}
+						/>
+					)}
 				</div>
 			)}
 

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -113,8 +113,24 @@ export function Widgets() {
 	const [activeId, setActiveId] = React.useState<string | null>(null);
 	const [activeDragData, setActiveDragData] = React.useState<DragItemData | null>(null);
 	const [expandedWidgets, setExpandedWidgets] = React.useState<Set<string>>(new Set());
+	const [blockSidebarPanel, setBlockSidebarPanel] = React.useState<BlockSidebarPanel | null>(null);
 	// Track palette drag source across the full drag lifecycle (including drop animation)
 	const draggingFromPaletteRef = React.useRef(false);
+
+	const handleBlockSidebarOpen = React.useCallback((panel: BlockSidebarPanel) => {
+		setBlockSidebarPanel((prev) => {
+			// Close any existing panel before opening a new one so only one is ever active
+			prev?.onClose();
+			return panel;
+		});
+	}, []);
+
+	const handleBlockSidebarClose = React.useCallback(() => {
+		setBlockSidebarPanel((prev) => {
+			prev?.onClose();
+			return null;
+		});
+	}, []);
 
 	const { data: areas = [], isLoading } = useQuery({
 		queryKey: ["widget-areas"],
@@ -426,6 +442,8 @@ export function Widgets() {
 									isDraggingPalette={activeDragData !== null && isPaletteItem(activeDragData)}
 									components={components}
 									pluginBlocks={pluginBlocks}
+									onBlockSidebarOpen={handleBlockSidebarOpen}
+									onBlockSidebarClose={handleBlockSidebarClose}
 								/>
 							))
 						)}
@@ -450,6 +468,25 @@ export function Widgets() {
 					</div>
 				) : null}
 			</DragOverlay>
+
+			{/* A single block-sidebar panel for the whole page — ensures only one is ever
+			    open at a time, preventing stacked fixed overlays and duplicated window listeners. */}
+			{blockSidebarPanel?.type === "image" && (
+				<ImageDetailPanel
+					attributes={blockSidebarPanel.attrs as unknown as ImageAttributes}
+					onUpdate={(attrs) =>
+						blockSidebarPanel.onUpdate(attrs as unknown as Record<string, unknown>)
+					}
+					onReplace={(attrs) =>
+						blockSidebarPanel.onReplace(attrs as unknown as Record<string, unknown>)
+					}
+					onDelete={() => {
+						blockSidebarPanel.onDelete();
+						setBlockSidebarPanel(null);
+					}}
+					onClose={handleBlockSidebarClose}
+				/>
+			)}
 		</DndContext>
 	);
 }
@@ -497,6 +534,8 @@ function WidgetAreaPanel({
 	isDraggingPalette,
 	components,
 	pluginBlocks,
+	onBlockSidebarOpen,
+	onBlockSidebarClose,
 }: {
 	area: WidgetArea;
 	expandedWidgets: Set<string>;
@@ -504,6 +543,8 @@ function WidgetAreaPanel({
 	isDraggingPalette: boolean;
 	components: WidgetComponent[];
 	pluginBlocks: PluginBlockDef[];
+	onBlockSidebarOpen: (panel: BlockSidebarPanel) => void;
+	onBlockSidebarClose: () => void;
 }) {
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
@@ -559,6 +600,8 @@ function WidgetAreaPanel({
 								onToggle={() => onToggleWidget(widget.id)}
 								components={components}
 								pluginBlocks={pluginBlocks}
+								onBlockSidebarOpen={onBlockSidebarOpen}
+								onBlockSidebarClose={onBlockSidebarClose}
 							/>
 						))}
 					</SortableContext>
@@ -605,6 +648,8 @@ function WidgetItem({
 	onToggle,
 	components,
 	pluginBlocks,
+	onBlockSidebarOpen,
+	onBlockSidebarClose,
 }: {
 	widget: Widget;
 	areaName: string;
@@ -612,6 +657,8 @@ function WidgetItem({
 	onToggle: () => void;
 	components: WidgetComponent[];
 	pluginBlocks: PluginBlockDef[];
+	onBlockSidebarOpen: (panel: BlockSidebarPanel) => void;
+	onBlockSidebarClose: () => void;
 }) {
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();
@@ -697,6 +744,8 @@ function WidgetItem({
 					pluginBlocks={pluginBlocks}
 					onSave={(input) => updateMutation.mutate(input)}
 					isSaving={updateMutation.isPending}
+					onBlockSidebarOpen={onBlockSidebarOpen}
+					onBlockSidebarClose={onBlockSidebarClose}
 				/>
 			)}
 		</div>
@@ -710,12 +759,16 @@ function WidgetEditor({
 	pluginBlocks,
 	onSave,
 	isSaving,
+	onBlockSidebarOpen,
+	onBlockSidebarClose,
 }: {
 	widget: Widget;
 	components: WidgetComponent[];
 	pluginBlocks: PluginBlockDef[];
 	onSave: (input: UpdateWidgetInput) => void;
 	isSaving: boolean;
+	onBlockSidebarOpen: (panel: BlockSidebarPanel) => void;
+	onBlockSidebarClose: () => void;
 }) {
 	const [title, setTitle] = React.useState(widget.title ?? "");
 	const [content, setContent] = React.useState<unknown[]>(
@@ -726,18 +779,6 @@ function WidgetEditor({
 	const [componentProps, setComponentProps] = React.useState<Record<string, unknown>>(
 		widget.componentProps ?? {},
 	);
-	const [blockSidebarPanel, setBlockSidebarPanel] = React.useState<BlockSidebarPanel | null>(null);
-
-	const handleBlockSidebarOpen = React.useCallback((panel: BlockSidebarPanel) => {
-		setBlockSidebarPanel(panel);
-	}, []);
-
-	const handleBlockSidebarClose = React.useCallback(() => {
-		setBlockSidebarPanel((prev) => {
-			prev?.onClose();
-			return null;
-		});
-	}, []);
 
 	const { data: menus = [] } = useQuery({
 		queryKey: ["menus"],
@@ -778,25 +819,9 @@ function WidgetEditor({
 						minimal
 						placeholder="Write widget content..."
 						pluginBlocks={pluginBlocks}
-						onBlockSidebarOpen={handleBlockSidebarOpen}
-						onBlockSidebarClose={handleBlockSidebarClose}
+						onBlockSidebarOpen={onBlockSidebarOpen}
+						onBlockSidebarClose={onBlockSidebarClose}
 					/>
-					{blockSidebarPanel?.type === "image" && (
-						<ImageDetailPanel
-							attributes={blockSidebarPanel.attrs as unknown as ImageAttributes}
-							onUpdate={(attrs) =>
-								blockSidebarPanel.onUpdate(attrs as unknown as Record<string, unknown>)
-							}
-							onReplace={(attrs) =>
-								blockSidebarPanel.onReplace(attrs as unknown as Record<string, unknown>)
-							}
-							onDelete={() => {
-								blockSidebarPanel.onDelete();
-								setBlockSidebarPanel(null);
-							}}
-							onClose={handleBlockSidebarClose}
-						/>
-					)}
 				</div>
 			)}
 


### PR DESCRIPTION
## What does this PR do?

The `PortableTextEditor` nested inside `WidgetEditor` does not receive the `onBlockSidebarOpen` / `onBlockSidebarClose` callbacks. As a result, clicking a block's settings button or the media picker inside widget content has no visible effect — no configuration sidebar opens, even though the equivalent editor on content-entry pages works.

This PR:

- Adds `blockSidebarPanel` local state in `WidgetEditor` alongside `handleBlockSidebarOpen` / `handleBlockSidebarClose` callbacks.
- Passes those callbacks into the nested `PortableTextEditor`.
- Renders `ImageDetailPanel` when the panel type is `"image"`, matching how the content-entry editor dispatches per-block panels.

Scoped to the sidebar wiring only. A companion PR (#610) handles the plugin-block registry (`pluginBlocks`) — these two fixes ship independently so each block diff is reviewable on its own. Both are needed for full plugin-block editing inside widgets.

### Reproduction

1. Ensure a content widget contains an image block.
2. Open `/_emdash/admin/widgets`, expand the widget, and click the image block's settings button (or the media picker trigger).

**Before:** nothing opens.
**After:** the image detail sidebar opens, the media picker works, and updates round-trip through the widget's content.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes on unchecked items:

- **Tests:** wiring fix between components that already have coverage. Happy to add a React Testing Library test asserting `ImageDetailPanel` renders on `onBlockSidebarOpen` if maintainers want one in this PR.
- **i18n:** no new user-visible strings.

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

`pnpm --filter @emdash-cms/admin typecheck`, `pnpm lint`, and `pnpm format:check` all pass locally.