### PR TITLE
fix: use config fingerprint for manifest cache validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@ This file provides guidance to agentic coding tools when working with code in th
 
 ## Project Status
 
-**Beta.** EmDash is published to npm. All development happens inside this monorepo using `workspace:*` links. See [CONTRIBUTING.md](CONTRIBUTING.md) for the human-readable contributor guide (setup, repo layout, "build your own site" workflow).
+**Beta, post pre-release.** EmDash is published to npm and in active use, with i18n, RTL, and the plugin system shipped. We're no longer in the scorched-earth pre-release phase -- real users depend on current behavior, so backwards compatibility now matters (see Rules below). All development happens inside this monorepo using `workspace:*` links. See [CONTRIBUTING.md](CONTRIBUTING.md) for the human-readable contributor guide (setup, repo layout, "build your own site" workflow).
 
 ## Repository Structure
 
@@ -18,11 +18,11 @@ This is a monorepo using pnpm workspaces.
 
 # Rules
 
-This is a pre-release project. Do not add backwards compatibility or legacy patterns. Do not deprecate -- remove instead. Do not add migration paths.
-
-**Build for the known future.** If we know we'll need something, build it now. Only defer things where there's genuine uncertainty about whether or how we'll need them. "We'll need it later" is a reason to do it now, not a reason to punt.
+**Backwards compatibility matters now.** We're out of pre-release, but pre-1.0. Real installs depend on current behavior, schemas, and API shapes. Breaking changes are allowed in minors, but need an explicit decision, a bump on the affected package, and a changeset that calls the break out clearly. Prefer additive changes: new fields, new routes, new options with sensible defaults. If an old API is obsolete, mark the replacement as preferred and keep the old path working unless there's a reason it can't. Database migrations are forward-only -- never write one that leaves existing content inaccessible. When in doubt, open a Discussion before coding.
 
 **TDD for bugs.** Write a failing test -> fix the bug -> verify the test passes. A bug without a reproducing test is not fixed.
+
+**Localize everything user-facing.** All admin UI strings, aria labels, and toast messages go through Lingui. All admin layout uses RTL-safe logical Tailwind classes. See the Localization and RTL sections below.
 
 ## Contribution Rules (for AI agents and human contributors)
 
@@ -86,19 +86,9 @@ See [CONTRIBUTING.md § Changesets](CONTRIBUTING.md#changesets) for full guidanc
 4. Add a changeset if the change affects a published package: `pnpm changeset`.
 5. Open the PR with the `pr` skill. Fill out every section of the PR template. Check the AI disclosure box.
 
-### Dev Servers
-
-Use `bgproc` (not raw process management):
-
-```bash
-bgproc start -n devserver -w -- pnpm dev   # start and wait for port
-bgproc stop devserver                       # stop
-bgproc logs devserver                       # view logs
-```
-
 ## Architecture Overview
 
-EmDash is an Astro-native CMS that stores its schema in the database, not in code.
+EmDash is an Astro-native CMS
 
 ### Core Architecture
 
@@ -306,6 +296,165 @@ Handlers in `api/handlers/*.ts` contain business logic. Routes should be thin wr
 - Entire body wrapped in try/catch. Errors return `{ success: false, error: { code, message } }`.
 - Error codes are `SCREAMING_SNAKE_CASE`: `NOT_FOUND`, `VALIDATION_ERROR`, `CONTENT_CREATE_ERROR`, etc.
 
+### Admin UI: Use Kumo Components
+
+The admin UI is built on [Kumo](https://github.com/cloudflare/kumo) (Cloudflare's design system). Use Kumo components for all standard UI elements -- never roll your own buttons, inputs, dialogs, selects, etc. This gives us consistent styling, dark mode, accessibility, and RTL support for free.
+
+**Look up component docs from the CLI** -- don't guess at props:
+
+```bash
+npx @cloudflare/kumo doc Button    # docs for a specific component
+npx @cloudflare/kumo ls            # list all available components
+npx @cloudflare/kumo docs          # docs for everything
+```
+
+Key components (all from `@cloudflare/kumo`):
+
+- **`Button`** -- all clickable actions. Supports `variant`, `size`, `icon`, and `loading`.
+- **`LinkButton`** -- anchor styled as a button. Use for navigation, never `<a>` with manual styling. Supports `external` prop for new-tab links.
+- **`Dialog`** -- all modals. Use `ConfirmDialog` (ours) for simple confirm/cancel flows.
+- **`Input`**, **`InputArea`**, **`Select`**, **`Checkbox`**, **`Switch`** -- form controls.
+- **`Toast`** / **`Toasty`** -- notifications.
+- **`Loader`** -- loading spinners.
+- **`Badge`** -- status labels, counts.
+- **`Popover`**, **`Dropdown`**, **`Tooltip`** -- overlays.
+- **`CommandPalette`** -- the admin command palette.
+- **`Label`** -- form labels (pairs with inputs).
+
+```typescript
+import { Button, LinkButton, Loader } from "@cloudflare/kumo";
+
+// loading prop -- shows spinner and disables interaction automatically
+<Button variant="primary" loading={mutation.isPending}>
+	{t`Save`}
+</Button>
+
+// icon prop with conditional Loader -- use when the icon itself changes per state
+// (e.g. different icons for idle/pending/done -- see SaveButton.tsx for the full pattern)
+<Button
+	variant={isSaved ? "secondary" : "primary"}
+	icon={isSaving ? <Loader size="sm" /> : isSaved ? <Check /> : <FloppyDisk />}
+	disabled={isSaving || isSaved}
+	aria-busy={isSaving}
+>
+	{isSaving ? t`Saving...` : isSaved ? t`Saved` : t`Save`}
+</Button>
+
+// icon prop -- pass a Phosphor icon component or React element
+<Button variant="secondary" icon={PlusIcon}>{t`Add item`}</Button>
+
+// icon-only buttons require shape + aria-label
+<Button shape="square" icon={TrashIcon} aria-label={t`Delete`} variant="ghost" />
+
+// LinkButton for navigation -- never use <a> with manual button classes
+<LinkButton href="/_emdash/admin" variant="ghost" icon={HouseIcon}>
+	{t`Dashboard`}
+</LinkButton>
+
+// external links open in new tab with rel="noopener noreferrer"
+<LinkButton href="https://docs.example.com" external>{t`Docs`}</LinkButton>
+```
+
+**Styling rules:**
+
+- **Use semantic color tokens**, not raw Tailwind colors. `bg-kumo-brand` not `bg-blue-500`. `text-kumo-subtle` not `text-gray-500`. The full token list is in the Kumo styles.
+- **Never use `dark:` prefixes.** Kumo's semantic tokens use CSS `light-dark()` to handle dark mode automatically. If you're writing `dark:bg-something`, you're bypassing the design system.
+- Don't reach for raw HTML elements or Tailwind-only solutions when a Kumo component exists. If you need a button, use `Button`. If you need a link that looks like a button, use `LinkButton`. If you need `buttonVariants()` classes on a non-button element, import `buttonVariants` from `@cloudflare/kumo`.
+
+### Admin UI: Localization (Lingui)
+
+Every user-facing string in the admin UI goes through Lingui. No hard-coded English literals in JSX, attributes, or TypeScript strings that end up in the DOM.
+
+- Catalogs live in `packages/admin/src/locales/{locale}/messages.po`. English is the source.
+- Enabled locales are defined in `packages/admin/src/locales/locales.ts`.
+- After adding or changing strings, run `pnpm locale:extract` then `pnpm locale:compile`. CI fails if catalogs are stale.
+- Set `EMDASH_PSEUDO_LOCALE=1` in dev to render pseudo-localized text -- any untranslated English leaking through is immediately visible.
+
+```typescript
+import { useLingui } from "@lingui/react/macro";
+import { Trans } from "@lingui/react/macro";
+
+// Simple strings -- tagged template
+function DeleteButton() {
+	const { t } = useLingui();
+	return (
+		<button type="button" aria-label={t`Delete post`}>
+			{t`Delete`}
+		</button>
+	);
+}
+
+// JSX with interpolation or nested components -- <Trans> macro
+<Trans>
+	Published by <strong>{authorName}</strong> on {formattedDate}
+</Trans>;
+
+// Pluralization -- use plural macro
+import { plural } from "@lingui/core/macro";
+const label = plural(count, { one: "# item", other: "# items" });
+
+// Module-scope constants -- use msg`` descriptors, resolve with t() inside component
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+
+interface BlockTransform {
+	id: string;
+	label: MessageDescriptor;
+}
+
+const blockTransforms: BlockTransform[] = [
+	{ id: "paragraph", label: msg`Paragraph` },
+	{ id: "heading1", label: msg`Heading 1` },
+];
+
+function BlockMenu() {
+	const { t } = useLingui();
+	return blockTransforms.map((b) => <span key={b.id}>{t(b.label)}</span>);
+}
+```
+
+Common mistakes to avoid:
+
+- **Bare string literals in JSX**: `<button>Save</button>` -- must be `<button>{t\`Save\`}</button>`or`<button><Trans>Save</Trans></button>`.
+- **Unwrapped aria labels, titles, placeholders, alt text**: these are user-facing too. `aria-label="Close"` -> ``aria-label={t`Close`}``.
+- **Concatenating translated pieces**: ``t`Hello ` + name`` breaks word order in other languages. Use `` t`Hello ${name}` `` or `<Trans>`.
+- **Calling `t` at module scope**: the locale isn't bound yet. Use `msg` to create a `MessageDescriptor`, then resolve it with `t(descriptor)` inside the component. Type the constant as `MessageDescriptor` (from `@lingui/core`).
+- **Reusing the same key for different meanings**: give them distinct messages or use context.
+
+Server-side (API error messages): still English-only for now. Keep error codes stable (`SCREAMING_SNAKE_CASE`) -- the admin UI maps codes to localized messages client-side.
+
+### Admin UI: RTL-safe Tailwind
+
+The admin supports RTL locales. Use logical Tailwind classes, never physical ones. An LTR-only class that slips in will misplace UI in Arabic.
+
+| Use                                          | Not                           |
+| -------------------------------------------- | ----------------------------- |
+| `ms-*` / `me-*` (margin-inline-start/end)    | `ml-*` / `mr-*`               |
+| `ps-*` / `pe-*` (padding-inline-start/end)   | `pl-*` / `pr-*`               |
+| `start-*` / `end-*` (inset-inline-start/end) | `left-*` / `right-*`          |
+| `text-start` / `text-end`                    | `text-left` / `text-right`    |
+| `border-s` / `border-e`                      | `border-l` / `border-r`       |
+| `rounded-s-*` / `rounded-e-*`                | `rounded-l-*` / `rounded-r-*` |
+| `float-start` / `float-end`                  | `float-left` / `float-right`  |
+
+For icons that indicate direction (chevrons, arrows, back/forward), flip them in RTL. Use `rtl:-scale-x-100` on the icon, or pick a bidi-aware icon. Don't rely on the icon being visually neutral.
+
+`LocaleDirectionProvider` (`packages/admin/src/locales/LocaleDirectionProvider.tsx`) syncs `document.documentElement.dir` and `lang` with the active locale. You don't need to set these manually.
+
+**Always test new admin UI in Arabic** before considering it done. Switch the locale in the admin and walk through the feature. Broken directionality is the single most common i18n regression.
+
+### Content Localization
+
+Content tables use a row-per-locale model (see migration `019_i18n.ts`):
+
+- Every `ec_*` table has a `locale` column (defaults to `'en'`) and a `translation_group` ULID shared across translations of the same piece of content.
+- Slug uniqueness is `UNIQUE(slug, locale)` -- not global. Two posts can share a slug across locales.
+- Any new query against a content table must filter by `locale` or deliberately operate across locales (e.g. the translations endpoint). Forgetting the filter is a correctness bug, not a style issue.
+- Indexes exist on both `locale` and `translation_group`. Use them.
+- Fetch all translations of a single piece via `GET /_emdash/api/content/{collection}/{id}/translations`.
+
+When adding new content-table features (new columns, new filters, new list endpoints), ask: does this need to be per-locale or per-translation-group? Per-locale is usually correct for display fields; per-group is correct for anything identifying "the same thing" across languages (e.g. comment counts, view counts might aggregate across the group).
+
 ### Admin UI: API Error Handling
 
 All admin API functions use `throwResponseError()` from `lib/api/client.ts` to surface server error messages to the user. Never throw a generic error when the response body contains a message.
@@ -426,7 +575,7 @@ When accepting redirect URLs from query params or request bodies:
 - **pnpm** -- package manager
 - **tsdown** -- TypeScript builds (ESM + DTS)
 - **vitest** -- testing
-- **oxfmt** -- code formatting (tabs for indentation, configured in `.prettierrc`). All source files use tabs, not spaces.
+- **oxfmt** -- code formatting (tabs for indentation). All source files use tabs, not spaces.
 
 ## TypeScript Configuration
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -371,12 +371,19 @@ export class EmDashRuntime {
 		this.pipelineRef = pipelineRef;
 
 		// Build-time config fingerprint for manifest cache validation.
-		// Catches plugin/i18n config changes across deploys even when
-		// the emdash package version stays the same.
+		// Includes everything that affects the manifest shape: emdash
+		// version, plugin IDs/versions/options, i18n config, marketplace.
 		this._configFingerprint = [
-			...configuredPlugins.map((p) => `${p.id}@${p.version ?? ""}`),
-			...sandboxedPluginEntries.map((e) => `${e.id}@${e.version}`),
+			VERSION,
+			COMMIT,
+			...configuredPlugins.map(
+				(p) => `${p.id}@${p.version ?? ""}:${JSON.stringify(p.options ?? {})}`,
+			),
+			...sandboxedPluginEntries.map(
+				(e) => `${e.id}@${e.version}:${JSON.stringify(e.options ?? {})}`,
+			),
 			config.marketplace ? "marketplace" : "",
+			virtualConfig?.i18n?.defaultLocale ?? "",
 			virtualConfig?.i18n?.locales?.join(",") ?? "",
 		].join("|");
 	}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -288,6 +288,8 @@ export class EmDashRuntime {
 
 	private _cachedManifest: EmDashManifest | null = null;
 	private _manifestPromise: Promise<EmDashManifest> | null = null;
+	/** Fingerprint of build-time config that affects the manifest shape */
+	private readonly _configFingerprint: string;
 
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
@@ -367,6 +369,16 @@ export class EmDashRuntime {
 		this.pipelineFactoryOptions = pipelineFactoryOptions;
 		this.runtimeDeps = runtimeDeps;
 		this.pipelineRef = pipelineRef;
+
+		// Build-time config fingerprint for manifest cache validation.
+		// Catches plugin/i18n config changes across deploys even when
+		// the emdash package version stays the same.
+		this._configFingerprint = [
+			...configuredPlugins.map((p) => `${p.id}@${p.version ?? ""}`),
+			...sandboxedPluginEntries.map((e) => `${e.id}@${e.version}`),
+			config.marketplace ? "marketplace" : "",
+			virtualConfig?.i18n?.locales?.join(",") ?? "",
+		].join("|");
 	}
 
 	/**
@@ -1179,16 +1191,13 @@ export class EmDashRuntime {
 		// DB-persisted cache (1 query instead of N+1 rebuild on cold start)
 		try {
 			const options = new OptionsRepository(this.db);
-			const cached = await options.get<EmDashManifest>("emdash:manifest_cache");
-			if (
-				cached &&
-				typeof cached === "object" &&
-				"version" in cached &&
-				cached.version === VERSION &&
-				cached.commit === COMMIT
-			) {
-				this._cachedManifest = cached;
-				return cached;
+			const cached = await options.get<{
+				fingerprint: string;
+				manifest: EmDashManifest;
+			}>("emdash:manifest_cache");
+			if (cached && cached.fingerprint === this._configFingerprint && cached.manifest) {
+				this._cachedManifest = cached.manifest;
+				return cached.manifest;
 			}
 		} catch {
 			// Options table may not exist yet
@@ -1214,7 +1223,10 @@ export class EmDashRuntime {
 
 				try {
 					const options = new OptionsRepository(this.db);
-					await options.set("emdash:manifest_cache", manifest);
+					await options.set("emdash:manifest_cache", {
+						fingerprint: this._configFingerprint,
+						manifest,
+					});
 				} catch {
 					// Non-fatal — will just rebuild next time
 				}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -288,8 +288,7 @@ export class EmDashRuntime {
 
 	private _cachedManifest: EmDashManifest | null = null;
 	private _manifestPromise: Promise<EmDashManifest> | null = null;
-	/** Fingerprint of build-time config that affects the manifest shape */
-	private readonly _configFingerprint: string;
+	private readonly _manifestCacheKey: string;
 
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
@@ -349,6 +348,7 @@ export class EmDashRuntime {
 		},
 		runtimeDeps: RuntimeDependencies,
 		pipelineRef: { current: HookPipeline },
+		manifestCacheKey: string,
 	) {
 		this._db = db;
 		this.storage = storage;
@@ -369,23 +369,7 @@ export class EmDashRuntime {
 		this.pipelineFactoryOptions = pipelineFactoryOptions;
 		this.runtimeDeps = runtimeDeps;
 		this.pipelineRef = pipelineRef;
-
-		// Build-time config fingerprint for manifest cache validation.
-		// Includes everything that affects the manifest shape: emdash
-		// version, plugin IDs/versions/options, i18n config, marketplace.
-		this._configFingerprint = [
-			VERSION,
-			COMMIT,
-			...configuredPlugins.map(
-				(p) => `${p.id}@${p.version ?? ""}:${JSON.stringify(p.options ?? {})}`,
-			),
-			...sandboxedPluginEntries.map(
-				(e) => `${e.id}@${e.version}:${JSON.stringify(e.options ?? {})}`,
-			),
-			config.marketplace ? "marketplace" : "",
-			virtualConfig?.i18n?.defaultLocale ?? "",
-			virtualConfig?.i18n?.locales?.join(",") ?? "",
-		].join("|");
+		this._manifestCacheKey = manifestCacheKey;
 	}
 
 	/**
@@ -812,6 +796,20 @@ export class EmDashRuntime {
 			// Non-fatal — CMS works without cron
 		}
 
+		// SHA of emdash commit + user config that affects the manifest.
+		// COMMIT captures emdash code changes; plugin IDs and i18n config
+		// capture user astro.config changes. DB-driven changes (collections,
+		// fields, plugin toggle) go through invalidateManifest().
+		const manifestCacheKey = await hashString(
+			[
+				COMMIT,
+				...deps.plugins.map((p) => p.id),
+				...deps.sandboxedPluginEntries.map((e) => e.id),
+				virtualConfig?.i18n?.defaultLocale ?? "",
+				virtualConfig?.i18n?.locales?.join(",") ?? "",
+			].join("|"),
+		);
+
 		return new EmDashRuntime(
 			db,
 			storage,
@@ -831,6 +829,7 @@ export class EmDashRuntime {
 			pipelineFactoryOptions,
 			deps,
 			pipelineRef,
+			manifestCacheKey,
 		);
 	}
 
@@ -1195,14 +1194,16 @@ export class EmDashRuntime {
 
 		if (this._cachedManifest) return this._cachedManifest;
 
-		// DB-persisted cache (1 query instead of N+1 rebuild on cold start)
+		// DB-persisted cache (1 query instead of N+1 rebuild on cold start).
+		// Keyed by SHA of commit + config to bust on deploys. DB-driven
+		// changes (collections, fields, plugins, taxonomies) go through
+		// invalidateManifest().
 		try {
 			const options = new OptionsRepository(this.db);
-			const cached = await options.get<{
-				fingerprint: string;
-				manifest: EmDashManifest;
-			}>("emdash:manifest_cache");
-			if (cached && cached.fingerprint === this._configFingerprint && cached.manifest) {
+			const cached = await options.get<{ key: string; manifest: EmDashManifest }>(
+				"emdash:manifest_cache",
+			);
+			if (cached && cached.key === this._manifestCacheKey && cached.manifest) {
 				this._cachedManifest = cached.manifest;
 				return cached.manifest;
 			}
@@ -1231,7 +1232,7 @@ export class EmDashRuntime {
 				try {
 					const options = new OptionsRepository(this.db);
 					await options.set("emdash:manifest_cache", {
-						fingerprint: this._configFingerprint,
+						key: this._manifestCacheKey,
 						manifest,
 					});
 				} catch {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -797,16 +797,18 @@ export class EmDashRuntime {
 		}
 
 		// SHA of emdash commit + user config that affects the manifest.
-		// COMMIT captures emdash code changes; plugin IDs and i18n config
-		// capture user astro.config changes. DB-driven changes (collections,
-		// fields, plugin toggle) go through invalidateManifest().
+		// COMMIT captures emdash code changes; plugin IDs/versions and i18n
+		// capture user astro.config changes (e.g. upgrading a plugin package).
+		// DB-driven changes (collections, fields, plugin toggle) go through
+		// invalidateManifest(). Sorted for stability across nondeterministic
+		// plugin ordering.
 		const manifestCacheKey = await hashString(
 			[
 				COMMIT,
-				...deps.plugins.map((p) => p.id),
-				...deps.sandboxedPluginEntries.map((e) => e.id),
+				...deps.plugins.map((p) => `${p.id}@${p.version ?? ""}`).toSorted(),
+				...deps.sandboxedPluginEntries.map((e) => `${e.id}@${e.version}`).toSorted(),
 				virtualConfig?.i18n?.defaultLocale ?? "",
-				virtualConfig?.i18n?.locales?.join(",") ?? "",
+				(virtualConfig?.i18n?.locales ?? []).toSorted().join(","),
 			].join("|"),
 		);
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #606. The DB-persisted manifest cache was validated using `VERSION` and `COMMIT`, which are baked into the emdash npm package at publish time. They don't change when a user modifies their `astro.config` (adding plugins, changing i18n locales, toggling marketplace) and redeploys without upgrading emdash — so the cache could serve stale manifest data after a config change.

Replaces the version/commit check with a config fingerprint derived from the runtime's build-time inputs:
- Plugin IDs and versions (trusted + sandboxed)
- Marketplace flag
- i18n locale list

The fingerprint is computed once in the constructor, stored alongside the cached manifest in the DB, and checked on read. A config change on redeploy invalidates the cache automatically.

Addresses review feedback from #606.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2381 core + 127 cloudflare)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code