### PR TITLE
fix(perf): show all deploys in chart and fix PR resolution

### DIFF
--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -214,6 +214,21 @@
 				border-radius: 3px;
 				font-size: 11px;
 				font-weight: 500;
+				text-decoration: none;
+			}
+
+			.pr-badge:hover {
+				background: #3577c5;
+			}
+
+			a.sha-link {
+				color: var(--text-dim);
+				text-decoration: none;
+			}
+
+			a.sha-link:hover {
+				color: var(--text-muted);
+				text-decoration: underline;
 			}
 
 			.region-tag {
@@ -347,7 +362,7 @@
 					</div>
 					<div class="item">
 						<span class="swatch-marker"></span>
-						PR deploy
+						Deploy
 					</div>
 				</div>
 			</div>
@@ -387,6 +402,9 @@
 		</div>
 
 		<script>
+			const GITHUB_REPO = "emdash-cms/emdash";
+			const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
+
 			const REGION_COLORS = {
 				use: "#51cf66",
 				euw: "#4dabf7",
@@ -566,8 +584,11 @@
 									label: function (context) {
 										const point = context.raw;
 										let text = `${context.dataset.label}: ${formatMs(context.parsed.y)}`;
+										if (point && point.sha) {
+											text += ` [${point.sha.slice(0, 7)}]`;
+										}
 										if (point && point.prNumber) {
-											text += ` (PR #${point.prNumber})`;
+											text += ` PR #${point.prNumber}`;
 										}
 										return text;
 									},
@@ -613,25 +634,26 @@
 							y: d.coldTtfbMs,
 							prNumber: d.prNumber,
 							sha: d.sha,
+							source: d.source,
 						})),
 						borderColor: color,
 						backgroundColor: color + "20",
 						borderWidth: 1.5,
 						pointRadius: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? 5 : 1.5;
+							return point && point.sha ? 5 : 1.5;
 						},
 						pointBackgroundColor: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? "#ff6b6b" : color;
+							return point && point.sha ? "#ff6b6b" : color;
 						},
 						pointBorderColor: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? "#ff6b6b" : color;
+							return point && point.sha ? "#ff6b6b" : color;
 						},
 						pointBorderWidth: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? 2 : 0;
+							return point && point.sha ? 2 : 0;
 						},
 						tension: 0.3,
 						fill: false,
@@ -644,34 +666,37 @@
 							y: d.warmTtfbMs,
 							prNumber: d.prNumber,
 							sha: d.sha,
+							source: d.source,
 						})),
 						borderColor: color,
 						backgroundColor: color + "20",
 						borderWidth: 1.5,
 						pointRadius: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? 5 : 1.5;
+							return point && point.sha ? 5 : 1.5;
 						},
 						pointBackgroundColor: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? "#ff6b6b" : color;
+							return point && point.sha ? "#ff6b6b" : color;
 						},
 						pointBorderColor: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? "#ff6b6b" : color;
+							return point && point.sha ? "#ff6b6b" : color;
 						},
 						pointBorderWidth: (ctx) => {
 							const point = ctx.raw;
-							return point && point.prNumber ? 2 : 0;
+							return point && point.sha ? 2 : 0;
 						},
 						tension: 0.3,
 						fill: false,
 					});
 
-					// Add vertical lines for PR deploys
-					if (result.prMarkers) {
-						for (const marker of result.prMarkers) {
-							const key = `pr-${marker.prNumber}-${region}`;
+					// Add vertical lines for all deploys
+					if (result.deployMarkers) {
+						for (const marker of result.deployMarkers) {
+							const sha7 = marker.sha ? marker.sha.slice(0, 7) : "?";
+							const label = marker.prNumber ? `PR #${marker.prNumber}` : sha7;
+							const key = `deploy-${marker.sha || marker.timestamp}-${region}`;
 							annotations[key] = {
 								type: "line",
 								xMin: new Date(marker.timestamp),
@@ -681,7 +706,7 @@
 								borderDash: [4, 4],
 								label: {
 									display: regions.length <= 2,
-									content: `PR #${marker.prNumber}`,
+									content: label,
 									position: "start",
 									backgroundColor: "#2a1a1a",
 									color: "#ff6b6b",
@@ -738,6 +763,13 @@
 						const threshold = routeConfig?.coldThresholdMs ?? 2000;
 						const cls = ttfbClass(r.cold_ttfb_ms, threshold);
 
+						const prLink = r.pr_number
+							? ` <a class="pr-badge" href="${GITHUB_URL}/pull/${r.pr_number}" target="_blank" rel="noopener">PR #${r.pr_number}</a>`
+							: "";
+						const shaLink = r.sha
+							? ` <a class="sha-link mono" href="${GITHUB_URL}/commit/${r.sha}" target="_blank" rel="noopener">${r.sha.slice(0, 7)}</a>`
+							: "";
+
 						return `<tr>
               <td class="mono">${formatTime(r.timestamp)}</td>
               <td>${r.route}</td>
@@ -747,7 +779,7 @@
               <td class="mono">${formatMs(r.p95_ttfb_ms)}</td>
               <td class="mono">${r.status_code ?? "-"}</td>
               <td class="mono">${r.cf_colo ?? "-"}</td>
-              <td>${r.source}${r.pr_number ? ` <span class="pr-badge">PR #${r.pr_number}</span>` : ""}${r.sha ? ` <span class="mono" style="color:var(--text-dim)">${r.sha.slice(0, 7)}</span>` : ""}</td>
+              <td>${r.source}${prLink}${shaLink}</td>
             </tr>`;
 					})
 					.join("");

--- a/infra/perf-monitor/src/api.ts
+++ b/infra/perf-monitor/src/api.ts
@@ -81,9 +81,17 @@ async function handleChart(url: URL, env: Env): Promise<Response> {
 	// Query returns DESC -- reverse to chronological
 	results.reverse();
 
-	// Filter deploy results for PR markers on this route+region
-	const prMarkers = deployResults
-		.filter((r) => r.route === route && r.region === region && r.pr_number != null)
+	// Deduplicate deploy results by SHA — multiple route/region combos produce
+	// duplicates, but we only want one marker per deploy on the chart.
+	const seenShas = new Set<string>();
+	const deployMarkers = deployResults
+		.filter((r) => {
+			if (!r.sha) return false;
+			if (r.route !== route || r.region !== region) return false;
+			if (seenShas.has(r.sha)) return false;
+			seenShas.add(r.sha);
+			return true;
+		})
 		.map((r) => ({
 			timestamp: r.timestamp,
 			prNumber: r.pr_number,
@@ -103,7 +111,7 @@ async function handleChart(url: URL, env: Env): Promise<Response> {
 			sha: r.sha,
 			prNumber: r.pr_number,
 		})),
-		prMarkers,
+		deployMarkers,
 	});
 }
 

--- a/infra/perf-monitor/src/github.ts
+++ b/infra/perf-monitor/src/github.ts
@@ -17,12 +17,32 @@ interface AssociatedPR {
 	merged_at: string | null;
 	base: { ref: string };
 }
+const PR_NUMBER_REGEX = /\(#(\d+)\)\s*$/;
+/**
+ * Parse a PR number from a commit message. GitHub squash merges append the PR
+ * number in parentheses, e.g. "feat: add feature (#123)".
+ */
+function parsePrFromMessage(commitMessage: string): number | null {
+	const match = commitMessage.match(PR_NUMBER_REGEX);
+	if (!match?.[1]) return null;
+	return parseInt(match[1], 10);
+}
 
 /**
  * Find the merged PR for a given commit SHA, if any.
+ *
+ * Strategy:
+ * 1. Parse the commit message for `(#N)` — works for squash merges (the common case).
+ * 2. Fall back to the GitHub "list PRs for a commit" API — works for merge commits.
+ *
  * Returns null if no PR exists (e.g. direct push to main) or the lookup fails.
  */
-export async function resolvePrForSha(sha: string): Promise<number | null> {
+export async function resolvePrForSha(sha: string, commitMessage?: string): Promise<number | null> {
+	if (commitMessage) {
+		const fromMessage = parsePrFromMessage(commitMessage);
+		if (fromMessage) return fromMessage;
+	}
+
 	const url = `https://api.github.com/repos/${GITHUB_REPO}/commits/${sha}/pulls`;
 
 	let response: Response;

--- a/infra/perf-monitor/src/index.ts
+++ b/infra/perf-monitor/src/index.ts
@@ -127,7 +127,7 @@ async function handleBuildSucceeded(
 
 	console.log(`Running deploy-triggered measurement for ${workerName} @ ${sha.slice(0, 7)}`);
 
-	const prNumber = await resolvePrForSha(sha);
+	const prNumber = await resolvePrForSha(sha, meta.commitMessage);
 	const results = await runMeasurements(env, "deploy", sha, prNumber);
 
 	if (results.length > 0) {


### PR DESCRIPTION
## What does this PR do?

Fixes the perf monitor dashboard to show all CI deploy runs in the chart (not just ones where a PR was resolved) and adds clickable links to commits and PRs throughout the UI.

Also fixes PR number resolution which was failing for most deploys — squash merge commits aren't associated with their original PR via the GitHub API, so the lookup now parses `(#N)` from the commit message first.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — infra-only change to the perf monitor dashboard (`infra/perf-monitor/`). No changeset needed as this is not a published package.