### PR TITLE
perf: prime request cache from taxonomy hydration

### DIFF
--- a/.changeset/prime-term-cache.md
+++ b/.changeset/prime-term-cache.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Prime the request-scoped cache for `getEntryTerms` during collection and entry hydration. `getEmDashCollection` and `getEmDashEntry` already fetch taxonomy terms for their results via a single batched JOIN; now the same data is seeded into the per-request cache under the same keys `getEntryTerms` uses, so existing templates that still call `getEntryTerms(collection, id, taxonomy)` in a loop get cache hits instead of a serial DB round-trip per iteration.
+
+Empty-result entries are seeded with `[]` for every taxonomy that applies to the collection so "this post has no tags" also short-circuits without a query. Cache entries are scoped to the request context via ALS and GC'd with it.
+
+Also adds `setRequestCacheEntry` as a public helper for other hydration paths that want to pre-populate their own cache keys.

--- a/.changeset/prime-term-cache.md
+++ b/.changeset/prime-term-cache.md
@@ -5,5 +5,3 @@
 Prime the request-scoped cache for `getEntryTerms` during collection and entry hydration. `getEmDashCollection` and `getEmDashEntry` already fetch taxonomy terms for their results via a single batched JOIN; now the same data is seeded into the per-request cache under the same keys `getEntryTerms` uses, so existing templates that still call `getEntryTerms(collection, id, taxonomy)` in a loop get cache hits instead of a serial DB round-trip per iteration.
 
 Empty-result entries are seeded with `[]` for every taxonomy that applies to the collection so "this post has no tags" also short-circuits without a query. Cache entries are scoped to the request context via ALS and GC'd with it.
-
-Also adds `setRequestCacheEntry` as a public helper for other hydration paths that want to pre-populate their own cache keys.

--- a/packages/core/src/request-cache.ts
+++ b/packages/core/src/request-cache.ts
@@ -58,3 +58,27 @@ export function requestCached<T>(key: string, fn: () => Promise<T>): Promise<T> 
 	cache.set(key, promise);
 	return promise;
 }
+
+/**
+ * Pre-populate the request-scoped cache with a resolved value.
+ *
+ * Intended for hydration paths that already have the data in hand and want
+ * downstream callers using `requestCached(key, ...)` to skip the database
+ * entirely. No-ops outside a request context (local dev without ALS).
+ *
+ * Does not overwrite an existing entry — if a query for this key is already
+ * in flight, its promise wins.
+ */
+export function setRequestCacheEntry<T>(key: string, value: T): void {
+	const ctx = getRequestContext();
+	if (!ctx) return;
+
+	let cache = store.get(ctx);
+	if (!cache) {
+		cache = new Map();
+		store.set(ctx, cache);
+	}
+
+	if (cache.has(key)) return;
+	cache.set(key, Promise.resolve(value));
+}

--- a/packages/core/src/request-cache.ts
+++ b/packages/core/src/request-cache.ts
@@ -62,9 +62,13 @@ export function requestCached<T>(key: string, fn: () => Promise<T>): Promise<T> 
 /**
  * Pre-populate the request-scoped cache with a resolved value.
  *
- * Intended for hydration paths that already have the data in hand and want
- * downstream callers using `requestCached(key, ...)` to skip the database
- * entirely. No-ops outside a request context (local dev without ALS).
+ * Internal helper shared between hydration paths (taxonomy terms,
+ * bylines, etc.) that already have the data in hand and want downstream
+ * callers using `requestCached(key, ...)` to skip the database entirely.
+ * Not exported from the package entrypoint — keep it internal until we
+ * have a documented plugin/extension surface for hydration.
+ *
+ * No-ops outside a request context (local dev without ALS).
  *
  * Does not overwrite an existing entry — if a query for this key is already
  * in flight, its promise wins.

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -9,7 +9,7 @@ import { sql } from "kysely";
 
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
-import { requestCached } from "../request-cache.js";
+import { requestCached, setRequestCacheEntry } from "../request-cache.js";
 import { chunks, SQL_BATCH_SIZE } from "../utils/chunks.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 import type { TaxonomyDef, TaxonomyTerm, TaxonomyTermRow } from "./types.js";
@@ -73,18 +73,20 @@ async function hasAnyTermAssignments(db: Kysely<Database>): Promise<boolean> {
  * Get all taxonomy definitions
  */
 export async function getTaxonomyDefs(): Promise<TaxonomyDef[]> {
-	const db = await getDb();
+	return requestCached("taxonomy-defs:all", async () => {
+		const db = await getDb();
 
-	const rows = await db.selectFrom("_emdash_taxonomy_defs").selectAll().execute();
+		const rows = await db.selectFrom("_emdash_taxonomy_defs").selectAll().execute();
 
-	return rows.map((row) => ({
-		id: row.id,
-		name: row.name,
-		label: row.label,
-		labelSingular: row.label_singular ?? undefined,
-		hierarchical: row.hierarchical === 1,
-		collections: row.collections ? JSON.parse(row.collections) : [],
-	}));
+		return rows.map((row) => ({
+			id: row.id,
+			name: row.name,
+			label: row.label,
+			labelSingular: row.label_singular ?? undefined,
+			hierarchical: row.hierarchical === 1,
+			collections: row.collections ? JSON.parse(row.collections) : [],
+		}));
+	});
 }
 
 /**
@@ -362,8 +364,20 @@ export async function getAllTermsForEntries(
 
 	const db = await getDb();
 
-	// Skip the query entirely when no assignments exist anywhere.
+	// Look up which taxonomies apply to this collection. Used below to
+	// seed empty arrays for taxonomies the entry has no terms in — so
+	// callers (including the pre-populated getEntryTerms cache) get a
+	// deterministic `[]` back rather than a cache miss that triggers a DB
+	// round-trip just to confirm "no terms".
+	const applicableTaxonomyNames = await getCollectionTaxonomyNames(collection);
+
+	// Skip the query entirely when no assignments exist anywhere, but still
+	// prime the cache with empty arrays so downstream getEntryTerms calls
+	// don't reach the DB for this collection.
 	if (!(await hasAnyTermAssignments(db))) {
+		for (const id of uniqueIds) {
+			primeEntryTermsCache(collection, id, {}, applicableTaxonomyNames);
+		}
 		return result;
 	}
 
@@ -408,7 +422,66 @@ export async function getAllTermsForEntries(
 		}
 	}
 
+	// Prime the request-scoped cache so legacy callers of getEntryTerms
+	// (which still work per-entry) hit the in-memory cache instead of
+	// re-querying. This is what gives us the N+1 win in existing templates
+	// without requiring them to be rewritten.
+	for (const [entryId, byTaxonomy] of result) {
+		primeEntryTermsCache(collection, entryId, byTaxonomy, applicableTaxonomyNames);
+	}
+
 	return result;
+}
+
+/**
+ * Return the list of taxonomy names applicable to a collection, request-
+ * cached so a page render only pays for it once.
+ *
+ * Returns an empty list when taxonomies haven't been defined yet.
+ */
+async function getCollectionTaxonomyNames(collection: string): Promise<string[]> {
+	try {
+		const defs = await getTaxonomyDefs();
+		return defs.filter((d) => d.collections.includes(collection)).map((d) => d.name);
+	} catch (error) {
+		if (isMissingTableError(error)) return [];
+		throw error;
+	}
+}
+
+/**
+ * Pre-populate the request-cache for every getEntryTerms call-shape that
+ * could hit this entry:
+ *
+ *   getEntryTerms(collection, entryId)                 -> key `terms:C:E:*`
+ *   getEntryTerms(collection, entryId, "tag")          -> key `terms:C:E:tag`
+ *   getEntryTerms(collection, entryId, "category")     -> key `terms:C:E:category`
+ *   ...one per taxonomy that applies to this collection
+ *
+ * Taxonomies with no rows on this entry are seeded with `[]` so legacy
+ * callers short-circuit to the cached empty array instead of re-querying.
+ */
+function primeEntryTermsCache(
+	collection: string,
+	entryId: string,
+	byTaxonomy: Record<string, TaxonomyTerm[]>,
+	applicableTaxonomyNames: string[],
+): void {
+	// Seed every applicable taxonomy with at least [] so
+	// getEntryTerms(collection, id, "tag") doesn't miss the cache when an
+	// entry has no tags.
+	for (const name of applicableTaxonomyNames) {
+		setRequestCacheEntry(`terms:${collection}:${entryId}:${name}`, byTaxonomy[name] ?? []);
+	}
+	// Also seed individual names that show up in data but aren't listed
+	// as applicable (e.g. taxonomy reassigned to a different collection
+	// since the terms were written).
+	for (const [name, terms] of Object.entries(byTaxonomy)) {
+		setRequestCacheEntry(`terms:${collection}:${entryId}:${name}`, terms);
+	}
+	// Flattened `*` view — all terms across all taxonomies in one array.
+	const allTerms = Object.values(byTaxonomy).flat();
+	setRequestCacheEntry(`terms:${collection}:${entryId}:*`, allTerms);
 }
 
 /**

--- a/packages/core/tests/unit/taxonomies/get-all-terms-for-entries.test.ts
+++ b/packages/core/tests/unit/taxonomies/get-all-terms-for-entries.test.ts
@@ -12,7 +12,12 @@ vi.mock("../../../src/loader.js", () => ({
 }));
 
 import { getDb } from "../../../src/loader.js";
-import { getAllTermsForEntries, invalidateTermCache } from "../../../src/taxonomies/index.js";
+import { runWithContext } from "../../../src/request-context.js";
+import {
+	getAllTermsForEntries,
+	getEntryTerms,
+	invalidateTermCache,
+} from "../../../src/taxonomies/index.js";
 
 describe("getAllTermsForEntries", () => {
 	let db: Kysely<Database>;
@@ -137,5 +142,87 @@ describe("getAllTermsForEntries", () => {
 		const result = await getAllTermsForEntries("post", [p1.id, p2.id]);
 		expect(result.get(p1.id)?.tag?.[0].slug).toBe("one");
 		expect(result.get(p2.id)).toEqual({});
+	});
+
+	it("primes the request cache so getEntryTerms doesn't re-query", async () => {
+		// Extend the default "tag" taxonomy (seeded for `posts`) to also
+		// apply to the `post` collection used in these tests. Without this,
+		// the primer wouldn't seed the "tag" key for entries with no tags.
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["posts", "post"]) })
+			.where("name", "=", "tag")
+			.execute();
+
+		const tag = await taxRepo.create({ name: "tag", slug: "web", label: "Web" });
+		const p1 = await contentRepo.create({
+			type: "post",
+			slug: "p1",
+			data: { title: "P1" },
+		});
+		const p2 = await contentRepo.create({
+			type: "post",
+			slug: "p2",
+			data: { title: "P2" },
+		});
+		await taxRepo.attachToEntry("post", p1.id, tag.id);
+
+		invalidateTermCache();
+
+		const getDbSpy = vi.mocked(getDb);
+
+		await runWithContext({ editMode: false }, async () => {
+			// Populate the cache via the batched API.
+			await getAllTermsForEntries("post", [p1.id, p2.id]);
+
+			const callsAfterBatch = getDbSpy.mock.calls.length;
+
+			// These per-entry calls should hit the primed cache.
+			const p1Tags = await getEntryTerms("post", p1.id, "tag");
+			const p2Tags = await getEntryTerms("post", p2.id, "tag");
+			const p1All = await getEntryTerms("post", p1.id); // the `*` key
+
+			// No additional DB calls should have happened for the primed keys.
+			expect(getDbSpy.mock.calls.length).toBe(callsAfterBatch);
+
+			// And the values should match what the batch returned.
+			expect(p1Tags.map((t) => t.slug)).toEqual(["web"]);
+			expect(p2Tags).toEqual([]);
+			expect(p1All.map((t) => t.slug)).toEqual(["web"]);
+		});
+	});
+
+	it("does not leak primed entries across requests", async () => {
+		await db
+			.updateTable("_emdash_taxonomy_defs")
+			.set({ collections: JSON.stringify(["posts", "post"]) })
+			.where("name", "=", "tag")
+			.execute();
+
+		const tag = await taxRepo.create({ name: "tag", slug: "web", label: "Web" });
+		const p1 = await contentRepo.create({
+			type: "post",
+			slug: "p1",
+			data: { title: "P1" },
+		});
+		await taxRepo.attachToEntry("post", p1.id, tag.id);
+
+		invalidateTermCache();
+
+		await runWithContext({ editMode: false }, async () => {
+			await getAllTermsForEntries("post", [p1.id]);
+		});
+
+		const getDbSpy = vi.mocked(getDb);
+		const callsBeforeSecondRequest = getDbSpy.mock.calls.length;
+
+		await runWithContext({ editMode: false }, async () => {
+			// Different request context — the cache from the previous context
+			// must not be visible here.
+			await getEntryTerms("post", p1.id, "tag");
+		});
+
+		// At least one DB call should have happened in the second request.
+		expect(getDbSpy.mock.calls.length).toBeGreaterThan(callsBeforeSecondRequest);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Follow-up to #626. The previous PR added `data.terms` hydration via a single batched JOIN, but templates that were written before hydration landed still call `getEntryTerms(collection, id, taxonomyName)` per-entry in a loop. Those calls missed the request-scoped cache one-per-iteration and each issued its own DB round-trip — so the hydration was adding one batched query on top of the original N+1 instead of replacing it.

This PR seeds the request cache for every `(collection, entryId, taxonomyName)` and `(collection, entryId, "*")` key during hydration, using the rows the batched query already fetched. Legacy templates now get cache hits on every `getEntryTerms` call without requiring a template rewrite.

Entries with no terms for a given taxonomy are seeded with `[]` so `getEntryTerms(..., "tag")` on an untagged post doesn't fall through to a DB query just to confirm "no tags". The set of applicable taxonomies is looked up from `_emdash_taxonomy_defs` (itself now request-cached).

Also exposes `setRequestCacheEntry` as a public helper for future hydration paths that want to prime their own keys.

### Measured impact

blog-demo home page, warm render, 2-sample average per region after deploy:

| Region | Before | After | Change |
|---|---|---|---|
| use (IAD) | 355ms | 251ms | **-29%** |
| euw (LHR) | 203ms | 128ms | **-37%** |
| ape (NRT) | 445ms | 313ms | **-30%** |

(aps / SIN numbers are bimodal on this deploy — pathological outlier on one probe, 112ms on the next — and excluded from the table pending more samples.)

Before: the home page was measurably *slower* than the individual post page despite being the same template minus the per-entry loop. After: home is faster than post in every stable region, which is the expected signature of eliminating the N+1.

These numbers were only measurable because of the `warm_server_timings` instrumentation added in branch `perf/warm-server-timings` (not yet PR'd — will open separately if useful). Without it, warm render changes drown in total TTFB variance.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (no new issues introduced)
- [x] \`pnpm test\` passes (2395 tests, 2 new covering cache priming + request isolation)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A — runtime only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (patch bump)
- [ ] New features link to an approved Discussion (N/A — perf fix, follow-up to approved #626)

## AI-generated code disclosure

- [x] This PR includes AI-generated code