### PR TITLE
chore(perf): capture warm Server-Timing medians in perf monitor

### DIFF
--- a/infra/perf-monitor/migrations/0002_add_warm_server_timings.sql
+++ b/infra/perf-monitor/migrations/0002_add_warm_server_timings.sql
@@ -1,0 +1,14 @@
+-- Add column for the median-per-metric warm Server-Timing snapshot.
+--
+-- The original capture only stored cold Server-Timing (`cold_server_timings`).
+-- That's useful for cold-start investigation but useless for steady-state
+-- measurements -- which is what most performance work actually moves.
+--
+-- `warm_server_timings` stores the median duration per metric across all
+-- warm requests in a single probe, in the same JSON shape as
+-- `cold_server_timings`:
+--   { "<name>": { "dur": <number>, "desc"?: <string> } }
+--
+-- Null when the target site didn't emit Server-Timing on warm responses, or
+-- when no warm requests were issued.
+ALTER TABLE perf_results ADD COLUMN warm_server_timings TEXT;

--- a/infra/perf-monitor/probe/src/measure.ts
+++ b/infra/perf-monitor/probe/src/measure.ts
@@ -16,8 +16,13 @@ export interface RouteResult {
 	path: string;
 	label: string;
 	coldTtfbMs: number;
-	warmTtfbMs: number;
-	p95TtfbMs: number;
+	/**
+	 * Median warm-request TTFB. Null if warmRequests was 0 and no warm
+	 * samples were taken — caller should fall back to coldTtfbMs in that case.
+	 */
+	warmTtfbMs: number | null;
+	/** p95 warm-request TTFB. Null when no warm samples were taken. */
+	p95TtfbMs: number | null;
 	statusCode: number;
 	cfColo: string | null;
 	cfPlacement: string | null;
@@ -180,12 +185,21 @@ export async function measureRoutes(req: MeasureRequest): Promise<RouteResult[]>
 				)
 			: null;
 
+		// Handle the (uncommon) warmRequests=0 case: without warm samples,
+		// median/p95 would compute against an empty array and produce NaN.
+		// Report the cold TTFB in both slots so the row remains valid;
+		// warm timings are reported as null so downstream code knows there's
+		// no warm breakdown to render.
+		const hasWarm = warmTimings.length > 0;
+		const warmTtfbMs = hasWarm ? Math.round(median(warmTimings) * 100) / 100 : null;
+		const p95TtfbMs = hasWarm ? Math.round(p95(warmTimings) * 100) / 100 : null;
+
 		results.push({
 			path: route.path,
 			label: route.label,
 			coldTtfbMs: Math.round(cold.ttfbMs * 100) / 100,
-			warmTtfbMs: Math.round(median(warmTimings) * 100) / 100,
-			p95TtfbMs: Math.round(p95(warmTimings) * 100) / 100,
+			warmTtfbMs,
+			p95TtfbMs,
 			statusCode: lastStatusCode,
 			cfColo: cold.cfColo,
 			cfPlacement: cold.cfPlacement,

--- a/infra/perf-monitor/probe/src/measure.ts
+++ b/infra/perf-monitor/probe/src/measure.ts
@@ -23,6 +23,13 @@ export interface RouteResult {
 	cfPlacement: string | null;
 	/** Parsed from the cold response. Null if header absent or unparseable. */
 	coldServerTimings: ServerTimings | null;
+	/**
+	 * Median of each Server-Timing metric across all warm requests.
+	 * Null if no warm responses carried the header or no warm requests
+	 * were issued. Use this to isolate steady-state render/middleware/
+	 * runtime cost, independent of cold-start.
+	 */
+	warmServerTimings: ServerTimings | null;
 }
 
 export interface MeasureResponse {
@@ -141,14 +148,37 @@ export async function measureRoutes(req: MeasureRequest): Promise<RouteResult[]>
 		const coldUrl = url + (url.includes("?") ? "&" : "?") + `_perf_cold=${Date.now()}`;
 		const cold = await measureTtfb(coldUrl);
 
-		// Warm requests
+		// Warm requests — keep per-metric samples so we can median each one.
 		const warmTimings: number[] = [];
+		const warmMetricSamples: Record<string, { durs: number[]; desc?: string }> = {};
 		let lastStatusCode = cold.statusCode;
 		for (let i = 0; i < req.warmRequests; i++) {
 			const warm = await measureTtfb(url);
 			warmTimings.push(warm.ttfbMs);
 			lastStatusCode = warm.statusCode;
+			if (warm.serverTimings) {
+				for (const [name, entry] of Object.entries(warm.serverTimings)) {
+					const acc = warmMetricSamples[name] ?? { durs: [], desc: entry.desc };
+					acc.durs.push(entry.dur);
+					if (!acc.desc && entry.desc) acc.desc = entry.desc;
+					warmMetricSamples[name] = acc;
+				}
+			}
 		}
+
+		// Collapse per-metric samples into medians so the stored shape
+		// mirrors coldServerTimings.
+		const warmServerTimings: ServerTimings | null = Object.keys(warmMetricSamples).length
+			? Object.fromEntries(
+					Object.entries(warmMetricSamples).map(([name, { durs, desc }]) => {
+						const entry: { dur: number; desc?: string } = {
+							dur: Math.round(median(durs) * 100) / 100,
+						};
+						if (desc) entry.desc = desc;
+						return [name, entry];
+					}),
+				)
+			: null;
 
 		results.push({
 			path: route.path,
@@ -160,6 +190,7 @@ export async function measureRoutes(req: MeasureRequest): Promise<RouteResult[]>
 			cfColo: cold.cfColo,
 			cfPlacement: cold.cfPlacement,
 			coldServerTimings: cold.serverTimings,
+			warmServerTimings,
 		});
 	}
 

--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -432,7 +432,8 @@
 								<th>P95</th>
 								<th>Status</th>
 								<th>Colo</th>
-								<th>Server Timings</th>
+								<th>Cold Timings</th>
+								<th>Warm Timings</th>
 								<th>Source</th>
 							</tr>
 						</thead>
@@ -840,7 +841,7 @@
 
 				if (!data.results || data.results.length === 0) {
 					tbody.innerHTML =
-						'<tr><td colspan="10" style="text-align:center;color:var(--text-dim)">No results</td></tr>';
+						'<tr><td colspan="11" style="text-align:center;color:var(--text-dim)">No results</td></tr>';
 					return;
 				}
 
@@ -871,6 +872,7 @@
               <td class="mono">${r.status_code ?? "-"}</td>
               <td class="mono">${r.cf_colo ?? "-"}</td>
               <td>${renderServerTimings(r.cold_server_timings)}</td>
+              <td>${renderServerTimings(r.warm_server_timings)}</td>
               <td>${sourceBadge}${prLink}${shaLink}</td>
             </tr>`;
 					})

--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -439,7 +439,7 @@
 						</thead>
 						<tbody id="results-body">
 							<tr>
-								<td colspan="10" class="loading">Loading...</td>
+								<td colspan="11" class="loading">Loading...</td>
 							</tr>
 						</tbody>
 					</table>

--- a/infra/perf-monitor/scripts/trigger.mjs
+++ b/infra/perf-monitor/scripts/trigger.mjs
@@ -163,23 +163,41 @@ for (const r of parsed.results ?? []) {
 for (const [route, rows] of byRoute) {
 	console.log(`\n  ${bold(route)}`);
 
-	// Collect the union of timing names present on this route so every row
-	// gets a cell in each timing column, even if one probe's response lacked
-	// a particular timing entry.
-	const timingNames = [];
-	const seen = new Set();
+	// Collect the union of timing names present on this route across BOTH
+	// cold and warm snapshots so every row gets a cell in each column,
+	// even when a particular probe response lacked some entries.
+	// Warm timings are prefixed with "warm." in the column header to make
+	// the split obvious (cold and warm snapshots share the same metric
+	// names — "render", "rt", "mw" — so we'd collide otherwise).
+	const coldNames = [];
+	const warmNames = [];
+	const seenCold = new Set();
+	const seenWarm = new Set();
 	for (const r of rows) {
-		if (!r.coldServerTimings) continue;
-		for (const name of Object.keys(r.coldServerTimings)) {
-			if (!seen.has(name)) {
-				seen.add(name);
-				timingNames.push(name);
+		if (r.coldServerTimings) {
+			for (const name of Object.keys(r.coldServerTimings)) {
+				if (!seenCold.has(name)) {
+					seenCold.add(name);
+					coldNames.push(name);
+				}
+			}
+		}
+		if (r.warmServerTimings) {
+			for (const name of Object.keys(r.warmServerTimings)) {
+				if (!seenWarm.has(name)) {
+					seenWarm.add(name);
+					warmNames.push(name);
+				}
 			}
 		}
 	}
 
-	// Build row cells as arrays of strings, then compute widths once.
-	const header = ["region", "cold", "warm", "p95", "colo", ...timingNames];
+	// Build row cells. Column order: region, cold, warm, p95, colo,
+	// then all cold timings (cold-* intent), then warm timings.
+	// Cold timings keep their bare names for backwards-compatible output;
+	// warm timings get a "w." prefix.
+	const warmHeaders = warmNames.map((n) => `w.${n}`);
+	const header = ["region", "cold", "warm", "p95", "colo", ...coldNames, ...warmHeaders];
 	const tableRows = rows.map((r) => {
 		const cells = [
 			r.region,
@@ -188,8 +206,12 @@ for (const [route, rows] of byRoute) {
 			formatMs(r.p95TtfbMs),
 			r.cfColo ?? "-",
 		];
-		for (const name of timingNames) {
+		for (const name of coldNames) {
 			const t = r.coldServerTimings?.[name];
+			cells.push(t ? formatMs(t.dur) : "-");
+		}
+		for (const name of warmNames) {
+			const t = r.warmServerTimings?.[name];
 			cells.push(t ? formatMs(t.dur) : "-");
 		}
 		return cells;

--- a/infra/perf-monitor/scripts/trigger.mjs
+++ b/infra/perf-monitor/scripts/trigger.mjs
@@ -166,7 +166,7 @@ for (const [route, rows] of byRoute) {
 	// Collect the union of timing names present on this route across BOTH
 	// cold and warm snapshots so every row gets a cell in each column,
 	// even when a particular probe response lacked some entries.
-	// Warm timings are prefixed with "warm." in the column header to make
+	// Warm timings are prefixed with "w." in the column header to make
 	// the split obvious (cold and warm snapshots share the same metric
 	// names — "render", "rt", "mw" — so we'd collide otherwise).
 	const coldNames = [];

--- a/infra/perf-monitor/src/api.ts
+++ b/infra/perf-monitor/src/api.ts
@@ -213,6 +213,7 @@ async function handleTrigger(request: Request, env: Env): Promise<Response> {
 			p95TtfbMs: r.p95TtfbMs,
 			cfColo: r.cfColo,
 			coldServerTimings: r.coldServerTimings,
+			warmServerTimings: r.warmServerTimings,
 		})),
 	});
 }

--- a/infra/perf-monitor/src/measure.ts
+++ b/infra/perf-monitor/src/measure.ts
@@ -72,6 +72,7 @@ export async function runMeasurements(env: Env, opts: RunOptions): Promise<Inser
 					cfColo: r.cfColo,
 					cfPlacement: r.cfPlacement,
 					coldServerTimings: r.coldServerTimings,
+					warmServerTimings: r.warmServerTimings,
 					note,
 					source,
 				}),

--- a/infra/perf-monitor/src/store.ts
+++ b/infra/perf-monitor/src/store.ts
@@ -17,6 +17,12 @@ export interface PerfResult {
 	cf_placement: string | null;
 	/** Raw JSON string as stored. Use {@link parseColdServerTimings} to decode. */
 	cold_server_timings: string | null;
+	/**
+	 * Median duration per metric across warm requests, same JSON shape as
+	 * `cold_server_timings`. Null when the target didn't emit Server-Timing
+	 * on warm responses, or when no warm requests were issued.
+	 */
+	warm_server_timings: string | null;
 	note: string | null;
 	timestamp: string;
 	source: string;
@@ -36,14 +42,16 @@ export interface InsertParams {
 	cfPlacement: string | null;
 	/** Will be JSON.stringify'd on the way in. Null if unavailable. */
 	coldServerTimings: Record<string, { dur: number; desc?: string }> | null;
+	/** Median-per-metric snapshot of warm Server-Timing. Null if unavailable. */
+	warmServerTimings: Record<string, { dur: number; desc?: string }> | null;
 	note: string | null;
 	source: Source;
 }
 
 /** Column list shared between insertResult and insertResults. */
 const INSERT_COLUMNS =
-	"id, sha, pr_number, route, region, cold_ttfb_ms, warm_ttfb_ms, p95_ttfb_ms, status_code, cf_colo, cf_placement, cold_server_timings, note, source";
-const INSERT_PLACEHOLDERS = "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?";
+	"id, sha, pr_number, route, region, cold_ttfb_ms, warm_ttfb_ms, p95_ttfb_ms, status_code, cf_colo, cf_placement, cold_server_timings, warm_server_timings, note, source";
+const INSERT_PLACEHOLDERS = "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?";
 
 function bindInsert(stmt: D1PreparedStatement, p: InsertParams): D1PreparedStatement {
 	return stmt.bind(
@@ -59,6 +67,7 @@ function bindInsert(stmt: D1PreparedStatement, p: InsertParams): D1PreparedState
 		p.cfColo,
 		p.cfPlacement,
 		p.coldServerTimings ? JSON.stringify(p.coldServerTimings) : null,
+		p.warmServerTimings ? JSON.stringify(p.warmServerTimings) : null,
 		p.note,
 		p.source,
 	);


### PR DESCRIPTION
## What does this PR do?

The perf monitor was parsing Server-Timing headers only from the cold-boot probe and discarding warm ones. Warm TTFB was stored as a single millisecond number with no breakdown, so any runtime change that moved the warm \`render\` component (most of them) was invisible on the dashboard and in \`pnpm trigger\` output. Homepage render changes in #626 and #627 were only measurable because of this instrumentation.

### Changes

- Probe now records Server-Timing on each warm request and returns the per-metric median alongside the existing cold snapshot.
- New \`warm_server_timings\` column on \`perf_results\` (migration \`0002\`, same JSON shape as \`cold_server_timings\`).
- Dashboard table shows cold and warm timings side by side.
- \`pnpm trigger\` output prefixes warm metric columns with \`w.\` so existing cold columns stay in place.

Migration has been applied to the production \`emdash_perf\` D1 database, and the coordinator + probes are already deployed — this PR is mostly making the source of truth catch up.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (N/A — infra instrumentation; probe output is verified by running the probes live)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A — internal dashboard)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (N/A — infra only, no published package affected)
- [ ] New features link to an approved Discussion (N/A — infra chore)

## AI-generated code disclosure

- [x] This PR includes AI-generated code