### PR TITLE
fix(admin): add toast feedback for taxonomy assignment saves

### DIFF
--- a/.changeset/taxonomy-save-feedback.md
+++ b/.changeset/taxonomy-save-feedback.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds toast feedback when taxonomy assignments are saved or fail on content items.

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -6,7 +6,7 @@
  * - Tag input for flat taxonomies (tags)
  */
 
-import { Button, Input, Label } from "@cloudflare/kumo";
+import { Button, Input, Label, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -286,6 +286,7 @@ function TaxonomySection({
 }) {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const toastManager = Toast.useToastManager();
 	const [newCategoryLabel, setNewCategoryLabel] = React.useState("");
 	const [showCategoryInput, setShowCategoryInput] = React.useState(false);
 
@@ -311,6 +312,14 @@ function TaxonomySection({
 		onSuccess: () => {
 			void queryClient.invalidateQueries({
 				queryKey: ["entry-terms", collection, entryId, taxonomy.name],
+			});
+			toastManager.add({ title: t`${taxonomy.label} updated` });
+		},
+		onError: (error) => {
+			toastManager.add({
+				title: t`Failed to update ${taxonomy.label.toLowerCase()}`,
+				description: error instanceof Error ? error.message : t`An error occurred`,
+				type: "error",
 			});
 		},
 	});


### PR DESCRIPTION
## What does this PR do?

Adds toast notifications when taxonomy assignments (categories/tags) are saved or fail on content items. Previously, these auto-saves were completely silent: no success or error feedback.

In the future, we might want to add notifications throughout the admin.

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #228

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

<img width="516" height="490" alt="Screenshot 2026-04-17 at 5 50 14 PM" src="https://github.com/user-attachments/assets/d64be681-fab2-46e4-a64d-f04329a46654" />

