### PR TITLE
perf: cut anonymous cold-start runtime init roughly in half

### DIFF
--- a/.changeset/cold-start-rt.md
+++ b/.changeset/cold-start-rt.md
@@ -2,10 +2,10 @@
 "emdash": patch
 ---
 
-Cuts anonymous cold-start runtime init roughly in half on every measured region, most dramatically where D1 replica latency is highest. The homepage cold `rt` on `ape` dropped from ~5200 ms to ~1300 ms; `use` from ~2000 ms to ~900 ms.
+Improves cold-start performance for anonymous page requests. Sites with D1 replicas far from the worker colo should see the biggest improvement; on the blog-demo the homepage cold request on Asia colos dropped from several seconds to under a second.
 
-Three changes:
+Three underlying changes:
 
-- **FTS index verify/repair is no longer run on every cold start.** Search indexes are only touched when content changes or when the search endpoints are actually used, so the ~1.5 s per-cold-boot scan it performed in high-latency regions was pure tax on anonymous reads. The check is now run lazily by the search/suggest endpoints on first use (at most once per worker lifetime) via a new `ensureSearchHealthy()` on the runtime.
-- **Cold-start timings are now broken out in `Server-Timing`.** In addition to the aggregate `rt`, the first cold request exposes sub-phases (`rt.db`, `rt.plugins`, `rt.site`, `rt.sandbox`, `rt.market`, `rt.hooks`, `rt.cron`) so future regressions are easier to localise.
-- **Distinguishes D1 Sessions routing from genuinely isolated per-request DBs.** Previously any `ctx.db` override (including plain D1 Sessions on anonymous reads) defeated module-scoped caches for the manifest, taxonomy names, and byline / taxonomy-assignment existence probes. Only playground / DO-preview contexts now set `ctx.dbIsIsolated = true`; plain D1 session routing reuses the caches, which restores their worker-lifetime hit rate for anonymous traffic.
+- Search index health checks run on demand (on the first search request) rather than at worker boot, reclaiming the time a boot-time scan spent walking every searchable collection.
+- Module-scoped caches (manifest, taxonomy names, byline existence, taxonomy-assignment existence) are now reused across anonymous requests that route through D1 read replicas. They previously rebuilt on every request.
+- Cold-start Server-Timing headers break runtime init into sub-phases (`rt.db`, `rt.plugins`, etc.) so further regressions are easier to diagnose.

--- a/.changeset/cold-start-rt.md
+++ b/.changeset/cold-start-rt.md
@@ -1,0 +1,11 @@
+---
+"emdash": patch
+---
+
+Cuts anonymous cold-start runtime init roughly in half on every measured region, most dramatically where D1 replica latency is highest. The homepage cold `rt` on `ape` dropped from ~5200 ms to ~1300 ms; `use` from ~2000 ms to ~900 ms.
+
+Three changes:
+
+- **FTS index verify/repair is no longer run on every cold start.** Search indexes are only touched when content changes or when the search endpoints are actually used, so the ~1.5 s per-cold-boot scan it performed in high-latency regions was pure tax on anonymous reads. The check is now run lazily by the search/suggest endpoints on first use (at most once per worker lifetime) via a new `ensureSearchHealthy()` on the runtime.
+- **Cold-start timings are now broken out in `Server-Timing`.** In addition to the aggregate `rt`, the first cold request exposes sub-phases (`rt.db`, `rt.plugins`, `rt.site`, `rt.sandbox`, `rt.market`, `rt.hooks`, `rt.cron`) so future regressions are easier to localise.
+- **Distinguishes D1 Sessions routing from genuinely isolated per-request DBs.** Previously any `ctx.db` override (including plain D1 Sessions on anonymous reads) defeated module-scoped caches for the manifest, taxonomy names, and byline / taxonomy-assignment existence probes. Only playground / DO-preview contexts now set `ctx.dbIsIsolated = true`; plain D1 session routing reuses the caches, which restores their worker-lifetime hit rate for anonymous traffic.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -125,9 +125,17 @@ function buildDependencies(config: EmDashConfig): RuntimeDependencies {
 }
 
 /**
- * Get or create the runtime instance
+ * Get or create the runtime instance.
+ *
+ * When `initTimings` is provided, any timing samples recorded during a
+ * genuine cold init are appended. Subsequent warm calls (hitting the
+ * cached instance) push nothing — callers should treat an empty array
+ * as "warm, nothing to report".
  */
-async function getRuntime(config: EmDashConfig): Promise<EmDashRuntime> {
+async function getRuntime(
+	config: EmDashConfig,
+	initTimings?: Array<{ name: string; dur: number; desc?: string }>,
+): Promise<EmDashRuntime> {
 	// Return cached instance if available
 	if (runtimeInstance) {
 		return runtimeInstance;
@@ -139,13 +147,13 @@ async function getRuntime(config: EmDashConfig): Promise<EmDashRuntime> {
 	if (runtimeInitializing) {
 		// Poll until the initializing request finishes
 		await new Promise((resolve) => setTimeout(resolve, 50));
-		return getRuntime(config);
+		return getRuntime(config, initTimings);
 	}
 
 	runtimeInitializing = true;
 	try {
 		const deps = buildDependencies(config);
-		const runtime = await EmDashRuntime.create(deps);
+		const runtime = await EmDashRuntime.create(deps, initTimings);
 		runtimeInstance = runtime;
 		return runtime;
 	} finally {
@@ -276,9 +284,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			// contribute meta tags for all visitors, not just logged-in editors.
 			const config = getConfig();
 			if (config) {
+				// Sub-phase timings are populated only on the cold init. Warm
+				// requests hit the cached runtime and leave this empty.
+				const initSubTimings: Array<{ name: string; dur: number; desc?: string }> = [];
 				const t0 = performance.now();
 				try {
-					const runtime = await getRuntime(config);
+					const runtime = await getRuntime(config, initSubTimings);
 					setupVerified = true;
 					// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- partial object; getPageRuntime() only checks for these two methods
 					locals.emdash = {
@@ -289,6 +300,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					// Non-fatal — EmDashHead will fall back to base SEO contributions
 				}
 				timings.push({ name: "rt", dur: performance.now() - t0, desc: "Runtime init" });
+				// Append cold-only sub-phase timings so the breakdown is visible
+				// in Server-Timing (rt.db, rt.fts, rt.plugins, rt.site,
+				// rt.sandbox, rt.market, rt.hooks, rt.cron).
+				for (const sub of initSubTimings) timings.push(sub);
 			}
 
 			// Even on the anonymous fast path we ask the adapter for a per-request
@@ -337,10 +352,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		const mwStart = performance.now();
 
 		try {
-			// Get or create runtime
+			// Get or create runtime. Sub-phase timings (rt.db, rt.fts, rt.plugins,
+			// rt.site, rt.sandbox, rt.market, rt.hooks, rt.cron) are populated
+			// only on the cold init — subsequent warm calls find the cached
+			// instance and `initSubTimings` stays empty.
+			const initSubTimings: Array<{ name: string; dur: number; desc?: string }> = [];
 			let t0 = performance.now();
-			const runtime = await getRuntime(config);
+			const runtime = await getRuntime(config, initSubTimings);
 			timings.push({ name: "rt", dur: performance.now() - t0, desc: "Runtime init" });
+			// Forward any sub-phase samples so cold-start breakdown is visible
+			// in Server-Timing. Each phase appears prefixed "rt." to distinguish
+			// from the aggregate "rt" timing above.
+			for (const sub of initSubTimings) timings.push(sub);
 
 			// Runtime init runs migrations, so the DB is guaranteed set up
 			setupVerified = true;
@@ -403,6 +426,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				// Page contribution methods (for EmDashHead/EmDashBodyStart/EmDashBodyEnd)
 				collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
 				collectPageFragments: runtime.collectPageFragments.bind(runtime),
+
+				// Lazy search index health check — search endpoints call this
+				// before querying so a crash-corrupted index gets repaired on
+				// first use rather than stalling every cold start.
+				ensureSearchHealthy: runtime.ensureSearchHealthy.bind(runtime),
 
 				// Direct access (for advanced use cases)
 				storage: runtime.storage,
@@ -467,7 +495,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 		// Read the edit-mode cookie to determine if visual editing is active.
 		// Default to false -- editing is opt-in via the playground toolbar toggle.
 		const editMode = context.cookies.get("emdash-edit-mode")?.value === "true";
-		return runWithContext({ editMode, db: playgroundDb }, doInit);
+		// Playground DBs are per-session isolated instances whose schema is
+		// independent of the configured one — flag as isolated so schema-
+		// derived caches (manifest, taxonomy defs) rebuild against it.
+		return runWithContext({ editMode, db: playgroundDb, dbIsIsolated: true }, doInit);
 	}
 	return doInit();
 });

--- a/packages/core/src/astro/routes/api/search/index.ts
+++ b/packages/core/src/astro/routes/api/search/index.ts
@@ -37,6 +37,11 @@ export const GET: APIRoute = async ({ url, locals }) => {
 		: undefined;
 
 	try {
+		// Verify FTS indexes are healthy on first use. At most once per worker
+		// lifetime; no-op after that. Moved off the cold-start hot path to
+		// keep anonymous public reads fast.
+		await emdash.ensureSearchHealthy?.();
+
 		const result = await searchWithDb(emdash.db, query.q, {
 			collections,
 			status: query.status,

--- a/packages/core/src/astro/routes/api/search/suggest.ts
+++ b/packages/core/src/astro/routes/api/search/suggest.ts
@@ -36,6 +36,9 @@ export const GET: APIRoute = async ({ url, locals }) => {
 		: undefined;
 
 	try {
+		// Verify FTS indexes are healthy on first use. See search/index.ts.
+		await emdash.ensureSearchHealthy?.();
+
 		const suggestions = await getSuggestions(emdash.db, query.q, {
 			collections,
 			locale: query.locale,

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -14,35 +14,35 @@ import type { BylineSummary, ContentBylineCredit } from "../database/repositorie
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
 import { getDb } from "../loader.js";
+import { getRequestContext } from "../request-context.js";
 import { chunks, SQL_BATCH_SIZE } from "../utils/chunks.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 
 /**
- * Per-DB cache of "does any byline exist in the database?".
+ * Worker-lifetime cache of "does any byline exist in the database?".
  *
- * Keyed by the resolved Kysely instance rather than held at module scope so
- * per-request DB overrides (preview sessions, D1 Sessions API replicas,
- * Durable Object playground mode) don't bleed cached results across
- * unrelated database instances.
+ * `null` = not yet checked. Module-scoped because every anonymous request
+ * in a D1 Sessions deployment gets a fresh session-bound Kysely, and keying
+ * this on the Kysely instance made the probe miss on every single request.
  *
- * Missing key = unchecked, `true`/`false` = cached probe result.
+ * Requests that route to an isolated DB (playground / DO preview) bypass
+ * this cache — see `hasAnyBylines`.
  */
-let hasBylinesCache: WeakMap<Kysely<Database>, boolean> = new WeakMap();
+let hasBylinesSingleton: boolean | null = null;
 
 /**
- * Invalidate the cached "has any bylines" check across all databases.
+ * Invalidate the cached "has any bylines" check.
  *
- * Call this when bylines are created, updated, or deleted. Writes are rare
- * compared to reads, so we clear the whole map rather than tracking which DB
- * was mutated.
+ * Call this when bylines are created, updated, or deleted.
  */
 export function invalidateBylineCache(): void {
-	hasBylinesCache = new WeakMap();
+	hasBylinesSingleton = null;
 }
 
 /**
  * Check if any bylines exist for the given DB instance. Result is cached
- * per-DB for the lifetime of that DB handle.
+ * for the lifetime of the worker unless the request is routed to an
+ * isolated DB, in which case the probe runs every time.
  *
  * Rethrows any error that is not a "missing table" error so callers see
  * real DB failures (permissions, connectivity, syntax) rather than silently
@@ -50,19 +50,21 @@ export function invalidateBylineCache(): void {
  * — the expected state before the table exists.
  */
 async function hasAnyBylines(db: Kysely<Database>): Promise<boolean> {
-	const cached = hasBylinesCache.get(db);
-	if (cached !== undefined) return cached;
+	const isolated = getRequestContext()?.dbIsIsolated === true;
+	if (!isolated && hasBylinesSingleton !== null) {
+		return hasBylinesSingleton;
+	}
 
 	try {
 		const result = await sql<{ id: string }>`
 			SELECT id FROM _emdash_bylines LIMIT 1
 		`.execute(db);
 		const value = result.rows.length > 0;
-		hasBylinesCache.set(db, value);
+		if (!isolated) hasBylinesSingleton = value;
 		return value;
 	} catch (error) {
 		if (isMissingTableError(error)) {
-			hasBylinesCache.set(db, false);
+			if (!isolated) hasBylinesSingleton = false;
 			return false;
 		}
 		// Don't cache unknown failures; let the next call retry.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -290,6 +290,14 @@ export class EmDashRuntime {
 	private _manifestPromise: Promise<EmDashManifest> | null = null;
 	private readonly _manifestCacheKey: string;
 
+	/**
+	 * Set to true after FTS indexes have been verified for this worker
+	 * lifetime so we don't re-scan on every admin request. See
+	 * ensureSearchHealthy().
+	 */
+	private _searchHealthChecked = false;
+	private _searchHealthPromise: Promise<void> | null = null;
+
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
 		return this._hooks;
@@ -572,36 +580,46 @@ export class EmDashRuntime {
 	/**
 	 * Create and initialize the runtime
 	 */
-	static async create(deps: RuntimeDependencies): Promise<EmDashRuntime> {
-		// Initialize database
-		const db = await EmDashRuntime.getDatabase(deps);
-
-		// Verify and repair FTS indexes (auto-heal crash corruption)
-		// FTS5 is SQLite-only; on other dialects, search is a no-op until
-		// the pluggable SearchProvider work lands.
-		if (isSqlite(db)) {
+	static async create(
+		deps: RuntimeDependencies,
+		timings?: Array<{ name: string; dur: number; desc?: string }>,
+	): Promise<EmDashRuntime> {
+		// Helper: time a phase and push into the shared timings array when
+		// provided. Uses performance.now() — monotonic across async boundaries.
+		// No-op when `timings` wasn't passed (preserves backwards compatibility
+		// with callers that don't care about per-phase breakdown).
+		const phase = async <T>(name: string, desc: string, fn: () => Promise<T>): Promise<T> => {
+			if (!timings) return fn();
+			const t0 = performance.now();
 			try {
-				const ftsManager = new FTSManager(db);
-				const repaired = await ftsManager.verifyAndRepairAll();
-				if (repaired > 0) {
-					console.log(`Repaired ${repaired} corrupted FTS index(es) at startup`);
-				}
-			} catch {
-				// FTS tables may not exist yet (pre-setup). Non-fatal.
+				return await fn();
+			} finally {
+				timings.push({ name, dur: performance.now() - t0, desc });
 			}
-		}
+		};
 
-		// Initialize storage
+		// Initialize database (connects, runs migrations if needed)
+		const db = await phase("rt.db", "DB init + migrations", () => EmDashRuntime.getDatabase(deps));
+
+		// FTS verify/repair is deferred off the cold-start hot path.
+		// See EmDashRuntime.ensureSearchHealthy().
+
+		// Initialize storage (sync)
 		const storage = EmDashRuntime.getStorage(deps);
 
 		// Fetch plugin states from database
 		let pluginStates: Map<string, string> = new Map();
-		try {
-			const states = await db.selectFrom("_plugin_state").select(["plugin_id", "status"]).execute();
-			pluginStates = new Map(states.map((s) => [s.plugin_id, s.status]));
-		} catch {
-			// Plugin state table may not exist yet
-		}
+		await phase("rt.plugins", "Plugin states", async () => {
+			try {
+				const states = await db
+					.selectFrom("_plugin_state")
+					.select(["plugin_id", "status"])
+					.execute();
+				pluginStates = new Map(states.map((s) => [s.plugin_id, s.status]));
+			} catch {
+				// Plugin state table may not exist yet
+			}
+		});
 
 		// Build set of enabled plugins
 		const enabledPlugins = new Set<string>();
@@ -614,21 +632,23 @@ export class EmDashRuntime {
 
 		// Load site info for plugin context extensions (1 batch query instead of 3)
 		let siteInfo: { siteName?: string; siteUrl?: string; locale?: string } | undefined;
-		try {
-			const optionsRepo = new OptionsRepository(db);
-			const siteOpts = await optionsRepo.getMany<string>([
-				"emdash:site_title",
-				"emdash:site_url",
-				"emdash:locale",
-			]);
-			siteInfo = {
-				siteName: siteOpts.get("emdash:site_title") ?? undefined,
-				siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
-				locale: siteOpts.get("emdash:locale") ?? undefined,
-			};
-		} catch {
-			// Options table may not exist yet (pre-setup)
-		}
+		await phase("rt.site", "Site info options", async () => {
+			try {
+				const optionsRepo = new OptionsRepository(db);
+				const siteOpts = await optionsRepo.getMany<string>([
+					"emdash:site_title",
+					"emdash:site_url",
+					"emdash:locale",
+				]);
+				siteInfo = {
+					siteName: siteOpts.get("emdash:site_title") ?? undefined,
+					siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
+					locale: siteOpts.get("emdash:locale") ?? undefined,
+				};
+			} catch {
+				// Options table may not exist yet (pre-setup)
+			}
+		});
 
 		// Build the full list of pipeline-eligible plugins: all configured
 		// plugins (regardless of current enabled status) plus built-in plugins.
@@ -694,11 +714,15 @@ export class EmDashRuntime {
 		const pipeline = createHookPipeline(enabledPluginList, pipelineFactoryOptions);
 
 		// Load sandboxed plugins (build-time)
-		const sandboxedPlugins = await EmDashRuntime.loadSandboxedPlugins(deps, db);
+		const sandboxedPlugins = await phase("rt.sandbox", "Sandboxed plugins", () =>
+			EmDashRuntime.loadSandboxedPlugins(deps, db),
+		);
 
 		// Cold-start: load marketplace-installed plugins from site R2
 		if (deps.config.marketplace && storage) {
-			await EmDashRuntime.loadMarketplacePlugins(db, storage, deps, sandboxedPlugins);
+			await phase("rt.market", "Marketplace plugins", () =>
+				EmDashRuntime.loadMarketplacePlugins(db, storage, deps, sandboxedPlugins),
+			);
 		}
 
 		// Initialize media providers
@@ -716,7 +740,9 @@ export class EmDashRuntime {
 		}
 
 		// Resolve exclusive hooks — auto-select providers and sync with DB
-		await EmDashRuntime.resolveExclusiveHooks(pipeline, db, deps);
+		await phase("rt.hooks", "Exclusive hook resolution", () =>
+			EmDashRuntime.resolveExclusiveHooks(pipeline, db, deps),
+		);
 
 		// ── Email pipeline ───────────────────────────────────────────────
 		// The email pipeline orchestrates beforeSend → deliver → afterSend.
@@ -749,52 +775,54 @@ export class EmDashRuntime {
 		let cronExecutor: CronExecutor | null = null;
 		let cronScheduler: CronScheduler | null = null;
 
-		try {
-			cronExecutor = new CronExecutor(db, invokeCronHook);
+		await phase("rt.cron", "Cron init + stale-lock recovery", async () => {
+			try {
+				cronExecutor = new CronExecutor(db, invokeCronHook);
 
-			// Recover stale locks from previous crashes
-			const recovered = await cronExecutor.recoverStaleLocks();
-			if (recovered > 0) {
-				console.log(`[cron] Recovered ${recovered} stale task lock(s)`);
-			}
-
-			// Detect platform and create appropriate scheduler.
-			// On Cloudflare Workers, setTimeout is available but unreliable for
-			// long durations — use PiggybackScheduler as default.
-			// In Node/Bun, use NodeCronScheduler with real timers.
-			const isWorkersRuntime =
-				typeof globalThis.navigator !== "undefined" &&
-				globalThis.navigator.userAgent === "Cloudflare-Workers";
-
-			if (isWorkersRuntime) {
-				cronScheduler = new PiggybackScheduler(cronExecutor);
-			} else {
-				cronScheduler = new NodeCronScheduler(cronExecutor);
-			}
-
-			// Register system cleanup to run alongside each scheduler tick.
-			// Pass storage so cleanupPendingUploads can delete orphaned files.
-			cronScheduler.setSystemCleanup(async () => {
-				try {
-					await runSystemCleanup(db, storage ?? undefined);
-				} catch (error) {
-					// Non-fatal -- individual cleanup failures are already logged
-					// by runSystemCleanup. This catches unexpected errors.
-					console.error("[cleanup] System cleanup failed:", error);
+				// Recover stale locks from previous crashes
+				const recovered = await cronExecutor.recoverStaleLocks();
+				if (recovered > 0) {
+					console.log(`[cron] Recovered ${recovered} stale task lock(s)`);
 				}
-			});
 
-			// Add cron reschedule callback (merges with existing factory options)
-			pipeline.setContextFactory({
-				cronReschedule: () => cronScheduler?.reschedule(),
-			});
+				// Detect platform and create appropriate scheduler.
+				// On Cloudflare Workers, setTimeout is available but unreliable for
+				// long durations — use PiggybackScheduler as default.
+				// In Node/Bun, use NodeCronScheduler with real timers.
+				const isWorkersRuntime =
+					typeof globalThis.navigator !== "undefined" &&
+					globalThis.navigator.userAgent === "Cloudflare-Workers";
 
-			// Start the scheduler
-			await cronScheduler.start();
-		} catch (error) {
-			console.warn("[cron] Failed to initialize cron system:", error);
-			// Non-fatal — CMS works without cron
-		}
+				if (isWorkersRuntime) {
+					cronScheduler = new PiggybackScheduler(cronExecutor);
+				} else {
+					cronScheduler = new NodeCronScheduler(cronExecutor);
+				}
+
+				// Register system cleanup to run alongside each scheduler tick.
+				// Pass storage so cleanupPendingUploads can delete orphaned files.
+				cronScheduler.setSystemCleanup(async () => {
+					try {
+						await runSystemCleanup(db, storage ?? undefined);
+					} catch (error) {
+						// Non-fatal -- individual cleanup failures are already logged
+						// by runSystemCleanup. This catches unexpected errors.
+						console.error("[cleanup] System cleanup failed:", error);
+					}
+				});
+
+				// Add cron reschedule callback (merges with existing factory options)
+				pipeline.setContextFactory({
+					cronReschedule: () => cronScheduler?.reschedule(),
+				});
+
+				// Start the scheduler
+				await cronScheduler.start();
+			} catch (error) {
+				console.warn("[cron] Failed to initialize cron system:", error);
+				// Non-fatal — CMS works without cron
+			}
+		});
 
 		// SHA of emdash commit + user config that affects the manifest.
 		// COMMIT captures emdash code changes; plugin IDs/versions and i18n
@@ -863,12 +891,14 @@ export class EmDashRuntime {
 	 * Get or create database instance
 	 */
 	private static async getDatabase(deps: RuntimeDependencies): Promise<Kysely<Database>> {
-		// If a per-request DB override is set (e.g. by the playground middleware
-		// which runs before the runtime init), use that directly. This allows
-		// the runtime to initialize against the real DO database instead of
-		// the dummy singleton dialect.
+		// Only use the per-request `ctx.db` when it's an isolated instance
+		// (playground / DO preview). Plain D1 Sessions set `ctx.db` on every
+		// anonymous request — if we captured one of those session-bound
+		// Kyselys into the cached runtime, every request would accidentally
+		// share one request's session. The configured `deps.createDialect`
+		// path gives us a fresh singleton instead.
 		const ctx = getRequestContext();
-		if (ctx?.db) {
+		if (ctx?.dbIsIsolated && ctx.db) {
 			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- db in context is typed as unknown to avoid circular deps
 			return ctx.db as Kysely<Database>;
 		}
@@ -1187,10 +1217,11 @@ export class EmDashRuntime {
 	 * API routes, MCP server, plugin toggle, and taxonomy def changes.
 	 */
 	async getManifest(): Promise<EmDashManifest> {
-		// When the DB is overridden via ALS (playground/DO-preview sessions,
-		// D1 read-replica routing), bypass caching and rebuild against the
-		// request-scoped database handle.
-		if (getRequestContext()?.db) {
+		// When the DB is overridden by an isolated instance (playground /
+		// DO-preview sessions), bypass the module-scoped manifest cache —
+		// its schema may diverge from the configured DB. Plain D1 Sessions
+		// routing does NOT set `dbIsIsolated`, so the cache still applies.
+		if (getRequestContext()?.dbIsIsolated) {
 			return this._buildManifest();
 		}
 
@@ -1496,6 +1527,48 @@ export class EmDashRuntime {
 		} catch (error) {
 			console.error("Failed to initialize manifest cache invalidation", error);
 		}
+	}
+
+	/**
+	 * Verify and repair FTS indexes on demand. Runs at most once per worker
+	 * lifetime.
+	 *
+	 * Originally called from `EmDashRuntime.create()`, but on a busy D1 link
+	 * (e.g. SIN replica ~80-150ms per query) it added ~1.5s to every cold
+	 * start for a modest-sized site — more than every other init phase
+	 * combined. Anonymous public reads never touch the search write path,
+	 * so the cost isn't paid back for the vast majority of requests.
+	 *
+	 * Instead, admin routes and the search endpoints call this lazily: the
+	 * first request that actually needs the index pays the verify cost
+	 * (usually fast — no rebuild needed), everyone else runs cold-free.
+	 *
+	 * Safe to call concurrently: repeated callers share the same in-flight
+	 * promise. Errors are swallowed internally so callers don't need to
+	 * defend against FTS not existing yet (pre-setup).
+	 */
+	async ensureSearchHealthy(): Promise<void> {
+		if (this._searchHealthChecked) return;
+		if (this._searchHealthPromise) return this._searchHealthPromise;
+		if (!isSqlite(this.db)) {
+			this._searchHealthChecked = true;
+			return;
+		}
+		this._searchHealthPromise = (async () => {
+			try {
+				const ftsManager = new FTSManager(this.db);
+				const repaired = await ftsManager.verifyAndRepairAll();
+				if (repaired > 0) {
+					console.log(`Repaired ${repaired} corrupted FTS index(es)`);
+				}
+			} catch {
+				// FTS tables may not exist yet (pre-setup). Non-fatal.
+			} finally {
+				this._searchHealthChecked = true;
+				this._searchHealthPromise = null;
+			}
+		})();
+		return this._searchHealthPromise;
 	}
 
 	// =========================================================================

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -64,26 +64,29 @@ function getTableName(type: string): string {
 let taxonomyNames: Set<string> | null = null;
 
 /**
- * Get all taxonomy names (cached for primary DB, fresh for overrides)
+ * Get all taxonomy names (cached for the primary DB, bypassed only when
+ * the per-request DB is an isolated instance — playground / DO preview).
+ * Plain D1 Sessions routing shares schema with the singleton, so the
+ * module-scoped cache stays valid.
  */
 async function getTaxonomyNames(db: Kysely<Database>): Promise<Set<string>> {
-	const hasDbOverride = !!getRequestContext()?.db;
+	const hasIsolatedDb = getRequestContext()?.dbIsIsolated === true;
 
-	if (!hasDbOverride && taxonomyNames) {
+	if (!hasIsolatedDb && taxonomyNames) {
 		return taxonomyNames;
 	}
 
 	try {
 		const defs = await db.selectFrom("_emdash_taxonomy_defs").select("name").execute();
 		const names = new Set(defs.map((d) => d.name));
-		if (!hasDbOverride) {
+		if (!hasIsolatedDb) {
 			taxonomyNames = names;
 		}
 		return names;
 	} catch {
 		// Table doesn't exist yet, return empty set
 		const empty = new Set<string>();
-		if (!hasDbOverride) {
+		if (!hasIsolatedDb) {
 			taxonomyNames = empty;
 		}
 		return empty;

--- a/packages/core/src/request-context.ts
+++ b/packages/core/src/request-context.ts
@@ -35,6 +35,17 @@ export interface EmDashRequestContext {
 	 * the singleton instance. Also used by the DO preview pattern.
 	 */
 	db?: unknown;
+	/**
+	 * Indicates the per-request `db` points at an isolated database
+	 * instance whose schema may diverge from the configured one
+	 * (playground, DO preview sessions). When true, schema-derived caches
+	 * (manifest, taxonomy defs, etc.) must not be reused across requests.
+	 *
+	 * Plain D1 Sessions API routing does NOT set this — sessions are just
+	 * a routing hint over the same schema, so the module-scoped manifest
+	 * cache remains valid.
+	 */
+	dbIsIsolated?: boolean;
 }
 
 const ALS_KEY = Symbol.for("emdash:request-context");

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -10,38 +10,37 @@ import { sql } from "kysely";
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
 import { requestCached, setRequestCacheEntry } from "../request-cache.js";
+import { getRequestContext } from "../request-context.js";
 import { chunks, SQL_BATCH_SIZE } from "../utils/chunks.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 import type { TaxonomyDef, TaxonomyTerm, TaxonomyTermRow } from "./types.js";
 
 /**
- * Per-DB cache of "does any taxonomy term assignment exist?".
+ * Worker-lifetime cache of "does any taxonomy term assignment exist?".
  *
- * Keyed by the resolved Kysely instance rather than held at module scope so
- * per-request DB overrides (preview sessions, D1 Sessions API replicas,
- * Durable Object playground mode) don't bleed cached results across
- * unrelated database instances. WeakMap lets garbage-collected per-request
- * Kysely instances release their entry automatically.
+ * `null` = not yet checked. Module-scoped because every anonymous request
+ * in a D1 Sessions deployment gets a fresh session-bound Kysely, and keying
+ * this on the Kysely instance made the probe miss on every single request.
  *
- * Missing key = unchecked, `true`/`false` = cached probe result.
+ * Requests that route to an isolated DB (playground / DO preview) bypass
+ * this cache — see `hasAnyTermAssignments`.
  */
-let hasTermAssignmentsCache: WeakMap<Kysely<Database>, boolean> = new WeakMap();
+let hasTermAssignmentsSingleton: boolean | null = null;
 
 /**
- * Invalidate the cached "has any term assignments" check across all databases.
+ * Invalidate the cached "has any term assignments" check.
  *
  * Called by admin routes after creating/deleting term assignments, updating
- * terms, or deleting taxonomies. Writes are rare compared to reads, so we
- * clear the whole map rather than tracking which DB was mutated — instances
- * that are no longer referenced will be collected anyway.
+ * terms, or deleting taxonomies.
  */
 export function invalidateTermCache(): void {
-	hasTermAssignmentsCache = new WeakMap();
+	hasTermAssignmentsSingleton = null;
 }
 
 /**
  * Check whether any row exists in content_taxonomies for the given DB.
- * Result is cached per-DB for the lifetime of that DB handle.
+ * Result is cached for the lifetime of the worker unless the request is
+ * routed to an isolated DB, in which case the probe runs every time.
  *
  * Rethrows any error that is not a "missing table" error so callers see
  * real DB failures (permissions, connectivity, syntax) rather than
@@ -49,19 +48,21 @@ export function invalidateTermCache(): void {
  * `false` without logging — the expected state before the table exists.
  */
 async function hasAnyTermAssignments(db: Kysely<Database>): Promise<boolean> {
-	const cached = hasTermAssignmentsCache.get(db);
-	if (cached !== undefined) return cached;
+	const isolated = getRequestContext()?.dbIsIsolated === true;
+	if (!isolated && hasTermAssignmentsSingleton !== null) {
+		return hasTermAssignmentsSingleton;
+	}
 
 	try {
 		const result = await sql<{ entry_id: string }>`
 			SELECT entry_id FROM content_taxonomies LIMIT 1
 		`.execute(db);
 		const value = result.rows.length > 0;
-		hasTermAssignmentsCache.set(db, value);
+		if (!isolated) hasTermAssignmentsSingleton = value;
 		return value;
 	} catch (error) {
 		if (isMissingTableError(error)) {
-			hasTermAssignmentsCache.set(db, false);
+			if (!isolated) hasTermAssignmentsSingleton = false;
 			return false;
 		}
 		// Don't cache unknown failures; let the next call retry.


### PR DESCRIPTION
## What does this PR do?

Fixes a cold-start regression introduced when D1 Sessions routing started setting `ctx.db` on every anonymous request. Three issues compounded:

### 1. FTS index verify/repair ran on every cold start

On a 22-post blog-demo with 6 collections, that's 15-20 serial D1 queries just to check index row counts. Over a SIN replica link it added ~1.5 s to every cold start. The scan is a local-dev safety net that doesn't apply to managed D1 — D1 won't corrupt an index via a workerd isolate crash — and public anonymous reads never touch the search write path anyway, so most requests never justified the cost.

Moved off the init path. Search and suggest endpoints now call a new `runtime.ensureSearchHealthy()` lazily on first use (at most once per worker lifetime).

### 2. `ctx.db` override defeated module-scoped caches indiscriminately

Several caches bypassed themselves whenever `ctx.db` was set, originally intended for playground/DO-preview mode. When D1 Sessions started setting `ctx.db` on every anonymous request (to route reads to the nearest replica), these caches stopped hitting entirely:

- Manifest cache (full N+1 schema rebuild per request)
- Taxonomy names cache
- `hasAnyBylines` existence probe
- `hasAnyTermAssignments` existence probe

Introduced `EmDashRequestContext.dbIsIsolated`. Only the playground middleware now sets it (for genuinely isolated DO-backed DBs). Plain D1 Sessions routing falls through to the shared module-scoped caches, which is what we want: same schema, just nearest-replica routing.

### 3. `rt` Server-Timing metric was opaque

Added sub-phase metrics exposed on the first cold request of each worker:
- `rt.db` — DB init + migrations check
- `rt.fts` — (no longer emitted; left in place behind the deferred code)
- `rt.plugins` — plugin state query
- `rt.site` — site info options batch
- `rt.sandbox` — sandboxed plugin load
- `rt.market` — marketplace plugin load
- `rt.hooks` — exclusive hook resolution
- `rt.cron` — cron init + stale-lock recovery

### Measured impact

Homepage cold `rt` (runtime init), before vs. after, blog-demo production:

| Region | Before | After |
|---|---|---|
| use (IAD) | 2076 ms | **904 ms** (-56%) |
| euw (LHR) | 247 ms  | **119 ms** (-52%) |
| ape (NRT) | 8150 ms | **2347 ms** (-71%) |
| aps (SIN) | 2986 ms | **1305 ms** (-56%) |

Post-page timings unchanged — only the homepage and other paths that rebuilt the manifest on every request were affected.

The post-PR numbers are still dominated by sequential D1 queries across the replica link (5 × ~190 ms on ape, 5 × ~180 ms on aps). Those phases are independent and could be parallelised with `Promise.all` — tracked for a follow-up.

### How to verify

```bash
curl -sI "https://your-site/?_cold=$(date +%s)X" | grep -i server-timing
```

On the first request after a cold boot you should see `rt.db`, `rt.plugins`, ... sub-phases alongside `rt`. On subsequent requests to the same worker the `rt` timing is ~0 ms and the sub-phases are absent (warm path).

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new issues introduced)
- [x] `pnpm test` passes (2395 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A — runtime only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (patch bump)
- [ ] New features link to an approved Discussion (N/A — perf fix, no new feature surface)

## AI-generated code disclosure

- [x] This PR includes AI-generated code