### PR TITLE
fix: address #631 review feedback

### DIFF
--- a/.changeset/pr-631-followup.md
+++ b/.changeset/pr-631-followup.md
@@ -1,0 +1,8 @@
+---
+"emdash": patch
+---
+
+Fixes two correctness issues from the #631 cold-start work:
+
+- `ensureSearchHealthy()` now runs against the runtime's singleton database instead of the per-request session-bound one. The verify step reads, but a corrupted index triggers a rebuild write, and D1 Sessions on a GET request uses `first-unconstrained` routing that's free to land on a replica. The singleton goes through the default binding, which the adapter correctly promotes to `first-primary` for writes.
+- The playground request-context middleware now sets `dbIsIsolated: true`. Without it, schema-derived caches (manifest, taxonomy defs, byline/term existence probes) could carry values across playground sessions that have independent schemas.

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -49,11 +49,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// Playground mode: the playground middleware (from @emdash-cms/cloudflare) stashes
 	// the per-session DO database on locals.__playgroundDb. We set it via ALS here
 	// (same module instance as the loader) so getDb() picks it up correctly.
+	//
+	// `dbIsIsolated: true` tells schema-derived caches (manifest, taxonomy defs,
+	// byline/term existence probes) to bypass module-scope memoization — each
+	// playground session is its own database with its own schema, so a cached
+	// value from another session would be wrong.
 	const playgroundDb = context.locals.__playgroundDb;
 	if (playgroundDb) {
 		// Check if playground user has toggled edit mode on
 		const hasEditCookie = cookies.get("emdash-edit-mode")?.value === "true";
-		return runWithContext({ editMode: hasEditCookie, db: playgroundDb }, () => next());
+		return runWithContext({ editMode: hasEditCookie, db: playgroundDb, dbIsIsolated: true }, () =>
+			next(),
+		);
 	}
 
 	// Fast path: check for CMS signals before doing any work

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1539,9 +1539,16 @@ export class EmDashRuntime {
 	 * combined. Anonymous public reads never touch the search write path,
 	 * so the cost isn't paid back for the vast majority of requests.
 	 *
-	 * Instead, admin routes and the search endpoints call this lazily: the
-	 * first request that actually needs the index pays the verify cost
-	 * (usually fast — no rebuild needed), everyone else runs cold-free.
+	 * Instead, search endpoints call this lazily: the first request that
+	 * actually needs the index pays the verify cost (usually fast — no
+	 * rebuild needed), everyone else runs cold-free.
+	 *
+	 * Uses the runtime's singleton database (`this._db`) rather than the
+	 * request-scoped DB. Verify reads only, but `rebuildIndex` writes, and
+	 * a GET search request on D1 carries a `first-unconstrained` session
+	 * that's free to route at a read replica — unsafe for writes. The
+	 * singleton always goes through the default binding, which the D1
+	 * adapter will promote to `first-primary` for write statements.
 	 *
 	 * Safe to call concurrently: repeated callers share the same in-flight
 	 * promise. Errors are swallowed internally so callers don't need to
@@ -1550,13 +1557,13 @@ export class EmDashRuntime {
 	async ensureSearchHealthy(): Promise<void> {
 		if (this._searchHealthChecked) return;
 		if (this._searchHealthPromise) return this._searchHealthPromise;
-		if (!isSqlite(this.db)) {
+		if (!isSqlite(this._db)) {
 			this._searchHealthChecked = true;
 			return;
 		}
 		this._searchHealthPromise = (async () => {
 			try {
-				const ftsManager = new FTSManager(this.db);
+				const ftsManager = new FTSManager(this._db);
 				const repaired = await ftsManager.verifyAndRepairAll();
 				if (repaired > 0) {
 					console.log(`Repaired ${repaired} corrupted FTS index(es)`);


### PR DESCRIPTION
Follow-up to #631. Addresses two real issues raised in the Copilot review:

- `ensureSearchHealthy()` was calling `FTSManager` with `this.db`, which on GET search requests is a D1 Sessions Kysely bound to `first-unconstrained` routing. The verify step reads, but a mismatched row count triggers a rebuild write, which can land on a replica instead of the primary. Switched to `this._db` (singleton) so repair writes always route to the primary via the adapter's own `first-primary` promotion.
- The playground branch in `request-context.ts` middleware was creating an ALS context without `dbIsIsolated`, which meant module-scoped caches (manifest, taxonomy defs, byline/term probes) would be reused across playground sessions with independent schemas. Added the flag.

Also tidied the `ensureSearchHealthy` docstring; the original mentioned "admin routes" as callers but only the search/suggest endpoints actually call it.

The two other review comments are left unaddressed intentionally:

- "Async recursion in `getRuntime` risks stack overflow" — `await` suspends the stack, so recursion through async calls doesn't accumulate frames the way sync recursion does. The loop form would be functionally identical; not worth changing.
- "Changeset numbers don't match PR body" — already reconciled before merge; the changeset now describes the improvement qualitatively and the PR body carries the measurement table.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2395)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (N/A — one behavioral fix affects only a rarely-hit repair path on D1 Sessions; covering it reliably would require mocking the D1 adapter internals)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)

## AI-generated code disclosure

- [x] This PR includes AI-generated code
