### PR TITLE
ci: auto-update query-count snapshots instead of failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,24 +33,6 @@ jobs:
       - run: pnpm run --filter emdash-demo --filter @emdash-cms/demo-cloudflare typecheck
       - run: pnpm typecheck:templates
 
-  query-counts:
-    name: Query Counts
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: node scripts/query-counts.mjs --target sqlite
-      - run: node scripts/query-counts.mjs --target d1
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -10,6 +10,10 @@ on:
     types: [completed]
 
 permissions:
+  # actions:read is needed for listWorkflowRunArtifacts /
+  # downloadArtifact. contents:read is a safety default; the commit-back
+  # step uses the app token, not GITHUB_TOKEN.
+  actions: read
   contents: read
 
 jobs:
@@ -86,7 +90,13 @@ jobs:
             }
             core.setOutput('number', String(match.number));
             core.setOutput('ref', match.head.ref);
-            core.setOutput('sha', match.head.sha);
+            // Use the workflow_run's head_sha — the commit that was
+            // actually measured — rather than the PR's current head.
+            // If the branch has moved on since, we want to push onto
+            // the measured commit (and let the push fail non-fast-
+            // forward) rather than apply stale snapshots to a newer
+            // tree.
+            core.setOutput('sha', headSha);
             core.setOutput('full_name', match.head.repo.full_name);
             const isFork = match.head.repo.fork
               || match.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
@@ -100,13 +110,13 @@ jobs:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      # --- Same-repo PRs: checkout and push directly ---
+      # --- Same-repo PRs: checkout the pinned SHA and push directly ---
 
       - name: Checkout (same-repo)
         if: steps.download.outputs.found == 'true' && steps.pr.outputs.is_fork == 'false'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.pr.outputs.ref }}
+          ref: ${{ steps.pr.outputs.sha }}
           token: ${{ steps.app-token.outputs.token }}
 
       # --- Fork PRs: checkout the fork at the pinned SHA so we can push back ---
@@ -139,10 +149,19 @@ jobs:
           && steps.pr.outputs.is_fork == 'false'
           && steps.apply.outputs.no_diff == 'false'
         run: |
+          set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
           git commit -m "ci: update query-count snapshots"
-          git push
+          # Detached-HEAD push onto the PR branch. If the branch has
+          # advanced past the measured SHA, this fails with a non-fast-
+          # forward — safe outcome, since applying stale counts to a
+          # newer tree would hide a regression. The next PR event will
+          # kick off a fresh measure+apply against the new head.
+          if ! git push origin "HEAD:${{ steps.pr.outputs.ref }}"; then
+            echo "::error::Non-fast-forward push — the PR branch moved past the measured SHA ${{ steps.pr.outputs.sha }}. Rerun the harness against the new head (the next PR event will do this automatically)." >&2
+            exit 1
+          fi
 
       - name: Commit and push (fork)
         if: |

--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -1,0 +1,168 @@
+name: Query Counts — Apply
+
+# Runs after the "Query Counts" workflow completes on a PR. This job has
+# elevated permissions to push back to the PR branch and comment, but it
+# never executes code from the PR — it only downloads the inert JSON +
+# diff artifact produced by the measure job.
+on:
+  workflow_run:
+    workflows: ["Query Counts"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download snapshot artifact
+        id: download
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const artifact = data.artifacts.find((a) => a.name === 'query-counts-snapshots');
+            if (!artifact) {
+              core.setOutput('found', 'false');
+              core.info('No snapshot artifact — nothing to apply.');
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip',
+            });
+            const outDir = path.join(process.env.GITHUB_WORKSPACE, 'artifact');
+            fs.mkdirSync(outDir, { recursive: true });
+            fs.writeFileSync(path.join(outDir, 'artifact.zip'), Buffer.from(download.data));
+            core.setOutput('found', 'true');
+            core.setOutput('dir', outDir);
+
+      - name: Unpack artifact
+        if: steps.download.outputs.found == 'true'
+        run: |
+          cd artifact
+          unzip -o artifact.zip
+          ls -la
+
+      - name: Resolve PR
+        if: steps.download.outputs.found == 'true'
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('node:fs');
+            const prNumber = Number(fs.readFileSync('artifact/pr-number', 'utf8').trim());
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number in artifact: ${prNumber}`);
+              return;
+            }
+            // Cross-check: look up the PR from the workflow_run's head SHA
+            // to make sure the artifact wasn't tampered with to point at a
+            // different PR.
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const match = prs.find((p) => p.number === prNumber);
+            if (!match) {
+              core.setFailed(
+                `PR #${prNumber} from artifact is not associated with commit ${headSha}`,
+              );
+              return;
+            }
+            core.setOutput('number', String(match.number));
+            core.setOutput('ref', match.head.ref);
+            core.setOutput('sha', match.head.sha);
+            core.setOutput('full_name', match.head.repo.full_name);
+            const isFork = match.head.repo.fork
+              || match.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+            core.setOutput('is_fork', isFork.toString());
+
+      - name: Generate app token
+        if: steps.download.outputs.found == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # --- Same-repo PRs: checkout and push directly ---
+
+      - name: Checkout (same-repo)
+        if: steps.download.outputs.found == 'true' && steps.pr.outputs.is_fork == 'false'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      # --- Fork PRs: checkout the fork at the pinned SHA so we can push back ---
+
+      - name: Checkout (fork)
+        if: steps.download.outputs.found == 'true' && steps.pr.outputs.is_fork == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.pr.outputs.full_name }}
+          ref: ${{ steps.pr.outputs.sha }}
+          persist-credentials: false
+
+      - name: Apply snapshots
+        if: steps.download.outputs.found == 'true'
+        id: apply
+        run: |
+          cp "$GITHUB_WORKSPACE/artifact/query-counts.snapshot.sqlite.json" scripts/
+          cp "$GITHUB_WORKSPACE/artifact/query-counts.snapshot.d1.json" scripts/
+          git add scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json
+          if git diff --staged --quiet; then
+            echo "no_diff=true" >> "$GITHUB_OUTPUT"
+            echo "Artifact matches the PR head — nothing to push (probably a race with a newer commit)."
+          else
+            echo "no_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push (same-repo)
+        if: |
+          steps.download.outputs.found == 'true'
+          && steps.pr.outputs.is_fork == 'false'
+          && steps.apply.outputs.no_diff == 'false'
+        run: |
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git commit -m "ci: update query-count snapshots"
+          git push
+
+      - name: Commit and push (fork)
+        if: |
+          steps.download.outputs.found == 'true'
+          && steps.pr.outputs.is_fork == 'true'
+          && steps.apply.outputs.no_diff == 'false'
+        id: push-fork
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "emdashbot[bot]"
+          git config user.email "emdashbot[bot]@users.noreply.github.com"
+          git commit -m "ci: update query-count snapshots"
+          export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
+          printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
+          chmod +x "$GIT_ASKPASS"
+          git remote add fork "https://x-access-token@github.com/${{ steps.pr.outputs.full_name }}.git"
+          if git push fork "HEAD:${{ steps.pr.outputs.ref }}"; then
+            echo "push_failed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+          fi
+          rm -f "$GIT_ASKPASS"

--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -149,10 +149,10 @@ jobs:
           steps.download.outputs.found == 'true'
           && steps.pr.outputs.is_fork == 'true'
           && steps.apply.outputs.no_diff == 'false'
-        id: push-fork
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
           git commit -m "ci: update query-count snapshots"
@@ -160,9 +160,12 @@ jobs:
           printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
           chmod +x "$GIT_ASKPASS"
           git remote add fork "https://x-access-token@github.com/${{ steps.pr.outputs.full_name }}.git"
-          if git push fork "HEAD:${{ steps.pr.outputs.ref }}"; then
-            echo "push_failed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+          # Fail the workflow if we can't push — most likely cause is
+          # "Allow edits by maintainers" being disabled on the fork PR.
+          # The reviewer needs to know the snapshots couldn't be applied.
+          if ! git push fork "HEAD:${{ steps.pr.outputs.ref }}"; then
+            rm -f "$GIT_ASKPASS"
+            echo "::error::Failed to push snapshots to fork. The contributor may have 'Allow edits by maintainers' disabled. They need to run 'pnpm query-counts --target sqlite --update && pnpm query-counts --target d1 --update' locally and commit, or re-enable maintainer edits." >&2
+            exit 1
           fi
           rm -f "$GIT_ASKPASS"

--- a/.github/workflows/query-counts-label.yml
+++ b/.github/workflows/query-counts-label.yml
@@ -1,0 +1,44 @@
+name: Query Counts — Label
+
+# Applies the "query-count changed" label when a PR's diff touches either
+# snapshot file. The label is informational — it flags that the PR alters
+# per-route DB query counts (either because the author's change regressed
+# them, or because the Apply workflow auto-updated the baseline).
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - scripts/query-counts.snapshot.sqlite.json
+      - scripts/query-counts.snapshot.d1.json
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = 'query-count changed';
+            // Create the label if it doesn't exist yet. Ignore 422 (already exists).
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'fbca04',
+                description: 'PR diff modifies query-count snapshot files',
+              });
+            } catch (err) {
+              if (err.status !== 422) throw err;
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });

--- a/.github/workflows/query-counts.yml
+++ b/.github/workflows/query-counts.yml
@@ -36,18 +36,18 @@ jobs:
       - name: Detect snapshot drift
         id: drift
         run: |
-          mkdir -p .query-counts-out
+          mkdir -p query-counts-out
           if git diff --quiet scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No drift — snapshots match the committed baseline."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            cp scripts/query-counts.snapshot.sqlite.json .query-counts-out/
-            cp scripts/query-counts.snapshot.d1.json .query-counts-out/
-            git diff scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json > .query-counts-out/snapshots.diff
-            echo "${{ github.event.pull_request.number }}" > .query-counts-out/pr-number
+            cp scripts/query-counts.snapshot.sqlite.json query-counts-out/
+            cp scripts/query-counts.snapshot.d1.json query-counts-out/
+            git diff scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json > query-counts-out/snapshots.diff
+            echo "${{ github.event.pull_request.number }}" > query-counts-out/pr-number
             echo "Drift detected — uploading artifact for the Apply workflow."
-            cat .query-counts-out/snapshots.diff
+            cat query-counts-out/snapshots.diff
           fi
 
       - name: Upload snapshot artifact
@@ -55,6 +55,6 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: query-counts-snapshots
-          path: .query-counts-out/
+          path: query-counts-out/
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/query-counts.yml
+++ b/.github/workflows/query-counts.yml
@@ -1,0 +1,60 @@
+name: Query Counts
+
+on:
+  pull_request:
+    branches: [main]
+
+# Runs with the default read-only token; this workflow never pushes or
+# comments. The companion "Query Counts — Apply" workflow (triggered by
+# workflow_run) handles that with elevated permissions, safely isolated
+# from PR-authored code.
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      - name: Regenerate snapshots
+        run: |
+          node scripts/query-counts.mjs --target sqlite --update
+          node scripts/query-counts.mjs --target d1 --update
+
+      - name: Detect snapshot drift
+        id: drift
+        run: |
+          mkdir -p .query-counts-out
+          if git diff --quiet scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No drift — snapshots match the committed baseline."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            cp scripts/query-counts.snapshot.sqlite.json .query-counts-out/
+            cp scripts/query-counts.snapshot.d1.json .query-counts-out/
+            git diff scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json > .query-counts-out/snapshots.diff
+            echo "${{ github.event.pull_request.number }}" > .query-counts-out/pr-number
+            echo "Drift detected — uploading artifact for the Apply workflow."
+            cat .query-counts-out/snapshots.diff
+          fi
+
+      - name: Upload snapshot artifact
+        if: steps.drift.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: query-counts-snapshots
+          path: .query-counts-out/
+          retention-days: 7
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ examples/wp-theme-unit-test/
 .opencode
 
 .perf-query-counts
+query-counts-out/

--- a/scripts/query-counts.mjs
+++ b/scripts/query-counts.mjs
@@ -441,7 +441,12 @@ async function main() {
 
 	const counts = aggregate(events);
 	if (update) {
-		writeFileSync(snapshotPath, JSON.stringify(counts, null, 2) + "\n");
+		// Use tab indent so the output matches oxfmt's default and
+		// doesn't thrash under `pnpm format`. Space-indented output
+		// would be reformatted to tabs by the formatter, producing
+		// a false-positive "drift" signal in CI (the raw harness
+		// output wouldn't match the committed file).
+		writeFileSync(snapshotPath, JSON.stringify(counts, null, "\t") + "\n");
 		process.stdout.write(`Wrote ${Object.keys(counts).length} entries to ${snapshotPath}\n`);
 		return 0;
 	}


### PR DESCRIPTION
## What does this PR do?

Changes the query-count review flow so drift auto-updates the PR instead of blocking CI. Three workflows replace the single fail-on-drift job:

### Workflow 1 — \`Query Counts\` (\`.github/workflows/query-counts.yml\`)
- Triggered on \`pull_request\`.
- Runs the harness for both targets with \`--update\`.
- If the snapshot files drift, uploads them (plus a unified diff and the PR number) as an artifact.
- Always exits 0, runs with \`contents: read\` — safely isolated from anything the PR might try to do with secrets.

### Workflow 2 — \`Query Counts — Apply\` (\`.github/workflows/query-counts-apply.yml\`)
- Triggered on \`workflow_run\` completion of workflow 1.
- Downloads the artifact. Cross-verifies the PR number against the workflow_run's head SHA via \`listPullRequestsAssociatedWithCommit\` to guard against a tampered artifact pointing at the wrong PR.
- Pushes the regenerated snapshots back to the PR head — directly for same-repo PRs, via \`GIT_ASKPASS\` with the app token for fork PRs (same pattern as \`auto-format.yml\`).
- Never executes PR-authored code, so holding the app token is safe.

### Workflow 3 — \`Query Counts — Label\` (\`.github/workflows/query-counts-label.yml\`)
- Triggered on \`pull_request_target\` with a \`paths:\` filter on the two snapshot files.
- Applies (and creates, first time) the \`query-count changed\` label. Label stays sticky; reviewers know the PR changes DB query behavior on at least one route.
- Fires both on human-authored changes (the author ran \`--update\` locally) and on workflow 2's auto-push (the synchronize event re-triggers this workflow).

Removes the old \`query-counts\` job from \`ci.yml\`.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] \`pnpm typecheck\` passes (workflow changes only, nothing to typecheck)
- [ ] \`pnpm lint\` passes (workflow changes only)
- [ ] \`pnpm test\` passes (workflow changes only)
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (workflow changes — no project tests)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (CI-only, no published-package impact)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Notes for the reviewer

- A fork PR where the contributor disabled \"Allow edits by maintainers\" will silently skip the auto-push. The label won't fire either (snapshot files never land in the diff), which is a small gap — flagged in the apply workflow's logs rather than on the PR. If that becomes a pain point, easiest fix is to add the label directly from the apply workflow on push-failure.
- The \`query-count changed\` label is created on first use; no manual setup needed.