### PR TITLE
fix(perf): surface site selector in perf dashboard

### DIFF
--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -358,6 +358,10 @@
 
 			<div class="controls">
 				<div>
+					<label>Site</label>
+					<select id="site-select"></select>
+				</div>
+				<div>
 					<label>Route</label>
 					<select id="route-select"></select>
 				</div>
@@ -558,13 +562,16 @@
 			async function loadConfig() {
 				configData = await fetchJson("/api/config");
 
-				// Show the target site (without protocol, it's tidier)
-				if (configData.target) {
-					document.getElementById("target-label").textContent = configData.target.replace(
-						/^https?:\/\//,
-						"",
-					);
+				const siteSelect = document.getElementById("site-select");
+				const sites = configData.sites ?? [];
+				for (const site of sites) {
+					const opt = document.createElement("option");
+					opt.value = site.id;
+					opt.textContent = site.label ? `${site.label} (${site.id})` : site.id;
+					if (site.id === configData.defaultSite) opt.selected = true;
+					siteSelect.appendChild(opt);
 				}
+				updateTargetLabel();
 
 				const routeSelect = document.getElementById("route-select");
 				for (const route of configData.routes) {
@@ -583,8 +590,22 @@
 				}
 			}
 
+			function currentSite() {
+				return document.getElementById("site-select").value || configData?.defaultSite || "blog";
+			}
+
+			function updateTargetLabel() {
+				const site = (configData?.sites ?? []).find((s) => s.id === currentSite());
+				const label = document.getElementById("target-label");
+				if (site?.targetUrl) {
+					label.textContent = site.targetUrl.replace(/^https?:\/\//, "");
+				} else {
+					label.textContent = "";
+				}
+			}
+
 			async function loadSummary() {
-				const data = await fetchJson("/api/summary");
+				const data = await fetchJson(`/api/summary?site=${encodeURIComponent(currentSite())}`);
 				const container = document.getElementById("summary-cards");
 				container.innerHTML = "";
 
@@ -700,10 +721,12 @@
 				const regions =
 					regionFilter === "all" ? configData.regions.map((r) => r.id) : [regionFilter];
 
+				const site = currentSite();
+
 				// Fetch chart data for each region in parallel
 				const chartDataPromises = regions.map((region) =>
 					fetchJson(
-						`/api/chart?route=${encodeURIComponent(route)}&region=${region}&since=${since}&limit=500`,
+						`/api/chart?site=${encodeURIComponent(site)}&route=${encodeURIComponent(route)}&region=${region}&since=${since}&limit=500`,
 					),
 				);
 				const chartResults = await Promise.all(chartDataPromises);
@@ -833,6 +856,7 @@
 				const since = periodToSince(period);
 
 				const params = new URLSearchParams({
+					site: currentSite(),
 					since,
 					limit: "50",
 				});
@@ -896,6 +920,10 @@
 					await refresh();
 
 					// Refresh on control changes
+					document.getElementById("site-select").addEventListener("change", () => {
+						updateTargetLabel();
+						refresh();
+					});
 					document.getElementById("route-select").addEventListener("change", refresh);
 					document.getElementById("region-select").addEventListener("change", refresh);
 					document.getElementById("period-select").addEventListener("change", refresh);


### PR DESCRIPTION
## What does this PR do?

Follow-up to #661. That PR taught the perf-monitor about multiple demo sites but left the dashboard unable to display any of them: `/api/config` no longer includes `target`, and there was no UI control for switching sites, so the header target label rendered blank and every panel silently defaulted to `site=blog`.

- Adds a **Site** dropdown to the controls, populated from `/api/config.sites`, with `configData.defaultSite` pre-selected.
- Threads `site=<id>` into the `/api/summary`, `/api/chart`, and `/api/results` fetches.
- Introduces `updateTargetLabel()` so the header target text reflects the selected site's URL and refreshes when the selection changes.

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (no TS changes)
- [x] `pnpm lint` passes (no new diagnostics; 22 pre-existing, all outside `infra/`)
- [ ] `pnpm test` passes — no tests added or affected
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes — N/A for a static dashboard
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A (operator-facing dashboard, not the admin UI)
- [ ] I have added a changeset — not required; `infra/*` is not a published package
- [ ] New features link to an approved Discussion — N/A

## Verification

Confirmed against `https://perf.emdashcms.com`:

- `curl /api/config` returns both `blog` and `cache` sites and `defaultSite: "blog"`.
- `curl /api/summary?site=cache` returns 12 latest rows and 12 medians, so data exists for the cache site — it just had no way into the dashboard.

After this PR, switching the Site dropdown should immediately swap the summary cards, charts, and results table to the chosen site.

## AI-generated code disclosure

- [x] This PR includes AI-generated code