### PR TITLE
fix (admin): boolean field checkbox reverting to unchecked after publish

### DIFF
--- a/.changeset/fix-boolean-checkbox-display.md
+++ b/.changeset/fix-boolean-checkbox-display.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes boolean field checkbox displaying as unchecked after publish in the admin UI.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1169,7 +1169,7 @@ function FieldRenderer({
 				<Switch
 					id={id}
 					label={label}
-					checked={typeof value === "boolean" ? value : false}
+					checked={Boolean(value)}
 					onCheckedChange={handleChange}
 				/>
 			);

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1166,12 +1166,7 @@ function FieldRenderer({
 
 		case "boolean":
 			return (
-				<Switch
-					id={id}
-					label={label}
-					checked={Boolean(value)}
-					onCheckedChange={handleChange}
-				/>
+				<Switch id={id} label={label} checked={Boolean(value)} onCheckedChange={handleChange} />
 			);
 
 		case "portableText": {

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -867,7 +867,7 @@ function ComponentPropField({
 			return (
 				<Switch
 					label={def.label}
-					checked={typeof value === "boolean" ? value : false}
+					checked={Boolean(value)}
 					onCheckedChange={onChange}
 				/>
 			);

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -864,13 +864,7 @@ function ComponentPropField({
 				/>
 			);
 		case "boolean":
-			return (
-				<Switch
-					label={def.label}
-					checked={Boolean(value)}
-					onCheckedChange={onChange}
-				/>
-			);
+			return <Switch label={def.label} checked={Boolean(value)} onCheckedChange={onChange} />;
 		case "select": {
 			const items: Record<string, string> = {};
 			for (const opt of def.options ?? []) {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #651 

Boolean field checkboxes in the admin content editor display as unchecked after publishing, even though the value is correctly stored in the database.

### The issue
The root cause is that SQLite stores booleans as integers (`1`/`0`), and after publish the content is re-fetched from the API. The Switch components in `ContentEditor.tsx` and `Widgets.tsx` checked `typeof value === "boolean" ? value : false`, which rejects integer `1` since `typeof 1` is `"number"`.

https://github.com/user-attachments/assets/16754f81-90ed-4f64-9202-37421a5b3050

### The fix
This PR replaces the strict type check with `Boolean(value)`. The fix is scoped to the `case "boolean":` branch of the field renderer, so number fields are unaffected.

https://github.com/user-attachments/assets/7c9e7851-1f3d-4f89-b0d8-f561de567e6e

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

