### PR TITLE
fix(core): Fix MCP OAuth discovery and client registration

### DIFF
--- a/.changeset/olive-cups-compete.md
+++ b/.changeset/olive-cups-compete.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes MCP OAuth discovery and dynamic client registration so EmDash only advertises supported client registration mechanisms and rejects unsupported redirect URIs or token endpoint auth methods during client registration.
+Fixes MCP OAuth discovery and dynamic client registration so EmDash only advertises supported client registration mechanisms and rejects unsupported redirect URIs or token endpoint auth methods during client registration. Also exempts OAuth protocol endpoints (token, register, device code, device token) from the Origin-based CSRF check, since these endpoints are called cross-origin by design (MCP clients, CLIs, native apps) and carry no ambient credentials, and sends the required CORS headers so browser-based MCP clients can reach them.

--- a/.changeset/olive-cups-compete.md
+++ b/.changeset/olive-cups-compete.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes MCP OAuth discovery and dynamic client registration so EmDash only advertises supported client registration mechanisms and rejects unsupported redirect URIs or token endpoint auth methods during client registration.

--- a/packages/core/src/api/handlers/oauth-authorization.ts
+++ b/packages/core/src/api/handlers/oauth-authorization.ts
@@ -20,6 +20,7 @@ import {
 	VALID_SCOPES,
 } from "../../auth/api-tokens.js";
 import type { Database } from "../../database/types.js";
+import { validateRedirectUri } from "../oauth/redirect-uri.js";
 import type { ApiResult } from "../types.js";
 import { lookupOAuthClient, validateClientRedirectUri } from "./oauth-clients.js";
 
@@ -76,38 +77,7 @@ function expiresAt(seconds: number): string {
 	return new Date(Date.now() + seconds * 1000).toISOString();
 }
 
-/**
- * Validate a redirect URI per OAuth 2.1 security requirements.
- * Allows localhost (loopback) over HTTP, and any HTTPS URL.
- */
-export function validateRedirectUri(uri: string): string | null {
-	try {
-		const url = new URL(uri);
-
-		// Reject protocol-relative URLs
-		if (uri.startsWith("//")) {
-			return "Protocol-relative redirect URIs are not allowed";
-		}
-
-		// Allow localhost/loopback over HTTP (for desktop MCP clients)
-		if (url.protocol === "http:") {
-			const host = url.hostname;
-			if (host === "127.0.0.1" || host === "localhost" || host === "[::1]") {
-				return null; // OK
-			}
-			return "HTTP redirect URIs are only allowed for localhost";
-		}
-
-		// Allow HTTPS
-		if (url.protocol === "https:") {
-			return null; // OK
-		}
-
-		return `Unsupported redirect URI scheme: ${url.protocol}`;
-	} catch {
-		return "Invalid redirect URI";
-	}
-}
+export { validateRedirectUri };
 
 /**
  * Validate and normalize scopes. Returns validated scope list.

--- a/packages/core/src/api/handlers/oauth-clients.ts
+++ b/packages/core/src/api/handlers/oauth-clients.ts
@@ -9,6 +9,7 @@
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
+import { validateRedirectUri } from "../oauth/redirect-uri.js";
 import type { ApiResult } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -19,6 +20,16 @@ import type { ApiResult } from "../types.js";
 function parseJsonColumn<T>(value: string): T {
 	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- JSON.parse returns unknown, callers provide the expected shape
 	return JSON.parse(value) as T;
+}
+
+function validateRegisteredRedirectUris(redirectUris: string[]): string | null {
+	for (const redirectUri of redirectUris) {
+		const error = validateRedirectUri(redirectUri);
+		if (error) {
+			return `Invalid redirect URI: ${error}`;
+		}
+	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +72,17 @@ export async function handleOAuthClientCreate(
 			};
 		}
 
+		const redirectUriError = validateRegisteredRedirectUris(input.redirectUris);
+		if (redirectUriError) {
+			return {
+				success: false,
+				error: {
+					code: "VALIDATION_ERROR",
+					message: redirectUriError,
+				},
+			};
+		}
+
 		// Check for duplicate client ID
 		const existing = await db
 			.selectFrom("_emdash_oauth_clients")
@@ -83,7 +105,7 @@ export async function handleOAuthClientCreate(
 				id: input.id,
 				name: input.name,
 				redirect_uris: JSON.stringify(input.redirectUris),
-				scopes: input.scopes ? JSON.stringify(input.scopes) : null,
+				scopes: input.scopes && input.scopes.length > 0 ? JSON.stringify(input.scopes) : null,
 			})
 			.execute();
 
@@ -93,7 +115,7 @@ export async function handleOAuthClientCreate(
 				id: input.id,
 				name: input.name,
 				redirectUris: input.redirectUris,
-				scopes: input.scopes ?? null,
+				scopes: input.scopes && input.scopes.length > 0 ? input.scopes : null,
 				createdAt: now,
 				updatedAt: now,
 			},
@@ -222,7 +244,20 @@ export async function handleOAuthClientUpdate(
 			};
 		}
 
-		const updates: Record<string, string> = {
+		if (input.redirectUris !== undefined) {
+			const redirectUriError = validateRegisteredRedirectUris(input.redirectUris);
+			if (redirectUriError) {
+				return {
+					success: false,
+					error: {
+						code: "VALIDATION_ERROR",
+						message: redirectUriError,
+					},
+				};
+			}
+		}
+
+		const updates: Record<string, string | null> = {
 			updated_at: new Date().toISOString(),
 		};
 
@@ -233,7 +268,8 @@ export async function handleOAuthClientUpdate(
 			updates.redirect_uris = JSON.stringify(input.redirectUris);
 		}
 		if (input.scopes !== undefined) {
-			updates.scopes = input.scopes ? JSON.stringify(input.scopes) : "";
+			updates.scopes =
+				input.scopes && input.scopes.length > 0 ? JSON.stringify(input.scopes) : null;
 		}
 
 		await db.updateTable("_emdash_oauth_clients").set(updates).where("id", "=", clientId).execute();

--- a/packages/core/src/api/oauth/redirect-uri.ts
+++ b/packages/core/src/api/oauth/redirect-uri.ts
@@ -1,0 +1,34 @@
+/**
+ * Validate a redirect URI per OAuth 2.1 security requirements.
+ *
+ * Allows localhost / loopback redirect URIs over HTTP for native clients,
+ * and any HTTPS URL for web-based flows.
+ */
+export function validateRedirectUri(uri: string): string | null {
+	try {
+		const url = new URL(uri);
+
+		// Reject protocol-relative URLs
+		if (uri.startsWith("//")) {
+			return "Protocol-relative redirect URIs are not allowed";
+		}
+
+		// Allow localhost/loopback over HTTP (for desktop MCP clients)
+		if (url.protocol === "http:") {
+			const host = url.hostname;
+			if (host === "127.0.0.1" || host === "localhost" || host === "[::1]") {
+				return null;
+			}
+			return "HTTP redirect URIs are only allowed for localhost";
+		}
+
+		// Allow HTTPS
+		if (url.protocol === "https:") {
+			return null;
+		}
+
+		return `Unsupported redirect URI scheme: ${url.protocol}`;
+	} catch {
+		return "Invalid redirect URI";
+	}
+}

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -515,6 +515,12 @@ export function injectCoreRoutes(injectRoute: InjectRoute): void {
 		entrypoint: resolveRoute("api/well-known/oauth-authorization-server.ts"),
 	});
 
+	// RFC 7591 Dynamic Client Registration
+	injectRoute({
+		pattern: "/_emdash/api/oauth/register",
+		entrypoint: resolveRoute("api/oauth/register.ts"),
+	});
+
 	// Plugin-defined API routes
 	// All plugin routes are handled by a single catch-all handler
 	injectRoute({

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -119,11 +119,39 @@ const PUBLIC_API_EXACT = new Set([
 	"/_emdash/api/search",
 ]);
 
+/**
+ * OAuth protocol endpoints that are CSRF-exempt by design.
+ *
+ * These are RFC-defined endpoints (RFC 6749 §3.2, RFC 7591 §3, RFC 8628 §3.1/§3.4)
+ * specified to be called cross-origin by external clients (MCP clients, CLIs,
+ * native apps). They authenticate each request on its own merits:
+ *
+ * - /oauth/token: requires PKCE code_verifier, device_code, or refresh_token
+ * - /oauth/register: RFC 7591 dynamic client registration — anonymous by design
+ * - /oauth/device/code: RFC 8628 device flow initiation — anonymous by design
+ * - /oauth/device/token: requires device_code the client already holds
+ *
+ * None of these rely on ambient cookie credentials, so browser-based CSRF
+ * attacks have nothing to exploit. The endpoints themselves advertise
+ * `Access-Control-Allow-Origin: *`. Note: /oauth/device/authorize (the user
+ * consent step) is NOT in this list — it is session-authenticated.
+ */
+const CSRF_EXEMPT_PUBLIC_ROUTES = new Set([
+	"/_emdash/api/oauth/token",
+	"/_emdash/api/oauth/register",
+	"/_emdash/api/oauth/device/code",
+	"/_emdash/api/oauth/device/token",
+]);
+
 function isPublicEmDashRoute(pathname: string): boolean {
 	if (PUBLIC_API_EXACT.has(pathname)) return true;
 	if (PUBLIC_API_PREFIXES.some((p) => pathname.startsWith(p))) return true;
 	if (import.meta.env.DEV && pathname === "/_emdash/api/typegen") return true;
 	return false;
+}
+
+function isCsrfExemptPublicRoute(pathname: string): boolean {
+	return CSRF_EXEMPT_PUBLIC_ROUTES.has(pathname);
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {
@@ -142,7 +170,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	// This prevents cross-origin form submissions and fetch requests from malicious sites.
 	if (isPublicApiRoute) {
 		const method = context.request.method.toUpperCase();
-		if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
+		if (
+			isUnsafeMethod(method) &&
+			!isCsrfExemptPublicRoute(url.pathname) // OAuth protocol endpoints — cross-origin by design
+		) {
 			const publicOrigin = getPublicOrigin(url, context.locals.emdash?.config);
 			const csrfError = checkPublicCsrf(context.request, url, publicOrigin);
 			if (csrfError) return csrfError;

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -102,6 +102,7 @@ const PUBLIC_API_PREFIXES = [
 	"/_emdash/api/oauth/device/token",
 	"/_emdash/api/oauth/device/code",
 	"/_emdash/api/oauth/token",
+	"/_emdash/api/oauth/register",
 	"/_emdash/api/comments/",
 	"/_emdash/api/media/file/",
 	"/_emdash/.well-known/",

--- a/packages/core/src/astro/routes/api/oauth/register.ts
+++ b/packages/core/src/astro/routes/api/oauth/register.ts
@@ -16,6 +16,17 @@ export const prerender = false;
 const OAUTH_REGISTRATION_HEADERS: HeadersInit = {
 	"Cache-Control": "no-store",
 	Pragma: "no-cache",
+	// RFC 7591 dynamic client registration is called cross-origin by MCP clients,
+	// CLIs, and native apps. The endpoint is anonymous and carries no ambient
+	// credentials, so CORS `*` is safe.
+	"Access-Control-Allow-Origin": "*",
+};
+
+const OAUTH_PREFLIGHT_HEADERS: HeadersInit = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+	"Access-Control-Max-Age": "86400",
 };
 
 const SUPPORTED_GRANT_TYPES = new Set([
@@ -71,6 +82,10 @@ function parseSupportedStringArray(
 	}
 	return value;
 }
+
+export const OPTIONS: APIRoute = () => {
+	return new Response(null, { status: 204, headers: OAUTH_PREFLIGHT_HEADERS });
+};
 
 export const POST: APIRoute = async ({ request, locals }) => {
 	const { emdash } = locals;

--- a/packages/core/src/astro/routes/api/oauth/register.ts
+++ b/packages/core/src/astro/routes/api/oauth/register.ts
@@ -1,0 +1,163 @@
+/**
+ * POST /_emdash/api/oauth/register
+ *
+ * RFC 7591 Dynamic Client Registration. Public, unauthenticated.
+ * MCP clients (e.g. Claude Code) call this to register themselves
+ * before starting the OAuth authorization flow.
+ */
+
+import type { APIRoute } from "astro";
+
+import { apiError, handleError } from "#api/error.js";
+import { handleOAuthClientCreate } from "#api/handlers/oauth-clients.js";
+
+export const prerender = false;
+
+const OAUTH_REGISTRATION_HEADERS: HeadersInit = {
+	"Cache-Control": "no-store",
+	Pragma: "no-cache",
+};
+
+const SUPPORTED_GRANT_TYPES = new Set([
+	"authorization_code",
+	"refresh_token",
+	"urn:ietf:params:oauth:grant-type:device_code",
+]);
+const SUPPORTED_RESPONSE_TYPES = new Set(["code"]);
+
+function registrationError(description: string, status = 400): Response {
+	return Response.json(
+		{
+			error: "invalid_client_metadata",
+			error_description: description,
+		},
+		{ status, headers: OAUTH_REGISTRATION_HEADERS },
+	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function parseScope(value: unknown): string[] | Response | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "string") {
+		const scopes = value.split(" ").filter(Boolean);
+		return scopes.length > 0 ? scopes : undefined;
+	}
+	if (isStringArray(value)) {
+		const scopes = value.filter(Boolean);
+		return scopes.length > 0 ? scopes : undefined;
+	}
+	return registrationError("scope must be a string or array of strings");
+}
+
+function parseSupportedStringArray(
+	value: unknown,
+	field: string,
+	supported: ReadonlySet<string>,
+): string[] | Response | undefined {
+	if (value === undefined) return undefined;
+	if (!isStringArray(value)) {
+		return registrationError(`${field} must be an array of strings`);
+	}
+	const invalidValue = value.find((item) => !supported.has(item));
+	if (invalidValue) {
+		return registrationError(`${field} contains unsupported value: ${invalidValue}`);
+	}
+	return value;
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+	const { emdash } = locals;
+
+	if (!emdash?.db) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
+
+	try {
+		let body: unknown;
+		try {
+			body = await request.json();
+		} catch {
+			return registrationError("Request body must be valid JSON");
+		}
+
+		if (!isRecord(body)) {
+			return registrationError("Request body must be a JSON object");
+		}
+
+		// redirect_uris is the only required field per RFC 7591 §2
+		if (!isStringArray(body.redirect_uris) || body.redirect_uris.length === 0) {
+			return registrationError("redirect_uris must be a non-empty array of strings");
+		}
+
+		if (
+			body.token_endpoint_auth_method !== undefined &&
+			body.token_endpoint_auth_method !== "none"
+		) {
+			return registrationError("Only token_endpoint_auth_method=none is supported");
+		}
+
+		const grantTypes = parseSupportedStringArray(
+			body.grant_types,
+			"grant_types",
+			SUPPORTED_GRANT_TYPES,
+		);
+		if (grantTypes instanceof Response) {
+			return grantTypes;
+		}
+
+		const responseTypes = parseSupportedStringArray(
+			body.response_types,
+			"response_types",
+			SUPPORTED_RESPONSE_TYPES,
+		);
+		if (responseTypes instanceof Response) {
+			return responseTypes;
+		}
+
+		const scopes = parseScope(body.scope);
+		if (scopes instanceof Response) {
+			return scopes;
+		}
+
+		const clientId = crypto.randomUUID();
+		const clientName =
+			typeof body.client_name === "string" && body.client_name
+				? body.client_name
+				: `dynamic-${clientId.slice(0, 8)}`;
+
+		const result = await handleOAuthClientCreate(emdash.db, {
+			id: clientId,
+			name: clientName,
+			redirectUris: body.redirect_uris,
+			scopes,
+		});
+
+		if (!result.success) {
+			return registrationError(result.error.message);
+		}
+
+		// RFC 7591 §3.2.1 response
+		return Response.json(
+			{
+				client_id: result.data.id,
+				client_id_issued_at: Math.floor(new Date(result.data.createdAt).getTime() / 1000),
+				redirect_uris: result.data.redirectUris,
+				client_name: result.data.name,
+				grant_types: grantTypes ?? ["authorization_code", "refresh_token"],
+				response_types: responseTypes ?? ["code"],
+				token_endpoint_auth_method: "none",
+				scope: result.data.scopes ? result.data.scopes.join(" ") : undefined,
+			},
+			{ status: 201, headers: OAUTH_REGISTRATION_HEADERS },
+		);
+	} catch (error) {
+		return handleError(error, "Failed to register OAuth client", "CLIENT_REGISTER_ERROR");
+	}
+};

--- a/packages/core/src/astro/routes/api/oauth/token.ts
+++ b/packages/core/src/astro/routes/api/oauth/token.ts
@@ -87,6 +87,10 @@ const refreshSchema = z.object({
 // Handler
 // ---------------------------------------------------------------------------
 
+export const OPTIONS: APIRoute = () => {
+	return new Response(null, { status: 204, headers: OAUTH_PREFLIGHT_HEADERS });
+};
+
 export const POST: APIRoute = async ({ request, locals }) => {
 	const { emdash } = locals;
 
@@ -166,6 +170,17 @@ const OAUTH_TOKEN_HEADERS: HeadersInit = {
 	"Content-Type": "application/json",
 	"Cache-Control": "no-store",
 	Pragma: "no-cache",
+	// OAuth 2.1 token endpoint is called cross-origin by external clients. Caller
+	// must present PKCE code_verifier / device_code / refresh_token on each request,
+	// so there is no ambient credential for CSRF to exploit.
+	"Access-Control-Allow-Origin": "*",
+};
+
+const OAUTH_PREFLIGHT_HEADERS: HeadersInit = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+	"Access-Control-Max-Age": "86400",
 };
 
 function oauthSuccess(data: unknown): Response {

--- a/packages/core/src/astro/routes/api/well-known/oauth-authorization-server.ts
+++ b/packages/core/src/astro/routes/api/well-known/oauth-authorization-server.ts
@@ -33,8 +33,8 @@ export const GET: APIRoute = async ({ url, locals }) => {
 				"urn:ietf:params:oauth:grant-type:device_code",
 			],
 			code_challenge_methods_supported: ["S256"],
+			registration_endpoint: `${origin}/_emdash/api/oauth/register`,
 			token_endpoint_auth_methods_supported: ["none"],
-			client_id_metadata_document_supported: true,
 			device_authorization_endpoint: `${origin}/_emdash/api/oauth/device/code`,
 		},
 		{

--- a/packages/core/tests/integration/auth/oauth-clients.test.ts
+++ b/packages/core/tests/integration/auth/oauth-clients.test.ts
@@ -129,6 +129,19 @@ describe("OAuth Client CRUD", () => {
 		expect(result.error.code).toBe("VALIDATION_ERROR");
 	});
 
+	it("should reject clients with invalid redirect URIs", async () => {
+		const result = await handleOAuthClientCreate(db, {
+			id: "test-client",
+			name: "Test Client",
+			redirectUris: ["http://example.com/callback"],
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("VALIDATION_ERROR");
+		expect(result.error.message).toContain("HTTP redirect URIs are only allowed for localhost");
+	});
+
 	it("should list clients", async () => {
 		await handleOAuthClientCreate(db, {
 			id: "client-1",
@@ -201,6 +214,23 @@ describe("OAuth Client CRUD", () => {
 		expect(result.success).toBe(false);
 		if (result.success) return;
 		expect(result.error.code).toBe("VALIDATION_ERROR");
+	});
+
+	it("should reject update with invalid redirect URIs", async () => {
+		await handleOAuthClientCreate(db, {
+			id: "test-client",
+			name: "Test Client",
+			redirectUris: ["https://myapp.example.com/callback"],
+		});
+
+		const result = await handleOAuthClientUpdate(db, "test-client", {
+			redirectUris: ["myapp://callback"],
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.code).toBe("VALIDATION_ERROR");
+		expect(result.error.message).toContain("Unsupported redirect URI scheme");
 	});
 
 	it("should delete a client", async () => {

--- a/packages/core/tests/unit/auth/discovery-endpoints.test.ts
+++ b/packages/core/tests/unit/auth/discovery-endpoints.test.ts
@@ -98,6 +98,12 @@ describe("Authorization Server Metadata (RFC 8414)", () => {
 		expect(body.token_endpoint_auth_methods_supported).toEqual(["none"]);
 	});
 
+	it("advertises dynamic client registration", async () => {
+		const response = await getAuthorizationServer(mockContext());
+		const body = (await response.json()) as { registration_endpoint: string };
+		expect(body.registration_endpoint).toBe("https://example.com/_emdash/api/oauth/register");
+	});
+
 	it("includes all valid scopes", async () => {
 		const response = await getAuthorizationServer(mockContext());
 		const body = (await response.json()) as { scopes_supported: string[] };
@@ -110,9 +116,9 @@ describe("Authorization Server Metadata (RFC 8414)", () => {
 		expect(response.headers.get("Cache-Control")).toContain("public");
 	});
 
-	it("supports client_id_metadata_document", async () => {
+	it("does not advertise unsupported client_id metadata documents", async () => {
 		const response = await getAuthorizationServer(mockContext());
-		const body = (await response.json()) as { client_id_metadata_document_supported: boolean };
-		expect(body.client_id_metadata_document_supported).toBe(true);
+		const body = (await response.json()) as Record<string, unknown>;
+		expect(body).not.toHaveProperty("client_id_metadata_document_supported");
 	});
 });

--- a/packages/core/tests/unit/auth/oauth-register-route.test.ts
+++ b/packages/core/tests/unit/auth/oauth-register-route.test.ts
@@ -1,0 +1,131 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST as registerClient } from "../../../src/astro/routes/api/oauth/register.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("oauth register route", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("returns RFC 7591-style errors for malformed JSON", async () => {
+		const request = new Request("http://localhost:4321/_emdash/api/oauth/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "{",
+		});
+
+		const response = await registerClient({
+			request,
+			locals: {
+				emdash: {
+					db,
+					config: {},
+				},
+			},
+		} as Parameters<typeof registerClient>[0]);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			error: "invalid_client_metadata",
+			error_description: "Request body must be valid JSON",
+		});
+	});
+
+	it("rejects unsupported token endpoint auth methods", async () => {
+		const request = new Request("http://localhost:4321/_emdash/api/oauth/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				redirect_uris: ["http://127.0.0.1:9999/callback"],
+				token_endpoint_auth_method: "client_secret_basic",
+			}),
+		});
+
+		const response = await registerClient({
+			request,
+			locals: {
+				emdash: {
+					db,
+					config: {},
+				},
+			},
+		} as Parameters<typeof registerClient>[0]);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			error: "invalid_client_metadata",
+			error_description: "Only token_endpoint_auth_method=none is supported",
+		});
+	});
+
+	it("rejects redirect URIs that the authorize flow would later refuse", async () => {
+		const request = new Request("http://localhost:4321/_emdash/api/oauth/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				redirect_uris: ["http://example.com/callback"],
+			}),
+		});
+
+		const response = await registerClient({
+			request,
+			locals: {
+				emdash: {
+					db,
+					config: {},
+				},
+			},
+		} as Parameters<typeof registerClient>[0]);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			error: "invalid_client_metadata",
+			error_description: "Invalid redirect URI: HTTP redirect URIs are only allowed for localhost",
+		});
+	});
+
+	it("registers public clients with loopback redirect URIs", async () => {
+		const request = new Request("http://localhost:4321/_emdash/api/oauth/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				client_name: "Harness Test",
+				redirect_uris: ["http://127.0.0.1:9999/callback"],
+				token_endpoint_auth_method: "none",
+				grant_types: ["authorization_code", "refresh_token"],
+				response_types: ["code"],
+			}),
+		});
+
+		const response = await registerClient({
+			request,
+			locals: {
+				emdash: {
+					db,
+					config: {},
+				},
+			},
+		} as Parameters<typeof registerClient>[0]);
+
+		expect(response.status).toBe(201);
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+		expect(response.headers.get("Pragma")).toBe("no-cache");
+
+		const body = (await response.json()) as Record<string, unknown>;
+		expect(body.client_name).toBe("Harness Test");
+		expect(body.redirect_uris).toEqual(["http://127.0.0.1:9999/callback"]);
+		expect(body.token_endpoint_auth_method).toBe("none");
+		expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
+		expect(body.response_types).toEqual(["code"]);
+		expect(typeof body.client_id).toBe("string");
+	});
+});

--- a/packages/core/tests/unit/middleware/oauth-csrf.test.ts
+++ b/packages/core/tests/unit/middleware/oauth-csrf.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("virtual:emdash/auth", () => ({ authenticate: vi.fn() }));
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+vi.mock("@emdash-cms/auth", () => ({
+	TOKEN_PREFIXES: {},
+	generatePrefixedToken: vi.fn(),
+	hashPrefixedToken: vi.fn(),
+	VALID_SCOPES: [],
+	validateScopes: vi.fn(),
+	hasScope: vi.fn(() => false),
+	computeS256Challenge: vi.fn(),
+	Role: { ADMIN: 50 },
+}));
+vi.mock("@emdash-cms/auth/adapters/kysely", () => ({
+	createKyselyAdapter: vi.fn(() => ({
+		getUserById: vi.fn(),
+		getUserByEmail: vi.fn(),
+	})),
+}));
+
+type AuthMiddlewareModule = typeof import("../../../src/astro/middleware/auth.js");
+
+let onRequest: AuthMiddlewareModule["onRequest"];
+
+beforeAll(async () => {
+	({ onRequest } = await import("../../../src/astro/middleware/auth.js"));
+});
+
+async function runAuthMiddleware(opts: {
+	pathname: string;
+	method?: string;
+	origin?: string;
+	extraHeaders?: Record<string, string>;
+}): Promise<{ response: Response; next: ReturnType<typeof vi.fn> }> {
+	const url = new URL(opts.pathname, "https://site.example.com");
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		...opts.extraHeaders,
+	};
+	if (opts.origin) headers.Origin = opts.origin;
+
+	const session = {
+		get: vi.fn().mockResolvedValue(null),
+		set: vi.fn(),
+		destroy: vi.fn(),
+	};
+	const next = vi.fn(async () => new Response("ok"));
+	const response = await onRequest(
+		{
+			url,
+			request: new Request(url, {
+				method: opts.method ?? "POST",
+				headers,
+				body: "{}",
+			}),
+			locals: {
+				emdash: { db: {}, config: {} },
+			},
+			session,
+			redirect: (location: string) =>
+				new Response(null, { status: 302, headers: { Location: location } }),
+		} as Parameters<AuthMiddlewareModule["onRequest"]>[0],
+		next,
+	);
+
+	return { response, next };
+}
+
+/**
+ * OAuth protocol endpoints (RFC 6749, 7591, 8628) are designed to be called
+ * cross-origin. They must bypass the Origin-based CSRF check that applies to
+ * other public API routes.
+ *
+ * Regression test for PR #671: dynamic client registration and the token
+ * endpoint were unreachable from real MCP clients because an Origin header
+ * from a different origin triggered CSRF_REJECTED in middleware.
+ */
+describe("CSRF exemption for OAuth protocol endpoints", () => {
+	const EXEMPT_PATHS = [
+		"/_emdash/api/oauth/token",
+		"/_emdash/api/oauth/register",
+		"/_emdash/api/oauth/device/code",
+		"/_emdash/api/oauth/device/token",
+	] as const;
+
+	it.each(EXEMPT_PATHS)(
+		"allows cross-origin POST to %s (passes request through to handler)",
+		async (pathname) => {
+			const { response, next } = await runAuthMiddleware({
+				pathname,
+				origin: "https://claude.ai",
+			});
+
+			expect(next).toHaveBeenCalledOnce();
+			expect(response.status).toBe(200);
+		},
+	);
+
+	it.each(EXEMPT_PATHS)("allows same-origin POST to %s", async (pathname) => {
+		const { response, next } = await runAuthMiddleware({
+			pathname,
+			origin: "https://site.example.com",
+		});
+
+		expect(next).toHaveBeenCalledOnce();
+		expect(response.status).toBe(200);
+	});
+
+	it.each(EXEMPT_PATHS)("allows POST without any Origin header to %s", async (pathname) => {
+		const { response, next } = await runAuthMiddleware({ pathname });
+
+		expect(next).toHaveBeenCalledOnce();
+		expect(response.status).toBe(200);
+	});
+
+	it("still rejects cross-origin POST to non-exempt public routes (comments)", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/comments/some-id",
+			origin: "https://evil.example.com",
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: { code: "CSRF_REJECTED", message: "Cross-origin request blocked" },
+		});
+	});
+
+	it("still rejects cross-origin POST to device/authorize (session-authenticated consent step)", async () => {
+		// /oauth/device/authorize is NOT in the exempt list — it's where the user
+		// approves the CLI's device code from their browser session. It must be
+		// protected by the normal CSRF check.
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/oauth/device/authorize",
+			origin: "https://evil.example.com",
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(403);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes MCP OAuth discovery and dynamic client registration for remote MCP harnesses.

This change:
- adds an RFC 7591 dynamic client registration endpoint at `/_emdash/api/oauth/register`
- removes the unsupported `client_id_metadata_document_supported` claim from OAuth discovery metadata
- validates redirect URIs consistently for both dynamic and admin-created OAuth clients
- rejects unsupported `token_endpoint_auth_method` values during registration instead of accepting metadata EmDash cannot honor
- returns RFC 7591-style registration errors for malformed or invalid client metadata

This prevents MCP clients from discovering unsupported auth capabilities and from successfully registering clients that would later fail during authorization.

Closes #N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Targeted tests passed locally:

`pnpm test --run tests/unit/auth/discovery-endpoints.test.ts tests/unit/auth/oauth-register-route.test.ts tests/integration/auth/oauth-clients.test.ts`

Result: 3 test files passed, 40 tests passed.
