### PR TITLE
perf-monitor: fix 1h/24h filters, bucket 7d view; pin cache-demo to LHR

### DIFF
--- a/infra/cache-demo/wrangler.jsonc
+++ b/infra/cache-demo/wrangler.jsonc
@@ -5,7 +5,7 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
-	"placement": { "mode": "smart" },
+	"placement": { "mode": "targeted", "region": "aws:eu-west-2" },
 	"routes": [
 		{
 			"pattern": "cache-demo.emdashcms.com",

--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -503,6 +503,18 @@
 			// single cron spike doesn't pull the bucket.
 			const DAILY_BUCKET_PERIODS = new Set(["7d", "30d", "90d"]);
 
+			/**
+			 * Parse a D1-stored timestamp ("YYYY-MM-DD HH:MM:SS", no TZ) as UTC.
+			 * `new Date("YYYY-MM-DD HH:MM:SS")` is implementation-defined and most
+			 * browsers treat it as *local* time, which shifts samples across UTC
+			 * day boundaries when we bucket with `getUTC*`. Normalize first.
+			 */
+			function parseStoredTimestamp(ts) {
+				if (!ts) return null;
+				if (ts.includes("T") || ts.endsWith("Z")) return new Date(ts);
+				return new Date(ts.replace(" ", "T") + "Z");
+			}
+
 			function median(nums) {
 				const sorted = nums.filter((n) => n != null).sort((a, b) => a - b);
 				if (sorted.length === 0) return null;
@@ -540,8 +552,9 @@
 				return "bad";
 			}
 
-			function formatTime(iso) {
-				const d = new Date(iso);
+			function formatTime(ts) {
+				const d = parseStoredTimestamp(ts);
+				if (!d) return "";
 				const pad = (n) => String(n).padStart(2, "0");
 				return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 			}
@@ -772,14 +785,14 @@
 					const color = REGION_COLORS[region] || "#888";
 
 					const rawCold = result.data.map((d) => ({
-						x: new Date(d.timestamp),
+						x: parseStoredTimestamp(d.timestamp),
 						y: d.coldTtfbMs,
 						prNumber: d.prNumber,
 						sha: d.sha,
 						source: d.source,
 					}));
 					const rawWarm = result.data.map((d) => ({
-						x: new Date(d.timestamp),
+						x: parseStoredTimestamp(d.timestamp),
 						y: d.warmTtfbMs,
 						prNumber: d.prNumber,
 						sha: d.sha,
@@ -848,8 +861,8 @@
 							const key = `deploy-${marker.sha || marker.timestamp}-${region}`;
 							annotations[key] = {
 								type: "line",
-								xMin: new Date(marker.timestamp),
-								xMax: new Date(marker.timestamp),
+								xMin: parseStoredTimestamp(marker.timestamp),
+								xMax: parseStoredTimestamp(marker.timestamp),
 								borderColor: "#ff6b6b40",
 								borderWidth: 1,
 								borderDash: [4, 4],

--- a/infra/perf-monitor/public/index.html
+++ b/infra/perf-monitor/public/index.html
@@ -498,6 +498,35 @@
 				}
 			}
 
+			// 7d/30d/90d views show per-point samples that are too spiky to read.
+			// Bucket by UTC day so the trend is visible. Median, not mean, so a
+			// single cron spike doesn't pull the bucket.
+			const DAILY_BUCKET_PERIODS = new Set(["7d", "30d", "90d"]);
+
+			function median(nums) {
+				const sorted = nums.filter((n) => n != null).sort((a, b) => a - b);
+				if (sorted.length === 0) return null;
+				const mid = sorted.length >> 1;
+				return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+			}
+
+			function bucketByUtcDay(points) {
+				const byDay = new Map();
+				for (const p of points) {
+					const d = p.x instanceof Date ? p.x : new Date(p.x);
+					const day = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+					if (!byDay.has(day)) byDay.set(day, []);
+					byDay.get(day).push(p.y);
+				}
+				return [...byDay.entries()]
+					.map(([day, ys]) => ({
+						x: new Date(`${day}T12:00:00Z`),
+						y: median(ys),
+					}))
+					.filter((p) => p.y != null)
+					.sort((a, b) => a.x - b.x);
+			}
+
 			function formatMs(ms) {
 				if (ms == null) return "-";
 				if (ms < 1000) return Math.round(ms) + "ms";
@@ -722,6 +751,7 @@
 					regionFilter === "all" ? configData.regions.map((r) => r.id) : [regionFilter];
 
 				const site = currentSite();
+				const bucketDaily = DAILY_BUCKET_PERIODS.has(period);
 
 				// Fetch chart data for each region in parallel
 				const chartDataPromises = regions.map((region) =>
@@ -741,15 +771,26 @@
 					const result = chartResults[i];
 					const color = REGION_COLORS[region] || "#888";
 
+					const rawCold = result.data.map((d) => ({
+						x: new Date(d.timestamp),
+						y: d.coldTtfbMs,
+						prNumber: d.prNumber,
+						sha: d.sha,
+						source: d.source,
+					}));
+					const rawWarm = result.data.map((d) => ({
+						x: new Date(d.timestamp),
+						y: d.warmTtfbMs,
+						prNumber: d.prNumber,
+						sha: d.sha,
+						source: d.source,
+					}));
+					const coldPoints = bucketDaily ? bucketByUtcDay(rawCold) : rawCold;
+					const warmPoints = bucketDaily ? bucketByUtcDay(rawWarm) : rawWarm;
+
 					coldDatasets.push({
 						label: REGION_LABELS[region] || region,
-						data: result.data.map((d) => ({
-							x: new Date(d.timestamp),
-							y: d.coldTtfbMs,
-							prNumber: d.prNumber,
-							sha: d.sha,
-							source: d.source,
-						})),
+						data: coldPoints,
 						borderColor: color,
 						backgroundColor: color + "20",
 						borderWidth: 1.5,
@@ -775,13 +816,7 @@
 
 					warmDatasets.push({
 						label: REGION_LABELS[region] || region,
-						data: result.data.map((d) => ({
-							x: new Date(d.timestamp),
-							y: d.warmTtfbMs,
-							prNumber: d.prNumber,
-							sha: d.sha,
-							source: d.source,
-						})),
+						data: warmPoints,
 						borderColor: color,
 						backgroundColor: color + "20",
 						borderWidth: 1.5,

--- a/infra/perf-monitor/src/store.ts
+++ b/infra/perf-monitor/src/store.ts
@@ -111,8 +111,10 @@ export interface QueryParams {
  * LESS than since regardless of its actual time, so same-day filters (1h,
  * and the "today" portion of 24h) silently return zero rows.
  */
+const SINCE_TIMESTAMP_RE = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/;
+
 function normalizeSince(since: string): string {
-	const match = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/.exec(since);
+	const match = SINCE_TIMESTAMP_RE.exec(since);
 	return match ? `${match[1]} ${match[2]}` : since;
 }
 

--- a/infra/perf-monitor/src/store.ts
+++ b/infra/perf-monitor/src/store.ts
@@ -101,6 +101,21 @@ export interface QueryParams {
 	limit?: number;
 }
 
+/**
+ * Normalize an ISO-8601 timestamp (e.g. "2026-04-20T05:00:00.000Z") to the
+ * " "-separated form D1's `datetime('now')` writes ("2026-04-20 05:00:00").
+ *
+ * SQLite compares TEXT lexicographically: space (0x20) sorts before "T"
+ * (0x54). If we pass the client's ISO string straight into `timestamp >= ?`,
+ * any stored row whose calendar date matches the since-boundary compares
+ * LESS than since regardless of its actual time, so same-day filters (1h,
+ * and the "today" portion of 24h) silently return zero rows.
+ */
+function normalizeSince(since: string): string {
+	const match = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/.exec(since);
+	return match ? `${match[1]} ${match[2]}` : since;
+}
+
 /** Query historical results with optional filters. */
 export async function queryResults(db: D1Database, params: QueryParams): Promise<PerfResult[]> {
 	const conditions: string[] = [];
@@ -124,7 +139,7 @@ export async function queryResults(db: D1Database, params: QueryParams): Promise
 	}
 	if (params.since) {
 		conditions.push("timestamp >= ?");
-		bindings.push(params.since);
+		bindings.push(normalizeSince(params.since));
 	}
 
 	const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
@@ -214,7 +229,7 @@ export async function getDeployResults(
 ): Promise<PerfResult[]> {
 	const sinceClause = since ? "AND timestamp >= ?" : "";
 	const bindings: string[] = [site];
-	if (since) bindings.push(since);
+	if (since) bindings.push(normalizeSince(since));
 
 	const result = await db
 		.prepare(


### PR DESCRIPTION
## What does this PR do?

Three small infra changes, bundled because they share a deploy target (`perf.emdashcms.com` + the `cache-demo` Worker) and the dashboard edits don't touch any published package.

### 1. Fix `since` filtering on the perf dashboard

The 1h view was silently empty and 24h was behaving as "since midnight". Not DST, not clock skew — a text-comparison bug.

- D1 writes timestamps via `datetime('now')` as `"YYYY-MM-DD HH:MM:SS"` (space-separated).
- The client's `periodToSince()` returns `.toISOString()` → `"YYYY-MM-DDTHH:MM:SS.sssZ"` (T-separated).
- SQLite compares TEXT lexicographically. Space (`0x20`) < `T` (`0x54`). When the since-boundary lands on the same calendar date as stored rows, the space always sorts before the T, and every row is excluded regardless of its actual time.

Different calendar dates worked because the date portion differs before the separator, which is why 7d/30d/90d were fine and only 1h was fully broken while 24h only returned today's data.

Fix is one helper: `normalizeSince()` rewrites the incoming ISO string to the stored format before binding it into the SQL. Applied in both `queryResults` and `getDeployResults`.

### 2. Bucket 7d/30d/90d chart views to daily medians

Per-point samples at those ranges are too noisy to read the trend. Added client-side `bucketByUtcDay()` + `median()` helpers and a `DAILY_BUCKET_PERIODS` set (`7d`, `30d`, `90d`). Cold/warm datasets now render as one point per UTC day for those periods. 1h/24h still render per-sample, preserving PR/SHA markers. Deploy markers (vertical annotation lines from `deployMarkers`) are unchanged — PR attribution still shows on the chart.

### 3. Pin `cache-demo` to targeted LHR placement

Swap `{ mode: "smart" }` for `{ mode: "targeted", region: "aws:eu-west-2" }` on `emdash-demo-cache`.

`mode: "targeted"` isn't in the public Smart Placement docs but is in the wrangler config schema (both the top-level and `env.*` blocks), alongside the undocumented `hint` field under `smart` mode. Targeted mode pins the Worker to the named region for 100% of requests, eliminating Smart Placement's ~1% baseline-control traffic.

Why: on distant colos that ~1% is what drives the pathological cold tail — Worker runs locally, cold-init queries serialize back to the LHR D1 primary, 2–7 second responses. Pinning means 100% of traffic pays the same user↔LHR hop and gets the smart-placed path.

Trade-offs: loses adaptive failover if LHR has a regional incident; loses the `local-*` samples in `cf_placement` we've been using for diagnostics. cache-demo is the experimental arm, so this is the right Worker to try it on. blog-demo stays on smart.

**Confound:** cache-demo already has Astro's experimental cache provider enabled, so the A/B vs blog-demo now mixes two changes. If the numbers move, a third arm (targeted placement without the cache) would be needed to isolate cause.

## Type of change

- [x] Performance improvement
- [x] Bug fix

(Two types because it's a bundled infra PR — dashboard bug fix + placement experiment.)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable — dashboard + wrangler changes, no unit-testable surface)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable — infra only, not admin UI)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (infra-only, no published package affected)
- [ ] New features link to an approved Discussion: not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — visible after deploy on `perf.emdashcms.com`. 1h view should populate; 7d view should render ~7 points per region instead of ~200.