### PR TITLE
fix(import): emit relative URLs from WordPress media import (#657)

### DIFF
--- a/.changeset/fifty-moments-grab.md
+++ b/.changeset/fifty-moments-grab.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes WordPress media import to emit relative `/_emdash/api/media/file/...` URLs instead of absolute ones, matching every other media endpoint. Imported media is now recognized by `INTERNAL_MEDIA_PREFIX` for enrichment, and no longer pins URLs to the origin that happened to serve the import request (breaking renders on a different port or behind a reverse proxy).

--- a/packages/core/src/astro/routes/api/import/wordpress/media.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/media.ts
@@ -92,7 +92,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 						attachments,
 						emdash.db,
 						emdash.storage,
-						request.url,
 						sendProgress,
 					);
 
@@ -117,7 +116,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			attachments,
 			emdash.db,
 			emdash.storage,
-			request.url,
 			() => {}, // No-op progress callback
 		);
 
@@ -131,12 +129,9 @@ async function importMediaWithProgress(
 	attachments: AttachmentInfo[],
 	db: NonNullable<EmDashHandlers["db"]>,
 	storage: NonNullable<EmDashHandlers["storage"]>,
-	requestUrl: string,
 	onProgress: (progress: MediaImportProgress) => void,
 ): Promise<MediaImportResult> {
 	const repo = new MediaRepository(db);
-	const url = new URL(requestUrl);
-	const baseUrl = `${url.protocol}//${url.host}`;
 	const total = attachments.length;
 
 	const result: MediaImportResult = {
@@ -237,7 +232,7 @@ async function importMediaWithProgress(
 			const existing = await repo.findByContentHash(contentHash);
 			if (existing) {
 				// Same content already exists - reuse it
-				const existingUrl = `${baseUrl}/_emdash/api/media/file/${existing.storageKey}`;
+				const existingUrl = `/_emdash/api/media/file/${existing.storageKey}`;
 				result.urlMap[attachment.url] = existingUrl;
 				result.imported.push({
 					wpId: attachment.id,
@@ -290,7 +285,7 @@ async function importMediaWithProgress(
 			});
 
 			// Build the new URL
-			const newUrl = `${baseUrl}/_emdash/api/media/file/${storageKey}`;
+			const newUrl = `/_emdash/api/media/file/${storageKey}`;
 
 			result.imported.push({
 				wpId: attachment.id,


### PR DESCRIPTION
## What does this PR do?

Fixes `/_emdash/api/import/wordpress/media` so it returns the same relative `/_emdash/api/media/file/{key}` URL form every other media endpoint uses, instead of pinning an absolute URL built from `request.url`.

Two failure modes followed from the divergence (see #657):

1. `INTERNAL_MEDIA_PREFIX = "/_emdash/api/media/file/"` is matched with `url.startsWith(...)` in `packages/core/src/media/normalize.ts`, so absolute URLs fell through to the external-media branch and skipped the local provider's enrichment (dimensions, storage key, etc.).
2. The absolute URL was pinned to whatever origin `request.url` carried at import time. In dev that's whichever port Astro auto-selected (4322 when 4321 was busy), so later renders on 4321 got `ERR_CONNECTION_REFUSED`. Behind a reverse proxy it pins the internal origin rather than the public one.

The fix follows option 1 from the issue: drop `baseUrl`, return the relative form, and remove the now-unused `requestUrl` parameter from `importMediaWithProgress`. The `existingUrl` (content-hash dedup reuse) branch gets the same treatment.

Closes #657

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (packages/core; upstream/main has unrelated failures in packages/admin and packages/cloudflare)
- [x] `pnpm lint` passes (28 pre-existing diagnostics, none introduced by this change)
- [x] `pnpm test` passes (3 unrelated pre-existing test failures on upstream/main in auth/passkey-verify-route and invite)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Note on tests: the route handler has no existing unit-test harness (the `wordpress-import.test.ts` integration test covers the CLI commands, not the HTTP route), and `importMediaWithProgress` is not exported. Happy to add a targeted test if you'd like - the cleanest path is probably to export the helper or spin up a minimal route harness. Let me know which direction fits the codebase.

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A - change is URL format only.