### PR TITLE
fix(seo): emit locale-prefixed URLs in per-collection sitemap

### DIFF
--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -18,6 +18,8 @@ export interface SitemapContentEntry {
 	slug: string | null;
 	/** ISO date of last modification */
 	updatedAt: string;
+	/** Row locale (e.g. "en", "fr"). Always set — i18n migration backfills to "en". */
+	locale: string;
 }
 
 /** Per-collection sitemap data with entries and URL pattern */
@@ -93,8 +95,9 @@ export async function handleSitemapData(
 					slug: string | null;
 					id: string;
 					updated_at: string;
+					locale: string | null;
 				}>`
-					SELECT c.slug, c.id, c.updated_at
+					SELECT c.slug, c.id, c.updated_at, c.locale
 					FROM ${sql.ref(tableName)} c
 					LEFT JOIN _emdash_seo s
 						ON s.collection = ${col.slug}
@@ -114,6 +117,7 @@ export async function handleSitemapData(
 						id: row.id,
 						slug: row.slug,
 						updatedAt: row.updated_at,
+						locale: row.locale ?? "",
 					});
 				}
 

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -8,9 +8,17 @@
  */
 
 import type { APIRoute } from "astro";
+// @ts-ignore - virtual module populated by the EmDash integration
+import virtualConfig from "virtual:emdash/config";
 
 import { handleSitemapData } from "#api/handlers/seo.js";
 import { getSiteSettingsWithDb } from "#settings/index.js";
+
+interface VirtualI18nConfig {
+	defaultLocale: string;
+	locales: string[];
+	prefixDefaultLocale?: boolean;
+}
 
 export const prerender = false;
 
@@ -60,13 +68,30 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 			'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
 		];
 
+		// Read i18n straight from the virtual config (same source the loader uses),
+		// so we don't depend on middleware having initialized getI18nConfig().
+		const i18nCfg: VirtualI18nConfig | null =
+			virtualConfig && typeof virtualConfig === "object" && "i18n" in virtualConfig
+				? ((virtualConfig as { i18n?: VirtualI18nConfig }).i18n ?? null)
+				: null;
+		const i18nOn = i18nCfg !== null && i18nCfg.locales.length > 1;
+
 		for (const entry of col.entries) {
 			const slug = entry.slug || entry.id;
-			const path = col.urlPattern
+			const basePath = col.urlPattern
 				? col.urlPattern
 						.replace(SLUG_PLACEHOLDER, encodeURIComponent(slug))
 						.replace(ID_PLACEHOLDER, encodeURIComponent(entry.id))
 				: `/${encodeURIComponent(col.collection)}/${encodeURIComponent(slug)}`;
+
+			// Mirror loader.ts: prefix with /<locale> when i18n is on and the row
+			// isn't the default locale (or prefixDefaultLocale is enabled).
+			const shouldPrefix =
+				i18nOn &&
+				i18nCfg !== null &&
+				entry.locale !== "" &&
+				(entry.locale !== i18nCfg.defaultLocale || i18nCfg.prefixDefaultLocale === true);
+			const path = shouldPrefix ? `/${encodeURIComponent(entry.locale)}${basePath}` : basePath;
 
 			const loc = `${siteUrl}${path}`;
 

--- a/packages/core/tests/integration/seo/seo.test.ts
+++ b/packages/core/tests/integration/seo/seo.test.ts
@@ -1061,6 +1061,48 @@ describe("SEO", () => {
 			expect(result.success).toBe(true);
 			expect(result.data!.collections).toEqual([]);
 		});
+
+		it("should include locale on each entry (defaults to 'en')", async () => {
+			await repo.create({
+				type: "post",
+				slug: "english-post",
+				data: { title: "English" },
+				status: "published",
+			});
+
+			const result = await handleSitemapData(db);
+
+			expect(result.success).toBe(true);
+			const entry = result.data!.collections[0]!.entries[0]!;
+			expect(entry.locale).toBe("en");
+		});
+
+		it("should return locale for each translated row of a collection", async () => {
+			const en = await repo.create({
+				type: "post",
+				slug: "about",
+				data: { title: "About" },
+				status: "published",
+				locale: "en",
+			});
+
+			await repo.create({
+				type: "post",
+				slug: "a-propos",
+				data: { title: "À propos" },
+				status: "published",
+				locale: "fr",
+				translationOf: en.id,
+			});
+
+			const result = await handleSitemapData(db, "post");
+
+			expect(result.success).toBe(true);
+			const entries = result.data!.collections[0]!.entries;
+			const bySlug = new Map(entries.map((e) => [e.slug, e.locale]));
+			expect(bySlug.get("about")).toBe("en");
+			expect(bySlug.get("a-propos")).toBe("fr");
+		});
 	});
 
 	describe("has_seo opt-in per collection", () => {


### PR DESCRIPTION
## Summary

When Astro i18n is enabled with `prefixDefaultLocale: false`, the per-collection sitemap emits every translated row under the default-locale path. With a bilingual site (e.g. EN at `/`, FR at `/fr/`), the FR entries appear in the sitemap as `/a-propos` instead of `/fr/a-propos` and 404.

Root cause: `handleSitemapData` doesn't select the row's `locale`, and the route builds URLs from `url_pattern` alone.

## Changes

- `packages/core/src/api/handlers/seo.ts` — select `c.locale` and expose it on `SitemapContentEntry`. Safe to select unconditionally since migration `019_i18n` backfills `locale` on every `ec_*` table.
- `packages/core/src/astro/routes/sitemap-[collection].xml.ts` — mirror the prefix rule from `src/loader.ts`: prepend `/<locale>` when the row's locale isn't the default, or always when `prefixDefaultLocale: true`.
  - Reads i18n straight from `virtual:emdash/config` (same source the loader uses) rather than `getI18nConfig()`, so the route doesn't depend on middleware having initialized the i18n singleton before the injected route runs.
- `packages/core/tests/integration/seo/seo.test.ts` — two cases covering default-locale rows and translated rows.

## Notes

- No schema changes, no new `url_pattern` placeholder — locale prepending matches the loader's existing convention.
- `prefers-reduced-motion`: urlset output is unchanged when i18n is disabled (single-locale or no config).
- A follow-up PR addresses a separate pre-existing encoding bug where `encodeURIComponent(slug)` turned multi-segment slugs like `faq/products` into `faq%2Fproducts`. Kept out of this PR to keep the diff focused.

## Test plan

- [x] `pnpm --filter emdash test -- tests/integration/seo/seo.test.ts` — 57 tests pass
- [x] Verified live against a bilingual Astro site (EN at `/`, FR at `/fr/`): `/sitemap-pages.xml` emits both `/about` and `/fr/a-propos`; FR URLs load 200.