### PR TITLE
fix(seo): preserve path separators when encoding sitemap URLs

### DIFF
--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -64,9 +64,9 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 			const slug = entry.slug || entry.id;
 			const path = col.urlPattern
 				? col.urlPattern
-						.replace(SLUG_PLACEHOLDER, encodeURIComponent(slug))
-						.replace(ID_PLACEHOLDER, encodeURIComponent(entry.id))
-				: `/${encodeURIComponent(col.collection)}/${encodeURIComponent(slug)}`;
+						.replace(SLUG_PLACEHOLDER, encodePathSegments(slug))
+						.replace(ID_PLACEHOLDER, encodePathSegments(entry.id))
+				: `/${encodePathSegments(col.collection)}/${encodePathSegments(slug)}`;
 
 			const loc = `${siteUrl}${path}`;
 
@@ -101,4 +101,13 @@ function escapeXml(str: string): string {
 		.replace(GT_RE, "&gt;")
 		.replace(QUOT_RE, "&quot;")
 		.replace(APOS_RE, "&apos;");
+}
+
+/**
+ * Percent-encode a value that may contain `/` as a path, preserving the
+ * separators. `encodeURIComponent` alone would turn `faq/products` into
+ * `faq%2Fproducts`, which breaks multi-segment slugs.
+ */
+function encodePathSegments(value: string): string {
+	return value.split("/").map(encodeURIComponent).join("/");
 }


### PR DESCRIPTION
## Summary

The per-collection sitemap route calls `encodeURIComponent` on slugs, ids, and collection names when composing URLs. For multi-segment slugs like `faq/products`, that turns `/` into `%2F` and produces broken URLs like `/faq%2Fproducts` in the sitemap output.

Add an `encodePathSegments` helper that splits on `/`, `encodeURIComponent`s each segment, and rejoins — so path separators stay literal while other reserved characters continue to be escaped.

## Changes

- `packages/core/src/astro/routes/sitemap-[collection].xml.ts`
  - Add `encodePathSegments` helper.
  - Use it for the three spots the route inserts user-controlled identifiers into a path: `{slug}` and `{id}` placeholder substitutions in `url_pattern`, plus the default `/{collection}/{slug}` fallback.

## Test plan

- [x] Existing sitemap/seo tests still pass (`pnpm --filter emdash test -- tests/integration/seo/seo.test.ts`).
- [x] Verified live against a site with a collection using `url_pattern: /{slug}` and slugs like `faq/products`: output is `https://example.com/faq/products`, not `https://example.com/faq%2Fproducts`.