### PR TITLE
fix(admin): preserve RepeaterField item keys across value round-trip

### DIFF
--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -75,9 +75,10 @@ export function RepeaterField({
 		const incoming = Array.isArray(value) ? value : [];
 		setItems((prev) =>
 			incoming.map((item, i) => {
-				const obj = (typeof item === "object" && item !== null
-					? item
-					: {}) as Record<string, unknown>;
+				const obj = (typeof item === "object" && item !== null ? item : {}) as Record<
+					string,
+					unknown
+				>;
 				const existingKey = (obj._key as string) || prev[i]?._key;
 				return {
 					...obj,

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -68,10 +68,23 @@ export function RepeaterField({
 	const [items, setItems] = React.useState<RepeaterItem[]>(() => ensureKeys(rawItems));
 	const [collapsedItems, setCollapsedItems] = React.useState<Set<string>>(new Set());
 
-	// Sync from external value changes
+	// Sync from external value changes.
+	// Preserve each item's _key by position so round-trips through onChange
+	// (which strips _key) don't remount children on every keystroke.
 	React.useEffect(() => {
 		const incoming = Array.isArray(value) ? value : [];
-		setItems(ensureKeys(incoming));
+		setItems((prev) =>
+			incoming.map((item, i) => {
+				const obj = (typeof item === "object" && item !== null
+					? item
+					: {}) as Record<string, unknown>;
+				const existingKey = (obj._key as string) || prev[i]?._key;
+				return {
+					...obj,
+					_key: existingKey || `item-${i}-${Date.now()}`,
+				};
+			}),
+		);
 	}, [value]);
 
 	const emitChange = (updated: RepeaterItem[]) => {


### PR DESCRIPTION
## Summary

The `RepeaterField` sync effect was minting fresh item keys on every parent update, causing `SortableRepeaterItem` to unmount/remount on every keystroke. Inputs lost focus and the item card appeared to collapse back.

## Reproducer

1. Define a content type with a repeater field (or edit any existing one).
2. Expand an item and type a sentence into a sub-field.
3. Observe: focus drops after each character, and the editor feels like it's constantly remounting.

## Root cause

`packages/admin/src/components/RepeaterField.tsx`:

- `ensureKeys()` assigns `_key: \`item-\${i}-\${Date.now()}\`` when an item has no `_key`.
- `stripKeys()` removes `_key` before `onChange`, so the parent's value never carries keys.
- The `useEffect([value])` sync reruns `ensureKeys()` against the round-tripped (keyless) value → fresh `Date.now()` keys on every emit.
- `SortableRepeaterItem` is keyed by `item._key`, so changed keys = full unmount/remount of every item.
- Secondary: `collapsedItems: Set<string>` is keyed by `_key` and becomes orphaned on every keystroke.

## Fix

Preserve each item's `_key` by position: when the incoming value lacks `_key`, reuse the key from the previous state at the same index. Round-trips via `stripKeys` stop churning keys; new external values (add/remove/reorder) still get stable keys either from the incoming object or the previous slot. Initial loads fall back to the existing `item-\${i}-\${Date.now()}` generator.

No changes to `emitChange`, `handleAdd`, `handleRemove`, `handleDragEnd`, or `toggleCollapse` — they already operated correctly on `_key`-bearing items.

## Test plan

- [ ] Type a full sentence into a repeater sub-field → input keeps focus, item stays expanded.
- [ ] Add a new item → item gets a unique key and appears expanded.
- [ ] Remove an item → surviving items keep their keys and expand/collapse state.
- [ ] Drag-to-reorder → order persists and keys follow items.
- [ ] Reload the editor → persisted data loads without extraneous `_key` fields (still stripped in `emitChange`).