### PR TITLE
fix(admin): fixes dark mode toggle having no effect with the classic theme

### DIFF
--- a/.changeset/fix-classic-dark-mode.md
+++ b/.changeset/fix-classic-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes dark mode toggle having no effect with the classic theme.

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -34,7 +34,9 @@
 	--color-kumo-brand: #2271b1;
 	--color-kumo-brand-hover: #135e96;
 	--text-color-kumo-brand: #2271b1;
+}
 
+[data-theme="classic"]:not([data-mode="dark"]) {
 	/* Surfaces */
 	--color-kumo-base: #ffffff;
 	--color-kumo-elevated: #f0f0f1;


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #163 

### The issue

The classic theme hardcoded light color values, overriding Kumo's built-in dark mode support. The dark mode toggle changed the icon but had no visual effect.

https://github.com/user-attachments/assets/71a6aa28-dab3-406c-98b7-a2e2cdea420d


### The fix

Scoped the classic theme's color overrides to light mode only. In dark mode, Kumo's own dark values apply.

https://github.com/user-attachments/assets/e0603a57-7a57-426d-9615-8ab8f686b19f


## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
