### PR TITLE
fix(visual-editing): unwrap manifest data envelope in toolbar

### DIFF
--- a/.changeset/fix-toolbar-manifest-unwrap.md
+++ b/.changeset/fix-toolbar-manifest-unwrap.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes visual editing: clicking an editable field now opens the inline editor instead of always opening the admin in a new tab. The toolbar's manifest fetch was reading `manifest.collections` directly but the `/_emdash/api/manifest` endpoint wraps its payload in `{ data: … }`, so every field-kind lookup returned `null` and every click fell through to the admin-new-tab fallback.

--- a/packages/core/src/visual-editing/toolbar.ts
+++ b/packages/core/src/visual-editing/toolbar.ts
@@ -683,7 +683,12 @@ export function renderToolbar(config: ToolbarConfig): string {
     if (manifestPromise) return manifestPromise;
     manifestPromise = ecFetch("/_emdash/api/manifest", { credentials: "same-origin" })
       .then(function(r) { return r.json(); })
-      .then(function(m) { manifestCache = m; return m; });
+      .then(function(m) {
+        // The manifest endpoint wraps the payload in a { data } envelope (ApiResponse shape).
+        // Unwrap it so getFieldKind can read manifest.collections directly.
+        manifestCache = m && m.data ? m.data : m;
+        return manifestCache;
+      });
     return manifestPromise;
   }
 

--- a/packages/core/tests/unit/visual-editing/toolbar.test.ts
+++ b/packages/core/tests/unit/visual-editing/toolbar.test.ts
@@ -61,6 +61,19 @@ describe("renderToolbar", () => {
 		expect(html).toContain("/_emdash/api/manifest");
 	});
 
+	it("unwraps the { data } envelope returned by /_emdash/api/manifest", () => {
+		// Regression for #103 / #445: the manifest endpoint wraps the payload in
+		// { data: manifest } (ApiResponse shape), but getFieldKind reads
+		// manifest.collections directly. Without the unwrap, getFieldKind returns
+		// null for every field kind, and every click on an edit annotation opens
+		// the admin in a new tab instead of inline-editing.
+		const html = renderToolbar({ editMode: true, isPreview: false });
+		// The unwrap happens inside the fetchManifest .then() callback. Verify
+		// the generated HTML contains the conditional unwrap rather than
+		// assigning the raw response.
+		expect(html).toMatch(/manifestCache\s*=\s*m\s*&&\s*m\.data\s*\?\s*m\.data\s*:\s*m/);
+	});
+
 	it("skips toolbar interception for portableText (inline editor)", () => {
 		const html = renderToolbar({ editMode: true, isPreview: false });
 		expect(html).toContain("portableText");


### PR DESCRIPTION
## What does this PR do?

The toolbar's inline editing was completely non-functional: every click on an annotated field opened the admin in a new tab instead of inline-editing, even for simple `string` / `text` fields.

Root cause: `/_emdash/api/manifest` wraps its response in the standard `{ data: ... }` ApiResponse envelope, but `fetchManifest` in `toolbar.ts` cached the raw response. `getFieldKind` then read `manifest.collections` directly, which was always `undefined`, so every call returned `null` and `dispatchInline(null)` fell through to the `openAdmin(annotation)` branch.

Fix: unwrap the envelope inside the `fetchManifest` `.then()` callback. Kept the fallback (`m.data ? m.data : m`) so the toolbar continues to work if the manifest endpoint's response shape ever changes.

Verified live on `demos/simple`:

```js
await fetch('/_emdash/api/manifest', { credentials: 'same-origin' }).then(r => r.json()).then(m => Object.keys(m))
// Before: ["data"]
// Collections accessed via m.data.collections
```

Closes #103
Closes #445

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (22 pre-existing warnings unchanged; 0 new)
- [x] `pnpm test` passes (toolbar suite: 13/13)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
✓ tests/unit/visual-editing/toolbar.test.ts (13 tests) 3ms
  ✓ renderToolbar > unwraps the { data } envelope returned by /_emdash/api/manifest
```