### PR TITLE
fix(admin): accent-insensitive taxonomy term picker

### DIFF
--- a/.changeset/picker-accent-fold.md
+++ b/.changeset/picker-accent-fold.md
@@ -1,0 +1,11 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the taxonomy term picker to match across diacritic boundaries.
+
+Typing `Mexico` in the admin picker now surfaces a term labeled `México` instead of prompting a duplicate create. Input and term labels are folded via NFD decomposition + lowercase before substring-matching, so editors who type without diacritics — or with locale keyboards that produce precomposed vs. combining forms — still see the canonical term.
+
+Before this fix, `"mexico"` and `"méxico"` were treated as distinct strings, so the picker showed zero suggestions and the editor had no way to find the existing term except to create a duplicate. Duplicate terms then split the taxonomy and broke public-facing filter pages that group content by slug.
+
+The exact-match check that gates the "Create new term" button uses the same fold, so typing `Mexico` when `México` exists also suppresses Create — closing the duplicate-creation loop.

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -14,6 +14,7 @@ import * as React from "react";
 
 import { apiFetch, parseApiResponse, throwResponseError } from "../lib/api/client.js";
 import { createTerm } from "../lib/api/taxonomies.js";
+import { termExactMatches, termMatches } from "../lib/taxonomy-match.js";
 import { slugify } from "../lib/utils.js";
 
 interface TaxonomyTerm {
@@ -167,17 +168,13 @@ function TagInput({
 	const suggestions = React.useMemo(() => {
 		if (!trimmedInput) return [];
 		return terms
-			.filter(
-				(term) =>
-					term.label.toLowerCase().includes(trimmedInput.toLowerCase()) &&
-					!selectedIds.has(term.id),
-			)
+			.filter((term) => !selectedIds.has(term.id) && termMatches(term, trimmedInput))
 			.slice(0, 5);
 	}, [trimmedInput, terms, selectedIds]);
 
 	const hasExactMatch = React.useMemo(() => {
 		if (!trimmedInput) return false;
-		return terms.some((term) => term.label.toLowerCase() === trimmedInput.toLowerCase());
+		return terms.some((term) => termExactMatches(term, trimmedInput));
 	}, [trimmedInput, terms]);
 
 	const showCreateOption = trimmedInput.length > 0 && !hasExactMatch;

--- a/packages/admin/src/lib/taxonomy-match.ts
+++ b/packages/admin/src/lib/taxonomy-match.ts
@@ -1,0 +1,68 @@
+/**
+ * Taxonomy term matching for the admin picker.
+ *
+ * The picker filters an editor's typed input against existing terms. A naive
+ * `label.toLowerCase().includes(input.toLowerCase())` fails the accent case:
+ * typing `"Mexico"` does not substring-match a term labeled `"México"`
+ * because `"méxico".toLowerCase()` is still `"méxico"` and
+ * `"méxico".includes("mexico")` is `false`. The editor then sees zero
+ * suggestions and creates a duplicate `"Mexico"` term alongside the
+ * canonical `"México"`, splitting the taxonomy.
+ *
+ * This module folds diacritics via NFD decomposition before substring
+ * matching. No regexes are compiled from user input, so there is no ReDoS
+ * surface.
+ */
+
+const DIACRITIC_RANGE = /[\u0300-\u036f]/g;
+
+/**
+ * Case-fold + diacritic-fold normalization for substring matching.
+ *
+ * `"México"`, `"mexico"`, `"MÉXICO"` all collapse to `"mexico"`.
+ *
+ * NFD decomposes accented characters into a base + combining-diacritic
+ * sequence; the regex drops the combiners. Greek tonos, Vietnamese
+ * stacked diacritics, and other Latin-adjacent scripts are covered.
+ * Combining marks used meaningfully in non-Latin scripts (Arabic harakat
+ * U+064B–U+0652, Japanese dakuten U+3099) fall outside the U+0300–036F
+ * block and are left untouched — stripping them would change meaning.
+ */
+export function foldForMatch(value: string): string {
+	return value.normalize("NFD").replace(DIACRITIC_RANGE, "").toLowerCase();
+}
+
+/**
+ * Minimal shape a term must have to participate in matching.
+ * Kept structural so picker components and tests can use plain objects.
+ */
+export interface MatchableTerm {
+	label: string;
+}
+
+/**
+ * True if `input` is a substring of the term's label, ignoring case and
+ * diacritics.
+ *
+ * Empty or whitespace-only input returns `false` — the caller decides
+ * whether to show all terms or none in that state. The whitespace guard
+ * matters: without it, a needle of `"   "` would `.includes()`-match
+ * every term whose label contains a space.
+ */
+export function termMatches(term: MatchableTerm, input: string): boolean {
+	const needle = foldForMatch(input).trim();
+	if (!needle) return false;
+	return foldForMatch(term.label).includes(needle);
+}
+
+/**
+ * True if `input` is an exact (fold-equal) match for the term's label.
+ * Used to decide whether to show the "Create new term" button — if an
+ * editor types `"Mexico"` and a term labeled `"México"` already exists,
+ * Create must not appear or they'll produce a duplicate.
+ */
+export function termExactMatches(term: MatchableTerm, input: string): boolean {
+	const needle = foldForMatch(input).trim();
+	if (!needle) return false;
+	return foldForMatch(term.label).trim() === needle;
+}

--- a/packages/admin/tests/lib/taxonomy-match.test.ts
+++ b/packages/admin/tests/lib/taxonomy-match.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	foldForMatch,
+	termExactMatches,
+	termMatches,
+	type MatchableTerm,
+} from "../../src/lib/taxonomy-match.js";
+
+/**
+ * Tests for the admin picker matcher. The matcher is the sole gate between
+ * an editor's typed input and the "Create new term" escape hatch, so every
+ * branch has real user impact:
+ *
+ *   - accent-fold branch: `"Mexico"` must find `"México"` or editors create
+ *     a duplicate term and fragment the taxonomy.
+ *   - no-match branch: genuinely new terms must still offer Create.
+ *   - exact-match branch: governs whether Create is suppressed, so an
+ *     accent-insensitive exact match must count.
+ */
+
+const mexico: MatchableTerm = { label: "México" };
+const hongKong: MatchableTerm = { label: "Hong Kong" };
+
+describe("foldForMatch", () => {
+	it("folds diacritics and case to the same key", () => {
+		expect(foldForMatch("México")).toBe("mexico");
+		expect(foldForMatch("MEXICO")).toBe("mexico");
+		expect(foldForMatch("méxico")).toBe("mexico");
+	});
+
+	it("handles empty input", () => {
+		expect(foldForMatch("")).toBe("");
+	});
+
+	it("leaves non-accented characters unchanged", () => {
+		expect(foldForMatch("USA")).toBe("usa");
+		expect(foldForMatch("Hong Kong")).toBe("hong kong");
+	});
+
+	it("handles precomposed and decomposed forms identically", () => {
+		// Precomposed U+00E9 vs decomposed U+0065 U+0301 both fold to "e".
+		expect(foldForMatch("caf\u00e9")).toBe("cafe");
+		expect(foldForMatch("cafe\u0301")).toBe("cafe");
+	});
+});
+
+describe("termMatches", () => {
+	it("matches across the diacritic boundary (regression: Mexico/México)", () => {
+		expect(termMatches(mexico, "Mexico")).toBe(true);
+		expect(termMatches(mexico, "mexico")).toBe(true);
+		expect(termMatches(mexico, "MEX")).toBe(true);
+	});
+
+	it("matches an accented term against an accented query too", () => {
+		expect(termMatches(mexico, "México")).toBe(true);
+		expect(termMatches(mexico, "méx")).toBe(true);
+	});
+
+	it("does not match genuinely unrelated input (Create button must still appear)", () => {
+		expect(termMatches(mexico, "Japan")).toBe(false);
+		expect(termMatches(hongKong, "Canada")).toBe(false);
+	});
+
+	it("returns false for empty input so the dropdown stays closed", () => {
+		expect(termMatches(mexico, "")).toBe(false);
+	});
+
+	it("rejects whitespace-only input even when term labels contain spaces", () => {
+		// Regression guard: the label `"Hong Kong"` contains a space,
+		// so a naive `includes(needle)` without a whitespace guard would
+		// match a needle of `"   "` and surface every multi-word term.
+		expect(termMatches(hongKong, "   ")).toBe(false);
+		expect(termMatches(hongKong, " ")).toBe(false);
+	});
+
+	it("tolerates terms carrying unknown keys without crashing", () => {
+		const term = { label: "Canadá", extra: 42 } as unknown as MatchableTerm;
+		expect(termMatches(term, "Canada")).toBe(true);
+	});
+});
+
+describe("termExactMatches", () => {
+	it("treats diacritic-only differences as equal (so Create stays hidden)", () => {
+		expect(termExactMatches(mexico, "Mexico")).toBe(true);
+		expect(termExactMatches(mexico, "México")).toBe(true);
+	});
+
+	it("is stricter than termMatches — substrings do not count as exact", () => {
+		expect(termExactMatches(mexico, "Mex")).toBe(false);
+		expect(termExactMatches(hongKong, "Hong")).toBe(false);
+	});
+
+	it("returns false for empty or whitespace-only input", () => {
+		expect(termExactMatches(mexico, "")).toBe(false);
+		expect(termExactMatches(mexico, "   ")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

The admin's multi-term picker filters with `term.label.toLowerCase().includes(input.toLowerCase())`, which is not accent-insensitive. Typing `Mexico` against a taxonomy where a term labeled `México` exists shows zero suggestions and offers a **Create** button — so editors create a duplicate \`Mexico\` term alongside the canonical \`México\`.

Duplicate terms split the taxonomy: public-facing filter pages that group content by slug end up with half the entries under one slug and half under the other, and the category dropdown shows both.

**Fix:** fold input and term labels through NFD decomposition + diacritic strip + lowercase before substring-matching. `Mexico`, `MEXICO`, and `México` all collapse to `mexico` for matching purposes; labels still render as authored. The same fold gates the exact-match check that shows the Create button — so typing \`Mexico\` when \`México\` exists also suppresses Create.

## Before / after

| Input | Existing term | Before | After |
| --- | --- | --- | --- |
| `Mexico` | `México` | no suggestion, Create offered → duplicate | `México` surfaces as a suggestion |
| `méxico` | `México` | match (coincidentally) | match |
| `CAFE` | `Café` | no match | match |
| `Hong` | `Hong Kong` | match | match (unchanged) |
| `Canada` | `Japan` | no match, Create offered | no match, Create offered (unchanged) |

## Implementation

- New module \`packages/admin/src/lib/taxonomy-match.ts\` exporting pure \`foldForMatch\`, \`termMatches\`, \`termExactMatches\`. No regex compiled from user input — only the static character-class \`/[\u0300-\u036f]/g\`. No ReDoS surface.
- NFD + \`U+0300–036F\` covers Greek tonos, Vietnamese stacked diacritics, and precomposed ≡ decomposed equivalence. Non-Latin combining marks that carry meaning (Arabic harakat \`U+064B–0652\`, Japanese dakuten \`U+3099\`) fall outside the stripped range and are left untouched.
- \`TaxonomySidebar.tsx\` \`TagInput\` uses the new matcher for both suggestion filtering and the \`hasExactMatch\` gate.

## Scope

- **No schema or API changes.** Existing seed files and term payloads work unchanged.
- **No behaviour change** for terms that already match the naive substring check today.
- Single package affected: \`@emdash-cms/admin\` (patch changeset).

## Test plan

13 unit tests in \`packages/admin/tests/lib/taxonomy-match.test.ts\` covering:

- [x] Accent fold: \`Mexico\` / \`MEXICO\` / \`méxico\` match \`México\`.
- [x] Precomposed (\`U+00E9\`) vs decomposed (\`U+0065 U+0301\`) both fold identically.
- [x] Genuinely unrelated input does **not** match (Create must still be offered).
- [x] Empty and whitespace-only input return \`false\` — regression guard for the label \`Hong Kong\` (a needle of \`"   "\` would naively \`.includes()\`-match any multi-word label).
- [x] Exact-match check is strict — substrings do not satisfy it.
- [x] \`foldForMatch\` leaves non-accented input untouched.
- [x] Typecheck clean (\`pnpm --filter @emdash-cms/admin typecheck\`).

\`pnpm --filter @emdash-cms/admin test tests/lib/taxonomy-match.test.ts\` → 13 passed.

## Related / out of scope

I also prototyped an opt-in \`aliases: string[]\` field on taxonomy terms (search-only synonyms, so an editor typing \`USA\` finds a term labeled \`Estados Unidos\`). That is a **feature**, not a fix — it touches the seed schema, zod bodies, handler response, and the seed engine. I've kept it out of this PR and will open a **Discussion** pointing to the full branch at [\`edrpls:feat/taxonomy-picker-accent-aliases\`](https://github.com/edrpls/emdash/tree/feat/taxonomy-picker-accent-aliases) per CONTRIBUTING.md. Happy to pick that up if the maintainers are interested.

## AI disclosure

- [x] Drafted with AI assistance (Claude). I reviewed the diff and ran the test suite + typecheck locally before submitting.