### PR TITLE
fix(seed): create live revision for published content entries

### DIFF
--- a/.changeset/fix-seed-live-revisions.md
+++ b/.changeset/fix-seed-live-revisions.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash seed` so entries declared with `"status": "published"` are actually published. Previously the seed wrote the content row with `status: "published"` and a `published_at` timestamp but never created a live revision, so the admin UI showed "Save & Publish" instead of "Unpublish" and `live_revision_id` stayed null. The seed now promotes published entries to a live revision on both create and update paths.

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1032,6 +1032,25 @@ export class ContentRepository {
 	}
 
 	/**
+	 * Set the draft revision pointer for a content item.
+	 *
+	 * Used by seed/import paths that stage a new revision's data before
+	 * promoting it to live via `publish()`.
+	 */
+	async setDraftRevision(type: string, id: string, revisionId: string): Promise<void> {
+		const tableName = getTableName(type);
+		const now = new Date().toISOString();
+
+		await sql`
+			UPDATE ${sql.ref(tableName)}
+			SET draft_revision_id = ${revisionId},
+				updated_at = ${now}
+			WHERE id = ${id}
+			AND deleted_at IS NULL
+		`.execute(this.db);
+	}
+
+	/**
 	 * Discard pending draft changes
 	 *
 	 * Clears draft_revision_id. The content table columns already hold the

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -1036,10 +1036,30 @@ export class ContentRepository {
 	 *
 	 * Used by seed/import paths that stage a new revision's data before
 	 * promoting it to live via `publish()`.
+	 *
+	 * Validates that the content item exists and is not soft-deleted, that
+	 * the revision exists, and that the revision belongs to the same
+	 * collection and entry. Without these checks, a caller could leave the
+	 * content row pointing at a missing or unrelated revision.
 	 */
 	async setDraftRevision(type: string, id: string, revisionId: string): Promise<void> {
 		const tableName = getTableName(type);
 		const now = new Date().toISOString();
+
+		const existing = await this.findById(type, id);
+		if (!existing) {
+			throw new EmDashValidationError("Content item not found");
+		}
+
+		const revisionRepo = new RevisionRepository(this.db);
+		const revision = await revisionRepo.findById(revisionId);
+		if (!revision) {
+			throw new EmDashValidationError("Revision not found");
+		}
+
+		if (revision.collection !== type || revision.entryId !== id) {
+			throw new EmDashValidationError("Revision does not belong to the specified content item");
+		}
 
 		await sql`
 			UPDATE ${sql.ref(tableName)}

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -14,6 +14,7 @@ import { BylineRepository } from "../database/repositories/byline.js";
 import { ContentRepository } from "../database/repositories/content.js";
 import { MediaRepository } from "../database/repositories/media.js";
 import { RedirectRepository } from "../database/repositories/redirect.js";
+import { RevisionRepository } from "../database/repositories/revision.js";
 import { TaxonomyRepository } from "../database/repositories/taxonomy.js";
 import { withTransaction } from "../database/transaction.js";
 import type { Database } from "../database/types.js";
@@ -371,6 +372,7 @@ export async function applySeed(
 						await withTransaction(db, async (trx) => {
 							const trxContentRepo = new ContentRepository(trx);
 							const trxBylineRepo = new BylineRepository(trx);
+							const trxRevisionRepo = new RevisionRepository(trx);
 
 							await trxContentRepo.update(collectionSlug, existing.id, {
 								status,
@@ -386,6 +388,23 @@ export async function applySeed(
 								true,
 							);
 							await applyContentTaxonomies(trx, collectionSlug, existing.id, entry, true);
+
+							// Seed is declarative — when status is "published", promote to a live
+							// revision so the admin UI shows "Unpublish" instead of "Save & Publish"
+							// and `live_revision_id` is populated for downstream queries.
+							//
+							// Create a fresh revision from the updated data and stage it as the
+							// draft so `publish()` picks it up instead of re-syncing stale data
+							// from an existing live revision.
+							if (status === "published") {
+								const draft = await trxRevisionRepo.create({
+									collection: collectionSlug,
+									entryId: existing.id,
+									data: resolvedData,
+								});
+								await trxContentRepo.setDraftRevision(collectionSlug, existing.id, draft.id);
+								await trxContentRepo.publish(collectionSlug, existing.id);
+							}
 						});
 
 						seedIdMap.set(entry.id, existing.id);
@@ -433,6 +452,13 @@ export async function applySeed(
 
 					await applyContentBylines(trxBylineRepo, collectionSlug, item.id, entry, seedBylineIdMap);
 					await applyContentTaxonomies(trx, collectionSlug, item.id, entry, false);
+
+					// Seed is declarative — when status is "published", promote to a live
+					// revision so the admin UI shows "Unpublish" instead of "Save & Publish"
+					// and `live_revision_id` is populated for downstream queries.
+					if (status === "published") {
+						await trxContentRepo.publish(collectionSlug, item.id);
+					}
 
 					return item;
 				});

--- a/packages/core/tests/integration/seed-live-revisions.test.ts
+++ b/packages/core/tests/integration/seed-live-revisions.test.ts
@@ -15,7 +15,7 @@ import { applySeed } from "../../src/seed/apply.js";
 import type { SeedFile } from "../../src/seed/types.js";
 import { setupTestDatabase, teardownTestDatabase } from "../utils/test-db.js";
 
-function seedWith(status: "draft" | "published" | "scheduled"): SeedFile {
+function seedWith(status: "draft" | "published"): SeedFile {
 	return {
 		version: "1",
 		collections: [

--- a/packages/core/tests/integration/seed-live-revisions.test.ts
+++ b/packages/core/tests/integration/seed-live-revisions.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests that `applySeed()` creates a live revision for entries seeded with
+ * `status: "published"`.
+ *
+ * Regression for #650: seeded published content was missing `live_revision_id`,
+ * causing the admin UI to show "Save & Publish" instead of "Unpublish" for
+ * content that was already supposed to be live.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Database } from "../../src/database/types.js";
+import { applySeed } from "../../src/seed/apply.js";
+import type { SeedFile } from "../../src/seed/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../utils/test-db.js";
+
+function seedWith(status: "draft" | "published" | "scheduled"): SeedFile {
+	return {
+		version: "1",
+		collections: [
+			{
+				slug: "posts",
+				label: "Posts",
+				labelSingular: "Post",
+				fields: [
+					{ slug: "title", label: "Title", type: "string" },
+					{ slug: "body", label: "Body", type: "text" },
+				],
+			},
+		],
+		content: {
+			posts: [
+				{
+					id: "post-1",
+					slug: "hello-world",
+					status,
+					data: { title: "Hello World", body: "body" },
+				},
+			],
+		},
+	};
+}
+
+describe("applySeed creates live revisions for published content", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("populates live_revision_id when seed status is 'published'", async () => {
+		await applySeed(db, seedWith("published"), { includeContent: true });
+
+		const row = await db
+			.selectFrom("ec_posts" as any)
+			.selectAll()
+			.where("slug", "=", "hello-world")
+			.executeTakeFirstOrThrow();
+
+		const r = row as Record<string, unknown>;
+		expect(r.status).toBe("published");
+		expect(r.live_revision_id).toBeTruthy();
+		expect(r.draft_revision_id).toBeNull();
+		expect(r.published_at).toBeTruthy();
+	});
+
+	it("does not create a live revision when seed status is 'draft'", async () => {
+		await applySeed(db, seedWith("draft"), { includeContent: true });
+
+		const row = await db
+			.selectFrom("ec_posts" as any)
+			.selectAll()
+			.where("slug", "=", "hello-world")
+			.executeTakeFirstOrThrow();
+
+		const r = row as Record<string, unknown>;
+		expect(r.status).toBe("draft");
+		expect(r.live_revision_id).toBeNull();
+	});
+
+	it("populates live_revision_id when updating an existing entry to 'published' via onConflict: 'update'", async () => {
+		// First pass: create as draft
+		await applySeed(db, seedWith("draft"), { includeContent: true });
+
+		// Second pass: same slug, now published
+		await applySeed(db, seedWith("published"), {
+			includeContent: true,
+			onConflict: "update",
+		});
+
+		const row = await db
+			.selectFrom("ec_posts" as any)
+			.selectAll()
+			.where("slug", "=", "hello-world")
+			.executeTakeFirstOrThrow();
+
+		const r = row as Record<string, unknown>;
+		expect(r.status).toBe("published");
+		expect(r.live_revision_id).toBeTruthy();
+	});
+
+	it("writes a revision row to the revisions table", async () => {
+		await applySeed(db, seedWith("published"), { includeContent: true });
+
+		const row = await db
+			.selectFrom("ec_posts" as any)
+			.select(["id", "live_revision_id"] as never)
+			.where("slug", "=", "hello-world")
+			.executeTakeFirstOrThrow();
+
+		const r = row as { id: string; live_revision_id: string };
+
+		const revision = await db
+			.selectFrom("revisions")
+			.selectAll()
+			.where("id", "=", r.live_revision_id)
+			.executeTakeFirstOrThrow();
+
+		expect(revision.collection).toBe("posts");
+		expect(revision.entry_id).toBe(r.id);
+	});
+});

--- a/packages/core/tests/unit/database/repositories/content.test.ts
+++ b/packages/core/tests/unit/database/repositories/content.test.ts
@@ -474,6 +474,31 @@ describe("ContentRepository", () => {
 		});
 	});
 
+	describe("setDraftRevision()", () => {
+		it("sets the draft_revision_id so publish() picks it up", async () => {
+			const post = await repo.create(createPostFixture());
+			// Create a revision directly so we have a valid id to stage.
+			const { RevisionRepository } =
+				await import("../../../../src/database/repositories/revision.js");
+			const revisionRepo = new RevisionRepository(db);
+			const draft = await revisionRepo.create({
+				collection: "post",
+				entryId: post.id,
+				data: { ...post.data, title: "Staged for publish" },
+			});
+
+			await repo.setDraftRevision("post", post.id, draft.id);
+
+			const afterStaging = await repo.findById("post", post.id);
+			expect(afterStaging?.draftRevisionId).toBe(draft.id);
+
+			const published = await repo.publish("post", post.id);
+
+			expect(published.liveRevisionId).toBe(draft.id);
+			expect(published.draftRevisionId).toBeNull();
+		});
+	});
+
 	describe("publish() clears schedule", () => {
 		it("should clear scheduled_at when publishing a scheduled draft", async () => {
 			const post = await repo.create(createPostFixture());

--- a/packages/core/tests/unit/database/repositories/content.test.ts
+++ b/packages/core/tests/unit/database/repositories/content.test.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { ContentRepository } from "../../../../src/database/repositories/content.js";
+import { RevisionRepository } from "../../../../src/database/repositories/revision.js";
 import { EmDashValidationError } from "../../../../src/database/repositories/types.js";
 import type { Database } from "../../../../src/database/types.js";
 import { createPostFixture, createPageFixture } from "../../../utils/fixtures.js";
@@ -477,9 +478,6 @@ describe("ContentRepository", () => {
 	describe("setDraftRevision()", () => {
 		it("sets the draft_revision_id so publish() picks it up", async () => {
 			const post = await repo.create(createPostFixture());
-			// Create a revision directly so we have a valid id to stage.
-			const { RevisionRepository } =
-				await import("../../../../src/database/repositories/revision.js");
 			const revisionRepo = new RevisionRepository(db);
 			const draft = await revisionRepo.create({
 				collection: "post",
@@ -496,6 +494,34 @@ describe("ContentRepository", () => {
 
 			expect(published.liveRevisionId).toBe(draft.id);
 			expect(published.draftRevisionId).toBeNull();
+		});
+
+		it("throws when the content item does not exist", async () => {
+			await expect(
+				repo.setDraftRevision("post", "01K0000000000000000000000", "01K0000000000000000000001"),
+			).rejects.toThrow(EmDashValidationError);
+		});
+
+		it("throws when the revision does not exist", async () => {
+			const post = await repo.create(createPostFixture());
+			await expect(
+				repo.setDraftRevision("post", post.id, "01K0000000000000000000001"),
+			).rejects.toThrow(EmDashValidationError);
+		});
+
+		it("throws when the revision belongs to a different content item", async () => {
+			const post1 = await repo.create(createPostFixture({ slug: "one" }));
+			const post2 = await repo.create(createPostFixture({ slug: "two" }));
+			const revisionRepo = new RevisionRepository(db);
+			const draft = await revisionRepo.create({
+				collection: "post",
+				entryId: post2.id,
+				data: post2.data,
+			});
+
+			await expect(repo.setDraftRevision("post", post1.id, draft.id)).rejects.toThrow(
+				EmDashValidationError,
+			);
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Fixes \`emdash seed\` so entries declared with \`\"status\": \"published\"\` are actually published.

Before this PR, the seed wrote the content row with \`status: \"published\"\` and a \`published_at\` timestamp but never created a live revision. The admin UI checks \`live_revision_id\` to decide between \"Save & Publish\" and \"Unpublish\", so seeded content showed up as unpublished in the editor even though the site rendered it as live. Users had to re-save every seeded entry manually to fix it.

The fix promotes published entries to a live revision on both create and update seed paths.

- **Create path**: after \`ContentRepository.create()\` writes the content columns, call \`publish()\` in the same transaction. \`publish()\` creates a revision from the current content data when no draft exists, which is the correct outcome for a freshly-created entry.
- **Update path**: before calling \`publish()\`, stage the updated seed data as a new draft revision via a new \`ContentRepository.setDraftRevision()\` helper. Without staging, \`publish()\` picks up the existing live revision and re-syncs stale data back into the content columns, which silently wipes the seed update.

Drafts and scheduled entries are unaffected — the promotion only runs when \`status === \"published\"\`.

Closes #650

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (22 pre-existing warnings unchanged; 0 new)
- [x] \`pnpm test\` passes (2444/2444 in core)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Four new integration tests cover the create path, draft-not-promoted path, update-to-published path, and verify a revision row exists in \`revisions\`:

\`\`\`
✓ tests/integration/seed-live-revisions.test.ts (4 tests)
  ✓ populates live_revision_id when seed status is 'published'
  ✓ does not create a live revision when seed status is 'draft'
  ✓ populates live_revision_id when updating an existing entry to 'published' via onConflict: 'update'
  ✓ writes a revision row to the revisions table
\`\`\`

One new unit test on the new helper:

\`\`\`
✓ tests/unit/database/repositories/content.test.ts
  ✓ setDraftRevision() sets the draft_revision_id so publish() picks it up
\`\`\`