### PR TITLE
fix(admin): prefill site title and tagline in Setup Wizard from seed file

### DIFF
--- a/.changeset/ninety-apes-bet.md
+++ b/.changeset/ninety-apes-bet.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Prefill site title and tagline in Setup Wizard from seed file

--- a/docs/src/content/docs/themes/seed-files.mdx
+++ b/docs/src/content/docs/themes/seed-files.mdx
@@ -70,7 +70,7 @@ Site-wide configuration values:
 }
 ```
 
-Settings are applied to the `options` table with the `site:` prefix. The Setup Wizard lets users override `title` and `tagline`.
+Settings are applied to the `options` table with the `site:` prefix. The Setup Wizard will prefill `title` and `tagline` from the seed file (if provided), allowing users to override them during initial setup.
 
 ## Collections
 

--- a/packages/admin/src/components/SetupWizard.tsx
+++ b/packages/admin/src/components/SetupWizard.tsx
@@ -32,6 +32,8 @@ interface SetupStatusResponse {
 		description: string;
 		collections: number;
 		hasContent: boolean;
+		title?: string;
+		tagline?: string;
 	};
 	/** Auth mode - "cloudflare-access" or "passkey" */
 	authMode?: "cloudflare-access" | "passkey";
@@ -114,8 +116,8 @@ interface SiteStepProps {
 
 function SiteStep({ seedInfo, onNext, isLoading, error }: SiteStepProps) {
 	const { t } = useLingui();
-	const [title, setTitle] = React.useState("");
-	const [tagline, setTagline] = React.useState("");
+	const [title, setTitle] = React.useState(seedInfo?.title ?? "");
+	const [tagline, setTagline] = React.useState(seedInfo?.tagline ?? "");
 	const [includeContent, setIncludeContent] = React.useState(true);
 	const [errors, setErrors] = React.useState<Record<string, string>>({});
 

--- a/packages/admin/tests/components/SetupWizard.test.tsx
+++ b/packages/admin/tests/components/SetupWizard.test.tsx
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "../utils/render.tsx";
 
 // Mock API
+let mockSeedInfo: any = null;
+
 vi.mock("../../src/lib/api/client", async () => {
 	const actual = await vi.importActual("../../src/lib/api/client");
 	return {
@@ -12,9 +14,18 @@ vi.mock("../../src/lib/api/client", async () => {
 		apiFetch: vi.fn().mockImplementation((url: string) => {
 			if (url.includes("/setup/status")) {
 				return Promise.resolve(
-					new Response(JSON.stringify({ data: { needsSetup: true, authMode: "passkey" } }), {
-						status: 200,
-					}),
+					new Response(
+						JSON.stringify({
+							data: {
+								needsSetup: true,
+								authMode: "passkey",
+								...(mockSeedInfo ? { seedInfo: mockSeedInfo } : {}),
+							},
+						}),
+						{
+							status: 200,
+						},
+					),
 				);
 			}
 			if (url.includes("/setup/admin")) {
@@ -51,6 +62,7 @@ function QueryWrapper({ children }: { children: React.ReactNode }) {
 describe("SetupWizard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockSeedInfo = null;
 	});
 
 	it("shows site setup step first with title input", async () => {
@@ -135,5 +147,98 @@ describe("SetupWizard", () => {
 		// Step indicator labels - use exact matching via role
 		await expect.element(screen.getByText("Account")).toBeInTheDocument();
 		await expect.element(screen.getByText("Passkey")).toBeInTheDocument();
+	});
+
+	it("prefills title and tagline from seedInfo", async () => {
+		mockSeedInfo = {
+			name: "Blog Template",
+			description: "A blog template",
+			collections: 2,
+			hasContent: true,
+			title: "My Awesome Blog",
+			tagline: "Thoughts and tutorials",
+		};
+
+		const screen = await render(
+			<QueryWrapper>
+				<SetupWizard />
+			</QueryWrapper>,
+		);
+
+		await expect.element(screen.getByText("Set up your site")).toBeInTheDocument();
+
+		const titleInput = screen.getByPlaceholder("My Awesome Blog");
+		const taglineInput = screen.getByPlaceholder("Thoughts, tutorials, and more");
+
+		await vi.waitFor(() => {
+			expect((titleInput.element() as HTMLInputElement).value).toBe("My Awesome Blog");
+		});
+		await vi.waitFor(() => {
+			expect((taglineInput.element() as HTMLInputElement).value).toBe("Thoughts and tutorials");
+		});
+	});
+
+	it("uses empty string for title and tagline when not in seedInfo", async () => {
+		mockSeedInfo = {
+			name: "Blank Template",
+			description: "A blank template",
+			collections: 0,
+			hasContent: false,
+			// title and tagline not provided
+		};
+
+		const screen = await render(
+			<QueryWrapper>
+				<SetupWizard />
+			</QueryWrapper>,
+		);
+
+		await expect.element(screen.getByText("Set up your site")).toBeInTheDocument();
+
+		const titleInput = screen.getByPlaceholder("My Awesome Blog");
+		const taglineInput = screen.getByPlaceholder("Thoughts, tutorials, and more");
+
+		await vi.waitFor(() => {
+			expect((titleInput.element() as HTMLInputElement).value).toBe("");
+		});
+		await vi.waitFor(() => {
+			expect((taglineInput.element() as HTMLInputElement).value).toBe("");
+		});
+	});
+
+	it("prefilled title can be edited and submitted", async () => {
+		mockSeedInfo = {
+			name: "Blog Template",
+			description: "A blog template",
+			collections: 2,
+			hasContent: true,
+			title: "My Awesome Blog",
+			tagline: "Thoughts and tutorials",
+		};
+
+		const screen = await render(
+			<QueryWrapper>
+				<SetupWizard />
+			</QueryWrapper>,
+		);
+
+		await expect.element(screen.getByText("Set up your site")).toBeInTheDocument();
+
+		const titleInput = screen.getByPlaceholder("My Awesome Blog");
+		await vi.waitFor(() => {
+			expect((titleInput.element() as HTMLInputElement).value).toBe("My Awesome Blog");
+		});
+
+		// Edit the title
+		await titleInput.fill("My Custom Blog");
+		await vi.waitFor(() => {
+			expect((screen.getByPlaceholder("My Awesome Blog").element() as HTMLInputElement).value).toBe(
+				"My Custom Blog",
+			);
+		});
+
+		// Should be able to advance with the edited value
+		await screen.getByText("Continue →").click();
+		await expect.element(screen.getByText("Create your account")).toBeInTheDocument();
 	});
 });

--- a/packages/core/src/astro/routes/api/setup/status.ts
+++ b/packages/core/src/astro/routes/api/setup/status.ts
@@ -106,6 +106,8 @@ export const GET: APIRoute = async ({ locals }) => {
 					description: seed.meta?.description || "",
 					collections: seed.collections?.length || 0,
 					hasContent: !!(seed.content && Object.keys(seed.content).length > 0),
+					title: seed.settings?.title,
+					tagline: seed.settings?.tagline,
 				}
 			: null;
 


### PR DESCRIPTION
## What does this PR do?

The Setup Wizard should prefill the title and tagline fields with the values from seed.json if present.

Users should still be able to edit these if needed before completing setup.


Closes #684

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
