### PR TITLE
feat: admin white-labeling (custom logo, site name, favicon)

### DIFF
--- a/.changeset/few-falcons-post.md
+++ b/.changeset/few-falcons-post.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds admin white-labeling support via `admin` config in `astro.config.mjs`. Agencies can set a custom logo, site name, and favicon for the admin panel, separate from public site settings.

--- a/packages/admin/src/components/LoginPage.tsx
+++ b/packages/admin/src/components/LoginPage.tsx
@@ -24,7 +24,7 @@ import { sanitizeRedirectUrl } from "../lib/url";
 import { SUPPORTED_LOCALES } from "../locales/index.js";
 import { useLocale } from "../locales/useLocale.js";
 import { PasskeyLogin } from "./auth/PasskeyLogin";
-import { LogoLockup } from "./Logo.js";
+import { BrandLogo } from "./Logo.js";
 
 // ============================================================================
 // Types
@@ -266,7 +266,11 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 		return (
 			<div className="min-h-screen flex items-center justify-center bg-kumo-base p-4">
 				<div className="flex flex-col items-center">
-					<LogoLockup className="h-10 mb-4" />
+					<BrandLogo
+						logoUrl={manifest?.admin?.logo}
+						siteName={manifest?.admin?.siteName}
+						className="h-10 mb-4"
+					/>
 					<Loader />
 				</div>
 			</div>
@@ -278,7 +282,11 @@ export function LoginPage({ redirectUrl = "/_emdash/admin" }: LoginPageProps) {
 			<div className="w-full max-w-md">
 				{/* Header */}
 				<div className="text-center mb-8">
-					<LogoLockup className="h-10 mx-auto mb-2" />
+					<BrandLogo
+						logoUrl={manifest?.admin?.logo}
+						siteName={manifest?.admin?.siteName}
+						className="h-10 mx-auto mb-2"
+					/>
 					<h1 className="text-2xl font-semibold text-kumo-default">
 						{method === "passkey" && t`Sign in to your site`}
 						{method === "magic-link" && t`Sign in with email`}

--- a/packages/admin/src/components/Logo.tsx
+++ b/packages/admin/src/components/Logo.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import * as React from "react";
 
 /**
  * EmDash icon mark — the rounded-rect em dash symbol.
@@ -145,4 +145,44 @@ export function LogoLockup({ className, ...props }: React.SVGProps<SVGSVGElement
 			</defs>
 		</svg>
 	);
+}
+
+interface BrandLogoProps {
+	logoUrl?: string;
+	siteName?: string;
+	className?: string;
+}
+
+export function BrandLogo({ logoUrl, siteName, className }: BrandLogoProps) {
+	if (logoUrl) {
+		return (
+			<img
+				src={logoUrl}
+				alt={siteName || ""}
+				className={className}
+				style={{ objectFit: "contain" }}
+			/>
+		);
+	}
+	return <LogoLockup className={className} />;
+}
+
+interface BrandIconProps {
+	logoUrl?: string;
+	siteName?: string;
+	className?: string;
+}
+
+export function BrandIcon({ logoUrl, siteName, className }: BrandIconProps) {
+	if (logoUrl) {
+		return (
+			<img
+				src={logoUrl}
+				alt={siteName || ""}
+				className={className}
+				style={{ objectFit: "contain" }}
+			/>
+		);
+	}
+	return <LogoIcon className={className} />;
 }

--- a/packages/admin/src/components/SetupWizard.tsx
+++ b/packages/admin/src/components/SetupWizard.tsx
@@ -16,9 +16,9 @@ import { useLingui } from "@lingui/react/macro";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
-import { apiFetch, parseApiResponse } from "../lib/api/client";
+import { apiFetch, fetchManifest, parseApiResponse } from "../lib/api/client";
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
-import { LogoLockup } from "./Logo.js";
+import { BrandLogo } from "./Logo.js";
 
 // ============================================================================
 // Types
@@ -405,6 +405,12 @@ export function SetupWizard() {
 		retry: false,
 	});
 
+	// Fetch manifest for admin branding
+	const { data: manifest } = useQuery({
+		queryKey: ["manifest"],
+		queryFn: fetchManifest,
+	});
+
 	// Check if using Cloudflare Access auth
 	const useAccessAuth = status?.authMode === "cloudflare-access";
 
@@ -489,7 +495,11 @@ export function SetupWizard() {
 			<div className="w-full max-w-lg">
 				{/* Header */}
 				<div className="text-center mb-6">
-					<LogoLockup className="h-10 mx-auto mb-2" />
+					<BrandLogo
+						logoUrl={manifest?.admin?.logo}
+						siteName={manifest?.admin?.siteName}
+						className="h-10 mx-auto mb-2"
+					/>
 					<h1 className="text-2xl font-semibold text-kumo-default">
 						{currentStep === "site" && t`Set up your site`}
 						{currentStep === "admin" && t`Create your account`}

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -25,7 +25,7 @@ import { fetchCommentCounts } from "../lib/api/comments";
 import { useCurrentUser } from "../lib/api/current-user";
 import { usePluginAdmins } from "../lib/plugin-context";
 import { cn } from "../lib/utils";
-import { LogoIcon } from "./Logo.js";
+import { BrandIcon } from "./Logo.js";
 
 // Re-export for Shell.tsx and Header.tsx
 export { KumoSidebar as Sidebar, useSidebar };
@@ -59,6 +59,11 @@ export interface SidebarNavProps {
 		version?: string;
 		commit?: string;
 		marketplace?: string;
+		admin?: {
+			logo?: string;
+			siteName?: string;
+			favicon?: string;
+		};
 	};
 }
 
@@ -376,8 +381,15 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 						to="/"
 						className="emdash-brand-link flex w-full min-w-0 items-center gap-2 px-3 py-1"
 					>
-						<LogoIcon className="size-5 shrink-0" aria-hidden="true" />
-						<span className="emdash-brand-text font-semibold truncate">EmDash</span>
+						<BrandIcon
+							logoUrl={manifest.admin?.logo}
+							siteName={manifest.admin?.siteName}
+							className="size-5 shrink-0"
+							aria-hidden="true"
+						/>
+						<span className="emdash-brand-text font-semibold truncate">
+							{manifest.admin?.siteName || "EmDash"}
+						</span>
 					</Link>
 				</KumoSidebar.Header>
 
@@ -446,7 +458,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 
 				<KumoSidebar.Footer>
 					<p className="emdash-nav-label px-3 py-2 text-[11px] text-white/30">
-						EmDash CMS v{manifest.version || "0.0.0"}
+						{manifest.admin?.siteName || "EmDash CMS"} v{manifest.version || "0.0.0"}
 						{manifest.commit && ` (${manifest.commit})`}
 					</p>
 				</KumoSidebar.Footer>

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -146,6 +146,15 @@ export interface AdminManifest {
 	 * in the EmDash integration. Enables marketplace features in the UI.
 	 */
 	marketplace?: string;
+	/**
+	 * Admin branding overrides for white-labeling.
+	 * Set via the `admin` config in `astro.config.mjs`.
+	 */
+	admin?: {
+		logo?: string;
+		siteName?: string;
+		favicon?: string;
+	};
 }
 
 /**

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -160,6 +160,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 		marketplace: resolvedConfig.marketplace,
 		siteUrl: resolvedConfig.siteUrl,
 		maxUploadSize: resolvedConfig.maxUploadSize,
+		admin: resolvedConfig.admin,
 	};
 
 	// Determine auth mode for route injection

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -385,6 +385,34 @@ export interface EmDashConfig {
 				 */
 				scripts?: string[];
 		  };
+
+	/**
+	 * Admin UI branding (white-labeling).
+	 *
+	 * Overrides the default EmDash logo and name in the admin panel.
+	 * Use this to white-label the CMS for agency or enterprise deployments.
+	 * These settings are separate from the public site settings (title, logo,
+	 * favicon) which remain available for SEO and front-end use.
+	 *
+	 * @example
+	 * ```ts
+	 * emdash({
+	 *   admin: {
+	 *     logo: "/images/agency-logo.webp",
+	 *     siteName: "AgencyX CMS",
+	 *     favicon: "/favicon.ico",
+	 *   },
+	 * })
+	 * ```
+	 */
+	admin?: {
+		/** URL or path to a custom logo image for the admin UI (login page, sidebar). */
+		logo?: string;
+		/** Custom name displayed in the admin sidebar and browser tab. */
+		siteName?: string;
+		/** URL or path to a custom favicon for the admin panel. */
+		favicon?: string;
+	};
 }
 
 /**

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -14,10 +14,14 @@ import { Font } from "astro:assets";
 export const prerender = false;
 
 import { resolveLocale, loadMessages, getLocaleDir } from "@emdash-cms/admin/locales";
+import { getStoredConfig } from "../../integration/runtime.js";
 
 const resolvedLocale = resolveLocale(Astro.request);
 const resolvedDir = getLocaleDir(resolvedLocale);
 const messages = await loadMessages(resolvedLocale);
+
+const adminConfig = getStoredConfig()?.admin;
+const pageTitle = adminConfig?.siteName ? `${adminConfig.siteName} Admin` : "EmDash Admin";
 ---
 
 <!doctype html>
@@ -26,11 +30,15 @@ const messages = await loadMessages(resolvedLocale);
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<Font cssVariable="--font-emdash" />
-		<link
-			rel="icon"
-			href="data:image/svg+xml,<svg width='75' height='75' viewBox='0 0 75 75' fill='none' xmlns='http://www.w3.org/2000/svg'> <g clip-path='url(%23clip0_50_99)'> <rect x='3' y='3' width='69' height='69' rx='10.518' stroke='url(%23paint0_linear_50_99)' stroke-width='6'/> <rect x='18' y='34' width='39.3661' height='6.56101' fill='url(%23paint1_linear_50_99)'/> </g> <defs> <linearGradient id='paint0_linear_50_99' x1='-42.9996' y1='124' x2='92.4233' y2='-41.7456' gradientUnits='userSpaceOnUse'> <stop stop-color='%230F006B'/> <stop offset='0.0833333' stop-color='%23281A81'/> <stop offset='0.166667' stop-color='%235D0C83'/> <stop offset='0.25' stop-color='%23911475'/> <stop offset='0.333333' stop-color='%23CE2F55'/> <stop offset='0.416667' stop-color='%23FF6633'/> <stop offset='0.5' stop-color='%23F6821F'/> <stop offset='0.583333' stop-color='%23FBAD41'/> <stop offset='0.666667' stop-color='%23FFCD89'/> <stop offset='0.75' stop-color='%23FFE9CB'/> <stop offset='0.833333' stop-color='%23FFF7EC'/> <stop offset='0.916667' stop-color='%23FFF8EE'/> <stop offset='1' stop-color='white'/> </linearGradient> <linearGradient id='paint1_linear_50_99' x1='91.4992' y1='27.4982' x2='28.1217' y2='54.1775' gradientUnits='userSpaceOnUse'> <stop stop-color='white'/> <stop offset='0.129253' stop-color='%23FFF8EE'/> <stop offset='0.617058' stop-color='%23FBAD41'/> <stop offset='0.848019' stop-color='%23F6821F'/> <stop offset='1' stop-color='%23FF6633'/> </linearGradient> <clipPath id='clip0_50_99'> <rect width='75' height='75' fill='white'/> </clipPath> </defs> </svg>"
-		/>
-		<title>EmDash Admin</title>
+		{adminConfig?.favicon ? (
+			<link rel="icon" href={adminConfig.favicon} />
+		) : (
+			<link
+				rel="icon"
+				href="data:image/svg+xml,<svg width='75' height='75' viewBox='0 0 75 75' fill='none' xmlns='http://www.w3.org/2000/svg'> <g clip-path='url(%23clip0_50_99)'> <rect x='3' y='3' width='69' height='69' rx='10.518' stroke='url(%23paint0_linear_50_99)' stroke-width='6'/> <rect x='18' y='34' width='39.3661' height='6.56101' fill='url(%23paint1_linear_50_99)'/> </g> <defs> <linearGradient id='paint0_linear_50_99' x1='-42.9996' y1='124' x2='92.4233' y2='-41.7456' gradientUnits='userSpaceOnUse'> <stop stop-color='%230F006B'/> <stop offset='0.0833333' stop-color='%23281A81'/> <stop offset='0.166667' stop-color='%235D0C83'/> <stop offset='0.25' stop-color='%23911475'/> <stop offset='0.333333' stop-color='%23CE2F55'/> <stop offset='0.416667' stop-color='%23FF6633'/> <stop offset='0.5' stop-color='%23F6821F'/> <stop offset='0.583333' stop-color='%23FBAD41'/> <stop offset='0.666667' stop-color='%23FFCD89'/> <stop offset='0.75' stop-color='%23FFE9CB'/> <stop offset='0.833333' stop-color='%23FFF7EC'/> <stop offset='0.916667' stop-color='%23FFF8EE'/> <stop offset='1' stop-color='white'/> </linearGradient> <linearGradient id='paint1_linear_50_99' x1='91.4992' y1='27.4982' x2='28.1217' y2='54.1775' gradientUnits='userSpaceOnUse'> <stop stop-color='white'/> <stop offset='0.129253' stop-color='%23FFF8EE'/> <stop offset='0.617058' stop-color='%23FBAD41'/> <stop offset='0.848019' stop-color='%23F6821F'/> <stop offset='1' stop-color='%23FF6633'/> </linearGradient> <clipPath id='clip0_50_99'> <rect width='75' height='75' fill='white'/> </clipPath> </defs> </svg>"
+			/>
+		)}
+		<title>{pageTitle}</title>
 	</head>
 	<body>
 		<div id="admin-root" class="min-h-screen">
@@ -82,7 +90,7 @@ const messages = await loadMessages(resolvedLocale);
 				</style>
 				<div class="loader-inner">
 					<div class="spinner"></div>
-					<p>Loading EmDash...</p>
+					<p>{adminConfig?.siteName ? `Loading ${adminConfig.siteName}...` : "Loading EmDash..."}</p>
 				</div>
 			</div>
 			<AdminWrapper client:only="react" locale={resolvedLocale} messages={messages} />

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -14,13 +14,12 @@ import { Font } from "astro:assets";
 export const prerender = false;
 
 import { resolveLocale, loadMessages, getLocaleDir } from "@emdash-cms/admin/locales";
-import { getStoredConfig } from "../../integration/runtime.js";
 
 const resolvedLocale = resolveLocale(Astro.request);
 const resolvedDir = getLocaleDir(resolvedLocale);
 const messages = await loadMessages(resolvedLocale);
 
-const adminConfig = getStoredConfig()?.admin;
+const adminConfig = Astro.locals.emdash?.config?.admin;
 const pageTitle = adminConfig?.siteName ? `${adminConfig.siteName} Admin` : "EmDash Admin";
 ---
 

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -12,6 +12,7 @@ import type { APIRoute } from "astro";
 import { getAuthMode } from "#auth/mode.js";
 
 import { COMMIT, VERSION } from "../../../version.js";
+import { getStoredConfig } from "../../integration/runtime.js";
 import type { EmDashManifest } from "../../types.js";
 
 export const prerender = false;
@@ -21,6 +22,10 @@ export const GET: APIRoute = async ({ locals }) => {
 
 	// Determine auth mode from config
 	const authMode = getAuthMode(emdash?.config);
+
+	// Read admin branding from build-time config
+	const storedConfig = getStoredConfig();
+	const adminBranding = storedConfig?.admin;
 
 	// Check if self-signup is enabled (any allowed domain with enabled = 1)
 	// Only relevant for passkey auth — external auth providers handle their own signup
@@ -42,6 +47,7 @@ export const GET: APIRoute = async ({ locals }) => {
 				...emdashManifest,
 				authMode: authMode.type === "external" ? authMode.providerType : "passkey",
 				signupEnabled,
+				admin: adminBranding,
 			}
 		: {
 				version: VERSION,
@@ -52,6 +58,7 @@ export const GET: APIRoute = async ({ locals }) => {
 				taxonomies: [],
 				authMode: "passkey",
 				signupEnabled,
+				admin: adminBranding,
 			};
 
 	return Response.json(

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -142,6 +142,15 @@ export interface EmDashManifest {
 	 * When true, the admin UI can show marketplace browse/install features.
 	 */
 	marketplace?: boolean;
+	/**
+	 * Admin branding overrides for white-labeling.
+	 * Set via the `admin` config in `astro.config.mjs`.
+	 */
+	admin?: {
+		logo?: string;
+		siteName?: string;
+		favicon?: string;
+	};
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Adds admin UI white-labeling support via build-time configuration. Agencies deploying EmDash for clients can now customize the admin panel branding (logo, site name, favicon) across all their instances without affecting public-facing site settings used for SEO.

Configuration is set in `astro.config.mjs`:

```js
emdash({
  admin: {
    logo: "/images/agency-logo.webp",
    siteName: "AgencyX CMS",
    favicon: "/favicon.ico",
  },
})
```

All three fields are optional. When omitted, the default EmDash branding is used.

Closes https://github.com/emdash-cms/emdash/discussions/639

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## How it works

1. New optional `admin` block added to `EmDashConfig` interface (`runtime.ts`)
2. Config is serialized into the virtual module alongside existing config (`integration/index.ts`)
3. Manifest endpoint reads admin branding from stored config and includes it in the response (`manifest.ts`)
4. Admin UI components read branding from the manifest and render accordingly:
   - **Sidebar**: custom icon + site name in header, custom name in footer
   - **Login page**: custom logo lockup
   - **Setup wizard**: custom logo lockup
   - **Admin HTML shell** (`admin.astro`): custom favicon, page title, loading text
5. New `BrandLogo` and `BrandIcon` components render custom `<img>` when a logo URL is configured, falling back to the default EmDash SVGs

No database migrations required - config lives entirely in `astro.config.mjs`.

## Where branding appears

| Location | Default | With `admin` config |
|----------|---------|-------------------|
| Sidebar header | EmDash icon + "EmDash" | Custom logo + custom name |
| Sidebar footer | "EmDash CMS v..." | "{siteName} v..." |
| Login page | EmDash lockup | Custom logo |
| Setup wizard | EmDash lockup | Custom logo |
| Browser tab title | "EmDash Admin" | "{siteName} Admin" |
| Favicon | EmDash SVG icon | Custom favicon |
| Loading screen | "Loading EmDash..." | "Loading {siteName}..." |

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/639

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A - visual changes are conditional on setting the `admin` config block.