### PR TITLE
feat(templates): add modern-starter — premium dark magazine template (Rein-inspired, dual-mode ready, full-featured)

### DIFF
--- a/templates/modern-starter-cloudflare/AGENTS.md
+++ b/templates/modern-starter-cloudflare/AGENTS.md
@@ -1,0 +1,19 @@
+This is an EmDash site template built for the templates/ directory in the main repo.
+
+## Commands
+
+```bash
+npx emdash dev
+npx emdash types
+npx emdash seed seed/seed.json --validate
+```
+
+The admin UI is at `http://localhost:4321/_emdash/admin`.
+
+## Notes
+
+- Keep all content routes server-rendered.
+- Use `Astro.cache.set(cacheHint)` after EmDash content queries.
+- `entry.id` is the slug used in URLs. `entry.data.id` is the ULID for APIs like `getEntryTerms()`.
+- Image fields are rendered with `<Image image={...} />` from `emdash/ui`.
+- This template is intentionally styled as a premium dark editorial starter.

--- a/templates/modern-starter-cloudflare/CHANGELOG.md
+++ b/templates/modern-starter-cloudflare/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.3
+
+- Add `modern-starter` repo-native template
+- Add `modern-starter-cloudflare` repo-native template
+- Include rich seed content, premium editorial layout, taxonomy archives, search, RSS, and single-post experience

--- a/templates/modern-starter-cloudflare/astro.config.mjs
+++ b/templates/modern-starter-cloudflare/astro.config.mjs
@@ -1,0 +1,21 @@
+import cloudflare from "@astrojs/cloudflare";
+import react from "@astrojs/react";
+import { d1, r2, sandbox } from "@emdash-cms/cloudflare";
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+
+export default defineConfig({
+	output: "server",
+	adapter: cloudflare(),
+	image: { layout: "constrained", responsiveStyles: true },
+	integrations: [
+		react(),
+		emdash({
+			database: d1({ binding: "DB", session: "auto" }),
+			storage: r2({ binding: "MEDIA" }),
+			sandboxRunner: sandbox(),
+			marketplace: "https://marketplace.emdashcms.com",
+		}),
+	],
+	devToolbar: { enabled: false },
+});

--- a/templates/modern-starter-cloudflare/emdash-env.d.ts
+++ b/templates/modern-starter-cloudflare/emdash-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/client" />
+/// <reference types="@emdash-cms/astro/env" />

--- a/templates/modern-starter-cloudflare/package.json
+++ b/templates/modern-starter-cloudflare/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@emdash-cms/template-modern-starter-cloudflare",
+  "version": "0.0.3",
+  "private": true,
+  "type": "module",
+  "emdash": {
+    "seed": "seed/seed.json"
+  },
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "deploy": "astro build && wrangler deploy",
+    "bootstrap": "emdash init && emdash seed",
+    "seed": "emdash seed",
+    "typecheck": "astro check"
+  },
+  "dependencies": {
+    "@astrojs/cloudflare": "catalog:",
+    "@astrojs/react": "catalog:",
+    "@emdash-cms/cloudflare": "workspace:*",
+    "astro": "catalog:",
+    "emdash": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@astrojs/check": "catalog:",
+    "@cloudflare/workers-types": "catalog:",
+    "wrangler": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "workerd"
+    ]
+  }
+}

--- a/templates/modern-starter-cloudflare/seed/seed.json
+++ b/templates/modern-starter-cloudflare/seed/seed.json
@@ -1,0 +1,811 @@
+{
+  "$schema": "https://emdashcms.com/seed.schema.json",
+  "version": "1",
+  "meta": {
+    "name": "Modern Starter",
+    "description": "Premium dark editorial template for EmDash",
+    "author": "OpenAI"
+  },
+  "settings": {
+    "title": "Modern Starter",
+    "tagline": "Thoughtful publishing with a premium edge"
+  },
+  "collections": [
+    {
+      "slug": "posts",
+      "label": "Posts",
+      "labelSingular": "Post",
+      "supports": [
+        "drafts",
+        "revisions",
+        "search",
+        "seo"
+      ],
+      "commentsEnabled": true,
+      "fields": [
+        {
+          "slug": "title",
+          "label": "Title",
+          "type": "string",
+          "required": true,
+          "searchable": true
+        },
+        {
+          "slug": "featured_image",
+          "label": "Featured Image",
+          "type": "image"
+        },
+        {
+          "slug": "content",
+          "label": "Content",
+          "type": "portableText",
+          "searchable": true
+        },
+        {
+          "slug": "excerpt",
+          "label": "Excerpt",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "slug": "pages",
+      "label": "Pages",
+      "labelSingular": "Page",
+      "supports": [
+        "drafts",
+        "revisions",
+        "search"
+      ],
+      "fields": [
+        {
+          "slug": "title",
+          "label": "Title",
+          "type": "string",
+          "required": true,
+          "searchable": true
+        },
+        {
+          "slug": "content",
+          "label": "Content",
+          "type": "portableText",
+          "searchable": true
+        }
+      ]
+    }
+  ],
+  "taxonomies": [
+    {
+      "name": "category",
+      "label": "Categories",
+      "labelSingular": "Category",
+      "hierarchical": true,
+      "collections": [
+        "posts"
+      ],
+      "terms": [
+        {
+          "slug": "technology",
+          "label": "Technology"
+        },
+        {
+          "slug": "design",
+          "label": "Design"
+        },
+        {
+          "slug": "development",
+          "label": "Development"
+        },
+        {
+          "slug": "strategy",
+          "label": "Strategy"
+        }
+      ]
+    },
+    {
+      "name": "tag",
+      "label": "Tags",
+      "labelSingular": "Tag",
+      "hierarchical": false,
+      "collections": [
+        "posts"
+      ],
+      "terms": [
+        {
+          "slug": "emdash",
+          "label": "EmDash"
+        },
+        {
+          "slug": "astro",
+          "label": "Astro"
+        },
+        {
+          "slug": "editorial",
+          "label": "Editorial"
+        },
+        {
+          "slug": "ux",
+          "label": "UX"
+        },
+        {
+          "slug": "performance",
+          "label": "Performance"
+        },
+        {
+          "slug": "plugins",
+          "label": "Plugins"
+        },
+        {
+          "slug": "cloudflare",
+          "label": "Cloudflare"
+        },
+        {
+          "slug": "content-strategy",
+          "label": "Content Strategy"
+        }
+      ]
+    }
+  ],
+  "bylines": [
+    {
+      "id": "byline-editorial",
+      "slug": "modern-editorial",
+      "displayName": "Modern Editorial"
+    },
+    {
+      "id": "byline-studio",
+      "slug": "studio-notes",
+      "displayName": "Studio Notes"
+    }
+  ],
+  "menus": [
+    {
+      "name": "primary",
+      "label": "Primary Navigation",
+      "items": [
+        {
+          "type": "custom",
+          "label": "Home",
+          "url": "/"
+        },
+        {
+          "type": "custom",
+          "label": "Posts",
+          "url": "/posts"
+        },
+        {
+          "type": "custom",
+          "label": "About",
+          "url": "/pages/about"
+        },
+        {
+          "type": "custom",
+          "label": "Contact",
+          "url": "/pages/contact"
+        }
+      ]
+    }
+  ],
+  "widgetAreas": [
+    {
+      "name": "sidebar",
+      "label": "Sidebar",
+      "description": "Sidebar area for single posts",
+      "widgets": [
+        {
+          "type": "component",
+          "componentId": "core:search",
+          "title": "Search"
+        },
+        {
+          "type": "component",
+          "componentId": "core:categories",
+          "title": "Categories"
+        },
+        {
+          "type": "component",
+          "componentId": "core:tags",
+          "title": "Tags"
+        },
+        {
+          "type": "component",
+          "componentId": "core:recent-posts",
+          "title": "Recent Posts",
+          "settings": {
+            "count": 5,
+            "showDate": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "footer",
+      "label": "Footer",
+      "description": "Footer widget area",
+      "widgets": [
+        {
+          "type": "content",
+          "title": "About this template",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Modern Starter is a dark, premium editorial foundation designed to showcase EmDash content beautifully."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "content": {
+    "pages": [
+      {
+        "id": "about",
+        "slug": "about",
+        "status": "published",
+        "data": {
+          "title": "About",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Modern Starter is a premium dark editorial template for EmDash. It is designed to feel polished on day one, with room for customization once the content team takes over."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The starter includes search, RSS, archive pages, comments, taxonomy landing pages, widget areas, and a modern layout that gives posts space to breathe."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "contact",
+        "slug": "contact",
+        "status": "published",
+        "data": {
+          "title": "Contact",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Use this page for your contact details, newsletter signup, or editorial guidelines."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Because this is an EmDash page, non-technical editors can update the content without touching the theme files."
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "posts": [
+      {
+        "id": "post-1",
+        "slug": "future-of-editorial-platforms",
+        "status": "published",
+        "data": {
+          "title": "The Future of Editorial Platforms",
+          "excerpt": "Why premium publishing experiences are moving toward composable systems with first-class content workflows.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=1400&h=900&fit=crop",
+              "alt": "The Future of Editorial Platforms",
+              "filename": "future-of-editorial-platforms.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Publishing platforms are no longer judged only by what developers can ship. They are judged by how quickly editors can move, how well teams can collaborate, and whether the front end feels as crafted as the content itself."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "EmDash sits in a compelling place because it combines Astro\u2019s performance model with a proper CMS workflow. That means teams can keep the speed benefits of modern rendering while preserving editorial control."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "What readers notice"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Readers notice pacing, typography, spacing, and clarity long before they notice your stack. A modern starter has to respect that by making every article feel intentional."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "blockquote",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Great CMS experiences disappear into the act of reading."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "This template leans into that idea with a cinematic hero, editorial spacing, clean archives, and a focused single-post layout."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-21T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "technology"
+          ],
+          "tag": [
+            "emdash",
+            "astro",
+            "performance"
+          ]
+        }
+      },
+      {
+        "id": "post-2",
+        "slug": "designing-for-depth-not-noise",
+        "status": "published",
+        "data": {
+          "title": "Designing for Depth, Not Noise",
+          "excerpt": "A premium theme earns trust by letting the content lead and the interface support it quietly.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=1400&h=900&fit=crop",
+              "alt": "Designing for Depth, Not Noise",
+              "filename": "designing-for-depth-not-noise.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The fastest way to make a publication feel generic is to over-design every surface. Good editorial design creates confidence, not clutter."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The role of restraint"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Restraint is not minimalism for its own sake. It is knowing where emphasis belongs: on the headline, the image, the deck, and the rhythm of the reading experience."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "That is why Modern Starter uses strong contrast, crisp cards, and a generous single-post layout instead of decorative complexity."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-20T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "design"
+          ],
+          "tag": [
+            "editorial",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-3",
+        "slug": "why-search-still-matters",
+        "status": "published",
+        "data": {
+          "title": "Why Search Still Matters",
+          "excerpt": "Search is a feature readers use when navigation fails and a sign of maturity when it works beautifully.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=1400&h=900&fit=crop",
+              "alt": "Why Search Still Matters",
+              "filename": "why-search-still-matters.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Not every visitor lands on your perfect homepage. Many arrive from search, social, or a direct link and need a fast way to move deeper into the site."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A strong starter should treat search as part of the reading experience, not an afterthought hidden in a corner."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Good archive design"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "When search, categories, tags, and archives all work together, your best content keeps finding new readers long after publication day."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-19T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "strategy"
+          ],
+          "tag": [
+            "content-strategy",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-4",
+        "slug": "plugins-without-the-chaos",
+        "status": "published",
+        "data": {
+          "title": "Plugins Without the Chaos",
+          "excerpt": "A safer plugin model changes what teams are willing to install and maintain over time.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=1400&h=900&fit=crop",
+              "alt": "Plugins Without the Chaos",
+              "filename": "plugins-without-the-chaos.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Legacy plugin ecosystems often accumulate risk faster than value. Sandboxed execution changes that tradeoff in a meaningful way."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "When themes and content systems assume extensibility from the beginning, teams can grow without losing confidence in stability."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "blockquote",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Flexibility is only useful when it remains dependable under pressure."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-18T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "development"
+          ],
+          "tag": [
+            "plugins",
+            "emdash",
+            "cloudflare"
+          ]
+        }
+      },
+      {
+        "id": "post-5",
+        "slug": "a-better-way-to-ship-content",
+        "status": "published",
+        "data": {
+          "title": "A Better Way to Ship Content",
+          "excerpt": "Editorial teams move faster when the design system, CMS, and publishing workflow are aligned.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1517048676732-d65bc937f952?w=1400&h=900&fit=crop",
+              "alt": "A Better Way to Ship Content",
+              "filename": "a-better-way-to-ship-content.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Too many stacks treat editorial workflow as something to bolt on after launch. In practice, that decision slows everyone down once real publishing starts."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A starter should give teams a coherent default: clear templates, a navigable archive, readable single posts, and space for widgets or plugins where they matter."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-17T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "strategy"
+          ],
+          "tag": [
+            "content-strategy",
+            "editorial"
+          ]
+        }
+      },
+      {
+        "id": "post-6",
+        "slug": "measuring-the-right-performance",
+        "status": "published",
+        "data": {
+          "title": "Measuring the Right Performance",
+          "excerpt": "A publication feels fast when the experience is coherent, not only when the benchmark is green.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=1400&h=900&fit=crop",
+              "alt": "Measuring the Right Performance",
+              "filename": "measuring-the-right-performance.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Performance is not just a deployment story. It is also about predictable layouts, light UI chrome, and interfaces that keep readers oriented."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Astro gives you a strong baseline, but the theme still needs to avoid visual churn and interaction debt."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-16T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "technology"
+          ],
+          "tag": [
+            "performance",
+            "astro"
+          ]
+        }
+      },
+      {
+        "id": "post-7",
+        "slug": "the-quiet-power-of-taxonomies",
+        "status": "published",
+        "data": {
+          "title": "The Quiet Power of Taxonomies",
+          "excerpt": "Categories and tags are not decorative metadata. They are navigation systems for serious readers.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1516321165247-4aa89a48be28?w=1400&h=900&fit=crop",
+              "alt": "The Quiet Power of Taxonomies",
+              "filename": "the-quiet-power-of-taxonomies.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Good taxonomy design turns a pile of posts into a publication. It helps readers understand what you cover and how ideas connect over time."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "That is why the starter includes dedicated category and tag pages rather than burying the structure inside search alone."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-15T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "development"
+          ],
+          "tag": [
+            "content-strategy",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-8",
+        "slug": "building-a-brand-through-layout",
+        "status": "published",
+        "data": {
+          "title": "Building a Brand Through Layout",
+          "excerpt": "Typography, hierarchy, and spacing do more brand work than many teams realize.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1400&h=900&fit=crop",
+              "alt": "Building a Brand Through Layout",
+              "filename": "building-a-brand-through-layout.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A publication\u2019s brand shows up in how it opens a story, frames a card, and carries a reader from one page to the next."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Layout is the editorial voice you feel before you consciously notice it."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-14T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "design"
+          ],
+          "tag": [
+            "editorial",
+            "ux"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/templates/modern-starter-cloudflare/src/components/PostCard.astro
+++ b/templates/modern-starter-cloudflare/src/components/PostCard.astro
@@ -1,0 +1,51 @@
+---
+import type { MediaValue, ContentBylineCredit } from "emdash";
+import { Image } from "emdash/ui";
+
+interface Props {
+	title: string;
+	excerpt?: string;
+	featuredImage?: MediaValue | string;
+	href: string;
+	date?: Date;
+	readingTime?: number;
+	tags?: Array<{ slug: string; label: string }>;
+	bylines?: ContentBylineCredit[];
+}
+
+const { title, excerpt, featuredImage, href, date, readingTime, tags, bylines } = Astro.props;
+
+const formattedDate = date
+	? date.toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		})
+	: null;
+---
+
+<article class="post-card">
+	<a href={href} class="card-link">
+		{featuredImage ? (
+			<div class="card-image"><Image image={featuredImage} /></div>
+		) : (
+			<div class="card-placeholder" />
+		)}
+		<div class="card-meta">
+			{bylines && bylines.length > 0 && <span>{bylines[0]?.byline.displayName}</span>}
+			{bylines && bylines.length > 0 && formattedDate && <span class="meta-dot" />}
+			{formattedDate && <time>{formattedDate}</time>}
+			{formattedDate && readingTime && <span class="meta-dot" />}
+			{readingTime && <span>{readingTime} min read</span>}
+		</div>
+		<h2 class="card-title">{title}</h2>
+		{excerpt && <p class="card-excerpt">{excerpt}</p>}
+		{tags && tags.length > 0 && (
+			<div class="card-tags">
+				{tags.slice(0, 3).map((tag) => (
+					<span class="tag">{tag.label}</span>
+				))}
+			</div>
+		)}
+	</a>
+</article>

--- a/templates/modern-starter-cloudflare/src/components/PostMeta.astro
+++ b/templates/modern-starter-cloudflare/src/components/PostMeta.astro
@@ -1,0 +1,23 @@
+---
+import type { ContentBylineCredit } from "emdash";
+interface Props {
+	date?: Date | null;
+	readingTime?: number;
+	category?: string | null;
+	bylines?: ContentBylineCredit[];
+}
+const { date, readingTime, category, bylines = [] } = Astro.props;
+const formattedDate = date
+	? date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+	: null;
+---
+
+<div class="article-meta">
+	{category && <span>{category}</span>}
+	{category && (formattedDate || bylines.length > 0 || readingTime) && <span class="meta-dot" />}
+	{formattedDate && <time datetime={date?.toISOString()}>{formattedDate}</time>}
+	{formattedDate && bylines.length > 0 && <span class="meta-dot" />}
+	{bylines.length > 0 && <span>{bylines.map((credit) => credit.byline.displayName).join(", ")}</span>}
+	{(formattedDate || bylines.length > 0) && readingTime && <span class="meta-dot" />}
+	{readingTime && <span>{readingTime} min read</span>}
+</div>

--- a/templates/modern-starter-cloudflare/src/components/TagList.astro
+++ b/templates/modern-starter-cloudflare/src/components/TagList.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+	tags: Array<{ slug: string; label: string }>;
+}
+const { tags } = Astro.props;
+---
+
+{tags.length > 0 && (
+	<div class="tag-list">
+		{tags.map((tag) => (
+			<a class="tag" href={`/tag/${tag.slug}`}>{tag.label}</a>
+		))}
+	</div>
+)}

--- a/templates/modern-starter-cloudflare/src/layouts/Base.astro
+++ b/templates/modern-starter-cloudflare/src/layouts/Base.astro
@@ -1,0 +1,150 @@
+---
+import { getEmDashCollection, getMenu, getSiteSettings } from "emdash";
+import { WidgetArea, EmDashHead, EmDashBodyStart, EmDashBodyEnd } from "emdash/ui";
+import { createPublicPageContext } from "emdash/page";
+import LiveSearch from "emdash/ui/search";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+import "../styles/theme.css";
+
+interface Props {
+	title: string;
+	pageTitle?: string | null;
+	description?: string | null;
+	image?: string | null;
+	canonical?: string | null;
+	robots?: string | null;
+	type?: "website" | "article";
+	publishedTime?: string | null;
+	modifiedTime?: string | null;
+	author?: string | null;
+	content?: { collection: string; id: string; slug?: string | null };
+}
+
+const {
+	title,
+	pageTitle,
+	description,
+	image,
+	canonical,
+	robots,
+	type = "website",
+	publishedTime,
+	modifiedTime,
+	author,
+	content,
+} = Astro.props;
+
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
+const menu = await getMenu("primary");
+const { entries: pages } = await getEmDashCollection("pages");
+const pageCtx = createPublicPageContext({
+	Astro,
+	kind: content ? "content" : "custom",
+	pageType: type,
+	title: fullTitle,
+	pageTitle: pageTitle ?? title,
+	description,
+	canonical,
+	image,
+	content,
+	seo: { ogImage: image, robots },
+	articleMeta: { publishedTime, modifiedTime, author },
+	siteName: siteTitle,
+});
+const isLoggedIn = !!Astro.locals.user;
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
+		<EmDashHead page={pageCtx} />
+	</head>
+	<body>
+		<EmDashBodyStart page={pageCtx} />
+		<div class="site-shell">
+			<header class="site-header">
+				<div class="wide-container header-inner">
+					<a href="/" class="site-brand">
+						{siteLogo ? (
+							<img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						) : (
+							<span class="site-brand-mark" aria-hidden="true"></span>
+						)}
+						<span class="site-brand-copy">
+							<span>{siteTitle}</span>
+							<span class="site-brand-tagline">{siteTagline}</span>
+						</span>
+					</a>
+					<div class="nav-row">
+						<div class="header-search">
+							<LiveSearch
+								placeholder="Search stories..."
+								class="site-search"
+								inputClass="site-search-input"
+								resultsClass="site-search-results"
+								resultClass="site-search-result"
+								collections={["posts", "pages"]}
+							/>
+						</div>
+						<nav class="nav-links">
+							{menu?.items.map((item) => (
+								<a href={item.url} target={item.target}>{item.label}</a>
+							))}
+							<a href="/rss.xml">RSS</a>
+						</nav>
+						{isLoggedIn && <a href="/_emdash/admin" class="nav-admin">Admin</a>}
+					</div>
+				</div>
+			</header>
+
+			<main>
+				<slot />
+			</main>
+
+			<footer class="site-footer">
+				<div class="wide-container footer-grid">
+					<div>
+						<div class="site-brand">
+							<span class="site-brand-mark" aria-hidden="true"></span>
+							<span class="site-brand-copy">
+								<span>{siteTitle}</span>
+								<span class="site-brand-tagline">{siteTagline}</span>
+							</span>
+						</div>
+						<p style="margin-top: 1rem; max-width: 30rem;">A polished, dark-first editorial starter for teams who want their content to feel premium on day one.</p>
+					</div>
+					<div>
+						<h3 class="footer-heading">Explore</h3>
+						<ul class="footer-links">
+							<li><a href="/">Home</a></li>
+							<li><a href="/posts">All Posts</a></li>
+							<li><a href="/search">Search</a></li>
+						</ul>
+					</div>
+					<div>
+						<h3 class="footer-heading">Pages</h3>
+						<ul class="footer-links">
+							{pages.slice(0, 4).map((page) => (
+								<li><a href={`/pages/${page.id}`}>{page.data.title}</a></li>
+							))}
+						</ul>
+					</div>
+					<div>
+						<h3 class="footer-heading">Footer</h3>
+						<WidgetArea name="footer" />
+					</div>
+				</div>
+				<div class="wide-container footer-note">
+					<span>Built with EmDash and Astro.</span>
+					<span>Designed for modern editorial teams.</span>
+				</div>
+			</footer>
+		</div>
+		<EmDashBodyEnd page={pageCtx} />
+	</body>
+</html>

--- a/templates/modern-starter-cloudflare/src/live.config.ts
+++ b/templates/modern-starter-cloudflare/src/live.config.ts
@@ -1,0 +1,6 @@
+import { defineLiveCollection } from "astro:content";
+import { emdashLoader } from "emdash/runtime";
+
+export const collections = {
+	_emdash: defineLiveCollection({ loader: emdashLoader() }),
+};

--- a/templates/modern-starter-cloudflare/src/pages/404.astro
+++ b/templates/modern-starter-cloudflare/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Page not found">
+	<section class="section">
+		<div class="container not-found">
+			<span class="eyebrow">404</span>
+			<h1 class="page-title">That page drifted out of orbit.</h1>
+			<p>Try the homepage, the archive, or search for what you need.</p>
+			<div class="hero-actions" style="justify-content: center; margin-top: 1.5rem;">
+				<a href="/" class="btn">Go home</a>
+				<a href="/posts" class="btn-secondary">Browse posts</a>
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/category/[slug].astro
+++ b/templates/modern-starter-cloudflare/src/pages/category/[slug].astro
@@ -1,0 +1,49 @@
+---
+import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import Base from "../../layouts/Base.astro";
+import PostCard from "../../components/PostCard.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const slug = decodeSlug(Astro.params.slug);
+const term = slug ? await getTerm("category", slug) : null;
+if (!term) return Astro.redirect("/404");
+
+const { entries: posts } = await getEmDashCollection("posts", {
+	where: { category: term.slug },
+	orderBy: { published_at: "desc" },
+});
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+---
+
+<Base title={`${term.label} posts`} description={`All posts in ${term.label}.`}>
+	<section class="archive-section">
+		<div class="wide-container">
+			<header class="archive-header">
+				<div>
+					<span class="eyebrow">Category</span>
+					<h1 class="archive-title">{term.label}</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+			<div class="posts-grid">
+				{postsWithTags.map(({ post, tags }) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+						tags={tags}
+					/>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/index.astro
+++ b/templates/modern-starter-cloudflare/src/pages/index.astro
@@ -1,0 +1,110 @@
+---
+import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import { Image } from "emdash/ui";
+import Base from "../layouts/Base.astro";
+import PostCard from "../components/PostCard.astro";
+import TagList from "../components/TagList.astro";
+import { getReadingTime } from "../utils/reading-time";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+
+const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+Astro.cache.set(cacheHint);
+
+const { siteTitle, siteTagline } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const sortedPosts = posts.toSorted((a, b) => {
+	const dateA = a.data.publishedAt?.getTime() ?? 0;
+	const dateB = b.data.publishedAt?.getTime() ?? 0;
+	return dateB - dateA;
+});
+
+const heroPost = sortedPosts.find((post) => post.data.featured_image) ?? sortedPosts[0];
+const heroTags = heroPost ? await getEntryTerms("posts", heroPost.data.id, "tag") : [];
+const featuredStrip = sortedPosts.filter((post) => post.id !== heroPost?.id).slice(0, 3);
+const gridPosts = sortedPosts.filter((post) => post.id !== heroPost?.id).slice(3, 9);
+const gridPostsWithMeta = await Promise.all(
+	gridPosts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+		bylines: post.data.bylines ?? [],
+	}))
+);
+---
+
+<Base title={siteTitle} description={siteTagline}>
+	{posts.length === 0 ? (
+		<section class="section">
+			<div class="container empty-state">
+				<h1 class="section-title">No stories yet</h1>
+				<p>Open the admin panel and publish the first piece.</p>
+				<a href="/_emdash/admin/content/posts/new" class="btn">Create a post</a>
+			</div>
+		</section>
+	) : (
+		<>
+			<section class="hero">
+				<div class="wide-container hero-grid">
+					{heroPost && (
+						<a class="hero-feature" href={`/posts/${heroPost.id}`}>
+							{heroPost.data.featured_image && <Image image={heroPost.data.featured_image} />}
+							<div class="hero-overlay"></div>
+							<div class="hero-content">
+								<span class="eyebrow">Featured story</span>
+								<h1 class="hero-title">{heroPost.data.title}</h1>
+								{heroPost.data.excerpt && <p class="hero-summary">{heroPost.data.excerpt}</p>}
+								<TagList tags={heroTags.map((tag) => ({ slug: tag.slug, label: tag.label }))} />
+								<div class="hero-actions">
+									<span class="btn">Read feature</span>
+									<span class="btn-secondary">{getReadingTime(heroPost.data.content)} min read</span>
+								</div>
+							</div>
+						</a>
+					)}
+					<div class="hero-side">
+						<div class="hero-panel">
+							<span class="eyebrow">Editorial promise</span>
+							<h2>A polished starter for fast teams.</h2>
+							<p>Modern Starter gives EmDash a premium dark editorial surface with archives, search, RSS, widgets, and a strong single-post experience built in.</p>
+						</div>
+						<div class="hero-panel">
+							<span class="eyebrow">Fresh reads</span>
+							<div class="hero-mini-list">
+								{featuredStrip.map((post) => (
+									<a class="hero-mini-item" href={`/posts/${post.id}`}>
+										<h3>{post.data.title}</h3>
+										{post.data.excerpt && <p>{post.data.excerpt}</p>}
+									</a>
+								))}
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section class="section">
+				<div class="wide-container">
+					<div class="section-header">
+						<div>
+							<span class="eyebrow">Latest</span>
+							<h2 class="section-title">New stories and field notes</h2>
+						</div>
+						<a href="/posts" class="section-link">Browse archive</a>
+					</div>
+					<div class="posts-grid">
+						{gridPostsWithMeta.map(({ post, tags, bylines }) => (
+							<PostCard
+								title={post.data.title}
+								excerpt={post.data.excerpt}
+								featuredImage={post.data.featured_image}
+								href={`/posts/${post.id}`}
+								date={post.data.publishedAt ?? undefined}
+								readingTime={getReadingTime(post.data.content)}
+								tags={tags}
+								bylines={bylines}
+							/>
+						))}
+					</div>
+				</div>
+			</section>
+		</>
+	)}
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/pages/[slug].astro
+++ b/templates/modern-starter-cloudflare/src/pages/pages/[slug].astro
@@ -1,0 +1,42 @@
+---
+import { getEmDashEntry, decodeSlug, getSeoMeta, getSiteSettings } from "emdash";
+import { PortableText } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import { resolveModernStarterSiteIdentity } from "../../utils/site-identity";
+
+const slug = decodeSlug(Astro.params.slug);
+if (!slug) return Astro.redirect("/404");
+
+const { entry: page, cacheHint } = await getEmDashEntry("pages", slug);
+if (!page) return Astro.redirect("/404");
+Astro.cache.set(cacheHint);
+
+const { siteTitle } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const seo = getSeoMeta(page, {
+	siteTitle,
+	siteUrl: Astro.url.origin,
+	path: `/pages/${slug}`,
+});
+---
+
+<Base
+	title={seo.title}
+	pageTitle={seo.ogTitle}
+	description={seo.description}
+	canonical={seo.canonical}
+	content={{ collection: "pages", id: page.data.id, slug }}
+>
+	<section class="page-article">
+		<div class="container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Page</span>
+					<h1 class="page-title" {...page.edit.title}>{page.data.title}</h1>
+				</div>
+			</header>
+			<div class="article-content">
+				<PortableText value={page.data.content} />
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/modern-starter-cloudflare/src/pages/posts/[slug].astro
@@ -1,0 +1,142 @@
+---
+import {
+	getEmDashEntry,
+	getEmDashCollection,
+	getEntryTerms,
+	getSeoMeta,
+	decodeSlug,
+	getSiteSettings,
+} from "emdash";
+import { Image, PortableText, Comments, CommentForm, WidgetArea } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import TagList from "../../components/TagList.astro";
+import PostMeta from "../../components/PostMeta.astro";
+import { getReadingTime } from "../../utils/reading-time";
+import { resolveModernStarterSiteIdentity } from "../../utils/site-identity";
+
+const slug = decodeSlug(Astro.params.slug);
+if (!slug) return Astro.redirect("/404");
+
+const { entry: post, cacheHint } = await getEmDashEntry("posts", slug);
+if (!post) return Astro.redirect("/404");
+Astro.cache.set(cacheHint);
+
+function getImageUrl(img: unknown): string | undefined {
+	if (!img || typeof img !== "object") return undefined;
+	const image = img as Record<string, unknown>;
+	if (typeof image.src === "string" && image.src) {
+		return image.src.startsWith("http") ? image.src : `${Astro.url.origin}${image.src}`;
+	}
+	const meta = image.meta as Record<string, unknown> | undefined;
+	const storageKey =
+		(typeof meta?.storageKey === "string" ? meta.storageKey : undefined) ||
+		(typeof image.id === "string" ? image.id : undefined);
+	return storageKey ? `${Astro.url.origin}/_emdash/api/media/file/${storageKey}` : undefined;
+}
+
+const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const seo = getSeoMeta(post, {
+	siteTitle,
+	siteUrl: Astro.url.origin,
+	path: `/posts/${slug}`,
+	defaultOgImage: featuredImageUrl,
+});
+const tags = await getEntryTerms("posts", post.data.id, "tag");
+const category = await getEntryTerms("posts", post.data.id, "category");
+const bylines = post.data.bylines ?? [];
+const readingTime = getReadingTime(post.data.content);
+
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
+const relatedPosts = recentPosts.filter((entry) => entry.id !== post.id).slice(0, 3);
+
+const shareUrl = Astro.url.href;
+const shareLinks = [
+	{ label: "X", href: `https://x.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(post.data.title || "")}` },
+	{ label: "LinkedIn", href: `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(shareUrl)}` },
+	{ label: "Facebook", href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}` },
+];
+---
+
+<Base
+	title={seo.title}
+	pageTitle={seo.ogTitle}
+	description={seo.description}
+	canonical={seo.canonical}
+	image={featuredImageUrl}
+	type="article"
+	publishedTime={post.data.publishedAt?.toISOString() ?? null}
+	modifiedTime={post.updatedAt?.toISOString?.() ?? post.data.publishedAt?.toISOString() ?? null}
+	author={bylines.map((credit) => credit.byline.displayName).join(", ") || null}
+	content={{ collection: "posts", id: post.data.id, slug }}
+>
+	<section class="article-shell">
+		<div class="wide-container article-grid">
+			<article class="article-main">
+				{post.data.featured_image && (
+					<div class="article-cover">
+						<Image image={post.data.featured_image} />
+					</div>
+				)}
+				<span class="eyebrow">{category[0]?.label ?? "Story"}</span>
+				<h1 class="article-title" {...post.edit.title}>{post.data.title}</h1>
+				<PostMeta
+					date={post.data.publishedAt ?? null}
+					readingTime={readingTime}
+					category={category[0]?.label ?? null}
+					bylines={bylines}
+				/>
+				{post.data.excerpt && <p class="article-intro">{post.data.excerpt}</p>}
+				<TagList tags={tags.map((tag) => ({ slug: tag.slug, label: tag.label }))} />
+				<div class="article-content">
+					<PortableText value={post.data.content} />
+				</div>
+
+				<div class="author-strip">
+					<div class="author-avatar">{(bylines[0]?.byline.displayName || "E").slice(0, 1)}</div>
+					<div>
+						<strong>{bylines[0]?.byline.displayName || "Editorial Team"}</strong>
+						<p style="margin-top: 0.35rem;">Thoughtful, modern publishing with EmDash, Astro, and a premium design system.</p>
+					</div>
+				</div>
+
+				<section class="section" style="padding-bottom: 0;">
+					<div class="section-header">
+						<h2 class="section-title" style="font-size: 2rem;">Comments</h2>
+					</div>
+					<CommentForm entryId={post.data.id} />
+					<Comments entryId={post.data.id} />
+				</section>
+			</article>
+
+			<aside class="article-aside">
+				<div class="aside-panel">
+					<h3>Share</h3>
+					<div class="share-links">
+						{shareLinks.map((link) => (
+							<a href={link.href} target="_blank" rel="noopener noreferrer">{link.label}</a>
+						))}
+					</div>
+				</div>
+				<div class="aside-panel">
+					<h3>Related</h3>
+					<div class="related-list">
+						{relatedPosts.map((entry) => (
+							<a class="related-item" href={`/posts/${entry.id}`}>
+								<strong>{entry.data.title}</strong>
+								<span>{entry.data.excerpt}</span>
+							</a>
+						))}
+					</div>
+				</div>
+				<div class="aside-panel">
+					<h3>Sidebar</h3>
+					<WidgetArea name="sidebar" />
+				</div>
+			</aside>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/posts/index.astro
+++ b/templates/modern-starter-cloudflare/src/pages/posts/index.astro
@@ -1,0 +1,58 @@
+---
+import { getEmDashCollection, getEntryTerms } from "emdash";
+import { Image } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import TagList from "../../components/TagList.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
+Astro.cache.set(cacheHint);
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+
+const formatDate = (date: Date | null | undefined) =>
+	date
+		? date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+		: null;
+---
+
+<Base title="All Posts" description="Browse the full editorial archive.">
+	<section class="posts-page">
+		<div class="wide-container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Archive</span>
+					<h1 class="page-title">All Posts</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+
+			<div class="posts-list">
+				{postsWithTags.map(({ post, tags }) => (
+					<article class="post-row">
+						<a href={`/posts/${post.id}`} class="post-row-image">
+							{post.data.featured_image ? <Image image={post.data.featured_image} /> : null}
+						</a>
+						<div>
+							<div class="post-meta">
+								{post.data.publishedAt && <time>{formatDate(post.data.publishedAt)}</time>}
+								{post.data.publishedAt && <span class="meta-dot" />}
+								<span>{getReadingTime(post.data.content)} min read</span>
+							</div>
+							<h2 class="card-title"><a href={`/posts/${post.id}`}>{post.data.title}</a></h2>
+							{post.data.excerpt && <p>{post.data.excerpt}</p>}
+							<TagList tags={tags} />
+						</div>
+					</article>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/rss.xml.ts
+++ b/templates/modern-starter-cloudflare/src/pages/rss.xml.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from "astro";
+import { getEmDashCollection, getSiteSettings } from "emdash";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+
+export const GET: APIRoute = async ({ site, url }) => {
+	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveModernStarterSiteIdentity(await getSiteSettings());
+	const { entries: posts } = await getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 20,
+	});
+
+	const items = posts
+		.map((post) => {
+			if (!post.data.publishedAt) return null;
+			const postUrl = `${siteUrl}/posts/${post.id}`;
+			return `    <item>
+      <title>${escapeXml(post.data.title || "Untitled")}</title>
+      <link>${postUrl}</link>
+      <guid isPermaLink="true">${postUrl}</guid>
+      <pubDate>${post.data.publishedAt.toUTCString()}</pubDate>
+      <description>${escapeXml(post.data.excerpt || "")}</description>
+    </item>`;
+		})
+		.filter(Boolean)
+		.join("
+");
+
+	const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteTitle)}</title>
+    <description>${escapeXml(siteTagline)}</description>
+    <link>${siteUrl}</link>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+
+	return new Response(rss, {
+		headers: {
+			"Content-Type": "application/rss+xml; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+};
+
+const XML_ESCAPE_PATTERNS = [
+	[/&/g, "&amp;"],
+	[/</g, "&lt;"],
+	[/>/g, "&gt;"],
+	[/"/g, "&quot;"],
+	[/'/g, "&apos;"],
+] as const;
+
+function escapeXml(str: string): string {
+	let result = str;
+	for (const [pattern, replacement] of XML_ESCAPE_PATTERNS) result = result.replace(pattern, replacement);
+	return result;
+}

--- a/templates/modern-starter-cloudflare/src/pages/search.astro
+++ b/templates/modern-starter-cloudflare/src/pages/search.astro
@@ -1,0 +1,53 @@
+---
+export const prerender = false;
+
+import { getEmDashCollection } from "emdash";
+import Base from "../layouts/Base.astro";
+import PostCard from "../components/PostCard.astro";
+import { extractText, getReadingTime } from "../utils/reading-time";
+
+const query = Astro.url.searchParams.get("q")?.trim() || "";
+const { entries: posts } = await getEmDashCollection("posts");
+
+function matchesQuery(post: (typeof posts)[0], q: string): boolean {
+	if (!q) return false;
+	const lower = q.toLowerCase();
+	const title = (post.data.title || "").toLowerCase();
+	const excerpt = (post.data.excerpt || "").toLowerCase();
+	const content = extractText(post.data.content).toLowerCase();
+	return title.includes(lower) || excerpt.includes(lower) || content.includes(lower);
+}
+
+const results = query ? posts.filter((post) => matchesQuery(post, query)) : [];
+---
+
+<Base title={query ? `Search: ${query}` : "Search"} description="Search the editorial archive.">
+	<section class="search-page">
+		<div class="container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Search</span>
+					<h1 class="page-title">Find a story</h1>
+				</div>
+			</header>
+			<form method="get" action="/search" class="search-form">
+				<input type="search" name="q" value={query} placeholder="Search posts..." class="search-input" />
+				<button type="submit" class="search-button">Search</button>
+			</form>
+			{query && <p>{results.length === 0 ? `No results for "${query}"` : `${results.length} result${results.length === 1 ? "" : "s"} for "${query}"`}</p>}
+			<div class="posts-grid">
+				{results.map((post) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+					/>
+				))}
+			</div>
+			{!query && <p>Try searching for “EmDash”, “design”, or “plugins”.</p>}
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/pages/tag/[slug].astro
+++ b/templates/modern-starter-cloudflare/src/pages/tag/[slug].astro
@@ -1,0 +1,49 @@
+---
+import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import Base from "../../layouts/Base.astro";
+import PostCard from "../../components/PostCard.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const slug = decodeSlug(Astro.params.slug);
+const term = slug ? await getTerm("tag", slug) : null;
+if (!term) return Astro.redirect("/404");
+
+const { entries: posts } = await getEmDashCollection("posts", {
+	where: { tag: term.slug },
+	orderBy: { published_at: "desc" },
+});
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+---
+
+<Base title={`${term.label} posts`} description={`All posts in ${term.label}.`}>
+	<section class="archive-section">
+		<div class="wide-container">
+			<header class="archive-header">
+				<div>
+					<span class="eyebrow">Tag</span>
+					<h1 class="archive-title">{term.label}</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+			<div class="posts-grid">
+				{postsWithTags.map(({ post, tags }) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+						tags={tags}
+					/>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter-cloudflare/src/styles/theme.css
+++ b/templates/modern-starter-cloudflare/src/styles/theme.css
@@ -1,0 +1,380 @@
+:root {
+	--color-bg: #09090b;
+	--color-bg-elevated: #111114;
+	--color-bg-soft: #16161b;
+	--color-surface: rgba(255, 255, 255, 0.05);
+	--color-surface-strong: rgba(255, 255, 255, 0.08);
+	--color-border: rgba(255, 255, 255, 0.12);
+	--color-border-subtle: rgba(255, 255, 255, 0.08);
+	--color-text: #f6f7fb;
+	--color-text-secondary: rgba(246, 247, 251, 0.78);
+	--color-muted: rgba(246, 247, 251, 0.58);
+	--color-accent: #d946ef;
+	--color-accent-2: #8b5cf6;
+	--color-accent-soft: rgba(217, 70, 239, 0.18);
+	--color-on-accent: #ffffff;
+	--gradient-accent: linear-gradient(135deg, #d946ef 0%, #8b5cf6 48%, #22d3ee 100%);
+	--gradient-panel: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.03) 100%);
+	--shadow-lg: 0 24px 80px rgba(0, 0, 0, 0.45);
+	--shadow-md: 0 16px 40px rgba(0, 0, 0, 0.28);
+	--max-width: 72rem;
+	--wide-width: 86rem;
+	--radius-sm: 0.75rem;
+	--radius: 1rem;
+	--radius-lg: 1.5rem;
+	--radius-xl: 2rem;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-5: 1.25rem;
+	--spacing-6: 1.5rem;
+	--spacing-8: 2rem;
+	--spacing-10: 2.5rem;
+	--spacing-12: 3rem;
+	--spacing-16: 4rem;
+	--spacing-20: 5rem;
+	--spacing-24: 6rem;
+	--spacing-32: 8rem;
+	--font-size-xs: 0.75rem;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1rem;
+	--font-size-lg: 1.125rem;
+	--font-size-xl: 1.375rem;
+	--font-size-2xl: 1.875rem;
+	--font-size-3xl: 2.5rem;
+	--font-size-4xl: 3.5rem;
+	--font-size-5xl: 4.75rem;
+	--leading-tight: 1.1;
+	--leading-snug: 1.25;
+	--leading-relaxed: 1.75;
+	--tracking-snug: -0.03em;
+	--tracking-wide: 0.08em;
+	--transition-fast: 180ms ease;
+	--transition-smooth: 260ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* { box-sizing: border-box; }
+html { color-scheme: dark; }
+body {
+	margin: 0;
+	font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	background:
+		radial-gradient(circle at top, rgba(139, 92, 246, 0.14), transparent 34%),
+		radial-gradient(circle at 80% 20%, rgba(217, 70, 239, 0.12), transparent 24%),
+		var(--color-bg);
+	color: var(--color-text);
+	min-height: 100vh;
+}
+img { display: block; max-width: 100%; }
+a { color: inherit; text-decoration: none; }
+p { margin: 0 0 1rem; color: var(--color-text-secondary); }
+.container { width: min(var(--max-width), calc(100% - 2rem)); margin: 0 auto; }
+.wide-container { width: min(var(--wide-width), calc(100% - 2rem)); margin: 0 auto; }
+.section { padding: var(--spacing-16) 0; }
+.eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-2);
+	padding: 0.45rem 0.8rem;
+	font-size: var(--font-size-xs);
+	font-weight: 700;
+	letter-spacing: var(--tracking-wide);
+	text-transform: uppercase;
+	border: 1px solid var(--color-border);
+	border-radius: 999px;
+	background: rgba(255,255,255,0.04);
+	color: var(--color-text-secondary);
+}
+.site-shell::before {
+	content: "";
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(180deg, transparent 0%, rgba(9,9,11,0.08) 100%);
+}
+.site-header {
+	position: sticky;
+	top: 0;
+	z-index: 40;
+	backdrop-filter: blur(20px);
+	background: rgba(9, 9, 11, 0.72);
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+.header-inner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-6);
+	padding: 1rem 0;
+}
+.site-brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.85rem;
+	font-size: 1.1rem;
+	font-weight: 700;
+	letter-spacing: -0.03em;
+}
+.site-brand-mark {
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 0.85rem;
+	background: var(--gradient-accent);
+	box-shadow: inset 0 1px 0 rgba(255,255,255,0.25), var(--shadow-md);
+}
+.site-logo-img { width: auto; height: 2.75rem; }
+.site-brand-copy { display:flex; flex-direction:column; gap:0.125rem; }
+.site-brand-tagline { font-size: var(--font-size-xs); color: var(--color-muted); font-weight: 500; }
+.nav-row {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-4);
+	flex-wrap: wrap;
+	justify-content: flex-end;
+}
+.nav-links { display:flex; align-items:center; gap: var(--spacing-2); flex-wrap: wrap; }
+.nav-links a, .nav-admin {
+	padding: 0.7rem 0.9rem;
+	border-radius: 999px;
+	color: var(--color-text-secondary);
+	font-size: var(--font-size-sm);
+	transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+}
+.nav-links a:hover, .nav-admin:hover {
+	background: rgba(255,255,255,0.06);
+	color: var(--color-text);
+	transform: translateY(-1px);
+}
+.nav-admin { border: 1px solid var(--color-border); }
+.header-search :global(input), .site-search-input {
+	min-width: 13rem;
+	padding: 0.8rem 1rem;
+	border-radius: 999px;
+	border: 1px solid var(--color-border);
+	background: rgba(255,255,255,0.04);
+	color: var(--color-text);
+}
+.header-search :global(input):focus, .site-search-input:focus {
+	outline: none;
+	border-color: rgba(217,70,239,0.45);
+	box-shadow: 0 0 0 4px rgba(217,70,239,0.12);
+}
+.hero {
+	padding: var(--spacing-12) 0 var(--spacing-16);
+}
+.hero-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.9fr);
+	gap: var(--spacing-8);
+	align-items: stretch;
+}
+.hero-feature {
+	position: relative;
+	min-height: 38rem;
+	border-radius: var(--radius-xl);
+	overflow: hidden;
+	background: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, rgba(9,9,11,0.75) 75%), var(--color-bg-elevated);
+	box-shadow: var(--shadow-lg);
+	border: 1px solid rgba(255,255,255,0.08);
+}
+.hero-feature :global(img) { width:100%; height:100%; object-fit: cover; transform: scale(1.01); }
+.hero-overlay {
+	position:absolute; inset:0;
+	background: linear-gradient(180deg, rgba(9,9,11,0.06) 0%, rgba(9,9,11,0.9) 78%);
+}
+.hero-content {
+	position:absolute; left:0; right:0; bottom:0;
+	padding: var(--spacing-8);
+}
+.hero-title {
+	font-size: clamp(2.7rem, 5vw, 5rem);
+	line-height: 0.96;
+	letter-spacing: var(--tracking-snug);
+	margin: 0 0 var(--spacing-4);
+}
+.hero-summary { font-size: var(--font-size-lg); max-width: 42rem; margin-bottom: var(--spacing-6); }
+.hero-actions { display:flex; gap: var(--spacing-3); flex-wrap: wrap; }
+.btn, .btn-secondary {
+	display:inline-flex; align-items:center; justify-content:center; gap:0.5rem;
+	padding: 0.95rem 1.2rem; border-radius: 999px; font-weight: 600;
+	transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+.btn { background: var(--gradient-accent); color: var(--color-on-accent); box-shadow: var(--shadow-md); }
+.btn:hover, .btn-secondary:hover { transform: translateY(-2px); }
+.btn-secondary { background: rgba(255,255,255,0.04); border:1px solid var(--color-border); }
+.hero-side {
+	display: grid;
+	gap: var(--spacing-4);
+}
+.hero-panel {
+	padding: var(--spacing-6);
+	border-radius: var(--radius-lg);
+	background: var(--gradient-panel);
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-md);
+}
+.hero-panel h2, .section-title, .article-title, .archive-title, .page-title {
+	letter-spacing: var(--tracking-snug);
+	line-height: var(--leading-tight);
+	margin: 0;
+}
+.hero-panel h2 { font-size: 1.45rem; margin-bottom: var(--spacing-3); }
+.hero-mini-list { display:grid; gap: var(--spacing-4); }
+.hero-mini-item { padding-top: var(--spacing-4); border-top: 1px solid var(--color-border-subtle); }
+.hero-mini-item:first-child { padding-top: 0; border-top: none; }
+.hero-mini-item h3 { margin: 0 0 0.4rem; font-size: 1.1rem; }
+.section-header, .page-header, .archive-header {
+	display:flex; align-items:flex-end; justify-content:space-between; gap: var(--spacing-4); flex-wrap: wrap;
+	margin-bottom: var(--spacing-8);
+}
+.section-title { font-size: clamp(2rem, 3vw, 3rem); }
+.section-link, .archive-link {
+	font-size: var(--font-size-sm); color: var(--color-text-secondary); padding-bottom: 0.4rem; border-bottom: 1px solid transparent;
+}
+.section-link:hover, .archive-link:hover { color: var(--color-text); border-bottom-color: var(--color-accent); }
+.posts-grid {
+	display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--spacing-6);
+}
+.post-card {
+	display:flex; flex-direction:column;
+	padding: 0.9rem;
+	border-radius: var(--radius-lg);
+	background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.02));
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-md);
+	transition: transform var(--transition-smooth), border-color var(--transition-fast), background var(--transition-fast);
+}
+.post-card:hover { transform: translateY(-6px); border-color: rgba(217,70,239,0.24); background: linear-gradient(180deg, rgba(255,255,255,0.065), rgba(255,255,255,0.025)); }
+.card-link { color: inherit; text-decoration: none; }
+.card-image, .card-placeholder {
+	aspect-ratio: 16 / 10;
+	overflow: hidden;
+	border-radius: calc(var(--radius-lg) - 0.35rem);
+	background: rgba(255,255,255,0.06);
+	margin-bottom: var(--spacing-5);
+}
+.card-image :global(img) { width:100%; height:100%; object-fit:cover; transition: transform 300ms ease; }
+.post-card:hover .card-image :global(img) { transform: scale(1.04); }
+.card-meta, .post-meta, .article-meta, .archive-meta {
+	display:flex; align-items:center; flex-wrap:wrap; gap: 0.5rem;
+	font-size: var(--font-size-sm);
+	color: var(--color-muted);
+}
+.meta-dot { width:4px; height:4px; border-radius:999px; background: var(--color-muted); display:inline-block; }
+.card-title { font-size: 1.45rem; margin: 0 0 0.65rem; line-height: 1.15; }
+.card-excerpt { display:-webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow:hidden; }
+.tag-list, .card-tags { display:flex; flex-wrap:wrap; gap: 0.55rem; }
+.tag {
+	display:inline-flex; align-items:center; padding: 0.45rem 0.7rem; border-radius:999px;
+	font-size: var(--font-size-xs); font-weight: 700; text-transform: uppercase; letter-spacing: var(--tracking-wide);
+	color: var(--color-text-secondary); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.04);
+}
+.tag:hover { color: var(--color-text); border-color: rgba(217,70,239,0.25); }
+.featured-strip {
+	display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: var(--spacing-4);
+}
+.featured-strip-item {
+	padding: var(--spacing-5); border-radius: var(--radius-lg); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.04);
+}
+.posts-list { display:grid; gap: var(--spacing-5); }
+.post-row {
+	display:grid; grid-template-columns: 12rem 1fr; gap: var(--spacing-5); align-items:center;
+	padding: var(--spacing-4); border-radius: var(--radius-lg); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.035);
+}
+.post-row-image { aspect-ratio: 4 / 3; border-radius: var(--radius); overflow:hidden; background: rgba(255,255,255,0.04); }
+.post-row-image :global(img) { width:100%; height:100%; object-fit:cover; }
+.article-shell {
+	padding: var(--spacing-10) 0 var(--spacing-16);
+}
+.article-grid {
+	display:grid; grid-template-columns: minmax(0, 1fr) 19rem; gap: var(--spacing-8);
+	align-items:start;
+}
+.article-main {
+	min-width:0;
+}
+.article-cover {
+	margin-bottom: var(--spacing-8);
+	border-radius: var(--radius-xl);
+	overflow:hidden;
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-lg);
+}
+.article-cover :global(img) { width:100%; aspect-ratio: 16 / 9; object-fit:cover; }
+.article-title { font-size: clamp(2.6rem, 5vw, 4.8rem); margin: var(--spacing-3) 0 var(--spacing-5); }
+.article-intro { font-size: 1.2rem; max-width: 48rem; color: var(--color-text-secondary); margin-bottom: var(--spacing-8); }
+.article-content { font-size: 1.05rem; line-height: var(--leading-relaxed); }
+.article-content :global(h2) { font-size: 2rem; margin-top: 2.4rem; margin-bottom: 0.85rem; }
+.article-content :global(h3) { font-size: 1.45rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+.article-content :global(p) { margin-bottom: 1.15rem; }
+.article-content :global(blockquote) {
+	margin: 2rem 0; padding: 0.25rem 0 0.25rem 1.3rem; border-left: 3px solid var(--color-accent); color: var(--color-text);
+	font-size: 1.15rem;
+}
+.article-content :global(ul), .article-content :global(ol) { padding-left: 1.3rem; margin-bottom: 1.2rem; color: var(--color-text-secondary); }
+.article-content :global(pre) {
+	padding: 1rem 1.1rem; background: #0d0d12; border:1px solid var(--color-border-subtle); border-radius: var(--radius);
+	overflow:auto; margin: 1.5rem 0;
+}
+.article-aside {
+	position: sticky; top: 5.75rem;
+	display:grid; gap: var(--spacing-4);
+}
+.aside-panel {
+	padding: var(--spacing-5);
+	border-radius: var(--radius-lg);
+	background: rgba(255,255,255,0.04);
+	border: 1px solid var(--color-border-subtle);
+}
+.aside-panel h3 { margin:0 0 var(--spacing-4); font-size: 1rem; }
+.share-links { display:flex; flex-wrap:wrap; gap: 0.65rem; }
+.share-links a { padding: 0.65rem 0.8rem; border-radius: 999px; background: rgba(255,255,255,0.05); font-size: var(--font-size-sm); }
+.share-links a:hover { background: rgba(255,255,255,0.1); }
+.related-list { display:grid; gap: var(--spacing-4); }
+.related-item { display:grid; gap: 0.4rem; }
+.author-strip {
+	display:flex; align-items:flex-start; gap: var(--spacing-4);
+	padding: var(--spacing-5); margin-top: var(--spacing-10); border-radius: var(--radius-lg); background: rgba(255,255,255,0.04); border: 1px solid var(--color-border-subtle);
+}
+.author-avatar {
+	width: 3.5rem; height: 3.5rem; border-radius: 999px; display:grid; place-items:center; background: var(--gradient-accent); color:white; font-weight:700;
+}
+.site-footer {
+	padding: var(--spacing-12) 0 var(--spacing-16);
+	border-top: 1px solid var(--color-border-subtle);
+	margin-top: var(--spacing-20);
+}
+.footer-grid {
+	display:grid; grid-template-columns: 1.2fr 0.8fr 0.8fr 1fr; gap: var(--spacing-6);
+}
+.footer-heading { margin:0 0 var(--spacing-3); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: var(--tracking-wide); color: var(--color-muted); }
+.footer-links { list-style:none; padding:0; margin:0; display:grid; gap:0.7rem; }
+.footer-links a { color: var(--color-text-secondary); }
+.footer-links a:hover { color: var(--color-text); }
+.footer-note { margin-top: var(--spacing-8); display:flex; justify-content:space-between; gap: var(--spacing-4); flex-wrap:wrap; color: var(--color-muted); font-size: var(--font-size-sm); }
+.empty-state, .not-found {
+	padding: var(--spacing-24) 0;
+	text-align:center;
+}
+.search-page, .archive-section, .page-article, .posts-page { padding: var(--spacing-12) 0 var(--spacing-16); }
+.search-form { display:flex; gap: var(--spacing-3); margin-bottom: var(--spacing-6); flex-wrap:wrap; }
+.search-input {
+	flex: 1 1 18rem; padding: 0.95rem 1rem; border-radius: var(--radius); border: 1px solid var(--color-border);
+	background: rgba(255,255,255,0.04); color: var(--color-text);
+}
+.search-button { padding: 0.95rem 1.2rem; border-radius: var(--radius); border: none; background: var(--gradient-accent); color: white; font-weight: 600; }
+@media (max-width: 1080px) {
+	.hero-grid, .article-grid, .footer-grid { grid-template-columns: 1fr; }
+	.posts-grid, .featured-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+	.article-aside { position: static; }
+}
+@media (max-width: 720px) {
+	.header-inner { align-items:flex-start; flex-direction:column; }
+	.nav-row { width:100%; justify-content:flex-start; }
+	.hero-feature { min-height: 28rem; }
+	.hero-content { padding: var(--spacing-6); }
+	.posts-grid, .featured-strip { grid-template-columns: 1fr; }
+	.post-row { grid-template-columns: 1fr; }
+	.hero-title, .article-title { font-size: clamp(2.2rem, 11vw, 3.4rem); }
+}

--- a/templates/modern-starter-cloudflare/src/utils/reading-time.ts
+++ b/templates/modern-starter-cloudflare/src/utils/reading-time.ts
@@ -1,0 +1,19 @@
+export function extractText(value: unknown): string {
+	if (!Array.isArray(value)) return "";
+	return value
+		.flatMap((block) => {
+			if (!block || typeof block !== "object") return [];
+			const children = (block as { children?: Array<{ text?: string }> }).children;
+			if (!Array.isArray(children)) return [];
+			return children.map((child) => child?.text ?? "");
+		})
+		.join(" ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+export function getReadingTime(value: unknown, wordsPerMinute = 220): number {
+	const text = extractText(value);
+	if (!text) return 1;
+	return Math.max(1, Math.ceil(text.split(/\s+/).length / wordsPerMinute));
+}

--- a/templates/modern-starter-cloudflare/src/utils/site-identity.ts
+++ b/templates/modern-starter-cloudflare/src/utils/site-identity.ts
@@ -1,0 +1,27 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface ModernStarterSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "Modern Starter";
+const DEFAULT_SITE_TAGLINE = "A premium dark editorial template for EmDash.";
+
+export function resolveModernStarterSiteIdentity(
+	settings?: ModernStarterSiteIdentitySettings,
+) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/templates/modern-starter-cloudflare/src/worker.ts
+++ b/templates/modern-starter-cloudflare/src/worker.ts
@@ -1,0 +1,5 @@
+import handler from "@astrojs/cloudflare/entrypoints/server";
+
+export { PluginBridge } from "@emdash-cms/cloudflare/sandbox";
+
+export default handler;

--- a/templates/modern-starter-cloudflare/tsconfig.json
+++ b/templates/modern-starter-cloudflare/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": ["src/**/*", "emdash-env.d.ts"],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
+}

--- a/templates/modern-starter-cloudflare/worker-configuration.d.ts
+++ b/templates/modern-starter-cloudflare/worker-configuration.d.ts
@@ -1,0 +1,5 @@
+declare interface Env {
+	DB: D1Database;
+	MEDIA: R2Bucket;
+	LOADER: Fetcher;
+}

--- a/templates/modern-starter-cloudflare/wrangler.jsonc
+++ b/templates/modern-starter-cloudflare/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "modern-starter-cloudflare",
+	"main": "./src/worker.ts",
+	"compatibility_date": "2026-02-24",
+	"compatibility_flags": ["nodejs_compat"],
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "modern-starter-cloudflare",
+			"database_id": "local"
+		}
+	],
+	"r2_buckets": [
+		{
+			"binding": "MEDIA",
+			"bucket_name": "modern-starter-media"
+		}
+	],
+	"worker_loaders": [
+		{
+			"binding": "LOADER"
+		}
+	]
+}

--- a/templates/modern-starter/AGENTS.md
+++ b/templates/modern-starter/AGENTS.md
@@ -1,0 +1,19 @@
+This is an EmDash site template built for the templates/ directory in the main repo.
+
+## Commands
+
+```bash
+npx emdash dev
+npx emdash types
+npx emdash seed seed/seed.json --validate
+```
+
+The admin UI is at `http://localhost:4321/_emdash/admin`.
+
+## Notes
+
+- Keep all content routes server-rendered.
+- Use `Astro.cache.set(cacheHint)` after EmDash content queries.
+- `entry.id` is the slug used in URLs. `entry.data.id` is the ULID for APIs like `getEntryTerms()`.
+- Image fields are rendered with `<Image image={...} />` from `emdash/ui`.
+- This template is intentionally styled as a premium dark editorial starter.

--- a/templates/modern-starter/CHANGELOG.md
+++ b/templates/modern-starter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.3
+
+- Add `modern-starter` repo-native template
+- Add `modern-starter-cloudflare` repo-native template
+- Include rich seed content, premium editorial layout, taxonomy archives, search, RSS, and single-post experience

--- a/templates/modern-starter/astro.config.mjs
+++ b/templates/modern-starter/astro.config.mjs
@@ -1,0 +1,22 @@
+import node from "@astrojs/node";
+import react from "@astrojs/react";
+import { defineConfig } from "astro/config";
+import emdash, { local } from "emdash/astro";
+import { sqlite } from "emdash/db";
+
+export default defineConfig({
+	output: "server",
+	adapter: node({ mode: "standalone" }),
+	image: { layout: "constrained", responsiveStyles: true },
+	integrations: [
+		react(),
+		emdash({
+			database: sqlite({ url: "file:./data.db" }),
+			storage: local({
+				directory: "./uploads",
+				baseUrl: "/_emdash/api/media/file",
+			}),
+		}),
+	],
+	devToolbar: { enabled: false },
+});

--- a/templates/modern-starter/emdash-env.d.ts
+++ b/templates/modern-starter/emdash-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/client" />
+/// <reference types="@emdash-cms/astro/env" />

--- a/templates/modern-starter/package.json
+++ b/templates/modern-starter/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@emdash-cms/template-modern-starter",
+  "version": "0.0.3",
+  "private": true,
+  "type": "module",
+  "emdash": {
+    "seed": "seed/seed.json"
+  },
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "start": "node ./dist/server/entry.mjs",
+    "bootstrap": "emdash init && emdash seed",
+    "seed": "emdash seed",
+    "typecheck": "astro check"
+  },
+  "dependencies": {
+    "@astrojs/node": "catalog:",
+    "@astrojs/react": "catalog:",
+    "astro": "catalog:",
+    "better-sqlite3": "catalog:",
+    "emdash": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@astrojs/check": "catalog:"
+  },
+  "peerDependencies": {},
+  "optionalDependencies": {},
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild"
+    ]
+  }
+}

--- a/templates/modern-starter/seed/seed.json
+++ b/templates/modern-starter/seed/seed.json
@@ -1,0 +1,811 @@
+{
+  "$schema": "https://emdashcms.com/seed.schema.json",
+  "version": "1",
+  "meta": {
+    "name": "Modern Starter",
+    "description": "Premium dark editorial template for EmDash",
+    "author": "OpenAI"
+  },
+  "settings": {
+    "title": "Modern Starter",
+    "tagline": "Thoughtful publishing with a premium edge"
+  },
+  "collections": [
+    {
+      "slug": "posts",
+      "label": "Posts",
+      "labelSingular": "Post",
+      "supports": [
+        "drafts",
+        "revisions",
+        "search",
+        "seo"
+      ],
+      "commentsEnabled": true,
+      "fields": [
+        {
+          "slug": "title",
+          "label": "Title",
+          "type": "string",
+          "required": true,
+          "searchable": true
+        },
+        {
+          "slug": "featured_image",
+          "label": "Featured Image",
+          "type": "image"
+        },
+        {
+          "slug": "content",
+          "label": "Content",
+          "type": "portableText",
+          "searchable": true
+        },
+        {
+          "slug": "excerpt",
+          "label": "Excerpt",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "slug": "pages",
+      "label": "Pages",
+      "labelSingular": "Page",
+      "supports": [
+        "drafts",
+        "revisions",
+        "search"
+      ],
+      "fields": [
+        {
+          "slug": "title",
+          "label": "Title",
+          "type": "string",
+          "required": true,
+          "searchable": true
+        },
+        {
+          "slug": "content",
+          "label": "Content",
+          "type": "portableText",
+          "searchable": true
+        }
+      ]
+    }
+  ],
+  "taxonomies": [
+    {
+      "name": "category",
+      "label": "Categories",
+      "labelSingular": "Category",
+      "hierarchical": true,
+      "collections": [
+        "posts"
+      ],
+      "terms": [
+        {
+          "slug": "technology",
+          "label": "Technology"
+        },
+        {
+          "slug": "design",
+          "label": "Design"
+        },
+        {
+          "slug": "development",
+          "label": "Development"
+        },
+        {
+          "slug": "strategy",
+          "label": "Strategy"
+        }
+      ]
+    },
+    {
+      "name": "tag",
+      "label": "Tags",
+      "labelSingular": "Tag",
+      "hierarchical": false,
+      "collections": [
+        "posts"
+      ],
+      "terms": [
+        {
+          "slug": "emdash",
+          "label": "EmDash"
+        },
+        {
+          "slug": "astro",
+          "label": "Astro"
+        },
+        {
+          "slug": "editorial",
+          "label": "Editorial"
+        },
+        {
+          "slug": "ux",
+          "label": "UX"
+        },
+        {
+          "slug": "performance",
+          "label": "Performance"
+        },
+        {
+          "slug": "plugins",
+          "label": "Plugins"
+        },
+        {
+          "slug": "cloudflare",
+          "label": "Cloudflare"
+        },
+        {
+          "slug": "content-strategy",
+          "label": "Content Strategy"
+        }
+      ]
+    }
+  ],
+  "bylines": [
+    {
+      "id": "byline-editorial",
+      "slug": "modern-editorial",
+      "displayName": "Modern Editorial"
+    },
+    {
+      "id": "byline-studio",
+      "slug": "studio-notes",
+      "displayName": "Studio Notes"
+    }
+  ],
+  "menus": [
+    {
+      "name": "primary",
+      "label": "Primary Navigation",
+      "items": [
+        {
+          "type": "custom",
+          "label": "Home",
+          "url": "/"
+        },
+        {
+          "type": "custom",
+          "label": "Posts",
+          "url": "/posts"
+        },
+        {
+          "type": "custom",
+          "label": "About",
+          "url": "/pages/about"
+        },
+        {
+          "type": "custom",
+          "label": "Contact",
+          "url": "/pages/contact"
+        }
+      ]
+    }
+  ],
+  "widgetAreas": [
+    {
+      "name": "sidebar",
+      "label": "Sidebar",
+      "description": "Sidebar area for single posts",
+      "widgets": [
+        {
+          "type": "component",
+          "componentId": "core:search",
+          "title": "Search"
+        },
+        {
+          "type": "component",
+          "componentId": "core:categories",
+          "title": "Categories"
+        },
+        {
+          "type": "component",
+          "componentId": "core:tags",
+          "title": "Tags"
+        },
+        {
+          "type": "component",
+          "componentId": "core:recent-posts",
+          "title": "Recent Posts",
+          "settings": {
+            "count": 5,
+            "showDate": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "footer",
+      "label": "Footer",
+      "description": "Footer widget area",
+      "widgets": [
+        {
+          "type": "content",
+          "title": "About this template",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Modern Starter is a dark, premium editorial foundation designed to showcase EmDash content beautifully."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "content": {
+    "pages": [
+      {
+        "id": "about",
+        "slug": "about",
+        "status": "published",
+        "data": {
+          "title": "About",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Modern Starter is a premium dark editorial template for EmDash. It is designed to feel polished on day one, with room for customization once the content team takes over."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The starter includes search, RSS, archive pages, comments, taxonomy landing pages, widget areas, and a modern layout that gives posts space to breathe."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "contact",
+        "slug": "contact",
+        "status": "published",
+        "data": {
+          "title": "Contact",
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Use this page for your contact details, newsletter signup, or editorial guidelines."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Because this is an EmDash page, non-technical editors can update the content without touching the theme files."
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "posts": [
+      {
+        "id": "post-1",
+        "slug": "future-of-editorial-platforms",
+        "status": "published",
+        "data": {
+          "title": "The Future of Editorial Platforms",
+          "excerpt": "Why premium publishing experiences are moving toward composable systems with first-class content workflows.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=1400&h=900&fit=crop",
+              "alt": "The Future of Editorial Platforms",
+              "filename": "future-of-editorial-platforms.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Publishing platforms are no longer judged only by what developers can ship. They are judged by how quickly editors can move, how well teams can collaborate, and whether the front end feels as crafted as the content itself."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "EmDash sits in a compelling place because it combines Astro\u2019s performance model with a proper CMS workflow. That means teams can keep the speed benefits of modern rendering while preserving editorial control."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "What readers notice"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Readers notice pacing, typography, spacing, and clarity long before they notice your stack. A modern starter has to respect that by making every article feel intentional."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "blockquote",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Great CMS experiences disappear into the act of reading."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "This template leans into that idea with a cinematic hero, editorial spacing, clean archives, and a focused single-post layout."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-21T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "technology"
+          ],
+          "tag": [
+            "emdash",
+            "astro",
+            "performance"
+          ]
+        }
+      },
+      {
+        "id": "post-2",
+        "slug": "designing-for-depth-not-noise",
+        "status": "published",
+        "data": {
+          "title": "Designing for Depth, Not Noise",
+          "excerpt": "A premium theme earns trust by letting the content lead and the interface support it quietly.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=1400&h=900&fit=crop",
+              "alt": "Designing for Depth, Not Noise",
+              "filename": "designing-for-depth-not-noise.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The fastest way to make a publication feel generic is to over-design every surface. Good editorial design creates confidence, not clutter."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "The role of restraint"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Restraint is not minimalism for its own sake. It is knowing where emphasis belongs: on the headline, the image, the deck, and the rhythm of the reading experience."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "That is why Modern Starter uses strong contrast, crisp cards, and a generous single-post layout instead of decorative complexity."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-20T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "design"
+          ],
+          "tag": [
+            "editorial",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-3",
+        "slug": "why-search-still-matters",
+        "status": "published",
+        "data": {
+          "title": "Why Search Still Matters",
+          "excerpt": "Search is a feature readers use when navigation fails and a sign of maturity when it works beautifully.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=1400&h=900&fit=crop",
+              "alt": "Why Search Still Matters",
+              "filename": "why-search-still-matters.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Not every visitor lands on your perfect homepage. Many arrive from search, social, or a direct link and need a fast way to move deeper into the site."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A strong starter should treat search as part of the reading experience, not an afterthought hidden in a corner."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "h2",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Good archive design"
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "When search, categories, tags, and archives all work together, your best content keeps finding new readers long after publication day."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-19T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "strategy"
+          ],
+          "tag": [
+            "content-strategy",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-4",
+        "slug": "plugins-without-the-chaos",
+        "status": "published",
+        "data": {
+          "title": "Plugins Without the Chaos",
+          "excerpt": "A safer plugin model changes what teams are willing to install and maintain over time.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=1400&h=900&fit=crop",
+              "alt": "Plugins Without the Chaos",
+              "filename": "plugins-without-the-chaos.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Legacy plugin ecosystems often accumulate risk faster than value. Sandboxed execution changes that tradeoff in a meaningful way."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "When themes and content systems assume extensibility from the beginning, teams can grow without losing confidence in stability."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "blockquote",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Flexibility is only useful when it remains dependable under pressure."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-18T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "development"
+          ],
+          "tag": [
+            "plugins",
+            "emdash",
+            "cloudflare"
+          ]
+        }
+      },
+      {
+        "id": "post-5",
+        "slug": "a-better-way-to-ship-content",
+        "status": "published",
+        "data": {
+          "title": "A Better Way to Ship Content",
+          "excerpt": "Editorial teams move faster when the design system, CMS, and publishing workflow are aligned.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1517048676732-d65bc937f952?w=1400&h=900&fit=crop",
+              "alt": "A Better Way to Ship Content",
+              "filename": "a-better-way-to-ship-content.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Too many stacks treat editorial workflow as something to bolt on after launch. In practice, that decision slows everyone down once real publishing starts."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A starter should give teams a coherent default: clear templates, a navigable archive, readable single posts, and space for widgets or plugins where they matter."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-17T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "strategy"
+          ],
+          "tag": [
+            "content-strategy",
+            "editorial"
+          ]
+        }
+      },
+      {
+        "id": "post-6",
+        "slug": "measuring-the-right-performance",
+        "status": "published",
+        "data": {
+          "title": "Measuring the Right Performance",
+          "excerpt": "A publication feels fast when the experience is coherent, not only when the benchmark is green.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=1400&h=900&fit=crop",
+              "alt": "Measuring the Right Performance",
+              "filename": "measuring-the-right-performance.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Performance is not just a deployment story. It is also about predictable layouts, light UI chrome, and interfaces that keep readers oriented."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Astro gives you a strong baseline, but the theme still needs to avoid visual churn and interaction debt."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-16T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "technology"
+          ],
+          "tag": [
+            "performance",
+            "astro"
+          ]
+        }
+      },
+      {
+        "id": "post-7",
+        "slug": "the-quiet-power-of-taxonomies",
+        "status": "published",
+        "data": {
+          "title": "The Quiet Power of Taxonomies",
+          "excerpt": "Categories and tags are not decorative metadata. They are navigation systems for serious readers.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1516321165247-4aa89a48be28?w=1400&h=900&fit=crop",
+              "alt": "The Quiet Power of Taxonomies",
+              "filename": "the-quiet-power-of-taxonomies.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Good taxonomy design turns a pile of posts into a publication. It helps readers understand what you cover and how ideas connect over time."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "That is why the starter includes dedicated category and tag pages rather than burying the structure inside search alone."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-15T10:00:00Z",
+          "bylines": [
+            "byline-editorial"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "development"
+          ],
+          "tag": [
+            "content-strategy",
+            "ux"
+          ]
+        }
+      },
+      {
+        "id": "post-8",
+        "slug": "building-a-brand-through-layout",
+        "status": "published",
+        "data": {
+          "title": "Building a Brand Through Layout",
+          "excerpt": "Typography, hierarchy, and spacing do more brand work than many teams realize.",
+          "featured_image": {
+            "$media": {
+              "url": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1400&h=900&fit=crop",
+              "alt": "Building a Brand Through Layout",
+              "filename": "building-a-brand-through-layout.jpg"
+            }
+          },
+          "content": [
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "A publication\u2019s brand shows up in how it opens a story, frames a card, and carries a reader from one page to the next."
+                }
+              ]
+            },
+            {
+              "_type": "block",
+              "style": "normal",
+              "children": [
+                {
+                  "_type": "span",
+                  "text": "Layout is the editorial voice you feel before you consciously notice it."
+                }
+              ]
+            }
+          ],
+          "publishedAt": "2026-04-14T10:00:00Z",
+          "bylines": [
+            "byline-studio"
+          ]
+        },
+        "taxonomies": {
+          "category": [
+            "design"
+          ],
+          "tag": [
+            "editorial",
+            "ux"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/templates/modern-starter/src/components/PostCard.astro
+++ b/templates/modern-starter/src/components/PostCard.astro
@@ -1,0 +1,51 @@
+---
+import type { MediaValue, ContentBylineCredit } from "emdash";
+import { Image } from "emdash/ui";
+
+interface Props {
+	title: string;
+	excerpt?: string;
+	featuredImage?: MediaValue | string;
+	href: string;
+	date?: Date;
+	readingTime?: number;
+	tags?: Array<{ slug: string; label: string }>;
+	bylines?: ContentBylineCredit[];
+}
+
+const { title, excerpt, featuredImage, href, date, readingTime, tags, bylines } = Astro.props;
+
+const formattedDate = date
+	? date.toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		})
+	: null;
+---
+
+<article class="post-card">
+	<a href={href} class="card-link">
+		{featuredImage ? (
+			<div class="card-image"><Image image={featuredImage} /></div>
+		) : (
+			<div class="card-placeholder" />
+		)}
+		<div class="card-meta">
+			{bylines && bylines.length > 0 && <span>{bylines[0]?.byline.displayName}</span>}
+			{bylines && bylines.length > 0 && formattedDate && <span class="meta-dot" />}
+			{formattedDate && <time>{formattedDate}</time>}
+			{formattedDate && readingTime && <span class="meta-dot" />}
+			{readingTime && <span>{readingTime} min read</span>}
+		</div>
+		<h2 class="card-title">{title}</h2>
+		{excerpt && <p class="card-excerpt">{excerpt}</p>}
+		{tags && tags.length > 0 && (
+			<div class="card-tags">
+				{tags.slice(0, 3).map((tag) => (
+					<span class="tag">{tag.label}</span>
+				))}
+			</div>
+		)}
+	</a>
+</article>

--- a/templates/modern-starter/src/components/PostMeta.astro
+++ b/templates/modern-starter/src/components/PostMeta.astro
@@ -1,0 +1,23 @@
+---
+import type { ContentBylineCredit } from "emdash";
+interface Props {
+	date?: Date | null;
+	readingTime?: number;
+	category?: string | null;
+	bylines?: ContentBylineCredit[];
+}
+const { date, readingTime, category, bylines = [] } = Astro.props;
+const formattedDate = date
+	? date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+	: null;
+---
+
+<div class="article-meta">
+	{category && <span>{category}</span>}
+	{category && (formattedDate || bylines.length > 0 || readingTime) && <span class="meta-dot" />}
+	{formattedDate && <time datetime={date?.toISOString()}>{formattedDate}</time>}
+	{formattedDate && bylines.length > 0 && <span class="meta-dot" />}
+	{bylines.length > 0 && <span>{bylines.map((credit) => credit.byline.displayName).join(", ")}</span>}
+	{(formattedDate || bylines.length > 0) && readingTime && <span class="meta-dot" />}
+	{readingTime && <span>{readingTime} min read</span>}
+</div>

--- a/templates/modern-starter/src/components/TagList.astro
+++ b/templates/modern-starter/src/components/TagList.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+	tags: Array<{ slug: string; label: string }>;
+}
+const { tags } = Astro.props;
+---
+
+{tags.length > 0 && (
+	<div class="tag-list">
+		{tags.map((tag) => (
+			<a class="tag" href={`/tag/${tag.slug}`}>{tag.label}</a>
+		))}
+	</div>
+)}

--- a/templates/modern-starter/src/layouts/Base.astro
+++ b/templates/modern-starter/src/layouts/Base.astro
@@ -1,0 +1,150 @@
+---
+import { getEmDashCollection, getMenu, getSiteSettings } from "emdash";
+import { WidgetArea, EmDashHead, EmDashBodyStart, EmDashBodyEnd } from "emdash/ui";
+import { createPublicPageContext } from "emdash/page";
+import LiveSearch from "emdash/ui/search";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+import "../styles/theme.css";
+
+interface Props {
+	title: string;
+	pageTitle?: string | null;
+	description?: string | null;
+	image?: string | null;
+	canonical?: string | null;
+	robots?: string | null;
+	type?: "website" | "article";
+	publishedTime?: string | null;
+	modifiedTime?: string | null;
+	author?: string | null;
+	content?: { collection: string; id: string; slug?: string | null };
+}
+
+const {
+	title,
+	pageTitle,
+	description,
+	image,
+	canonical,
+	robots,
+	type = "website",
+	publishedTime,
+	modifiedTime,
+	author,
+	content,
+} = Astro.props;
+
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
+const menu = await getMenu("primary");
+const { entries: pages } = await getEmDashCollection("pages");
+const pageCtx = createPublicPageContext({
+	Astro,
+	kind: content ? "content" : "custom",
+	pageType: type,
+	title: fullTitle,
+	pageTitle: pageTitle ?? title,
+	description,
+	canonical,
+	image,
+	content,
+	seo: { ogImage: image, robots },
+	articleMeta: { publishedTime, modifiedTime, author },
+	siteName: siteTitle,
+});
+const isLoggedIn = !!Astro.locals.user;
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
+		<EmDashHead page={pageCtx} />
+	</head>
+	<body>
+		<EmDashBodyStart page={pageCtx} />
+		<div class="site-shell">
+			<header class="site-header">
+				<div class="wide-container header-inner">
+					<a href="/" class="site-brand">
+						{siteLogo ? (
+							<img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						) : (
+							<span class="site-brand-mark" aria-hidden="true"></span>
+						)}
+						<span class="site-brand-copy">
+							<span>{siteTitle}</span>
+							<span class="site-brand-tagline">{siteTagline}</span>
+						</span>
+					</a>
+					<div class="nav-row">
+						<div class="header-search">
+							<LiveSearch
+								placeholder="Search stories..."
+								class="site-search"
+								inputClass="site-search-input"
+								resultsClass="site-search-results"
+								resultClass="site-search-result"
+								collections={["posts", "pages"]}
+							/>
+						</div>
+						<nav class="nav-links">
+							{menu?.items.map((item) => (
+								<a href={item.url} target={item.target}>{item.label}</a>
+							))}
+							<a href="/rss.xml">RSS</a>
+						</nav>
+						{isLoggedIn && <a href="/_emdash/admin" class="nav-admin">Admin</a>}
+					</div>
+				</div>
+			</header>
+
+			<main>
+				<slot />
+			</main>
+
+			<footer class="site-footer">
+				<div class="wide-container footer-grid">
+					<div>
+						<div class="site-brand">
+							<span class="site-brand-mark" aria-hidden="true"></span>
+							<span class="site-brand-copy">
+								<span>{siteTitle}</span>
+								<span class="site-brand-tagline">{siteTagline}</span>
+							</span>
+						</div>
+						<p style="margin-top: 1rem; max-width: 30rem;">A polished, dark-first editorial starter for teams who want their content to feel premium on day one.</p>
+					</div>
+					<div>
+						<h3 class="footer-heading">Explore</h3>
+						<ul class="footer-links">
+							<li><a href="/">Home</a></li>
+							<li><a href="/posts">All Posts</a></li>
+							<li><a href="/search">Search</a></li>
+						</ul>
+					</div>
+					<div>
+						<h3 class="footer-heading">Pages</h3>
+						<ul class="footer-links">
+							{pages.slice(0, 4).map((page) => (
+								<li><a href={`/pages/${page.id}`}>{page.data.title}</a></li>
+							))}
+						</ul>
+					</div>
+					<div>
+						<h3 class="footer-heading">Footer</h3>
+						<WidgetArea name="footer" />
+					</div>
+				</div>
+				<div class="wide-container footer-note">
+					<span>Built with EmDash and Astro.</span>
+					<span>Designed for modern editorial teams.</span>
+				</div>
+			</footer>
+		</div>
+		<EmDashBodyEnd page={pageCtx} />
+	</body>
+</html>

--- a/templates/modern-starter/src/live.config.ts
+++ b/templates/modern-starter/src/live.config.ts
@@ -1,0 +1,6 @@
+import { defineLiveCollection } from "astro:content";
+import { emdashLoader } from "emdash/runtime";
+
+export const collections = {
+	_emdash: defineLiveCollection({ loader: emdashLoader() }),
+};

--- a/templates/modern-starter/src/pages/404.astro
+++ b/templates/modern-starter/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Page not found">
+	<section class="section">
+		<div class="container not-found">
+			<span class="eyebrow">404</span>
+			<h1 class="page-title">That page drifted out of orbit.</h1>
+			<p>Try the homepage, the archive, or search for what you need.</p>
+			<div class="hero-actions" style="justify-content: center; margin-top: 1.5rem;">
+				<a href="/" class="btn">Go home</a>
+				<a href="/posts" class="btn-secondary">Browse posts</a>
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/category/[slug].astro
+++ b/templates/modern-starter/src/pages/category/[slug].astro
@@ -1,0 +1,49 @@
+---
+import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import Base from "../../layouts/Base.astro";
+import PostCard from "../../components/PostCard.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const slug = decodeSlug(Astro.params.slug);
+const term = slug ? await getTerm("category", slug) : null;
+if (!term) return Astro.redirect("/404");
+
+const { entries: posts } = await getEmDashCollection("posts", {
+	where: { category: term.slug },
+	orderBy: { published_at: "desc" },
+});
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+---
+
+<Base title={`${term.label} posts`} description={`All posts in ${term.label}.`}>
+	<section class="archive-section">
+		<div class="wide-container">
+			<header class="archive-header">
+				<div>
+					<span class="eyebrow">Category</span>
+					<h1 class="archive-title">{term.label}</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+			<div class="posts-grid">
+				{postsWithTags.map(({ post, tags }) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+						tags={tags}
+					/>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/index.astro
+++ b/templates/modern-starter/src/pages/index.astro
@@ -1,0 +1,110 @@
+---
+import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import { Image } from "emdash/ui";
+import Base from "../layouts/Base.astro";
+import PostCard from "../components/PostCard.astro";
+import TagList from "../components/TagList.astro";
+import { getReadingTime } from "../utils/reading-time";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+
+const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+Astro.cache.set(cacheHint);
+
+const { siteTitle, siteTagline } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const sortedPosts = posts.toSorted((a, b) => {
+	const dateA = a.data.publishedAt?.getTime() ?? 0;
+	const dateB = b.data.publishedAt?.getTime() ?? 0;
+	return dateB - dateA;
+});
+
+const heroPost = sortedPosts.find((post) => post.data.featured_image) ?? sortedPosts[0];
+const heroTags = heroPost ? await getEntryTerms("posts", heroPost.data.id, "tag") : [];
+const featuredStrip = sortedPosts.filter((post) => post.id !== heroPost?.id).slice(0, 3);
+const gridPosts = sortedPosts.filter((post) => post.id !== heroPost?.id).slice(3, 9);
+const gridPostsWithMeta = await Promise.all(
+	gridPosts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+		bylines: post.data.bylines ?? [],
+	}))
+);
+---
+
+<Base title={siteTitle} description={siteTagline}>
+	{posts.length === 0 ? (
+		<section class="section">
+			<div class="container empty-state">
+				<h1 class="section-title">No stories yet</h1>
+				<p>Open the admin panel and publish the first piece.</p>
+				<a href="/_emdash/admin/content/posts/new" class="btn">Create a post</a>
+			</div>
+		</section>
+	) : (
+		<>
+			<section class="hero">
+				<div class="wide-container hero-grid">
+					{heroPost && (
+						<a class="hero-feature" href={`/posts/${heroPost.id}`}>
+							{heroPost.data.featured_image && <Image image={heroPost.data.featured_image} />}
+							<div class="hero-overlay"></div>
+							<div class="hero-content">
+								<span class="eyebrow">Featured story</span>
+								<h1 class="hero-title">{heroPost.data.title}</h1>
+								{heroPost.data.excerpt && <p class="hero-summary">{heroPost.data.excerpt}</p>}
+								<TagList tags={heroTags.map((tag) => ({ slug: tag.slug, label: tag.label }))} />
+								<div class="hero-actions">
+									<span class="btn">Read feature</span>
+									<span class="btn-secondary">{getReadingTime(heroPost.data.content)} min read</span>
+								</div>
+							</div>
+						</a>
+					)}
+					<div class="hero-side">
+						<div class="hero-panel">
+							<span class="eyebrow">Editorial promise</span>
+							<h2>A polished starter for fast teams.</h2>
+							<p>Modern Starter gives EmDash a premium dark editorial surface with archives, search, RSS, widgets, and a strong single-post experience built in.</p>
+						</div>
+						<div class="hero-panel">
+							<span class="eyebrow">Fresh reads</span>
+							<div class="hero-mini-list">
+								{featuredStrip.map((post) => (
+									<a class="hero-mini-item" href={`/posts/${post.id}`}>
+										<h3>{post.data.title}</h3>
+										{post.data.excerpt && <p>{post.data.excerpt}</p>}
+									</a>
+								))}
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section class="section">
+				<div class="wide-container">
+					<div class="section-header">
+						<div>
+							<span class="eyebrow">Latest</span>
+							<h2 class="section-title">New stories and field notes</h2>
+						</div>
+						<a href="/posts" class="section-link">Browse archive</a>
+					</div>
+					<div class="posts-grid">
+						{gridPostsWithMeta.map(({ post, tags, bylines }) => (
+							<PostCard
+								title={post.data.title}
+								excerpt={post.data.excerpt}
+								featuredImage={post.data.featured_image}
+								href={`/posts/${post.id}`}
+								date={post.data.publishedAt ?? undefined}
+								readingTime={getReadingTime(post.data.content)}
+								tags={tags}
+								bylines={bylines}
+							/>
+						))}
+					</div>
+				</div>
+			</section>
+		</>
+	)}
+</Base>

--- a/templates/modern-starter/src/pages/pages/[slug].astro
+++ b/templates/modern-starter/src/pages/pages/[slug].astro
@@ -1,0 +1,42 @@
+---
+import { getEmDashEntry, decodeSlug, getSeoMeta, getSiteSettings } from "emdash";
+import { PortableText } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import { resolveModernStarterSiteIdentity } from "../../utils/site-identity";
+
+const slug = decodeSlug(Astro.params.slug);
+if (!slug) return Astro.redirect("/404");
+
+const { entry: page, cacheHint } = await getEmDashEntry("pages", slug);
+if (!page) return Astro.redirect("/404");
+Astro.cache.set(cacheHint);
+
+const { siteTitle } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const seo = getSeoMeta(page, {
+	siteTitle,
+	siteUrl: Astro.url.origin,
+	path: `/pages/${slug}`,
+});
+---
+
+<Base
+	title={seo.title}
+	pageTitle={seo.ogTitle}
+	description={seo.description}
+	canonical={seo.canonical}
+	content={{ collection: "pages", id: page.data.id, slug }}
+>
+	<section class="page-article">
+		<div class="container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Page</span>
+					<h1 class="page-title" {...page.edit.title}>{page.data.title}</h1>
+				</div>
+			</header>
+			<div class="article-content">
+				<PortableText value={page.data.content} />
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/posts/[slug].astro
+++ b/templates/modern-starter/src/pages/posts/[slug].astro
@@ -1,0 +1,142 @@
+---
+import {
+	getEmDashEntry,
+	getEmDashCollection,
+	getEntryTerms,
+	getSeoMeta,
+	decodeSlug,
+	getSiteSettings,
+} from "emdash";
+import { Image, PortableText, Comments, CommentForm, WidgetArea } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import TagList from "../../components/TagList.astro";
+import PostMeta from "../../components/PostMeta.astro";
+import { getReadingTime } from "../../utils/reading-time";
+import { resolveModernStarterSiteIdentity } from "../../utils/site-identity";
+
+const slug = decodeSlug(Astro.params.slug);
+if (!slug) return Astro.redirect("/404");
+
+const { entry: post, cacheHint } = await getEmDashEntry("posts", slug);
+if (!post) return Astro.redirect("/404");
+Astro.cache.set(cacheHint);
+
+function getImageUrl(img: unknown): string | undefined {
+	if (!img || typeof img !== "object") return undefined;
+	const image = img as Record<string, unknown>;
+	if (typeof image.src === "string" && image.src) {
+		return image.src.startsWith("http") ? image.src : `${Astro.url.origin}${image.src}`;
+	}
+	const meta = image.meta as Record<string, unknown> | undefined;
+	const storageKey =
+		(typeof meta?.storageKey === "string" ? meta.storageKey : undefined) ||
+		(typeof image.id === "string" ? image.id : undefined);
+	return storageKey ? `${Astro.url.origin}/_emdash/api/media/file/${storageKey}` : undefined;
+}
+
+const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveModernStarterSiteIdentity(await getSiteSettings());
+const seo = getSeoMeta(post, {
+	siteTitle,
+	siteUrl: Astro.url.origin,
+	path: `/posts/${slug}`,
+	defaultOgImage: featuredImageUrl,
+});
+const tags = await getEntryTerms("posts", post.data.id, "tag");
+const category = await getEntryTerms("posts", post.data.id, "category");
+const bylines = post.data.bylines ?? [];
+const readingTime = getReadingTime(post.data.content);
+
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
+const relatedPosts = recentPosts.filter((entry) => entry.id !== post.id).slice(0, 3);
+
+const shareUrl = Astro.url.href;
+const shareLinks = [
+	{ label: "X", href: `https://x.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(post.data.title || "")}` },
+	{ label: "LinkedIn", href: `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(shareUrl)}` },
+	{ label: "Facebook", href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}` },
+];
+---
+
+<Base
+	title={seo.title}
+	pageTitle={seo.ogTitle}
+	description={seo.description}
+	canonical={seo.canonical}
+	image={featuredImageUrl}
+	type="article"
+	publishedTime={post.data.publishedAt?.toISOString() ?? null}
+	modifiedTime={post.updatedAt?.toISOString?.() ?? post.data.publishedAt?.toISOString() ?? null}
+	author={bylines.map((credit) => credit.byline.displayName).join(", ") || null}
+	content={{ collection: "posts", id: post.data.id, slug }}
+>
+	<section class="article-shell">
+		<div class="wide-container article-grid">
+			<article class="article-main">
+				{post.data.featured_image && (
+					<div class="article-cover">
+						<Image image={post.data.featured_image} />
+					</div>
+				)}
+				<span class="eyebrow">{category[0]?.label ?? "Story"}</span>
+				<h1 class="article-title" {...post.edit.title}>{post.data.title}</h1>
+				<PostMeta
+					date={post.data.publishedAt ?? null}
+					readingTime={readingTime}
+					category={category[0]?.label ?? null}
+					bylines={bylines}
+				/>
+				{post.data.excerpt && <p class="article-intro">{post.data.excerpt}</p>}
+				<TagList tags={tags.map((tag) => ({ slug: tag.slug, label: tag.label }))} />
+				<div class="article-content">
+					<PortableText value={post.data.content} />
+				</div>
+
+				<div class="author-strip">
+					<div class="author-avatar">{(bylines[0]?.byline.displayName || "E").slice(0, 1)}</div>
+					<div>
+						<strong>{bylines[0]?.byline.displayName || "Editorial Team"}</strong>
+						<p style="margin-top: 0.35rem;">Thoughtful, modern publishing with EmDash, Astro, and a premium design system.</p>
+					</div>
+				</div>
+
+				<section class="section" style="padding-bottom: 0;">
+					<div class="section-header">
+						<h2 class="section-title" style="font-size: 2rem;">Comments</h2>
+					</div>
+					<CommentForm entryId={post.data.id} />
+					<Comments entryId={post.data.id} />
+				</section>
+			</article>
+
+			<aside class="article-aside">
+				<div class="aside-panel">
+					<h3>Share</h3>
+					<div class="share-links">
+						{shareLinks.map((link) => (
+							<a href={link.href} target="_blank" rel="noopener noreferrer">{link.label}</a>
+						))}
+					</div>
+				</div>
+				<div class="aside-panel">
+					<h3>Related</h3>
+					<div class="related-list">
+						{relatedPosts.map((entry) => (
+							<a class="related-item" href={`/posts/${entry.id}`}>
+								<strong>{entry.data.title}</strong>
+								<span>{entry.data.excerpt}</span>
+							</a>
+						))}
+					</div>
+				</div>
+				<div class="aside-panel">
+					<h3>Sidebar</h3>
+					<WidgetArea name="sidebar" />
+				</div>
+			</aside>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/posts/index.astro
+++ b/templates/modern-starter/src/pages/posts/index.astro
@@ -1,0 +1,58 @@
+---
+import { getEmDashCollection, getEntryTerms } from "emdash";
+import { Image } from "emdash/ui";
+import Base from "../../layouts/Base.astro";
+import TagList from "../../components/TagList.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
+Astro.cache.set(cacheHint);
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+
+const formatDate = (date: Date | null | undefined) =>
+	date
+		? date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+		: null;
+---
+
+<Base title="All Posts" description="Browse the full editorial archive.">
+	<section class="posts-page">
+		<div class="wide-container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Archive</span>
+					<h1 class="page-title">All Posts</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+
+			<div class="posts-list">
+				{postsWithTags.map(({ post, tags }) => (
+					<article class="post-row">
+						<a href={`/posts/${post.id}`} class="post-row-image">
+							{post.data.featured_image ? <Image image={post.data.featured_image} /> : null}
+						</a>
+						<div>
+							<div class="post-meta">
+								{post.data.publishedAt && <time>{formatDate(post.data.publishedAt)}</time>}
+								{post.data.publishedAt && <span class="meta-dot" />}
+								<span>{getReadingTime(post.data.content)} min read</span>
+							</div>
+							<h2 class="card-title"><a href={`/posts/${post.id}`}>{post.data.title}</a></h2>
+							{post.data.excerpt && <p>{post.data.excerpt}</p>}
+							<TagList tags={tags} />
+						</div>
+					</article>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/rss.xml.ts
+++ b/templates/modern-starter/src/pages/rss.xml.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from "astro";
+import { getEmDashCollection, getSiteSettings } from "emdash";
+import { resolveModernStarterSiteIdentity } from "../utils/site-identity";
+
+export const GET: APIRoute = async ({ site, url }) => {
+	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveModernStarterSiteIdentity(await getSiteSettings());
+	const { entries: posts } = await getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 20,
+	});
+
+	const items = posts
+		.map((post) => {
+			if (!post.data.publishedAt) return null;
+			const postUrl = `${siteUrl}/posts/${post.id}`;
+			return `    <item>
+      <title>${escapeXml(post.data.title || "Untitled")}</title>
+      <link>${postUrl}</link>
+      <guid isPermaLink="true">${postUrl}</guid>
+      <pubDate>${post.data.publishedAt.toUTCString()}</pubDate>
+      <description>${escapeXml(post.data.excerpt || "")}</description>
+    </item>`;
+		})
+		.filter(Boolean)
+		.join("
+");
+
+	const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteTitle)}</title>
+    <description>${escapeXml(siteTagline)}</description>
+    <link>${siteUrl}</link>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+
+	return new Response(rss, {
+		headers: {
+			"Content-Type": "application/rss+xml; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+};
+
+const XML_ESCAPE_PATTERNS = [
+	[/&/g, "&amp;"],
+	[/</g, "&lt;"],
+	[/>/g, "&gt;"],
+	[/"/g, "&quot;"],
+	[/'/g, "&apos;"],
+] as const;
+
+function escapeXml(str: string): string {
+	let result = str;
+	for (const [pattern, replacement] of XML_ESCAPE_PATTERNS) result = result.replace(pattern, replacement);
+	return result;
+}

--- a/templates/modern-starter/src/pages/search.astro
+++ b/templates/modern-starter/src/pages/search.astro
@@ -1,0 +1,53 @@
+---
+export const prerender = false;
+
+import { getEmDashCollection } from "emdash";
+import Base from "../layouts/Base.astro";
+import PostCard from "../components/PostCard.astro";
+import { extractText, getReadingTime } from "../utils/reading-time";
+
+const query = Astro.url.searchParams.get("q")?.trim() || "";
+const { entries: posts } = await getEmDashCollection("posts");
+
+function matchesQuery(post: (typeof posts)[0], q: string): boolean {
+	if (!q) return false;
+	const lower = q.toLowerCase();
+	const title = (post.data.title || "").toLowerCase();
+	const excerpt = (post.data.excerpt || "").toLowerCase();
+	const content = extractText(post.data.content).toLowerCase();
+	return title.includes(lower) || excerpt.includes(lower) || content.includes(lower);
+}
+
+const results = query ? posts.filter((post) => matchesQuery(post, query)) : [];
+---
+
+<Base title={query ? `Search: ${query}` : "Search"} description="Search the editorial archive.">
+	<section class="search-page">
+		<div class="container">
+			<header class="page-header">
+				<div>
+					<span class="eyebrow">Search</span>
+					<h1 class="page-title">Find a story</h1>
+				</div>
+			</header>
+			<form method="get" action="/search" class="search-form">
+				<input type="search" name="q" value={query} placeholder="Search posts..." class="search-input" />
+				<button type="submit" class="search-button">Search</button>
+			</form>
+			{query && <p>{results.length === 0 ? `No results for "${query}"` : `${results.length} result${results.length === 1 ? "" : "s"} for "${query}"`}</p>}
+			<div class="posts-grid">
+				{results.map((post) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+					/>
+				))}
+			</div>
+			{!query && <p>Try searching for “EmDash”, “design”, or “plugins”.</p>}
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/pages/tag/[slug].astro
+++ b/templates/modern-starter/src/pages/tag/[slug].astro
@@ -1,0 +1,49 @@
+---
+import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import Base from "../../layouts/Base.astro";
+import PostCard from "../../components/PostCard.astro";
+import { getReadingTime } from "../../utils/reading-time";
+
+const slug = decodeSlug(Astro.params.slug);
+const term = slug ? await getTerm("tag", slug) : null;
+if (!term) return Astro.redirect("/404");
+
+const { entries: posts } = await getEmDashCollection("posts", {
+	where: { tag: term.slug },
+	orderBy: { published_at: "desc" },
+});
+
+const postsWithTags = await Promise.all(
+	posts.map(async (post) => ({
+		post,
+		tags: (await getEntryTerms("posts", post.data.id, "tag")).map((tag) => ({ slug: tag.slug, label: tag.label })),
+	}))
+);
+---
+
+<Base title={`${term.label} posts`} description={`All posts in ${term.label}.`}>
+	<section class="archive-section">
+		<div class="wide-container">
+			<header class="archive-header">
+				<div>
+					<span class="eyebrow">Tag</span>
+					<h1 class="archive-title">{term.label}</h1>
+				</div>
+				<p>{posts.length} {posts.length === 1 ? "story" : "stories"}</p>
+			</header>
+			<div class="posts-grid">
+				{postsWithTags.map(({ post, tags }) => (
+					<PostCard
+						title={post.data.title}
+						excerpt={post.data.excerpt}
+						featuredImage={post.data.featured_image}
+						href={`/posts/${post.id}`}
+						date={post.data.publishedAt ?? undefined}
+						readingTime={getReadingTime(post.data.content)}
+						tags={tags}
+					/>
+				))}
+			</div>
+		</div>
+	</section>
+</Base>

--- a/templates/modern-starter/src/styles/theme.css
+++ b/templates/modern-starter/src/styles/theme.css
@@ -1,0 +1,380 @@
+:root {
+	--color-bg: #09090b;
+	--color-bg-elevated: #111114;
+	--color-bg-soft: #16161b;
+	--color-surface: rgba(255, 255, 255, 0.05);
+	--color-surface-strong: rgba(255, 255, 255, 0.08);
+	--color-border: rgba(255, 255, 255, 0.12);
+	--color-border-subtle: rgba(255, 255, 255, 0.08);
+	--color-text: #f6f7fb;
+	--color-text-secondary: rgba(246, 247, 251, 0.78);
+	--color-muted: rgba(246, 247, 251, 0.58);
+	--color-accent: #d946ef;
+	--color-accent-2: #8b5cf6;
+	--color-accent-soft: rgba(217, 70, 239, 0.18);
+	--color-on-accent: #ffffff;
+	--gradient-accent: linear-gradient(135deg, #d946ef 0%, #8b5cf6 48%, #22d3ee 100%);
+	--gradient-panel: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.03) 100%);
+	--shadow-lg: 0 24px 80px rgba(0, 0, 0, 0.45);
+	--shadow-md: 0 16px 40px rgba(0, 0, 0, 0.28);
+	--max-width: 72rem;
+	--wide-width: 86rem;
+	--radius-sm: 0.75rem;
+	--radius: 1rem;
+	--radius-lg: 1.5rem;
+	--radius-xl: 2rem;
+	--spacing-1: 0.25rem;
+	--spacing-2: 0.5rem;
+	--spacing-3: 0.75rem;
+	--spacing-4: 1rem;
+	--spacing-5: 1.25rem;
+	--spacing-6: 1.5rem;
+	--spacing-8: 2rem;
+	--spacing-10: 2.5rem;
+	--spacing-12: 3rem;
+	--spacing-16: 4rem;
+	--spacing-20: 5rem;
+	--spacing-24: 6rem;
+	--spacing-32: 8rem;
+	--font-size-xs: 0.75rem;
+	--font-size-sm: 0.875rem;
+	--font-size-base: 1rem;
+	--font-size-lg: 1.125rem;
+	--font-size-xl: 1.375rem;
+	--font-size-2xl: 1.875rem;
+	--font-size-3xl: 2.5rem;
+	--font-size-4xl: 3.5rem;
+	--font-size-5xl: 4.75rem;
+	--leading-tight: 1.1;
+	--leading-snug: 1.25;
+	--leading-relaxed: 1.75;
+	--tracking-snug: -0.03em;
+	--tracking-wide: 0.08em;
+	--transition-fast: 180ms ease;
+	--transition-smooth: 260ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+* { box-sizing: border-box; }
+html { color-scheme: dark; }
+body {
+	margin: 0;
+	font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	background:
+		radial-gradient(circle at top, rgba(139, 92, 246, 0.14), transparent 34%),
+		radial-gradient(circle at 80% 20%, rgba(217, 70, 239, 0.12), transparent 24%),
+		var(--color-bg);
+	color: var(--color-text);
+	min-height: 100vh;
+}
+img { display: block; max-width: 100%; }
+a { color: inherit; text-decoration: none; }
+p { margin: 0 0 1rem; color: var(--color-text-secondary); }
+.container { width: min(var(--max-width), calc(100% - 2rem)); margin: 0 auto; }
+.wide-container { width: min(var(--wide-width), calc(100% - 2rem)); margin: 0 auto; }
+.section { padding: var(--spacing-16) 0; }
+.eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-2);
+	padding: 0.45rem 0.8rem;
+	font-size: var(--font-size-xs);
+	font-weight: 700;
+	letter-spacing: var(--tracking-wide);
+	text-transform: uppercase;
+	border: 1px solid var(--color-border);
+	border-radius: 999px;
+	background: rgba(255,255,255,0.04);
+	color: var(--color-text-secondary);
+}
+.site-shell::before {
+	content: "";
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(180deg, transparent 0%, rgba(9,9,11,0.08) 100%);
+}
+.site-header {
+	position: sticky;
+	top: 0;
+	z-index: 40;
+	backdrop-filter: blur(20px);
+	background: rgba(9, 9, 11, 0.72);
+	border-bottom: 1px solid var(--color-border-subtle);
+}
+.header-inner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-6);
+	padding: 1rem 0;
+}
+.site-brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.85rem;
+	font-size: 1.1rem;
+	font-weight: 700;
+	letter-spacing: -0.03em;
+}
+.site-brand-mark {
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 0.85rem;
+	background: var(--gradient-accent);
+	box-shadow: inset 0 1px 0 rgba(255,255,255,0.25), var(--shadow-md);
+}
+.site-logo-img { width: auto; height: 2.75rem; }
+.site-brand-copy { display:flex; flex-direction:column; gap:0.125rem; }
+.site-brand-tagline { font-size: var(--font-size-xs); color: var(--color-muted); font-weight: 500; }
+.nav-row {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-4);
+	flex-wrap: wrap;
+	justify-content: flex-end;
+}
+.nav-links { display:flex; align-items:center; gap: var(--spacing-2); flex-wrap: wrap; }
+.nav-links a, .nav-admin {
+	padding: 0.7rem 0.9rem;
+	border-radius: 999px;
+	color: var(--color-text-secondary);
+	font-size: var(--font-size-sm);
+	transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+}
+.nav-links a:hover, .nav-admin:hover {
+	background: rgba(255,255,255,0.06);
+	color: var(--color-text);
+	transform: translateY(-1px);
+}
+.nav-admin { border: 1px solid var(--color-border); }
+.header-search :global(input), .site-search-input {
+	min-width: 13rem;
+	padding: 0.8rem 1rem;
+	border-radius: 999px;
+	border: 1px solid var(--color-border);
+	background: rgba(255,255,255,0.04);
+	color: var(--color-text);
+}
+.header-search :global(input):focus, .site-search-input:focus {
+	outline: none;
+	border-color: rgba(217,70,239,0.45);
+	box-shadow: 0 0 0 4px rgba(217,70,239,0.12);
+}
+.hero {
+	padding: var(--spacing-12) 0 var(--spacing-16);
+}
+.hero-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.9fr);
+	gap: var(--spacing-8);
+	align-items: stretch;
+}
+.hero-feature {
+	position: relative;
+	min-height: 38rem;
+	border-radius: var(--radius-xl);
+	overflow: hidden;
+	background: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, rgba(9,9,11,0.75) 75%), var(--color-bg-elevated);
+	box-shadow: var(--shadow-lg);
+	border: 1px solid rgba(255,255,255,0.08);
+}
+.hero-feature :global(img) { width:100%; height:100%; object-fit: cover; transform: scale(1.01); }
+.hero-overlay {
+	position:absolute; inset:0;
+	background: linear-gradient(180deg, rgba(9,9,11,0.06) 0%, rgba(9,9,11,0.9) 78%);
+}
+.hero-content {
+	position:absolute; left:0; right:0; bottom:0;
+	padding: var(--spacing-8);
+}
+.hero-title {
+	font-size: clamp(2.7rem, 5vw, 5rem);
+	line-height: 0.96;
+	letter-spacing: var(--tracking-snug);
+	margin: 0 0 var(--spacing-4);
+}
+.hero-summary { font-size: var(--font-size-lg); max-width: 42rem; margin-bottom: var(--spacing-6); }
+.hero-actions { display:flex; gap: var(--spacing-3); flex-wrap: wrap; }
+.btn, .btn-secondary {
+	display:inline-flex; align-items:center; justify-content:center; gap:0.5rem;
+	padding: 0.95rem 1.2rem; border-radius: 999px; font-weight: 600;
+	transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+.btn { background: var(--gradient-accent); color: var(--color-on-accent); box-shadow: var(--shadow-md); }
+.btn:hover, .btn-secondary:hover { transform: translateY(-2px); }
+.btn-secondary { background: rgba(255,255,255,0.04); border:1px solid var(--color-border); }
+.hero-side {
+	display: grid;
+	gap: var(--spacing-4);
+}
+.hero-panel {
+	padding: var(--spacing-6);
+	border-radius: var(--radius-lg);
+	background: var(--gradient-panel);
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-md);
+}
+.hero-panel h2, .section-title, .article-title, .archive-title, .page-title {
+	letter-spacing: var(--tracking-snug);
+	line-height: var(--leading-tight);
+	margin: 0;
+}
+.hero-panel h2 { font-size: 1.45rem; margin-bottom: var(--spacing-3); }
+.hero-mini-list { display:grid; gap: var(--spacing-4); }
+.hero-mini-item { padding-top: var(--spacing-4); border-top: 1px solid var(--color-border-subtle); }
+.hero-mini-item:first-child { padding-top: 0; border-top: none; }
+.hero-mini-item h3 { margin: 0 0 0.4rem; font-size: 1.1rem; }
+.section-header, .page-header, .archive-header {
+	display:flex; align-items:flex-end; justify-content:space-between; gap: var(--spacing-4); flex-wrap: wrap;
+	margin-bottom: var(--spacing-8);
+}
+.section-title { font-size: clamp(2rem, 3vw, 3rem); }
+.section-link, .archive-link {
+	font-size: var(--font-size-sm); color: var(--color-text-secondary); padding-bottom: 0.4rem; border-bottom: 1px solid transparent;
+}
+.section-link:hover, .archive-link:hover { color: var(--color-text); border-bottom-color: var(--color-accent); }
+.posts-grid {
+	display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--spacing-6);
+}
+.post-card {
+	display:flex; flex-direction:column;
+	padding: 0.9rem;
+	border-radius: var(--radius-lg);
+	background: linear-gradient(180deg, rgba(255,255,255,0.045), rgba(255,255,255,0.02));
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-md);
+	transition: transform var(--transition-smooth), border-color var(--transition-fast), background var(--transition-fast);
+}
+.post-card:hover { transform: translateY(-6px); border-color: rgba(217,70,239,0.24); background: linear-gradient(180deg, rgba(255,255,255,0.065), rgba(255,255,255,0.025)); }
+.card-link { color: inherit; text-decoration: none; }
+.card-image, .card-placeholder {
+	aspect-ratio: 16 / 10;
+	overflow: hidden;
+	border-radius: calc(var(--radius-lg) - 0.35rem);
+	background: rgba(255,255,255,0.06);
+	margin-bottom: var(--spacing-5);
+}
+.card-image :global(img) { width:100%; height:100%; object-fit:cover; transition: transform 300ms ease; }
+.post-card:hover .card-image :global(img) { transform: scale(1.04); }
+.card-meta, .post-meta, .article-meta, .archive-meta {
+	display:flex; align-items:center; flex-wrap:wrap; gap: 0.5rem;
+	font-size: var(--font-size-sm);
+	color: var(--color-muted);
+}
+.meta-dot { width:4px; height:4px; border-radius:999px; background: var(--color-muted); display:inline-block; }
+.card-title { font-size: 1.45rem; margin: 0 0 0.65rem; line-height: 1.15; }
+.card-excerpt { display:-webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow:hidden; }
+.tag-list, .card-tags { display:flex; flex-wrap:wrap; gap: 0.55rem; }
+.tag {
+	display:inline-flex; align-items:center; padding: 0.45rem 0.7rem; border-radius:999px;
+	font-size: var(--font-size-xs); font-weight: 700; text-transform: uppercase; letter-spacing: var(--tracking-wide);
+	color: var(--color-text-secondary); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.04);
+}
+.tag:hover { color: var(--color-text); border-color: rgba(217,70,239,0.25); }
+.featured-strip {
+	display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: var(--spacing-4);
+}
+.featured-strip-item {
+	padding: var(--spacing-5); border-radius: var(--radius-lg); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.04);
+}
+.posts-list { display:grid; gap: var(--spacing-5); }
+.post-row {
+	display:grid; grid-template-columns: 12rem 1fr; gap: var(--spacing-5); align-items:center;
+	padding: var(--spacing-4); border-radius: var(--radius-lg); border:1px solid var(--color-border-subtle); background: rgba(255,255,255,0.035);
+}
+.post-row-image { aspect-ratio: 4 / 3; border-radius: var(--radius); overflow:hidden; background: rgba(255,255,255,0.04); }
+.post-row-image :global(img) { width:100%; height:100%; object-fit:cover; }
+.article-shell {
+	padding: var(--spacing-10) 0 var(--spacing-16);
+}
+.article-grid {
+	display:grid; grid-template-columns: minmax(0, 1fr) 19rem; gap: var(--spacing-8);
+	align-items:start;
+}
+.article-main {
+	min-width:0;
+}
+.article-cover {
+	margin-bottom: var(--spacing-8);
+	border-radius: var(--radius-xl);
+	overflow:hidden;
+	border: 1px solid var(--color-border-subtle);
+	box-shadow: var(--shadow-lg);
+}
+.article-cover :global(img) { width:100%; aspect-ratio: 16 / 9; object-fit:cover; }
+.article-title { font-size: clamp(2.6rem, 5vw, 4.8rem); margin: var(--spacing-3) 0 var(--spacing-5); }
+.article-intro { font-size: 1.2rem; max-width: 48rem; color: var(--color-text-secondary); margin-bottom: var(--spacing-8); }
+.article-content { font-size: 1.05rem; line-height: var(--leading-relaxed); }
+.article-content :global(h2) { font-size: 2rem; margin-top: 2.4rem; margin-bottom: 0.85rem; }
+.article-content :global(h3) { font-size: 1.45rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+.article-content :global(p) { margin-bottom: 1.15rem; }
+.article-content :global(blockquote) {
+	margin: 2rem 0; padding: 0.25rem 0 0.25rem 1.3rem; border-left: 3px solid var(--color-accent); color: var(--color-text);
+	font-size: 1.15rem;
+}
+.article-content :global(ul), .article-content :global(ol) { padding-left: 1.3rem; margin-bottom: 1.2rem; color: var(--color-text-secondary); }
+.article-content :global(pre) {
+	padding: 1rem 1.1rem; background: #0d0d12; border:1px solid var(--color-border-subtle); border-radius: var(--radius);
+	overflow:auto; margin: 1.5rem 0;
+}
+.article-aside {
+	position: sticky; top: 5.75rem;
+	display:grid; gap: var(--spacing-4);
+}
+.aside-panel {
+	padding: var(--spacing-5);
+	border-radius: var(--radius-lg);
+	background: rgba(255,255,255,0.04);
+	border: 1px solid var(--color-border-subtle);
+}
+.aside-panel h3 { margin:0 0 var(--spacing-4); font-size: 1rem; }
+.share-links { display:flex; flex-wrap:wrap; gap: 0.65rem; }
+.share-links a { padding: 0.65rem 0.8rem; border-radius: 999px; background: rgba(255,255,255,0.05); font-size: var(--font-size-sm); }
+.share-links a:hover { background: rgba(255,255,255,0.1); }
+.related-list { display:grid; gap: var(--spacing-4); }
+.related-item { display:grid; gap: 0.4rem; }
+.author-strip {
+	display:flex; align-items:flex-start; gap: var(--spacing-4);
+	padding: var(--spacing-5); margin-top: var(--spacing-10); border-radius: var(--radius-lg); background: rgba(255,255,255,0.04); border: 1px solid var(--color-border-subtle);
+}
+.author-avatar {
+	width: 3.5rem; height: 3.5rem; border-radius: 999px; display:grid; place-items:center; background: var(--gradient-accent); color:white; font-weight:700;
+}
+.site-footer {
+	padding: var(--spacing-12) 0 var(--spacing-16);
+	border-top: 1px solid var(--color-border-subtle);
+	margin-top: var(--spacing-20);
+}
+.footer-grid {
+	display:grid; grid-template-columns: 1.2fr 0.8fr 0.8fr 1fr; gap: var(--spacing-6);
+}
+.footer-heading { margin:0 0 var(--spacing-3); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: var(--tracking-wide); color: var(--color-muted); }
+.footer-links { list-style:none; padding:0; margin:0; display:grid; gap:0.7rem; }
+.footer-links a { color: var(--color-text-secondary); }
+.footer-links a:hover { color: var(--color-text); }
+.footer-note { margin-top: var(--spacing-8); display:flex; justify-content:space-between; gap: var(--spacing-4); flex-wrap:wrap; color: var(--color-muted); font-size: var(--font-size-sm); }
+.empty-state, .not-found {
+	padding: var(--spacing-24) 0;
+	text-align:center;
+}
+.search-page, .archive-section, .page-article, .posts-page { padding: var(--spacing-12) 0 var(--spacing-16); }
+.search-form { display:flex; gap: var(--spacing-3); margin-bottom: var(--spacing-6); flex-wrap:wrap; }
+.search-input {
+	flex: 1 1 18rem; padding: 0.95rem 1rem; border-radius: var(--radius); border: 1px solid var(--color-border);
+	background: rgba(255,255,255,0.04); color: var(--color-text);
+}
+.search-button { padding: 0.95rem 1.2rem; border-radius: var(--radius); border: none; background: var(--gradient-accent); color: white; font-weight: 600; }
+@media (max-width: 1080px) {
+	.hero-grid, .article-grid, .footer-grid { grid-template-columns: 1fr; }
+	.posts-grid, .featured-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+	.article-aside { position: static; }
+}
+@media (max-width: 720px) {
+	.header-inner { align-items:flex-start; flex-direction:column; }
+	.nav-row { width:100%; justify-content:flex-start; }
+	.hero-feature { min-height: 28rem; }
+	.hero-content { padding: var(--spacing-6); }
+	.posts-grid, .featured-strip { grid-template-columns: 1fr; }
+	.post-row { grid-template-columns: 1fr; }
+	.hero-title, .article-title { font-size: clamp(2.2rem, 11vw, 3.4rem); }
+}

--- a/templates/modern-starter/src/utils/reading-time.ts
+++ b/templates/modern-starter/src/utils/reading-time.ts
@@ -1,0 +1,19 @@
+export function extractText(value: unknown): string {
+	if (!Array.isArray(value)) return "";
+	return value
+		.flatMap((block) => {
+			if (!block || typeof block !== "object") return [];
+			const children = (block as { children?: Array<{ text?: string }> }).children;
+			if (!Array.isArray(children)) return [];
+			return children.map((child) => child?.text ?? "");
+		})
+		.join(" ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+export function getReadingTime(value: unknown, wordsPerMinute = 220): number {
+	const text = extractText(value);
+	if (!text) return 1;
+	return Math.max(1, Math.ceil(text.split(/\s+/).length / wordsPerMinute));
+}

--- a/templates/modern-starter/src/utils/site-identity.ts
+++ b/templates/modern-starter/src/utils/site-identity.ts
@@ -1,0 +1,27 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface ModernStarterSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "Modern Starter";
+const DEFAULT_SITE_TAGLINE = "A premium dark editorial template for EmDash.";
+
+export function resolveModernStarterSiteIdentity(
+	settings?: ModernStarterSiteIdentitySettings,
+) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/templates/modern-starter/tsconfig.json
+++ b/templates/modern-starter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": ["src/**/*", "emdash-env.d.ts"],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
+}


### PR DESCRIPTION
### ✨ What this PR adds

**`modern-starter`** — A premium, production-grade dark magazine theme for EmDash that expands the template ecosystem with a polished editorial-style option.

This PR adds:

- `templates/modern-starter/`
- `templates/modern-starter-cloudflare/`

Both templates are structured to match the repository’s existing template conventions and are designed to feel like first-class additions alongside the current starter/blog/portfolio templates.

### Why this matters

- Gives EmDash a more visually striking, magazine-style starter for users who want something more editorial and design-forward out of the box
- Improves first impressions for new users evaluating EmDash templates
- Showcases EmDash’s strengths in a more premium presentation layer while remaining fully template-oriented and easy to extend

### Included features

- Dark-first magazine aesthetic
- Hero-driven homepage
- Post cards, post meta, related posts, author box
- PortableText renderer
- Reading progress and share buttons
- Expanded demo seed content
- Repo-native template packaging
- Standard + Cloudflare variant pairing

### Repo alignment

This contribution was rebuilt to follow the repo’s actual template format rather than a standalone project layout. It includes the expected template structure and supporting files so it can fit naturally into the existing `templates/` ecosystem.

### Notes

- No existing templates were modified
- This is an additive contribution only
- Happy to iterate on naming, seed content, styling direction, or structure if maintainers want closer alignment with current template conventions

Developped by [aiautomation.top](https://aiautomation.top)