### PR TITLE
Fix R2 publicUrl being ignored for API, local provider, plugins, settings (follow-up to #675)

### DIFF
--- a/.changeset/fix-media-url-server-surfaces.md
+++ b/.changeset/fix-media-url-server-surfaces.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Extends the storage-`publicUrl` fix so the REST API, local media provider, plugin context, and site-settings resolver all honor the configured CDN / custom domain. Previously the media list/upload/confirm endpoints, the signed-upload dedup path, the `createMediaAccessWithWrite().upload()` plugin capability, the local media provider's `list`/`get`/`getEmbed`/`getThumbnailUrl`, and `resolveMediaReference` in settings all hard-coded `/_emdash/api/media/file/{key}` — so JSON responses, plugin payloads, admin list thumbnails, and `site.logo.url` / `site.favicon.url` all round-tripped through the Worker even when a CDN was configured. Each site now goes through the `resolvePublicMediaUrl()` helper introduced by the render-layer fix.

--- a/.changeset/quiet-rivers-bloom.md
+++ b/.changeset/quiet-rivers-bloom.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Renders local media through storage `publicUrl` when configured. `EmDashImage` and the Portable Text image block now call a new `locals.emdash.getPublicMediaUrl()` helper, so R2 and S3 deployments with a custom domain serve images from that domain. `S3Storage.getPublicUrl` now returns the `/_emdash/api/media/file/{key}` path when no `publicUrl` is set (previously `{endpoint}/{bucket}/{key}`).

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -43,6 +43,7 @@ import {
 } from "../emdash-runtime.js";
 import { setI18nConfig } from "../i18n/config.js";
 import type { Database, Storage } from "../index.js";
+import { resolvePublicMediaUrl } from "../media/url.js";
 import type { SandboxRunner } from "../plugins/sandbox/types.js";
 import type { ResolvedPlugin } from "../plugins/types.js";
 import { getRequestContext, runWithContext } from "../request-context.js";
@@ -301,10 +302,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					try {
 						const runtime = await getRuntime(config, initSubTimings);
 						setupVerified = true;
-						// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- partial object; getPageRuntime() only checks for these two methods
+						// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- partial object; getPageRuntime() only checks for the page-contribution methods
 						locals.emdash = {
 							collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
 							collectPageFragments: runtime.collectPageFragments.bind(runtime),
+							getPublicMediaUrl: (key: string) => resolvePublicMediaUrl(runtime.storage, key),
 						} as EmDashHandlers;
 					} catch {
 						// Non-fatal — EmDashHead will fall back to base SEO contributions
@@ -445,6 +447,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					// Direct access (for advanced use cases)
 					storage: runtime.storage,
 					db: runtime.db,
+					getPublicMediaUrl: (key: string) => resolvePublicMediaUrl(runtime.storage, key),
 					hooks: runtime.hooks,
 					email: runtime.email,
 					configuredPlugins: runtime.configuredPlugins,

--- a/packages/core/src/astro/routes/api/media.ts
+++ b/packages/core/src/astro/routes/api/media.ts
@@ -16,20 +16,28 @@ import { isParseError, parseQuery } from "#api/parse.js";
 import { DEFAULT_MAX_UPLOAD_SIZE, formatFileSize, mediaListQuery } from "#api/schemas.js";
 import { MediaRepository } from "#db/repositories/media.js";
 import { generatePlaceholder } from "#media/placeholder.js";
+import { resolvePublicMediaUrl } from "#media/url.js";
 import { computeContentHash } from "#utils/hash.js";
 
+import type { Storage } from "../../../storage/types.js";
 import type { MediaItem } from "../../types.js";
 
 export const prerender = false;
 
 /**
- * Add URL to media items
- * Uses relative URLs to ensure portability across deployments
+ * Add URL to media items.
+ *
+ * Defers to the storage adapter's `getPublicUrl()` so CDN / custom-domain
+ * configuration (e.g. R2 `publicUrl`) is honored; falls back to the internal
+ * file route when no adapter is configured.
  */
-function addUrlToMedia(item: MediaItem): MediaItem & { url: string } {
+function addUrlToMedia(
+	item: MediaItem,
+	storage: Storage | null | undefined,
+): MediaItem & { url: string } {
 	return {
 		...item,
-		url: `/_emdash/api/media/file/${item.storageKey}`,
+		url: resolvePublicMediaUrl(storage, item.storageKey),
 	};
 }
 
@@ -60,8 +68,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
 		return unwrapResult(result);
 	}
 
-	// Add URL to each media item (relative URLs for portability)
-	const itemsWithUrl = result.data.items.map((item) => addUrlToMedia(item));
+	// Add URL to each media item (honors configured storage publicUrl when set)
+	const itemsWithUrl = result.data.items.map((item) => addUrlToMedia(item, emdash.storage));
 
 	return apiSuccess({ items: itemsWithUrl, nextCursor: result.data.nextCursor });
 };
@@ -130,7 +138,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const existing = await repo.findByContentHash(contentHash);
 		if (existing) {
 			// Same content already exists - return existing item
-			const itemWithUrl = addUrlToMedia(existing);
+			const itemWithUrl = addUrlToMedia(existing, emdash.storage);
 			return apiSuccess({ item: itemWithUrl, deduplicated: true });
 		}
 
@@ -195,8 +203,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			return unwrapResult(result);
 		}
 
-		// Add URL to the response (relative URL for portability)
-		const itemWithUrl = addUrlToMedia(result.data.item);
+		// Add URL to the response (honors configured storage publicUrl when set)
+		const itemWithUrl = addUrlToMedia(result.data.item, emdash.storage);
 
 		return apiSuccess({ item: itemWithUrl }, 201);
 	} catch (error) {

--- a/packages/core/src/astro/routes/api/media/[id]/confirm.ts
+++ b/packages/core/src/astro/routes/api/media/[id]/confirm.ts
@@ -14,17 +14,27 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseOptionalBody } from "#api/parse.js";
 import { mediaConfirmBody } from "#api/schemas.js";
+import { resolvePublicMediaUrl } from "#media/url.js";
 import type { MediaItem } from "#types";
+
+import type { Storage } from "../../../../../storage/types.js";
 
 export const prerender = false;
 
 /**
- * Add URL to media item (relative URL for portability)
+ * Add URL to media item.
+ *
+ * Defers to the storage adapter's `getPublicUrl()` so CDN / custom-domain
+ * configuration (e.g. R2 `publicUrl`) is honored; falls back to the internal
+ * file route when no adapter is configured.
  */
-function addUrlToMedia(item: MediaItem): MediaItem & { url: string } {
+function addUrlToMedia(
+	item: MediaItem,
+	storage: Storage | null | undefined,
+): MediaItem & { url: string } {
 	return {
 		...item,
-		url: `/_emdash/api/media/file/${item.storageKey}`,
+		url: resolvePublicMediaUrl(storage, item.storageKey),
 	};
 }
 
@@ -83,8 +93,8 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 			return apiError("CONFIRM_FAILED", "Failed to confirm upload", 500);
 		}
 
-		// Add URL to the response (relative URL for portability)
-		const itemWithUrl = addUrlToMedia(item);
+		// Add URL to the response (honors configured storage publicUrl when set)
+		const itemWithUrl = addUrlToMedia(item, emdash.storage);
 
 		return apiSuccess({ item: itemWithUrl });
 	} catch (error) {

--- a/packages/core/src/astro/routes/api/media/upload-url.ts
+++ b/packages/core/src/astro/routes/api/media/upload-url.ts
@@ -17,6 +17,7 @@ import { requirePerm } from "#api/authorize.js";
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { DEFAULT_MAX_UPLOAD_SIZE, mediaUploadUrlBody } from "#api/schemas.js";
+import { resolvePublicMediaUrl } from "#media/url.js";
 
 export const prerender = false;
 
@@ -86,7 +87,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 					existing: true,
 					mediaId: existing.id,
 					storageKey: existing.storageKey,
-					url: `/_emdash/api/media/file/${existing.storageKey}`,
+					url: resolvePublicMediaUrl(emdash.storage, existing.storageKey),
 				};
 				return apiSuccess(response);
 			}

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -348,6 +348,7 @@ export interface EmDashHandlers {
 	// Direct access to storage and database for advanced use cases
 	storage: import("../index.js").Storage | null;
 	db: Kysely<import("../index.js").Database>;
+	getPublicMediaUrl?: (storageKey: string) => string;
 
 	// Hook pipeline for plugin integrations
 	hooks: import("../plugins/hooks.js").HookPipeline;

--- a/packages/core/src/components/EmDashImage.astro
+++ b/packages/core/src/components/EmDashImage.astro
@@ -57,10 +57,9 @@ function normalizeImage(
  */
 function buildLocalImageUrl(img: MediaValue): string {
 	const storageKey = (img.meta?.storageKey as string) || img.id;
-	if (storageKey) {
-		return `/_emdash/api/media/file/${storageKey}`;
-	}
-	return "";
+	if (!storageKey) return "";
+	const resolve = Astro.locals.emdash?.getPublicMediaUrl;
+	return resolve ? resolve(storageKey) : `/_emdash/api/media/file/${storageKey}`;
 }
 
 /**

--- a/packages/core/src/components/Image.astro
+++ b/packages/core/src/components/Image.astro
@@ -125,7 +125,8 @@ if (providerId && providerId !== "local") {
 // Fallback for local provider — prefer stored URL (includes storage key with extension),
 // fall back to _ref (bare ULID, works if media file endpoint supports ID lookup)
 if (!src) {
-	src = asset.url || `/_emdash/api/media/file/${asset._ref}`;
+	const resolve = Astro.locals.emdash?.getPublicMediaUrl;
+	src = asset.url || resolve?.(asset._ref) || `/_emdash/api/media/file/${asset._ref}`;
 }
 
 // Build placeholder background style

--- a/packages/core/src/media/local-runtime.ts
+++ b/packages/core/src/media/local-runtime.ts
@@ -183,19 +183,22 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 /**
  * Helper to convert a MediaRepository item to MediaProviderItem
  */
-export function repoItemToProviderItem(item: {
-	id: string;
-	filename: string;
-	mimeType: string;
-	size: number | null;
-	width: number | null;
-	height: number | null;
-	alt: string | null;
-	caption: string | null;
-	storageKey: string;
-	blurhash: string | null;
-	dominantColor: string | null;
-}): MediaProviderItem {
+export function repoItemToProviderItem(
+	item: {
+		id: string;
+		filename: string;
+		mimeType: string;
+		size: number | null;
+		width: number | null;
+		height: number | null;
+		alt: string | null;
+		caption: string | null;
+		storageKey: string;
+		blurhash: string | null;
+		dominantColor: string | null;
+	},
+	storage?: import("../storage/types.js").Storage | null,
+): MediaProviderItem {
 	return {
 		id: item.id,
 		filename: item.filename,
@@ -204,7 +207,7 @@ export function repoItemToProviderItem(item: {
 		width: item.width ?? undefined,
 		height: item.height ?? undefined,
 		alt: item.alt ?? undefined,
-		previewUrl: `/_emdash/api/media/file/${item.storageKey}`,
+		previewUrl: resolvePublicMediaUrl(storage, item.storageKey),
 		meta: {
 			storageKey: item.storageKey,
 			caption: item.caption,

--- a/packages/core/src/media/local-runtime.ts
+++ b/packages/core/src/media/local-runtime.ts
@@ -23,6 +23,7 @@ import type {
 	EmbedResult,
 	EmbedOptions,
 } from "./types.js";
+import { resolvePublicMediaUrl } from "./url.js";
 
 export interface LocalMediaRuntimeConfig {
 	enabled?: boolean;
@@ -61,7 +62,7 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 					width: item.width ?? undefined,
 					height: item.height ?? undefined,
 					alt: item.alt ?? undefined,
-					previewUrl: `/_emdash/api/media/file/${item.storageKey}`,
+					previewUrl: resolvePublicMediaUrl(storage, item.storageKey),
 					meta: {
 						storageKey: item.storageKey,
 						caption: item.caption,
@@ -85,7 +86,7 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 				width: item.width ?? undefined,
 				height: item.height ?? undefined,
 				alt: item.alt ?? undefined,
-				previewUrl: `/_emdash/api/media/file/${item.storageKey}`,
+				previewUrl: resolvePublicMediaUrl(storage, item.storageKey),
 				meta: {
 					storageKey: item.storageKey,
 					caption: item.caption,
@@ -125,7 +126,7 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 		getEmbed(value: MediaValue, _options?: EmbedOptions): EmbedResult {
 			const storageKey =
 				typeof value.meta?.storageKey === "string" ? value.meta.storageKey : value.id;
-			const src = `/_emdash/api/media/file/${storageKey}`;
+			const src = resolvePublicMediaUrl(storage, storageKey);
 			const mimeType = value.mimeType || "";
 
 			// Determine embed type based on MIME type
@@ -170,8 +171,9 @@ export const createMediaProvider: CreateMediaProviderFn<LocalMediaRuntimeConfig>
 		},
 
 		getThumbnailUrl(id: string, _mimeType?: string) {
-			// For local media, return the file URL
-			return `/_emdash/api/media/file/${id}`;
+			// For local media, return the file URL via the configured storage
+			// adapter (honors CDN/custom-domain) or the built-in file route.
+			return resolvePublicMediaUrl(storage, id);
 		},
 	};
 

--- a/packages/core/src/media/url.ts
+++ b/packages/core/src/media/url.ts
@@ -1,0 +1,22 @@
+/**
+ * Public media URL resolution.
+ *
+ * Used at render time by the Image components to decide whether a storage
+ * key should be served from the configured `publicUrl` (R2 custom domain,
+ * S3 CDN) or through the internal `/_emdash/api/media/file/{key}` route.
+ */
+import type { Storage } from "../storage/types.js";
+
+/**
+ * Resolve the public URL for a locally stored media key. Returns an empty
+ * string when no key is given. When a storage adapter is supplied, defers to
+ * `storage.getPublicUrl()`; otherwise returns the internal proxy route.
+ */
+export function resolvePublicMediaUrl(
+	storage: Storage | null | undefined,
+	storageKey: string,
+): string {
+	if (!storageKey) return "";
+	if (storage) return storage.getPublicUrl(storageKey);
+	return `/_emdash/api/media/file/${storageKey}`;
+}

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -21,6 +21,7 @@ import {
 	SsrfError,
 	stripCredentialHeaders,
 } from "../import/ssrf.js";
+import { resolvePublicMediaUrl } from "../media/url.js";
 import type { Storage } from "../storage/types.js";
 import { CronAccessImpl } from "./cron.js";
 import type { EmailPipeline } from "./email.js";
@@ -497,7 +498,7 @@ export function createMediaAccessWithWrite(
 			return {
 				mediaId: media.id,
 				storageKey,
-				url: `/_emdash/api/media/file/${storageKey}`,
+				url: resolvePublicMediaUrl(storage, storageKey),
 			};
 		},
 

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -11,6 +11,7 @@ import { MediaRepository } from "../database/repositories/media.js";
 import { OptionsRepository } from "../database/repositories/options.js";
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
+import { resolvePublicMediaUrl } from "../media/url.js";
 import { peekRequestCache, requestCached } from "../request-cache.js";
 import type { Storage } from "../storage/types.js";
 import type { SiteSettings, SiteSettingKey, MediaReference } from "./types.js";
@@ -31,7 +32,7 @@ function isMediaReference(value: unknown): value is MediaReference {
 async function resolveMediaReference(
 	mediaRef: MediaReference | undefined,
 	db: Kysely<Database>,
-	_storage: Storage | null,
+	storage: Storage | null,
 ): Promise<(MediaReference & { url?: string }) | undefined> {
 	if (!mediaRef?.mediaId) {
 		return mediaRef;
@@ -42,10 +43,12 @@ async function resolveMediaReference(
 		const media = await mediaRepo.findById(mediaRef.mediaId);
 
 		if (media) {
-			// Construct URL using the same pattern as API handlers
+			// Defer URL construction to the storage adapter so CDN/custom-domain
+			// configuration (e.g. R2 publicUrl) is honored. Falls back to the
+			// internal /_emdash/api/media/file route when no adapter is available.
 			return {
 				...mediaRef,
-				url: `/_emdash/api/media/file/${media.storageKey}`,
+				url: resolvePublicMediaUrl(storage, media.storageKey),
 			};
 		}
 	} catch {

--- a/packages/core/src/storage/s3.ts
+++ b/packages/core/src/storage/s3.ts
@@ -323,8 +323,8 @@ export class S3Storage implements Storage {
 		if (this.publicUrl) {
 			return `${this.publicUrl.replace(TRAILING_SLASH_PATTERN, "")}/${key}`;
 		}
-		// Default to endpoint + bucket + key
-		return `${this.endpoint.replace(TRAILING_SLASH_PATTERN, "")}/${this.bucket}/${key}`;
+		// No public URL configured; defer to the /_emdash/api/media/file route.
+		return `/_emdash/api/media/file/${key}`;
 	}
 }
 

--- a/packages/core/tests/unit/media/url.test.ts
+++ b/packages/core/tests/unit/media/url.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { resolvePublicMediaUrl } from "../../../src/media/url.js";
+import type { Storage } from "../../../src/storage/types.js";
+
+function storageWith(publicUrl: string): Storage {
+	return {
+		upload: async () => ({ key: "", url: "", size: 0 }),
+		download: async () => {
+			throw new Error("not used");
+		},
+		delete: async () => {},
+		exists: async () => true,
+		list: async () => ({ files: [] }),
+		getSignedUploadUrl: async () => {
+			throw new Error("not used");
+		},
+		getPublicUrl: (key) => `${publicUrl}/${key}`,
+	};
+}
+
+describe("resolvePublicMediaUrl", () => {
+	it("returns an empty string when storageKey is empty", () => {
+		expect(resolvePublicMediaUrl(null, "")).toBe("");
+	});
+
+	it("uses the proxied media endpoint when no storage is provided", () => {
+		expect(resolvePublicMediaUrl(null, "01ABC.jpg")).toBe("/_emdash/api/media/file/01ABC.jpg");
+	});
+
+	it("uses storage.getPublicUrl when a storage adapter is provided", () => {
+		const storage = storageWith("https://media.example.com");
+		expect(resolvePublicMediaUrl(storage, "01ABC.jpg")).toBe("https://media.example.com/01ABC.jpg");
+	});
+});

--- a/packages/core/tests/unit/settings/settings.test.ts
+++ b/packages/core/tests/unit/settings/settings.test.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach } from "vitest";
 
+import { MediaRepository } from "../../../src/database/repositories/media.js";
 import { OptionsRepository } from "../../../src/database/repositories/options.js";
 import type { Database } from "../../../src/database/types.js";
 import {
@@ -10,7 +11,24 @@ import {
 	getSiteSettingsWithDb,
 	setSiteSettings,
 } from "../../../src/settings/index.js";
+import type { Storage } from "../../../src/storage/types.js";
 import { setupTestDatabase } from "../../utils/test-db.js";
+
+function fakeStorage(publicUrl: string): Storage {
+	return {
+		upload: async () => ({ key: "", url: "", size: 0 }),
+		download: async () => {
+			throw new Error("not implemented");
+		},
+		delete: async () => {},
+		exists: async () => false,
+		list: async () => ({ files: [] }),
+		getSignedUploadUrl: async () => {
+			throw new Error("not implemented");
+		},
+		getPublicUrl: (key: string) => `${publicUrl.replace(/\/$/, "")}/${key}`,
+	};
+}
 
 describe("Site Settings", () => {
 	let db: Kysely<Database>;
@@ -214,6 +232,50 @@ describe("Site Settings", () => {
 
 			const favicon = await getSiteSettingWithDb("favicon", db, null);
 			expect(favicon?.mediaId).toBe("med_456");
+		});
+
+		it("resolves logo url via storage.getPublicUrl when storage is provided", async () => {
+			const mediaRepo = new MediaRepository(db);
+			const media = await mediaRepo.create({
+				filename: "logo.png",
+				mimeType: "image/png",
+				storageKey: "01J-logo.png",
+			});
+			await setSiteSettings({ logo: { mediaId: media.id, alt: "Logo" } }, db);
+
+			const storage = fakeStorage("https://cdn.example.com");
+			const logo = await getSiteSettingWithDb("logo", db, storage);
+
+			expect(logo?.url).toBe("https://cdn.example.com/01J-logo.png");
+		});
+
+		it("falls back to /_emdash/api/media/file when no storage is provided", async () => {
+			const mediaRepo = new MediaRepository(db);
+			const media = await mediaRepo.create({
+				filename: "logo.png",
+				mimeType: "image/png",
+				storageKey: "01J-fallback.png",
+			});
+			await setSiteSettings({ logo: { mediaId: media.id } }, db);
+
+			const logo = await getSiteSettingWithDb("logo", db, null);
+
+			expect(logo?.url).toBe("/_emdash/api/media/file/01J-fallback.png");
+		});
+
+		it("resolves logo url through getSiteSettingsWithDb when storage is provided", async () => {
+			const mediaRepo = new MediaRepository(db);
+			const media = await mediaRepo.create({
+				filename: "logo.png",
+				mimeType: "image/png",
+				storageKey: "01J-bulk.png",
+			});
+			await setSiteSettings({ logo: { mediaId: media.id } }, db);
+
+			const storage = fakeStorage("https://cdn.example.com/");
+			const settings = await getSiteSettingsWithDb(db, storage);
+
+			expect(settings.logo?.url).toBe("https://cdn.example.com/01J-bulk.png");
 		});
 	});
 });

--- a/packages/core/tests/unit/storage/s3.test.ts
+++ b/packages/core/tests/unit/storage/s3.test.ts
@@ -248,4 +248,18 @@ describe("resolveS3Config", () => {
 			expect(typeof storage.getPublicUrl).toBe("function");
 		});
 	});
+
+	describe("getPublicUrl", () => {
+		it("uses publicUrl when configured", () => {
+			setEnv({ ...FULL_ENV, S3_PUBLIC_URL: "https://cdn.example.com/" });
+			const storage = createStorage({});
+			expect(storage.getPublicUrl("01ABC.jpg")).toBe("https://cdn.example.com/01ABC.jpg");
+		});
+
+		it("falls back to the proxied media endpoint when no publicUrl is configured", () => {
+			setEnv({ ...FULL_ENV, S3_PUBLIC_URL: undefined });
+			const storage = createStorage({});
+			expect(storage.getPublicUrl("01ABC.jpg")).toBe("/_emdash/api/media/file/01ABC.jpg");
+		});
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Extends the storage-`publicUrl` fix from #675 to the server surfaces that the render-layer PR explicitly left as a follow-up.

#675 routes `EmDashImage` and the Portable Text image block through the new `resolvePublicMediaUrl()` helper so rendered media on R2/S3 deployments picks up the configured CDN. Several server surfaces still hard-code `/_emdash/api/media/file/{key}`, so the same deployments continue to round-trip through the Worker for everything that isn't a direct image render:

- `astro/routes/api/media.ts` — GET list, POST upload, dedup path
- `astro/routes/api/media/[id]/confirm.ts` — confirm response
- `astro/routes/api/media/upload-url.ts` — dedup path
- `plugins/context.ts` — `createMediaAccessWithWrite().upload` return value
- `media/local-runtime.ts` — `list`, `get`, `getEmbed`, `getThumbnailUrl`
- `settings/index.ts` — `resolveMediaReference` (was accepting an unused `_storage` arg; now actually uses it so `site.logo.url` / `site.favicon.url` are CDN-aware)

Every call site goes through `resolvePublicMediaUrl()` from #675, so there's still a single source of truth for the URL shape. Admin list thumbnails, JSON API consumers, and plugin authors now see the same CDN URL that `EmDashImage` already emits.

Related: partial follow-up to #508; the scope note in #675 calls this out explicitly.

### Stacking note

Based on top of #675. If #675 merges first, the first commit on this branch drops out as a no-op and this PR rebases cleanly to just the server-surface commit. If this one is reviewed first, merging it will subsume #675.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors; the 22 pre-existing warnings are unchanged)
- [x] `pnpm test` passes (2456 tests, including the 3 new settings cases)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (3 new cases in ``tests/unit/settings/settings.test.ts``)
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A, no admin UI changes
- [x] I have added a changeset (``.changeset/fix-media-url-server-surfaces.md``, patch bump)
- [ ] New features link to an approved Discussion — N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
 ✓ tests/unit/media/url.test.ts (3 tests) 1ms
 ✓ tests/unit/settings/settings.test.ts (20 tests) 225ms

 Test Files  147 passed (147)
      Tests  2456 passed (2456)
```