### PR TITLE
fix(admin): select dropdown appearing behind dialog

### DIFF
--- a/.changeset/fix-dialog-select-z-index.md
+++ b/.changeset/fix-dialog-select-z-index.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes select dropdown appearing behind dialog by removing explicit z-index values and adding `isolate` to the admin body for proper stacking context.

--- a/packages/admin/src/components/users/UserDetail.tsx
+++ b/packages/admin/src/components/users/UserDetail.tsx
@@ -99,13 +99,13 @@ export function UserDetail({
 			<Dialog.Portal>
 				<Dialog.Backdrop
 					className={cn(
-						"fixed inset-0 z-40 bg-black/50 transition-opacity duration-200",
+						"fixed inset-0 bg-black/50 transition-opacity duration-200",
 						"data-starting-style:opacity-0 data-ending-style:opacity-0",
 					)}
 				/>
 				<Dialog.Popup
 					className={cn(
-						"fixed top-0 end-0 z-50 flex h-full w-full max-w-md flex-col bg-kumo-base shadow-xl outline-none",
+						"fixed top-0 end-0 flex h-full w-full max-w-md flex-col bg-kumo-base shadow-xl outline-none",
 						"transform transition-transform duration-200 ease-out",
 						"data-starting-style:ltr:translate-x-full data-starting-style:rtl:-translate-x-full",
 						"data-ending-style:ltr:translate-x-full data-ending-style:rtl:-translate-x-full",

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -39,7 +39,7 @@ const pageTitle = adminConfig?.siteName ? `${adminConfig.siteName} Admin` : "EmD
 		)}
 		<title>{pageTitle}</title>
 	</head>
-	<body>
+	<body class="isolate">
 		<div id="admin-root" class="min-h-screen">
 			<div id="emdash-boot-loader">
 				<style>


### PR DESCRIPTION
## What does this PR do?

Fixes select dropdowns rendering behind dialog overlays in the admin UI. The root cause was explicit `z-index` values on the UserDetail dialog competing with select dropdown z-indexes. The fix:

1. Removes `z-40`/`z-50` from UserDetail dialog backdrop and popup
2. Adds `isolate` (CSS `isolation: isolate`) to the admin `<body>` to create a proper stacking context

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

before:
<img width="578" height="878" alt="CleanShot 2026-04-23 at 10 26 58@2x" src="https://github.com/user-attachments/assets/eecee745-b859-4382-8674-0c2418c44ab2" />

after:
<img width="482" height="618" alt="CleanShot 2026-04-23 at 10 28 40@2x" src="https://github.com/user-attachments/assets/4bdf0c1b-1bc6-46b3-a557-39ef4673abdd" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)