### PR TITLE
Fix and complete ATProto plugin syndication

### DIFF
--- a/.changeset/fix-atproto-plugin-settings.md
+++ b/.changeset/fix-atproto-plugin-settings.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-atproto": patch
+---
+
+Fixes AT Protocol plugin setup by declaring the storage collection used by the sandbox implementation, normalizing pasted PDS URLs, and exposing the missing site name and publication sync controls in the admin page.

--- a/.changeset/soft-mugs-tickle.md
+++ b/.changeset/soft-mugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Preserve clearer error logging and run sandboxed `after()` content hook tasks in parallel when deferred plugin hooks execute after save and publish.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2222,22 +2222,24 @@ export class EmDashRuntime {
 		collection: string,
 		isNew: boolean,
 	): void {
-		// Trusted plugins
-		if (this.hooks.hasHooks("content:afterSave")) {
-			this.hooks
-				.runContentAfterSave(content, collection, isNew)
-				.catch((err) => console.error("EmDash afterSave hook error:", err));
-		}
+		after(async () => {
+			// Trusted plugins
+			if (this.hooks.hasHooks("content:afterSave")) {
+				await this.hooks.runContentAfterSave(content, collection, isNew);
+			}
 
-		// Sandboxed plugins
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [id] = pluginKey.split(":");
-			if (!id || !this.isPluginEnabled(id)) continue;
+			// Sandboxed plugins
+			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
+				const [id] = pluginKey.split(":");
+				if (!id || !this.isPluginEnabled(id)) continue;
 
-			plugin
-				.invokeHook("content:afterSave", { content, collection, isNew })
-				.catch((err) => console.error(`EmDash: Sandboxed plugin ${id} afterSave error:`, err));
-		}
+				try {
+					await plugin.invokeHook("content:afterSave", { content, collection, isNew });
+				} catch (err) {
+					console.error(`EmDash: Sandboxed plugin ${id} afterSave error:`, err);
+				}
+			}
+		});
 	}
 
 	private runAfterDeleteHooks(id: string, collection: string, permanent: boolean): void {
@@ -2262,24 +2264,24 @@ export class EmDashRuntime {
 	}
 
 	private runAfterPublishHooks(content: Record<string, unknown>, collection: string): void {
-		// Trusted plugins
-		if (this.hooks.hasHooks("content:afterPublish")) {
-			this.hooks
-				.runContentAfterPublish(content, collection)
-				.catch((err) => console.error("EmDash afterPublish hook error:", err));
-		}
+		after(async () => {
+			// Trusted plugins
+			if (this.hooks.hasHooks("content:afterPublish")) {
+				await this.hooks.runContentAfterPublish(content, collection);
+			}
 
-		// Sandboxed plugins
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [pluginId] = pluginKey.split(":");
-			if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
+			// Sandboxed plugins
+			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
+				const [pluginId] = pluginKey.split(":");
+				if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
 
-			plugin
-				.invokeHook("content:afterPublish", { content, collection })
-				.catch((err) =>
-					console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err),
-				);
-		}
+				try {
+					await plugin.invokeHook("content:afterPublish", { content, collection });
+				} catch (err) {
+					console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err);
+				}
+			}
+		});
 	}
 
 	private runAfterUnpublishHooks(content: Record<string, unknown>, collection: string): void {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2225,20 +2225,30 @@ export class EmDashRuntime {
 		after(async () => {
 			// Trusted plugins
 			if (this.hooks.hasHooks("content:afterSave")) {
-				await this.hooks.runContentAfterSave(content, collection, isNew);
+				try {
+					await this.hooks.runContentAfterSave(content, collection, isNew);
+				} catch (err) {
+					console.error("EmDash afterSave hook error:", err);
+				}
 			}
 
 			// Sandboxed plugins
+			const tasks: Promise<void>[] = [];
 			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
 				const [id] = pluginKey.split(":");
 				if (!id || !this.isPluginEnabled(id)) continue;
 
-				try {
-					await plugin.invokeHook("content:afterSave", { content, collection, isNew });
-				} catch (err) {
-					console.error(`EmDash: Sandboxed plugin ${id} afterSave error:`, err);
-				}
+				tasks.push(
+					(async () => {
+						try {
+							await plugin.invokeHook("content:afterSave", { content, collection, isNew });
+						} catch (err) {
+							console.error(`EmDash: Sandboxed plugin ${id} afterSave error:`, err);
+						}
+					})(),
+				);
 			}
+			await Promise.allSettled(tasks);
 		});
 	}
 
@@ -2267,20 +2277,30 @@ export class EmDashRuntime {
 		after(async () => {
 			// Trusted plugins
 			if (this.hooks.hasHooks("content:afterPublish")) {
-				await this.hooks.runContentAfterPublish(content, collection);
+				try {
+					await this.hooks.runContentAfterPublish(content, collection);
+				} catch (err) {
+					console.error("EmDash afterPublish hook error:", err);
+				}
 			}
 
 			// Sandboxed plugins
+			const tasks: Promise<void>[] = [];
 			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
 				const [pluginId] = pluginKey.split(":");
 				if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
 
-				try {
-					await plugin.invokeHook("content:afterPublish", { content, collection });
-				} catch (err) {
-					console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err);
-				}
+				tasks.push(
+					(async () => {
+						try {
+							await plugin.invokeHook("content:afterPublish", { content, collection });
+						} catch (err) {
+							console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err);
+						}
+					})(),
+				);
 			}
+			await Promise.allSettled(tasks);
 		});
 	}
 

--- a/packages/plugins/atproto/src/admin-routing.ts
+++ b/packages/plugins/atproto/src/admin-routing.ts
@@ -1,0 +1,16 @@
+export interface AdminInteraction {
+	type?: string;
+	page?: string;
+	action_id?: string;
+	values?: Record<string, unknown>;
+}
+
+export function getAdminPageTarget(interaction?: AdminInteraction): "status" | "sync-widget" | null {
+	const interactionType = interaction?.type ?? "page_load";
+	const page = interaction?.page ?? "/status";
+
+	if (interactionType !== "page_load") return null;
+	if (page === "widget:sync-status") return "sync-widget";
+	if (page === "/" || page === "/status" || page === "/settings") return "status";
+	return null;
+}

--- a/packages/plugins/atproto/src/admin-routing.ts
+++ b/packages/plugins/atproto/src/admin-routing.ts
@@ -5,7 +5,9 @@ export interface AdminInteraction {
 	values?: Record<string, unknown>;
 }
 
-export function getAdminPageTarget(interaction?: AdminInteraction): "status" | "sync-widget" | null {
+export function getAdminPageTarget(
+	interaction?: AdminInteraction,
+): "status" | "sync-widget" | null {
 	const interactionType = interaction?.type ?? "page_load";
 	const page = interaction?.page ?? "/status";
 

--- a/packages/plugins/atproto/src/atproto.ts
+++ b/packages/plugins/atproto/src/atproto.ts
@@ -38,6 +38,32 @@ export function requireHttp(ctx: PluginContext) {
 	return ctx.http;
 }
 
+/**
+ * Normalize user-entered PDS values to the host portion expected by the
+ * AT Protocol XRPC helpers. Users often paste a full service URL.
+ */
+export function normalizePdsHost(value: string | null | undefined): string {
+	const raw = value?.trim() || "bsky.social";
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
+
+	let url: URL;
+	try {
+		url = new URL(withScheme);
+	} catch {
+		throw new Error(`Invalid PDS host: ${raw}`);
+	}
+
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		throw new Error(`Invalid PDS host protocol: ${url.protocol}`);
+	}
+
+	return url.host;
+}
+
+function xrpcUrl(pdsHost: string, method: string): string {
+	return `https://${normalizePdsHost(pdsHost)}/xrpc/${method}`;
+}
+
 /** Validate that a PDS response contains expected string fields. */
 function requireString(data: Record<string, unknown>, field: string, context: string): string {
 	const value = data[field];
@@ -59,7 +85,7 @@ export async function createSession(
 	password: string,
 ): Promise<AtSession> {
 	const http = requireHttp(ctx);
-	const res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.server.createSession`, {
+	const res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.server.createSession"), {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ identifier, password }),
@@ -88,7 +114,7 @@ export async function refreshSession(
 	refreshJwt: string,
 ): Promise<AtSession> {
 	const http = requireHttp(ctx);
-	const res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.server.refreshSession`, {
+	const res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.server.refreshSession"), {
 		method: "POST",
 		headers: { Authorization: `Bearer ${refreshJwt}` },
 	});
@@ -123,7 +149,7 @@ export async function ensureSession(ctx: PluginContext): Promise<{
 	did: string;
 	pdsHost: string;
 }> {
-	const pdsHost = (await ctx.kv.get<string>("settings:pdsHost")) || "bsky.social";
+	const pdsHost = normalizePdsHost(await ctx.kv.get<string>("settings:pdsHost"));
 	const handle = await ctx.kv.get<string>("settings:handle");
 	const appPassword = await ctx.kv.get<string>("settings:appPassword");
 
@@ -187,7 +213,7 @@ export async function createRecord(
 	record: unknown,
 ): Promise<AtRecord> {
 	const http = requireHttp(ctx);
-	let res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.createRecord`, {
+	let res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.createRecord"), {
 		method: "POST",
 		headers: {
 			Authorization: `Bearer ${accessJwt}`,
@@ -200,7 +226,7 @@ export async function createRecord(
 	if (res.status === 401) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
-			res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.createRecord`, {
+			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.createRecord"), {
 				method: "POST",
 				headers: {
 					Authorization: `Bearer ${refreshed.accessJwt}`,
@@ -237,7 +263,7 @@ export async function putRecord(
 	record: unknown,
 ): Promise<AtRecord> {
 	const http = requireHttp(ctx);
-	let res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.putRecord`, {
+	let res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.putRecord"), {
 		method: "POST",
 		headers: {
 			Authorization: `Bearer ${accessJwt}`,
@@ -249,7 +275,7 @@ export async function putRecord(
 	if (res.status === 401) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
-			res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.putRecord`, {
+			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.putRecord"), {
 				method: "POST",
 				headers: {
 					Authorization: `Bearer ${refreshed.accessJwt}`,
@@ -285,7 +311,7 @@ export async function deleteRecord(
 	rkey: string,
 ): Promise<void> {
 	const http = requireHttp(ctx);
-	let res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.deleteRecord`, {
+	let res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.deleteRecord"), {
 		method: "POST",
 		headers: {
 			Authorization: `Bearer ${accessJwt}`,
@@ -297,7 +323,7 @@ export async function deleteRecord(
 	if (res.status === 401) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
-			res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.deleteRecord`, {
+			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.deleteRecord"), {
 				method: "POST",
 				headers: {
 					Authorization: `Bearer ${refreshed.accessJwt}`,
@@ -367,7 +393,7 @@ export async function uploadBlob(
 	mimeType: string,
 ): Promise<BlobRef> {
 	const http = requireHttp(ctx);
-	const res = await http.fetch(`https://${pdsHost}/xrpc/com.atproto.repo.uploadBlob`, {
+	const res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.uploadBlob"), {
 		method: "POST",
 		headers: {
 			Authorization: `Bearer ${accessJwt}`,

--- a/packages/plugins/atproto/src/atproto.ts
+++ b/packages/plugins/atproto/src/atproto.ts
@@ -64,6 +64,18 @@ function xrpcUrl(pdsHost: string, method: string): string {
 	return `https://${normalizePdsHost(pdsHost)}/xrpc/${method}`;
 }
 
+async function responseNeedsSessionRefresh(res: Response): Promise<boolean> {
+	if (res.status === 401) return true;
+	if (res.status !== 400) return false;
+
+	try {
+		const body = (await res.clone().json()) as Record<string, unknown>;
+		return body.error === "ExpiredToken";
+	} catch {
+		return false;
+	}
+}
+
 /** Validate that a PDS response contains expected string fields. */
 function requireString(data: Record<string, unknown>, field: string, context: string): string {
 	const value = data[field];
@@ -222,8 +234,8 @@ export async function createRecord(
 		body: JSON.stringify({ repo: did, collection, record }),
 	});
 
-	// Retry once on 401 with refreshed token
-	if (res.status === 401) {
+	// Retry once when the PDS reports an expired access token.
+	if (await responseNeedsSessionRefresh(res)) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
 			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.createRecord"), {
@@ -272,7 +284,7 @@ export async function putRecord(
 		body: JSON.stringify({ repo: did, collection, rkey, record }),
 	});
 
-	if (res.status === 401) {
+	if (await responseNeedsSessionRefresh(res)) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
 			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.putRecord"), {
@@ -320,7 +332,7 @@ export async function deleteRecord(
 		body: JSON.stringify({ repo: did, collection, rkey }),
 	});
 
-	if (res.status === 401) {
+	if (await responseNeedsSessionRefresh(res)) {
 		const refreshed = await ensureSessionFresh(ctx, pdsHost);
 		if (refreshed) {
 			res = await http.fetch(xrpcUrl(pdsHost, "com.atproto.repo.deleteRecord"), {

--- a/packages/plugins/atproto/src/atproto.ts
+++ b/packages/plugins/atproto/src/atproto.ts
@@ -30,6 +30,8 @@ export interface BlobRef {
 
 // ── Helpers ─────────────────────────────────────────────────────
 
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 /** Get the HTTP client from plugin context, or throw a helpful error. */
 export function requireHttp(ctx: PluginContext) {
 	if (!ctx.http) {
@@ -44,7 +46,7 @@ export function requireHttp(ctx: PluginContext) {
  */
 export function normalizePdsHost(value: string | null | undefined): string {
 	const raw = value?.trim() || "bsky.social";
-	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
+	const withScheme = URL_SCHEME_RE.test(raw) ? raw : `https://${raw}`;
 
 	let url: URL;
 	try {
@@ -53,7 +55,7 @@ export function normalizePdsHost(value: string | null | undefined): string {
 		throw new Error(`Invalid PDS host: ${raw}`);
 	}
 
-	if (url.protocol !== "https:" && url.protocol !== "http:") {
+	if (url.protocol !== "https:") {
 		throw new Error(`Invalid PDS host protocol: ${url.protocol}`);
 	}
 

--- a/packages/plugins/atproto/src/bluesky.ts
+++ b/packages/plugins/atproto/src/bluesky.ts
@@ -52,17 +52,19 @@ export type BskyEmbed = {
  */
 export function buildBskyPost(opts: {
 	template: string;
+	collection?: string;
 	content: Record<string, unknown>;
 	siteUrl: string;
 	thumbBlob?: BlobRef;
 	langs?: string[];
 }): BskyPost {
-	const { template, content, siteUrl, thumbBlob, langs } = opts;
+	const { template, collection, content, siteUrl, thumbBlob, langs } = opts;
 
-	const title = (content.title as string) || "Untitled";
-	const slug = content.slug as string;
-	const excerpt = (content.excerpt || content.description || "") as string;
-	const url = slug ? `${stripTrailingSlash(siteUrl)}/${slug}` : siteUrl;
+	const title = getContentString(content, "title") || "Untitled";
+	const excerpt =
+		getContentString(content, "excerpt") || getContentString(content, "description") || "";
+	const path = buildContentPath(collection, content);
+	const url = path ? `${stripTrailingSlash(siteUrl)}${path}` : siteUrl;
 
 	// Apply template -- substitute before truncation so we can detect
 	// if the URL survives intact after truncation
@@ -182,4 +184,30 @@ function truncateGraphemes(text: string, maxGraphemes: number): string {
 
 function stripTrailingSlash(url: string): string {
 	return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+	const value = obj[key];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getContentData(content: Record<string, unknown>): Record<string, unknown> {
+	return content.data && typeof content.data === "object"
+		? (content.data as Record<string, unknown>)
+		: {};
+}
+
+function getContentString(content: Record<string, unknown>, key: string): string | undefined {
+	return getString(content, key) || getString(getContentData(content), key);
+}
+
+function buildContentPath(
+	collection: string | undefined,
+	content: Record<string, unknown>,
+): string | undefined {
+	const slug = getString(content, "slug");
+	if (!slug) return undefined;
+
+	if (!collection || collection === "pages") return `/${slug}`;
+	return `/${collection}/${slug}`;
 }

--- a/packages/plugins/atproto/src/bluesky.ts
+++ b/packages/plugins/atproto/src/bluesky.ts
@@ -5,6 +5,7 @@
  */
 
 import type { BlobRef } from "./atproto.js";
+import { buildContentPath, getContentString } from "./content.js";
 
 // ── Pre-compiled regexes ────────────────────────────────────────
 
@@ -184,30 +185,4 @@ function truncateGraphemes(text: string, maxGraphemes: number): string {
 
 function stripTrailingSlash(url: string): string {
 	return url.endsWith("/") ? url.slice(0, -1) : url;
-}
-
-function getString(obj: Record<string, unknown>, key: string): string | undefined {
-	const value = obj[key];
-	return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function getContentData(content: Record<string, unknown>): Record<string, unknown> {
-	return content.data && typeof content.data === "object"
-		? (content.data as Record<string, unknown>)
-		: {};
-}
-
-function getContentString(content: Record<string, unknown>, key: string): string | undefined {
-	return getString(content, key) || getString(getContentData(content), key);
-}
-
-function buildContentPath(
-	collection: string | undefined,
-	content: Record<string, unknown>,
-): string | undefined {
-	const slug = getString(content, "slug");
-	if (!slug) return undefined;
-
-	if (!collection || collection === "pages") return `/${slug}`;
-	return `/${collection}/${slug}`;
 }

--- a/packages/plugins/atproto/src/content.ts
+++ b/packages/plugins/atproto/src/content.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared content helpers for ATProto outputs.
+ *
+ * These helpers intentionally stay small and boring so standard.site and
+ * Bluesky can share path/field lookup behavior without coupling their
+ * output-specific formatting logic.
+ */
+
+export function getString(obj: Record<string, unknown>, key: string): string | undefined {
+	const value = obj[key];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function getContentData(content: Record<string, unknown>): Record<string, unknown> {
+	return content.data && typeof content.data === "object"
+		? (content.data as Record<string, unknown>)
+		: {};
+}
+
+export function getContentString(
+	content: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	return getString(content, key) || getString(getContentData(content), key);
+}
+
+export function buildContentPath(
+	collection: string | undefined,
+	content: Record<string, unknown>,
+): string | undefined {
+	const slug = getContentString(content, "slug");
+	if (!slug) return undefined;
+
+	if (!collection || collection === "pages") return `/${slug}`;
+	return `/${collection}/${slug}`;
+}

--- a/packages/plugins/atproto/src/index.ts
+++ b/packages/plugins/atproto/src/index.ts
@@ -33,7 +33,7 @@ export function atprotoPlugin(): PluginDescriptor {
 		entrypoint: "@emdash-cms/plugin-atproto/sandbox",
 		capabilities: ["read:content", "network:fetch:any"],
 		storage: {
-			publications: { indexes: ["contentId", "platform", "publishedAt"] },
+			records: { indexes: ["contentId", "status", "lastSyncedAt"] },
 		},
 		// Block Kit admin pages (no adminEntry needed -- sandboxed)
 		adminPages: [{ path: "/status", label: "AT Protocol", icon: "globe" }],

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -519,14 +519,15 @@ async function buildStatusPage(ctx: PluginContext) {
 		if (did) {
 			blocks.push({
 				type: "banner",
-				style: "success",
-				text: `Connected as ${handle} (${did})`,
+				title: "Connected",
+				description: `Connected as ${handle} (${did})`,
 			});
 		} else if (handle) {
 			blocks.push({
 				type: "banner",
-				style: "warning",
-				text: "Handle configured but not yet connected. Save settings and test the connection.",
+				variant: "alert",
+				title: "Not connected",
+				description: "Handle configured but not yet connected. Save settings and test the connection.",
 			});
 		}
 
@@ -642,7 +643,7 @@ async function buildStatusPage(ctx: PluginContext) {
 		return { blocks };
 	} catch (error) {
 		ctx.log.error("Failed to build status page", error);
-		return { blocks: [{ type: "banner", style: "error", text: "Failed to load settings" }] };
+		return { blocks: [{ type: "banner", variant: "error", title: "Failed to load settings" }] };
 	}
 }
 
@@ -665,7 +666,7 @@ async function saveSettings(ctx: PluginContext, values: Record<string, unknown>)
 	} catch (error) {
 		ctx.log.error("Failed to save settings", error);
 		return {
-			blocks: [{ type: "banner", style: "error", text: "Failed to save settings" }],
+			blocks: [{ type: "banner", variant: "error", title: "Failed to save settings" }],
 			toast: { message: "Failed to save settings", type: "error" },
 		};
 	}

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -101,6 +101,7 @@ async function syndicateContent(
 		const rkey = rkeyFromUri(existing.atUri);
 		const doc = buildDocument({
 			publicationUri,
+			collection,
 			content,
 			coverImageBlob,
 			bskyPostRef:
@@ -134,7 +135,7 @@ async function syndicateContent(
 
 		ctx.log.info(`Updated AT Protocol document for ${collection}/${contentId}`);
 	} else {
-		const doc = buildDocument({ publicationUri, content, coverImageBlob });
+		const doc = buildDocument({ publicationUri, collection, content, coverImageBlob });
 		const result = await createRecord(ctx, pdsHost, accessJwt, did, "site.standard.document", doc);
 
 		const enableCrosspost = (await ctx.kv.get<boolean>("settings:enableBskyCrosspost")) ?? true;
@@ -150,6 +151,7 @@ async function syndicateContent(
 					.slice(0, 3);
 				const post = buildBskyPost({
 					template,
+					collection,
 					content,
 					siteUrl,
 					thumbBlob: coverImageBlob,
@@ -167,7 +169,13 @@ async function syndicateContent(
 				bskyPostRef = { uri: postResult.uri, cid: postResult.cid };
 
 				const rkey = rkeyFromUri(result.uri);
-				const updatedDoc = buildDocument({ publicationUri, content, coverImageBlob, bskyPostRef });
+				const updatedDoc = buildDocument({
+					publicationUri,
+					collection,
+					content,
+					coverImageBlob,
+					bskyPostRef,
+				});
 				await putRecord(ctx, pdsHost, accessJwt, did, "site.standard.document", rkey, updatedDoc);
 
 				ctx.log.info(`Cross-posted ${collection}/${contentId} to Bluesky`);

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -17,6 +17,7 @@ import {
 	rkeyFromUri,
 	uploadBlob,
 	requireHttp,
+	normalizePdsHost,
 } from "./atproto.js";
 import { buildBskyPost } from "./bluesky.js";
 import { buildPublication, buildDocument } from "./standard-site.js";
@@ -42,7 +43,7 @@ interface SyndicationRecord {
 async function isCollectionAllowed(ctx: PluginContext, collection: string): Promise<boolean> {
 	const setting = await ctx.kv.get<string>("settings:collections");
 	if (!setting || setting.trim() === "") return true;
-	const allowed = setting.split(",").map((s) => s.trim().toLowerCase());
+	const allowed = setting.split(",").map((s: string) => s.trim().toLowerCase());
 	return allowed.includes(collection.toLowerCase());
 }
 
@@ -143,7 +144,7 @@ async function syndicateContent(
 				const langsStr = (await ctx.kv.get<string>("settings:langs")) || "en";
 				const langs = langsStr
 					.split(",")
-					.map((s) => s.trim())
+					.map((s: string) => s.trim())
 					.filter(Boolean)
 					.slice(0, 3);
 				const post = buildBskyPost({
@@ -188,6 +189,51 @@ async function syndicateContent(
 
 		ctx.log.info(`Created AT Protocol document for ${collection}/${contentId}`);
 	}
+}
+
+async function syncPublication(ctx: PluginContext) {
+	const siteUrl = await ctx.kv.get<string>("settings:siteUrl");
+	const siteName = await ctx.kv.get<string>("settings:siteName");
+	if (!siteUrl || !siteName)
+		return {
+			success: false,
+			error: "Site URL and name are required",
+		};
+
+	const { accessJwt, did, pdsHost } = await ensureSession(ctx);
+	const publication = buildPublication(siteUrl, siteName);
+	const existingUri = await ctx.kv.get<string>("state:publicationUri");
+
+	let result;
+	if (existingUri) {
+		const rkey = rkeyFromUri(existingUri);
+		result = await putRecord(
+			ctx,
+			pdsHost,
+			accessJwt,
+			did,
+			"site.standard.publication",
+			rkey,
+			publication,
+		);
+	} else {
+		result = await createRecord(
+			ctx,
+			pdsHost,
+			accessJwt,
+			did,
+			"site.standard.publication",
+			publication,
+		);
+	}
+
+	await ctx.kv.set("state:publicationUri", result.uri);
+	await ctx.kv.set("state:publicationCid", result.cid);
+	return {
+		success: true,
+		uri: result.uri,
+		cid: result.cid,
+	};
 }
 
 // ── Plugin definition ───────────────────────────────────────────
@@ -345,48 +391,7 @@ export default definePlugin({
 		"sync-publication": {
 			handler: async (_routeCtx: unknown, ctx: PluginContext) => {
 				try {
-					const siteUrl = await ctx.kv.get<string>("settings:siteUrl");
-					const siteName = await ctx.kv.get<string>("settings:siteName");
-					if (!siteUrl || !siteName)
-						return {
-							success: false,
-							error: "Site URL and name are required",
-						};
-
-					const { accessJwt, did, pdsHost } = await ensureSession(ctx);
-					const publication = buildPublication(siteUrl, siteName);
-					const existingUri = await ctx.kv.get<string>("state:publicationUri");
-
-					let result;
-					if (existingUri) {
-						const rkey = rkeyFromUri(existingUri);
-						result = await putRecord(
-							ctx,
-							pdsHost,
-							accessJwt,
-							did,
-							"site.standard.publication",
-							rkey,
-							publication,
-						);
-					} else {
-						result = await createRecord(
-							ctx,
-							pdsHost,
-							accessJwt,
-							did,
-							"site.standard.publication",
-							publication,
-						);
-					}
-
-					await ctx.kv.set("state:publicationUri", result.uri);
-					await ctx.kv.set("state:publicationCid", result.cid);
-					return {
-						success: true,
-						uri: result.uri,
-						cid: result.cid,
-					};
+					return await syncPublication(ctx);
 				} catch (error) {
 					return {
 						success: false,
@@ -450,6 +455,9 @@ export default definePlugin({
 				if (interaction.type === "block_action" && interaction.action_id === "test_connection") {
 					return testConnection(ctx);
 				}
+				if (interaction.type === "block_action" && interaction.action_id === "sync_publication") {
+					return syncPublicationAdmin(ctx);
+				}
 				return { blocks: [] };
 			},
 		},
@@ -498,7 +506,10 @@ async function buildStatusPage(ctx: PluginContext) {
 		const appPassword = await ctx.kv.get<string>("settings:appPassword");
 		const pdsHost = await ctx.kv.get<string>("settings:pdsHost");
 		const siteUrl = await ctx.kv.get<string>("settings:siteUrl");
-		const enableCrosspost = await ctx.kv.get<boolean>("settings:enableCrosspost");
+		const siteName = await ctx.kv.get<string>("settings:siteName");
+		const enableBskyCrosspost =
+			(await ctx.kv.get<boolean>("settings:enableBskyCrosspost")) ??
+			(await ctx.kv.get<boolean>("settings:enableCrosspost"));
 		const did = await ctx.kv.get<string>("state:did");
 		const pubUri = await ctx.kv.get<string>("state:publicationUri");
 
@@ -540,7 +551,7 @@ async function buildStatusPage(ctx: PluginContext) {
 					type: "text_input",
 					action_id: "pdsHost",
 					label: "PDS Host",
-					initial_value: pdsHost ?? "https://bsky.social",
+					initial_value: pdsHost ?? "bsky.social",
 				},
 				{
 					type: "text_input",
@@ -549,10 +560,16 @@ async function buildStatusPage(ctx: PluginContext) {
 					initial_value: siteUrl ?? "",
 				},
 				{
+					type: "text_input",
+					action_id: "siteName",
+					label: "Site Name",
+					initial_value: siteName ?? "",
+				},
+				{
 					type: "toggle",
-					action_id: "enableCrosspost",
+					action_id: "enableBskyCrosspost",
 					label: "Cross-post to Bluesky",
-					initial_value: enableCrosspost ?? false,
+					initial_value: enableBskyCrosspost ?? true,
 				},
 			],
 			submit: { label: "Save Settings", action_id: "save_settings" },
@@ -566,6 +583,12 @@ async function buildStatusPage(ctx: PluginContext) {
 					text: "Test Connection",
 					action_id: "test_connection",
 					style: handle && appPassword ? "primary" : undefined,
+				},
+				{
+					type: "button",
+					text: pubUri ? "Update Publication" : "Sync Publication",
+					action_id: "sync_publication",
+					style: did && siteUrl && siteName ? "primary" : undefined,
 				},
 			],
 		});
@@ -592,7 +615,7 @@ async function buildStatusPage(ctx: PluginContext) {
 							{ key: "status", label: "Status", format: "badge" },
 							{ key: "lastSyncedAt", label: "Synced", format: "relative_time" },
 						],
-						rows: items.map((r) => ({
+						rows: items.map((r: SyndicationRecord & { id: string }) => ({
 							collection: r.collection,
 							contentId: r.contentId,
 							status: r.status,
@@ -634,10 +657,14 @@ async function saveSettings(ctx: PluginContext, values: Record<string, unknown>)
 		if (typeof values.handle === "string") await ctx.kv.set("settings:handle", values.handle);
 		if (typeof values.appPassword === "string" && values.appPassword)
 			await ctx.kv.set("settings:appPassword", values.appPassword);
-		if (typeof values.pdsHost === "string") await ctx.kv.set("settings:pdsHost", values.pdsHost);
+		if (typeof values.pdsHost === "string")
+			await ctx.kv.set("settings:pdsHost", normalizePdsHost(values.pdsHost));
 		if (typeof values.siteUrl === "string") await ctx.kv.set("settings:siteUrl", values.siteUrl);
+		if (typeof values.siteName === "string") await ctx.kv.set("settings:siteName", values.siteName);
+		if (typeof values.enableBskyCrosspost === "boolean")
+			await ctx.kv.set("settings:enableBskyCrosspost", values.enableBskyCrosspost);
 		if (typeof values.enableCrosspost === "boolean")
-			await ctx.kv.set("settings:enableCrosspost", values.enableCrosspost);
+			await ctx.kv.set("settings:enableBskyCrosspost", values.enableCrosspost);
 
 		const page = await buildStatusPage(ctx);
 		return { ...page, toast: { message: "Settings saved", type: "success" } };
@@ -664,6 +691,30 @@ async function testConnection(ctx: PluginContext) {
 			...page,
 			toast: {
 				message: `Connection failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+				type: "error",
+			},
+		};
+	}
+}
+
+async function syncPublicationAdmin(ctx: PluginContext) {
+	try {
+		const result = await syncPublication(ctx);
+		const page = await buildStatusPage(ctx);
+		return {
+			...page,
+			toast: result.success
+				? { message: "Publication synced", type: "success" }
+				: { message: result.error ?? "Failed to sync publication", type: "error" },
+		};
+	} catch (error) {
+		const page = await buildStatusPage(ctx);
+		return {
+			...page,
+			toast: {
+				message: `Publication sync failed: ${
+					error instanceof Error ? error.message : "Unknown error"
+				}`,
 				type: "error",
 			},
 		};

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -99,15 +99,51 @@ async function syndicateContent(
 
 	if (existing && existing.atUri) {
 		const rkey = rkeyFromUri(existing.atUri);
+		bskyPostRef =
+			existing.bskyPostUri && existing.bskyPostCid
+				? { uri: existing.bskyPostUri, cid: existing.bskyPostCid }
+				: undefined;
+
+		const enableCrosspost = (await ctx.kv.get<boolean>("settings:enableBskyCrosspost")) ?? true;
+		if (enableCrosspost && existing.bskyPostUri) {
+			try {
+				const template =
+					(await ctx.kv.get<string>("settings:crosspostTemplate")) || "{title}\n\n{url}";
+				const langsStr = (await ctx.kv.get<string>("settings:langs")) || "en";
+				const langs = langsStr
+					.split(",")
+					.map((s: string) => s.trim())
+					.filter(Boolean)
+					.slice(0, 3);
+				const post = buildBskyPost({
+					template,
+					collection,
+					content,
+					siteUrl,
+					thumbBlob: coverImageBlob,
+					langs,
+				});
+				const postResult = await putRecord(
+					ctx,
+					pdsHost,
+					accessJwt,
+					did,
+					"app.bsky.feed.post",
+					rkeyFromUri(existing.bskyPostUri),
+					post,
+				);
+				bskyPostRef = { uri: postResult.uri, cid: postResult.cid };
+			} catch (error) {
+				ctx.log.warn("Failed to update Bluesky cross-post, document still synced", error);
+			}
+		}
+
 		const doc = buildDocument({
 			publicationUri,
 			collection,
 			content,
 			coverImageBlob,
-			bskyPostRef:
-				existing.bskyPostUri && existing.bskyPostCid
-					? { uri: existing.bskyPostUri, cid: existing.bskyPostCid }
-					: undefined,
+			bskyPostRef,
 		});
 
 		const result = await putRecord(
@@ -125,8 +161,8 @@ async function syndicateContent(
 			contentId: existing.contentId,
 			atUri: result.uri,
 			atCid: result.cid,
-			bskyPostUri: existing.bskyPostUri,
-			bskyPostCid: existing.bskyPostCid,
+			bskyPostUri: bskyPostRef?.uri,
+			bskyPostCid: bskyPostRef?.cid,
 			publishedAt: existing.publishedAt,
 			lastSyncedAt: new Date().toISOString(),
 			status: "synced",

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -41,10 +41,14 @@ interface SyndicationRecord {
 
 // ── Helpers ─────────────────────────────────────────────────────
 
+const DEFAULT_SYNDICATED_COLLECTIONS = ["posts"];
+
 async function isCollectionAllowed(ctx: PluginContext, collection: string): Promise<boolean> {
 	const setting = await ctx.kv.get<string>("settings:collections");
-	if (!setting || setting.trim() === "") return true;
-	const allowed = setting.split(",").map((s: string) => s.trim().toLowerCase());
+	const configured = setting?.trim();
+	const allowed = configured
+		? configured.split(",").map((s: string) => s.trim().toLowerCase())
+		: DEFAULT_SYNDICATED_COLLECTIONS;
 	return allowed.includes(collection.toLowerCase());
 }
 
@@ -565,6 +569,7 @@ async function buildStatusPage(ctx: PluginContext) {
 		const pdsHost = await ctx.kv.get<string>("settings:pdsHost");
 		const siteUrl = await ctx.kv.get<string>("settings:siteUrl");
 		const siteName = await ctx.kv.get<string>("settings:siteName");
+		const collections = await ctx.kv.get<string>("settings:collections");
 		const enableBskyCrosspost =
 			(await ctx.kv.get<boolean>("settings:enableBskyCrosspost")) ??
 			(await ctx.kv.get<boolean>("settings:enableCrosspost"));
@@ -624,6 +629,12 @@ async function buildStatusPage(ctx: PluginContext) {
 					action_id: "siteName",
 					label: "Site Name",
 					initial_value: siteName ?? "",
+				},
+				{
+					type: "text_input",
+					action_id: "collections",
+					label: "Collections to syndicate",
+					initial_value: collections ?? DEFAULT_SYNDICATED_COLLECTIONS.join(","),
 				},
 				{
 					type: "toggle",
@@ -721,6 +732,8 @@ async function saveSettings(ctx: PluginContext, values: Record<string, unknown>)
 			await ctx.kv.set("settings:pdsHost", normalizePdsHost(values.pdsHost));
 		if (typeof values.siteUrl === "string") await ctx.kv.set("settings:siteUrl", values.siteUrl);
 		if (typeof values.siteName === "string") await ctx.kv.set("settings:siteName", values.siteName);
+		if (typeof values.collections === "string")
+			await ctx.kv.set("settings:collections", values.collections);
 		if (typeof values.enableBskyCrosspost === "boolean")
 			await ctx.kv.set("settings:enableBskyCrosspost", values.enableBskyCrosspost);
 		if (typeof values.enableCrosspost === "boolean")

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -19,6 +19,7 @@ import {
 	requireHttp,
 	normalizePdsHost,
 } from "./atproto.js";
+import { getAdminPageTarget, type AdminInteraction } from "./admin-routing.js";
 import { buildBskyPost } from "./bluesky.js";
 import { buildPublication, buildDocument } from "./standard-site.js";
 
@@ -436,26 +437,19 @@ export default definePlugin({
 
 		admin: {
 			handler: async (routeCtx: any, ctx: PluginContext) => {
-				const interaction = routeCtx.input as {
-					type: string;
-					page?: string;
-					action_id?: string;
-					values?: Record<string, unknown>;
-				};
+				const interaction = routeCtx.input as AdminInteraction | undefined;
+				const interactionType = interaction?.type ?? "page_load";
+				const pageTarget = getAdminPageTarget(interaction);
 
-				if (interaction.type === "page_load" && interaction.page === "widget:sync-status") {
-					return buildSyncWidget(ctx);
-				}
-				if (interaction.type === "page_load" && interaction.page === "/status") {
-					return buildStatusPage(ctx);
-				}
-				if (interaction.type === "form_submit" && interaction.action_id === "save_settings") {
+				if (pageTarget === "sync-widget") return buildSyncWidget(ctx);
+				if (pageTarget === "status") return buildStatusPage(ctx);
+				if (interactionType === "form_submit" && interaction?.action_id === "save_settings") {
 					return saveSettings(ctx, interaction.values ?? {});
 				}
-				if (interaction.type === "block_action" && interaction.action_id === "test_connection") {
+				if (interactionType === "block_action" && interaction?.action_id === "test_connection") {
 					return testConnection(ctx);
 				}
-				if (interaction.type === "block_action" && interaction.action_id === "sync_publication") {
+				if (interactionType === "block_action" && interaction?.action_id === "sync_publication") {
 					return syncPublicationAdmin(ctx);
 				}
 				return { blocks: [] };

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -574,13 +574,13 @@ async function buildStatusPage(ctx: PluginContext) {
 			elements: [
 				{
 					type: "button",
-					text: "Test Connection",
+					label: "Test Connection",
 					action_id: "test_connection",
 					style: handle && appPassword ? "primary" : undefined,
 				},
 				{
 					type: "button",
-					text: pubUri ? "Update Publication" : "Sync Publication",
+					label: pubUri ? "Update Publication" : "Sync Publication",
 					action_id: "sync_publication",
 					style: did && siteUrl && siteName ? "primary" : undefined,
 				},

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -9,6 +9,7 @@
 import { definePlugin } from "emdash";
 import type { PluginContext } from "emdash";
 
+import { getAdminPageTarget, type AdminInteraction } from "./admin-routing.js";
 import {
 	ensureSession,
 	createRecord,
@@ -19,7 +20,6 @@ import {
 	requireHttp,
 	normalizePdsHost,
 } from "./atproto.js";
-import { getAdminPageTarget, type AdminInteraction } from "./admin-routing.js";
 import { buildBskyPost } from "./bluesky.js";
 import { buildPublication, buildDocument } from "./standard-site.js";
 

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -527,7 +527,8 @@ async function buildStatusPage(ctx: PluginContext) {
 				type: "banner",
 				variant: "alert",
 				title: "Not connected",
-				description: "Handle configured but not yet connected. Save settings and test the connection.",
+				description:
+					"Handle configured but not yet connected. Save settings and test the connection.",
 			});
 		}
 

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -237,6 +237,42 @@ async function syncPublication(ctx: PluginContext) {
 	};
 }
 
+async function syndicatePublishedContent(
+	event: { content: Record<string, unknown>; collection: string },
+	ctx: PluginContext,
+) {
+	const { content, collection } = event;
+	const contentId = typeof content.id === "string" ? content.id : String(content.id);
+	const status = content.status as string | undefined;
+
+	if (status !== "published") return;
+	if (!(await isCollectionAllowed(ctx, collection))) return;
+
+	try {
+		await syndicateContent(ctx, collection, contentId, content);
+	} catch (error) {
+		ctx.log.error(`Failed to syndicate ${collection}/${contentId}`, error);
+
+		const storageKey = `${collection}:${contentId}`;
+		const existing = await ctx.storage.records!.get(storageKey);
+		const record = (existing as SyndicationRecord | null) || {
+			collection,
+			contentId,
+			atUri: "",
+			atCid: "",
+			publishedAt: new Date().toISOString(),
+		};
+
+		await ctx.storage.records!.put(storageKey, {
+			...record,
+			status: "error",
+			lastSyncedAt: new Date().toISOString(),
+			errorMessage: error instanceof Error ? error.message : String(error),
+			retryCount: ((record as SyndicationRecord).retryCount || 0) + 1,
+		});
+	}
+}
+
 // ── Plugin definition ───────────────────────────────────────────
 
 export default definePlugin({
@@ -250,36 +286,16 @@ export default definePlugin({
 				event: { content: Record<string, unknown>; collection: string; isNew: boolean },
 				ctx: PluginContext,
 			) => {
-				const { content, collection } = event;
-				const contentId = typeof content.id === "string" ? content.id : String(content.id);
-				const status = content.status as string | undefined;
+				await syndicatePublishedContent(event, ctx);
+			},
+		},
 
-				if (status !== "published") return;
-				if (!(await isCollectionAllowed(ctx, collection))) return;
-
-				try {
-					await syndicateContent(ctx, collection, contentId, content);
-				} catch (error) {
-					ctx.log.error(`Failed to syndicate ${collection}/${contentId}`, error);
-
-					const storageKey = `${collection}:${contentId}`;
-					const existing = await ctx.storage.records!.get(storageKey);
-					const record = (existing as SyndicationRecord | null) || {
-						collection,
-						contentId,
-						atUri: "",
-						atCid: "",
-						publishedAt: new Date().toISOString(),
-					};
-
-					await ctx.storage.records!.put(storageKey, {
-						...record,
-						status: "error",
-						lastSyncedAt: new Date().toISOString(),
-						errorMessage: error instanceof Error ? error.message : String(error),
-						retryCount: ((record as SyndicationRecord).retryCount || 0) + 1,
-					});
-				}
+		"content:afterPublish": {
+			handler: async (
+				event: { content: Record<string, unknown>; collection: string },
+				ctx: PluginContext,
+			) => {
+				await syndicatePublishedContent(event, ctx);
 			},
 		},
 

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -53,9 +53,12 @@ async function syndicateContent(
 	collection: string,
 	contentId: string,
 	content: Record<string, unknown>,
+	options: { allowCreate?: boolean } = {},
 ): Promise<void> {
 	const storageKey = `${collection}:${contentId}`;
 	const existing = (await ctx.storage.records!.get(storageKey)) as SyndicationRecord | null;
+
+	if (!existing?.atUri && options.allowCreate === false) return;
 
 	if (existing && existing.status === "synced") {
 		const syncOnUpdate = (await ctx.kv.get<boolean>("settings:syncOnUpdate")) ?? true;
@@ -284,6 +287,7 @@ async function syncPublication(ctx: PluginContext) {
 async function syndicatePublishedContent(
 	event: { content: Record<string, unknown>; collection: string },
 	ctx: PluginContext,
+	options: { allowCreate?: boolean } = {},
 ) {
 	const { content, collection } = event;
 	const contentId = typeof content.id === "string" ? content.id : String(content.id);
@@ -293,7 +297,7 @@ async function syndicatePublishedContent(
 	if (!(await isCollectionAllowed(ctx, collection))) return;
 
 	try {
-		await syndicateContent(ctx, collection, contentId, content);
+		await syndicateContent(ctx, collection, contentId, content, options);
 	} catch (error) {
 		ctx.log.error(`Failed to syndicate ${collection}/${contentId}`, error);
 
@@ -330,7 +334,7 @@ export default definePlugin({
 				event: { content: Record<string, unknown>; collection: string; isNew: boolean },
 				ctx: PluginContext,
 			) => {
-				await syndicatePublishedContent(event, ctx);
+				await syndicatePublishedContent(event, ctx, { allowCreate: false });
 			},
 		},
 
@@ -339,7 +343,7 @@ export default definePlugin({
 				event: { content: Record<string, unknown>; collection: string },
 				ctx: PluginContext,
 			) => {
-				await syndicatePublishedContent(event, ctx);
+				await syndicatePublishedContent(event, ctx, { allowCreate: true });
 			},
 		},
 

--- a/packages/plugins/atproto/src/sandbox-entry.ts
+++ b/packages/plugins/atproto/src/sandbox-entry.ts
@@ -385,6 +385,7 @@ export default definePlugin({
 		) => {
 			const pageContent = event.page.content;
 			if (!pageContent) return null;
+			if (!(await isCollectionAllowed(ctx, pageContent.collection))) return null;
 
 			const storageKey = `${pageContent.collection}:${pageContent.id}`;
 			const record = (await ctx.storage.records!.get(storageKey)) as SyndicationRecord | null;

--- a/packages/plugins/atproto/src/standard-site.ts
+++ b/packages/plugins/atproto/src/standard-site.ts
@@ -61,17 +61,20 @@ export function buildPublication(
  */
 export function buildDocument(opts: {
 	publicationUri: string;
+	collection?: string;
 	content: Record<string, unknown>;
 	coverImageBlob?: BlobRefLike;
 	bskyPostRef?: { uri: string; cid: string };
 }): StandardDocument {
-	const { publicationUri, content, coverImageBlob, bskyPostRef } = opts;
+	const { publicationUri, collection, content, coverImageBlob, bskyPostRef } = opts;
 
-	const slug = getString(content, "slug");
-	const title = getString(content, "title") || "Untitled";
-	const description = getString(content, "excerpt") || getString(content, "description");
-	const publishedAt = getString(content, "published_at") || new Date().toISOString();
-	const updatedAt = getString(content, "updated_at");
+	const title = getContentString(content, "title") || "Untitled";
+	const description = getContentString(content, "excerpt") || getContentString(content, "description");
+	const publishedAt =
+		getString(content, "publishedAt") ||
+		getString(content, "published_at") ||
+		new Date().toISOString();
+	const updatedAt = getString(content, "updatedAt") || getString(content, "updated_at");
 	const tags = extractTags(content);
 
 	const doc: StandardDocument = {
@@ -81,9 +84,8 @@ export function buildDocument(opts: {
 		publishedAt,
 	};
 
-	if (slug) {
-		doc.path = `/${slug}`;
-	}
+	const path = buildContentPath(collection, content);
+	if (path) doc.path = path;
 
 	if (description) {
 		doc.description = description;
@@ -136,12 +138,33 @@ function getString(obj: Record<string, unknown>, key: string): string | undefine
 	return typeof v === "string" && v.length > 0 ? v : undefined;
 }
 
+function getContentData(content: Record<string, unknown>): Record<string, unknown> {
+	return content.data && typeof content.data === "object"
+		? (content.data as Record<string, unknown>)
+		: {};
+}
+
+function getContentString(content: Record<string, unknown>, key: string): string | undefined {
+	return getString(content, key) || getString(getContentData(content), key);
+}
+
+export function buildContentPath(
+	collection: string | undefined,
+	content: Record<string, unknown>,
+): string | undefined {
+	const slug = getString(content, "slug");
+	if (!slug) return undefined;
+
+	if (!collection || collection === "pages") return `/${slug}`;
+	return `/${collection}/${slug}`;
+}
+
 /**
  * Extract tags from content. Handles both string arrays and
  * tag objects with a name property.
  */
 function extractTags(content: Record<string, unknown>): string[] {
-	const raw = content.tags;
+	const raw = content.tags || getContentData(content).tags;
 	if (!Array.isArray(raw)) return [];
 
 	const tags: string[] = [];
@@ -167,7 +190,9 @@ function extractTags(content: Record<string, unknown>): string[] {
 export function extractPlainText(content: Record<string, unknown>): string | undefined {
 	// Try common content field names
 	const body =
-		getString(content, "body") || getString(content, "content") || getString(content, "text");
+		getContentString(content, "body") ||
+		getContentString(content, "content") ||
+		getContentString(content, "text");
 
 	if (!body) return undefined;
 

--- a/packages/plugins/atproto/src/standard-site.ts
+++ b/packages/plugins/atproto/src/standard-site.ts
@@ -69,7 +69,8 @@ export function buildDocument(opts: {
 	const { publicationUri, collection, content, coverImageBlob, bskyPostRef } = opts;
 
 	const title = getContentString(content, "title") || "Untitled";
-	const description = getContentString(content, "excerpt") || getContentString(content, "description");
+	const description =
+		getContentString(content, "excerpt") || getContentString(content, "description");
 	const publishedAt =
 		getString(content, "publishedAt") ||
 		getString(content, "published_at") ||

--- a/packages/plugins/atproto/src/standard-site.ts
+++ b/packages/plugins/atproto/src/standard-site.ts
@@ -5,6 +5,8 @@
  * from EmDash content.
  */
 
+import { buildContentPath, getContentData, getContentString, getString } from "./content.js";
+
 // ── Types ───────────────────────────────────────────────────────
 
 export interface StandardPublication {
@@ -133,32 +135,6 @@ const APOS_RE = /&#39;/g;
 const WHITESPACE_RE = /\s+/g;
 const HASH_PREFIX_RE = /^#/;
 const MAX_TEXT_CONTENT_LENGTH = 10_000;
-
-function getString(obj: Record<string, unknown>, key: string): string | undefined {
-	const v = obj[key];
-	return typeof v === "string" && v.length > 0 ? v : undefined;
-}
-
-function getContentData(content: Record<string, unknown>): Record<string, unknown> {
-	return content.data && typeof content.data === "object"
-		? (content.data as Record<string, unknown>)
-		: {};
-}
-
-function getContentString(content: Record<string, unknown>, key: string): string | undefined {
-	return getString(content, key) || getString(getContentData(content), key);
-}
-
-export function buildContentPath(
-	collection: string | undefined,
-	content: Record<string, unknown>,
-): string | undefined {
-	const slug = getString(content, "slug");
-	if (!slug) return undefined;
-
-	if (!collection || collection === "pages") return `/${slug}`;
-	return `/${collection}/${slug}`;
-}
 
 /**
  * Extract tags from content. Handles both string arrays and

--- a/packages/plugins/atproto/tests/admin-routing.test.ts
+++ b/packages/plugins/atproto/tests/admin-routing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getAdminPageTarget } from "../src/admin-routing.js";
+
+describe("getAdminPageTarget", () => {
+	it.each([
+		[undefined, "status"],
+		[{}, "status"],
+		[{ type: "page_load" }, "status"],
+		[{ type: "page_load", page: "/" }, "status"],
+		[{ type: "page_load", page: "/settings" }, "status"],
+		[{ type: "page_load", page: "/status" }, "status"],
+		[{ type: "page_load", page: "widget:sync-status" }, "sync-widget"],
+		[{ type: "page_load", page: "/unknown" }, null],
+		[{ type: "block_action", page: "/status" }, null],
+	])("maps %j to %s", (interaction, expected) => {
+		expect(getAdminPageTarget(interaction)).toBe(expected);
+	});
+});

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -66,9 +66,12 @@ describe("createRecord", () => {
 				),
 			)
 			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ uri: "at://did:plc:test/site.standard.publication/abc", cid: "cid" }), {
-					status: 200,
-				}),
+				new Response(
+					JSON.stringify({ uri: "at://did:plc:test/site.standard.publication/abc", cid: "cid" }),
+					{
+						status: 200,
+					},
+				),
 			);
 		const ctx = {
 			http: { fetch },

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -41,7 +41,7 @@ describe("createRecord", () => {
 	it("refreshes the session when the PDS returns a 400 ExpiredToken response", async () => {
 		const kv = new Map<string, unknown>([
 			["settings:pdsHost", "bsky.social"],
-			["settings:handle", "afterword.blog"],
+			["settings:handle", "example.com"],
 			["settings:appPassword", "app-password"],
 			["state:accessJwt", "stale-access"],
 			["state:refreshJwt", "refresh-token"],
@@ -60,7 +60,7 @@ describe("createRecord", () => {
 						accessJwt: "fresh-access",
 						refreshJwt: "fresh-refresh",
 						did: "did:plc:test",
-						handle: "afterword.blog",
+						handle: "example.com",
 					}),
 					{ status: 200 },
 				),
@@ -89,7 +89,7 @@ describe("createRecord", () => {
 			"stale-access",
 			"did:plc:test",
 			"site.standard.publication",
-			{ name: "Afterword" },
+			{ name: "Example Site" },
 		);
 
 		expect(result).toEqual({ uri: "at://did:plc:test/site.standard.publication/abc", cid: "cid" });

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -16,8 +16,14 @@ describe("normalizePdsHost", () => {
 		expect(normalizePdsHost("https://example.com/")).toBe("example.com");
 	});
 
-	it("preserves ports", () => {
-		expect(normalizePdsHost("http://localhost:2583")).toBe("localhost:2583");
+	it("preserves ports for https URLs", () => {
+		expect(normalizePdsHost("https://localhost:2583")).toBe("localhost:2583");
+	});
+
+	it("rejects non-https protocols", () => {
+		expect(() => normalizePdsHost("http://localhost:2583")).toThrow(
+			"Invalid PDS host protocol: http:",
+		);
 	});
 });
 

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-import { normalizePdsHost, rkeyFromUri } from "../src/atproto.js";
+import { createRecord, normalizePdsHost, rkeyFromUri } from "../src/atproto.js";
 
 describe("normalizePdsHost", () => {
 	it("defaults to bsky.social", () => {
@@ -34,5 +34,64 @@ describe("rkeyFromUri", () => {
 
 	it("throws on empty URI", () => {
 		expect(() => rkeyFromUri("")).toThrow("Invalid AT-URI");
+	});
+});
+
+describe("createRecord", () => {
+	it("refreshes the session when the PDS returns a 400 ExpiredToken response", async () => {
+		const kv = new Map<string, unknown>([
+			["settings:pdsHost", "bsky.social"],
+			["settings:handle", "afterword.blog"],
+			["settings:appPassword", "app-password"],
+			["state:accessJwt", "stale-access"],
+			["state:refreshJwt", "refresh-token"],
+			["state:did", "did:plc:test"],
+		]);
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ error: "ExpiredToken", message: "Token has expired" }), {
+					status: 400,
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						accessJwt: "fresh-access",
+						refreshJwt: "fresh-refresh",
+						did: "did:plc:test",
+						handle: "afterword.blog",
+					}),
+					{ status: 200 },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ uri: "at://did:plc:test/site.standard.publication/abc", cid: "cid" }), {
+					status: 200,
+				}),
+			);
+		const ctx = {
+			http: { fetch },
+			kv: {
+				get: vi.fn(async (key: string) => kv.get(key)),
+				set: vi.fn(async (key: string, value: unknown) => {
+					kv.set(key, value);
+				}),
+			},
+		} as any;
+
+		const result = await createRecord(
+			ctx,
+			"bsky.social",
+			"stale-access",
+			"did:plc:test",
+			"site.standard.publication",
+			{ name: "Afterword" },
+		);
+
+		expect(result).toEqual({ uri: "at://did:plc:test/site.standard.publication/abc", cid: "cid" });
+		expect(fetch).toHaveBeenCalledTimes(3);
+		expect(kv.get("state:accessJwt")).toBe("fresh-access");
+		expect(kv.get("state:refreshJwt")).toBe("fresh-refresh");
 	});
 });

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect } from "vitest";
 
-import { rkeyFromUri } from "../src/atproto.js";
+import { normalizePdsHost, rkeyFromUri } from "../src/atproto.js";
+
+describe("normalizePdsHost", () => {
+	it("defaults to bsky.social", () => {
+		expect(normalizePdsHost(undefined)).toBe("bsky.social");
+	});
+
+	it("accepts host-only values", () => {
+		expect(normalizePdsHost("bsky.social")).toBe("bsky.social");
+	});
+
+	it("accepts full PDS URLs", () => {
+		expect(normalizePdsHost("https://bsky.social")).toBe("bsky.social");
+		expect(normalizePdsHost("https://example.com/")).toBe("example.com");
+	});
+
+	it("preserves ports", () => {
+		expect(normalizePdsHost("http://localhost:2583")).toBe("localhost:2583");
+	});
+});
 
 describe("rkeyFromUri", () => {
 	it("extracts rkey from a standard AT-URI", () => {

--- a/packages/plugins/atproto/tests/bluesky.test.ts
+++ b/packages/plugins/atproto/tests/bluesky.test.ts
@@ -193,6 +193,20 @@ describe("buildBskyPost", () => {
 		expect(post.text).toBe("https://myblog.com/my-article");
 	});
 
+	it("reads slug from content.data when building URLs", () => {
+		const post = buildBskyPost({
+			template: "{url}",
+			collection: "posts",
+			content: {
+				title: "Nested Slug",
+				data: { slug: "nested-slug" },
+			},
+			siteUrl: "https://myblog.com",
+		});
+		expect(post.text).toBe("https://myblog.com/posts/nested-slug");
+		expect(post.embed?.external.uri).toBe("https://myblog.com/posts/nested-slug");
+	});
+
 	it("skips facets when text is truncated to avoid partial URL links", () => {
 		// Create content with very long excerpt that forces truncation
 		const longExcerpt = "A".repeat(300);

--- a/packages/plugins/atproto/tests/plugin.test.ts
+++ b/packages/plugins/atproto/tests/plugin.test.ts
@@ -28,7 +28,9 @@ describe("atprotoPlugin descriptor", () => {
 
 	it("exposes an admin status page and widget", () => {
 		const descriptor = atprotoPlugin();
-		expect(descriptor.adminPages).toEqual([{ path: "/status", label: "AT Protocol", icon: "globe" }]);
+		expect(descriptor.adminPages).toEqual([
+			{ path: "/status", label: "AT Protocol", icon: "globe" },
+		]);
 		expect(descriptor.adminWidgets).toEqual([
 			{ id: "sync-status", title: "AT Protocol", size: "third" },
 		]);

--- a/packages/plugins/atproto/tests/plugin.test.ts
+++ b/packages/plugins/atproto/tests/plugin.test.ts
@@ -1,82 +1,36 @@
 import { describe, it, expect } from "vitest";
 
-import { atprotoPlugin, createPlugin } from "../src/index.js";
+import { atprotoPlugin } from "../src/index.js";
 
 describe("atprotoPlugin descriptor", () => {
 	it("returns a valid PluginDescriptor", () => {
 		const descriptor = atprotoPlugin();
 		expect(descriptor.id).toBe("atproto");
 		expect(descriptor.version).toBe("0.1.0");
-		expect(descriptor.entrypoint).toBe("@emdash-cms/plugin-atproto");
+		expect(descriptor.entrypoint).toBe("@emdash-cms/plugin-atproto/sandbox");
 		expect(descriptor.adminPages).toHaveLength(1);
 		expect(descriptor.adminWidgets).toHaveLength(1);
 	});
 
-	it("passes options through", () => {
-		const descriptor = atprotoPlugin({});
-		expect(descriptor.options).toEqual({});
-	});
-});
-
-describe("createPlugin", () => {
-	it("returns a valid ResolvedPlugin", () => {
-		const plugin = createPlugin();
-		expect(plugin.id).toBe("atproto");
-		expect(plugin.version).toBe("0.1.0");
-		expect(plugin.capabilities).toContain("read:content");
-		expect(plugin.capabilities).toContain("network:fetch:any");
+	it("declares the storage used by the sandbox implementation", () => {
+		const descriptor = atprotoPlugin();
+		expect(descriptor.storage).toHaveProperty("records");
+		expect(descriptor.storage!.records!.indexes).toContain("contentId");
+		expect(descriptor.storage!.records!.indexes).toContain("status");
+		expect(descriptor.storage!.records!.indexes).toContain("lastSyncedAt");
 	});
 
-	it("uses unrestricted network access (implies network:fetch)", () => {
-		const plugin = createPlugin();
-		expect(plugin.capabilities).toContain("network:fetch:any");
-		// network:fetch:any implies network:fetch via definePlugin normalization
-		expect(plugin.capabilities).toContain("network:fetch");
+	it("declares required capabilities", () => {
+		const descriptor = atprotoPlugin();
+		expect(descriptor.capabilities).toContain("read:content");
+		expect(descriptor.capabilities).toContain("network:fetch:any");
 	});
 
-	it("declares storage with records collection", () => {
-		const plugin = createPlugin();
-		expect(plugin.storage).toHaveProperty("records");
-		expect(plugin.storage!.records!.indexes).toContain("contentId");
-		expect(plugin.storage!.records!.indexes).toContain("status");
-	});
-
-	it("has content:afterSave hook with errorPolicy continue", () => {
-		const plugin = createPlugin();
-		const hook = plugin.hooks!["content:afterSave"];
-		expect(hook).toBeDefined();
-		// Hook is configured with full config object
-		expect((hook as { errorPolicy: string }).errorPolicy).toBe("continue");
-	});
-
-	it("has content:afterDelete hook", () => {
-		const plugin = createPlugin();
-		expect(plugin.hooks!["content:afterDelete"]).toBeDefined();
-	});
-
-	it("has page:metadata hook", () => {
-		const plugin = createPlugin();
-		expect(plugin.hooks!["page:metadata"]).toBeDefined();
-	});
-
-	it("has settings schema with required fields", () => {
-		const plugin = createPlugin();
-		const schema = plugin.admin!.settingsSchema!;
-		expect(schema).toHaveProperty("handle");
-		expect(schema).toHaveProperty("appPassword");
-		expect(schema).toHaveProperty("siteUrl");
-		expect(schema).toHaveProperty("enableBskyCrosspost");
-		expect(schema).toHaveProperty("crosspostTemplate");
-		expect(schema).toHaveProperty("langs");
-		expect(schema.appPassword!.type).toBe("secret");
-	});
-
-	it("has routes for status, test-connection, sync-publication", () => {
-		const plugin = createPlugin();
-		expect(plugin.routes).toHaveProperty("status");
-		expect(plugin.routes).toHaveProperty("test-connection");
-		expect(plugin.routes).toHaveProperty("sync-publication");
-		expect(plugin.routes).toHaveProperty("recent-syncs");
-		expect(plugin.routes).toHaveProperty("verification");
+	it("exposes an admin status page and widget", () => {
+		const descriptor = atprotoPlugin();
+		expect(descriptor.adminPages).toEqual([{ path: "/status", label: "AT Protocol", icon: "globe" }]);
+		expect(descriptor.adminWidgets).toEqual([
+			{ id: "sync-status", title: "AT Protocol", size: "third" },
+		]);
 	});
 });

--- a/packages/plugins/atproto/tests/sandbox-entry.test.ts
+++ b/packages/plugins/atproto/tests/sandbox-entry.test.ts
@@ -51,4 +51,27 @@ describe("sandbox hooks", () => {
 		expect(ctx.http.fetch).not.toHaveBeenCalled();
 		expect(ctx.kv.get).not.toHaveBeenCalledWith("settings:siteUrl");
 	});
+
+	it("does not syndicate pages by default", async () => {
+		const { default: plugin } = await import("../src/sandbox-entry.js");
+		const ctx = createCtx();
+		const handler = (plugin as any).hooks["content:afterPublish"].handler;
+
+		await handler(
+			{
+				collection: "pages",
+				content: {
+					id: "page-1",
+					status: "published",
+					title: "About",
+				},
+			},
+			ctx,
+		);
+
+		expect(ctx.kv.get).toHaveBeenCalledWith("settings:collections");
+		expect(ctx.storage.records.get).not.toHaveBeenCalled();
+		expect(ctx.storage.records.put).not.toHaveBeenCalled();
+		expect(ctx.http.fetch).not.toHaveBeenCalled();
+	});
 });

--- a/packages/plugins/atproto/tests/sandbox-entry.test.ts
+++ b/packages/plugins/atproto/tests/sandbox-entry.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("emdash", () => ({
+	definePlugin: (definition: unknown) => definition,
+}));
+
+function createCtx() {
+	return {
+		kv: {
+			get: vi.fn(async () => undefined),
+			set: vi.fn(async () => undefined),
+		},
+		storage: {
+			records: {
+				get: vi.fn(async () => null),
+				put: vi.fn(async () => undefined),
+			},
+		},
+		http: {
+			fetch: vi.fn(),
+		},
+		log: {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	};
+}
+
+describe("sandbox hooks", () => {
+	it("does not create syndication records from afterSave when published content has not been synced", async () => {
+		const { default: plugin } = await import("../src/sandbox-entry.js");
+		const ctx = createCtx();
+		const handler = (plugin as any).hooks["content:afterSave"].handler;
+
+		await handler(
+			{
+				collection: "posts",
+				isNew: false,
+				content: {
+					id: "post-1",
+					status: "published",
+					title: "A published edit",
+				},
+			},
+			ctx,
+		);
+
+		expect(ctx.storage.records.get).toHaveBeenCalledWith("posts:post-1");
+		expect(ctx.storage.records.put).not.toHaveBeenCalled();
+		expect(ctx.http.fetch).not.toHaveBeenCalled();
+		expect(ctx.kv.get).not.toHaveBeenCalledWith("settings:siteUrl");
+	});
+});

--- a/packages/plugins/atproto/tests/sandbox-entry.test.ts
+++ b/packages/plugins/atproto/tests/sandbox-entry.test.ts
@@ -74,4 +74,29 @@ describe("sandbox hooks", () => {
 		expect(ctx.storage.records.put).not.toHaveBeenCalled();
 		expect(ctx.http.fetch).not.toHaveBeenCalled();
 	});
+
+	it("does not expose standard.site metadata for pages by default", async () => {
+		const { default: plugin } = await import("../src/sandbox-entry.js");
+		const ctx = createCtx();
+		ctx.storage.records.get.mockResolvedValueOnce({
+			atUri: "at://did:example/site.standard.document/abc",
+			status: "synced",
+		});
+
+		const result = await (plugin as any).hooks["page:metadata"](
+			{
+				page: {
+					content: {
+						collection: "pages",
+						id: "page-1",
+					},
+				},
+			},
+			ctx,
+		);
+
+		expect(result).toBeNull();
+		expect(ctx.kv.get).toHaveBeenCalledWith("settings:collections");
+		expect(ctx.storage.records.get).not.toHaveBeenCalled();
+	});
 });

--- a/packages/plugins/atproto/tests/standard-site.test.ts
+++ b/packages/plugins/atproto/tests/standard-site.test.ts
@@ -79,6 +79,19 @@ describe("buildDocument", () => {
 		expect(doc.path).toBeUndefined();
 	});
 
+	it("reads slug from content.data", () => {
+		const doc = buildDocument({
+			...baseOpts,
+			collection: "posts",
+			content: {
+				title: "Nested Slug",
+				data: { slug: "nested-slug" },
+				published_at: "2025-01-15T12:00:00.000Z",
+			},
+		});
+		expect(doc.path).toBe("/posts/nested-slug");
+	});
+
 	it("includes bskyPostRef when provided", () => {
 		const doc = buildDocument({
 			...baseOpts,


### PR DESCRIPTION
## What does this PR do?

Fixes and completes the ATProto plugin syndication flow so standard.site publication setup, Bluesky cross-posting, and sandbox runtime behavior all line up in real use.

This PR:

- declares the `records` storage collection that the sandbox implementation actually reads and writes
- normalizes pasted PDS host/service values before calling AT Protocol XRPC endpoints
- exposes the missing `siteName` setting and adds an explicit publication sync action
- uses `enableBskyCrosspost` consistently across settings and syndication
- maps EmDash content fields from both top-level and `data` payloads so standard.site documents and Bluesky posts get titles, descriptions, dates, and paths
- creates standard.site documents and Bluesky cross-posts from publish events, while save events only update existing synced records
- limits automatic syndication and standard.site metadata links to `posts` by default, with an explicit collections setting for opt-in syndication of other content types
- runs sandboxed publish/save hooks through `after(...)` so plugin side effects can finish after the response
- refreshes ATProto plugin tests around storage, settings, PDS host normalization, token refresh, routing, hook behavior, default collection filtering, and content mapping

Root cause in practice was a combination of setup drift and runtime drift:
- the plugin descriptor declared `publications`, but the sandbox runtime uses `ctx.storage.records`
- the admin page saved `enableCrosspost` while syndication reads `enableBskyCrosspost`
- `siteName` was missing from setup even though publication sync needs it
- PDS host input accepted full URLs even though downstream helpers expected a host value
- content field access needed to support both top-level values and nested `data`
- broad default collection matching could unintentionally syndicate page updates

This was validated in real-world use against a live EmDash site using standard.site publication sync and Bluesky cross-posting.

## Type of change

- [x] Bug fix
- [x] Refactor (no behavior change)
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

- `pnpm --filter @emdash-cms/plugin-atproto test`
- `pnpm --filter @emdash-cms/plugin-atproto typecheck`
- `pnpm --filter @emdash-cms/plugin-atproto build`
