### PR TITLE
fix(auth): restrict Subscriber access to non-published content

### DIFF
--- a/.changeset/subscriber-draft-access.md
+++ b/.changeset/subscriber-draft-access.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/auth": patch
+---
+
+Restricts Subscriber-role access to draft, scheduled, and trashed content. Subscribers retain `content:read` for member-only published content but no longer see non-published items via the REST API or MCP server. Adds a new `content:read_drafts` permission (Contributor and above) that gates `/compare`, `/revisions`, `/trash`, `/preview-url`, and the corresponding MCP tools.

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -97,15 +97,19 @@ See the [Configuration guide](/reference/configuration#oauth) for setup instruct
 
 EmDash uses role-based access control with five levels:
 
-| Role        | Level | Description                     |
-| ----------- | ----- | ------------------------------- |
-| Subscriber  | 10    | View-only access                |
-| Contributor | 20    | Create content (needs approval) |
-| Author      | 30    | Create/edit/publish own content |
-| Editor      | 40    | Manage all content              |
-| Admin       | 50    | Full access including settings  |
+| Role        | Level | Description                                |
+| ----------- | ----- | ------------------------------------------ |
+| Subscriber  | 10    | Read published content (no draft access)   |
+| Contributor | 20    | Create content (needs approval to publish) |
+| Author      | 30    | Create/edit/publish own content            |
+| Editor      | 40    | Manage all content                         |
+| Admin       | 50    | Full access including settings             |
 
 Each role inherits permissions from all lower levels. The first user is always created as Admin.
+
+### Subscribers and draft content
+
+Subscribers hold the `content:read` permission so member-only published content can be served to authenticated readers. They cannot see drafts, scheduled items, trashed items, revisions, or preview URLs — those are gated on `content:read_drafts`, granted to Contributor and above. The list and get endpoints transparently filter to `status=published` for Subscribers; editor-only views (`/compare`, `/revisions`, `/trash`, `/preview-url`) reject Subscriber requests outright.
 
 ## Inviting Users
 

--- a/packages/auth/src/rbac.test.ts
+++ b/packages/auth/src/rbac.test.ts
@@ -58,6 +58,20 @@ describe("rbac", () => {
 		it("denies author from editing any media", () => {
 			expect(hasPermission({ role: Role.AUTHOR }, "media:edit_any")).toBe(false);
 		});
+
+		// content:read_drafts gates non-published content reads and editor-only
+		// views (revisions, compare, trash, preview-url).
+		it("denies subscriber from reading drafts", () => {
+			expect(hasPermission({ role: Role.SUBSCRIBER }, "content:read_drafts")).toBe(false);
+		});
+
+		it("allows contributor to read drafts", () => {
+			expect(hasPermission({ role: Role.CONTRIBUTOR }, "content:read_drafts")).toBe(true);
+		});
+
+		it("allows editor to read drafts", () => {
+			expect(hasPermission({ role: Role.EDITOR }, "content:read_drafts")).toBe(true);
+		});
 	});
 
 	describe("requirePermission", () => {

--- a/packages/auth/src/rbac.ts
+++ b/packages/auth/src/rbac.ts
@@ -11,6 +11,11 @@ import { Role, type RoleLevel } from "./types.js";
 export const Permissions = {
 	// Content
 	"content:read": Role.SUBSCRIBER,
+	// content:read_drafts gates non-published content (drafts, scheduled, trash)
+	// and editor-only views (revisions, compare, preview-url). Subscribers may
+	// hold content:read for member-only published content but must not see
+	// drafts.
+	"content:read_drafts": Role.CONTRIBUTOR,
 	"content:create": Role.CONTRIBUTOR,
 	"content:edit_own": Role.AUTHOR,
 	"content:edit_any": Role.EDITOR,

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -32,7 +32,7 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 
 	// Hide non-published items from users without content:read_drafts. Return
 	// 404 (not 403) so subscribers can't enumerate draft IDs by status code.
-	if (result.success && !hasPermission(user, "content:read_drafts" as Permission)) {
+	if (result.success && !hasPermission(user, "content:read_drafts")) {
 		const data =
 			result.data && typeof result.data === "object"
 				? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -30,6 +30,25 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 
 	const result = await emdash.handleContentGet(collection, id, locale);
 
+	// Hide non-published items from users without content:read_drafts. Return
+	// 404 (not 403) so subscribers can't enumerate draft IDs by status code.
+	if (result.success && !hasPermission(user, "content:read_drafts" as Permission)) {
+		const data =
+			result.data && typeof result.data === "object"
+				? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check
+					(result.data as Record<string, unknown>)
+				: undefined;
+		const item =
+			data?.item && typeof data.item === "object"
+				? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- narrowed by typeof check
+					(data.item as Record<string, unknown>)
+				: undefined;
+		const status = typeof item?.status === "string" ? item.status : null;
+		if (status !== "published") {
+			return apiError("NOT_FOUND", `Content item not found: ${id}`, 404);
+		}
+	}
+
 	return unwrapResult(result);
 };
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/compare.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/compare.ts
@@ -13,7 +13,7 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
@@ -30,7 +30,7 @@ const DURATION_PATTERN = /^(\d+)([smhdw])$/;
 
 export const POST: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/revisions.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/revisions.ts
@@ -13,7 +13,7 @@ export const prerender = false;
 
 export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 	const collection = params.collection!;
 	const id = params.id!;

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
@@ -38,7 +38,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
 	// Filter out non-published translations for users without read_drafts so a
 	// subscriber can't enumerate locales that aren't yet live.
-	if (result.success && !hasPermission(user, "content:read_drafts" as Permission)) {
+	if (result.success && !hasPermission(user, "content:read_drafts")) {
 		const data =
 			result.data && typeof result.data === "object"
 				? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/translations.ts
@@ -6,12 +6,22 @@
  * Returns all locale variants linked to the same translation group.
  */
 
+import { hasPermission, type Permission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
 import { apiError, unwrapResult } from "#api/error.js";
 
 export const prerender = false;
+
+function isPublished(t: unknown): boolean {
+	return (
+		typeof t === "object" &&
+		t !== null &&
+		"status" in t &&
+		(t as Record<string, unknown>).status === "published"
+	);
+}
 
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
@@ -25,6 +35,22 @@ export const GET: APIRoute = async ({ params, locals }) => {
 	}
 
 	const result = await emdash.handleContentTranslations(collection, id);
+
+	// Filter out non-published translations for users without read_drafts so a
+	// subscriber can't enumerate locales that aren't yet live.
+	if (result.success && !hasPermission(user, "content:read_drafts" as Permission)) {
+		const data =
+			result.data && typeof result.data === "object"
+				? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check
+					(result.data as Record<string, unknown>)
+				: undefined;
+		const translations = Array.isArray(data?.translations) ? data.translations : [];
+		const filtered = translations.filter(isPublished);
+		return unwrapResult({
+			success: true,
+			data: { ...data, translations: filtered },
+		});
+	}
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -5,6 +5,7 @@
  * POST /_emdash/api/content/{collection} - Create content
  */
 
+import { hasPermission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm, requireOwnerPerm } from "#api/authorize.js";
@@ -26,7 +27,14 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
 
-	const result = await emdash.handleContentList(collection, query);
+	// Subscribers must only see published content; force the status filter
+	// regardless of caller-supplied value. Any user with content:read_drafts
+	// (CONTRIBUTOR+) keeps the requested filter.
+	const params_ = hasPermission(user, "content:read_drafts")
+		? query
+		: { ...query, status: "published" };
+
+	const result = await emdash.handleContentList(collection, params_);
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/trash.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/trash.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "content:read_drafts");
 	if (denied) return denied;
 
 	if (!emdash?.handleContentListTrashed) {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -84,6 +84,15 @@ interface EmDashExtra {
 	tokenScopes?: string[];
 }
 
+function isPublished(t: unknown): boolean {
+	return (
+		typeof t === "object" &&
+		t !== null &&
+		"status" in t &&
+		(t as Record<string, unknown>).status === "published"
+	);
+}
+
 function getExtra(extra: { authInfo?: { extra?: Record<string, unknown> } }): EmDashExtra {
 	const payload = extra.authInfo?.extra as EmDashExtra | undefined;
 	if (!payload?.emdash) {
@@ -126,6 +135,26 @@ function requireRole(
 ): void {
 	const payload = getExtra(extra);
 	if (payload.userRole < minRole) {
+		throw new McpError(ErrorCode.InvalidRequest, "Insufficient permissions for this operation");
+	}
+}
+
+/**
+ * Whether the current user may read non-published content (drafts, scheduled,
+ * trashed, revisions, compare). SUBSCRIBER may hold content:read for
+ * member-only published content but must not see drafts.
+ */
+function canReadDrafts(extra: { authInfo?: { extra?: Record<string, unknown> } }): boolean {
+	const payload = getExtra(extra);
+	return hasPermission({ role: payload.userRole }, "content:read_drafts");
+}
+
+/**
+ * Throw if the current user cannot read non-published content. Used by
+ * editor-only views (revisions, compare, trash, preview-url).
+ */
+function requireDraftAccess(extra: { authInfo?: { extra?: Record<string, unknown> } }): void {
+	if (!canReadDrafts(extra)) {
 		throw new McpError(ErrorCode.InvalidRequest, "Insufficient permissions for this operation");
 	}
 }
@@ -240,9 +269,12 @@ export function createMcpServer(): McpServer {
 		async (args, extra) => {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
+			// Subscribers must only see published content; force the status
+			// filter regardless of caller-supplied value.
+			const status = canReadDrafts(extra) ? args.status : "published";
 			return unwrap(
 				await ec.handleContentList(args.collection, {
-					status: args.status,
+					status,
 					limit: args.limit,
 					cursor: args.cursor,
 					orderBy: args.orderBy,
@@ -276,7 +308,29 @@ export function createMcpServer(): McpServer {
 		async (args, extra) => {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
-			return unwrap(await ec.handleContentGet(args.collection, args.id, args.locale));
+			const result = await ec.handleContentGet(args.collection, args.id, args.locale);
+			// Hide non-published items from users without draft access. Return a
+			// not-found error so subscribers can't enumerate draft IDs by status.
+			if (result.success && !canReadDrafts(extra)) {
+				const data =
+					result.data && typeof result.data === "object"
+						? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check
+							(result.data as Record<string, unknown>)
+						: undefined;
+				const item =
+					data?.item && typeof data.item === "object"
+						? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- narrowed by typeof check
+							(data.item as Record<string, unknown>)
+						: undefined;
+				const status = typeof item?.status === "string" ? item.status : null;
+				if (status !== "published") {
+					return unwrap({
+						success: false,
+						error: { code: "NOT_FOUND", message: `Content item not found: ${args.id}` },
+					});
+				}
+			}
+			return unwrap(result);
 		},
 	);
 
@@ -676,6 +730,7 @@ export function createMcpServer(): McpServer {
 		},
 		async (args, extra) => {
 			requireScope(extra, "content:read");
+			requireDraftAccess(extra);
 			const ec = getEmDash(extra);
 			return unwrap(await ec.handleContentCompare(args.collection, args.id));
 		},
@@ -733,6 +788,7 @@ export function createMcpServer(): McpServer {
 		},
 		async (args, extra) => {
 			requireScope(extra, "content:read");
+			requireDraftAccess(extra);
 			const ec = getEmDash(extra);
 			return unwrap(
 				await ec.handleContentListTrashed(args.collection, {
@@ -780,7 +836,23 @@ export function createMcpServer(): McpServer {
 		async (args, extra) => {
 			requireScope(extra, "content:read");
 			const ec = getEmDash(extra);
-			return unwrap(await ec.handleContentTranslations(args.collection, args.id));
+			const result = await ec.handleContentTranslations(args.collection, args.id);
+			// Filter out non-published translations for users without draft
+			// access so a subscriber can't enumerate locales that aren't yet live.
+			if (result.success && !canReadDrafts(extra)) {
+				const data =
+					result.data && typeof result.data === "object"
+						? // eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- handler returns unknown data; narrowed by typeof check
+							(result.data as Record<string, unknown>)
+						: undefined;
+				const translations = Array.isArray(data?.translations) ? data.translations : [];
+				const filtered = translations.filter(isPublished);
+				return unwrap({
+					success: true,
+					data: { ...data, translations: filtered },
+				});
+			}
+			return unwrap(result);
 		},
 	);
 
@@ -1460,6 +1532,7 @@ export function createMcpServer(): McpServer {
 		},
 		async (args, extra) => {
 			requireScope(extra, "content:read");
+			requireDraftAccess(extra);
 			const ec = getEmDash(extra);
 			return unwrap(
 				await ec.handleRevisionList(args.collection, args.id, {

--- a/packages/core/tests/unit/astro/content-routes-authz.test.ts
+++ b/packages/core/tests/unit/astro/content-routes-authz.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Content read endpoint authorization.
+ *
+ * content:read is granted to SUBSCRIBER so member-only published content can
+ * be read via the admin API. Drafts, scheduled, trashed items, and editor
+ * views (revisions, compare, preview-url) are gated on content:read_drafts
+ * (CONTRIBUTOR+):
+ *
+ *   - GET /content/:c forces status=published for SUBSCRIBER, ignoring any
+ *     caller-supplied status filter.
+ *   - GET /content/:c/:id returns 404 to SUBSCRIBER for non-published items
+ *     (404 to avoid leaking existence via status code).
+ *   - /compare, /revisions, /trash, /preview-url require content:read_drafts.
+ *   - /translations filters non-published locales out for SUBSCRIBER.
+ */
+
+import { Role, type RoleLevel } from "@emdash-cms/auth";
+import type { APIContext } from "astro";
+import { describe, it, expect, vi } from "vitest";
+
+import { GET as getItem } from "../../../src/astro/routes/api/content/[collection]/[id].js";
+import { GET as getCompare } from "../../../src/astro/routes/api/content/[collection]/[id]/compare.js";
+import { POST as postPreviewUrl } from "../../../src/astro/routes/api/content/[collection]/[id]/preview-url.js";
+import { GET as getRevisions } from "../../../src/astro/routes/api/content/[collection]/[id]/revisions.js";
+import { GET as getTranslations } from "../../../src/astro/routes/api/content/[collection]/[id]/translations.js";
+import { GET as getList } from "../../../src/astro/routes/api/content/[collection]/index.js";
+import { GET as getTrash } from "../../../src/astro/routes/api/content/[collection]/trash.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface StubUser {
+	id: string;
+	role: RoleLevel;
+}
+
+const subscriber: StubUser = { id: "u-sub", role: Role.SUBSCRIBER };
+const contributor: StubUser = { id: "u-con", role: Role.CONTRIBUTOR };
+const editor: StubUser = { id: "u-edit", role: Role.EDITOR };
+
+interface StubItem {
+	id: string;
+	type: string;
+	slug: string | null;
+	status: string;
+	data: Record<string, unknown>;
+	authorId: string | null;
+	primaryBylineId: string | null;
+	createdAt: string;
+	updatedAt: string;
+	publishedAt: string | null;
+	scheduledAt: string | null;
+	liveRevisionId: string | null;
+	draftRevisionId: string | null;
+	version: number;
+	locale: string | null;
+	translationGroup: string | null;
+}
+
+function makeItem(partial: Partial<StubItem> & { id: string; status: string }): StubItem {
+	return {
+		type: "post",
+		slug: partial.id,
+		data: {},
+		authorId: null,
+		primaryBylineId: null,
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		publishedAt: partial.status === "published" ? "2026-01-01T00:00:00Z" : null,
+		scheduledAt: null,
+		liveRevisionId: null,
+		draftRevisionId: null,
+		version: 1,
+		locale: null,
+		translationGroup: null,
+		...partial,
+	};
+}
+
+function buildEmdash(
+	opts: {
+		listItems?: StubItem[];
+		getItem?: StubItem | null;
+		translations?: Array<{
+			id: string;
+			status: string;
+			locale: string | null;
+			slug: string | null;
+			updatedAt: string;
+		}>;
+		trashItems?: StubItem[];
+		revisions?: Array<{ id: string }>;
+		compare?: { hasChanges: boolean; live: unknown; draft: unknown };
+	} = {},
+) {
+	const handleContentList = vi.fn(async (_collection: string, params: { status?: string }) => {
+		const items = params.status
+			? (opts.listItems ?? []).filter((i) => i.status === params.status)
+			: (opts.listItems ?? []);
+		return { success: true as const, data: { items, nextCursor: undefined } };
+	});
+
+	const handleContentGet = vi.fn(async (_collection: string, _id: string) => {
+		if (!opts.getItem) {
+			return { success: false as const, error: { code: "NOT_FOUND", message: "not found" } };
+		}
+		return { success: true as const, data: { item: opts.getItem, _rev: "rev1" } };
+	});
+
+	const handleContentTranslations = vi.fn(async () => ({
+		success: true as const,
+		data: { translationGroup: "tg-1", translations: opts.translations ?? [] },
+	}));
+
+	const handleContentListTrashed = vi.fn(async () => ({
+		success: true as const,
+		data: { items: opts.trashItems ?? [], nextCursor: undefined },
+	}));
+
+	const handleRevisionList = vi.fn(async () => ({
+		success: true as const,
+		data: { items: opts.revisions ?? [] },
+	}));
+
+	const handleContentCompare = vi.fn(async () => ({
+		success: true as const,
+		data: opts.compare ?? { hasChanges: false, live: null, draft: null },
+	}));
+
+	return {
+		handleContentList,
+		handleContentGet,
+		handleContentTranslations,
+		handleContentListTrashed,
+		handleRevisionList,
+		handleContentCompare,
+	};
+}
+
+function ctx(opts: {
+	user: StubUser | null;
+	emdash: ReturnType<typeof buildEmdash>;
+	params?: Record<string, string>;
+	url?: string;
+	request?: Request;
+}): APIContext {
+	const url = new URL(opts.url ?? "http://localhost/");
+	return {
+		params: opts.params ?? { collection: "post" },
+		url,
+		request: opts.request ?? new Request(url),
+		locals: {
+			user: opts.user,
+			emdash: opts.emdash,
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub for tests
+	} as unknown as APIContext;
+}
+
+// ---------------------------------------------------------------------------
+// LIST endpoint
+// ---------------------------------------------------------------------------
+
+describe("GET /content/:collection — subscriber drafts leak", () => {
+	const items = [
+		makeItem({ id: "draft-1", status: "draft" }),
+		makeItem({ id: "pub-1", status: "published" }),
+		makeItem({ id: "sched-1", status: "scheduled" }),
+	];
+
+	it("forces status=published filter for SUBSCRIBER", async () => {
+		const emdash = buildEmdash({ listItems: items });
+		const res = await getList(ctx({ user: subscriber, emdash }));
+		expect(res.status).toBe(200);
+		expect(emdash.handleContentList).toHaveBeenCalledWith(
+			"post",
+			expect.objectContaining({ status: "published" }),
+		);
+		const body = (await res.json()) as { data: { items: StubItem[] } };
+		expect(body.data.items.map((i) => i.id)).toEqual(["pub-1"]);
+	});
+
+	it("rejects subscriber attempt to override status filter to draft", async () => {
+		const emdash = buildEmdash({ listItems: items });
+		const res = await getList(
+			ctx({
+				user: subscriber,
+				emdash,
+				url: "http://localhost/?status=draft",
+			}),
+		);
+		expect(res.status).toBe(200);
+		// The route must not honour ?status=draft for SUBSCRIBER — should still
+		// be forced to published.
+		expect(emdash.handleContentList).toHaveBeenCalledWith(
+			"post",
+			expect.objectContaining({ status: "published" }),
+		);
+		const body = (await res.json()) as { data: { items: StubItem[] } };
+		expect(body.data.items.every((i) => i.status === "published")).toBe(true);
+	});
+
+	it("returns full set for CONTRIBUTOR (has read_drafts)", async () => {
+		const emdash = buildEmdash({ listItems: items });
+		const res = await getList(ctx({ user: contributor, emdash }));
+		expect(res.status).toBe(200);
+		// status param is undefined (caller-controlled), not forced
+		const call = emdash.handleContentList.mock.calls[0]?.[1];
+		expect(call?.status).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GET single item
+// ---------------------------------------------------------------------------
+
+describe("GET /content/:collection/:id — subscriber drafts leak", () => {
+	it("returns 404 to SUBSCRIBER fetching a draft", async () => {
+		const emdash = buildEmdash({ getItem: makeItem({ id: "p1", status: "draft" }) });
+		const res = await getItem(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 to SUBSCRIBER fetching a scheduled item", async () => {
+		const emdash = buildEmdash({ getItem: makeItem({ id: "p1", status: "scheduled" }) });
+		const res = await getItem(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("allows SUBSCRIBER to fetch a published item", async () => {
+		const emdash = buildEmdash({ getItem: makeItem({ id: "p1", status: "published" }) });
+		const res = await getItem(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("allows CONTRIBUTOR to fetch a draft", async () => {
+		const emdash = buildEmdash({ getItem: makeItem({ id: "p1", status: "draft" }) });
+		const res = await getItem(
+			ctx({ user: contributor, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Editor-only views — must require content:read_drafts
+// ---------------------------------------------------------------------------
+
+describe("editor-only content views require content:read_drafts", () => {
+	it("denies SUBSCRIBER on /compare", async () => {
+		const emdash = buildEmdash({ compare: { hasChanges: false, live: null, draft: null } });
+		const res = await getCompare(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentCompare).not.toHaveBeenCalled();
+	});
+
+	it("allows CONTRIBUTOR on /compare", async () => {
+		const emdash = buildEmdash({ compare: { hasChanges: false, live: null, draft: null } });
+		const res = await getCompare(
+			ctx({ user: contributor, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("denies SUBSCRIBER on /revisions", async () => {
+		const emdash = buildEmdash({ revisions: [] });
+		const res = await getRevisions(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(403);
+		expect(emdash.handleRevisionList).not.toHaveBeenCalled();
+	});
+
+	it("denies SUBSCRIBER on /trash", async () => {
+		const emdash = buildEmdash({ trashItems: [] });
+		const res = await getTrash(ctx({ user: subscriber, emdash }));
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentListTrashed).not.toHaveBeenCalled();
+	});
+
+	it("denies SUBSCRIBER on /preview-url POST", async () => {
+		const emdash = buildEmdash({ getItem: makeItem({ id: "p1", status: "published" }) });
+		const url = "http://localhost/";
+		const res = await postPreviewUrl(
+			ctx({
+				user: subscriber,
+				emdash,
+				params: { collection: "post", id: "p1" },
+				url,
+				request: new Request(url, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{}",
+				}),
+			}),
+		);
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentGet).not.toHaveBeenCalled();
+	});
+
+	it("allows EDITOR on /trash", async () => {
+		const emdash = buildEmdash({ trashItems: [] });
+		const res = await getTrash(ctx({ user: editor, emdash }));
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Translations endpoint — must status-filter for SUBSCRIBER
+// ---------------------------------------------------------------------------
+
+describe("GET /content/:collection/:id/translations", () => {
+	const translations = [
+		{
+			id: "t-en",
+			locale: "en",
+			slug: "p1",
+			status: "published",
+			updatedAt: "2026-01-01T00:00:00Z",
+		},
+		{ id: "t-fr", locale: "fr", slug: "p1", status: "draft", updatedAt: "2026-01-01T00:00:00Z" },
+		{
+			id: "t-de",
+			locale: "de",
+			slug: "p1",
+			status: "scheduled",
+			updatedAt: "2026-01-01T00:00:00Z",
+		},
+	];
+
+	it("filters non-published translations for SUBSCRIBER", async () => {
+		const emdash = buildEmdash({ translations });
+		const res = await getTranslations(
+			ctx({ user: subscriber, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			data: { translations: Array<{ id: string; status: string }> };
+		};
+		expect(body.data.translations.map((t) => t.id)).toEqual(["t-en"]);
+	});
+
+	it("returns all translations for CONTRIBUTOR", async () => {
+		const emdash = buildEmdash({ translations });
+		const res = await getTranslations(
+			ctx({ user: contributor, emdash, params: { collection: "post", id: "p1" } }),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			data: { translations: Array<{ id: string; status: string }> };
+		};
+		expect(body.data.translations).toHaveLength(3);
+	});
+});

--- a/packages/core/tests/unit/mcp/authorization.test.ts
+++ b/packages/core/tests/unit/mcp/authorization.test.ts
@@ -858,4 +858,247 @@ describe("MCP Authorization", () => {
 			expect(text).toMatch(NO_AUTHOR_ID_RE);
 		});
 	});
+
+	// -----------------------------------------------------------------------
+	// Draft visibility — SUBSCRIBER must not see non-published content
+	// -----------------------------------------------------------------------
+
+	describe("draft visibility", () => {
+		it("forces status=published on content_list for SUBSCRIBER", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			await client.callTool({
+				name: "content_list",
+				arguments: { collection: "post" },
+			});
+
+			expect(handlers.handleContentList).toHaveBeenCalledWith(
+				"post",
+				expect.objectContaining({ status: "published" }),
+			);
+		});
+
+		it("ignores caller-supplied status=draft from SUBSCRIBER on content_list", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			await client.callTool({
+				name: "content_list",
+				arguments: { collection: "post", status: "draft" },
+			});
+
+			// Even though caller asked for "draft", route forces "published"
+			expect(handlers.handleContentList).toHaveBeenCalledWith(
+				"post",
+				expect.objectContaining({ status: "published" }),
+			);
+		});
+
+		it("respects caller-supplied status filter for CONTRIBUTOR on content_list", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.CONTRIBUTOR,
+				handlers,
+			}));
+
+			await client.callTool({
+				name: "content_list",
+				arguments: { collection: "post", status: "draft" },
+			});
+
+			expect(handlers.handleContentList).toHaveBeenCalledWith(
+				"post",
+				expect.objectContaining({ status: "draft" }),
+			);
+		});
+
+		it("hides draft items from SUBSCRIBER on content_get", async () => {
+			// Default mock returns status: "draft"
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_get",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBe(true);
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toMatch(/not found/i);
+		});
+
+		it("allows SUBSCRIBER to read published items via content_get", async () => {
+			const handlers = createMockHandlers();
+			// Override to return published content
+			handlers.handleContentGet = vi.fn().mockResolvedValue({
+				success: true,
+				data: {
+					item: {
+						id: CONTENT_ID,
+						slug: CONTENT_SLUG,
+						authorId: AUTHOR_USER_ID,
+						status: "published",
+					},
+					_rev: "rev1",
+				},
+			});
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_get",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBeFalsy();
+		});
+
+		it("allows CONTRIBUTOR to read drafts via content_get", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.CONTRIBUTOR,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_get",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBeFalsy();
+		});
+
+		it("denies SUBSCRIBER on content_compare", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_compare",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBe(true);
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toMatch(INSUFFICIENT_PERMISSIONS_RE);
+			expect(handlers.handleContentCompare).not.toHaveBeenCalled();
+		});
+
+		it("denies SUBSCRIBER on content_list_trashed", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_list_trashed",
+				arguments: { collection: "post" },
+			});
+
+			expect(result.isError).toBe(true);
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toMatch(INSUFFICIENT_PERMISSIONS_RE);
+			expect(handlers.handleContentListTrashed).not.toHaveBeenCalled();
+		});
+
+		it("denies SUBSCRIBER on revision_list", async () => {
+			const handlers = createMockHandlers();
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "revision_list",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBe(true);
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toMatch(INSUFFICIENT_PERMISSIONS_RE);
+			expect(handlers.handleRevisionList).not.toHaveBeenCalled();
+		});
+
+		it("filters non-published translations for SUBSCRIBER", async () => {
+			const handlers = createMockHandlers();
+			handlers.handleContentTranslations = vi.fn().mockResolvedValue({
+				success: true,
+				data: {
+					translationGroup: "tg-1",
+					translations: [
+						{ id: "t-en", locale: "en", slug: "p", status: "published", updatedAt: "" },
+						{ id: "t-fr", locale: "fr", slug: "p", status: "draft", updatedAt: "" },
+					],
+				},
+			});
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.SUBSCRIBER,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_translations",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBeFalsy();
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toContain("t-en");
+			expect(text).not.toContain("t-fr");
+		});
+
+		it("allows CONTRIBUTOR to see all translations", async () => {
+			const handlers = createMockHandlers();
+			handlers.handleContentTranslations = vi.fn().mockResolvedValue({
+				success: true,
+				data: {
+					translationGroup: "tg-1",
+					translations: [
+						{ id: "t-en", locale: "en", slug: "p", status: "published", updatedAt: "" },
+						{ id: "t-fr", locale: "fr", slug: "p", status: "draft", updatedAt: "" },
+					],
+				},
+			});
+			({ client, cleanup } = await setupMcpPair({
+				userId: OTHER_USER_ID,
+				userRole: Role.CONTRIBUTOR,
+				handlers,
+			}));
+
+			const result = await client.callTool({
+				name: "content_translations",
+				arguments: { collection: "post", id: CONTENT_ID },
+			});
+
+			expect(result.isError).toBeFalsy();
+			const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+			expect(text).toContain("t-en");
+			expect(text).toContain("t-fr");
+		});
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Tightens authorization on the content read paths so the SUBSCRIBER role no longer sees draft, scheduled, trashed, or revision content via the admin REST API or MCP server.

`content:read` stays at SUBSCRIBER so member-only published content can still be served. A new `content:read_drafts` permission (CONTRIBUTOR and above) gates everything else.

**REST behaviour**
- `GET /content/:c` — caller-supplied `?status=` is ignored for SUBSCRIBER; forced to `published`. CONTRIBUTOR+ unchanged.
- `GET /content/:c/:id` — returns 404 (not 403) when SUBSCRIBER fetches a non-published item, to avoid leaking IDs.
- `GET /content/:c/:id/compare`, `/revisions`, `/trash`, `POST /preview-url` — require `content:read_drafts`.
- `GET /content/:c/:id/translations` — filters out non-published locales for SUBSCRIBER.

**MCP behaviour** — same fix applied to `content_list`, `content_get`, `content_compare`, `content_list_trashed`, `content_translations`, `revision_list`. `search` already defaulted to `status=published`, no change needed.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

22 new tests added across the route layer (11) and MCP layer (11), plus 3 in the auth package for the new permission. Full suite green:

\`\`\`
@emdash-cms/auth   50 passed
emdash             2474 passed (+25)
@emdash-cms/admin  785 passed
@emdash-cms/cloudflare 127 passed
\`\`\`

Lint count unchanged from baseline (22 pre-existing warnings, none in touched files). Typecheck clean across the workspace. Docs build clean.

Docs updated in \`docs/src/content/docs/guides/authentication.mdx\` to clarify Subscriber semantics and document the new permission.