### PR TITLE
fix(auth): rate-limit signup request endpoint

### DIFF
--- a/.changeset/signup-rate-limit.md
+++ b/.changeset/signup-rate-limit.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Rate-limits the self-signup request endpoint to prevent abuse. `POST /_emdash/api/auth/signup/request` now allows 3 requests per 5 minutes per IP, matching the existing limit on magic-link/send. Over-limit requests return the same generic success response as allowed-but-ignored requests, so the limit isn't observable to callers.

--- a/packages/core/src/astro/routes/api/auth/signup/request.ts
+++ b/packages/core/src/astro/routes/api/auth/signup/request.ts
@@ -3,6 +3,8 @@
  *
  * Request self-signup. Sends verification email if domain is allowed.
  * Always returns 200 to prevent email enumeration.
+ *
+ * Rate limited: 3 requests per 5 minutes per IP. Mirrors magic-link/send.
  */
 
 import type { APIRoute } from "astro";
@@ -16,7 +18,16 @@ import { apiError, apiSuccess } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { signupRequestBody } from "#api/schemas.js";
 import { getSiteBaseUrl } from "#api/site-url.js";
+import { checkRateLimit, getClientIp } from "#auth/rate-limit.js";
 import { OptionsRepository } from "#db/repositories/options.js";
+
+// Generic response body used for both the real success path and the
+// rate-limited / domain-disallowed paths. Keeping them identical prevents
+// the caller from distinguishing between them.
+const GENERIC_SUCCESS = {
+	success: true,
+	message: "If your email domain is allowed, you'll receive a verification email.",
+};
 
 export const POST: APIRoute = async ({ request, locals }) => {
 	const { emdash } = locals;
@@ -35,8 +46,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	}
 
 	try {
+		// Parse the body first — this avoids burning a rate-limit slot on
+		// malformed input and keeps the timing of the rate-limited and
+		// real paths aligned.
 		const body = await parseBody(request, signupRequestBody);
 		if (isParseError(body)) return body;
+
+		// Rate limit: 3 requests per 300 seconds per IP. Matches magic-link/send.
+		const ip = getClientIp(request);
+		const rateLimit = await checkRateLimit(emdash.db, ip, "signup/request", 3, 300);
+		if (!rateLimit.allowed) {
+			// Return success-shaped response to avoid revealing rate limiting
+			// (and by extension, the fact that the caller is probing).
+			return apiSuccess(GENERIC_SUCCESS);
+		}
 
 		const adapter = createKyselyAdapter(emdash.db);
 
@@ -60,18 +83,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		);
 
 		// Always return success to prevent email enumeration
-		return apiSuccess({
-			success: true,
-			message: "If your email domain is allowed, you'll receive a verification email.",
-		});
+		return apiSuccess(GENERIC_SUCCESS);
 	} catch (error) {
 		console.error("Signup request error:", error);
 
 		// Don't reveal internal errors - just return generic success
 		// to prevent information leakage
-		return apiSuccess({
-			success: true,
-			message: "If your email domain is allowed, you'll receive a verification email.",
-		});
+		return apiSuccess(GENERIC_SUCCESS);
 	}
 };

--- a/packages/core/tests/unit/astro/signup-rate-limit.test.ts
+++ b/packages/core/tests/unit/astro/signup-rate-limit.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Rate-limit enforcement on POST /_emdash/api/auth/signup/request.
+ *
+ * The signup request route must be rate-limited per IP, mirroring the
+ * existing protection on magic-link/send. Without a limit, a caller on
+ * Cloudflare can trigger unlimited signup verification emails for any
+ * allowed domain.
+ *
+ * Tests drive the route handler directly with a real in-memory SQLite
+ * database (so checkRateLimit actually persists) and a stubbed email
+ * pipeline to observe send counts.
+ */
+
+import { Role } from "@emdash-cms/auth";
+import type { AuthAdapter } from "@emdash-cms/auth";
+import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST as signupRequest } from "../../../src/astro/routes/api/auth/signup/request.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+// Simulate a Cloudflare request so getClientIp returns a value. Without the
+// `cf` marker, the rate limiter short-circuits with null-IP and nothing is
+// enforced.
+function cfRequest(url: string, body: unknown): Request {
+	const req = new Request(url, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"cf-connecting-ip": "198.51.100.7",
+		},
+		body: JSON.stringify(body),
+	});
+	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- test harness
+	(req as unknown as { cf: Record<string, unknown> }).cf = { country: "US" };
+	return req;
+}
+
+interface StubEmail {
+	send: ReturnType<typeof vi.fn>;
+	isAvailable: () => boolean;
+}
+
+function buildEmail(): StubEmail {
+	return {
+		send: vi.fn().mockResolvedValue(undefined),
+		isAvailable: () => true,
+	};
+}
+
+function ctx(opts: {
+	db: Kysely<Database>;
+	email: StubEmail;
+	body: { email: string };
+}): APIContext {
+	const url = "http://localhost/_emdash/api/auth/signup/request";
+	return {
+		request: cfRequest(url, opts.body),
+		locals: {
+			emdash: {
+				db: opts.db,
+				email: opts.email,
+			},
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub for tests
+	} as unknown as APIContext;
+}
+
+describe("POST /auth/signup/request rate limiting", () => {
+	let db: Kysely<Database>;
+	let adapter: AuthAdapter;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		adapter = createKyselyAdapter(db);
+		await adapter.createAllowedDomain("allowed.com", Role.AUTHOR);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("sends email on the first request from an IP", async () => {
+		const email = buildEmail();
+		const res = await signupRequest(ctx({ db, email, body: { email: "a@allowed.com" } }));
+		expect(res.status).toBe(200);
+		expect(email.send).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops sending emails after the per-IP limit is exceeded", async () => {
+		const email = buildEmail();
+
+		// Use 4 distinct addresses so each one would normally send — if the
+		// limit is absent, the stub is called 4 times. With the fix, it's 3.
+		for (const local of ["a", "b", "c", "d"]) {
+			await signupRequest(ctx({ db, email, body: { email: `${local}@allowed.com` } }));
+		}
+
+		// Matches magic-link/send: 3 requests per 5 minutes per IP.
+		expect(email.send).toHaveBeenCalledTimes(3);
+	});
+
+	it("always returns 200 to avoid revealing the rate limit", async () => {
+		const email = buildEmail();
+		const responses = [];
+		for (const local of ["a", "b", "c", "d", "e"]) {
+			responses.push(
+				await signupRequest(ctx({ db, email, body: { email: `${local}@allowed.com` } })),
+			);
+		}
+
+		// All responses are 200 with the generic success envelope. The rate
+		// limit is invisible to the caller (which also keeps signup
+		// indistinguishable from disallowed-domain).
+		expect(responses.every((r) => r.status === 200)).toBe(true);
+	});
+
+	it("tracks the limit per IP, not globally", async () => {
+		const email = buildEmail();
+		const url = "http://localhost/_emdash/api/auth/signup/request";
+
+		function req(ip: string, addr: string): Request {
+			const r = new Request(url, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"cf-connecting-ip": ip,
+				},
+				body: JSON.stringify({ email: addr }),
+			});
+			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- test harness
+			(r as unknown as { cf: Record<string, unknown> }).cf = { country: "US" };
+			return r;
+		}
+
+		function makeCtx(request: Request): APIContext {
+			return {
+				request,
+				locals: { emdash: { db, email } },
+				// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+			} as unknown as APIContext;
+		}
+
+		// Exhaust IP A
+		for (const local of ["a", "b", "c", "d"]) {
+			await signupRequest(makeCtx(req("198.51.100.7", `${local}@allowed.com`)));
+		}
+		expect(email.send).toHaveBeenCalledTimes(3);
+
+		// IP B still gets through
+		await signupRequest(makeCtx(req("198.51.100.8", "x@allowed.com")));
+		expect(email.send).toHaveBeenCalledTimes(4);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Applies the same per-IP rate limit to `POST /_emdash/api/auth/signup/request` that `magic-link/send` already uses: 3 requests per 5 minutes per IP.

Over-limit requests return the same generic success response (`"If your email domain is allowed..."`) that legitimate-but-ignored requests get, so the limit is invisible to callers and doesn't help probe for allowed domains.

The email-not-configured 503 path is preserved above the rate-limit check so config errors remain visible to operators.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

4 new route-level tests in \`tests/unit/astro/signup-rate-limit.test.ts\` covering: first request sends, 4th request from same IP is dropped at 3-per-window, all responses remain 200 (limit invisible), limit tracks per-IP not globally. All 3676 tests pass across the monorepo. Lint and typecheck clean, no new warnings in touched files.