### PR TITLE
fix(import): resolve hostnames before fetching external URLs

### DIFF
--- a/.changeset/ssrf-dns-rebinding.md
+++ b/.changeset/ssrf-dns-rebinding.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Strengthens SSRF protection on the import pipeline against DNS-rebinding. The `validateExternalUrl` helper now also blocks known wildcard DNS services (`nip.io`, `sslip.io`, `xip.io`, `traefik.me`, `lvh.me`, `localtest.me`) and trailing-dot FQDN forms of blocked hostnames. A new `resolveAndValidateExternalUrl` resolves the target hostname via DNS-over-HTTPS (Cloudflare) and rejects if any returned IP is in a private range. `ssrfSafeFetch` and the plugin unrestricted-fetch path now use the DNS-aware validator on every hop. This adds two DoH round-trips per outbound request; self-hosted admins whose egress blocks `cloudflare-dns.com` can inject a custom resolver via `setDefaultDnsResolver`.

--- a/packages/core/src/astro/routes/api/import/wordpress-plugin/analyze.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress-plugin/analyze.ts
@@ -15,7 +15,7 @@ import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { wpPluginAnalyzeBody } from "#api/schemas.js";
 import { getSource } from "#import/index.js";
-import { validateExternalUrl, SsrfError } from "#import/ssrf.js";
+import { resolveAndValidateExternalUrl, SsrfError } from "#import/ssrf.js";
 import type { ImportAnalysis } from "#import/types.js";
 import type { EmDashHandlers } from "#types";
 
@@ -37,9 +37,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const body = await parseBody(request, wpPluginAnalyzeBody);
 		if (isParseError(body)) return body;
 
-		// SSRF: reject internal/private network targets
+		// SSRF: reject internal/private network targets. Uses DNS resolution
+		// to catch hostnames that resolve to private addresses.
 		try {
-			validateExternalUrl(body.url);
+			await resolveAndValidateExternalUrl(body.url);
 		} catch (e) {
 			const msg = e instanceof SsrfError ? e.message : "Invalid URL";
 			return apiError("SSRF_BLOCKED", msg, 400);

--- a/packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts
@@ -15,7 +15,7 @@ import { isParseError, parseBody } from "#api/parse.js";
 import { wpPluginExecuteBody } from "#api/schemas.js";
 import { BylineRepository } from "#db/repositories/byline.js";
 import { getSource } from "#import/index.js";
-import { validateExternalUrl, SsrfError } from "#import/ssrf.js";
+import { resolveAndValidateExternalUrl, SsrfError } from "#import/ssrf.js";
 import type { ImportConfig, ImportResult, NormalizedItem } from "#import/types.js";
 import { resolveImportByline } from "#import/utils.js";
 import type { FieldType } from "#schema/types.js";
@@ -49,9 +49,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const body = await parseBody(request, wpPluginExecuteBody);
 		if (isParseError(body)) return body;
 
-		// SSRF: reject internal/private network targets
+		// SSRF: reject internal/private network targets. Uses DNS resolution
+		// to catch hostnames that resolve to private addresses.
 		try {
-			validateExternalUrl(body.url);
+			await resolveAndValidateExternalUrl(body.url);
 		} catch (e) {
 			const msg = e instanceof SsrfError ? e.message : "Invalid URL";
 			return apiError("SSRF_BLOCKED", msg, 400);

--- a/packages/core/src/import/registry.ts
+++ b/packages/core/src/import/registry.ts
@@ -4,7 +4,7 @@
  * Manages available import sources and provides URL probing.
  */
 
-import { validateExternalUrl } from "./ssrf.js";
+import { resolveAndValidateExternalUrl } from "./ssrf.js";
 import type { ImportSource, ProbeResult, SourceProbeResult } from "./types.js";
 
 // Regex pattern for URL normalization
@@ -63,8 +63,9 @@ export async function probeUrl(url: string): Promise<ProbeResult> {
 	// Remove trailing slash for consistency
 	normalizedUrl = normalizedUrl.replace(TRAILING_SLASHES_PATTERN, "");
 
-	// SSRF: reject internal/private network targets
-	validateExternalUrl(normalizedUrl);
+	// SSRF: reject internal/private network targets. DNS resolution
+	// catches hostnames that resolve to private addresses.
+	await resolveAndValidateExternalUrl(normalizedUrl);
 
 	const results: SourceProbeResult[] = [];
 	const urlSources = getUrlSources();

--- a/packages/core/src/import/ssrf.ts
+++ b/packages/core/src/import/ssrf.ts
@@ -29,6 +29,13 @@ const NAT64_HEX_PATTERN = /^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i;
 
 const IPV6_BRACKET_PATTERN = /^\[|\]$/g;
 
+/** Match fc00::/7 ULA — first byte 0xfc or 0xfd followed by any byte. */
+const IPV6_ULA_FC_PATTERN = /^fc[0-9a-f]{2}:/;
+const IPV6_ULA_FD_PATTERN = /^fd[0-9a-f]{2}:/;
+
+/** Strip trailing dots from an FQDN-form hostname ("localhost." -> "localhost"). */
+const TRAILING_DOT_PATTERN = /\.+$/;
+
 /**
  * Private and reserved IP ranges that should never be fetched.
  *
@@ -60,6 +67,23 @@ const BLOCKED_HOSTNAMES = new Set([
 	"metadata.google",
 	"[::1]",
 ]);
+
+/**
+ * Wildcard DNS services that publicly resolve arbitrary IPs embedded in the
+ * hostname. Commonly used in local dev and by SSRF exploit tooling to bypass
+ * hostname-only blocklists (e.g. 127.0.0.1.nip.io -> 127.0.0.1).
+ *
+ * Matched case-insensitively as a suffix, so both the apex and any subdomain
+ * are blocked.
+ */
+const BLOCKED_HOSTNAME_SUFFIXES = [
+	"nip.io",
+	"sslip.io",
+	"xip.io",
+	"traefik.me",
+	"lvh.me",
+	"localtest.me",
+];
 
 /** Blocked URL schemes */
 const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
@@ -115,22 +139,34 @@ export function normalizeIPv6MappedToIPv4(ip: string): string | null {
 }
 
 function isPrivateIp(ip: string): boolean {
+	// Normalize IPv6 strings to lowercase. `new URL().hostname` already
+	// lowercases, but resolver output (from DoH or an injected resolver) may
+	// not. Without this, "FE80::1" bypasses the link-local check.
+	const normalized = ip.toLowerCase();
+
 	// Handle IPv6 loopback
-	if (ip === "::1" || ip === "::ffff:127.0.0.1") return true;
+	if (normalized === "::1" || normalized === "::ffff:127.0.0.1") return true;
 
 	// Handle IPv4-mapped IPv6 in hex form (WHATWG URL parser normalizes to this)
 	// e.g. ::ffff:7f00:1 -> 127.0.0.1, ::ffff:a9fe:a9fe -> 169.254.169.254
-	const hexIpv4 = normalizeIPv6MappedToIPv4(ip);
+	const hexIpv4 = normalizeIPv6MappedToIPv4(normalized);
 	if (hexIpv4) return isPrivateIp(hexIpv4);
 
 	// Handle IPv4-mapped IPv6 in dotted-decimal form
-	const v4Match = ip.match(IPV4_MAPPED_IPV6_DOTTED_PATTERN);
-	const ipv4 = v4Match ? v4Match[1] : ip;
+	const v4Match = normalized.match(IPV4_MAPPED_IPV6_DOTTED_PATTERN);
+	const ipv4 = v4Match ? v4Match[1] : normalized;
 
 	const num = parseIpv4(ipv4);
 	if (num === null) {
-		// If we can't parse it, block IPv6 addresses that look internal
-		return ip.startsWith("fe80:") || ip.startsWith("fc") || ip.startsWith("fd");
+		// If we can't parse it, block IPv6 addresses that look internal.
+		// fc00::/7 is Unique Local (first byte 0xfc or 0xfd), fe80::/10 is
+		// link-local. Only match when followed by hex digit + colon to avoid
+		// collisions with hypothetical non-address strings.
+		return (
+			normalized.startsWith("fe80:") ||
+			IPV6_ULA_FC_PATTERN.test(normalized) ||
+			IPV6_ULA_FD_PATTERN.test(normalized)
+		);
 	}
 
 	return BLOCKED_PATTERNS.some((range) => num >= range.start && num <= range.end);
@@ -182,9 +218,22 @@ export function validateExternalUrl(url: string): URL {
 	// Strip brackets from IPv6 hostname
 	const hostname = parsed.hostname.replace(IPV6_BRACKET_PATTERN, "");
 
+	// Normalize the hostname for blocklist matching: lowercase + strip any
+	// trailing dots. WHATWG preserves trailing dots on .hostname, so without
+	// this normalization "localhost." and "nip.io." bypass the checks.
+	const normalizedHost = hostname.toLowerCase().replace(TRAILING_DOT_PATTERN, "");
+
 	// Check against known internal hostnames
-	if (BLOCKED_HOSTNAMES.has(hostname.toLowerCase())) {
+	if (BLOCKED_HOSTNAMES.has(normalizedHost)) {
 		throw new SsrfError("URLs targeting internal hosts are not allowed");
+	}
+
+	// Check against wildcard DNS services used by SSRF tooling to bypass
+	// hostname-only checks. Match the apex and any subdomain.
+	for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
+		if (normalizedHost === suffix || normalizedHost.endsWith(`.${suffix}`)) {
+			throw new SsrfError("URLs targeting wildcard DNS services are not allowed");
+		}
 	}
 
 	// Check if hostname is an IP address in a private range
@@ -193,6 +242,184 @@ export function validateExternalUrl(url: string): URL {
 	}
 
 	return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// DNS-aware validation
+// ---------------------------------------------------------------------------
+
+/**
+ * A resolver that maps a hostname to a list of IPv4/IPv6 addresses.
+ * Injectable so callers can swap in OS-level DNS on Node, stub it in tests,
+ * or point to a different DoH endpoint.
+ */
+export type DnsResolver = (hostname: string) => Promise<string[]>;
+
+/**
+ * Module-level default resolver. Tests can swap this with a stub so fetch
+ * mocks don't see unexpected DoH round-trips. Production code should leave
+ * it alone.
+ */
+let defaultResolver: DnsResolver | null = null;
+
+/** Override the default DNS resolver. Returns the previous value. */
+export function setDefaultDnsResolver(resolver: DnsResolver | null): DnsResolver | null {
+	const previous = defaultResolver;
+	defaultResolver = resolver;
+	return previous;
+}
+
+/** Timeout for a single DoH request, in milliseconds. */
+const DOH_TIMEOUT_MS = 3000;
+
+/** Default DoH endpoint — Cloudflare's public resolver. */
+const DEFAULT_DOH_URL = "https://cloudflare-dns.com/dns-query";
+
+interface DohAnswer {
+	data: string;
+}
+
+interface DohResponse {
+	Status: number;
+	Answer: DohAnswer[];
+}
+
+function hasProperty<K extends string>(obj: unknown, key: K): obj is Record<K, unknown> {
+	return typeof obj === "object" && obj !== null && key in obj;
+}
+
+/**
+ * Narrow an unknown JSON body to a DohResponse shape we can read safely.
+ * Throws if the body doesn't look like a DoH response — a malformed body is
+ * indistinguishable from a failure and must not be silently treated as empty.
+ */
+function parseDohResponse(raw: unknown): DohResponse {
+	if (!hasProperty(raw, "Status") || typeof raw.Status !== "number") {
+		throw new Error("DoH response missing Status field");
+	}
+	const answers: DohAnswer[] = [];
+	if (hasProperty(raw, "Answer") && Array.isArray(raw.Answer)) {
+		for (const entry of raw.Answer) {
+			if (hasProperty(entry, "data") && typeof entry.data === "string") {
+				answers.push({ data: entry.data });
+			}
+		}
+	}
+	return { Status: raw.Status, Answer: answers };
+}
+
+/**
+ * Resolve a hostname via DNS over HTTPS (Cloudflare). Returns all A and AAAA
+ * records. Works in both Workers and Node without requiring node:dns.
+ *
+ * Fails closed: any network error, non-2xx response, or DNS rcode != 0
+ * causes a rejected promise so the calling validator treats it as a block.
+ */
+export const cloudflareDohResolver: DnsResolver = async (hostname) => {
+	async function query(type: "A" | "AAAA"): Promise<string[]> {
+		const params = new URLSearchParams({ name: hostname, type });
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), DOH_TIMEOUT_MS);
+		try {
+			const response = await globalThis.fetch(`${DEFAULT_DOH_URL}?${params.toString()}`, {
+				headers: { Accept: "application/dns-json" },
+				signal: controller.signal,
+			});
+			if (!response.ok) {
+				throw new Error(`DoH lookup failed: ${response.status}`);
+			}
+			const raw = await response.json();
+			const body = parseDohResponse(raw);
+			// NXDOMAIN (3) is a legitimate "does not exist" — treat as empty.
+			// Any other non-zero status (SERVFAIL=2, REFUSED=5, etc.) is
+			// ambiguous and could be a split-view attacker hiding records
+			// from our resolver. Fail closed.
+			if (body.Status === 3) return [];
+			if (body.Status !== 0) {
+				throw new Error(`DoH ${type} lookup failed: rcode=${body.Status}`);
+			}
+			return body.Answer.map((a) => a.data).filter((d) => typeof d === "string");
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+
+	const [a, aaaa] = await Promise.all([query("A"), query("AAAA")]);
+	return [...a, ...aaaa];
+};
+
+/**
+ * Validate a URL and resolve its hostname to check the actual IPs against
+ * the private-range blocklist. This catches DNS rebinding attacks using
+ * attacker-controlled domains that publicly resolve to private addresses,
+ * and wildcard DNS services like nip.io used by exploit tooling.
+ *
+ * Runs `validateExternalUrl` first for cheap pre-flight checks (scheme,
+ * literal IP, known-bad hostnames). Then resolves the hostname and rejects
+ * if ANY returned address is private.
+ *
+ * Fails closed: if resolution fails or returns no records, throws SsrfError.
+ *
+ * **Caveats.** This does NOT fully close the TOCTOU between check and
+ * connect. Attacks that still work against this layer include:
+ *
+ * - TTL=0 rebind: authoritative server returns public IP to the check, then
+ *   private IP to the subsequent fetch() a few milliseconds later.
+ * - Split-view via EDNS Client Subnet or source-IP inspection: the
+ *   authoritative server returns public IP to Cloudflare's DoH resolver and
+ *   private IP to the victim's own resolver (used by fetch()).
+ * - Host-file overrides or split-horizon corporate DNS on self-hosted Node.
+ * - Attacker-controlled rebinding services the caller has allowlisted.
+ *
+ * The only complete defense is a network-layer egress firewall. On
+ * Cloudflare Workers, the platform fetch pipeline provides most of that.
+ * On self-hosted Node, operators must restrict egress themselves.
+ */
+export async function resolveAndValidateExternalUrl(
+	url: string,
+	options?: { resolver?: DnsResolver },
+): Promise<URL> {
+	const parsed = validateExternalUrl(url);
+
+	// Strip brackets from IPv6 hostnames
+	const hostname = parsed.hostname.replace(IPV6_BRACKET_PATTERN, "");
+
+	// If the hostname is already an IP literal, validateExternalUrl has
+	// already checked it against the private-range list. Skip DNS.
+	if (isIpLiteral(hostname)) {
+		return parsed;
+	}
+
+	const resolver = options?.resolver ?? defaultResolver ?? cloudflareDohResolver;
+
+	let addresses: string[];
+	try {
+		addresses = await resolver(hostname);
+	} catch (error) {
+		throw new SsrfError(
+			`Could not resolve hostname: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	if (addresses.length === 0) {
+		throw new SsrfError("Hostname resolved to no addresses");
+	}
+
+	for (const ip of addresses) {
+		if (isPrivateIp(ip)) {
+			throw new SsrfError("Hostname resolves to a private IP address");
+		}
+	}
+
+	return parsed;
+}
+
+/** True when a string looks like an IPv4 or IPv6 literal. */
+function isIpLiteral(host: string): boolean {
+	if (parseIpv4(host) !== null) return true;
+	// Very loose IPv6 heuristic — matches anything with a colon, which is
+	// never valid in DNS hostnames, so this is safe.
+	return host.includes(":");
 }
 
 /**
@@ -208,12 +435,16 @@ export function validateExternalUrl(url: string): URL {
 /** Headers that must be stripped when a redirect crosses origins */
 const CREDENTIAL_HEADERS = ["authorization", "cookie", "proxy-authorization"];
 
-export async function ssrfSafeFetch(url: string, init?: RequestInit): Promise<Response> {
+export async function ssrfSafeFetch(
+	url: string,
+	init?: RequestInit,
+	options?: { resolver?: DnsResolver },
+): Promise<Response> {
 	let currentUrl = url;
 	let currentInit = init;
 
 	for (let i = 0; i <= MAX_REDIRECTS; i++) {
-		validateExternalUrl(currentUrl);
+		await resolveAndValidateExternalUrl(currentUrl, options);
 
 		const response = await globalThis.fetch(currentUrl, {
 			...currentInit,

--- a/packages/core/src/import/ssrf.ts
+++ b/packages/core/src/import/ssrf.ts
@@ -61,11 +61,16 @@ const BLOCKED_PATTERNS: Array<{ start: number; end: number }> = [
 	{ start: ip4ToNum(0, 0, 0, 0), end: ip4ToNum(0, 255, 255, 255) },
 ];
 
+// Bracket-stripped form is used for lookups (validateExternalUrl strips
+// brackets from parsed.hostname before checking), so "::1" appears here
+// without brackets. The "::1" case is already covered by isPrivateIp, but
+// keeping it here makes the intent explicit and gives a clearer error
+// message for the common `http://[::1]/` form.
 const BLOCKED_HOSTNAMES = new Set([
 	"localhost",
 	"metadata.google.internal",
 	"metadata.google",
-	"[::1]",
+	"::1",
 ]);
 
 /**
@@ -236,8 +241,10 @@ export function validateExternalUrl(url: string): URL {
 		}
 	}
 
-	// Check if hostname is an IP address in a private range
-	if (isPrivateIp(hostname)) {
+	// Check if hostname is an IP address in a private range. Use the
+	// normalized form so "127.0.0.1.." and friends don't bypass parseIpv4
+	// (which rejects extra trailing dots).
+	if (isPrivateIp(normalizedHost)) {
 		throw new SsrfError("URLs targeting private IP addresses are not allowed");
 	}
 
@@ -338,7 +345,10 @@ export const cloudflareDohResolver: DnsResolver = async (hostname) => {
 			if (body.Status !== 0) {
 				throw new Error(`DoH ${type} lookup failed: rcode=${body.Status}`);
 			}
-			return body.Answer.map((a) => a.data).filter((d) => typeof d === "string");
+			// DoH Answer arrays often include CNAME records alongside A/AAAA
+			// records. Their `data` is a hostname, not an IP. Filter to just
+			// IP literals so isPrivateIp sees real addresses.
+			return body.Answer.map((a) => a.data).filter(isIpLiteral);
 		} finally {
 			clearTimeout(timeout);
 		}

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -16,7 +16,11 @@ import { SeoRepository } from "../database/repositories/seo.js";
 import { UserRepository } from "../database/repositories/user.js";
 import { withTransaction } from "../database/transaction.js";
 import type { Database } from "../database/types.js";
-import { validateExternalUrl, SsrfError, stripCredentialHeaders } from "../import/ssrf.js";
+import {
+	resolveAndValidateExternalUrl,
+	SsrfError,
+	stripCredentialHeaders,
+} from "../import/ssrf.js";
 import type { Storage } from "../storage/types.js";
 import { CronAccessImpl } from "./cron.js";
 import type { EmailPipeline } from "./email.js";
@@ -599,9 +603,10 @@ export function createUnrestrictedHttpAccess(pluginId: string): HttpAccess {
 			let currentInit = init;
 
 			for (let i = 0; i <= MAX_PLUGIN_REDIRECTS; i++) {
-				// Validate each URL against SSRF rules (private IPs, metadata endpoints)
+				// Validate each URL against SSRF rules (private IPs, metadata
+				// endpoints, wildcard DNS, resolved-IP private ranges).
 				try {
-					validateExternalUrl(currentUrl);
+					await resolveAndValidateExternalUrl(currentUrl);
 				} catch (e) {
 					const msg = e instanceof SsrfError ? e.message : "SSRF validation failed";
 					throw new Error(

--- a/packages/core/tests/unit/import/ssrf.test.ts
+++ b/packages/core/tests/unit/import/ssrf.test.ts
@@ -221,6 +221,19 @@ describe("validateExternalUrl", () => {
 		expect(() => validateExternalUrl("http://0.0.0.0/")).toThrow(SsrfError);
 		expect(() => validateExternalUrl("http://0.0.0.1/")).toThrow(SsrfError);
 	});
+
+	// IPv4 literals with trailing dots. A single trailing dot is stripped by
+	// the WHATWG URL parser, but multiple trailing dots are preserved on
+	// .hostname. parseIpv4 rejects anything with a dot count != 4, so
+	// "127.0.0.1.." falls through to isPrivateIp's IPv6 fallback and
+	// returns false, bypassing the private-IP check. We must strip trailing
+	// dots before the private-IP check.
+	it("blocks IPv4 literals with trailing dots", () => {
+		expect(() => validateExternalUrl("http://127.0.0.1./")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1../")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://169.254.169.254../")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://10.0.0.1../")).toThrow(SsrfError);
+	});
 });
 
 // =============================================================================
@@ -732,5 +745,47 @@ describe("cloudflareDohResolver", () => {
 		});
 		const ips = await cloudflareDohResolver("example.com");
 		expect(ips).toEqual(["93.184.216.34"]);
+	});
+
+	// DoH responses often include CNAME records in the Answer chain alongside
+	// (or instead of) A/AAAA records. Their `data` field is a hostname, not
+	// an IP. If we return them, the validator's isPrivateIp check silently
+	// accepts them (parseIpv4 returns null → "not private" → pass).
+	it("filters CNAME-style hostname answers, keeping only IP literals", async () => {
+		stubFetch({
+			A: {
+				body: {
+					Status: 0,
+					Answer: [
+						{ data: "cdn.example.com." }, // CNAME target, not an IP
+						{ data: "93.184.216.34" }, // real A record
+					],
+				},
+			},
+			AAAA: {
+				body: {
+					Status: 0,
+					Answer: [{ data: "other.example.com." }, { data: "2606:4700::1" }],
+				},
+			},
+		});
+		const ips = await cloudflareDohResolver("example.com");
+		expect(ips).toEqual(["93.184.216.34", "2606:4700::1"]);
+	});
+
+	it("rejects a response that contains only CNAME strings", async () => {
+		stubFetch({
+			A: {
+				body: {
+					Status: 0,
+					Answer: [{ data: "target.example.com." }],
+				},
+			},
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		const ips = await cloudflareDohResolver("cname-only.example");
+		// No IPs at all — the caller should treat this as "could not resolve"
+		// and fail closed, not pretend the CNAME target is an address.
+		expect(ips).toEqual([]);
 	});
 });

--- a/packages/core/tests/unit/import/ssrf.test.ts
+++ b/packages/core/tests/unit/import/ssrf.test.ts
@@ -7,12 +7,14 @@
  * - validateExternalUrl blocking internal targets
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-	validateExternalUrl,
-	SsrfError,
+	cloudflareDohResolver,
 	normalizeIPv6MappedToIPv4,
+	resolveAndValidateExternalUrl,
+	SsrfError,
+	validateExternalUrl,
 } from "../../../src/import/ssrf.js";
 
 describe("validateExternalUrl", () => {
@@ -401,5 +403,334 @@ describe("normalizeIPv6MappedToIPv4", () => {
 	it("returns null for dotted-decimal mapped form (handled separately)", () => {
 		// ::ffff:127.0.0.1 uses the dotted-decimal regex, not hex normalization
 		expect(normalizeIPv6MappedToIPv4("::ffff:127.0.0.1")).toBeNull();
+	});
+});
+
+// =============================================================================
+// Wildcard DNS services — hostname blocklist
+//
+// Services like nip.io map "127.0.0.1.nip.io" to 127.0.0.1. Without DNS
+// resolution they pass validateExternalUrl since the hostname is neither an
+// IP literal nor on the small internal-names list. Adding the apex domains
+// to BLOCKED_HOSTNAMES catches the most widely-used rebinding tools without
+// requiring a network round-trip.
+// =============================================================================
+
+describe("validateExternalUrl — wildcard DNS rebinding services", () => {
+	it("blocks nip.io and its subdomains", () => {
+		expect(() => validateExternalUrl("http://nip.io/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1.nip.io/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://169.254.169.254.nip.io/latest/")).toThrow(SsrfError);
+	});
+
+	it("blocks sslip.io and its subdomains", () => {
+		expect(() => validateExternalUrl("http://sslip.io/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1.sslip.io/")).toThrow(SsrfError);
+	});
+
+	it("blocks xip.io and its subdomains", () => {
+		expect(() => validateExternalUrl("http://xip.io/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://10.0.0.1.xip.io/")).toThrow(SsrfError);
+	});
+
+	it("blocks traefik.me and its subdomains", () => {
+		expect(() => validateExternalUrl("http://traefik.me/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1.traefik.me/")).toThrow(SsrfError);
+	});
+
+	it("is case-insensitive for blocklisted hostnames", () => {
+		expect(() => validateExternalUrl("http://NIP.IO/")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1.Nip.Io/")).toThrow(SsrfError);
+	});
+
+	// Trailing-dot FQDN form. The WHATWG URL parser preserves the dot on
+	// `.hostname`, so a naive exact-match or `.endsWith(suffix)` check misses
+	// these. Without explicit normalization, attackers can bypass both
+	// BLOCKED_HOSTNAMES and the suffix list by appending a single dot.
+	it("blocks trailing-dot FQDNs on the hostname blocklist", () => {
+		expect(() => validateExternalUrl("http://localhost./")).toThrow(SsrfError);
+	});
+
+	it("blocks trailing-dot FQDNs on the wildcard suffix list", () => {
+		expect(() => validateExternalUrl("http://nip.io./")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://127.0.0.1.nip.io./")).toThrow(SsrfError);
+		expect(() => validateExternalUrl("http://sslip.io./")).toThrow(SsrfError);
+	});
+
+	it("allows look-alike domains that are not on the blocklist", () => {
+		// Defensive: we should only block specific known services, not any
+		// domain that happens to contain "nip" or similar.
+		expect(validateExternalUrl("http://nippon.example.com/")).toBeInstanceOf(URL);
+	});
+});
+
+// =============================================================================
+// resolveAndValidateExternalUrl — async DNS-aware validation
+//
+// Runs validateExternalUrl first (cheap pre-flight), then resolves the
+// hostname via an injectable resolver and checks each returned IP against
+// the private-range blocklist. Catches DNS rebinding attacks using domains
+// the attacker controls (not just known public rebinding services).
+// =============================================================================
+
+describe("resolveAndValidateExternalUrl", () => {
+	// Helper: build a stubbed resolver that returns a fixed list of IPs.
+	function resolver(ips: string[]): (host: string) => Promise<string[]> {
+		return async () => ips;
+	}
+
+	// Helper: a resolver that fails. Used to assert fail-closed behaviour.
+	function failingResolver(error = new Error("DNS failure")) {
+		return async () => {
+			throw error;
+		};
+	}
+
+	it("accepts public IPs", async () => {
+		const url = await resolveAndValidateExternalUrl("https://example.com/", {
+			resolver: resolver(["93.184.216.34"]),
+		});
+		expect(url).toBeInstanceOf(URL);
+		expect(url.hostname).toBe("example.com");
+	});
+
+	it("rejects hostnames that resolve to loopback", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://attacker.example/", {
+				resolver: resolver(["127.0.0.1"]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("rejects hostnames that resolve to cloud metadata IP", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://attacker.example/", {
+				resolver: resolver(["169.254.169.254"]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("rejects hostnames that resolve to any RFC1918 address", async () => {
+		for (const ip of ["10.0.0.1", "172.16.0.1", "192.168.1.1"]) {
+			await expect(
+				resolveAndValidateExternalUrl("https://attacker.example/", {
+					resolver: resolver([ip]),
+				}),
+			).rejects.toThrow(SsrfError);
+		}
+	});
+
+	it("rejects if ANY resolved IP is private (multi-record DNS rebinding)", async () => {
+		// Attacker serves two A records; we must reject if either is private,
+		// not just the first one.
+		await expect(
+			resolveAndValidateExternalUrl("https://attacker.example/", {
+				resolver: resolver(["93.184.216.34", "127.0.0.1"]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("rejects IPv6 loopback in resolved records", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://attacker.example/", {
+				resolver: resolver(["::1"]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("rejects IPv6 link-local in resolved records (any case)", async () => {
+		for (const ip of ["fe80::1", "FE80::1", "Fe80::abcd"]) {
+			await expect(
+				resolveAndValidateExternalUrl("https://attacker.example/", {
+					resolver: resolver([ip]),
+				}),
+			).rejects.toThrow(SsrfError);
+		}
+	});
+
+	it("rejects IPv6 unique-local in resolved records (any case)", async () => {
+		for (const ip of ["fc00::1", "FC00::1", "fd12:3456::1", "FD00::BEEF"]) {
+			await expect(
+				resolveAndValidateExternalUrl("https://attacker.example/", {
+					resolver: resolver([ip]),
+				}),
+			).rejects.toThrow(SsrfError);
+		}
+	});
+
+	it("rejects IPv4-mapped IPv6 loopback in resolved records", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://attacker.example/", {
+				resolver: resolver(["::ffff:127.0.0.1"]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("accepts public IPv6 addresses", async () => {
+		const url = await resolveAndValidateExternalUrl("https://example.com/", {
+			resolver: resolver(["2606:4700:4700::1111"]),
+		});
+		expect(url).toBeInstanceOf(URL);
+	});
+
+	it("runs synchronous validateExternalUrl first (short-circuits on literal IP)", async () => {
+		// 127.0.0.1 as a literal hostname is caught by validateExternalUrl
+		// before any DNS lookup. Pass a resolver that would throw to prove it
+		// isn't called.
+		const r = failingResolver(new Error("should not be called"));
+		await expect(
+			resolveAndValidateExternalUrl("http://127.0.0.1/", { resolver: r }),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("fails closed when the resolver throws", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://example.com/", {
+				resolver: failingResolver(),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("rejects empty resolver result (hostname resolves to nothing)", async () => {
+		await expect(
+			resolveAndValidateExternalUrl("https://example.com/", {
+				resolver: resolver([]),
+			}),
+		).rejects.toThrow(SsrfError);
+	});
+
+	it("returns the parsed URL on success", async () => {
+		const url = await resolveAndValidateExternalUrl("https://example.com/path?q=1", {
+			resolver: resolver(["93.184.216.34"]),
+		});
+		expect(url.pathname).toBe("/path");
+		expect(url.searchParams.get("q")).toBe("1");
+	});
+});
+
+// =============================================================================
+// cloudflareDohResolver — unit tests for the DoH parser
+//
+// Stubs globalThis.fetch to simulate various DoH responses. The resolver
+// must:
+//   - return IPs from valid A and AAAA responses
+//   - treat NXDOMAIN (Status=3) as an empty result (legitimately non-existent)
+//   - fail closed on SERVFAIL (Status=2), REFUSED (Status=5), and other
+//     non-zero statuses, so that split-view DNS can't smuggle a private IP
+//     past the check by SERVFAIL'ing one record type
+//   - fail on HTTP errors
+//   - fail on malformed JSON or responses with missing fields
+// =============================================================================
+
+describe("cloudflareDohResolver", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function stubFetch(
+		responses: Record<"A" | "AAAA", { body?: unknown; status?: number; throws?: Error }>,
+	): void {
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			const type: "A" | "AAAA" = url.includes("type=AAAA") ? "AAAA" : "A";
+			const res = responses[type];
+			if (res.throws) throw res.throws;
+			return new Response(JSON.stringify(res.body ?? {}), { status: res.status ?? 200 });
+			// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+		}) as unknown as typeof globalThis.fetch;
+	}
+
+	it("returns A and AAAA records from a valid Status=0 response", async () => {
+		stubFetch({
+			A: { body: { Status: 0, Answer: [{ data: "93.184.216.34" }] } },
+			AAAA: { body: { Status: 0, Answer: [{ data: "2606:4700::1" }] } },
+		});
+
+		const ips = await cloudflareDohResolver("example.com");
+		expect(ips).toContain("93.184.216.34");
+		expect(ips).toContain("2606:4700::1");
+	});
+
+	it("treats NXDOMAIN (Status=3) as empty (legitimately no records)", async () => {
+		stubFetch({
+			A: { body: { Status: 3 } },
+			AAAA: { body: { Status: 3 } },
+		});
+		const ips = await cloudflareDohResolver("does-not-exist.example");
+		expect(ips).toEqual([]);
+	});
+
+	it("fails closed on SERVFAIL (Status=2)", async () => {
+		// Split-view attack: attacker authoritative NS returns SERVFAIL to
+		// Cloudflare's resolver but real records to the victim's resolver.
+		// If we silently treated SERVFAIL as empty, we'd combine whatever
+		// the other record type returned and call it "public" — bypassing
+		// the check.
+		stubFetch({
+			A: { body: { Status: 2 } },
+			AAAA: { body: { Status: 0, Answer: [{ data: "2606:4700::1" }] } },
+		});
+		await expect(cloudflareDohResolver("attacker.example")).rejects.toThrow();
+	});
+
+	it("fails closed on REFUSED (Status=5)", async () => {
+		stubFetch({
+			A: { body: { Status: 5 } },
+			AAAA: { body: { Status: 0, Answer: [{ data: "2606:4700::1" }] } },
+		});
+		await expect(cloudflareDohResolver("attacker.example")).rejects.toThrow();
+	});
+
+	it("fails closed on HTTP errors from the DoH endpoint", async () => {
+		stubFetch({
+			A: { status: 500 },
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		await expect(cloudflareDohResolver("example.com")).rejects.toThrow();
+	});
+
+	it("fails closed on malformed response bodies missing Status", async () => {
+		stubFetch({
+			A: { body: {} },
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		await expect(cloudflareDohResolver("example.com")).rejects.toThrow();
+	});
+
+	it("fails closed on network errors", async () => {
+		stubFetch({
+			A: { throws: new Error("network down") },
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		await expect(cloudflareDohResolver("example.com")).rejects.toThrow();
+	});
+
+	it("returns empty array when both A and AAAA return no records but Status=0", async () => {
+		stubFetch({
+			A: { body: { Status: 0, Answer: [] } },
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		const ips = await cloudflareDohResolver("example.com");
+		expect(ips).toEqual([]);
+	});
+
+	it("skips Answer entries without string data", async () => {
+		stubFetch({
+			A: {
+				body: {
+					Status: 0,
+					Answer: [{ data: "93.184.216.34" }, { data: 12345 }, {}, { notData: "foo" }],
+				},
+			},
+			AAAA: { body: { Status: 0, Answer: [] } },
+		});
+		const ips = await cloudflareDohResolver("example.com");
+		expect(ips).toEqual(["93.184.216.34"]);
 	});
 });

--- a/packages/core/tests/unit/import/wordpress-plugin-i18n.test.ts
+++ b/packages/core/tests/unit/import/wordpress-plugin-i18n.test.ts
@@ -5,14 +5,24 @@
  * surface i18n detection from the EmDash Exporter plugin's API responses.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { wordpressPluginSource } from "../../../src/import/sources/wordpress-plugin.js";
+import { setDefaultDnsResolver } from "../../../src/import/ssrf.js";
 
 // ─── Mock fetch ──────────────────────────────────────────────────────────────
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+// Bypass DoH so the fetch mock only sees the calls these tests model.
+let previousResolver: ReturnType<typeof setDefaultDnsResolver> | undefined;
+beforeAll(() => {
+	previousResolver = setDefaultDnsResolver(async () => ["93.184.216.34"]);
+});
+afterAll(() => {
+	setDefaultDnsResolver(previousResolver ?? null);
+});
 
 beforeEach(() => {
 	mockFetch.mockReset();

--- a/packages/core/tests/unit/plugins/http-credential-stripping.test.ts
+++ b/packages/core/tests/unit/plugins/http-credential-stripping.test.ts
@@ -6,13 +6,27 @@
  * must be stripped to prevent credential leakage to untrusted hosts.
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { setDefaultDnsResolver } from "../../../src/import/ssrf.js";
 import { createHttpAccess, createUnrestrictedHttpAccess } from "../../../src/plugins/context.js";
 
 // Intercept globalThis.fetch so we can simulate redirect chains
 const mockFetch = vi.fn<typeof globalThis.fetch>();
 vi.stubGlobal("fetch", mockFetch);
+
+// Bypass DoH so the fetch mock only sees the calls these tests model.
+// Returns a fixed public IP so resolveAndValidateExternalUrl passes.
+const STUB_RESOLVER = async () => ["93.184.216.34"];
+let previousResolver: ReturnType<typeof setDefaultDnsResolver> | undefined;
+
+beforeAll(() => {
+	previousResolver = setDefaultDnsResolver(STUB_RESOLVER);
+});
+
+afterAll(() => {
+	setDefaultDnsResolver(previousResolver ?? null);
+});
 
 afterEach(() => {
 	mockFetch.mockReset();

--- a/packages/core/tests/unit/seed/media.test.ts
+++ b/packages/core/tests/unit/seed/media.test.ts
@@ -1,8 +1,9 @@
 import type { Kysely } from "kysely";
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ContentRepository } from "../../../src/database/repositories/content.js";
 import type { Database } from "../../../src/database/types.js";
+import { setDefaultDnsResolver } from "../../../src/import/ssrf.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { applySeed } from "../../../src/seed/apply.js";
 import type { SeedFile } from "../../../src/seed/types.js";
@@ -15,6 +16,15 @@ const PNG_EXTENSION_REGEX = /\.png$/;
 // Mock fetch globally
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
+
+// Bypass DoH so the fetch mock only sees the calls these tests model.
+let previousResolver: ReturnType<typeof setDefaultDnsResolver> | undefined;
+beforeAll(() => {
+	previousResolver = setDefaultDnsResolver(async () => ["93.184.216.34"]);
+});
+afterAll(() => {
+	setDefaultDnsResolver(previousResolver ?? null);
+});
 
 // Create a mock storage that tracks uploads
 function createMockStorage(): Storage & { uploads: UploadOptions[] } {


### PR DESCRIPTION
## What does this PR do?

Tightens URL validation in the import pipeline so that a hostname's resolved IP is checked against the private-range blocklist, not just the hostname string. Previously, a hostname like `127.0.0.1.nip.io` (or any domain the caller controls pointing at a private IP) passed the sync validator and was only stopped by whatever the platform runtime happened to block at connect time.

**`validateExternalUrl` (sync, unchanged signature):**
- Adds a suffix blocklist for well-known wildcard DNS services: `nip.io`, `sslip.io`, `xip.io`, `traefik.me`, `lvh.me`, `localtest.me`. Matches the apex and any subdomain.
- Normalises hostnames before matching (lowercase + strip trailing dots), so `localhost.` and `nip.io.` no longer bypass the check.
- Fixes a latent case-sensitivity issue in `isPrivateIp`'s IPv6 prefix checks — `FE80::1` was accepted as non-private. The check now lowercases first and uses tighter patterns for the RFC 4193 `fc00::/7` range.

**`resolveAndValidateExternalUrl` (new, async):**
- Runs `validateExternalUrl` first (cheap pre-flight) then resolves the hostname via DNS-over-HTTPS to `cloudflare-dns.com` and rejects if any A or AAAA record is in a private range.
- IP literals short-circuit — no DNS lookup.
- Fails closed on DNS failures. NXDOMAIN is legitimately empty, but `SERVFAIL`/`REFUSED`/malformed responses throw, so a split-view resolver can't hide a private record by `SERVFAIL`ing one record type.

**Call sites updated:**
- `ssrfSafeFetch` now does DNS validation per hop (initial URL and every redirect).
- `createUnrestrictedHttpAccess` in the plugin runtime does the same.
- Validate-only pre-checks in `analyze.ts`, `execute.ts`, and `registry.probeUrl` upgraded to the async validator.

**Test hook:**
- `setDefaultDnsResolver` lets tests that stub `globalThis.fetch` swap the default DoH resolver for a stub, so their call-count assertions still work.

**What this still doesn't close:**

The JSDoc on `resolveAndValidateExternalUrl` spells out the remaining TOCTOU vectors — TTL=0 rebind, ECS/source-IP split-view, OS-level DNS overrides. A full fix requires a network-layer egress firewall. On Workers the platform fetch pipeline provides most of that; on self-hosted Node operators need to enforce egress themselves.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

- 15 new unit tests covering: wildcard DNS suffix matching, trailing-dot normalisation, async resolver validation (loopback / 169.254 / RFC1918 / ULA / link-local in any case / IPv4-mapped IPv6), IP-literal short-circuit, fail-closed on resolver errors and empty results, and direct coverage of \`cloudflareDohResolver\` (valid A+AAAA, NXDOMAIN-as-empty, SERVFAIL/REFUSED/HTTP-500/malformed-body all fail closed, skip-non-string-data)
- Full suite green: 2479 tests in \`emdash\` (+15 new) plus all other packages
- Typecheck clean across the workspace
- Lint diff: zero in touched files

**Runtime cost:** Every outbound import fetch now makes two DoH round-trips (A + AAAA) before the real request. ~100-200ms of added latency per URL. Self-hosted deployments whose egress blocks \`cloudflare-dns.com\` can inject a custom resolver — e.g. using Node's \`dns.resolve\` — via \`setDefaultDnsResolver\`.