### PR TITLE
fix(core): accept publishedAt/createdAt on content create/update

### DIFF
--- a/.changeset/fix-content-date-overrides.md
+++ b/.changeset/fix-content-date-overrides.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the REST content API silently stripping `publishedAt` on create/update and `createdAt` on create. Importers can now preserve original publish and creation dates on migrated content. Gated behind `content:publish_any` (EDITOR+) so regular contributors cannot backdate posts. `createdAt` is intentionally not accepted on update — `created_at` is treated as immutable.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -483,6 +483,7 @@ export async function handleContentUpdate(
 		bylines?: ContentBylineInput[];
 		_rev?: string;
 		seo?: ContentSeoInput;
+		publishedAt?: string | null;
 	},
 ): Promise<ApiResult<ContentResponse>> {
 	try {
@@ -542,6 +543,7 @@ export async function handleContentUpdate(
 				slug: body.slug,
 				status: body.status,
 				authorId: body.authorId,
+				publishedAt: body.publishedAt,
 			});
 
 			if (body.bylines !== undefined) {

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -29,7 +29,7 @@ export const contentListQuery = cursorPaginationQuery
 
 /** ISO 8601 datetime for `publishedAt` / `createdAt`. Routes gate writes behind `content:publish_any`. */
 const contentDateOverride = z.iso
-	.datetime({ offset: true, error: "must be an ISO 8601 datetime" })
+	.datetime({ offset: true, message: "must be an ISO 8601 datetime" })
 	.nullish();
 
 export const contentCreateBody = z

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -27,6 +27,11 @@ export const contentListQuery = cursorPaginationQuery
 	})
 	.meta({ id: "ContentListQuery" });
 
+/** ISO 8601 datetime for `publishedAt` / `createdAt`. Routes gate writes behind `content:publish_any`. */
+const contentDateOverride = z.iso
+	.datetime({ offset: true, error: "must be an ISO 8601 datetime" })
+	.nullish();
+
 export const contentCreateBody = z
 	.object({
 		data: z.record(z.string(), z.unknown()),
@@ -36,6 +41,8 @@ export const contentCreateBody = z
 		locale: localeCode.optional(),
 		translationOf: z.string().optional(),
 		seo: contentSeoInput.optional(),
+		publishedAt: contentDateOverride,
+		createdAt: contentDateOverride,
 	})
 	.meta({ id: "ContentCreateBody" });
 
@@ -52,6 +59,7 @@ export const contentUpdateBody = z
 			.meta({ description: "Opaque revision token for optimistic concurrency" }),
 		skipRevision: z.boolean().optional(),
 		seo: contentSeoInput.optional(),
+		publishedAt: contentDateOverride,
 	})
 	.meta({ id: "ContentUpdateBody" });
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -6,7 +6,7 @@
  * DELETE /_emdash/api/content/{collection}/{id} - Delete content
  */
 
-import { hasPermission, type Permission } from "@emdash-cms/auth";
+import { hasPermission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm, requireOwnerPerm } from "#api/authorize.js";
@@ -89,7 +89,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	if (editDenied) return editDenied;
 
 	// Only EDITOR+ can write publishedAt directly — incl. clearing to null.
-	if (body.publishedAt !== undefined && !hasPermission(user, "content:publish_any" as Permission)) {
+	if (body.publishedAt !== undefined && !hasPermission(user, "content:publish_any")) {
 		return apiError(
 			"FORBIDDEN",
 			"Writing publishedAt requires content:publish_any permission",
@@ -102,7 +102,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 
 	// Only allow authorId changes if user has content:edit_any permission (editor+)
 	const canChangeAuthor =
-		body.authorId !== undefined && user && hasPermission(user, "content:edit_any" as Permission);
+		body.authorId !== undefined && user && hasPermission(user, "content:edit_any");
 	const updateBody = canChangeAuthor ? body : { ...body, authorId: undefined };
 
 	// Pass _rev through for optimistic concurrency validation

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -88,6 +88,15 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const editDenied = requireOwnerPerm(user, authorId, "content:edit_own", "content:edit_any");
 	if (editDenied) return editDenied;
 
+	// Only EDITOR+ can write publishedAt directly — incl. clearing to null.
+	if (body.publishedAt !== undefined && !hasPermission(user, "content:publish_any" as Permission)) {
+		return apiError(
+			"FORBIDDEN",
+			"Writing publishedAt requires content:publish_any permission",
+			403,
+		);
+	}
+
 	// Use the resolved ID (handles slug → ID resolution)
 	const resolvedId = typeof existingItem?.id === "string" ? existingItem.id : id;
 

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -5,7 +5,7 @@
  * POST /_emdash/api/content/{collection} - Create content
  */
 
-import { hasPermission, type Permission } from "@emdash-cms/auth";
+import { hasPermission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm, requireOwnerPerm } from "#api/authorize.js";
@@ -81,7 +81,7 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 
 	// Only EDITOR+ can write publishedAt / createdAt directly — incl. clearing to null.
 	const hasDateOverride = body.publishedAt !== undefined || body.createdAt !== undefined;
-	if (hasDateOverride && !hasPermission(user, "content:publish_any" as Permission)) {
+	if (hasDateOverride && !hasPermission(user, "content:publish_any")) {
 		return apiError(
 			"FORBIDDEN",
 			"Writing publishedAt or createdAt requires content:publish_any permission",

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -5,7 +5,7 @@
  * POST /_emdash/api/content/{collection} - Create content
  */
 
-import { hasPermission } from "@emdash-cms/auth";
+import { hasPermission, type Permission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm, requireOwnerPerm } from "#api/authorize.js";
@@ -77,6 +77,16 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 			"content:edit_any",
 		);
 		if (translationDenied) return translationDenied;
+	}
+
+	// Only EDITOR+ can write publishedAt / createdAt directly — incl. clearing to null.
+	const hasDateOverride = body.publishedAt !== undefined || body.createdAt !== undefined;
+	if (hasDateOverride && !hasPermission(user, "content:publish_any" as Permission)) {
+		return apiError(
+			"FORBIDDEN",
+			"Writing publishedAt or createdAt requires content:publish_any permission",
+			403,
+		);
 	}
 
 	// Auto-set authorId to current user when creating content

--- a/packages/core/tests/unit/api/content-handlers.test.ts
+++ b/packages/core/tests/unit/api/content-handlers.test.ts
@@ -145,6 +145,21 @@ describe("Content Handlers — auto-slug generation", () => {
 			expect(postResult.data?.item.slug).toBe("about");
 			expect(pageResult.data?.item.slug).toBe("about");
 		});
+
+		it("preserves publishedAt and createdAt when provided — content migration use case", async () => {
+			const originalCreated = "2019-03-15T10:30:00.000Z";
+			const originalPublished = "2019-03-16T09:00:00.000Z";
+
+			const result = await handleContentCreate(db, "post", {
+				data: { title: "Migrated Post" },
+				createdAt: originalCreated,
+				publishedAt: originalPublished,
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data?.item.createdAt).toBe(originalCreated);
+			expect(result.data?.item.publishedAt).toBe(originalPublished);
+		});
 	});
 
 	describe("handleContentDuplicate", () => {
@@ -262,6 +277,38 @@ describe("Content Handlers — auto-slug generation", () => {
 			expect(duplicated.success).toBe(true);
 			expect(duplicated.data?.item.byline?.id).toBe(byline.id);
 			expect(duplicated.data?.item.bylines).toHaveLength(1);
+		});
+	});
+
+	describe("handleContentUpdate — publishedAt override", () => {
+		it("persists publishedAt when provided", async () => {
+			const created = await handleContentCreate(db, "post", { data: { title: "Hi" } });
+			expect(created.success).toBe(true);
+
+			const newPublishedAt = "2019-03-16T09:00:00.000Z";
+			const updated = await handleContentUpdate(db, "post", created.data!.item.id, {
+				publishedAt: newPublishedAt,
+			});
+
+			expect(updated.success).toBe(true);
+			expect(updated.data?.item.publishedAt).toBe(newPublishedAt);
+		});
+
+		it("leaves createdAt untouched on update", async () => {
+			const originalCreated = "2019-03-15T10:30:00.000Z";
+			const created = await handleContentCreate(db, "post", {
+				data: { title: "Hi" },
+				createdAt: originalCreated,
+			});
+			expect(created.success).toBe(true);
+
+			const updated = await handleContentUpdate(db, "post", created.data!.item.id, {
+				data: { title: "Edited" },
+				publishedAt: "2020-01-01T00:00:00.000Z",
+			});
+
+			expect(updated.success).toBe(true);
+			expect(updated.data?.item.createdAt).toBe(originalCreated);
 		});
 	});
 });

--- a/packages/core/tests/unit/api/content-route-permissions.test.ts
+++ b/packages/core/tests/unit/api/content-route-permissions.test.ts
@@ -1,0 +1,279 @@
+import { Role } from "@emdash-cms/auth";
+import { describe, it, expect, vi } from "vitest";
+
+import { PUT as updateContent } from "../../../src/astro/routes/api/content/[collection]/[id].js";
+import { POST as createContent } from "../../../src/astro/routes/api/content/[collection]/index.js";
+
+/**
+ * Regression tests for the `publishedAt` / `createdAt` permission gate.
+ *
+ * The gate must trigger on *any* explicit presence of these fields —
+ * including `null` (explicit clear) — not just on non-null values. Checking
+ * only `!= null` would let a regular AUTHOR clear `published_at` on any item
+ * they can edit, bypassing `content:publish_any`.
+ */
+describe("content route — publishedAt / createdAt permission gate", () => {
+	const makeUser = (role: (typeof Role)[keyof typeof Role]) => ({
+		id: "user-1",
+		role,
+	});
+
+	const makeCache = () => ({ enabled: false, invalidate: vi.fn() });
+
+	describe("POST /_emdash/api/content/{collection}", () => {
+		it("returns 403 when an AUTHOR tries to set publishedAt", async () => {
+			const request = new Request("http://localhost/_emdash/api/content/post", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					data: { title: "Hi" },
+					publishedAt: "2019-03-15T10:30:00.000Z",
+				}),
+			});
+
+			const response = await createContent({
+				params: { collection: "post" },
+				request,
+				locals: {
+					emdash: {
+						handleContentCreate: vi.fn(),
+						handleContentGet: vi.fn(),
+					},
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof createContent>[0]);
+
+			expect(response.status).toBe(403);
+			await expect(response.json()).resolves.toMatchObject({
+				error: { code: "FORBIDDEN" },
+			});
+		});
+
+		it("returns 403 when an AUTHOR tries to clear publishedAt via null", async () => {
+			const request = new Request("http://localhost/_emdash/api/content/post", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: { title: "Hi" }, publishedAt: null }),
+			});
+
+			const response = await createContent({
+				params: { collection: "post" },
+				request,
+				locals: {
+					emdash: {
+						handleContentCreate: vi.fn(),
+						handleContentGet: vi.fn(),
+					},
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof createContent>[0]);
+
+			expect(response.status).toBe(403);
+		});
+
+		it("returns 403 when an AUTHOR tries to set createdAt", async () => {
+			const request = new Request("http://localhost/_emdash/api/content/post", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					data: { title: "Hi" },
+					createdAt: "2019-03-15T10:30:00.000Z",
+				}),
+			});
+
+			const response = await createContent({
+				params: { collection: "post" },
+				request,
+				locals: {
+					emdash: {
+						handleContentCreate: vi.fn(),
+						handleContentGet: vi.fn(),
+					},
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof createContent>[0]);
+
+			expect(response.status).toBe(403);
+		});
+
+		it("lets EDITOR set publishedAt", async () => {
+			const handleContentCreate = vi.fn().mockResolvedValue({
+				success: true,
+				data: {
+					item: { id: "c1", publishedAt: "2019-03-15T10:30:00.000Z" },
+					_rev: "rev1",
+				},
+			});
+
+			const request = new Request("http://localhost/_emdash/api/content/post", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					data: { title: "Hi" },
+					publishedAt: "2019-03-15T10:30:00.000Z",
+				}),
+			});
+
+			const response = await createContent({
+				params: { collection: "post" },
+				request,
+				locals: {
+					emdash: { handleContentCreate, handleContentGet: vi.fn() },
+					user: makeUser(Role.EDITOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof createContent>[0]);
+
+			expect(response.status).toBe(201);
+			expect(handleContentCreate).toHaveBeenCalledWith(
+				"post",
+				expect.objectContaining({ publishedAt: "2019-03-15T10:30:00.000Z" }),
+			);
+		});
+
+		it("lets AUTHOR create without date overrides", async () => {
+			const handleContentCreate = vi.fn().mockResolvedValue({
+				success: true,
+				data: { item: { id: "c1" }, _rev: "rev1" },
+			});
+
+			const request = new Request("http://localhost/_emdash/api/content/post", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: { title: "Hi" } }),
+			});
+
+			const response = await createContent({
+				params: { collection: "post" },
+				request,
+				locals: {
+					emdash: { handleContentCreate, handleContentGet: vi.fn() },
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof createContent>[0]);
+
+			expect(response.status).toBe(201);
+			expect(handleContentCreate).toHaveBeenCalled();
+		});
+	});
+
+	describe("PUT /_emdash/api/content/{collection}/{id}", () => {
+		const ownedItem = {
+			success: true,
+			data: { item: { id: "c1", authorId: "user-1" }, _rev: "rev1" },
+		};
+
+		it("returns 403 when an AUTHOR tries to clear publishedAt via null on their own post", async () => {
+			const handleContentGet = vi.fn().mockResolvedValue(ownedItem);
+			const handleContentUpdate = vi.fn();
+
+			const request = new Request("http://localhost/_emdash/api/content/post/c1", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ publishedAt: null }),
+			});
+
+			const response = await updateContent({
+				params: { collection: "post", id: "c1" },
+				request,
+				locals: {
+					emdash: { handleContentUpdate, handleContentGet },
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof updateContent>[0]);
+
+			expect(response.status).toBe(403);
+			expect(handleContentUpdate).not.toHaveBeenCalled();
+		});
+
+		it("returns 403 when an AUTHOR tries to set publishedAt on their own post", async () => {
+			const handleContentGet = vi.fn().mockResolvedValue(ownedItem);
+			const handleContentUpdate = vi.fn();
+
+			const request = new Request("http://localhost/_emdash/api/content/post/c1", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ publishedAt: "2019-03-15T10:30:00.000Z" }),
+			});
+
+			const response = await updateContent({
+				params: { collection: "post", id: "c1" },
+				request,
+				locals: {
+					emdash: { handleContentUpdate, handleContentGet },
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof updateContent>[0]);
+
+			expect(response.status).toBe(403);
+			expect(handleContentUpdate).not.toHaveBeenCalled();
+		});
+
+		it("lets EDITOR set publishedAt", async () => {
+			const handleContentGet = vi.fn().mockResolvedValue(ownedItem);
+			const handleContentUpdate = vi.fn().mockResolvedValue({
+				success: true,
+				data: {
+					item: { id: "c1", publishedAt: "2019-03-15T10:30:00.000Z" },
+					_rev: "rev2",
+				},
+			});
+
+			const request = new Request("http://localhost/_emdash/api/content/post/c1", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ publishedAt: "2019-03-15T10:30:00.000Z" }),
+			});
+
+			const response = await updateContent({
+				params: { collection: "post", id: "c1" },
+				request,
+				locals: {
+					emdash: { handleContentUpdate, handleContentGet },
+					user: makeUser(Role.EDITOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof updateContent>[0]);
+
+			expect(response.status).toBe(200);
+			expect(handleContentUpdate).toHaveBeenCalledWith(
+				"post",
+				"c1",
+				expect.objectContaining({ publishedAt: "2019-03-15T10:30:00.000Z" }),
+			);
+		});
+
+		it("lets AUTHOR update their own post without date overrides", async () => {
+			const handleContentGet = vi.fn().mockResolvedValue(ownedItem);
+			const handleContentUpdate = vi.fn().mockResolvedValue({
+				success: true,
+				data: { item: { id: "c1" }, _rev: "rev2" },
+			});
+
+			const request = new Request("http://localhost/_emdash/api/content/post/c1", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: { title: "Edited" } }),
+			});
+
+			const response = await updateContent({
+				params: { collection: "post", id: "c1" },
+				request,
+				locals: {
+					emdash: { handleContentUpdate, handleContentGet },
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof updateContent>[0]);
+
+			expect(response.status).toBe(200);
+			expect(handleContentUpdate).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/core/tests/unit/api/schemas.test.ts
+++ b/packages/core/tests/unit/api/schemas.test.ts
@@ -26,6 +26,38 @@ describe("contentCreateBody schema", () => {
 	it("rejects status 'scheduled'", () => {
 		expect(() => contentCreateBody.parse({ data: { title: "Hi" }, status: "scheduled" })).toThrow();
 	});
+
+	it("preserves publishedAt and createdAt when valid ISO 8601 datetimes are provided", () => {
+		const result = contentCreateBody.parse({
+			data: { title: "Hi" },
+			publishedAt: "2019-03-15T10:30:00.000Z",
+			createdAt: "2019-03-15T10:30:00.000Z",
+		});
+		expect(result.publishedAt).toBe("2019-03-15T10:30:00.000Z");
+		expect(result.createdAt).toBe("2019-03-15T10:30:00.000Z");
+	});
+
+	it("accepts offset-suffixed ISO datetimes", () => {
+		const result = contentCreateBody.parse({
+			data: { title: "Hi" },
+			publishedAt: "2019-03-15T10:30:00+00:00",
+		});
+		expect(result.publishedAt).toBe("2019-03-15T10:30:00+00:00");
+	});
+
+	it("rejects malformed datetime strings", () => {
+		expect(() =>
+			contentCreateBody.parse({ data: { title: "Hi" }, publishedAt: "yesterday" }),
+		).toThrow();
+		expect(() =>
+			contentCreateBody.parse({ data: { title: "Hi" }, createdAt: "2019-03-15" }),
+		).toThrow();
+	});
+
+	it("accepts null to explicitly clear the field", () => {
+		const result = contentCreateBody.parse({ data: { title: "Hi" }, publishedAt: null });
+		expect(result.publishedAt).toBeNull();
+	});
 });
 
 describe("contentUpdateBody schema", () => {
@@ -62,6 +94,28 @@ describe("contentUpdateBody schema", () => {
 
 	it("rejects status 'scheduled'", () => {
 		expect(() => contentUpdateBody.parse({ data: { title: "Hi" }, status: "scheduled" })).toThrow();
+	});
+
+	it("preserves publishedAt when a valid ISO 8601 datetime is provided", () => {
+		const result = contentUpdateBody.parse({
+			data: { title: "Hi" },
+			publishedAt: "2019-03-15T10:30:00.000Z",
+		});
+		expect(result.publishedAt).toBe("2019-03-15T10:30:00.000Z");
+	});
+
+	it("rejects malformed publishedAt strings", () => {
+		expect(() =>
+			contentUpdateBody.parse({ data: { title: "Hi" }, publishedAt: "yesterday" }),
+		).toThrow();
+	});
+
+	it("strips createdAt — treat created_at as immutable on update", () => {
+		const result = contentUpdateBody.parse({
+			data: { title: "Hi" },
+			createdAt: "2019-03-15T10:30:00.000Z",
+		} as Parameters<typeof contentUpdateBody.parse>[0]);
+		expect("createdAt" in result).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

The REST content API's Zod schemas (`contentCreateBody`, `contentUpdateBody`) silently stripped `publishedAt` and `createdAt` from request bodies, even though `handleContentCreate` and `ContentRepository` already supported them. Importers that went through the handler directly (WordPress) worked; any importer going through the public REST API lost the original dates — migrated posts showed "published today", breaking SEO metadata (`article:published_time`), RSS `pubDate`, and date-sorted listings.

The fix is small but has two distinct parts:

**1. Pass the fields through Zod**
- `contentCreateBody` now accepts `publishedAt` and `createdAt`
- `contentUpdateBody` now accepts `publishedAt`. `createdAt` is intentionally not accepted on update — `created_at` is treated as immutable by convention; one-off fix-ups on existing rows are a SQL concern, not an API one.
- Validated as ISO 8601 with `{ offset: true }` so both `Z` and `±HH:MM` suffixes are accepted
**2. Gate the fields at the route layer**
- Writing either field requires `content:publish_any` (EDITOR+). Regular contributors must not be able to backdate posts.
- The gate checks `!== undefined`, not `!= null`, so `{publishedAt: null}` (explicit clear) is also gated. Matching only non-null values would have let an AUTHOR clear `published_at` via PUT without the permission — surfaced in review before merge.
- Lower-role callers now get a clear `403` instead of silent field-strip (strictly better feedback than the pre-PR behaviour).
No repository or handler changes beyond threading `publishedAt` from `handleContentUpdate` into the existing `ContentRepository.update`. The backing columns, queries, and indexes are unchanged.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
