### PR TITLE
fix(cloudflare): harden sandbox plugin HTTP bridge

### DIFF
--- a/.changeset/sandbox-bridge-redirect.md
+++ b/.changeset/sandbox-bridge-redirect.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Sandboxed plugin HTTP requests now follow redirects manually and re-validate the destination at every hop. The allowedHosts list is checked on each redirect target (not just the initial URL), so an allowed host that 302s to a disallowed one no longer bypasses the scope. Credential headers (Authorization, Cookie, Proxy-Authorization) are stripped on cross-origin redirects. `network:fetch:any` and `allowedHosts: ["*"]` now still reject literal private IPs, cloud-metadata addresses, and known internal hostnames — the allowlist scopes which public hosts a plugin may reach, not whether SSRF protection applies. Non-http(s) URL schemes are rejected. Caps redirect chains at 5 hops.

--- a/packages/cloudflare/src/sandbox/bridge-http.ts
+++ b/packages/cloudflare/src/sandbox/bridge-http.ts
@@ -1,0 +1,291 @@
+/**
+ * HTTP fetch helper for sandboxed plugins, called from the bridge.
+ *
+ * The bridge's httpFetch RPC method delegates here so the logic is pure and
+ * testable without standing up a real WorkerEntrypoint.
+ *
+ * Responsibilities:
+ *  - Enforce the `network:fetch` / `network:fetch:any` capability.
+ *  - Enforce the allowedHosts list, including on every redirect hop. The
+ *    native `fetch` follows 3xx responses automatically; without manual
+ *    redirect handling an allowed host that 302s to a disallowed host
+ *    would bypass the allowlist.
+ *  - Strip credential headers (Authorization, Cookie, Proxy-Authorization)
+ *    on cross-origin redirects so tokens don't leak to attacker hosts.
+ *  - For `network:fetch:any`, apply a minimal SSRF check on every hop so
+ *    plugins can't be tricked into reaching cloud-metadata endpoints or
+ *    literal private IPs even without an explicit allowlist.
+ */
+
+/** Maximum redirect chain length before we give up. */
+const MAX_REDIRECTS = 5;
+
+/** Headers that must be stripped when a redirect crosses origins. */
+const CREDENTIAL_HEADERS = ["authorization", "cookie", "proxy-authorization"];
+
+/**
+ * Known internal hostnames. Matched case-insensitively after stripping any
+ * trailing dots (FQDN form) and IPv6 brackets.
+ */
+const BLOCKED_HOSTNAMES = new Set(["localhost", "metadata.google.internal", "metadata.google"]);
+
+/**
+ * Wildcard DNS services commonly used by SSRF tooling to map hostnames to
+ * private IPs (e.g. 127.0.0.1.nip.io -> 127.0.0.1). Matched as a suffix.
+ */
+const BLOCKED_HOSTNAME_SUFFIXES = [
+	"nip.io",
+	"sslip.io",
+	"xip.io",
+	"traefik.me",
+	"lvh.me",
+	"localtest.me",
+	// RFC 6761 §6.3 — any subdomain of localhost must resolve to loopback.
+	// The apex is already in BLOCKED_HOSTNAMES, this catches *.localhost.
+	"localhost",
+];
+
+/** RFC1918, loopback, link-local, current-network IPv4 ranges. */
+const BLOCKED_IPV4_RANGES: Array<[number, number]> = [
+	[ip4(127, 0, 0, 0), ip4(127, 255, 255, 255)],
+	[ip4(10, 0, 0, 0), ip4(10, 255, 255, 255)],
+	[ip4(172, 16, 0, 0), ip4(172, 31, 255, 255)],
+	[ip4(192, 168, 0, 0), ip4(192, 168, 255, 255)],
+	[ip4(169, 254, 0, 0), ip4(169, 254, 255, 255)],
+	[ip4(0, 0, 0, 0), ip4(0, 255, 255, 255)],
+];
+
+function ip4(a: number, b: number, c: number, d: number): number {
+	return ((a << 24) | (b << 16) | (c << 8) | d) >>> 0;
+}
+
+const IPV4_PATTERN = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+/** Match IPv6 brackets at start/end for stripping. */
+const IPV6_BRACKET_PATTERN = /^\[|\]$/g;
+
+/** Match any number of trailing dots on an FQDN for stripping. */
+const TRAILING_DOT_PATTERN = /\.+$/;
+
+/** Match fc00::/7 ULA addresses — first byte 0xfc or 0xfd followed by any byte. */
+const IPV6_ULA_FC_PATTERN = /^fc[0-9a-f]{2}:/;
+const IPV6_ULA_FD_PATTERN = /^fd[0-9a-f]{2}:/;
+
+/**
+ * IPv4-mapped IPv6 in hex form: ::ffff:XXXX:XXXX
+ * The WHATWG URL parser normalises dotted-decimal to hex:
+ *   [::ffff:127.0.0.1]       -> [::ffff:7f00:1]
+ *   [::ffff:169.254.169.254] -> [::ffff:a9fe:a9fe]
+ * Without converting back, the hex form bypasses the IPv4 range check.
+ */
+const IPV4_MAPPED_IPV6_HEX_PATTERN = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i;
+
+/** URL schemes we allow for outbound plugin fetches. */
+const ALLOWED_SCHEMES = new Set(["http:", "https:"]);
+
+function parseIpv4(ip: string): number | null {
+	const m = IPV4_PATTERN.exec(ip);
+	if (!m) return null;
+	const parts = [m[1], m[2], m[3], m[4]].map((x) => Number(x));
+	if (parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return null;
+	return ip4(parts[0]!, parts[1]!, parts[2]!, parts[3]!);
+}
+
+/**
+ * Convert a hex-form IPv4-mapped IPv6 address back to dotted-decimal IPv4.
+ * Returns null if the input isn't in the hex-mapped form.
+ */
+function normalizeIPv4MappedIPv6(ip: string): string | null {
+	const match = IPV4_MAPPED_IPV6_HEX_PATTERN.exec(ip);
+	if (!match) return null;
+	const high = parseInt(match[1]!, 16);
+	const low = parseInt(match[2]!, 16);
+	return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+}
+
+function isPrivateLiteral(hostname: string): boolean {
+	// Strip IPv6 brackets
+	const bare = hostname.replace(IPV6_BRACKET_PATTERN, "").toLowerCase();
+	if (bare === "::1" || bare === "::ffff:127.0.0.1") return true;
+
+	// IPv4-mapped IPv6 in hex form (what WHATWG produces for [::ffff:127.0.0.1])
+	const mapped = normalizeIPv4MappedIPv6(bare);
+	if (mapped !== null) {
+		const num = parseIpv4(mapped);
+		if (num !== null) {
+			return BLOCKED_IPV4_RANGES.some(([start, end]) => num >= start && num <= end);
+		}
+	}
+
+	const num = parseIpv4(bare);
+	if (num !== null) {
+		return BLOCKED_IPV4_RANGES.some(([start, end]) => num >= start && num <= end);
+	}
+
+	// Loose IPv6 link-local / ULA detection. The bridge leaves full DNS
+	// resolution to the platform; we only need to catch literal addresses
+	// here. Anything containing a colon and matching one of these prefixes
+	// is private.
+	if (bare.includes(":")) {
+		return (
+			bare.startsWith("fe80:") || IPV6_ULA_FC_PATTERN.test(bare) || IPV6_ULA_FD_PATTERN.test(bare)
+		);
+	}
+	return false;
+}
+
+function isBlockedHostname(hostname: string): boolean {
+	// Strip brackets + trailing dots + lowercase. Trailing-dot FQDNs (e.g.
+	// "localhost.") are preserved by the WHATWG URL parser, so without
+	// normalisation they'd bypass exact-match checks.
+	const normalised = hostname
+		.replace(IPV6_BRACKET_PATTERN, "")
+		.replace(TRAILING_DOT_PATTERN, "")
+		.toLowerCase();
+
+	if (BLOCKED_HOSTNAMES.has(normalised)) return true;
+	for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
+		if (normalised === suffix || normalised.endsWith(`.${suffix}`)) return true;
+	}
+	return false;
+}
+
+/**
+ * Check if a hostname matches any pattern in the allowlist.
+ * Patterns: "*" matches all, "*.example.com" matches subdomains AND the bare
+ * apex, and any other string matches exactly.
+ *
+ * Both host and patterns are normalised (lowercase + trailing dots stripped)
+ * so "API.Example.com" in a manifest and "api.example.com." on a request
+ * still match.
+ */
+function isHostAllowed(host: string, allowedHosts: string[]): boolean {
+	const normHost = host.replace(TRAILING_DOT_PATTERN, "").toLowerCase();
+	return allowedHosts.some((pattern) => {
+		const p = pattern.replace(TRAILING_DOT_PATTERN, "").toLowerCase();
+		if (p === "*") return true;
+		if (p.startsWith("*.")) {
+			const suffix = p.slice(1);
+			return normHost.endsWith(suffix) || normHost === p.slice(2);
+		}
+		return normHost === p;
+	});
+}
+
+/** Return a copy of init with credential headers removed. */
+function stripCredentialHeaders(init: RequestInit): RequestInit {
+	if (!init.headers) return init;
+	const headers = new Headers(init.headers);
+	for (const name of CREDENTIAL_HEADERS) {
+		headers.delete(name);
+	}
+	return { ...init, headers };
+}
+
+export interface SandboxHttpFetchOptions {
+	capabilities: string[];
+	allowedHosts: string[];
+	/** Injectable fetch for tests. Defaults to globalThis.fetch. */
+	fetchImpl?: typeof fetch;
+}
+
+export interface SandboxHttpFetchResult {
+	status: number;
+	headers: Record<string, string>;
+	text: string;
+}
+
+/**
+ * Fetch a URL on behalf of a sandboxed plugin with manual redirect handling.
+ *
+ * @throws Error if the capability is missing, a host isn't allowed, or the
+ *   target resolves to a known-internal address.
+ */
+export async function sandboxHttpFetch(
+	url: string,
+	init: RequestInit | undefined,
+	options: SandboxHttpFetchOptions,
+): Promise<SandboxHttpFetchResult> {
+	const { capabilities, allowedHosts } = options;
+	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+
+	const hasUnrestricted = capabilities.includes("network:fetch:any");
+	const hasFetch = capabilities.includes("network:fetch") || hasUnrestricted;
+	if (!hasFetch) {
+		throw new Error("Missing capability: network:fetch");
+	}
+
+	if (!hasUnrestricted && allowedHosts.length === 0) {
+		throw new Error(
+			"Plugin has no allowed hosts configured. Add hosts to allowedHosts to enable HTTP requests.",
+		);
+	}
+
+	let currentUrl = url;
+	let currentInit: RequestInit | undefined = init;
+
+	for (let i = 0; i <= MAX_REDIRECTS; i++) {
+		const parsed = new URL(currentUrl);
+		const hostname = parsed.hostname;
+
+		// Only http(s) is allowed. Keeps file:, data:, ftp:, and friends out
+		// regardless of what the platform fetch happens to support.
+		if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+			throw new Error(`Unsupported scheme: ${parsed.protocol}`);
+		}
+
+		// Literal-IP / internal-hostname SSRF check runs on every request,
+		// including the restricted (allowedHosts) path. The allowlist scopes
+		// which public hosts a plugin may reach — it must not be a way to
+		// opt out of SSRF protection (e.g. `allowedHosts: ["*"]` does NOT
+		// grant access to 127.0.0.1).
+		if (isPrivateLiteral(hostname) || isBlockedHostname(hostname)) {
+			throw new Error(`Blocked fetch to internal host: ${hostname}`);
+		}
+
+		if (!hasUnrestricted && !isHostAllowed(hostname, allowedHosts)) {
+			throw new Error(`Host not allowed: ${hostname}`);
+		}
+
+		const response = await fetchImpl(currentUrl, {
+			...currentInit,
+			redirect: "manual",
+		});
+
+		// Not a redirect — return directly.
+		if (response.status < 300 || response.status >= 400) {
+			const headers: Record<string, string> = {};
+			response.headers.forEach((value, key) => {
+				headers[key] = value;
+			});
+			return {
+				status: response.status,
+				headers,
+				text: await response.text(),
+			};
+		}
+
+		const location = response.headers.get("Location");
+		if (!location) {
+			const headers: Record<string, string> = {};
+			response.headers.forEach((value, key) => {
+				headers[key] = value;
+			});
+			return {
+				status: response.status,
+				headers,
+				text: await response.text(),
+			};
+		}
+
+		// Resolve relative redirects; strip credentials on cross-origin hops.
+		const previousOrigin = parsed.origin;
+		currentUrl = new URL(location, currentUrl).href;
+		const nextOrigin = new URL(currentUrl).origin;
+		if (previousOrigin !== nextOrigin && currentInit) {
+			currentInit = stripCredentialHeaders(currentInit);
+		}
+	}
+
+	throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
+}

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -11,6 +11,8 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import type { SandboxEmailSendCallback } from "emdash";
 import { ulid } from "emdash";
 
+import { sandboxHttpFetch } from "./bridge-http.js";
+
 /** Regex to validate collection names (prevent SQL injection) */
 const COLLECTION_NAME_REGEX = /^[a-z][a-z0-9_]*$/;
 
@@ -809,41 +811,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		text: string;
 	}> {
 		const { capabilities, allowedHosts } = this.ctx.props;
-		const hasUnrestricted = capabilities.includes("network:fetch:any");
-		const hasFetch = capabilities.includes("network:fetch") || hasUnrestricted;
-		if (!hasFetch) {
-			throw new Error("Missing capability: network:fetch");
-		}
-
-		if (!hasUnrestricted) {
-			const host = new URL(url).host;
-			if (allowedHosts.length === 0) {
-				throw new Error(
-					`Plugin has no allowed hosts configured. Add hosts to allowedHosts to enable HTTP requests.`,
-				);
-			}
-			const allowed = allowedHosts.some((pattern) => {
-				if (pattern.startsWith("*.")) {
-					return host.endsWith(pattern.slice(1)) || host === pattern.slice(2);
-				}
-				return host === pattern;
-			});
-			if (!allowed) {
-				throw new Error(`Host not allowed: ${host}. Allowed: ${allowedHosts.join(", ")}`);
-			}
-		}
-
-		const response = await fetch(url, init);
-		const headers: Record<string, string> = {};
-		response.headers.forEach((value, key) => {
-			headers[key] = value;
-		});
-
-		return {
-			status: response.status,
-			headers,
-			text: await response.text(),
-		};
+		return sandboxHttpFetch(url, init, { capabilities, allowedHosts });
 	}
 
 	// =========================================================================

--- a/packages/cloudflare/tests/sandbox/bridge-http.test.ts
+++ b/packages/cloudflare/tests/sandbox/bridge-http.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for sandboxHttpFetch — the bridge's outbound HTTP helper used by
+ * sandboxed plugins.
+ *
+ * Two behaviours that need coverage:
+ *   - Redirects must re-validate against allowedHosts at every hop. The
+ *     native `fetch` follows 3xx responses automatically, so an allowed host
+ *     that 302s to a blocked host would otherwise bypass the allowlist.
+ *   - Credential headers (Authorization, Cookie, Proxy-Authorization) must
+ *     be stripped on cross-origin hops so they don't leak to attacker
+ *     destinations.
+ *   - With `network:fetch:any` (no allowlist), requests targeting literal
+ *     private IPs or known internal hostnames must still be rejected.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { sandboxHttpFetch } from "../../src/sandbox/bridge-http.js";
+
+function okResponse(body = "ok"): Response {
+	return new Response(body, { status: 200 });
+}
+
+function redirectResponse(location: string, status = 302): Response {
+	return new Response(null, { status, headers: { Location: location } });
+}
+
+type FetchImpl = NonNullable<Parameters<typeof sandboxHttpFetch>[2]["fetchImpl"]>;
+
+function mockFetchSequence(responses: Response[]): FetchImpl {
+	const queue = [...responses];
+	return vi.fn(async () => {
+		const next = queue.shift();
+		if (!next) throw new Error("fetch called more times than expected");
+		return next;
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- vi.fn's generic signature doesn't line up with Workers' fetch type; cast to the injectable contract
+	}) as unknown as FetchImpl;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Capability gating
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — capability enforcement", () => {
+	it("rejects when neither network:fetch nor network:fetch:any is held", async () => {
+		await expect(
+			sandboxHttpFetch("https://a.example.com/", undefined, {
+				capabilities: [],
+				allowedHosts: ["a.example.com"],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow(/network:fetch/);
+	});
+
+	it("allows when network:fetch is held and host is on the list", async () => {
+		const res = await sandboxHttpFetch("https://a.example.com/", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["a.example.com"],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("allows when network:fetch:any is held and skips the allowlist for public hosts", async () => {
+		const res = await sandboxHttpFetch("https://a.example.com/", undefined, {
+			capabilities: ["network:fetch:any"],
+			allowedHosts: [],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Host allowlist enforcement per redirect hop
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — redirect allowlist enforcement", () => {
+	it("rejects a redirect to a host not on the allowlist", async () => {
+		await expect(
+			sandboxHttpFetch("https://a.example.com/", undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com"],
+				fetchImpl: mockFetchSequence([redirectResponse("https://evil.example.com/"), okResponse()]),
+			}),
+		).rejects.toThrow(/not allowed|host/i);
+	});
+
+	it("follows a redirect to a host that IS on the allowlist", async () => {
+		const res = await sandboxHttpFetch("https://a.example.com/", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["a.example.com", "b.example.com"],
+			fetchImpl: mockFetchSequence([
+				redirectResponse("https://b.example.com/next"),
+				okResponse("from-b"),
+			]),
+		});
+		expect(res.status).toBe(200);
+		expect(res.text).toBe("from-b");
+	});
+
+	it("rejects chains that exceed the redirect limit", async () => {
+		// 6 redirects to the same allowed host — more than our max of 5
+		const fetchImpl = mockFetchSequence([
+			redirectResponse("https://a.example.com/1"),
+			redirectResponse("https://a.example.com/2"),
+			redirectResponse("https://a.example.com/3"),
+			redirectResponse("https://a.example.com/4"),
+			redirectResponse("https://a.example.com/5"),
+			redirectResponse("https://a.example.com/6"),
+			okResponse(),
+		]);
+
+		await expect(
+			sandboxHttpFetch("https://a.example.com/", undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com"],
+				fetchImpl,
+			}),
+		).rejects.toThrow(/too many redirects|redirect/i);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Credential header stripping on cross-origin redirects
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — credential header stripping", () => {
+	it("preserves credentials on same-origin redirect", async () => {
+		const fetchImpl = mockFetchSequence([
+			redirectResponse("https://a.example.com/page2"),
+			okResponse(),
+		]);
+
+		await sandboxHttpFetch(
+			"https://a.example.com/",
+			{
+				headers: { Authorization: "Bearer secret-token" },
+			},
+			{
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com"],
+				fetchImpl,
+			},
+		);
+
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- vi.Mock type hygiene
+		const secondCall = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[1];
+		const init = secondCall?.[1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBe("Bearer secret-token");
+	});
+
+	it("strips Authorization on cross-origin redirect", async () => {
+		const fetchImpl = mockFetchSequence([
+			redirectResponse("https://b.example.com/after"),
+			okResponse(),
+		]);
+
+		await sandboxHttpFetch(
+			"https://a.example.com/",
+			{
+				headers: { Authorization: "Bearer secret-token" },
+			},
+			{
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com", "b.example.com"],
+				fetchImpl,
+			},
+		);
+
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- vi.Mock type hygiene
+		const secondCall = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[1];
+		const init = secondCall?.[1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("authorization")).toBeNull();
+	});
+
+	it("strips Cookie and Proxy-Authorization on cross-origin redirect", async () => {
+		const fetchImpl = mockFetchSequence([
+			redirectResponse("https://b.example.com/after"),
+			okResponse(),
+		]);
+
+		await sandboxHttpFetch(
+			"https://a.example.com/",
+			{
+				headers: {
+					Cookie: "session=abc",
+					"Proxy-Authorization": "Basic creds",
+				},
+			},
+			{
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com", "b.example.com"],
+				fetchImpl,
+			},
+		);
+
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- vi.Mock type hygiene
+		const secondCall = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[1];
+		const init = secondCall?.[1] as RequestInit | undefined;
+		const headers = new Headers(init?.headers);
+		expect(headers.get("cookie")).toBeNull();
+		expect(headers.get("proxy-authorization")).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SSRF defence for network:fetch:any
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — SSRF defence with network:fetch:any", () => {
+	it("rejects literal loopback IPv4", async () => {
+		await expect(
+			sandboxHttpFetch("http://127.0.0.1/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects literal private IPv4 ranges", async () => {
+		for (const url of [
+			"http://10.0.0.1/",
+			"http://192.168.1.1/",
+			"http://172.16.0.1/",
+			"http://169.254.169.254/latest/meta-data/",
+		]) {
+			await expect(
+				sandboxHttpFetch(url, undefined, {
+					capabilities: ["network:fetch:any"],
+					allowedHosts: [],
+					fetchImpl: mockFetchSequence([okResponse()]),
+				}),
+			).rejects.toThrow();
+		}
+	});
+
+	it("rejects localhost and metadata hostnames", async () => {
+		for (const url of ["http://localhost/", "http://metadata.google.internal/"]) {
+			await expect(
+				sandboxHttpFetch(url, undefined, {
+					capabilities: ["network:fetch:any"],
+					allowedHosts: [],
+					fetchImpl: mockFetchSequence([okResponse()]),
+				}),
+			).rejects.toThrow();
+		}
+	});
+
+	it("rejects IPv6 loopback", async () => {
+		await expect(
+			sandboxHttpFetch("http://[::1]/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("re-applies the SSRF check on redirects", async () => {
+		// Public host redirects to a private IP — must be blocked.
+		await expect(
+			sandboxHttpFetch("https://public.example.com/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([
+					redirectResponse("http://169.254.169.254/latest/meta-data/"),
+					okResponse(),
+				]),
+			}),
+		).rejects.toThrow();
+	});
+
+	// The WHATWG URL parser normalises IPv4-mapped IPv6 to hex form:
+	//   [::ffff:127.0.0.1]       -> [::ffff:7f00:1]
+	//   [::ffff:169.254.169.254] -> [::ffff:a9fe:a9fe]
+	// A literal-string check against "::ffff:127.0.0.1" never matches the
+	// form the bridge actually sees. We must normalise the hex form back
+	// to dotted-decimal before the range check.
+	it("rejects IPv4-mapped IPv6 loopback in hex form", async () => {
+		await expect(
+			sandboxHttpFetch("http://[::ffff:7f00:1]/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects IPv4-mapped IPv6 metadata address in hex form", async () => {
+		await expect(
+			sandboxHttpFetch("http://[::ffff:a9fe:a9fe]/latest/meta-data/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects IPv4-mapped IPv6 private ranges in hex form", async () => {
+		for (const url of [
+			"http://[::ffff:a00:1]/", // 10.0.0.1
+			"http://[::ffff:c0a8:1]/", // 192.168.0.1
+			"http://[::ffff:ac10:1]/", // 172.16.0.1
+		]) {
+			await expect(
+				sandboxHttpFetch(url, undefined, {
+					capabilities: ["network:fetch:any"],
+					allowedHosts: [],
+					fetchImpl: mockFetchSequence([okResponse()]),
+				}),
+			).rejects.toThrow();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SSRF defence applies even when the restricted path uses allowedHosts=["*"]
+// ---------------------------------------------------------------------------
+
+describe('sandboxHttpFetch — SSRF defence with allowedHosts=["*"]', () => {
+	// A plugin with { capabilities: ["network:fetch"], allowedHosts: ["*"] }
+	// gets full egress with zero SSRF protection unless we apply the literal
+	// check on the restricted path too. The allowlist describes scope, not
+	// safety.
+	it("rejects literal private IPv4 even with allowedHosts=['*']", async () => {
+		await expect(
+			sandboxHttpFetch("http://127.0.0.1/", undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["*"],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects cloud-metadata IP even with allowedHosts=['*']", async () => {
+		await expect(
+			sandboxHttpFetch("http://169.254.169.254/", undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["*"],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects localhost even with allowedHosts=['*']", async () => {
+		await expect(
+			sandboxHttpFetch("http://localhost/", undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["*"],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("still allows public hosts with allowedHosts=['*']", async () => {
+		const res = await sandboxHttpFetch("https://api.example.com/", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["*"],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// URL scheme enforcement
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — scheme enforcement", () => {
+	it("rejects file: scheme", async () => {
+		await expect(
+			sandboxHttpFetch("file:///etc/passwd", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow(/scheme/i);
+	});
+
+	it("rejects data: scheme", async () => {
+		await expect(
+			sandboxHttpFetch("data:text/plain,secret", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow(/scheme/i);
+	});
+
+	it("rejects ftp: scheme", async () => {
+		await expect(
+			sandboxHttpFetch("ftp://example.com/file", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow(/scheme/i);
+	});
+
+	it("accepts http: and https:", async () => {
+		for (const url of ["http://a.example.com/", "https://a.example.com/"]) {
+			const res = await sandboxHttpFetch(url, undefined, {
+				capabilities: ["network:fetch"],
+				allowedHosts: ["a.example.com"],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			});
+			expect(res.status).toBe(200);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Allowlist normalisation — trailing dots and mixed case
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — allowlist normalisation", () => {
+	it("matches when the manifest uses mixed case", async () => {
+		const res = await sandboxHttpFetch("https://api.example.com/", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["API.Example.COM"],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("matches when the request uses a trailing dot FQDN", async () => {
+		const res = await sandboxHttpFetch("https://api.example.com./", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["api.example.com"],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("matches wildcard patterns case-insensitively", async () => {
+		const res = await sandboxHttpFetch("https://api.example.com/", undefined, {
+			capabilities: ["network:fetch"],
+			allowedHosts: ["*.Example.COM"],
+			fetchImpl: mockFetchSequence([okResponse()]),
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// *.localhost hostnames
+// ---------------------------------------------------------------------------
+
+describe("sandboxHttpFetch — *.localhost", () => {
+	// RFC 6761 reserves .localhost for loopback. Subdomains of localhost
+	// must be treated as internal too.
+	it("rejects app.localhost", async () => {
+		await expect(
+			sandboxHttpFetch("http://app.localhost/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects nested *.localhost subdomains", async () => {
+		await expect(
+			sandboxHttpFetch("http://admin.app.localhost/", undefined, {
+				capabilities: ["network:fetch:any"],
+				allowedHosts: [],
+				fetchImpl: mockFetchSequence([okResponse()]),
+			}),
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Hardens the outbound HTTP path sandboxed plugins use via RPC to the Host. The old `httpFetch` called `globalThis.fetch` with default redirect handling, which meant:

- An allowed host that 302s to a disallowed host silently bypassed the `allowedHosts` scope.
- Credential headers (`Authorization`, `Cookie`, `Proxy-Authorization`) leaked to attacker destinations on cross-origin redirects.
- `network:fetch:any` had no SSRF check, so a plugin holding that capability could reach `127.0.0.1`, `169.254.169.254`, RFC1918 addresses, etc. on self-hosted deployments where the platform fetch pipeline doesn't block them.

Fix moves the logic into a pure helper (`sandboxHttpFetch` in `bridge-http.ts`) so it can be unit-tested without standing up a `WorkerEntrypoint`. The bridge method is now a one-line delegator.

**Behaviour changes:**

- Manual redirect loop, max 5 hops. Each hop re-validates against `allowedHosts`.
- Credential headers stripped on cross-origin redirects.
- Literal-IP / internal-hostname SSRF checks run on **every** request, regardless of capability — the allowlist scopes which public hosts a plugin may reach, but `allowedHosts: [\"*\"]` no longer grants access to loopback or cloud metadata.
- Non-http(s) schemes rejected (closes `file:`, `data:`, `ftp:` surface).
- IPv4-mapped IPv6 addresses (`[::ffff:7f00:1]`, `[::ffff:a9fe:a9fe]`) normalised back to dotted-decimal before the range check, so the hex form can't bypass.
- Allowlist patterns normalise trailing dots and case — `\"API.Example.COM\"` in a manifest matches a request to `api.example.com`, and `api.example.com.` (FQDN form) is accepted against `api.example.com`.
- `*.localhost` blocked per RFC 6761 §6.3.
- Error message no longer leaks the full allowlist.

Ran through an adversarial review agent before committing; found and fixed the IPv4-mapped IPv6 bypass, the `allowedHosts: [\"*\"]` SSRF hole, and the missing scheme check before opening the PR.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

30 new unit tests in \`tests/sandbox/bridge-http.test.ts\` covering: capability gating, redirect allowlist enforcement, credential stripping, SSRF on \`:fetch:any\`, IPv4-mapped IPv6, SSRF with \`allowedHosts=['*']\`, scheme enforcement, allowlist normalisation, and \`*.localhost\`. Full suite green (3737 tests), lint baseline, typecheck clean.

**Note on duplication:** The helper re-implements a small amount of SSRF logic from \`packages/core/src/import/ssrf.ts\` instead of importing it. Reasoning: those helpers aren't part of the public \`emdash\` API and shouldn't be exported just so a sibling workspace package can reach them. The tradeoff is that the bridge path doesn't currently get the DoH-based DNS validation that \`resolveAndValidateExternalUrl\` provides in-process — plugins in the sandbox are protected against literal-IP SSRF but not against DNS-rebinding attacks on allowed hosts. Worth a follow-up.