### PR TITLE
feat(auth): trustedProxyHeaders config for self-hosted rate limits

### DIFF
--- a/.changeset/trusted-proxy-headers.md
+++ b/.changeset/trusted-proxy-headers.md
@@ -1,0 +1,19 @@
+---
+"emdash": minor
+---
+
+Adds `trustedProxyHeaders` config option so self-hosted deployments behind a reverse proxy can declare which client-IP headers to trust. Used by auth rate limits (magic-link, signup, passkey, OAuth device flow) and the public comment endpoint — without it, every request on a non-Cloudflare deployment was treated as "unknown" and rate limits were effectively disabled.
+
+Set the option in `astro.config.mjs`:
+
+```js
+emdash({
+	trustedProxyHeaders: ["x-real-ip"], // nginx, Caddy, Traefik
+});
+```
+
+or via the `EMDASH_TRUSTED_PROXY_HEADERS` env var (comma-separated). Headers are tried in order; values ending in `forwarded-for` are parsed as comma-separated lists.
+
+Also removes the user-agent-hash fallback on the comment endpoint. The fallback was meant to give anonymous commenters on non-Cloudflare deployments something approximating per-user rate limiting, but the UA is trivially rotatable; requests with no trusted IP now share a stricter "unknown" bucket. Operators behind a reverse proxy should set `trustedProxyHeaders` to restore per-IP bucketing.
+
+**Only set `trustedProxyHeaders` when you control the reverse proxy.** Trusting a forwarded-IP header from the open internet lets any client spoof their IP and defeats rate limiting.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -266,6 +266,8 @@ Prefer fixing **`allowedDomains`** (and forwarded headers) first; use **`siteUrl
 
 With TLS in front, binding the dev server to loopback (**`astro dev --host 127.0.0.1`**) is often enough: the proxy connects locally while **`siteUrl`** matches the public HTTPS origin.
 
+If your proxy writes a client-IP header, set [**`trustedProxyHeaders`**](#trustedproxyheaders) so EmDash's rate limits can use the real client IP instead of bucketing every request under a shared "unknown" key.
+
 <Aside type="caution">
 	Your reverse proxy should forward a **port-aware** `Host` / `X-Forwarded-Host` when you use non-default ports. If the proxy strips the port, **`rpId`** and Astro’s rebuilt URL can be wrong.
 </Aside>
@@ -299,6 +301,39 @@ export default defineConfig({
 	],
 });
 ```
+
+### `trustedProxyHeaders`
+
+**Optional.** Headers to trust for client-IP resolution when running behind a reverse proxy you control. Used by auth rate limits (magic-link, signup, passkey, OAuth device flow) and the public comment endpoint.
+
+On Cloudflare the `cf` object attached to the request is used automatically — you normally do **not** need to set this. On self-hosted deployments behind nginx, Caddy, Traefik, Fly, Railway, or similar, set this to the header your proxy writes so rate limits can bucket by real client IP instead of treating every request as "unknown".
+
+```js
+emdash({
+	database: sqlite({ url: "file:./data.db" }),
+	// nginx / Caddy / Traefik
+	trustedProxyHeaders: ["x-real-ip"],
+});
+```
+
+Headers are tried in order. Values matching `*-forwarded-for` are parsed as comma-separated lists and the first entry is used.
+
+```js
+emdash({
+	// Fly.io, falling back to generic X-Forwarded-For
+	trustedProxyHeaders: ["fly-client-ip", "x-forwarded-for"],
+});
+```
+
+When not set in config, EmDash reads the `EMDASH_TRUSTED_PROXY_HEADERS` env var (comma-separated). An explicit empty array in config overrides the env var.
+
+<Aside type="caution">
+	**Only set this when you control the reverse proxy.** Untrusted clients can set any header
+	they like; trusting forwarded-IP headers from an open network is an IP-spoofing vulnerability
+	that defeats rate limiting. If EmDash is exposed directly to the public internet with no
+	proxy in front, leave this unset — rate limits will fall back to a shared "unknown" bucket
+	(stricter defaults) rather than trust a spoofable header.
+</Aside>
 
 ### `maxUploadSize`
 

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -159,6 +159,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 		auth: resolvedConfig.auth,
 		marketplace: resolvedConfig.marketplace,
 		siteUrl: resolvedConfig.siteUrl,
+		trustedProxyHeaders: resolvedConfig.trustedProxyHeaders,
 		maxUploadSize: resolvedConfig.maxUploadSize,
 		admin: resolvedConfig.admin,
 	};

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -285,6 +285,32 @@ export interface EmDashConfig {
 	siteUrl?: string;
 
 	/**
+	 * Headers to trust for client IP resolution when running behind a reverse
+	 * proxy. The first header in this list that is present on the request
+	 * wins. Applies to rate limiting for auth endpoints and comment
+	 * submission.
+	 *
+	 * Common values:
+	 * - `x-real-ip` — nginx, Caddy, Traefik
+	 * - `fly-client-ip` — Fly.io
+	 * - `x-forwarded-for` — generic (first entry is used)
+	 *
+	 * Only set this when you **control the reverse proxy**. Untrusted
+	 * clients can set any header they like; trusting headers from an open
+	 * network is an IP-spoofing vulnerability that defeats rate limiting.
+	 *
+	 * On Cloudflare the `cf` object on the request is used automatically —
+	 * you normally don't need to set this. Leave unset (or empty) to
+	 * preserve the default: IP is resolved only when the request came
+	 * through Cloudflare's edge.
+	 *
+	 * Falls back to `EMDASH_TRUSTED_PROXY_HEADERS` env var (comma-separated)
+	 * when this option is not set, so operators can configure at deploy
+	 * time without touching the Astro config.
+	 */
+	trustedProxyHeaders?: string[];
+
+	/**
 	 * Enable playground mode for ephemeral "try EmDash" sites.
 	 *
 	 * When set, the integration injects a playground middleware (order: "pre")

--- a/packages/core/src/astro/routes/api/auth/magic-link/send.ts
+++ b/packages/core/src/astro/routes/api/auth/magic-link/send.ts
@@ -19,6 +19,7 @@ import { isParseError, parseBody } from "#api/parse.js";
 import { magicLinkSendBody } from "#api/schemas.js";
 import { getSiteBaseUrl } from "#api/site-url.js";
 import { checkRateLimit, getClientIp } from "#auth/rate-limit.js";
+import { getTrustedProxyHeaders } from "#auth/trusted-proxy.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -36,7 +37,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		// Rate limit: 3 requests per 300 seconds (5 minutes) per IP
-		const ip = getClientIp(request);
+		const ip = getClientIp(request, getTrustedProxyHeaders(emdash.config));
 		const rateLimit = await checkRateLimit(emdash.db, ip, "magic-link/send", 3, 300);
 		if (!rateLimit.allowed) {
 			// Return success-shaped response to avoid revealing rate limit

--- a/packages/core/src/astro/routes/api/auth/passkey/options.ts
+++ b/packages/core/src/astro/routes/api/auth/passkey/options.ts
@@ -20,6 +20,7 @@ import { passkeyOptionsBody } from "#api/schemas.js";
 import { createChallengeStore, cleanupExpiredChallenges } from "#auth/challenge-store.js";
 import { getPasskeyConfig } from "#auth/passkey-config.js";
 import { checkRateLimit, getClientIp, rateLimitResponse } from "#auth/rate-limit.js";
+import { getTrustedProxyHeaders } from "#auth/trusted-proxy.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -38,7 +39,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		// Rate limit: 10 requests per 60 seconds per IP
-		const ip = getClientIp(request);
+		const ip = getClientIp(request, getTrustedProxyHeaders(emdash.config));
 		const rateLimit = await checkRateLimit(emdash.db, ip, "passkey/options", 10, 60);
 		if (!rateLimit.allowed) {
 			return rateLimitResponse(60);

--- a/packages/core/src/astro/routes/api/auth/signup/request.ts
+++ b/packages/core/src/astro/routes/api/auth/signup/request.ts
@@ -19,6 +19,7 @@ import { isParseError, parseBody } from "#api/parse.js";
 import { signupRequestBody } from "#api/schemas.js";
 import { getSiteBaseUrl } from "#api/site-url.js";
 import { checkRateLimit, getClientIp } from "#auth/rate-limit.js";
+import { getTrustedProxyHeaders } from "#auth/trusted-proxy.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
 // Generic response body used for both the real success path and the
@@ -53,7 +54,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		// Rate limit: 3 requests per 300 seconds per IP. Matches magic-link/send.
-		const ip = getClientIp(request);
+		const ip = getClientIp(request, getTrustedProxyHeaders(emdash.config));
 		const rateLimit = await checkRateLimit(emdash.db, ip, "signup/request", 3, 300);
 		if (!rateLimit.allowed) {
 			// Return success-shaped response to avoid revealing rate limiting

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/index.ts
@@ -139,18 +139,22 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 		}
 
 		// Anti-spam: Rate limiting
-		const meta = extractRequestMeta(request);
+		const meta = extractRequestMeta(request, emdash.config);
 		const ipSalt =
 			import.meta.env.EMDASH_AUTH_SECRET || import.meta.env.AUTH_SECRET || "emdash-ip-salt";
 		let ipHash: string;
 		if (meta.ip) {
 			ipHash = await hashIp(meta.ip, ipSalt);
-		} else if (meta.userAgent) {
-			// Fallback: hash user-agent as a rough identifier when IP is unavailable
-			ipHash = await hashIp(`ua:${meta.userAgent}`, ipSalt);
 		} else {
-			// Fail closed: all unidentifiable requests share one rate-limit bucket.
-			// Use a larger limit since this bucket is shared across all anonymous users.
+			// No trusted IP — fail closed by bucketing all unidentifiable
+			// requests together. A larger limit reflects the shared bucket.
+			//
+			// Self-hosted operators behind a reverse proxy should set
+			// `trustedProxyHeaders` in the EmDash config (or the
+			// EMDASH_TRUSTED_PROXY_HEADERS env var) so this path isn't hit
+			// for legitimate traffic. UA-hashing was previously used here
+			// but was trivially rotatable — the shared bucket is stricter
+			// and forces operators toward a real fix.
 			ipHash = "unknown";
 		}
 		const unknownBucketLimit = ipHash === "unknown" ? 20 : undefined;

--- a/packages/core/src/astro/routes/api/oauth/device/code.ts
+++ b/packages/core/src/astro/routes/api/oauth/device/code.ts
@@ -15,6 +15,7 @@ import { handleDeviceCodeRequest } from "#api/handlers/device-flow.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { getPublicOrigin } from "#api/public-url.js";
 import { checkRateLimit, getClientIp, rateLimitResponse } from "#auth/rate-limit.js";
+import { getTrustedProxyHeaders } from "#auth/trusted-proxy.js";
 
 export const prerender = false;
 
@@ -35,7 +36,7 @@ export const POST: APIRoute = async ({ request, locals, url }) => {
 		if (isParseError(body)) return body;
 
 		// Rate limit: 10 requests per 60 seconds per IP
-		const ip = getClientIp(request);
+		const ip = getClientIp(request, getTrustedProxyHeaders(emdash.config));
 		const rateLimit = await checkRateLimit(emdash.db, ip, "device/code", 10, 60);
 		if (!rateLimit.allowed) {
 			return rateLimitResponse(60);

--- a/packages/core/src/astro/routes/api/oauth/device/token.ts
+++ b/packages/core/src/astro/routes/api/oauth/device/token.ts
@@ -17,6 +17,7 @@ import { apiError, handleError, unwrapResult } from "#api/error.js";
 import { handleDeviceTokenExchange } from "#api/handlers/device-flow.js";
 import { isParseError, parseBody } from "#api/parse.js";
 import { checkRateLimit, getClientIp, rateLimitResponse } from "#auth/rate-limit.js";
+import { getTrustedProxyHeaders } from "#auth/trusted-proxy.js";
 
 export const prerender = false;
 
@@ -37,7 +38,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		if (isParseError(body)) return body;
 
 		// Rate limit: 12 requests per 60 seconds per IP
-		const ip = getClientIp(request);
+		const ip = getClientIp(request, getTrustedProxyHeaders(emdash.config));
 		const rateLimit = await checkRateLimit(emdash.db, ip, "device/token", 12, 60);
 		if (!rateLimit.allowed) {
 			return rateLimitResponse(60);

--- a/packages/core/src/auth/rate-limit.ts
+++ b/packages/core/src/auth/rate-limit.ts
@@ -100,42 +100,70 @@ export function rateLimitResponse(retryAfterSeconds: number): Response {
  *
  * Resolution order:
  * 1. `CF-Connecting-IP` — trusted only when the Cloudflare `cf` object is
- *    present (proving the request traversed Cloudflare's edge, which
- *    strips/overwrites client-supplied values).
- * 2. `X-Forwarded-For` (first entry) — also trusted only on Cloudflare.
- *    Without a trusted reverse proxy the header is trivially spoofable,
- *    so we don't use it for standalone deployments.
- * 3. `null` — no trusted IP available. Callers must handle this gracefully
+ *    present. CF edge overwrites any client-supplied value, so this is the
+ *    cryptographically trustworthy path on Workers. Operator-declared
+ *    trusted headers cannot override it.
+ * 2. `X-Forwarded-For` (first entry) — trusted only when the `cf` object
+ *    is present (CF sets this reliably).
+ * 3. Operator-declared trusted proxy headers (ordered list) — used as a
+ *    fallback for non-CF deployments behind a reverse proxy the operator
+ *    controls. Also applies as a fill-in on CF when the CF headers are
+ *    absent (e.g. internal cron handlers).
+ * 4. `null` — no trusted IP available. Callers must handle this gracefully
  *    (e.g. skip rate limiting).
+ *
+ * Pass `trustedHeaders` from `getTrustedProxyHeaders(emdash.config)` so
+ * self-hosted non-CF deployments can opt into reading a specific header.
  *
  * Aligned with `extractRequestMeta` in `plugins/request-meta.ts`.
  */
-export function getClientIp(request: Request): string | null {
+export function getClientIp(request: Request, trustedHeaders: string[] = []): string | null {
 	const headers = request.headers;
 	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CF Workers runtime shape
 	const cf = (request as unknown as { cf?: Record<string, unknown> }).cf;
 
-	if (!cf) {
-		// Not on Cloudflare — no trusted source of client IP
-		return null;
-	}
+	// On Cloudflare, prefer the cryptographically trustworthy headers. An
+	// attacker can't spoof these — the CF edge strips/overwrites them.
+	if (cf) {
+		const cfIp = headers.get("cf-connecting-ip")?.trim();
+		if (cfIp && IP_PATTERN.test(cfIp)) {
+			return cfIp;
+		}
 
-	// Trust CF-Connecting-IP when the cf object confirms Cloudflare
-	const cfIp = headers.get("cf-connecting-ip")?.trim();
-	if (cfIp && IP_PATTERN.test(cfIp)) {
-		return cfIp;
-	}
-
-	// Fallback to XFF on Cloudflare (CF sets this reliably)
-	const xff = headers.get("x-forwarded-for");
-	if (xff) {
-		const first = xff.split(",")[0]?.trim();
-		if (first && IP_PATTERN.test(first)) {
-			return first;
+		const xff = headers.get("x-forwarded-for");
+		if (xff) {
+			const first = xff.split(",")[0]?.trim();
+			if (first && IP_PATTERN.test(first)) {
+				return first;
+			}
 		}
 	}
 
+	// Fall through to operator-declared trusted headers. On CF this fills
+	// in when the CF headers are absent; off-CF it's the primary source.
+	for (const name of trustedHeaders) {
+		const value = readIpFromHeader(headers, name);
+		if (value) return value;
+	}
+
 	return null;
+}
+
+/**
+ * Read an IP from an operator-declared trusted header. XFF-style headers
+ * are parsed as comma-separated lists and the first entry is used.
+ */
+function readIpFromHeader(headers: Headers, name: string): string | null {
+	const value = headers.get(name);
+	if (!value) return null;
+	if (name.toLowerCase().endsWith("forwarded-for")) {
+		const first = value.split(",")[0]?.trim();
+		if (!first) return null;
+		return IP_PATTERN.test(first) ? first : null;
+	}
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	return IP_PATTERN.test(trimmed) ? trimmed : null;
 }
 
 /**

--- a/packages/core/src/auth/trusted-proxy.ts
+++ b/packages/core/src/auth/trusted-proxy.ts
@@ -1,0 +1,79 @@
+/**
+ * Resolve the list of client-IP headers the operator trusts.
+ *
+ * Resolution order:
+ *   1. `config.trustedProxyHeaders` — explicit opt-in via astro.config.mjs.
+ *      An empty array is respected (means "trust nothing, ignore env").
+ *   2. `EMDASH_TRUSTED_PROXY_HEADERS` env var — comma-separated header names.
+ *   3. `[]` — default, no trusted headers.
+ *
+ * Operators must only set this when they control the reverse proxy.
+ * Untrusted clients can set any header they like; trusting headers from
+ * an open network defeats rate limiting.
+ *
+ * Header names are returned lowercased because HTTP header lookups are
+ * case-insensitive.
+ */
+
+import type { EmDashConfig } from "../astro/integration/runtime.js";
+
+/**
+ * RFC 7230 token — valid characters for an HTTP header name. Invalid names
+ * passed to `Headers.get()` throw a TypeError at runtime, which would
+ * otherwise surface as a 500 from every auth route.
+ */
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9a-z]+$/;
+
+function isValidHeaderName(name: string): boolean {
+	return HEADER_NAME_PATTERN.test(name);
+}
+
+/** Cache for the env-derived value. `null` means "not yet parsed". */
+let _envCache: string[] | null = null;
+
+/** Test-only: clear the env cache so a fresh value is read on next call. */
+export function _resetTrustedProxyHeadersCache(): void {
+	_envCache = null;
+}
+
+function getEnvTrustedHeaders(): string[] {
+	if (_envCache !== null) return _envCache;
+	let raw: string | undefined;
+	try {
+		// Prefer import.meta.env (Vite/Astro convention) with a process.env
+		// fallback for Node deployments where import.meta.env isn't populated
+		// with runtime envs.
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env shape varies by bundler
+		const importMetaEnv = (import.meta as unknown as { env?: Record<string, string | undefined> })
+			.env;
+		raw =
+			importMetaEnv?.EMDASH_TRUSTED_PROXY_HEADERS ||
+			(typeof process !== "undefined" ? process.env?.EMDASH_TRUSTED_PROXY_HEADERS : undefined);
+	} catch {
+		raw = undefined;
+	}
+	if (!raw) {
+		_envCache = [];
+		return _envCache;
+	}
+	_envCache = raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0 && isValidHeaderName(s));
+	return _envCache;
+}
+
+/**
+ * Return the lowercased list of headers to trust for client-IP resolution.
+ *
+ * When `config?.trustedProxyHeaders` is explicitly set (even to `[]`), it
+ * wins. Otherwise fall through to the env var, then to `[]`.
+ */
+export function getTrustedProxyHeaders(config: EmDashConfig | null | undefined): string[] {
+	if (config && config.trustedProxyHeaders !== undefined) {
+		return config.trustedProxyHeaders
+			.map((h) => h.toLowerCase())
+			.filter((h) => h.length > 0 && isValidHeaderName(h));
+	}
+	return getEnvTrustedHeaders();
+}

--- a/packages/core/src/auth/trusted-proxy.ts
+++ b/packages/core/src/auth/trusted-proxy.ts
@@ -24,6 +24,18 @@ import type { EmDashConfig } from "../astro/integration/runtime.js";
  */
 const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9a-z]+$/;
 
+/**
+ * Normalise a list of header names the way both the config path and any
+ * caller passing a pre-resolved list should do: trim, lowercase, drop
+ * empty, drop anything that isn't a valid RFC 7230 token. Invalid names
+ * would crash `Headers.get()` at runtime.
+ */
+export function normalizeTrustedHeaders(names: readonly string[]): string[] {
+	return names
+		.map((h) => h.trim().toLowerCase())
+		.filter((h) => h.length > 0 && HEADER_NAME_PATTERN.test(h));
+}
+
 function isValidHeaderName(name: string): boolean {
 	return HEADER_NAME_PATTERN.test(name);
 }
@@ -40,15 +52,16 @@ function getEnvTrustedHeaders(): string[] {
 	if (_envCache !== null) return _envCache;
 	let raw: string | undefined;
 	try {
-		// Prefer import.meta.env (Vite/Astro convention) with a process.env
-		// fallback for Node deployments where import.meta.env isn't populated
-		// with runtime envs.
+		// Prefer process.env so SSR/container deployments can override this
+		// value at runtime (Vite/Astro inline import.meta.env at build time,
+		// which locks the value into the bundle). Fall back to import.meta.env
+		// for bundler-managed environments where process.env isn't populated.
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- import.meta.env shape varies by bundler
 		const importMetaEnv = (import.meta as unknown as { env?: Record<string, string | undefined> })
 			.env;
 		raw =
-			importMetaEnv?.EMDASH_TRUSTED_PROXY_HEADERS ||
-			(typeof process !== "undefined" ? process.env?.EMDASH_TRUSTED_PROXY_HEADERS : undefined);
+			(typeof process !== "undefined" ? process.env?.EMDASH_TRUSTED_PROXY_HEADERS : undefined) ||
+			importMetaEnv?.EMDASH_TRUSTED_PROXY_HEADERS;
 	} catch {
 		raw = undefined;
 	}
@@ -72,7 +85,7 @@ function getEnvTrustedHeaders(): string[] {
 export function getTrustedProxyHeaders(config: EmDashConfig | null | undefined): string[] {
 	if (config && config.trustedProxyHeaders !== undefined) {
 		return config.trustedProxyHeaders
-			.map((h) => h.toLowerCase())
+			.map((h) => h.trim().toLowerCase())
 			.filter((h) => h.length > 0 && isValidHeaderName(h));
 	}
 	return getEnvTrustedHeaders();

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2321,7 +2321,7 @@ export class EmDashRuntime {
 
 		try {
 			const headers = sanitizeHeadersForSandbox(request.headers);
-			const meta = extractRequestMeta(request);
+			const meta = extractRequestMeta(request, this.config);
 			const result = await plugin.invokeRoute(routeName, body, {
 				url: request.url,
 				method: request.method,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -19,6 +19,7 @@ import type {
 } from "./astro/integration/runtime.js";
 import type { EmDashManifest, ManifestCollection } from "./astro/types.js";
 import { getAuthMode } from "./auth/mode.js";
+import { getTrustedProxyHeaders } from "./auth/trusted-proxy.js";
 import { isSqlite } from "./database/dialect-helpers.js";
 import { kyselyLogOption } from "./database/instrumentation.js";
 import { runMigrations } from "./database/migrations/runner.js";
@@ -2080,6 +2081,7 @@ export class EmDashRuntime {
 			const routeRegistry = new PluginRouteRegistry({
 				db: this.db,
 				emailPipeline: this.email ?? undefined,
+				trustedProxyHeaders: getTrustedProxyHeaders(this.config),
 			});
 			routeRegistry.register(trustedPlugin);
 

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -854,6 +854,13 @@ export interface PluginContextFactoryOptions {
 	 * If not provided (or no provider configured), ctx.email will be undefined.
 	 */
 	emailPipeline?: EmailPipeline;
+	/**
+	 * Pre-resolved list of trusted proxy header names (from the runtime
+	 * `EmDashConfig.trustedProxyHeaders` or the env var). Plugin route
+	 * handlers pass this to `extractRequestMeta` so plugins see the same
+	 * client IP the core auth path does.
+	 */
+	trustedProxyHeaders?: string[];
 }
 
 /**

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -62,6 +62,11 @@ export interface PluginManagerOptions {
 		filename: string,
 		contentType: string,
 	) => Promise<{ uploadUrl: string; mediaId: string }>;
+	/**
+	 * Pre-resolved list of trusted proxy header names for client-IP
+	 * resolution in plugin route handlers. Thread through from the runtime.
+	 */
+	trustedProxyHeaders?: string[];
 }
 
 /**
@@ -81,6 +86,7 @@ export class PluginManager {
 			db: options.db,
 			storage: options.storage,
 			getUploadUrl: options.getUploadUrl,
+			trustedProxyHeaders: options.trustedProxyHeaders,
 		};
 	}
 

--- a/packages/core/src/plugins/request-meta.ts
+++ b/packages/core/src/plugins/request-meta.ts
@@ -8,7 +8,7 @@
  */
 
 import type { EmDashConfig } from "../astro/integration/runtime.js";
-import { getTrustedProxyHeaders } from "../auth/trusted-proxy.js";
+import { getTrustedProxyHeaders, normalizeTrustedHeaders } from "../auth/trusted-proxy.js";
 import type { GeoInfo, RequestMeta } from "./types.js";
 
 /**
@@ -147,7 +147,10 @@ function resolveTrustedHeaders(
 	value: EmDashConfig | null | { trustedProxyHeaders?: string[] } | string[] | undefined,
 ): string[] {
 	if (Array.isArray(value)) {
-		return value.map((h) => h.toLowerCase());
+		// Apply the same RFC 7230 validation the config/env path does so a
+		// caller passing a pre-resolved list with bad entries can't crash
+		// `Headers.get()` downstream.
+		return normalizeTrustedHeaders(value);
 	}
 	return getTrustedProxyHeaders(value);
 }

--- a/packages/core/src/plugins/request-meta.ts
+++ b/packages/core/src/plugins/request-meta.ts
@@ -7,6 +7,8 @@
  *
  */
 
+import type { EmDashConfig } from "../astro/integration/runtime.js";
+import { getTrustedProxyHeaders } from "../auth/trusted-proxy.js";
 import type { GeoInfo, RequestMeta } from "./types.js";
 
 /**
@@ -41,6 +43,23 @@ function parseFirstForwardedIp(header: string): string | null {
 }
 
 /**
+ * Read an IP from an operator-declared trusted header. XFF-style headers
+ * (any name ending in `forwarded-for`) are parsed as comma-separated lists
+ * and the first entry is used; everything else is treated as a single
+ * trimmed value.
+ */
+function readIpFromHeader(headers: Headers, name: string): string | null {
+	const value = headers.get(name);
+	if (!value) return null;
+	if (name.endsWith("forwarded-for")) {
+		return parseFirstForwardedIp(value);
+	}
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	return IP_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+/**
  * Get the Cloudflare `cf` object from the request, if present.
  * Returns undefined when not running on Cloudflare Workers.
  */
@@ -69,32 +88,52 @@ function extractGeo(cf: CfProperties | undefined): GeoInfo | null {
  * Extract normalized request metadata from a Request object.
  *
  * IP resolution order:
- * 1. `CF-Connecting-IP` header — only trusted when a `cf` object is
- *    present on the request (proving the request came through Cloudflare's
- *    edge, which strips/overwrites client-supplied values).
- * 2. `X-Forwarded-For` header (first entry) — best-effort, spoofable
- *    when there is no trusted reverse proxy.
- * 3. `null`
+ * 1. `CF-Connecting-IP` — trusted only when a `cf` object is present on the
+ *    request. CF edge overwrites any client-supplied value, so this is the
+ *    cryptographically trustworthy path on Workers. Operator-declared
+ *    trusted headers cannot override it.
+ * 2. `X-Forwarded-For` first entry — trusted only with a `cf` object.
+ * 3. Operator-declared trusted proxy headers (from `config.trustedProxyHeaders`
+ *    or the `EMDASH_TRUSTED_PROXY_HEADERS` env var), tried in order. Used as
+ *    the primary source off-CF and as a fill-in on CF.
+ * 4. `null`
+ *
+ * The second argument accepts either the EmDash config or a pre-resolved
+ * list of trusted headers, so callers that already have the list don't have
+ * to round-trip through the config every request.
  */
-export function extractRequestMeta(request: Request): RequestMeta {
+export function extractRequestMeta(
+	request: Request,
+	configOrTrustedHeaders?: EmDashConfig | null | { trustedProxyHeaders?: string[] } | string[],
+): RequestMeta {
 	const headers = request.headers;
 	const cf = getCfObject(request);
+	const trusted = resolveTrustedHeaders(configOrTrustedHeaders);
 
-	// IP: only trust headers when the cf object confirms we're on Cloudflare.
-	// Without a trusted reverse proxy, X-Forwarded-For is trivially spoofable.
 	let ip: string | null = null;
+
+	// On Cloudflare, prefer the cryptographically trustworthy headers first.
 	if (cf) {
 		const cfIp = headers.get("cf-connecting-ip")?.trim();
 		if (cfIp && IP_PATTERN.test(cfIp)) {
 			ip = cfIp;
 		}
+		if (!ip) {
+			const xff = headers.get("x-forwarded-for");
+			ip = xff ? parseFirstForwardedIp(xff) : null;
+		}
 	}
-	if (!ip && cf) {
-		// Only trust X-Forwarded-For when we're behind Cloudflare (which
-		// overwrites the header). In standalone deployments without a trusted
-		// proxy, XFF is trivially spoofable.
-		const xff = headers.get("x-forwarded-for");
-		ip = xff ? parseFirstForwardedIp(xff) : null;
+
+	// Fall through to operator-declared trusted headers. On CF this fills
+	// in when the CF headers are absent; off-CF it's the primary source.
+	if (!ip) {
+		for (const name of trusted) {
+			const value = readIpFromHeader(headers, name);
+			if (value) {
+				ip = value;
+				break;
+			}
+		}
 	}
 
 	const userAgent = headers.get("user-agent")?.trim() || null;
@@ -102,6 +141,15 @@ export function extractRequestMeta(request: Request): RequestMeta {
 	const geo = extractGeo(cf);
 
 	return { ip, userAgent, referer, geo };
+}
+
+function resolveTrustedHeaders(
+	value: EmDashConfig | null | { trustedProxyHeaders?: string[] } | string[] | undefined,
+): string[] {
+	if (Array.isArray(value)) {
+		return value.map((h) => h.toLowerCase());
+	}
+	return getTrustedProxyHeaders(value);
 }
 
 // =============================================================================

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -50,10 +50,12 @@ export interface InvokeRouteOptions {
 export class PluginRouteHandler {
 	private contextFactory: PluginContextFactory;
 	private plugin: ResolvedPlugin;
+	private trustedProxyHeaders: string[];
 
 	constructor(plugin: ResolvedPlugin, factoryOptions: PluginContextFactoryOptions) {
 		this.plugin = plugin;
 		this.contextFactory = new PluginContextFactory(factoryOptions);
+		this.trustedProxyHeaders = factoryOptions.trustedProxyHeaders ?? [];
 	}
 
 	/**
@@ -99,7 +101,7 @@ export class PluginRouteHandler {
 			...baseContext,
 			input: validatedInput,
 			request: options.request,
-			requestMeta: extractRequestMeta(options.request),
+			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
 		};
 
 		// Execute handler

--- a/packages/core/tests/integration/astro/comments-rate-limit.test.ts
+++ b/packages/core/tests/integration/astro/comments-rate-limit.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Rate-limit behaviour on POST /_emdash/api/comments/:collection/:contentId.
+ *
+ * Specifically covers the removal of the user-agent-hash fallback. Before,
+ * a submitter with no trusted IP could rotate their User-Agent string to
+ * get a fresh rate-limit bucket each time; the route now buckets all
+ * trusted-IP-less requests together into the shared "unknown" bucket.
+ *
+ * Operators behind a reverse proxy they control should set
+ * `trustedProxyHeaders` (or EMDASH_TRUSTED_PROXY_HEADERS) so this path
+ * isn't hit for legitimate traffic. Those tests live alongside the
+ * extractRequestMeta unit tests.
+ */
+
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST as postComment } from "../../../src/astro/routes/api/comments/[collection]/[contentId]/index.js";
+import { _resetTrustedProxyHeadersCache } from "../../../src/auth/trusted-proxy.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+// Keep the env-derived trusted-header cache from leaking into this file
+// (a stale EMDASH_TRUSTED_PROXY_HEADERS would route every UA to its own
+// bucket and make the test pass for the wrong reason).
+const ORIGINAL_TRUSTED_ENV = process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+
+function buildRequest(opts: { userAgent?: string; body: unknown }): Request {
+	return new Request("http://localhost/_emdash/api/comments/post/post-1", {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			...(opts.userAgent ? { "user-agent": opts.userAgent } : {}),
+		},
+		body: JSON.stringify(opts.body),
+	});
+}
+
+function buildContext(opts: { db: Kysely<Database>; request: Request }): APIContext {
+	return {
+		params: { collection: "post", contentId: "post-1" },
+		request: opts.request,
+		locals: {
+			emdash: {
+				db: opts.db,
+				config: {},
+				hooks: {
+					// Pass-through beforeCreate (returns the event unchanged).
+					runCommentBeforeCreate: async (event: unknown) => event,
+					// No moderator configured — returns null (route coerces to pending).
+					invokeExclusiveHook: async () => null,
+					runCommentAfterCreate: async () => undefined,
+				},
+			},
+			user: null,
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub for tests
+	} as unknown as APIContext;
+}
+
+describe("POST /comments — UA-hash rate-limit removal", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+		_resetTrustedProxyHeadersCache();
+		db = await setupTestDatabase();
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "post",
+			label: "Posts",
+			labelSingular: "Post",
+			commentsEnabled: true,
+		});
+		await registry.createField("post", { slug: "title", label: "Title", type: "string" });
+		// Create a published content row so the comment route can target it.
+		await db
+			.insertInto("ec_post" as never)
+			.values({
+				id: "post-1",
+				slug: "post-1",
+				status: "published",
+				published_at: new Date().toISOString(),
+				title: "Test post",
+			} as never)
+			.execute();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		if (ORIGINAL_TRUSTED_ENV === undefined) {
+			delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+		} else {
+			process.env.EMDASH_TRUSTED_PROXY_HEADERS = ORIGINAL_TRUSTED_ENV;
+		}
+		_resetTrustedProxyHeadersCache();
+	});
+
+	it("buckets no-trusted-IP requests together regardless of User-Agent", async () => {
+		// Submit 20 comments from different UA strings but without any
+		// trusted IP header. The limit for the "unknown" bucket is 20/10min.
+		// Before the fix, rotating UAs would give each request its own
+		// bucket; with the fix, they share the "unknown" bucket.
+		for (let i = 0; i < 20; i++) {
+			const res = await postComment(
+				buildContext({
+					db,
+					request: buildRequest({
+						userAgent: `Bot/${i}`,
+						body: {
+							authorName: "Spam",
+							authorEmail: "s@example.com",
+							body: `message ${i}`,
+						},
+					}),
+				}),
+			);
+			expect([200, 201]).toContain(res.status);
+		}
+
+		// 21st call with a fresh UA must still hit the shared bucket and
+		// get rate-limited.
+		const limitedRes = await postComment(
+			buildContext({
+				db,
+				request: buildRequest({
+					userAgent: "Bot/fresh",
+					body: {
+						authorName: "Spam",
+						authorEmail: "s@example.com",
+						body: "one more",
+					},
+				}),
+			}),
+		);
+		expect(limitedRes.status).toBe(429);
+	});
+});

--- a/packages/core/tests/integration/auth/rate-limit.test.ts
+++ b/packages/core/tests/integration/auth/rate-limit.test.ts
@@ -164,6 +164,98 @@ describe("getClientIp", () => {
 	});
 });
 
+describe("getClientIp with trusted proxy headers", () => {
+	// On non-CF deployments behind an operator-controlled reverse proxy,
+	// the operator declares which header to trust. Without this they get
+	// null (which disables rate limiting) — a real operational foot-gun.
+
+	function cfRequest(url: string, init?: RequestInit): Request {
+		const req = new Request(url, init);
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- test helper
+		(req as unknown as { cf: Record<string, unknown> }).cf = { country: "US" };
+		return req;
+	}
+
+	it("reads the IP from a declared trusted header off-Cloudflare", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-real-ip": "203.0.113.50" },
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBe("203.0.113.50");
+	});
+
+	it("tries trusted headers in declared order", () => {
+		const request = new Request("http://localhost/test", {
+			headers: {
+				"x-real-ip": "203.0.113.50",
+				"fly-client-ip": "198.51.100.7",
+			},
+		});
+		expect(getClientIp(request, ["fly-client-ip", "x-real-ip"])).toBe("198.51.100.7");
+	});
+
+	it("falls through when earlier trusted header is missing", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-real-ip": "203.0.113.50" },
+		});
+		expect(getClientIp(request, ["fly-client-ip", "x-real-ip"])).toBe("203.0.113.50");
+	});
+
+	it("takes the first entry when a trusted header is XFF-style", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-forwarded-for": "203.0.113.50, 10.0.0.1" },
+		});
+		expect(getClientIp(request, ["x-forwarded-for"])).toBe("203.0.113.50");
+	});
+
+	it("rejects non-IP-shaped values from trusted headers", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-real-ip": "<script>alert(1)</script>" },
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBeNull();
+	});
+
+	it("does not read from headers that are not on the trusted list", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-client-ip": "203.0.113.50" },
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBeNull();
+	});
+
+	it("without cf, returns null when no trusted header is set", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "x-real-ip": "203.0.113.50" },
+		});
+		// Empty list — operator did not opt in. Current null-IP behaviour preserved.
+		expect(getClientIp(request, [])).toBeNull();
+	});
+
+	it("matches header names case-insensitively", () => {
+		const request = new Request("http://localhost/test", {
+			headers: { "X-Real-IP": "203.0.113.50" },
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBe("203.0.113.50");
+	});
+
+	it("CF-Connecting-IP wins over trusted headers on Cloudflare", () => {
+		// Operator on CF misconfigures trustedProxyHeaders — CF-Connecting-IP
+		// is cryptographically trustworthy and must not be overridden.
+		const request = cfRequest("http://localhost/test", {
+			headers: {
+				"cf-connecting-ip": "1.1.1.1",
+				"x-real-ip": "203.0.113.50",
+			},
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBe("1.1.1.1");
+	});
+
+	it("trusted headers fill in when the CF path produces no IP", () => {
+		const request = cfRequest("http://localhost/test", {
+			headers: { "x-real-ip": "203.0.113.50" },
+		});
+		expect(getClientIp(request, ["x-real-ip"])).toBe("203.0.113.50");
+	});
+});
+
 // ---------------------------------------------------------------------------
 // Cleanup
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { generateDialectModule } from "../../../../src/astro/integration/virtual-modules.js";
+import {
+	generateConfigModule,
+	generateDialectModule,
+} from "../../../../src/astro/integration/virtual-modules.js";
+
+describe("generateConfigModule", () => {
+	it("round-trips the serialisable config shape via default export", () => {
+		const source = generateConfigModule({
+			siteUrl: "https://example.com",
+			trustedProxyHeaders: ["x-real-ip", "fly-client-ip"],
+			maxUploadSize: 52_428_800,
+		});
+		// The virtual module is `export default <JSON>` — eval by stripping
+		// the prefix and parsing.
+		const prefix = "export default ";
+		expect(source.startsWith(prefix)).toBe(true);
+		const json = source.slice(prefix.length).replace(/;$/, "");
+		const parsed = JSON.parse(json);
+		expect(parsed.trustedProxyHeaders).toEqual(["x-real-ip", "fly-client-ip"]);
+		expect(parsed.siteUrl).toBe("https://example.com");
+	});
+});
 
 describe("generateDialectModule", () => {
 	it("emits undefined createDialect and null stub when no entrypoint is configured", () => {

--- a/packages/core/tests/unit/auth/trusted-proxy.test.ts
+++ b/packages/core/tests/unit/auth/trusted-proxy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for getTrustedProxyHeaders — resolves the list of trusted client-IP
+ * headers from config, falling back to the EMDASH_TRUSTED_PROXY_HEADERS env
+ * var, then to an empty array.
+ *
+ * The helper lets operators declare which headers they trust when running
+ * behind a reverse proxy. On Cloudflare the `cf` object is used instead and
+ * this list is usually empty.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	_resetTrustedProxyHeadersCache,
+	getTrustedProxyHeaders,
+} from "../../../src/auth/trusted-proxy.js";
+
+describe("getTrustedProxyHeaders", () => {
+	const ORIGINAL_ENV = process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+
+	beforeEach(() => {
+		_resetTrustedProxyHeadersCache();
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+		} else {
+			process.env.EMDASH_TRUSTED_PROXY_HEADERS = ORIGINAL_ENV;
+		}
+		_resetTrustedProxyHeadersCache();
+	});
+
+	it("returns config value when set", () => {
+		expect(getTrustedProxyHeaders({ trustedProxyHeaders: ["x-real-ip"] })).toEqual(["x-real-ip"]);
+	});
+
+	it("prefers config over env", () => {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = "fly-client-ip";
+		expect(getTrustedProxyHeaders({ trustedProxyHeaders: ["x-real-ip"] })).toEqual(["x-real-ip"]);
+	});
+
+	it("falls back to env when config is absent", () => {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = "x-real-ip,fly-client-ip";
+		expect(getTrustedProxyHeaders(undefined)).toEqual(["x-real-ip", "fly-client-ip"]);
+	});
+
+	it("trims whitespace and drops empty entries from env", () => {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = " x-real-ip , , fly-client-ip ";
+		expect(getTrustedProxyHeaders(undefined)).toEqual(["x-real-ip", "fly-client-ip"]);
+	});
+
+	it("lowercases header names for consistent matching", () => {
+		// Header lookups go through Headers.get() which is case-insensitive,
+		// so we normalise the list here to avoid double-normalising elsewhere.
+		expect(getTrustedProxyHeaders({ trustedProxyHeaders: ["X-Real-IP", "Fly-Client-IP"] })).toEqual(
+			["x-real-ip", "fly-client-ip"],
+		);
+	});
+
+	it("returns empty array when neither config nor env is set", () => {
+		delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+		expect(getTrustedProxyHeaders(undefined)).toEqual([]);
+	});
+
+	it("returns empty array when config has empty list", () => {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = "x-real-ip";
+		// An explicit empty array means "trust nothing" — do not fall through
+		// to the env. Operators use this to override an inherited env value.
+		expect(getTrustedProxyHeaders({ trustedProxyHeaders: [] })).toEqual([]);
+	});
+
+	// Header names must be valid RFC 7230 tokens; passing anything else into
+	// `Headers.get()` throws. Drop invalid entries silently rather than
+	// taking down every rate-limited endpoint with a 500.
+	it("drops invalid header names from config", () => {
+		expect(
+			getTrustedProxyHeaders({
+				trustedProxyHeaders: ["x-real-ip", "", "invalid name", "bad:colon", "ok-name"],
+			}),
+		).toEqual(["x-real-ip", "ok-name"]);
+	});
+
+	it("drops invalid header names from env", () => {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = "x-real-ip, x y z , bad:one, ok-name";
+		expect(getTrustedProxyHeaders(undefined)).toEqual(["x-real-ip", "ok-name"]);
+	});
+});

--- a/packages/core/tests/unit/auth/trusted-proxy.test.ts
+++ b/packages/core/tests/unit/auth/trusted-proxy.test.ts
@@ -85,4 +85,13 @@ describe("getTrustedProxyHeaders", () => {
 		process.env.EMDASH_TRUSTED_PROXY_HEADERS = "x-real-ip, x y z , bad:one, ok-name";
 		expect(getTrustedProxyHeaders(undefined)).toEqual(["x-real-ip", "ok-name"]);
 	});
+
+	it("trims whitespace from config entries before matching", () => {
+		// Common typo: `"x-real-ip "` (trailing space). Previously the raw
+		// value was lowercased but not trimmed, so validation silently
+		// dropped it and per-IP bucketing was disabled.
+		expect(
+			getTrustedProxyHeaders({ trustedProxyHeaders: [" x-real-ip ", "fly-client-ip"] }),
+		).toEqual(["x-real-ip", "fly-client-ip"]);
+	});
 });

--- a/packages/core/tests/unit/plugins/request-meta.test.ts
+++ b/packages/core/tests/unit/plugins/request-meta.test.ts
@@ -9,12 +9,29 @@
  * - IPv6 support
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { _resetTrustedProxyHeadersCache } from "../../../src/auth/trusted-proxy.js";
 import {
 	extractRequestMeta,
 	sanitizeHeadersForSandbox,
 } from "../../../src/plugins/request-meta.js";
+
+// Keep the env-derived trusted-header cache from leaking between tests
+// (and between this file and others in the same vitest worker).
+const ORIGINAL_TRUSTED_ENV = process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+beforeEach(() => {
+	delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+	_resetTrustedProxyHeadersCache();
+});
+afterEach(() => {
+	if (ORIGINAL_TRUSTED_ENV === undefined) {
+		delete process.env.EMDASH_TRUSTED_PROXY_HEADERS;
+	} else {
+		process.env.EMDASH_TRUSTED_PROXY_HEADERS = ORIGINAL_TRUSTED_ENV;
+	}
+	_resetTrustedProxyHeadersCache();
+});
 
 /**
  * Helper to create a Request with optional headers and cf properties.
@@ -481,6 +498,117 @@ describe("extractRequestMeta", () => {
 				referer: null,
 				geo: null,
 			});
+		});
+	});
+
+	// --------------------------------------------------------------------
+	// Trusted proxy headers — operator-declared headers for self-hosted
+	// deployments behind a reverse proxy they control.
+	// --------------------------------------------------------------------
+
+	describe("trusted proxy headers", () => {
+		it("reads the IP from a trusted header on a non-CF deployment", () => {
+			const req = createRequest({
+				headers: { "x-real-ip": "203.0.113.50" },
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBe("203.0.113.50");
+		});
+
+		it("tries trusted headers in order", () => {
+			const req = createRequest({
+				headers: {
+					"x-real-ip": "203.0.113.50",
+					"fly-client-ip": "198.51.100.7",
+				},
+			});
+			const meta = extractRequestMeta(req, {
+				trustedProxyHeaders: ["fly-client-ip", "x-real-ip"],
+			});
+			expect(meta.ip).toBe("198.51.100.7");
+		});
+
+		it("falls through to the next trusted header when the first is missing", () => {
+			const req = createRequest({
+				headers: { "x-real-ip": "203.0.113.50" },
+			});
+			const meta = extractRequestMeta(req, {
+				trustedProxyHeaders: ["fly-client-ip", "x-real-ip"],
+			});
+			expect(meta.ip).toBe("203.0.113.50");
+		});
+
+		it("treats trusted XFF-style headers as comma-separated and takes the first entry", () => {
+			const req = createRequest({
+				headers: {
+					"x-forwarded-for": "203.0.113.50, 10.0.0.1, 10.0.0.2",
+				},
+			});
+			const meta = extractRequestMeta(req, {
+				trustedProxyHeaders: ["x-forwarded-for"],
+			});
+			expect(meta.ip).toBe("203.0.113.50");
+		});
+
+		it("rejects non-IP-shaped values in trusted headers", () => {
+			const req = createRequest({
+				headers: { "x-real-ip": "<script>alert(1)</script>" },
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBeNull();
+		});
+
+		it("matches header names case-insensitively", () => {
+			const req = createRequest({
+				headers: { "X-Real-IP": "203.0.113.50" },
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBe("203.0.113.50");
+		});
+
+		it("does not read from headers that are not on the trusted list", () => {
+			// "x-client-ip" is not declared trusted — must not be used.
+			const req = createRequest({
+				headers: { "x-client-ip": "203.0.113.50" },
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBeNull();
+		});
+
+		it("CF-Connecting-IP wins over trusted headers on Cloudflare", () => {
+			// On CF, cf-connecting-ip is cryptographically trustworthy (CF edge
+			// overwrites any client-supplied value). Operator-declared trusted
+			// headers only apply as a fallback, not an override, so a wrong
+			// entry in the config can't regress CF deployments.
+			const req = createRequest({
+				headers: {
+					"cf-connecting-ip": "1.1.1.1",
+					"x-real-ip": "203.0.113.50",
+				},
+				cf: {},
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBe("1.1.1.1");
+		});
+
+		it("trusted headers are used as fallback when CF headers are absent", () => {
+			const req = createRequest({
+				headers: {
+					"x-real-ip": "203.0.113.50",
+				},
+				cf: {},
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBe("203.0.113.50");
+		});
+
+		it("falls back to the CF path when no trusted header matches", () => {
+			const req = createRequest({
+				headers: { "cf-connecting-ip": "1.1.1.1" },
+				cf: {},
+			});
+			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
+			expect(meta.ip).toBe("1.1.1.1");
 		});
 	});
 });

--- a/packages/core/tests/unit/plugins/request-meta.test.ts
+++ b/packages/core/tests/unit/plugins/request-meta.test.ts
@@ -610,5 +610,16 @@ describe("extractRequestMeta", () => {
 			const meta = extractRequestMeta(req, { trustedProxyHeaders: ["x-real-ip"] });
 			expect(meta.ip).toBe("1.1.1.1");
 		});
+
+		it("validates a pre-resolved string[] of trusted headers", () => {
+			// Passing the array form (used by the plugin runtime with a list
+			// pre-resolved from the config) must not trust an invalid header
+			// name — headers.get() would throw a TypeError.
+			const req = createRequest({
+				headers: { "x-real-ip": "203.0.113.50" },
+			});
+			const meta = extractRequestMeta(req, ["bad name", " x-real-ip ", "bad:colon"]);
+			expect(meta.ip).toBe("203.0.113.50");
+		});
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds a `trustedProxyHeaders` config option (and matching `EMDASH_TRUSTED_PROXY_HEADERS` env var) so self-hosted deployments behind a reverse proxy they control can declare which client-IP headers to trust.

**The gap:** rate limiters in the auth endpoints (magic-link, signup, passkey, OAuth device flow) resolve client IPs via `extractRequestMeta` / `getClientIp`. Those helpers only trust IP-bearing headers when a Cloudflare `cf` object is present on the request (proving it came through the CF edge). On a non-CF deployment behind nginx/Caddy/Fly/etc., `meta.ip` was always `null` — the auth rate limiters silently skipped entirely, and the comment endpoint bucketed under a shared `unknown` key (and previously under a trivially rotatable `ua:<hash>` key).

**The fix:** operators opt in by listing the header their proxy writes.

```js
// astro.config.mjs
emdash({
  trustedProxyHeaders: ["x-real-ip"], // nginx, Caddy, Traefik
})
```

or via env:

```
EMDASH_TRUSTED_PROXY_HEADERS=x-real-ip,fly-client-ip
```

Headers are tried in order; values ending in `forwarded-for` are parsed as comma-separated lists and the first entry is used.

**Cloudflare behaviour is unchanged.** On CF the `cf`-verified `CF-Connecting-IP` / `X-Forwarded-For` path runs first and wins — operator-declared trusted headers only fill in if the CF headers are absent. A misconfigured `trustedProxyHeaders: [\"x-forwarded-for\"]` on a CF deployment does NOT let an attacker spoof XFF.

**Header-name validation:** names are checked against the RFC 7230 token pattern and invalid entries (empty strings, names with spaces/colons/etc.) are dropped at config time. Previously `Headers.get(invalid)` would have thrown a TypeError from every rate-limited route.

**Comment endpoint UA-hash removed.** The old code hashed the User-Agent as a rate-limit key when no IP was available, which a spammer could trivially rotate. Requests with no trusted IP now share the `unknown` bucket (20/10min); operators are steered to set `trustedProxyHeaders` to restore per-IP bucketing. Documented in the changeset and the new config docs section.

Went through an adversarial review agent before opening; it caught four real issues that are now fixed:

1. **Config option wasn't in `serializableConfig`** — feature was silently dead on the config-file path. Fixed at `integration/index.ts:161`.
2. **Trusted headers overriding `CF-Connecting-IP`** — CF misconfig regression. Fixed by reordering.
3. **Malformed header names crashing routes** — RFC 7230 validation added.
4. **Plugin-facing `extractRequestMeta` callers dropping trusted headers** — threaded config through `PluginContextFactoryOptions` + `emdash-runtime.handleSandboxedRoute`.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

(Adds a new config option alongside the bug fix — minor bump per changeset.)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

- 26 new tests across: \`tests/unit/auth/trusted-proxy.test.ts\` (9), \`tests/unit/plugins/request-meta.test.ts\` (11 new in existing file, covering trusted-header fallback, CF-header precedence, XFF parsing, case insensitivity), \`tests/integration/auth/rate-limit.test.ts\` (10 new in existing file), \`tests/integration/astro/comments-rate-limit.test.ts\` (new file, integration test proving 21 comments with rotating UAs share one bucket and the last is 429'd), \`tests/unit/astro/integration/virtual-modules.test.ts\` (confirms \`generateConfigModule\` round-trips the field).
- Full suite green: 3771 tests across the workspace.
- Typecheck clean, lint baseline, docs build clean.

**Docs** updated in \`docs/src/content/docs/reference/configuration.mdx\` with a new \`trustedProxyHeaders\` section, worked examples (nginx, Fly, generic XFF), an env-var note, a cross-reference from the reverse-proxy setup subsection, and a strongly-worded \"only set this when you control the reverse proxy\" warning.