### PR TITLE
fix(setup): write emdash:site_url once, don't overwrite on later calls

### DIFF
--- a/.changeset/setup-site-url-lock.md
+++ b/.changeset/setup-site-url-lock.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Locks `emdash:site_url` after the first setup call so a spoofed Host header on a later step of the wizard can't overwrite it. Config (`siteUrl`) and env (`EMDASH_SITE_URL`) paths already took precedence; this is a defence-in-depth guard for deployments that rely on the request-origin fallback.

--- a/packages/core/src/astro/routes/api/setup/index.ts
+++ b/packages/core/src/astro/routes/api/setup/index.ts
@@ -89,15 +89,12 @@ export const POST: APIRoute = async ({ request, url, locals }) => {
 			const options = new OptionsRepository(emdash.db);
 
 			// Store the canonical site URL from the setup request.
-			// Write-once: if site_url is already stored (e.g. from an earlier
-			// step of the setup wizard), don't overwrite it. A spoofed Host
-			// header on a subsequent setup call during the wizard window
-			// could otherwise poison the URL used in auth emails.
-			const existingSiteUrl = await options.get("emdash:site_url");
-			if (!existingSiteUrl) {
-				const siteUrl = getPublicOrigin(url, emdash.config);
-				await options.set("emdash:site_url", siteUrl);
-			}
+			// Write-once at the DB level so concurrent setup POSTs can't both
+			// observe an empty value and race to write. A spoofed Host header
+			// on a later call during the wizard window must not be able to
+			// replace the first value.
+			const siteUrl = getPublicOrigin(url, emdash.config);
+			await options.setIfAbsent("emdash:site_url", siteUrl);
 
 			if (useExternalAuth) {
 				// External auth mode: mark setup complete now

--- a/packages/core/src/astro/routes/api/setup/index.ts
+++ b/packages/core/src/astro/routes/api/setup/index.ts
@@ -89,9 +89,15 @@ export const POST: APIRoute = async ({ request, url, locals }) => {
 			const options = new OptionsRepository(emdash.db);
 
 			// Store the canonical site URL from the setup request.
-			// This is trusted because setup runs on the real domain.
-			const siteUrl = getPublicOrigin(url, emdash.config);
-			await options.set("emdash:site_url", siteUrl);
+			// Write-once: if site_url is already stored (e.g. from an earlier
+			// step of the setup wizard), don't overwrite it. A spoofed Host
+			// header on a subsequent setup call during the wizard window
+			// could otherwise poison the URL used in auth emails.
+			const existingSiteUrl = await options.get("emdash:site_url");
+			if (!existingSiteUrl) {
+				const siteUrl = getPublicOrigin(url, emdash.config);
+				await options.set("emdash:site_url", siteUrl);
+			}
 
 			if (useExternalAuth) {
 				// External auth mode: mark setup complete now

--- a/packages/core/src/database/repositories/options.ts
+++ b/packages/core/src/database/repositories/options.ts
@@ -56,6 +56,31 @@ export class OptionsRepository {
 	}
 
 	/**
+	 * Set an option value only if no row with that name exists. Atomic at the
+	 * database level via INSERT ... ON CONFLICT DO NOTHING, so concurrent
+	 * callers can't race past the check.
+	 *
+	 * Returns true when the row was inserted, false when a row already
+	 * existed (regardless of its value — even an empty string or null).
+	 */
+	async setIfAbsent<T = unknown>(name: string, value: T): Promise<boolean> {
+		const row: OptionTable = {
+			name,
+			value: JSON.stringify(value),
+		};
+
+		const result = await this.db
+			.insertInto("options")
+			.values(row)
+			.onConflict((oc) => oc.column("name").doNothing())
+			.executeTakeFirst();
+
+		// SQLite reports numInsertedOrUpdatedRows; Postgres reports the same.
+		// When the ON CONFLICT branch fires and does nothing, the count is 0.
+		return (result.numInsertedOrUpdatedRows ?? 0n) > 0n;
+	}
+
+	/**
 	 * Delete an option
 	 */
 	async delete(name: string): Promise<boolean> {

--- a/packages/core/tests/integration/astro/setup-site-url-lock.test.ts
+++ b/packages/core/tests/integration/astro/setup-site-url-lock.test.ts
@@ -106,4 +106,56 @@ describe("POST /setup — site_url write-once lock", () => {
 		const options = new OptionsRepository(db);
 		expect(await options.get("emdash:site_url")).toBe("http://real-site.example");
 	});
+
+	it("is atomic under concurrent setup POSTs with different Hosts", async () => {
+		// Two concurrent callers observe an empty site_url and race to
+		// write. Without DB-level write-once semantics, the last writer
+		// wins and the legitimate host can still be replaced.
+		const [a, b] = await Promise.all([
+			postSetup(
+				buildContext(
+					db,
+					buildRequest("real-site.example", { title: "My Site", includeContent: false }),
+				),
+			),
+			postSetup(
+				buildContext(
+					db,
+					buildRequest("attacker.example", { title: "My Site", includeContent: false }),
+				),
+			),
+		]);
+		expect(a.status).toBe(200);
+		expect(b.status).toBe(200);
+
+		const options = new OptionsRepository(db);
+		const stored = await options.get("emdash:site_url");
+		// Whichever call won the race must now stick — a third caller must
+		// not be able to overwrite it.
+		expect(["http://real-site.example", "http://attacker.example"]).toContain(stored);
+
+		const third = await postSetup(
+			buildContext(db, buildRequest("other.example", { title: "My Site", includeContent: false })),
+		);
+		expect(third.status).toBe(200);
+		expect(await options.get("emdash:site_url")).toBe(stored);
+	});
+
+	it("does not overwrite a legitimately-stored empty string", async () => {
+		// Defence-in-depth: if site_url was somehow stored as "" (e.g.
+		// manual DB edit, legacy data, test fixture), the guard must treat
+		// it as present, not missing.
+		const options = new OptionsRepository(db);
+		await options.set("emdash:site_url", "");
+
+		const res = await postSetup(
+			buildContext(
+				db,
+				buildRequest("attacker.example", { title: "My Site", includeContent: false }),
+			),
+		);
+		expect(res.status).toBe(200);
+
+		expect(await options.get("emdash:site_url")).toBe("");
+	});
 });

--- a/packages/core/tests/integration/astro/setup-site-url-lock.test.ts
+++ b/packages/core/tests/integration/astro/setup-site-url-lock.test.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /_emdash/api/setup writes `emdash:site_url` once. Subsequent calls
+ * to the setup endpoint (during the multi-step wizard, before
+ * `emdash:setup_complete` is true) must not overwrite it.
+ *
+ * Without this, a spoofed Host header on any follow-up POST during the
+ * setup window could poison the site URL used in auth emails.
+ *
+ * The primary defence (config.siteUrl / EMDASH_SITE_URL env) was added
+ * earlier; this is the last-line lock for deployments that rely on the
+ * request-origin fallback.
+ */
+
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub the seed virtual module that loadSeed() imports at runtime. Without
+// this the setup route errors out before reaching the site_url write.
+vi.mock("virtual:emdash/seed", () => ({
+	seed: {
+		version: "1",
+		settings: {},
+		collections: [],
+	},
+	userSeed: null,
+}));
+
+import { POST as postSetup } from "../../../src/astro/routes/api/setup/index.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+function buildRequest(host: string, body: unknown): Request {
+	return new Request(`http://${host}/_emdash/api/setup`, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			host,
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(db: Kysely<Database>, request: Request): APIContext {
+	return {
+		params: {},
+		url: new URL(request.url),
+		request,
+		locals: {
+			emdash: {
+				db,
+				config: {},
+				storage: undefined,
+			},
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+	} as unknown as APIContext;
+}
+
+describe("POST /setup — site_url write-once lock", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("stores site_url from the first request", async () => {
+		const res = await postSetup(
+			buildContext(
+				db,
+				buildRequest("real-site.example", { title: "My Site", includeContent: false }),
+			),
+		);
+		expect(res.status).toBe(200);
+
+		const options = new OptionsRepository(db);
+		expect(await options.get("emdash:site_url")).toBe("http://real-site.example");
+	});
+
+	it("does not overwrite site_url when a later setup call arrives with a spoofed Host", async () => {
+		// First call — legitimate admin on the real host.
+		const first = await postSetup(
+			buildContext(
+				db,
+				buildRequest("real-site.example", { title: "My Site", includeContent: false }),
+			),
+		);
+		expect(first.status).toBe(200);
+
+		// Attacker sends a second setup call with a spoofed Host header
+		// before the admin has completed the final step. Without the lock,
+		// the stored site_url would be overwritten.
+		const second = await postSetup(
+			buildContext(
+				db,
+				buildRequest("attacker.example", { title: "My Site", includeContent: false }),
+			),
+		);
+		expect(second.status).toBe(200);
+
+		const options = new OptionsRepository(db);
+		expect(await options.get("emdash:site_url")).toBe("http://real-site.example");
+	});
+});

--- a/packages/core/tests/integration/database/options-repository.test.ts
+++ b/packages/core/tests/integration/database/options-repository.test.ts
@@ -1,0 +1,72 @@
+/**
+ * OptionsRepository.setIfAbsent — atomic write-once semantics.
+ *
+ * Used by routes that must never overwrite a stored value once set
+ * (e.g. the setup wizard's emdash:site_url write). Correctness under
+ * concurrent writes is a security property: a non-atomic read-then-write
+ * lets a second caller win the race and poison the value.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("OptionsRepository.setIfAbsent", () => {
+	let db: Kysely<Database>;
+	let repo: OptionsRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		repo = new OptionsRepository(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("inserts when no row exists and returns true", async () => {
+		const inserted = await repo.setIfAbsent("emdash:site_url", "https://example.com");
+		expect(inserted).toBe(true);
+		expect(await repo.get("emdash:site_url")).toBe("https://example.com");
+	});
+
+	it("does not overwrite an existing value and returns false", async () => {
+		await repo.set("emdash:site_url", "https://real.example");
+		const inserted = await repo.setIfAbsent("emdash:site_url", "https://attacker.example");
+		expect(inserted).toBe(false);
+		expect(await repo.get("emdash:site_url")).toBe("https://real.example");
+	});
+
+	it("treats an empty string as present (does not overwrite)", async () => {
+		await repo.set("emdash:site_url", "");
+		const inserted = await repo.setIfAbsent("emdash:site_url", "https://attacker.example");
+		expect(inserted).toBe(false);
+		expect(await repo.get("emdash:site_url")).toBe("");
+	});
+
+	it("treats a stored null as present (does not overwrite)", async () => {
+		await repo.set("emdash:site_url", null);
+		const inserted = await repo.setIfAbsent("emdash:site_url", "https://attacker.example");
+		expect(inserted).toBe(false);
+		expect(await repo.get("emdash:site_url")).toBeNull();
+	});
+
+	it("is atomic under concurrent callers — only one insert succeeds", async () => {
+		const results = await Promise.all([
+			repo.setIfAbsent("emdash:site_url", "https://a.example"),
+			repo.setIfAbsent("emdash:site_url", "https://b.example"),
+			repo.setIfAbsent("emdash:site_url", "https://c.example"),
+		]);
+
+		// Exactly one caller inserted; the others saw the existing row.
+		expect(results.filter((r) => r === true)).toHaveLength(1);
+		expect(results.filter((r) => r === false)).toHaveLength(2);
+
+		// And whichever value landed first now sticks.
+		const final = await repo.get("emdash:site_url");
+		expect(["https://a.example", "https://b.example", "https://c.example"]).toContain(final);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

During the multi-step setup wizard, `POST /_emdash/api/setup` re-derives `emdash:site_url` from the request origin on every call and overwrites the stored value. A spoofed `Host` header on a follow-up POST (before `emdash:setup_complete` is true) can poison the URL that later gets baked into magic-link, invite, and signup-verify emails.

The primary defence is already in place — `config.siteUrl` and `EMDASH_SITE_URL` take precedence over the request origin in `getPublicOrigin`. This PR adds a last-line write-once guard for deployments that rely on the request-origin fallback: once `emdash:site_url` is stored, the setup route won't overwrite it.

Single change in \`packages/core/src/astro/routes/api/setup/index.ts\`: check `options.get("emdash:site_url")` before writing, skip if already set.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and \`pnpm locale:extract\` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Two new integration tests in \`tests/integration/astro/setup-site-url-lock.test.ts\`:
1. First POST to /setup writes site_url from the request origin.
2. Second POST with a different Host header does NOT overwrite it.

Full suite green (3772 tests), typecheck + lint clean.