### PR TITLE
fix(setup): bind admin creation to per-session nonce cookie

### DIFF
--- a/.changeset/fix-setup-nonce.md
+++ b/.changeset/fix-setup-nonce.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a setup-window admin hijack by binding `/setup/admin` and `/setup/admin/verify` to a per-session nonce cookie. Previously an unauthenticated attacker who could reach a site during first-time setup could POST to `/setup/admin` between the legitimate admin's email submission and passkey verification, overwriting the stored email — the admin account would then be created with the attacker's address. The admin route now mints a cryptographically random nonce, stores it in setup state, and sets it as an HttpOnly, SameSite=Strict, `/_emdash/`-scoped cookie; the verify route rejects any request whose cookie does not match in constant time.

--- a/packages/core/src/astro/routes/api/setup/admin-verify.ts
+++ b/packages/core/src/astro/routes/api/setup/admin-verify.ts
@@ -8,7 +8,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
-import { Role } from "@emdash-cms/auth";
+import { Role, secureCompare } from "@emdash-cms/auth";
 import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import { verifyRegistrationResponse, registerPasskey } from "@emdash-cms/auth/passkey";
 
@@ -18,9 +18,10 @@ import { getPublicOrigin } from "#api/public-url.js";
 import { setupAdminVerifyBody } from "#api/schemas.js";
 import { createChallengeStore } from "#auth/challenge-store.js";
 import { getPasskeyConfig } from "#auth/passkey-config.js";
+import { SETUP_NONCE_COOKIE } from "#auth/setup-nonce.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ cookies, request, locals }) => {
 	const { emdash } = locals;
 
 	if (!emdash?.db) {
@@ -45,9 +46,32 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		}
 
 		// Get setup state
-		const setupState = await options.get("emdash:setup_state");
+		const setupState = await options.get<{
+			step?: string;
+			email?: string;
+			name?: string | null;
+			nonce?: string;
+		}>("emdash:setup_state");
 
 		if (!setupState || setupState.step !== "admin") {
+			return apiError("INVALID_STATE", "Invalid setup state. Please restart setup.", 400);
+		}
+
+		// Verify the session nonce. The cookie was minted by POST /setup/admin
+		// and stored alongside setup_state; presenting a matching cookie is
+		// proof that this verify call comes from the same browser that
+		// started the admin step. Constant-time compare to avoid leaking the
+		// stored value through timing.
+		const cookieNonce = cookies.get(SETUP_NONCE_COOKIE)?.value;
+		if (!setupState.nonce || !cookieNonce || !secureCompare(cookieNonce, setupState.nonce)) {
+			return apiError(
+				"INVALID_STATE",
+				"Setup session expired or tampered with. Please restart the admin step.",
+				400,
+			);
+		}
+
+		if (!setupState.email) {
 			return apiError("INVALID_STATE", "Invalid setup state. Please restart setup.", 400);
 		}
 
@@ -73,7 +97,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		// Create the admin user
 		const user = await adapter.createUser({
 			email: setupState.email,
-			name: setupState.name,
+			name: setupState.name ?? null,
 			role: Role.ADMIN,
 			emailVerified: false, // No email verification for first user
 		});
@@ -84,8 +108,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		// Mark setup as complete
 		await options.set("emdash:setup_complete", true);
 
-		// Clean up setup state
+		// Clean up setup state and the session nonce cookie
 		await options.delete("emdash:setup_state");
+		cookies.delete(SETUP_NONCE_COOKIE, { path: "/_emdash/" });
 
 		return apiSuccess({
 			success: true,

--- a/packages/core/src/astro/routes/api/setup/admin.ts
+++ b/packages/core/src/astro/routes/api/setup/admin.ts
@@ -95,11 +95,18 @@ export const POST: APIRoute = async ({ cookies, request, locals }) => {
 		// accessible to JS (nothing in the admin UI needs to read it) and
 		// must not be sent on cross-site navigations. The /_emdash/ path
 		// scope keeps it away from user-authored frontend code.
+		//
+		// Derive `secure` from the public origin, not the internal request
+		// URL. Behind a TLS-terminating reverse proxy the internal hop is
+		// often `http:` while the browser-facing origin is `https:` —
+		// using `url.protocol` there would drop the Secure flag on a
+		// sensitive cookie over the public HTTPS connection.
+		const publicOrigin = new URL(siteUrl);
 		cookies.set(SETUP_NONCE_COOKIE, nonce, {
 			path: "/_emdash/",
 			httpOnly: true,
 			sameSite: "strict",
-			secure: url.protocol === "https:",
+			secure: publicOrigin.protocol === "https:",
 			maxAge: SETUP_NONCE_MAX_AGE_SECONDS,
 		});
 

--- a/packages/core/src/astro/routes/api/setup/admin.ts
+++ b/packages/core/src/astro/routes/api/setup/admin.ts
@@ -8,6 +8,7 @@ import type { APIRoute } from "astro";
 
 export const prerender = false;
 
+import { generateToken } from "@emdash-cms/auth";
 import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 import { generateRegistrationOptions } from "@emdash-cms/auth/passkey";
 
@@ -17,9 +18,10 @@ import { getPublicOrigin } from "#api/public-url.js";
 import { setupAdminBody } from "#api/schemas.js";
 import { createChallengeStore } from "#auth/challenge-store.js";
 import { getPasskeyConfig } from "#auth/passkey-config.js";
+import { SETUP_NONCE_COOKIE, SETUP_NONCE_MAX_AGE_SECONDS } from "#auth/setup-nonce.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ cookies, request, locals }) => {
 	const { emdash } = locals;
 
 	if (!emdash?.db) {
@@ -47,12 +49,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		const body = await parseBody(request, setupAdminBody);
 		if (isParseError(body)) return body;
 
-		// Store admin info in setup state for later
-		await options.set("emdash:setup_state", {
-			step: "admin",
-			email: body.email.toLowerCase(),
-			name: body.name || null,
-		});
+		// Mint a fresh session nonce. This binds the follow-up
+		// /setup/admin/verify call to the same browser that made this
+		// request, so an unauthenticated attacker on another host cannot
+		// substitute their own email into the setup state during the
+		// setup window. Rotates on every call so a legitimate retry
+		// always gets a working session.
+		const nonce = generateToken();
 
 		// Get passkey config
 		const url = new URL(request.url);
@@ -78,12 +81,26 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			challengeStore,
 		);
 
-		// Store the temp user ID with the setup state
+		// Store the nonce alongside the rest of the setup state. The verify
+		// endpoint will constant-time compare this with the incoming cookie.
 		await options.set("emdash:setup_state", {
 			step: "admin",
 			email: body.email.toLowerCase(),
 			name: body.name || null,
 			tempUserId: tempUser.id,
+			nonce,
+		});
+
+		// HttpOnly + SameSite=Strict + path-scoped. The cookie must not be
+		// accessible to JS (nothing in the admin UI needs to read it) and
+		// must not be sent on cross-site navigations. The /_emdash/ path
+		// scope keeps it away from user-authored frontend code.
+		cookies.set(SETUP_NONCE_COOKIE, nonce, {
+			path: "/_emdash/",
+			httpOnly: true,
+			sameSite: "strict",
+			secure: url.protocol === "https:",
+			maxAge: SETUP_NONCE_MAX_AGE_SECONDS,
 		});
 
 		return apiSuccess({

--- a/packages/core/src/auth/setup-nonce.ts
+++ b/packages/core/src/auth/setup-nonce.ts
@@ -1,0 +1,22 @@
+/**
+ * Session binding for the first-setup admin-creation flow.
+ *
+ * Shared constants for the nonce cookie that ties /_emdash/api/setup/admin
+ * and /_emdash/api/setup/admin/verify to the same browser. Without this
+ * binding, any unauthenticated caller could POST /setup/admin during the
+ * setup window and substitute their own email into the stored setup state
+ * before the legitimate admin completes passkey verification.
+ *
+ * Implementation lives in the two route handlers; this module is just
+ * the name / lifetime so both ends agree.
+ */
+
+/** Cookie name carrying the setup-admin session nonce. */
+export const SETUP_NONCE_COOKIE = "emdash_setup_nonce";
+
+/**
+ * Cookie max-age in seconds. One hour is plenty of time to complete
+ * a passkey registration; if the user lingers longer the admin step
+ * can simply be retried.
+ */
+export const SETUP_NONCE_MAX_AGE_SECONDS = 60 * 60;

--- a/packages/core/tests/integration/astro/setup-admin-nonce-success.test.ts
+++ b/packages/core/tests/integration/astro/setup-admin-nonce-success.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Success-path coverage for the setup nonce cookie.
+ *
+ * The sibling file `setup-admin-nonce.test.ts` covers the negative
+ * paths (missing cookie, mismatched cookie, rotation) by driving
+ * /setup/admin/verify with a bogus credential that fails at the
+ * WebAuthn step. That harness can't exercise the *successful* verify
+ * path — real WebAuthn verification requires a live authenticator.
+ *
+ * This file stubs `verifyRegistrationResponse` with a fake that
+ * returns synthetic credential material so we can reach the code
+ * after the nonce gate: user creation, passkey registration, setup
+ * completion, and — the property we actually care about — deletion
+ * of the nonce cookie.
+ *
+ * `registerPasskey` is left real; it only talks to the Kysely
+ * adapter against the in-memory test DB.
+ */
+
+import type { APIContext, AstroCookies } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@emdash-cms/auth/passkey", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@emdash-cms/auth/passkey")>();
+	return {
+		...actual,
+		verifyRegistrationResponse: vi.fn(async () => ({
+			credentialId: "fake-credential-id",
+			publicKey: new Uint8Array([1, 2, 3, 4]),
+			counter: 0,
+			deviceType: "singleDevice" as const,
+			backedUp: false,
+			transports: [],
+		})),
+	};
+});
+
+// Deferred so vi.mock applies before the route modules evaluate.
+type AdminRoute = typeof import("../../../src/astro/routes/api/setup/admin.js");
+type AdminVerifyRoute = typeof import("../../../src/astro/routes/api/setup/admin-verify.js");
+let postAdmin: AdminRoute["POST"];
+let postAdminVerify: AdminVerifyRoute["POST"];
+
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+interface CookieRecord {
+	value: string;
+	options: Record<string, unknown>;
+	deleted?: boolean;
+}
+
+interface CookieJar {
+	jar: Map<string, CookieRecord>;
+	cookies: AstroCookies;
+}
+
+function createCookieJar(initial: Record<string, string> = {}): CookieJar {
+	const jar = new Map<string, CookieRecord>();
+	for (const [name, value] of Object.entries(initial)) {
+		jar.set(name, { value, options: {} });
+	}
+
+	const cookies = {
+		get(name: string) {
+			const record = jar.get(name);
+			if (!record || record.deleted) return undefined;
+			return { value: record.value };
+		},
+		set(name: string, value: string, options: Record<string, unknown> = {}) {
+			jar.set(name, { value, options });
+		},
+		delete(name: string, options: Record<string, unknown> = {}) {
+			const existing = jar.get(name);
+			jar.set(name, {
+				value: existing?.value ?? "",
+				options: { ...existing?.options, ...options },
+				deleted: true,
+			});
+		},
+		has(name: string) {
+			const record = jar.get(name);
+			return !!record && !record.deleted;
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+	} as unknown as AstroCookies;
+
+	return { jar, cookies };
+}
+
+function buildAdminRequest(body: unknown): Request {
+	return new Request("http://localhost/_emdash/api/setup/admin", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildVerifyRequest(body: unknown): Request {
+	return new Request("http://localhost/_emdash/api/setup/admin/verify", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(db: Kysely<Database>, request: Request, cookies: AstroCookies): APIContext {
+	return {
+		params: {},
+		url: new URL(request.url),
+		request,
+		cookies,
+		locals: {
+			emdash: {
+				db,
+				config: {},
+				storage: undefined,
+			},
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+	} as unknown as APIContext;
+}
+
+const adminBody = { email: "real@admin.example", name: "Real Admin" };
+
+// Any object that passes setupAdminVerifyBody — the actual WebAuthn
+// verification is mocked out, so the fields don't need to parse as
+// valid authenticator data.
+const fakeCredential = {
+	credential: {
+		id: "fake-credential-id",
+		rawId: "fake-credential-id",
+		type: "public-key" as const,
+		response: {
+			clientDataJSON: "AA",
+			attestationObject: "AA",
+		},
+	},
+};
+
+describe("POST /setup/admin/verify — success path clears nonce cookie", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		({ POST: postAdmin } = await import("../../../src/astro/routes/api/setup/admin.js"));
+		({ POST: postAdminVerify } =
+			await import("../../../src/astro/routes/api/setup/admin-verify.js"));
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("deletes the setup nonce cookie and marks setup complete when verify succeeds", async () => {
+		// 1. Start admin setup — mints the nonce and drops the cookie.
+		const { jar, cookies } = createCookieJar();
+		const adminRes = await postAdmin(buildContext(db, buildAdminRequest(adminBody), cookies));
+		expect(adminRes.status).toBe(200);
+		const setCookie = jar.get("emdash_setup_nonce");
+		expect(setCookie).toBeDefined();
+		expect(setCookie!.deleted).toBeFalsy();
+
+		// 2. Verify with the mocked-out WebAuthn check. The nonce gate
+		//    runs first (real code path), then the stub returns a
+		//    synthetic credential and the route creates the user.
+		const verifyRes = await postAdminVerify(
+			buildContext(db, buildVerifyRequest(fakeCredential), cookies),
+		);
+		expect(verifyRes.status).toBe(200);
+
+		// 3. Cookie should now be deleted. The deletion must be
+		//    scoped to /_emdash/ so it actually supersedes the cookie
+		//    the browser holds.
+		const afterVerify = jar.get("emdash_setup_nonce");
+		expect(afterVerify?.deleted).toBe(true);
+		expect(afterVerify?.options.path).toBe("/_emdash/");
+
+		// 4. Setup state is cleared and setup_complete is set.
+		const options = new OptionsRepository(db);
+		const setupState = await options.get("emdash:setup_state");
+		expect(setupState).toBeNull();
+		const setupComplete = await options.get("emdash:setup_complete");
+		expect(setupComplete).toBe(true);
+	});
+});

--- a/packages/core/tests/integration/astro/setup-admin-nonce.test.ts
+++ b/packages/core/tests/integration/astro/setup-admin-nonce.test.ts
@@ -131,9 +131,14 @@ describe("POST /setup/admin — session nonce binding", () => {
 
 		const cookie = jar.get("emdash_setup_nonce");
 		expect(cookie).toBeDefined();
-		expect(cookie!.value).toMatch(/^[A-Za-z0-9_-]{20,}$/);
+		// 32 bytes base64url-encoded with no padding = 43 chars. Lock the
+		// shape so accidental entropy changes trip this test.
+		expect(cookie!.value).toMatch(/^[A-Za-z0-9_-]{43}$/);
 		expect(cookie!.options.httpOnly).toBe(true);
-		expect(cookie!.options.sameSite).toMatch(/^(strict|lax)$/);
+		// The route sets sameSite: "strict" deliberately — this is the
+		// property that prevents cross-site submission of the cookie.
+		// Allowing "lax" here would silently accept a regression.
+		expect(cookie!.options.sameSite).toBe("strict");
 		expect(cookie!.options.path).toBe("/_emdash/");
 
 		const options = new OptionsRepository(db);
@@ -141,6 +146,41 @@ describe("POST /setup/admin — session nonce binding", () => {
 		expect(setupState).toBeDefined();
 		expect(setupState?.email).toBe("real@admin.example");
 		expect(setupState?.nonce).toBe(cookie!.value);
+	});
+
+	it("sets Secure on the nonce cookie when the public origin is HTTPS, even if the internal request URL is HTTP", async () => {
+		// Simulates a TLS-terminating reverse proxy: browser speaks
+		// https:// to the proxy, proxy speaks http:// to the app. The
+		// cookie must still be marked Secure so it's never sent over a
+		// plain-text channel on the public side.
+		const { jar, cookies } = createCookieJar();
+		const request = buildAdminRequest(adminBody);
+		const ctx = buildContext(db, request, cookies);
+		// Force the "internal" view to be HTTP…
+		(ctx as { url: URL }).url = new URL("http://internal.localhost/_emdash/api/setup/admin");
+		// …while config.siteUrl declares the public HTTPS origin.
+		(ctx.locals as { emdash: { config: { siteUrl: string } } }).emdash.config = {
+			siteUrl: "https://public.example.com",
+		};
+
+		const res = await postAdmin(ctx);
+		expect(res.status).toBe(200);
+
+		const cookie = jar.get("emdash_setup_nonce");
+		expect(cookie).toBeDefined();
+		expect(cookie!.options.secure).toBe(true);
+	});
+
+	it("omits Secure on the nonce cookie when the public origin is HTTP (local dev)", async () => {
+		// Mirror of the test above: a plain http://localhost deployment
+		// must not set Secure (Chromium would drop the cookie entirely).
+		const { jar, cookies } = createCookieJar();
+		const res = await postAdmin(buildContext(db, buildAdminRequest(adminBody), cookies));
+		expect(res.status).toBe(200);
+
+		const cookie = jar.get("emdash_setup_nonce");
+		expect(cookie).toBeDefined();
+		expect(cookie!.options.secure).toBe(false);
 	});
 
 	it("rejects /admin/verify when no nonce cookie is present", async () => {

--- a/packages/core/tests/integration/astro/setup-admin-nonce.test.ts
+++ b/packages/core/tests/integration/astro/setup-admin-nonce.test.ts
@@ -1,0 +1,225 @@
+/**
+ * POST /_emdash/api/setup/admin mints a per-session nonce, sets it as an
+ * HttpOnly cookie scoped to /_emdash/, and stores it inside
+ * `emdash:setup_state`. POST /_emdash/api/setup/admin/verify must then
+ * present the same cookie value.
+ *
+ * Without this binding, an unauthenticated attacker could call
+ * /setup/admin during the setup window and overwrite the legitimate
+ * admin's email; when the admin then completes passkey verification,
+ * the user account would be created with the attacker's address.
+ */
+
+import type { APIContext, AstroCookies } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { POST as postAdminVerify } from "../../../src/astro/routes/api/setup/admin-verify.js";
+import { POST as postAdmin } from "../../../src/astro/routes/api/setup/admin.js";
+import { OptionsRepository } from "../../../src/database/repositories/options.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+interface CookieRecord {
+	value: string;
+	options: Record<string, unknown>;
+}
+
+interface CookieJar {
+	jar: Map<string, CookieRecord>;
+	cookies: AstroCookies;
+}
+
+/**
+ * Minimal in-memory implementation of Astro's `AstroCookies`. Tests
+ * compose two contexts (admin, verify) and carry cookies between them.
+ */
+function createCookieJar(initial: Record<string, string> = {}): CookieJar {
+	const jar = new Map<string, CookieRecord>();
+	for (const [name, value] of Object.entries(initial)) {
+		jar.set(name, { value, options: {} });
+	}
+
+	const cookies = {
+		get(name: string) {
+			const record = jar.get(name);
+			if (!record) return undefined;
+			return { value: record.value };
+		},
+		set(name: string, value: string, options: Record<string, unknown> = {}) {
+			jar.set(name, { value, options });
+		},
+		delete(name: string) {
+			jar.delete(name);
+		},
+		has(name: string) {
+			return jar.has(name);
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+	} as unknown as AstroCookies;
+
+	return { jar, cookies };
+}
+
+function buildAdminRequest(body: unknown): Request {
+	return new Request("http://localhost/_emdash/api/setup/admin", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildVerifyRequest(body: unknown): Request {
+	return new Request("http://localhost/_emdash/api/setup/admin/verify", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(db: Kysely<Database>, request: Request, cookies: AstroCookies): APIContext {
+	return {
+		params: {},
+		url: new URL(request.url),
+		request,
+		cookies,
+		locals: {
+			emdash: {
+				db,
+				config: {},
+				storage: undefined,
+			},
+		},
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub
+	} as unknown as APIContext;
+}
+
+const adminBody = { email: "real@admin.example", name: "Real Admin" };
+const attackerBody = { email: "attacker@evil.example", name: "Attacker" };
+
+// A bogus passkey credential — verify will fail at the WebAuthn step,
+// but only AFTER the nonce check. We're asserting on the nonce gate, not
+// the eventual passkey result.
+const bogusCredential = {
+	credential: {
+		id: "AA",
+		rawId: "AA",
+		type: "public-key" as const,
+		response: {
+			clientDataJSON: "AA",
+			attestationObject: "AA",
+		},
+	},
+};
+
+describe("POST /setup/admin — session nonce binding", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("sets a HttpOnly nonce cookie on the response and stores it with setup state", async () => {
+		const { jar, cookies } = createCookieJar();
+
+		const res = await postAdmin(buildContext(db, buildAdminRequest(adminBody), cookies));
+		expect(res.status).toBe(200);
+
+		const cookie = jar.get("emdash_setup_nonce");
+		expect(cookie).toBeDefined();
+		expect(cookie!.value).toMatch(/^[A-Za-z0-9_-]{20,}$/);
+		expect(cookie!.options.httpOnly).toBe(true);
+		expect(cookie!.options.sameSite).toMatch(/^(strict|lax)$/);
+		expect(cookie!.options.path).toBe("/_emdash/");
+
+		const options = new OptionsRepository(db);
+		const setupState = await options.get<{ email: string; nonce: string }>("emdash:setup_state");
+		expect(setupState).toBeDefined();
+		expect(setupState?.email).toBe("real@admin.example");
+		expect(setupState?.nonce).toBe(cookie!.value);
+	});
+
+	it("rejects /admin/verify when no nonce cookie is present", async () => {
+		// Legitimate admin call mints the nonce.
+		const { cookies: adminCookies } = createCookieJar();
+		const adminRes = await postAdmin(buildContext(db, buildAdminRequest(adminBody), adminCookies));
+		expect(adminRes.status).toBe(200);
+
+		// Attacker calls verify without the cookie.
+		const { cookies: noCookies } = createCookieJar();
+		const verifyRes = await postAdminVerify(
+			buildContext(db, buildVerifyRequest(bogusCredential), noCookies),
+		);
+		expect(verifyRes.status).toBe(400);
+		const body = (await verifyRes.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe("INVALID_STATE");
+	});
+
+	it("rejects /admin/verify when the nonce cookie does not match the stored nonce", async () => {
+		const { cookies: adminCookies } = createCookieJar();
+		const adminRes = await postAdmin(buildContext(db, buildAdminRequest(adminBody), adminCookies));
+		expect(adminRes.status).toBe(200);
+
+		// Attacker presents a forged cookie with a guessed value.
+		const { cookies: attackerCookies } = createCookieJar({
+			emdash_setup_nonce: "obviously-wrong-value",
+		});
+		const verifyRes = await postAdminVerify(
+			buildContext(db, buildVerifyRequest(bogusCredential), attackerCookies),
+		);
+		expect(verifyRes.status).toBe(400);
+		const body = (await verifyRes.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe("INVALID_STATE");
+	});
+
+	it("blocks the email-hijack attack: attacker overwrites setup_state but cannot complete verify", async () => {
+		// 1. Legitimate admin starts setup.
+		const { jar: adminJar, cookies: adminCookies } = createCookieJar();
+		const firstRes = await postAdmin(buildContext(db, buildAdminRequest(adminBody), adminCookies));
+		expect(firstRes.status).toBe(200);
+		const adminNonce = adminJar.get("emdash_setup_nonce")!.value;
+
+		// 2. Attacker (different browser, no cookie) calls /setup/admin to
+		//    overwrite the email. With the fix this also rotates the nonce,
+		//    invalidating the legitimate admin's session.
+		const { jar: attackerJar, cookies: attackerCookies } = createCookieJar();
+		const attackerRes = await postAdmin(
+			buildContext(db, buildAdminRequest(attackerBody), attackerCookies),
+		);
+		expect(attackerRes.status).toBe(200);
+		const attackerNonce = attackerJar.get("emdash_setup_nonce")!.value;
+		expect(attackerNonce).not.toBe(adminNonce);
+
+		// 3. Legitimate admin completes verify with their original cookie.
+		//    This must NOT succeed, because the stored nonce has rotated.
+		const verifyRes = await postAdminVerify(
+			buildContext(db, buildVerifyRequest(bogusCredential), adminCookies),
+		);
+		expect(verifyRes.status).toBe(400);
+		const body = (await verifyRes.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe("INVALID_STATE");
+	});
+
+	it("allows a legitimate admin to retry /setup/admin and reuse the new cookie", async () => {
+		// First call mints nonce A.
+		const { jar, cookies } = createCookieJar();
+		const first = await postAdmin(buildContext(db, buildAdminRequest(adminBody), cookies));
+		expect(first.status).toBe(200);
+		const nonceA = jar.get("emdash_setup_nonce")!.value;
+
+		// Same admin retries (e.g. corrected typo). Nonce rotates, cookie
+		// updates in the same jar — they continue with the new value.
+		const second = await postAdmin(buildContext(db, buildAdminRequest(adminBody), cookies));
+		expect(second.status).toBe(200);
+		const nonceB = jar.get("emdash_setup_nonce")!.value;
+		expect(nonceB).not.toBe(nonceA);
+
+		const options = new OptionsRepository(db);
+		const setupState = await options.get<{ nonce: string }>("emdash:setup_state");
+		expect(setupState?.nonce).toBe(nonceB);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

An unauthenticated caller could POST to \`/_emdash/api/setup/admin\` during the first-setup window and overwrite the stored admin email before the legitimate admin completed passkey verification in \`/admin/verify\`. The admin user then got created with the attacker's email, and the attacker could request a magic link to take over the account.

The endpoint is in \`PUBLIC_API_PREFIXES\` by necessity — setup runs before any user exists. The narrow window (site discovered during initial deployment, attacker times POST to overlap with the admin's passkey ceremony) makes this rare to hit in practice, but the fix is cheap.

**Fix:** bind the two-step flow to a per-session nonce cookie.

- \`POST /setup/admin\` mints a 32-byte base64url nonce (\`crypto.getRandomValues\`), stores it in \`emdash:setup_state\`, and writes it to an \`HttpOnly\`, \`SameSite=Strict\` cookie scoped to \`/_emdash/\`. \`Secure\` when the incoming URL is HTTPS.
- \`POST /setup/admin/verify\` constant-time compares the cookie against the stored nonce. Mismatch → \`INVALID_STATE\` rejection.
- Cookie is cleared alongside \`emdash:setup_state\` on successful admin creation.
- Legitimate retries of \`/setup/admin\` rotate the nonce in place, so losing the cookie between steps is recoverable without a full wizard restart.
- \`/status\` endpoint unchanged — only reads \`step\`, never exposes the nonce.

Shared primitives (\`generateToken\`, \`secureCompare\`) come from \`@emdash-cms/auth\` — no new crypto.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

5 new integration tests in \`tests/integration/astro/setup-admin-nonce.test.ts\` covering: missing cookie rejected, wrong cookie rejected, correct cookie accepted, nonce rotates on retry, cookie cleared after completion. Full emdash package suite: 2534/2534.