### PR TITLE
fix(redirects): bound 404 log to prevent unauthenticated DoS

### DIFF
--- a/.changeset/fix-404-log-dos.md
+++ b/.changeset/fix-404-log-dos.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes an unauthenticated denial-of-service via the 404 log. Every 404 response previously inserted a new row into `_emdash_404_log`, so an attacker could grow the database without bound by requesting unique nonexistent URLs. Repeat hits to the same path now dedup into a single row with a `hits` counter and `last_seen_at` timestamp, referrer and user-agent headers are truncated to bounded lengths, and the log is capped at 10,000 rows with oldest-first eviction.

--- a/packages/core/src/database/migrations/035_bounded_404_log.ts
+++ b/packages/core/src/database/migrations/035_bounded_404_log.ts
@@ -1,0 +1,104 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+/**
+ * Migration: Bounded 404 logging
+ *
+ * Hardens `_emdash_404_log` against unauthenticated DoS. Previously every 404
+ * inserted a new row, so an attacker could grow the table without bound.
+ *
+ * Changes:
+ *   - Adds `hits` (default 1) and `last_seen_at` (default current timestamp)
+ *   - Backfills existing rows: hits=1, last_seen_at=created_at
+ *   - Deduplicates existing rows by path, keeping the most recent row per
+ *     path and summing hits
+ *   - Adds a UNIQUE index on `path` so upsert semantics work
+ */
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	// 1. Add columns.
+	await db.schema
+		.alterTable("_emdash_404_log")
+		.addColumn("hits", "integer", (col) => col.notNull().defaultTo(1))
+		.execute();
+
+	// SQLite won't accept a non-constant default when adding a NOT NULL column
+	// to a table with existing rows, so backfill in two steps: add nullable,
+	// populate, then rely on the application layer / future inserts to set it.
+	await db.schema.alterTable("_emdash_404_log").addColumn("last_seen_at", "text").execute();
+
+	// Backfill last_seen_at from created_at for existing rows.
+	await sql`
+		UPDATE _emdash_404_log
+		SET last_seen_at = created_at
+		WHERE last_seen_at IS NULL
+	`.execute(db);
+
+	// 2. Deduplicate existing rows by path.
+	//    For each path, keep the row with the most recent created_at, set its
+	//    hits to the count of rows for that path, set last_seen_at to the
+	//    latest created_at, and delete the rest.
+	await sql`
+		UPDATE _emdash_404_log
+		SET
+			hits = (
+				SELECT COUNT(*) FROM _emdash_404_log AS inner_log
+				WHERE inner_log.path = _emdash_404_log.path
+			),
+			last_seen_at = (
+				SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
+				WHERE inner_log.path = _emdash_404_log.path
+			)
+		WHERE id IN (
+			SELECT id FROM _emdash_404_log AS outer_log
+			WHERE created_at = (
+				SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
+				WHERE inner_log.path = outer_log.path
+			)
+		)
+	`.execute(db);
+
+	// Delete the duplicates (rows that weren't the most recent per path).
+	await sql`
+		DELETE FROM _emdash_404_log
+		WHERE id NOT IN (
+			SELECT id FROM (
+				SELECT id FROM _emdash_404_log AS outer_log
+				WHERE created_at = (
+					SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
+					WHERE inner_log.path = outer_log.path
+				)
+				GROUP BY path
+			)
+		)
+	`.execute(db);
+
+	// 3. Add unique index on path for upsert semantics.
+	await db.schema
+		.createIndex("idx_404_log_path_unique")
+		.on("_emdash_404_log")
+		.column("path")
+		.unique()
+		.execute();
+
+	// Drop the old non-unique index; the unique one covers the same lookups.
+	await db.schema.dropIndex("idx_404_log_path").execute();
+
+	// 4. Index on last_seen_at for eviction ordering.
+	await db.schema
+		.createIndex("idx_404_log_last_seen")
+		.on("_emdash_404_log")
+		.column("last_seen_at")
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.dropIndex("idx_404_log_last_seen").execute();
+	await db.schema.dropIndex("idx_404_log_path_unique").execute();
+
+	// Restore the original non-unique path index.
+	await db.schema.createIndex("idx_404_log_path").on("_emdash_404_log").column("path").execute();
+
+	await db.schema.alterTable("_emdash_404_log").dropColumn("last_seen_at").execute();
+	await db.schema.alterTable("_emdash_404_log").dropColumn("hits").execute();
+}

--- a/packages/core/src/database/migrations/035_bounded_404_log.ts
+++ b/packages/core/src/database/migrations/035_bounded_404_log.ts
@@ -8,8 +8,11 @@ import { sql } from "kysely";
  * inserted a new row, so an attacker could grow the table without bound.
  *
  * Changes:
- *   - Adds `hits` (default 1) and `last_seen_at` (default current timestamp)
- *   - Backfills existing rows: hits=1, last_seen_at=created_at
+ *   - Adds `hits` (default 1, NOT NULL)
+ *   - Adds `last_seen_at` (nullable; SQLite can't add NOT NULL with a
+ *     non-constant default to a populated table, so the column is nullable
+ *     at the schema level and backfilled from `created_at` for existing rows;
+ *     new inserts via `log404` always set it)
  *   - Deduplicates existing rows by path, keeping the most recent row per
  *     path and summing hits
  *   - Adds a UNIQUE index on `path` so upsert semantics work
@@ -35,41 +38,46 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 	`.execute(db);
 
 	// 2. Deduplicate existing rows by path.
-	//    For each path, keep the row with the most recent created_at, set its
-	//    hits to the count of rows for that path, set last_seen_at to the
-	//    latest created_at, and delete the rest.
+	//    For each path, roll up hits and pick the freshest last_seen_at onto
+	//    a single keeper row, then delete the non-keepers. Uses window
+	//    functions (ROW_NUMBER) so the dedup SQL is valid on both SQLite
+	//    (3.25+, 2018) and Postgres. The previous GROUP BY approach was
+	//    accepted by SQLite but invalid on Postgres because `id` wasn't in
+	//    the GROUP BY or wrapped in an aggregate.
 	await sql`
+		WITH ranked AS (
+			SELECT
+				id,
+				path,
+				ROW_NUMBER() OVER (
+					PARTITION BY path
+					ORDER BY created_at DESC, id DESC
+				) AS rn,
+				COUNT(*) OVER (PARTITION BY path) AS path_count,
+				MAX(created_at) OVER (PARTITION BY path) AS latest_created_at
+			FROM _emdash_404_log
+		)
 		UPDATE _emdash_404_log
 		SET
-			hits = (
-				SELECT COUNT(*) FROM _emdash_404_log AS inner_log
-				WHERE inner_log.path = _emdash_404_log.path
-			),
-			last_seen_at = (
-				SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
-				WHERE inner_log.path = _emdash_404_log.path
-			)
-		WHERE id IN (
-			SELECT id FROM _emdash_404_log AS outer_log
-			WHERE created_at = (
-				SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
-				WHERE inner_log.path = outer_log.path
-			)
-		)
+			hits = (SELECT path_count FROM ranked WHERE ranked.id = _emdash_404_log.id),
+			last_seen_at = (SELECT latest_created_at FROM ranked WHERE ranked.id = _emdash_404_log.id)
+		WHERE id IN (SELECT id FROM ranked WHERE rn = 1)
 	`.execute(db);
 
-	// Delete the duplicates (rows that weren't the most recent per path).
+	// Delete the non-keepers (every row except the freshest per path).
 	await sql`
 		DELETE FROM _emdash_404_log
-		WHERE id NOT IN (
+		WHERE id IN (
 			SELECT id FROM (
-				SELECT id FROM _emdash_404_log AS outer_log
-				WHERE created_at = (
-					SELECT MAX(created_at) FROM _emdash_404_log AS inner_log
-					WHERE inner_log.path = outer_log.path
-				)
-				GROUP BY path
-			)
+				SELECT
+					id,
+					ROW_NUMBER() OVER (
+						PARTITION BY path
+						ORDER BY created_at DESC, id DESC
+					) AS rn
+				FROM _emdash_404_log
+			) AS ranked
+			WHERE rn > 1
 		)
 	`.execute(db);
 

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -35,6 +35,7 @@ import * as m031 from "./031_bylines.js";
 import * as m032 from "./032_rate_limits.js";
 import * as m033 from "./033_optimize_content_indexes.js";
 import * as m034 from "./034_published_at_index.js";
+import * as m035 from "./035_bounded_404_log.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -70,6 +71,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"032_rate_limits": m032,
 	"033_optimize_content_indexes": m033,
 	"034_published_at_index": m034,
+	"035_bounded_404_log": m035,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/repositories/redirect.ts
+++ b/packages/core/src/database/repositories/redirect.ts
@@ -12,6 +12,32 @@ import type { Database, RedirectTable } from "../types.js";
 import { encodeCursor, decodeCursor, type FindManyResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
+// Bounded 404 logging
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard cap on rows stored in `_emdash_404_log`. When exceeded, the oldest
+ * rows (by `last_seen_at`) are evicted on insert. Prevents an unauthenticated
+ * attacker from growing the table without bound by requesting unique URLs.
+ */
+export const MAX_404_LOG_ROWS = 10_000;
+
+/** Max stored length for the `Referer` header — truncated on insert. */
+export const REFERRER_MAX_LENGTH = 512;
+
+/** Max stored length for the `User-Agent` header — truncated on insert. */
+export const USER_AGENT_MAX_LENGTH = 256;
+
+/**
+ * Truncate a header-derived string to `max` chars, preserving `null`/`undefined`
+ * as `null`. Empty strings stay empty (the caller decides whether to coerce).
+ */
+function truncateOrNull(value: string | null | undefined, max: number): string | null {
+	if (value === null || value === undefined) return null;
+	return value.length > max ? value.slice(0, max) : value;
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -369,22 +395,105 @@ export class RedirectRepository {
 
 	// --- 404 log ------------------------------------------------------------
 
+	/**
+	 * Record a 404 hit for `entry.path`.
+	 *
+	 * Dedups by path: repeat hits increment `hits` and refresh `last_seen_at`
+	 * on the existing row instead of inserting a new one. Referrer and
+	 * user-agent are truncated to bounded lengths so a malicious client can't
+	 * blow up storage with huge headers. When the table would exceed
+	 * MAX_404_LOG_ROWS, the oldest entries (by `last_seen_at`) are evicted.
+	 *
+	 * This is called from the public redirect middleware on every 404 and
+	 * must never throw for an unauthenticated caller — failures bubble up to
+	 * the middleware, which swallows them.
+	 */
 	async log404(entry: {
 		path: string;
 		referrer?: string | null;
 		userAgent?: string | null;
 		ip?: string | null;
 	}): Promise<void> {
+		const now = new Date().toISOString();
+		const referrer = truncateOrNull(entry.referrer, REFERRER_MAX_LENGTH);
+		const userAgent = truncateOrNull(entry.userAgent, USER_AGENT_MAX_LENGTH);
+		const ip = entry.ip ?? null;
+
+		// Upsert: check for existing row by path, bump if present, insert if not.
+		const existing = await this.db
+			.selectFrom("_emdash_404_log")
+			.select("id")
+			.where("path", "=", entry.path)
+			.executeTakeFirst();
+
+		if (existing) {
+			await this.db
+				.updateTable("_emdash_404_log")
+				.set({
+					hits: sql`hits + 1`,
+					last_seen_at: now,
+					referrer,
+					user_agent: userAgent,
+					ip,
+				})
+				.where("id", "=", existing.id)
+				.execute();
+			return;
+		}
+
 		await this.db
 			.insertInto("_emdash_404_log")
 			.values({
 				id: ulid(),
 				path: entry.path,
-				referrer: entry.referrer ?? null,
-				user_agent: entry.userAgent ?? null,
-				ip: entry.ip ?? null,
-				created_at: new Date().toISOString(),
+				referrer,
+				user_agent: userAgent,
+				ip,
+				hits: 1,
+				last_seen_at: now,
+				created_at: now,
 			})
+			.execute();
+
+		// Enforce the row cap. Deterministic: every insert of a brand-new path
+		// counts the table and evicts the oldest rows if over cap. Updates
+		// (dedup hits) don't grow the table, so they skip this step.
+		await this.enforce404Cap();
+	}
+
+	/**
+	 * Delete the oldest rows from `_emdash_404_log` if the row count exceeds
+	 * MAX_404_LOG_ROWS. "Oldest" is by `last_seen_at`, so a path that keeps
+	 * getting hit stays in the table even if it was first seen long ago.
+	 *
+	 * Exposed (package-private) for tests; callers should prefer `log404`.
+	 */
+	private async enforce404Cap(): Promise<void> {
+		const countRow = await this.db
+			.selectFrom("_emdash_404_log")
+			.select((eb) => eb.fn.countAll<number>().as("c"))
+			.executeTakeFirst();
+		const count = Number(countRow?.c ?? 0);
+		if (count <= MAX_404_LOG_ROWS) return;
+
+		const excess = count - MAX_404_LOG_ROWS;
+		const victims = await this.db
+			.selectFrom("_emdash_404_log")
+			.select("id")
+			.orderBy("last_seen_at", "asc")
+			.orderBy("id", "asc")
+			.limit(excess)
+			.execute();
+
+		if (victims.length === 0) return;
+
+		await this.db
+			.deleteFrom("_emdash_404_log")
+			.where(
+				"id",
+				"in",
+				victims.map((v) => v.id),
+			)
 			.execute();
 	}
 
@@ -438,6 +547,10 @@ export class RedirectRepository {
 	}
 
 	async get404Summary(limit = 50): Promise<NotFoundSummary[]> {
+		// Since rows are now deduped by path, each path has exactly one row
+		// with `hits` as the running count and `last_seen_at` as the latest
+		// timestamp. The subquery for `top_referrer` collapses to a simple
+		// pick of the row's stored referrer (the most recent one seen).
 		const rows = await sql<{
 			path: string;
 			count: number;
@@ -446,14 +559,12 @@ export class RedirectRepository {
 		}>`
 			SELECT
 				path,
-				COUNT(*) as count,
-				MAX(created_at) as last_seen,
+				SUM(hits) as count,
+				MAX(last_seen_at) as last_seen,
 				(
 					SELECT referrer FROM _emdash_404_log AS inner_log
 					WHERE inner_log.path = _emdash_404_log.path
 						AND referrer IS NOT NULL AND referrer != ''
-					GROUP BY referrer
-					ORDER BY COUNT(*) DESC
 					LIMIT 1
 				) as top_referrer
 			FROM _emdash_404_log

--- a/packages/core/src/database/repositories/redirect.ts
+++ b/packages/core/src/database/repositories/redirect.ts
@@ -419,28 +419,10 @@ export class RedirectRepository {
 		const userAgent = truncateOrNull(entry.userAgent, USER_AGENT_MAX_LENGTH);
 		const ip = entry.ip ?? null;
 
-		// Upsert: check for existing row by path, bump if present, insert if not.
-		const existing = await this.db
-			.selectFrom("_emdash_404_log")
-			.select("id")
-			.where("path", "=", entry.path)
-			.executeTakeFirst();
-
-		if (existing) {
-			await this.db
-				.updateTable("_emdash_404_log")
-				.set({
-					hits: sql`hits + 1`,
-					last_seen_at: now,
-					referrer,
-					user_agent: userAgent,
-					ip,
-				})
-				.where("id", "=", existing.id)
-				.execute();
-			return;
-		}
-
+		// Atomic upsert by path. The UNIQUE index on `path` makes this safe
+		// under concurrency: two requests for the same new path can't both
+		// insert — the second one hits the conflict branch and increments
+		// hits instead of failing with a uniqueness error.
 		await this.db
 			.insertInto("_emdash_404_log")
 			.values({
@@ -453,11 +435,20 @@ export class RedirectRepository {
 				last_seen_at: now,
 				created_at: now,
 			})
+			.onConflict((oc) =>
+				oc.column("path").doUpdateSet({
+					hits: sql`hits + 1`,
+					last_seen_at: now,
+					referrer,
+					user_agent: userAgent,
+					ip,
+				}),
+			)
 			.execute();
 
-		// Enforce the row cap. Deterministic: every insert of a brand-new path
-		// counts the table and evicts the oldest rows if over cap. Updates
-		// (dedup hits) don't grow the table, so they skip this step.
+		// Enforce the row cap. Cheap when the table is under cap (single
+		// COUNT(*) query); evicts oldest rows if we're over. Updates (dedup
+		// hits) don't grow the table so this is a no-op for repeat paths.
 		await this.enforce404Cap();
 	}
 
@@ -466,7 +457,7 @@ export class RedirectRepository {
 	 * MAX_404_LOG_ROWS. "Oldest" is by `last_seen_at`, so a path that keeps
 	 * getting hit stays in the table even if it was first seen long ago.
 	 *
-	 * Exposed (package-private) for tests; callers should prefer `log404`.
+	 * Private — callers use `log404`, which invokes this after every upsert.
 	 */
 	private async enforce404Cap(): Promise<void> {
 		const countRow = await this.db
@@ -477,22 +468,23 @@ export class RedirectRepository {
 		if (count <= MAX_404_LOG_ROWS) return;
 
 		const excess = count - MAX_404_LOG_ROWS;
-		const victims = await this.db
-			.selectFrom("_emdash_404_log")
-			.select("id")
-			.orderBy("last_seen_at", "asc")
-			.orderBy("id", "asc")
-			.limit(excess)
-			.execute();
 
-		if (victims.length === 0) return;
-
+		// Evict the oldest rows in a single SQL statement. Using a subquery
+		// (rather than materialising the victim IDs in JS and passing them
+		// back as bind parameters) keeps the statement bounded regardless of
+		// how far over cap the table is — important for existing installs
+		// that crossed the threshold before this cap was introduced.
 		await this.db
 			.deleteFrom("_emdash_404_log")
 			.where(
 				"id",
 				"in",
-				victims.map((v) => v.id),
+				this.db
+					.selectFrom("_emdash_404_log")
+					.select("id")
+					.orderBy("last_seen_at", "asc")
+					.orderBy("id", "asc")
+					.limit(excess),
 			)
 			.execute();
 	}

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -467,7 +467,14 @@ export interface NotFoundLogTable {
 	user_agent: string | null;
 	ip: string | null;
 	hits: number;
-	last_seen_at: string;
+	/**
+	 * Migration 035 adds this as a nullable column (SQLite can't add a
+	 * NOT NULL column with a non-constant default to an existing table).
+	 * The `log404` upsert always writes a value, so new and updated rows
+	 * always have one, but existing rows pre-migration were backfilled
+	 * without a NOT NULL constraint. Typed as nullable to match the schema.
+	 */
+	last_seen_at: string | null;
 	created_at: string;
 }
 

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -466,6 +466,8 @@ export interface NotFoundLogTable {
 	referrer: string | null;
 	user_agent: string | null;
 	ip: string | null;
+	hits: number;
+	last_seen_at: string;
 	created_at: string;
 }
 

--- a/packages/core/tests/integration/redirects/log404-bounded.test.ts
+++ b/packages/core/tests/integration/redirects/log404-bounded.test.ts
@@ -178,4 +178,33 @@ describe("RedirectRepository.log404 — bounded logging", () => {
 			.executeTakeFirstOrThrow();
 		expect(bumped.hits).toBe(2);
 	});
+
+	it("handles concurrent inserts for the same new path atomically", async () => {
+		// Regression: `log404` used to be SELECT-then-INSERT/UPDATE, which
+		// races under concurrency — both callers could miss the SELECT and
+		// the second INSERT would fail with a uniqueness violation once a
+		// UNIQUE index on `path` was added. The fix uses a single atomic
+		// upsert (ON CONFLICT DO UPDATE).
+		//
+		// better-sqlite3 is synchronous, so Promise.all doesn't produce real
+		// parallelism; the test instead sends a batch of concurrent upserts
+		// and asserts the end state: exactly one row, with the full count
+		// reflected in `hits`. Any lost updates or uniqueness errors would
+		// cause this to fail.
+		const concurrency = 10;
+		const pending: Array<Promise<void>> = [];
+		for (let i = 0; i < concurrency; i++) {
+			pending.push(repo.log404({ path: "/race" }));
+		}
+		await Promise.all(pending);
+
+		const rows = await db
+			.selectFrom("_emdash_404_log")
+			.selectAll()
+			.where("path", "=", "/race")
+			.execute();
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.hits).toBe(concurrency);
+	});
 });

--- a/packages/core/tests/integration/redirects/log404-bounded.test.ts
+++ b/packages/core/tests/integration/redirects/log404-bounded.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for the unbounded 404 logging DoS.
+ *
+ * `log404` was previously an unconditional INSERT for every 404 — an
+ * unauthenticated attacker could fill the database by hitting unique URLs.
+ *
+ * The hardened version:
+ *   - Dedups by path: existing rows are bumped (`hits++`, `last_seen_at` refreshed)
+ *     instead of inserting new rows.
+ *   - Caps the table at MAX_404_LOG_ROWS rows; oldest entries (by `last_seen_at`)
+ *     are evicted to make room for new paths.
+ *   - Truncates referrer / user_agent to bounded lengths so a malicious client
+ *     can't blow up storage by sending huge headers.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	MAX_404_LOG_ROWS,
+	REFERRER_MAX_LENGTH,
+	RedirectRepository,
+	USER_AGENT_MAX_LENGTH,
+} from "../../../src/database/repositories/redirect.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * Seed `_emdash_404_log` directly to MAX_404_LOG_ROWS, batching to stay
+ * under SQLite's per-statement bind-parameter limit (~32k by default).
+ *
+ * Rows are staggered in `last_seen_at` so `seed-000000` is the oldest.
+ */
+async function seedToCapacity(db: Kysely<Database>): Promise<void> {
+	const now = Date.now();
+	const batchSize = 500;
+	for (let start = 0; start < MAX_404_LOG_ROWS; start += batchSize) {
+		const end = Math.min(start + batchSize, MAX_404_LOG_ROWS);
+		const rows = [];
+		for (let i = start; i < end; i++) {
+			const ts = new Date(now - (MAX_404_LOG_ROWS - i) * 1000).toISOString();
+			rows.push({
+				id: `seed-${i.toString().padStart(6, "0")}`,
+				path: `/seed-${i}`,
+				referrer: null,
+				user_agent: null,
+				ip: null,
+				hits: 1,
+				last_seen_at: ts,
+				created_at: ts,
+			});
+		}
+		await db.insertInto("_emdash_404_log").values(rows).execute();
+	}
+}
+
+describe("RedirectRepository.log404 — bounded logging", () => {
+	let db: Kysely<Database>;
+	let repo: RedirectRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		repo = new RedirectRepository(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("dedups repeat hits by path instead of inserting new rows", async () => {
+		await repo.log404({ path: "/missing" });
+		await repo.log404({ path: "/missing" });
+		await repo.log404({ path: "/missing" });
+
+		const rows = await db
+			.selectFrom("_emdash_404_log")
+			.selectAll()
+			.where("path", "=", "/missing")
+			.execute();
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.hits).toBe(3);
+		expect(rows[0]!.last_seen_at).toBeTruthy();
+	});
+
+	it("truncates oversize referrer and user_agent on insert", async () => {
+		const bigReferrer = "https://evil.example.com/" + "a".repeat(10_000);
+		const bigUserAgent = "Mozilla/5.0 " + "b".repeat(10_000);
+
+		await repo.log404({
+			path: "/missing",
+			referrer: bigReferrer,
+			userAgent: bigUserAgent,
+		});
+
+		const row = await db
+			.selectFrom("_emdash_404_log")
+			.selectAll()
+			.where("path", "=", "/missing")
+			.executeTakeFirstOrThrow();
+
+		expect(row.referrer?.length).toBeLessThanOrEqual(REFERRER_MAX_LENGTH);
+		expect(row.user_agent?.length).toBeLessThanOrEqual(USER_AGENT_MAX_LENGTH);
+		// Confirm the truncation actually happened (sanity check on the constants).
+		expect(row.referrer!.length).toBe(REFERRER_MAX_LENGTH);
+		expect(row.user_agent!.length).toBe(USER_AGENT_MAX_LENGTH);
+	});
+
+	it("preserves null referrer / user_agent without coercing to empty string", async () => {
+		await repo.log404({ path: "/missing", referrer: null, userAgent: null });
+
+		const row = await db
+			.selectFrom("_emdash_404_log")
+			.selectAll()
+			.where("path", "=", "/missing")
+			.executeTakeFirstOrThrow();
+
+		expect(row.referrer).toBeNull();
+		expect(row.user_agent).toBeNull();
+	});
+
+	it("evicts the oldest entry when the table is at capacity", async () => {
+		// Stuffing the table to MAX_404_LOG_ROWS via the public API would be
+		// slow, so seed it directly. Batch the inserts to stay under SQLite's
+		// per-statement parameter limit.
+		await seedToCapacity(db);
+
+		// Sanity: at capacity.
+		const before = await db
+			.selectFrom("_emdash_404_log")
+			.select((eb) => eb.fn.countAll<number>().as("c"))
+			.executeTakeFirstOrThrow();
+		expect(Number(before.c)).toBe(MAX_404_LOG_ROWS);
+
+		// New unique path triggers eviction.
+		await repo.log404({ path: "/brand-new" });
+
+		const after = await db
+			.selectFrom("_emdash_404_log")
+			.select((eb) => eb.fn.countAll<number>().as("c"))
+			.executeTakeFirstOrThrow();
+		expect(Number(after.c)).toBe(MAX_404_LOG_ROWS);
+
+		// The oldest seed row is gone.
+		const oldest = await db
+			.selectFrom("_emdash_404_log")
+			.select("id")
+			.where("id", "=", "seed-000000")
+			.executeTakeFirst();
+		expect(oldest).toBeUndefined();
+
+		// The new path is present.
+		const fresh = await db
+			.selectFrom("_emdash_404_log")
+			.select("path")
+			.where("path", "=", "/brand-new")
+			.executeTakeFirst();
+		expect(fresh?.path).toBe("/brand-new");
+	});
+
+	it("does not evict when an existing path is hit again, even at capacity", async () => {
+		await seedToCapacity(db);
+
+		// Hit an existing path — should bump hits, not evict.
+		await repo.log404({ path: "/seed-500" });
+
+		const oldest = await db
+			.selectFrom("_emdash_404_log")
+			.select("id")
+			.where("id", "=", "seed-000000")
+			.executeTakeFirst();
+		expect(oldest?.id).toBe("seed-000000");
+
+		const bumped = await db
+			.selectFrom("_emdash_404_log")
+			.select(["hits"])
+			.where("path", "=", "/seed-500")
+			.executeTakeFirstOrThrow();
+		expect(bumped.hits).toBe(2);
+	});
+});

--- a/packages/core/tests/integration/redirects/redirect-repository.test.ts
+++ b/packages/core/tests/integration/redirects/redirect-repository.test.ts
@@ -478,13 +478,15 @@ describe("RedirectRepository", () => {
 			expect(summary[1]!.count).toBe(1);
 		});
 
-		it("includes top referrer", async () => {
+		it("includes the most recently seen referrer", async () => {
+			// 404 rows are now deduped by path, so the stored referrer is the
+			// most recent one seen for that path rather than the most frequent.
 			await repo.log404({ path: "/x", referrer: "https://google.com" });
 			await repo.log404({ path: "/x", referrer: "https://google.com" });
 			await repo.log404({ path: "/x", referrer: "https://bing.com" });
 
 			const summary = await repo.get404Summary();
-			expect(summary[0]!.topReferrer).toBe("https://google.com");
+			expect(summary[0]!.topReferrer).toBe("https://bing.com");
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Every 404 response previously inserted a new row into `_emdash_404_log` with no dedup, no cap, and no truncation. An unauthenticated attacker can grow the database without bound by requesting unique nonexistent URLs — on D1 that eats into the storage quota, on self-hosted SQLite it can fill the disk.

**Changes:**

- **Migration 035** adds `hits` (int, default 1) and `last_seen_at` (text) columns to `_emdash_404_log`, deduplicates existing rows by path (summing hits, keeping latest referrer/user-agent), and adds a unique index on `path` so upsert semantics work.
- **`log404()` rewritten** as upsert: on conflict `hits = hits + 1`, `last_seen_at = now`, referrer/user-agent refreshed to latest values truncated to 512/256 chars respectively. After insert of a new path, deterministic eviction of oldest rows once `MAX_404_LOG_ROWS` (10,000) is exceeded.
- **`get404Summary()` updated** to `SUM(hits)` and `MAX(last_seen_at)` so aggregates still make sense post-dedup.

**Observable behaviour change**: the `top_referrer` field on the summary now reflects the most recently seen referrer per path rather than the most frequent one. Keeping frequency ranking would require per-path referrer history, which would reintroduce the unbounded growth this PR fixes. Adjusted the existing admin-facing test to match.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

5 new integration tests in \`tests/integration/redirects/log404-bounded.test.ts\` covering: dedup increments hits, referrer/UA truncation, row cap with oldest-first eviction. Full emdash package suite: 2550/2550.