### PR TITLE
fix(import): invalidate manifest cache after wp prepare creates schema

### DIFF
--- a/.changeset/fix-wp-import-invalidate-manifest.md
+++ b/.changeset/fix-wp-import-invalidate-manifest.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Fixes the WordPress importer so collections created mid-import are visible to the subsequent execute phase.
+
+`POST /_emdash/api/import/wordpress/prepare` now calls `emdash.invalidateManifest()` when it creates new collections or fields. Without this, the DB-persisted manifest cache (`emdash:manifest_cache` in the `options` table) stays stale and the `execute` request reports `Collection "<slug>" does not exist` for every item destined for a freshly created collection — a bug that survived dev-server restarts and required manually deleting the cache row.

--- a/packages/core/src/astro/routes/api/import/wordpress/prepare.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/prepare.ts
@@ -58,6 +58,16 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Zod schema output narrowed to PrepareRequest
 		const result = await prepareImport(emdash.db, body as PrepareRequest);
 
+		// If prepare created any new collections or fields, invalidate the
+		// persisted manifest cache (`emdash:manifest_cache` in the options
+		// table) so that the execute endpoint -- a separate request -- sees
+		// the new schema. Without this the execute step reads a stale
+		// manifest and reports `Collection "<slug>" does not exist` for
+		// every item destined for a freshly-created collection. See #747.
+		if (result.collectionsCreated.length > 0 || result.fieldsCreated.length > 0) {
+			emdash.invalidateManifest();
+		}
+
 		return apiSuccess(result, result.success ? 200 : 400);
 	} catch (error) {
 		return handleError(error, "Failed to prepare import", "WXR_PREPARE_ERROR");

--- a/packages/core/tests/unit/import/wp-prepare-invalidate.test.ts
+++ b/packages/core/tests/unit/import/wp-prepare-invalidate.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for #747: WordPress importer must invalidate the manifest
+ * cache after creating new collections/fields. Without this the execute
+ * endpoint reads a stale DB-persisted manifest and reports
+ * `Collection "<slug>" does not exist` for every item destined for a freshly
+ * created collection.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { POST } from "../../../src/astro/routes/api/import/wordpress/prepare.js";
+import { setupTestDatabase } from "../../utils/test-db.js";
+
+function buildRequest(body: unknown): Request {
+	return new Request("http://localhost/_emdash/api/import/wordpress/prepare", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"X-EmDash-Request": "1",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function buildContext(emdash: any, user = { id: "test-user", role: 50 }) {
+	return {
+		request: buildRequest({
+			postTypes: [
+				{
+					name: "tablepress_table",
+					collection: "tablepress_table",
+					fields: [{ slug: "title", label: "Title", type: "string", required: true }],
+				},
+			],
+		}),
+		locals: { emdash, user },
+	};
+}
+
+describe("POST /api/import/wordpress/prepare", () => {
+	it("invalidates the manifest cache after creating a new collection (regression for #747)", async () => {
+		const db = await setupTestDatabase();
+		const invalidateManifest = vi.fn();
+
+		const emdash = {
+			db,
+			handleContentCreate: vi.fn(),
+			invalidateManifest,
+		};
+
+		const ctx = buildContext(emdash);
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion)
+		const response = await POST(ctx as any);
+
+		expect(response.status).toBe(200);
+		expect(invalidateManifest).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not invalidate the manifest when prepareImport makes no schema changes", async () => {
+		const db = await setupTestDatabase();
+		// Pre-create the collection so prepare finds nothing new to do.
+		const { SchemaRegistry } = await import("../../../src/schema/registry.js");
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "tablepress_table",
+			label: "Tablepress Tables",
+			labelSingular: "Tablepress Table",
+		});
+		await registry.createField("tablepress_table", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+
+		const invalidateManifest = vi.fn();
+		const emdash = {
+			db,
+			handleContentCreate: vi.fn(),
+			invalidateManifest,
+		};
+
+		const ctx = buildContext(emdash);
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion)
+		const response = await POST(ctx as any);
+
+		expect(response.status).toBe(200);
+		expect(invalidateManifest).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fix the WordPress importer so freshly created collections are visible to the subsequent `execute` phase.

`POST /_emdash/api/import/wordpress/prepare` creates collections and fields via `SchemaRegistry`, but never invalidated the manifest. The manifest is backed by a DB-persisted cache in the `options` table (`emdash:manifest_cache`), so when the browser then called `POST .../execute` — a separate request — that request read the **pre-creation** manifest from the DB cache and reported `Collection "<slug>" does not exist` for every item destined for the newly created collection. The bug survived `npx emdash dev` restarts because the cache was on disk, not in memory.

Fix is minimal: call `emdash.invalidateManifest()` from the `prepare` POST handler when `prepareImport` reports any `collectionsCreated` or `fieldsCreated`. Skipped when prepare makes no schema changes, so runs that only tweak existing mappings don't thrash the cache.

Closes #747

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — `pnpm test tests/unit/import/` → 142 tests pass including the two new cases
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable) — new `tests/unit/import/wp-prepare-invalidate.test.ts`, TDD-verified by reverting the fix and watching the test fail
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A, no UI strings
- [x] I have added a changeset (`.changeset/fix-wp-import-invalidate-manifest.md`, `emdash` patch)
- [ ] New features link to an approved Discussion — N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Test output

```
$ pnpm test tests/unit/import/wp-prepare-invalidate.test.ts
 ✓ tests/unit/import/wp-prepare-invalidate.test.ts (2 tests) 45ms
   ✓ POST /api/import/wordpress/prepare
     ✓ invalidates the manifest cache after creating a new collection (regression for #747)
     ✓ does not invalidate the manifest when prepareImport makes no schema changes

$ pnpm test tests/unit/import/
 Test Files  7 passed (7)
 Tests       142 passed (142)
```

Regression check: removing the `emdash.invalidateManifest()` call makes the first new test fail with `expected "spy" to be called 1 times, but got 0`.

## Scope notes

The issue also mentions `packages/core/src/astro/routes/api/import/wordpress-plugin/execute.ts:190` as an "apply the same fix" site. That path is different: the plugin variant creates **fields** inline during `execute`, not **collections**, and the check at that line (`manifest?.collections[collection]`) isn't affected by field creation. If field-level manifest staleness is also a bug there, it's a separate issue — I kept this PR scoped to the reproducer in the issue body.
