### PR TITLE
ci(review): trigger /review on top-level PR comments

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,4 +1,4 @@
-name: Review
+name: Review PR
 
 on:
   issue_comment:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,21 +1,25 @@
 name: Review
 
 on:
+  issue_comment:
+    types: [created]
   pull_request_review_comment:
     types: [created]
 
 concurrency:
   # share the bonk-* group so /review and /bonk don't pile up on the same PR
-  group: bonk-${{ github.event.pull_request.number || github.ref }}
+  group: bonk-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
   review:
-    # mentions in this check must match the `mentions` input below
+    # mentions in this check must match the `mentions` input below.
+    # For issue_comment events, require the comment to be on a PR (not an issue).
     if: >-
       github.event.sender.type != 'Bot'
       && contains(github.event.comment.body, '/review')
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      && (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -25,20 +29,26 @@ jobs:
     steps:
       - name: Get PR number
         id: pr-number
+        env:
+          # issue_comment on a PR exposes the number via github.event.issue.number;
+          # pull_request_review_comment exposes it via github.event.pull_request.number.
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Verify PR exists
         id: verify-pr
-        run: |
-          if gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "::warning::PR #${{ github.event.pull_request.number }} not found, skipping review"
-          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          if gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::PR #${PR_NUMBER} not found, skipping review"
+          fi
 
       - name: Checkout repository
         if: steps.verify-pr.outputs.exists == 'true'


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `/review` in a top-level PR comment didn't trigger the Review workflow. A top-level PR comment is an `issue_comment` event, not a `pull_request_review_comment` (which only fires on inline line-level review comments). The workflow was only listening for the latter, so the main way to request a review silently did nothing.

Reproduction: commented `/review` on #719 after #758 merged; no workflow ran.

The fix adds `issue_comment` to the triggers and gates the job with `github.event.issue.pull_request` so it only fires on PRs, not issues. The Get/Verify PR steps now resolve the PR number from either event shape, and interpolated values go through env vars (avoiding shell-expression injection via PR titles/numbers).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (N/A — workflow YAML only)
- [x] `pnpm lint` passes (N/A — workflow YAML only)
- [x] `pnpm test` passes (N/A — workflow YAML only)
- [x] `pnpm format` has been run (N/A — workflow YAML only)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

N/A — can be verified by commenting `/review` on this PR once merged.