### PR TITLE
ci(bonk): fix concurrency cancellation, missing PR templates, long timeouts

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -8,10 +8,10 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  # intentionally hardcoded so that all Bonk workflows coexist peacefully
-  group: bonk-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: false
+# Concurrency is at job level (below) rather than workflow level so it's only
+# evaluated when the `if:` filter passes. Otherwise every issue_comment event
+# in the repo would enter the group and could evict in-flight runs from
+# unrelated, non-matching comments.
 
 jobs:
   bonk:
@@ -24,8 +24,14 @@ jobs:
         || (github.event_name == 'pull_request_review'
           && (contains(github.event.review.body, '/bonk') || contains(github.event.review.body, '@ask-bonk')))
       )
+    # Per-workflow group key so /bonk, /ultrabonk, /review, /ultrareview all
+    # have independent queues per target. Spamming /bonk on the same issue/PR
+    # serializes; different actions on the same target run in parallel.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: write
@@ -66,3 +72,16 @@ jobs:
           mentions: "/bonk,@ask-bonk"
           opencode_version: "1.4.6"
           permissions: write
+          # Custom prompt so the model knows its response will become a PR body
+          # when an auto-PR is opened (issue → branch → PR flow). Without this,
+          # opencode uses the model's free-form response as the PR body verbatim
+          # and the pr-compliance CI check closes PRs missing the template.
+          # See .github/PULL_REQUEST_TEMPLATE.md.
+          prompt: |
+            ${{ github.event.comment.body || github.event.review.body }}
+
+            ---
+
+            If your work results in code changes that get pushed to a new branch (the workflow will commit, push, and open a pull request automatically), structure your final response so it can be used as the pull request body. The repo's pr-compliance check will close PRs that don't follow the template. Read `.github/PULL_REQUEST_TEMPLATE.md` and use that exact structure, filling in the checkboxes that apply and leaving the rest unchecked. Tick the AI-generated code disclosure box.
+
+            If your work doesn't result in code changes (you're answering a question, leaving feedback, or the change happens on an existing PR branch), respond normally -- your response will be posted as a comment, not a PR.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,10 +6,8 @@ on:
   pull_request_review_comment:
     types: [created]
 
-concurrency:
-  # share the bonk-* group so /review and /bonk don't pile up on the same PR
-  group: bonk-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+# Concurrency is at job level (below) rather than workflow level so it's only
+# evaluated when the `if:` filter passes.
 
 jobs:
   review:
@@ -20,7 +18,13 @@ jobs:
       && contains(github.event.comment.body, '/review')
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       && (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
+    # Per-workflow group key so /review, /ultrareview, /bonk, /ultrabonk all
+    # have independent queues per target.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ultrabonk.yml
+++ b/.github/workflows/ultrabonk.yml
@@ -14,11 +14,8 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  # share the bonk-* group so /review, /ultrareview, /bonk, /ultrabonk
-  # don't pile up on the same PR
-  group: bonk-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: false
+# Concurrency is at job level (below) rather than workflow level so it's only
+# evaluated when the `if:` filter passes.
 
 jobs:
   ultrabonk:
@@ -31,8 +28,13 @@ jobs:
         || (github.event_name == 'pull_request_review'
           && contains(github.event.review.body, '/ultrabonk'))
       )
+    # Per-workflow group key so /bonk, /ultrabonk, /review, /ultrareview all
+    # have independent queues per target.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: write
@@ -74,3 +76,16 @@ jobs:
           mentions: "/ultrabonk"
           opencode_version: "1.4.6"
           permissions: write
+          # Custom prompt so the model knows its response will become a PR body
+          # when an auto-PR is opened (issue → branch → PR flow). Without this,
+          # opencode uses the model's free-form response as the PR body verbatim
+          # and the pr-compliance CI check closes PRs missing the template.
+          # See .github/PULL_REQUEST_TEMPLATE.md.
+          prompt: |
+            ${{ github.event.comment.body || github.event.review.body }}
+
+            ---
+
+            If your work results in code changes that get pushed to a new branch (the workflow will commit, push, and open a pull request automatically), structure your final response so it can be used as the pull request body. The repo's pr-compliance check will close PRs that don't follow the template. Read `.github/PULL_REQUEST_TEMPLATE.md` and use that exact structure, filling in the checkboxes that apply and leaving the rest unchecked. Tick the AI-generated code disclosure box.
+
+            If your work doesn't result in code changes (you're answering a question, leaving feedback, or the change happens on an existing PR branch), respond normally -- your response will be posted as a comment, not a PR.

--- a/.github/workflows/ultrareview.yml
+++ b/.github/workflows/ultrareview.yml
@@ -12,11 +12,8 @@ on:
   pull_request_review_comment:
     types: [created]
 
-concurrency:
-  # share the bonk-* group so /review, /ultrareview, /bonk, /ultrabonk
-  # don't pile up on the same PR
-  group: bonk-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+# Concurrency is at job level (below) rather than workflow level so it's only
+# evaluated when the `if:` filter passes.
 
 jobs:
   ultrareview:
@@ -27,7 +24,13 @@ jobs:
       && contains(github.event.comment.body, '/ultrareview')
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       && (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
+    # Per-workflow group key so /review, /ultrareview, /bonk, /ultrabonk all
+    # have independent queues per target.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## What does this PR do?

Three independent fixes across the four bonk-family workflows (`/bonk`, `/ultrabonk`, `/review`, `/ultrareview`).

### 1. Concurrency was cancelling unrelated runs

All four workflows shared the workflow-level group `bonk-<number>`. GitHub evaluates workflow-level `concurrency:` at queue time, before any `if:` filter, so every `issue_comment` event in the repo enqueued all four workflows under the same group. With three or more arriving simultaneously (e.g. `/ultrabonk` on issue 649 + bonk + review + ultrareview all firing on the same comment), GitHub's "at most one running and one pending" rule cancels the rest -- which is what cancelled an in-flight `/bonk` PR run last week.

Moved `concurrency:` to job level (where it's evaluated only after `if:` passes, so non-matching events never enter the group) and made the group key per-workflow (`${{ github.workflow }}-<number>`). Behavior:

- Spamming `/bonk` on the same target serializes (queue, don't cancel).
- `/bonk` and `/review` on the same target run in parallel.
- Non-maintainer or non-matching comments never affect any group.

### 2. Auto-PR bodies were missing the template

When `/bonk` or `/ultrabonk` runs against an issue, opencode opens a PR via the Octokit API (`pulls.create`), which -- unlike the GitHub web UI -- doesn't auto-load `.github/PULL_REQUEST_TEMPLATE.md`. The model's free-form response was used as the PR body verbatim, so the `pr-compliance` check would close every auto-PR (e.g. #768).

Added a custom prompt to `/bonk` and `/ultrabonk` that tells the model to read `.github/PULL_REQUEST_TEMPLATE.md` and structure its response as the PR body when code changes are pushed. Conditional on "if your work results in code changes" so `/bonk` on an existing PR (no new PR created, just commits to the branch) flows through unchanged. Doesn't apply to `/review` and `/ultrareview` since they never auto-open PRs.

### 3. Workflow timeouts dropped from 45 to 30 minutes

Bounds the wall-clock blast radius when a model session stalls. One stalled run earlier this week burned 45 minutes of credit before the workflow timeout fired with no useful output. 30 minutes is plenty for a normal investigation; if the model genuinely needs longer, re-trigger.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (no TS files touched)
- [x] `pnpm lint` passes (verified `pnpm --silent lint:json | jq '.diagnostics | length'` returns `0`)
- [x] `pnpm test` passes (or targeted tests for my change) -- N/A, no production code changes
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) -- N/A; CI workflows
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable) -- N/A
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) -- N/A; CI only
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [x] This PR includes AI-generated code

The YAML changes and the prompt content were drafted with Claude Opus during a debugging session that started by investigating why `/ultrabonk` had cancelled an in-flight `/bonk` run. All edits reviewed and tested where possible.

## Screenshots / test output

- `pnpm --silent lint:json | jq '.diagnostics | length'` → `0`
- `pnpm format` → no changes
- Concurrency fix verified by re-reading [GitHub's concurrency docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) -- workflow-level `concurrency:` evaluates at queue time, job-level evaluates after `if:`.
- PR template fix verified by reading `opencode/v1.4.6/packages/opencode/src/cli/cmd/github.ts` -- the `createPR` call uses `octoRest.rest.pulls.create({ ..., body })` where `body = ${response}\n\nCloses #${issueId}${footer}`. No template loading anywhere.