### PR TITLE
ci(bonk): resolve opencode permission defaults that ask interactively

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -62,11 +62,22 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Register kimi-k2.6 (released 2026-04-20) with the pinned opencode
-          # version (1.4.6 published 2026-04-15), whose bundled models.dev
-          # snapshot predates it and would otherwise raise ProviderModelNotFoundError.
+          # OPENCODE_CONFIG_CONTENT bundles two unrelated overrides:
+          #
+          # 1. Register kimi-k2.6 (released 2026-04-20) with the pinned opencode
+          #    version (1.4.6 published 2026-04-15). Without this, opencode
+          #    raises ProviderModelNotFoundError because the model post-dates
+          #    its bundled models.dev snapshot.
+          #
+          # 2. Resolve the two opencode permission defaults that ask interactively
+          #    (`external_directory` and `doom_loop`) so a CI run with no TTY
+          #    can never deadlock waiting for approval. external_directory is
+          #    deny-by-default with /tmp/** and ~/** allowed (scratch files,
+          #    home-dir caches); doom_loop is deny so a stuck loop aborts
+          #    instead of prompting. Repro: PR #769 timed out at 30 min waiting
+          #    for an `external_directory` prompt on `git show ... > /tmp/foo`.
           OPENCODE_CONFIG_CONTENT: |
-            {"provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/moonshotai/kimi-k2.6":{"id":"workers-ai/@cf/moonshotai/kimi-k2.6","name":"Kimi K2.6","family":"kimi","attachment":true,"reasoning":true,"tool_call":true,"interleaved":{"field":"reasoning_content"},"temperature":true,"release_date":"2026-04-20","modalities":{"input":["text","image"],"output":["text"]},"cost":{"input":0.95,"output":4,"cache_read":0.16},"limit":{"context":256000,"output":256000}}}}}}
+            {"permission":{"external_directory":{"*":"deny","/tmp/**":"allow","~/**":"allow"},"doom_loop":"deny"},"provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/moonshotai/kimi-k2.6":{"id":"workers-ai/@cf/moonshotai/kimi-k2.6","name":"Kimi K2.6","family":"kimi","attachment":true,"reasoning":true,"tool_call":true,"interleaved":{"field":"reasoning_content"},"temperature":true,"release_date":"2026-04-20","modalities":{"input":["text","image"],"output":["text"]},"cost":{"input":0.95,"output":4,"cache_read":0.16},"limit":{"context":256000,"output":256000}}}}}}
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/bonk,@ask-bonk"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -105,11 +105,20 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Register kimi-k2.6 (released 2026-04-20) with the pinned opencode
-          # version, whose bundled models.dev snapshot predates it and would
-          # otherwise raise ProviderModelNotFoundError.
+          # OPENCODE_CONFIG_CONTENT bundles two unrelated overrides:
+          #
+          # 1. Register kimi-k2.6 (released 2026-04-20) with the pinned opencode
+          #    version, whose bundled models.dev snapshot predates it and would
+          #    otherwise raise ProviderModelNotFoundError.
+          #
+          # 2. Resolve the two opencode permission defaults that ask interactively
+          #    (`external_directory` and `doom_loop`) so a CI run with no TTY
+          #    can never deadlock waiting for approval. external_directory is
+          #    deny-by-default with /tmp/** and ~/** allowed (scratch files,
+          #    home-dir caches); doom_loop is deny so a stuck loop aborts
+          #    instead of prompting.
           OPENCODE_CONFIG_CONTENT: |
-            {"provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/moonshotai/kimi-k2.6":{"id":"workers-ai/@cf/moonshotai/kimi-k2.6","name":"Kimi K2.6","family":"kimi","attachment":true,"reasoning":true,"tool_call":true,"interleaved":{"field":"reasoning_content"},"temperature":true,"release_date":"2026-04-20","modalities":{"input":["text","image"],"output":["text"]},"cost":{"input":0.95,"output":4,"cache_read":0.16},"limit":{"context":256000,"output":256000}}}}}}
+            {"permission":{"external_directory":{"*":"deny","/tmp/**":"allow","~/**":"allow"},"doom_loop":"deny"},"provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/moonshotai/kimi-k2.6":{"id":"workers-ai/@cf/moonshotai/kimi-k2.6","name":"Kimi K2.6","family":"kimi","attachment":true,"reasoning":true,"tool_call":true,"interleaved":{"field":"reasoning_content"},"temperature":true,"release_date":"2026-04-20","modalities":{"input":["text","image"],"output":["text"]},"cost":{"input":0.95,"output":4,"cache_read":0.16},"limit":{"context":256000,"output":256000}}}}}}
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/review"

--- a/.github/workflows/ultrabonk.yml
+++ b/.github/workflows/ultrabonk.yml
@@ -65,12 +65,21 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Register claude-opus-4-7 (released 2026-04-16) with the pinned
-          # opencode version (1.4.6 published 2026-04-15), whose bundled
-          # models.dev snapshot predates it and would otherwise raise
-          # ProviderModelNotFoundError.
+          # OPENCODE_CONFIG_CONTENT bundles two unrelated overrides:
+          #
+          # 1. Register claude-opus-4-7 (released 2026-04-16) with the pinned
+          #    opencode version (1.4.6 published 2026-04-15), whose bundled
+          #    models.dev snapshot predates it and would otherwise raise
+          #    ProviderModelNotFoundError.
+          #
+          # 2. Resolve the two opencode permission defaults that ask interactively
+          #    (`external_directory` and `doom_loop`) so a CI run with no TTY
+          #    can never deadlock waiting for approval. external_directory is
+          #    deny-by-default with /tmp/** and ~/** allowed (scratch files,
+          #    home-dir caches); doom_loop is deny so a stuck loop aborts
+          #    instead of prompting.
           OPENCODE_CONFIG_CONTENT: |
-            {"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-7":{"id":"anthropic/claude-opus-4-7","name":"Claude Opus 4.7","family":"claude-opus","attachment":true,"reasoning":true,"tool_call":true,"temperature":false,"release_date":"2026-04-16","modalities":{"input":["text","image","pdf"],"output":["text"]},"cost":{"input":5,"output":25,"cache_read":0.5,"cache_write":6.25},"limit":{"context":1000000,"output":128000}}}}}}
+            {"permission":{"external_directory":{"*":"deny","/tmp/**":"allow","~/**":"allow"},"doom_loop":"deny"},"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-7":{"id":"anthropic/claude-opus-4-7","name":"Claude Opus 4.7","family":"claude-opus","attachment":true,"reasoning":true,"tool_call":true,"temperature":false,"release_date":"2026-04-16","modalities":{"input":["text","image","pdf"],"output":["text"]},"cost":{"input":5,"output":25,"cache_read":0.5,"cache_write":6.25},"limit":{"context":1000000,"output":128000}}}}}}
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
           mentions: "/ultrabonk"

--- a/.github/workflows/ultrareview.yml
+++ b/.github/workflows/ultrareview.yml
@@ -111,12 +111,21 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-          # Register claude-opus-4-7 (released 2026-04-16) with the pinned
-          # opencode version (1.4.6 published 2026-04-15), whose bundled
-          # models.dev snapshot predates it and would otherwise raise
-          # ProviderModelNotFoundError.
+          # OPENCODE_CONFIG_CONTENT bundles two unrelated overrides:
+          #
+          # 1. Register claude-opus-4-7 (released 2026-04-16) with the pinned
+          #    opencode version (1.4.6 published 2026-04-15), whose bundled
+          #    models.dev snapshot predates it and would otherwise raise
+          #    ProviderModelNotFoundError.
+          #
+          # 2. Resolve the two opencode permission defaults that ask interactively
+          #    (`external_directory` and `doom_loop`) so a CI run with no TTY
+          #    can never deadlock waiting for approval. external_directory is
+          #    deny-by-default with /tmp/** and ~/** allowed (scratch files,
+          #    home-dir caches); doom_loop is deny so a stuck loop aborts
+          #    instead of prompting.
           OPENCODE_CONFIG_CONTENT: |
-            {"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-7":{"id":"anthropic/claude-opus-4-7","name":"Claude Opus 4.7","family":"claude-opus","attachment":true,"reasoning":true,"tool_call":true,"temperature":false,"release_date":"2026-04-16","modalities":{"input":["text","image","pdf"],"output":["text"]},"cost":{"input":5,"output":25,"cache_read":0.5,"cache_write":6.25},"limit":{"context":1000000,"output":128000}}}}}}
+            {"permission":{"external_directory":{"*":"deny","/tmp/**":"allow","~/**":"allow"},"doom_loop":"deny"},"provider":{"cloudflare-ai-gateway":{"models":{"anthropic/claude-opus-4-7":{"id":"anthropic/claude-opus-4-7","name":"Claude Opus 4.7","family":"claude-opus","attachment":true,"reasoning":true,"tool_call":true,"temperature":false,"release_date":"2026-04-16","modalities":{"input":["text","image","pdf"],"output":["text"]},"cost":{"input":5,"output":25,"cache_read":0.5,"cache_write":6.25},"limit":{"context":1000000,"output":128000}}}}}}
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
           mentions: "/ultrareview"


### PR DESCRIPTION
## What does this PR do?

Resolves the two opencode permission defaults that ask for approval (rather than allowing or denying outright):

- `external_directory` — any tool touching paths outside the project cwd
- `doom_loop` — same tool call repeating 3x with identical input

CI runs have no TTY, so when either of these prompts fires the run deadlocks until the workflow timeout. #769 dropped that timeout from 45 to 30 min, but the underlying hang is still there. Last week the triggering case was a bash redirect (`git show ... > /tmp/foo`) — `/tmp/` is outside the project cwd, so it tripped `external_directory` → `ask` → 30-minute hang.

Sets both explicitly in `OPENCODE_CONFIG_CONTENT` for all four bonk-family workflows:

```jsonc
{
  "permission": {
    "external_directory": {
      "*": "deny",
      "/tmp/**": "allow",
      "~/**": "allow"
    },
    "doom_loop": "deny"
  }
}
```

`/tmp/**` and `~/**` cover the legitimate external paths a CI agent needs (scratch files, home-dir caches like `~/.config/...`). Everything else outside cwd is denied. `doom_loop` denies so a stuck loop aborts the run instead of waiting forever.

`read` defaults stay as opencode ships them (allow with `.env*` files denied) — that baseline is sensible.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (no TS files touched)
- [x] `pnpm lint` passes (`pnpm --silent lint:json | jq '.diagnostics | length'` → `0`)
- [x] `pnpm test` passes (or targeted tests for my change) — N/A, CI workflow only
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A
- [ ] I have added a changeset — N/A, CI only
- [ ] New features link to an approved Discussion — N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

JSON content drafted with Claude Opus, validated against the live opencode config schema (`https://opencode.ai/config.json` + the embedded models.dev schema). Reviewed line by line.

## Screenshots / test output

Validated each workflow's `OPENCODE_CONFIG_CONTENT` JSON parses and contains the expected permission rules:

```
=== bonk.yml ===
"deny"
=== ultrabonk.yml ===
"deny"
=== review.yml ===
"deny"
=== ultrareview.yml ===
"deny"
```

Repro from PR #769 logs: the run stalled exactly when the model issued `git show origin/main:packages/core/src/search/fts-manager.ts > /tmp/fts-main.ts`. The `> /tmp/...` redirect crosses out of cwd, triggers `external_directory: ask`, and CI has no one to answer.

Related: PR #769 (concurrency + auto-PR template + workflow timeout drop) — same workflow set, complementary fix.