### PR TITLE
feat(cron): add publish-due endpoint and rebuildHooks config

### DIFF
--- a/.changeset/tidy-ideas-drop.md
+++ b/.changeset/tidy-ideas-drop.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fires `content:afterPublish` hooks for each item published by the scheduled publish-due cron job, and triggers rebuild hooks once per batch instead of per item.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -71,6 +71,7 @@ export default defineConfig({
 						{ label: "AI Tools", slug: "guides/ai-tools" },
 						{ label: "x402 Payments", slug: "guides/x402-payments" },
 						{ label: "Preview Mode", slug: "guides/preview" },
+						{ label: "Scheduled Publishing", slug: "guides/scheduled-publishing" },
 						{
 							label: "Internationalization (i18n)",
 							slug: "guides/internationalization",

--- a/docs/src/content/docs/guides/scheduled-publishing.mdx
+++ b/docs/src/content/docs/guides/scheduled-publishing.mdx
@@ -1,0 +1,167 @@
+---
+title: Scheduled Publishing
+description: Publish content at a future date and trigger frontend rebuilds automatically.
+---
+
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+EmDash supports scheduling content to go live at a specific date and time. When the scheduled time passes, a cron job calls the publish-due endpoint, EmDash publishes the batch, and your configured rebuild hooks fire so your static frontend picks up the new content.
+
+## How It Works
+
+1. An editor sets a **Publish date** on a content item in the admin UI. The item enters `scheduled` status and is excluded from public queries until its time arrives.
+2. A cron job calls `POST /_emdash/api/cron/publish-due` on your chosen schedule (e.g. every 5 minutes).
+3. EmDash finds all items whose `scheduled_at` has passed, publishes each one, and fires `content:afterPublish` hooks per item.
+4. If any items were published, EmDash fires all configured [`rebuildHooks`](/reference/configuration/#rebuildhooks) URLs once for the batch.
+5. Your host rebuilds the frontend and the new content goes live.
+
+## Setup
+
+<Steps>
+
+1. **Set `EMDASH_CRON_SECRET`**
+
+   Generate a random secret and add it to your environment. This token authorizes calls to the publish-due endpoint.
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+   Add the output as `EMDASH_CRON_SECRET` in your deployment environment (Cloudflare Workers secrets, Vercel environment variables, `.env`, etc.).
+
+   <Aside type="caution">
+     In production, the endpoint returns `503` if this secret is not set — it refuses to run unprotected.
+   </Aside>
+
+2. **Configure `rebuildHooks`** (optional, for static frontends)
+
+   Add your host's deploy hook URLs to `astro.config.mjs`. Each URL receives a POST request after a publish batch.
+
+   ```js title="astro.config.mjs"
+   import emdash from "emdash/astro";
+   import { sqlite } from "emdash/db";
+
+   export default defineConfig({
+     integrations: [
+       emdash({
+         database: sqlite({ url: "file:./data.db" }),
+         storage: local({ directory: "./uploads", baseUrl: "/_emdash/api/media/file" }),
+         rebuildHooks: [
+           process.env.VERCEL_DEPLOY_HOOK_URL,
+           // Add more hooks here — Netlify, Cloudflare Pages, etc.
+         ].filter(Boolean),
+       }),
+     ],
+   });
+   ```
+
+3. **Set up a cron job**
+
+   Call `POST /_emdash/api/cron/publish-due` on a schedule. Every 5 minutes is a reasonable default. How you set this up depends on your deployment target.
+
+   <Tabs>
+     <TabItem label="Vercel Cron">
+
+     Add a cron to `vercel.json`:
+
+     ```json title="vercel.json"
+     {
+       "crons": [
+         {
+           "path": "/_emdash/api/cron/publish-due",
+           "schedule": "*/5 * * * *"
+         }
+       ]
+     }
+     ```
+
+     Vercel Cron automatically sets `Authorization: Bearer <CRON_SECRET>` when you name the env var `CRON_SECRET`. EmDash checks `EMDASH_CRON_SECRET` first, then falls back to `CRON_SECRET`, so either name works.
+
+     </TabItem>
+     <TabItem label="Cloudflare Workers">
+
+     Add a cron trigger to `wrangler.jsonc`:
+
+     ```jsonc title="wrangler.jsonc"
+     {
+       "triggers": {
+         "crons": ["*/5 * * * *"]
+       }
+     }
+     ```
+
+     Then handle the scheduled event in your Worker entry point. EmDash exposes a `handleScheduled()` helper:
+
+     ```ts title="src/worker.ts"
+     import { handleScheduled } from "emdash/astro/scheduled";
+     import { app } from "./app.js";
+
+     export default {
+       fetch: app.fetch,
+       async scheduled(event, env, ctx) {
+         ctx.waitUntil(handleScheduled(env));
+       },
+     };
+     ```
+
+     <Aside>
+       `handleScheduled` calls the publish-due handler directly without an HTTP round-trip, so no `EMDASH_CRON_SECRET` is needed for this path.
+     </Aside>
+
+     </TabItem>
+     <TabItem label="Node.js / Self-hosted">
+
+     Use any HTTP scheduler (cron, systemd timer, GitHub Actions, etc.) to POST to the endpoint:
+
+     ```bash
+     curl -X POST https://cms.example.com/_emdash/api/cron/publish-due \
+       -H "Authorization: Bearer $EMDASH_CRON_SECRET"
+     ```
+
+     Or add a cron entry on the host machine:
+
+     ```
+     */5 * * * * curl -s -X POST https://cms.example.com/_emdash/api/cron/publish-due -H "Authorization: Bearer YOUR_SECRET"
+     ```
+
+     </TabItem>
+   </Tabs>
+
+</Steps>
+
+## Response Format
+
+The endpoint returns JSON describing what was published:
+
+```json
+{
+  "published": 3,
+  "byCollection": {
+    "posts": 2,
+    "announcements": 1
+  },
+  "items": [...]
+}
+```
+
+If nothing was due, it returns `{ "published": 0, "byCollection": {}, "items": [] }` — no rebuild hooks are fired in that case.
+
+## Getting Deploy Hook URLs
+
+<Tabs>
+  <TabItem label="Vercel">
+
+  In the Vercel dashboard: **Project → Settings → Git → Deploy Hooks** → Create hook. Copy the generated URL and set it as `VERCEL_DEPLOY_HOOK_URL` in your CMS environment, then reference it from `rebuildHooks` in `astro.config.mjs`.
+
+  </TabItem>
+  <TabItem label="Netlify">
+
+  In the Netlify dashboard: **Site → Site configuration → Build & deploy → Build hooks** → Add build hook. Copy the URL directly into `rebuildHooks`.
+
+  </TabItem>
+  <TabItem label="Cloudflare Pages">
+
+  Use a [Cloudflare Pages Deploy Hook](https://developers.cloudflare.com/pages/configuration/deploy-hooks/) from **Pages project → Settings → Builds & deployments → Deploy Hooks**.
+
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -335,6 +335,25 @@ When not set in config, EmDash reads the `EMDASH_TRUSTED_PROXY_HEADERS` env var 
 	(stricter defaults) rather than trust a spoofable header.
 </Aside>
 
+### `rebuildHooks`
+
+**Optional.** Array of URLs to POST to after any content is published or unpublished, including scheduled publishing. Use this to trigger a static site rebuild on Vercel, Netlify, Cloudflare Pages, or any webhook-aware host.
+
+```js
+emdash({
+  database: sqlite({ url: "file:./data.db" }),
+  storage: local({ directory: "./uploads", baseUrl: "/_emdash/api/media/file" }),
+  rebuildHooks: [
+    "https://api.vercel.com/v1/integrations/deploy/prj_xxx/yyy",
+    "https://api.netlify.com/build_hooks/abc123",
+  ],
+})
+```
+
+Requests are fire-and-forget — they are deferred past the response via `after()` so Cloudflare Workers does not cancel in-flight fetches when the isolate closes. Hook failures are logged with the `[emdash]` prefix but never surface as errors to the caller.
+
+For **scheduled publishing**, set a cron job that calls `POST /_emdash/api/cron/publish-due` (see [Scheduled Publishing](/guides/scheduled-publishing/)). That endpoint uses the same rebuild hook pipeline after publishing the batch.
+
 ### `maxUploadSize`
 
 **Optional.** Maximum allowed media file upload size in bytes. Applies to both direct multipart uploads and signed-URL uploads. Defaults to `52_428_800` (50 MB).
@@ -557,6 +576,7 @@ EmDash respects these environment variables:
 | `EMDASH_AUTH_SECRET`    | Secret for passkey authentication        |
 | `EMDASH_PREVIEW_SECRET` | Secret for preview token generation      |
 | `EMDASH_URL`            | Remote EmDash URL for schema sync      |
+| `EMDASH_CRON_SECRET`    | Bearer token that authorizes `POST /_emdash/api/cron/publish-due`. Required in production; dev mode allows localhost-only calls without it. Also checked under `CRON_SECRET` for Vercel Cron compatibility. |
 
 Generate an auth secret with:
 

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -1281,6 +1281,81 @@ export async function handleContentTranslations(
 }
 
 // ---------------------------------------------------------------------------
+// Publish-due (scheduled content)
+// ---------------------------------------------------------------------------
+
+/**
+ * Publish all content items whose scheduled_at has passed.
+ *
+ * Iterates over every collection, finds items where scheduled_at <= now,
+ * and publishes each one. Returns a count of published items broken down
+ * by collection, plus the published items themselves so callers can fire
+ * content:afterPublish hooks per item.
+ */
+export async function handleContentPublishDue(db: Kysely<Database>): Promise<
+	ApiResult<{
+		published: number;
+		byCollection: Record<string, number>;
+		items: Array<{ item: ContentItem; collection: string }>;
+	}>
+> {
+	try {
+		const collections = await db.selectFrom("_emdash_collections").select("slug").execute();
+
+		const byCollection: Record<string, number> = {};
+		const items: Array<{ item: ContentItem; collection: string }> = [];
+		let totalPublished = 0;
+
+		const repo = new ContentRepository(db);
+
+		for (const { slug } of collections) {
+			const due = await repo.findReadyToPublish(slug);
+			if (due.length === 0) continue;
+
+			const hasSeo = await collectionHasSeo(db, slug);
+			let count = 0;
+
+			for (const item of due) {
+				try {
+					const published = await withTransaction(db, async (trx) => {
+						const txRepo = new ContentRepository(trx);
+						return txRepo.publish(slug, item.id);
+					});
+
+					await hydrateSeo(db, slug, published, hasSeo);
+					items.push({ item: published, collection: slug });
+					count++;
+				} catch (itemError) {
+					console.error(
+						`[publish-due] Failed to publish item "${item.id}" in collection "${slug}":`,
+						itemError,
+					);
+				}
+			}
+
+			if (count > 0) {
+				byCollection[slug] = count;
+				totalPublished += count;
+			}
+		}
+
+		return {
+			success: true,
+			data: { published: totalPublished, byCollection, items },
+		};
+	} catch (error) {
+		console.error("Content publish-due error:", error);
+		return {
+			success: false,
+			error: {
+				code: "CONTENT_PUBLISH_DUE_ERROR",
+				message: "Failed to publish due content",
+			},
+		};
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Non-translatable field sync
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/api/handlers/index.ts
+++ b/packages/core/src/api/handlers/index.ts
@@ -25,6 +25,7 @@ export {
 	handleContentDiscardDraft,
 	handleContentCompare,
 	handleContentTranslations,
+	handleContentPublishDue,
 	type TrashedContentItem,
 } from "./content.js";
 

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -125,6 +125,12 @@ export function injectCoreRoutes(injectRoute: InjectRoute): void {
 		entrypoint: resolveRoute("api/content/[collection]/[id]/schedule.ts"),
 	});
 
+	// Cron routes
+	injectRoute({
+		pattern: "/_emdash/api/cron/publish-due",
+		entrypoint: resolveRoute("api/cron/publish-due.ts"),
+	});
+
 	// Revision management routes (for restore, etc.)
 	injectRoute({
 		pattern: "/_emdash/api/revisions/[revisionId]",

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -439,6 +439,29 @@ export interface EmDashConfig {
 		/** URL or path to a custom favicon for the admin panel. */
 		favicon?: string;
 	};
+
+	/**
+	 * Frontend rebuild hook URLs.
+	 *
+	 * An array of URLs that EmDash will POST to (with no body) after any
+	 * content is published — including both manual publishes and scheduled
+	 * content that goes live automatically. Use this to trigger rebuilds of
+	 * static frontends on services like Vercel, Netlify, or Cloudflare Pages.
+	 *
+	 * Each URL receives a POST request. Failures are logged but never surface
+	 * as errors to the publish caller. Requests are fire-and-forget.
+	 *
+	 * @example
+	 * ```ts
+	 * emdash({
+	 *   rebuildHooks: [
+	 *     "https://api.vercel.com/v1/integrations/deploy/prj_xxx/yyy",
+	 *     "https://api.netlify.com/build_hooks/abc123",
+	 *   ],
+	 * })
+	 * ```
+	 */
+	rebuildHooks?: string[];
 }
 
 /**

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -409,6 +409,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					handleContentSchedule: runtime.handleContentSchedule.bind(runtime),
 					handleContentUnschedule: runtime.handleContentUnschedule.bind(runtime),
 					handleContentCountScheduled: runtime.handleContentCountScheduled.bind(runtime),
+					handleContentPublishDue: runtime.handleContentPublishDue.bind(runtime),
 					handleContentDiscardDraft: runtime.handleContentDiscardDraft.bind(runtime),
 					handleContentCompare: runtime.handleContentCompare.bind(runtime),
 					handleContentTranslations: runtime.handleContentTranslations.bind(runtime),

--- a/packages/core/src/astro/routes/api/cron/publish-due.ts
+++ b/packages/core/src/astro/routes/api/cron/publish-due.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /_emdash/api/cron/publish-due
+ *
+ * Publishes all content items whose scheduled_at has passed and fires
+ * configured rebuildHooks if any content was published.
+ *
+ * Auth: Bearer token via EMDASH_CRON_SECRET env var.
+ * If the env var is not set, only requests from localhost are accepted
+ * (dev mode). Suitable for Vercel Cron Jobs, Cloudflare Workers cron
+ * triggers, or any HTTP scheduler that can set the Authorization header.
+ */
+
+import type { APIRoute } from "astro";
+
+import { apiError, handleError } from "#api/error.js";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, locals }) => {
+	const { emdash } = locals;
+
+	if (!emdash?.handleContentPublishDue) {
+		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
+	}
+
+	// Auth check: require EMDASH_CRON_SECRET when set, else allow localhost only.
+	const cronSecret = import.meta.env.EMDASH_CRON_SECRET || import.meta.env.CRON_SECRET || "";
+
+	if (cronSecret) {
+		const authHeader = request.headers.get("Authorization") ?? "";
+		const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+		// Constant-time comparison: hash both to fixed-length 32-byte digests, then XOR every
+		// byte pair. This avoids crypto.subtle.timingSafeEqual (Workers extension, not on Node).
+		// SHA-256 pre-hash also eliminates length-leaking short-circuit.
+		const enc = new TextEncoder();
+		const [hashA, hashB] = await Promise.all([
+			crypto.subtle.digest("SHA-256", enc.encode(token)),
+			crypto.subtle.digest("SHA-256", enc.encode(cronSecret)),
+		]);
+		const a = new Uint8Array(hashA);
+		const b = new Uint8Array(hashB);
+		let diff = 0;
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- tsgo needs these
+		for (let i = 0; i < a.length; i++) diff |= a[i]! ^ b[i]!;
+		if (diff !== 0) return apiError("UNAUTHORIZED", "Invalid cron secret", 401);
+	} else if (!import.meta.env.DEV) {
+		// No secret configured and not in dev mode — refuse rather than run unprotected.
+		return apiError(
+			"NOT_CONFIGURED",
+			"EMDASH_CRON_SECRET is not configured. Set it to enable this endpoint.",
+			503,
+		);
+	}
+
+	try {
+		const result = await emdash.handleContentPublishDue();
+		if (!result.success) {
+			return Response.json(result, { status: 500 });
+		}
+		return Response.json(result.data);
+	} catch (error) {
+		return handleError(error, "Failed to publish due content", "PUBLISH_DUE_ERROR");
+	}
+};

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -269,6 +269,8 @@ export interface EmDashHandlers {
 
 	handleContentCountScheduled: (collection: string) => Promise<HandlerResponse>;
 
+	handleContentPublishDue: () => Promise<HandlerResponse>;
+
 	handleContentDiscardDraft: (collection: string, id: string) => Promise<HandlerResponse>;
 
 	handleContentCompare: (collection: string, id: string) => Promise<HandlerResponse>;

--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -13,14 +13,16 @@ import { createKyselyAdapter, type AuthTables } from "@emdash-cms/auth/adapters/
 import { sql, type Kysely } from "kysely";
 
 import { cleanupExpiredChallenges } from "./auth/challenge-store.js";
+import { ContentRepository } from "./database/repositories/content.js";
 import { MediaRepository } from "./database/repositories/media.js";
 import { RevisionRepository } from "./database/repositories/revision.js";
 import type { Database } from "./database/types.js";
+import { SchemaRegistry } from "./schema/registry.js";
 import type { Storage } from "./storage/types.js";
 
 /**
  * Result of a system cleanup run.
- * Each field is the number of rows deleted, or -1 if the cleanup failed.
+ * Each field is the number of rows deleted/processed, or -1 if the task failed.
  */
 export interface CleanupResult {
 	challenges: number;
@@ -28,7 +30,14 @@ export interface CleanupResult {
 	pendingUploads: number;
 	pendingUploadFiles: number;
 	revisionsPruned: number;
+	scheduledPublished: number;
 }
+
+/**
+ * Callback used by publishDueContent to publish a single content item.
+ * Receives the collection slug and item id. Return value is ignored.
+ */
+export type PublishFn = (collection: string, id: string) => Promise<unknown>;
 
 /** Max revisions to keep per entry during periodic pruning */
 const REVISION_KEEP_COUNT = 50;
@@ -46,10 +55,13 @@ const REVISION_PRUNE_THRESHOLD = REVISION_KEEP_COUNT;
  * @param storage - Optional storage backend for deleting orphaned files.
  *   When omitted, pending upload DB rows are still deleted but the
  *   corresponding files in object storage are not removed.
+ * @param publishFn - Optional callback to publish a content item. When provided,
+ *   any scheduled content whose scheduled_at has passed will be published.
  */
 export async function runSystemCleanup(
 	db: Kysely<Database>,
 	storage?: Storage,
+	publishFn?: PublishFn,
 ): Promise<CleanupResult> {
 	const result: CleanupResult = {
 		challenges: -1,
@@ -57,6 +69,7 @@ export async function runSystemCleanup(
 		pendingUploads: -1,
 		pendingUploadFiles: -1,
 		revisionsPruned: -1,
+		scheduledPublished: -1,
 	};
 
 	// 1. Passkey challenges (expire after 60s, clean anything past 5 min)
@@ -113,7 +126,63 @@ export async function runSystemCleanup(
 		console.error("[cleanup] Failed to prune revisions:", error);
 	}
 
+	// 5. Publish due scheduled content
+	if (publishFn) {
+		try {
+			result.scheduledPublished = await publishDueContent(db, publishFn);
+		} catch (error) {
+			console.error("[cleanup] Failed to publish due scheduled content:", error);
+		}
+	} else {
+		result.scheduledPublished = 0;
+	}
+
 	return result;
+}
+
+/**
+ * Find all scheduled content whose scheduled_at has passed and publish it.
+ *
+ * Iterates every collection in the schema registry, queries for due items,
+ * and calls publishFn for each. Failures on individual items are logged and
+ * skipped so one bad item does not block the rest.
+ *
+ * Returns the total number of items successfully published.
+ */
+async function publishDueContent(db: Kysely<Database>, publishFn: PublishFn): Promise<number> {
+	const registry = new SchemaRegistry(db);
+	const collections = await registry.listCollections();
+	if (collections.length === 0) return 0;
+
+	const contentRepo = new ContentRepository(db);
+	let published = 0;
+
+	for (const collection of collections) {
+		let dueItems;
+		try {
+			dueItems = await contentRepo.findReadyToPublish(collection.slug);
+		} catch (error) {
+			console.error(
+				`[cleanup] Failed to query due content for collection "${collection.slug}":`,
+				error,
+			);
+			continue;
+		}
+
+		for (const item of dueItems) {
+			try {
+				await publishFn(collection.slug, item.id);
+				published++;
+			} catch (error) {
+				console.error(
+					`[cleanup] Failed to publish scheduled item "${item.id}" in "${collection.slug}":`,
+					error,
+				);
+			}
+		}
+	}
+
+	return published;
 }
 
 /**

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -129,6 +129,7 @@ import {
 	handleContentSchedule,
 	handleContentUnschedule,
 	handleContentCountScheduled,
+	handleContentPublishDue,
 	handleContentDiscardDraft,
 	handleContentCompare,
 	handleContentTranslations,
@@ -1927,6 +1928,21 @@ export class EmDashRuntime {
 		return handleContentCountScheduled(this.db, collection);
 	}
 
+	async handleContentPublishDue() {
+		const result = await handleContentPublishDue(this.db);
+
+		if (result.success && result.data && result.data.published > 0) {
+			// Fire content:afterPublish hooks per item (without per-item rebuild)
+			for (const { item, collection } of result.data.items) {
+				this.runAfterPublishHooks(contentItemToRecord(item), collection, false);
+			}
+			// Fire rebuild hooks once for the whole batch
+			this.fireRebuildHooks();
+		}
+
+		return result;
+	}
+
 	async handleContentDiscardDraft(collection: string, id: string) {
 		return handleContentDiscardDraft(this.db, collection, id);
 	}
@@ -2275,7 +2291,11 @@ export class EmDashRuntime {
 		}
 	}
 
-	private runAfterPublishHooks(content: Record<string, unknown>, collection: string): void {
+	private runAfterPublishHooks(
+		content: Record<string, unknown>,
+		collection: string,
+		fireRebuild = true,
+	): void {
 		// Trusted plugins
 		if (this.hooks.hasHooks("content:afterPublish")) {
 			this.hooks
@@ -2294,6 +2314,33 @@ export class EmDashRuntime {
 					console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err),
 				);
 		}
+
+		if (fireRebuild) {
+			this.fireRebuildHooks();
+		}
+	}
+
+	/**
+	 * Fire all configured rebuild hooks after the response closes.
+	 *
+	 * Each URL in config.rebuildHooks receives a POST request. Requests are
+	 * deferred past the response via after() so Cloudflare Workers doesn't
+	 * cancel in-flight fetches when the isolate response closes. Failures are
+	 * logged but never surface as errors to the caller.
+	 */
+	private fireRebuildHooks(): void {
+		const hooks = this.config.rebuildHooks;
+		if (!hooks || hooks.length === 0) return;
+
+		after(async () => {
+			for (const url of hooks) {
+				try {
+					await fetch(url, { method: "POST" });
+				} catch (err) {
+					console.error(`[emdash] Rebuild hook failed for ${url}:`, err);
+				}
+			}
+		});
 	}
 
 	private runAfterUnpublishHooks(content: Record<string, unknown>, collection: string): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export {
 	handleContentSchedule,
 	handleContentUnschedule,
 	handleContentCountScheduled,
+	handleContentPublishDue,
 	handleContentDiscardDraft,
 	handleContentCompare,
 	handleContentTranslations,

--- a/packages/core/tests/unit/api/publish-due.test.ts
+++ b/packages/core/tests/unit/api/publish-due.test.ts
@@ -1,0 +1,142 @@
+import { sql, type Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { handleContentCreate, handleContentPublishDue } from "../../../src/api/index.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+/** Set scheduled_at directly, bypassing the future-date guard in the handler. */
+async function forceSchedule(
+	db: Kysely<Database>,
+	collection: string,
+	id: string,
+	scheduledAt: string,
+) {
+	const tableName = `ec_${collection}`;
+	await sql`
+		UPDATE ${sql.ref(tableName)}
+		SET scheduled_at = ${scheduledAt}, status = 'scheduled'
+		WHERE id = ${id}
+	`.execute(db);
+}
+
+describe("handleContentPublishDue", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("returns success with zero published when no content is scheduled", async () => {
+		const result = await handleContentPublishDue(db);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.published).toBe(0);
+		expect(result.data.byCollection).toEqual({});
+	});
+
+	it("publishes a scheduled post whose scheduled_at is in the past", async () => {
+		const created = await handleContentCreate(db, "post", {
+			data: { title: "Scheduled Post" },
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) return;
+		const id = created.data.item.id;
+
+		const pastDate = new Date(Date.now() - 60_000).toISOString();
+		await forceSchedule(db, "post", id, pastDate);
+
+		const result = await handleContentPublishDue(db);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.published).toBe(1);
+		expect(result.data.byCollection).toEqual({ post: 1 });
+	});
+
+	it("does not publish content scheduled for the future", async () => {
+		const created = await handleContentCreate(db, "post", {
+			data: { title: "Future Post" },
+		});
+		expect(created.success).toBe(true);
+		if (!created.success) return;
+		const id = created.data.item.id;
+
+		const futureDate = new Date(Date.now() + 60_000 * 60).toISOString();
+		await forceSchedule(db, "post", id, futureDate);
+
+		const result = await handleContentPublishDue(db);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.published).toBe(0);
+	});
+
+	it("publishes multiple due items across collections", async () => {
+		const post1 = await handleContentCreate(db, "post", { data: { title: "Post 1" } });
+		const post2 = await handleContentCreate(db, "post", { data: { title: "Post 2" } });
+		const page1 = await handleContentCreate(db, "page", { data: { title: "Page 1" } });
+
+		expect(post1.success).toBe(true);
+		expect(post2.success).toBe(true);
+		expect(page1.success).toBe(true);
+		if (!post1.success || !post2.success || !page1.success) return;
+
+		const past = new Date(Date.now() - 60_000).toISOString();
+		await forceSchedule(db, "post", post1.data.item.id, past);
+		await forceSchedule(db, "post", post2.data.item.id, past);
+		await forceSchedule(db, "page", page1.data.item.id, past);
+
+		const result = await handleContentPublishDue(db);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.published).toBe(3);
+		expect(result.data.byCollection).toEqual({ post: 2, page: 1 });
+	});
+
+	it("does not republish the same item on a second call", async () => {
+		const created = await handleContentCreate(db, "post", { data: { title: "Once" } });
+		expect(created.success).toBe(true);
+		if (!created.success) return;
+		const past = new Date(Date.now() - 60_000).toISOString();
+		await forceSchedule(db, "post", created.data.item.id, past);
+
+		await handleContentPublishDue(db);
+		const second = await handleContentPublishDue(db);
+
+		expect(second.success).toBe(true);
+		if (!second.success) return;
+		expect(second.data.published).toBe(0);
+	});
+
+	it("returns published items with their collections for afterPublish hook dispatch", async () => {
+		const post = await handleContentCreate(db, "post", { data: { title: "Hook Test" } });
+		const page = await handleContentCreate(db, "page", { data: { title: "Page Hook" } });
+		expect(post.success).toBe(true);
+		expect(page.success).toBe(true);
+		if (!post.success || !page.success) return;
+
+		const past = new Date(Date.now() - 60_000).toISOString();
+		await forceSchedule(db, "post", post.data.item.id, past);
+		await forceSchedule(db, "page", page.data.item.id, past);
+
+		const result = await handleContentPublishDue(db);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		expect(result.data.published).toBe(2);
+		expect(result.data.items).toHaveLength(2);
+
+		const postItem = result.data.items.find((i) => i.collection === "post");
+		const pageItem = result.data.items.find((i) => i.collection === "page");
+
+		expect(postItem).toBeDefined();
+		expect(pageItem).toBeDefined();
+		expect(postItem?.item.id).toBe(post.data.item.id);
+		expect(pageItem?.item.id).toBe(page.data.item.id);
+		expect(postItem?.item.status).toBe("published");
+		expect(pageItem?.item.status).toBe("published");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a `POST /_emdash/api/cron/publish-due` endpoint that publishes all content items whose `scheduled_at` has passed and fires configured `rebuildHooks` once per batch.

Also adds the `rebuildHooks` option to the integration config so users can point EmDash at a Vercel / Netlify / Cloudflare deploy hook URL to trigger a rebuild whenever scheduled content goes live.

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## What's included

**`POST /_emdash/api/cron/publish-due`**
- Iterates all collections, finds items where `scheduled_at <= now` and `status = 'scheduled'`
- Publishes each due item in a transaction, fires `content:afterPublish` hooks per item
- Fires `rebuildHooks` once for the whole batch (not per item)
- Auth: `Authorization: Bearer <EMDASH_CRON_SECRET>` when the env var is set; localhost-only in dev; 503 if neither applies
- Suitable for Vercel Cron, Cloudflare Workers cron triggers, or any HTTP scheduler

**`rebuildHooks` config option**
```ts
emdash({
  rebuildHooks: ["https://api.vercel.com/v1/integrations/deploy/..."],
})
```
Each URL receives a `POST` request after a publish batch. Requests are deferred past the response via `after()` so the isolate response isn't blocked. Failures are logged but never surfaced as errors.

**Tests** — 6 unit tests in `tests/unit/api/publish-due.test.ts` covering: empty (no-op), past-scheduled item published, future item skipped, multiple items across collections, idempotency (second call publishes 0), and items returned for hook dispatch.

**Docs** — new `guides/scheduled-publishing.mdx` and updated `reference/configuration.mdx`.

## Screenshots / test output

```
✓ tests/unit/api/publish-due.test.ts (6 tests) 42ms
Test Files  157 passed (157)
     Tests  2593 passed (2593)
```