### PR TITLE
Add missing zh-CN/zh-TW translations

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -1359,11 +1359,11 @@ msgstr "创建您的通行密钥"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "创建、更新、删除导航菜单"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "创建、更新、删除分类术语"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
@@ -2940,7 +2940,7 @@ msgstr "菜单 ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:89
 msgid "Menus Manage"
-msgstr ""
+msgstr "菜单管理"
 
 #: packages/admin/src/components/SeoPanel.tsx:161
 msgid "Meta Description"
@@ -3727,7 +3727,7 @@ msgstr "读取媒体文件"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
 msgid "Read site settings"
-msgstr ""
+msgstr "读取网站设置"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:267
 msgid "Reading"
@@ -4464,11 +4464,11 @@ msgstr "设置"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:99
 msgid "Settings Manage"
-msgstr ""
+msgstr "设置管理"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:94
 msgid "Settings Read"
-msgstr ""
+msgstr "设置读取"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:59
 msgid "Settings saved successfully"
@@ -4727,7 +4727,7 @@ msgstr "分类"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "分类管理"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:668
 msgid "Taxonomy created"
@@ -5126,7 +5126,7 @@ msgstr "更新 {0} 的设置"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:100
 msgid "Update site settings"
-msgstr ""
+msgstr "更新网站设置"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:218

--- a/packages/admin/src/locales/zh-TW/messages.po
+++ b/packages/admin/src/locales/zh-TW/messages.po
@@ -1359,11 +1359,11 @@ msgstr "創建您的通行密鑰"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "創建、更新、刪除導航菜單"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "創建、更新、刪除分類術語"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Create, update, delete content"
@@ -2940,7 +2940,7 @@ msgstr "菜單 ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:89
 msgid "Menus Manage"
-msgstr ""
+msgstr "菜單管理"
 
 #: packages/admin/src/components/SeoPanel.tsx:161
 msgid "Meta Description"
@@ -3727,7 +3727,7 @@ msgstr "讀取媒體文件"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
 msgid "Read site settings"
-msgstr ""
+msgstr "讀取網站設置"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:267
 msgid "Reading"
@@ -4464,11 +4464,11 @@ msgstr "設置"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:99
 msgid "Settings Manage"
-msgstr ""
+msgstr "設置管理"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:94
 msgid "Settings Read"
-msgstr ""
+msgstr "設置讀取"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:59
 msgid "Settings saved successfully"
@@ -4727,7 +4727,7 @@ msgstr "分類"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:84
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "分類管理"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:668
 msgid "Taxonomy created"
@@ -5126,7 +5126,7 @@ msgstr "更新 {0} 的設置"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:100
 msgid "Update site settings"
-msgstr ""
+msgstr "更新網站設置"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:218


### PR DESCRIPTION
Fill in previously empty msgstr entries in Simplified and Traditional Chinese locale files. 

## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
