### PR TITLE
docs: pluggable auth providers and Atmosphere login

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -68,6 +68,7 @@ export default defineConfig({
 						{ label: "Sections", slug: "guides/sections" },
 						{ label: "Site Settings", slug: "guides/site-settings" },
 						{ label: "Authentication", slug: "guides/authentication" },
+						{ label: "Atmosphere Login", slug: "guides/atmosphere-auth" },
 						{ label: "AI Tools", slug: "guides/ai-tools" },
 						{ label: "x402 Payments", slug: "guides/x402-payments" },
 						{ label: "Preview Mode", slug: "guides/preview" },

--- a/docs/src/content/docs/guides/atmosphere-auth.mdx
+++ b/docs/src/content/docs/guides/atmosphere-auth.mdx
@@ -1,0 +1,155 @@
+---
+title: Atmosphere Login
+description: Sign in to EmDash with an Atmosphere account — the open-network identity behind Bluesky and the wider AT Protocol ecosystem.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+The `@emdash-cms/auth-atproto` package adds an [**Atmosphere account**](https://atmosphereaccount.com) login option to EmDash. An Atmosphere account is a portable, user-owned identity used across [Bluesky](https://bsky.app) and other apps in the AT Protocol network. Users sign in with their handle (e.g. `alice.bsky.social`) and authenticate at their own provider — EmDash never sees a password.
+
+This is a good fit when:
+
+- Your contributors already have an Atmosphere account.
+- You want to gate an org-controlled domain (`*.yourcompany.com`) without managing OAuth apps or invites.
+- You're building something that's part of the wider Atmosphere and want consistent identity with the rest of your stack.
+
+## Install
+
+```bash
+pnpm add @emdash-cms/auth-atproto
+```
+
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import { atproto } from "@emdash-cms/auth-atproto";
+
+export default defineConfig({
+	integrations: [
+		emdash({
+			authProviders: [atproto()],
+			server: {
+				host: "127.0.0.1", // required for local dev — see "Local development" below
+			},
+		}),
+	],
+});
+```
+
+That's enough to put **Sign in with Atmosphere** on the login page and the setup wizard. With no allowlist configured, the first user becomes Admin and self-signup is closed for everyone after that — see [allowlists](#allowlists) to open it up.
+
+No environment variables, client secret, or OAuth-app registration is required. The provider is a public OAuth client and serves its own metadata document at `/.well-known/atproto-client-metadata.json`.
+
+## Configuration
+
+```js
+atproto({
+	allowedDIDs: ["did:plc:abc123..."],
+	allowedHandles: ["*.example.com", "alice.bsky.social"],
+	defaultRole: 30, // Author
+});
+```
+
+| Option           | Type       | Default                   | Description                                                                  |
+| ---------------- | ---------- | ------------------------- | ---------------------------------------------------------------------------- |
+| `allowedDIDs`    | `string[]` | none (allow all on first) | DID allowlist. DIDs are permanent and can't be spoofed.                      |
+| `allowedHandles` | `string[]` | none (allow all on first) | Handle allowlist. Supports wildcards (`*.example.com`).                      |
+| `defaultRole`    | `number`   | `10` (Subscriber)         | Role assigned to allowed users after the first. First user is always Admin. |
+
+The full role ladder is documented in the main [authentication guide](/guides/authentication/#user-roles).
+
+### Allowlists
+
+If neither `allowedDIDs` nor `allowedHandles` is set, only the **first user** can sign up — anyone else attempting to log in will be rejected with `signup_not_allowed`. Existing users can always sign back in regardless of the allowlist (so removing yourself from the list won't lock you out, but won't let new people in either).
+
+When at least one allowlist is configured, a user is admitted if **either** list matches:
+
+- **DID match.** The user's DID is in `allowedDIDs`. DIDs are cryptographic identifiers that can't be moved or impersonated, so this is the strictest form of gating.
+- **Handle match.** The user's handle matches an entry in `allowedHandles`, exactly or via a leading-wildcard pattern (`*.example.com` matches `alice.example.com` and `bob.team.example.com`).
+
+Handle allowlists are safe even though handles are mutable. Before admitting a user via a handle match, EmDash independently resolves the handle's DNS/HTTP record and verifies that it points at the same DID the provider claims. A misbehaving provider can't simply assert it owns `you@yourcompany.com`.
+
+<Aside>
+	Use `allowedDIDs` for individuals and `allowedHandles` with a wildcard for org-level access. The
+	two are additive — list specific external DIDs alongside a wildcard for staff handles.
+</Aside>
+
+### Default role
+
+Allowed users land on the role you set in `defaultRole`. Only the first user — the one who completes setup — is forced to Admin. There's no group/role mapping for Atmosphere accounts; if you need finer-grained roles, change the user's role from **Settings → Users** after they've logged in once.
+
+## First-user setup
+
+When you start a fresh site with the Atmosphere provider configured, the setup wizard offers it as an option for creating the initial admin account.
+
+<Steps>
+
+1. Visit `/_emdash/admin`. The setup wizard takes you through site title, tagline, and admin email.
+
+2. On the "Create admin account" step, choose **Atmosphere** and enter your handle (e.g. `alice.bsky.social`).
+
+3. You'll be redirected to your account's authorization page, where you sign in however your provider supports — password, passkey, or whatever else.
+
+4. After approval you're sent back to EmDash, the admin user is created with role 50 (Admin), and the email you entered in step 1 is stored against your account.
+
+</Steps>
+
+The same flow runs for every subsequent login — handle in, redirect to your provider, redirect back, you're signed in.
+
+## Local development
+
+The AT Protocol OAuth profile requires loopback redirect URIs to use an **IP literal** (`127.0.0.1` or `[::1]`), not `localhost`. EmDash transparently rewrites `://localhost` to `://127.0.0.1` when generating the redirect URI, but that means your dev session needs to start on `127.0.0.1` too — otherwise the session cookie set on `localhost` won't be visible after the redirect lands you on `127.0.0.1`.
+
+Astro's dev server is Vite's dev server, and Vite binds to `localhost` by default. Tell it to listen on the loopback IP as well:
+
+```js title="astro.config.mjs"
+export default defineConfig({
+	server: {
+		host: "127.0.0.1",
+	},
+	// ...
+});
+```
+
+Then open `http://127.0.0.1:4321/_emdash/admin` for the whole flow.
+
+<Aside type="caution">
+	If you stay on `http://localhost:4321`, the round-trip to your provider succeeds but you arrive
+	back on `127.0.0.1` with no session cookie and bounce back to the login page. This is a
+	dev-server-binding issue, not a bug in the auth flow.
+</Aside>
+
+## Production
+
+There's nothing extra to configure for production. The provider serves its own client metadata at:
+
+```
+https://your-site.example.com/.well-known/atproto-client-metadata.json
+```
+
+Authorization servers fetch this URL during the login dance to verify the client's redirect URI. Make sure your deployment's site URL is reachable on the public internet over HTTPS — internal-only deployments behind a VPN won't be able to complete a login because the user's authorization server can't fetch the metadata document.
+
+If you run EmDash behind a TLS-terminating reverse proxy, set [`siteUrl`](/reference/configuration#siteurl) so EmDash builds the right redirect URI. Without it, requests look like `http://internal-host:4321` and the metadata won't match what the auth server sees.
+
+## Troubleshooting
+
+### "Account is not in the allowlist"
+
+The handle or DID you signed in with isn't in `allowedDIDs` / `allowedHandles`. Check the wildcard pattern (it must start with `*.`) and remember the handle match is verified against DNS/HTTP — if the handle's DID record doesn't currently resolve to the same DID the provider returned, the match is rejected.
+
+### "Self-signup is not allowed"
+
+You hit the callback successfully but no allowlist is configured and you aren't the first user. Either add yourself to `allowedDIDs`/`allowedHandles`, or have an existing admin invite you so the user already exists when you log in.
+
+### Login redirects to the login page with no error
+
+This is almost always the loopback-cookie issue described in [Local development](#local-development). Open the admin at `http://127.0.0.1:4321` (after setting `server.host: "127.0.0.1"`) and try again.
+
+### Handle resolution fails for a self-hosted handle
+
+The provider verifies handles by racing DNS-over-HTTPS (Cloudflare's DoH endpoint) and an HTTP `/.well-known/atproto-did` lookup. Self-hosted handles need at least one of:
+
+- A `_atproto.<handle>` DNS TXT record containing `did=<your-did>`, or
+- An `https://<handle>/.well-known/atproto-did` file containing the DID.
+
+If both methods fail, the handle match is rejected even when the underlying account is valid. DIDs in `allowedDIDs` aren't affected — they're matched directly.

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -1,13 +1,15 @@
 ---
 title: Authentication
-description: Passkey-first authentication for your EmDash site.
+description: Passkey-first authentication with pluggable providers for GitHub, Google, and the Atmosphere.
 ---
 
 import { Aside, Steps, Tabs, TabItem, Code } from "@astrojs/starlight/components";
 
 EmDash uses passkey authentication as its primary login method. Passkeys are phishing-resistant, don't require passwords, and work across devices through your browser or password manager.
 
-For Cloudflare deployments, you can optionally use [Cloudflare Access](#cloudflare-access) as an alternative authentication provider.
+Beyond passkeys, you can add **pluggable login providers** — GitHub, Google, and [the Atmosphere](/guides/atmosphere-auth/) (AT Protocol) ship out of the box, and the same provider interface is open for third-party packages. Any configured provider can be used to create the first admin account, log in, or link to an existing user.
+
+For Cloudflare deployments, [Cloudflare Access](#cloudflare-access) is also available as an exclusive auth method that takes over the entire login flow.
 
 ## How It Works
 
@@ -87,11 +89,113 @@ If you can't use your passkey (e.g., lost device), magic links provide an altern
 	Magic links are single-use and expire after 15 minutes. Request a new link if yours has expired.
 </Aside>
 
-## OAuth Login
+## Login Providers
 
-EmDash supports OAuth login with GitHub and Google when configured. Users can link their accounts after initial passkey setup.
+In addition to passkeys, EmDash supports pluggable login providers that appear on the login page and in the setup wizard. GitHub, Google, and Atmosphere providers ship in the box; third-party packages can register their own using the same interface.
 
-See the [Configuration guide](/reference/configuration#oauth) for setup instructions.
+Providers are additive — passkeys keep working when providers are enabled, and users can link a provider to an existing passkey-only account. The first user can also be created through any configured provider, so a fresh install can skip passkeys entirely if you prefer.
+
+### Configuring providers
+
+Pass providers to the `authProviders` array on the EmDash integration:
+
+```js title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import { github } from "emdash/auth/providers/github";
+import { google } from "emdash/auth/providers/google";
+import { atproto } from "@emdash-cms/auth-atproto";
+
+export default defineConfig({
+	integrations: [
+		emdash({
+			authProviders: [github(), google(), atproto()],
+		}),
+	],
+});
+```
+
+Order matters for the login page: providers render in the order you list them, with compact button-only providers first and providers that need a custom form (like Atmosphere, which asks for a handle) shown after.
+
+### GitHub
+
+```js
+import { github } from "emdash/auth/providers/github";
+
+emdash({ authProviders: [github()] });
+```
+
+Set credentials via environment variables. EmDash checks the prefixed names first and falls back to the unprefixed ones:
+
+| Variable                                                      | Purpose                |
+| ------------------------------------------------------------- | ---------------------- |
+| `EMDASH_OAUTH_GITHUB_CLIENT_ID` / `GITHUB_CLIENT_ID`          | OAuth app client ID    |
+| `EMDASH_OAUTH_GITHUB_CLIENT_SECRET` / `GITHUB_CLIENT_SECRET`  | OAuth app secret       |
+
+Configure your GitHub OAuth app's callback URL as `https://your-site.example.com/_emdash/api/auth/oauth/github/callback`.
+
+### Google
+
+```js
+import { google } from "emdash/auth/providers/google";
+
+emdash({ authProviders: [google()] });
+```
+
+| Variable                                                      | Purpose                |
+| ------------------------------------------------------------- | ---------------------- |
+| `EMDASH_OAUTH_GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_ID`          | OAuth app client ID    |
+| `EMDASH_OAUTH_GOOGLE_CLIENT_SECRET` / `GOOGLE_CLIENT_SECRET`  | OAuth app secret       |
+
+Configure your Google OAuth client's redirect URI as `https://your-site.example.com/_emdash/api/auth/oauth/google/callback`.
+
+### Atmosphere (AT Protocol)
+
+For sites where contributors already have an account on the AT Protocol network — the same identity that powers Bluesky and a growing collection of other apps — install the Atmosphere provider:
+
+```bash
+pnpm add @emdash-cms/auth-atproto
+```
+
+```js
+import { atproto } from "@emdash-cms/auth-atproto";
+
+emdash({
+	authProviders: [
+		atproto({
+			allowedHandles: ["*.example.com"],
+		}),
+	],
+});
+```
+
+No client secret or environment variable is needed. See the [Atmosphere login guide](/guides/atmosphere-auth/) for handle/DID allowlists, role mapping, and the local-development setup that the AT Protocol OAuth profile requires.
+
+### Building your own provider
+
+A provider is just an `AuthProviderDescriptor` — an `id`, a human label, and any combination of admin-side React components, route handlers, public route prefixes, and storage collections. The shape is exported from `emdash`:
+
+```ts
+import type { AuthProviderDescriptor } from "emdash";
+
+export function myProvider(): AuthProviderDescriptor {
+	return {
+		id: "my-provider",
+		label: "My Provider",
+		adminEntry: "my-provider/admin", // exports LoginButton / LoginForm / SetupStep
+		routes: [
+			{ pattern: "/_emdash/api/auth/my-provider/login", entrypoint: "my-provider/routes/login.ts" },
+			{ pattern: "/_emdash/api/auth/my-provider/callback", entrypoint: "my-provider/routes/callback.ts" },
+		],
+		publicRoutes: ["/_emdash/api/auth/my-provider/"],
+		storage: {
+			sessions: {},
+		},
+	};
+}
+```
+
+The Atmosphere package (`@emdash-cms/auth-atproto`) is the most complete real-world reference for a provider that needs a custom login form, OAuth route handlers, and persistent storage.
 
 ## User Roles
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -133,44 +133,40 @@ The admin CSS uses the `--font-emdash` CSS variable. This is set automatically b
 **Optional.** Authentication configuration.
 
 ```js
-auth: {
-  // Self-signup configuration
-  selfSignup: {
-    domains: ["example.com"],
-    defaultRole: 20, // Contributor
-  },
-  
-  // OAuth providers
-  oauth: {
-    github: {
-      clientId: process.env.GITHUB_CLIENT_ID,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    },
-    google: {
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    },
-  },
-  
-  // Session configuration
-  session: {
-    maxAge: 30 * 24 * 60 * 60, // 30 days
-    sliding: true, // Reset expiry on activity
-  },
-  
-  // OR use Cloudflare Access (exclusive mode)
-  cloudflareAccess: {
-    teamDomain: "myteam.cloudflareaccess.com",
-    audience: "your-app-audience-tag",
-    autoProvision: true,
-    defaultRole: 30,
-    syncRoles: false,
-    roleMapping: {
-      "Admins": 50,
-      "Editors": 40,
-    },
-  },
-}
+import { github } from "emdash/auth/providers/github";
+import { google } from "emdash/auth/providers/google";
+import { atproto } from "@emdash-cms/auth-atproto";
+
+emdash({
+	auth: {
+		// Self-signup configuration
+		selfSignup: {
+			domains: ["example.com"],
+			defaultRole: 20, // Contributor
+		},
+
+		// Session configuration
+		session: {
+			maxAge: 30 * 24 * 60 * 60, // 30 days
+			sliding: true, // Reset expiry on activity
+		},
+
+		// OR use Cloudflare Access (exclusive mode)
+		cloudflareAccess: {
+			teamDomain: "myteam.cloudflareaccess.com",
+			audience: "your-app-audience-tag",
+			autoProvision: true,
+			defaultRole: 30,
+			syncRoles: false,
+			roleMapping: {
+				Admins: 50,
+				Editors: 40,
+			},
+		},
+	},
+	// Pluggable login providers (top-level, not nested under `auth`)
+	authProviders: [github(), google(), atproto()],
+});
 ```
 
 #### `auth.selfSignup`
@@ -189,22 +185,27 @@ selfSignup: {
 }
 ```
 
-#### `auth.oauth`
+### `authProviders`
 
-Configure OAuth login providers.
+**Optional.** An array of pluggable login providers (top-level, alongside `auth`). Each entry is the result of calling a provider factory:
 
 ```js
-oauth: {
-  github: {
-    clientId: process.env.GITHUB_CLIENT_ID,
-    clientSecret: process.env.GITHUB_CLIENT_SECRET,
-  },
-  google: {
-    clientId: process.env.GOOGLE_CLIENT_ID,
-    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-  },
-}
+import { github } from "emdash/auth/providers/github";
+import { google } from "emdash/auth/providers/google";
+import { atproto } from "@emdash-cms/auth-atproto";
+
+emdash({
+	authProviders: [github(), google(), atproto()],
+});
 ```
+
+Built-in providers:
+
+- `github()` — reads `EMDASH_OAUTH_GITHUB_CLIENT_ID` / `EMDASH_OAUTH_GITHUB_CLIENT_SECRET` (or unprefixed fallbacks).
+- `google()` — reads `EMDASH_OAUTH_GOOGLE_CLIENT_ID` / `EMDASH_OAUTH_GOOGLE_CLIENT_SECRET`.
+- `atproto()` — Atmosphere/AT Protocol login. No env vars needed. Accepts `{ allowedDIDs, allowedHandles, defaultRole }`. See the [Atmosphere login guide](/guides/atmosphere-auth/).
+
+Third-party packages can register their own providers using the same `AuthProviderDescriptor` shape — see [Login Providers](/guides/authentication/#login-providers).
 
 #### `auth.session`
 

--- a/packages/auth-atproto/README.md
+++ b/packages/auth-atproto/README.md
@@ -1,0 +1,63 @@
+# @emdash-cms/auth-atproto
+
+Atmosphere/AT Protocol login provider for [EmDash](https://emdashcms.com). Lets users sign in to your EmDash admin with their [Atmosphere account](https://atmosphereaccount.com) — the same identity behind [Bluesky](https://bsky.app) and the wider AT Protocol network.
+
+No client secrets, no OAuth-app registration. Users authenticate at their own provider; EmDash never sees a password.
+
+## Installation
+
+```shell
+pnpm add @emdash-cms/auth-atproto
+```
+
+## Quick Start
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+import { atproto } from "@emdash-cms/auth-atproto";
+
+export default defineConfig({
+	server: {
+		host: "127.0.0.1", // required for local dev — see below
+	},
+	integrations: [
+		emdash({
+			authProviders: [atproto()],
+		}),
+	],
+});
+```
+
+This adds **Sign in with Atmosphere** to the login page and the setup wizard. With no allowlist, the first user becomes Admin and self-signup is closed for everyone after that.
+
+## Configuration
+
+```js
+atproto({
+	allowedDIDs: ["did:plc:abc123..."],
+	allowedHandles: ["*.example.com", "alice.bsky.social"],
+	defaultRole: 30, // Author
+});
+```
+
+| Option           | Type       | Default           | Description                                                                 |
+| ---------------- | ---------- | ----------------- | --------------------------------------------------------------------------- |
+| `allowedDIDs`    | `string[]` | —                 | DID allowlist. DIDs are permanent and can't be spoofed.                     |
+| `allowedHandles` | `string[]` | —                 | Handle allowlist. Supports leading-wildcard patterns (`*.example.com`).     |
+| `defaultRole`    | `number`   | `10` (Subscriber) | Role assigned to allowed users after the first. First user is always Admin. |
+
+If both lists are set, a user matching either is admitted. Handle matches are independently verified against the handle's DNS/HTTP record before being trusted.
+
+## Local development
+
+The AT Protocol OAuth profile requires loopback redirect URIs to use the IP literal `127.0.0.1` rather than `localhost`. Vite (the dev server Astro uses) binds to `localhost` by default, so set `server.host` to `127.0.0.1` and visit `http://127.0.0.1:4321/_emdash/admin` for the whole flow. Otherwise the cookie set on `localhost` won't be visible after the redirect lands you on `127.0.0.1`.
+
+## Production
+
+The provider serves its own OAuth client metadata at `/.well-known/atproto-client-metadata.json`. Authorization servers fetch this URL during login, so your deployment needs to be reachable on the public internet over HTTPS. Set [`siteUrl`](https://docs.emdashcms.com/reference/configuration#siteurl) if you're behind a TLS-terminating reverse proxy.
+
+## Documentation
+
+See the [Atmosphere login guide](https://docs.emdashcms.com/guides/atmosphere-auth/) for the full reference, including allowlist semantics, role assignment, and troubleshooting.


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the pluggable auth provider system and the `@emdash-cms/auth-atproto` package, both of which shipped recently with no docs coverage.

- `docs/src/content/docs/guides/authentication.mdx`: replaces the 3-line "OAuth Login" stub with a real **Login Providers** section — how to register providers, the built-in `github()` / `google()` factories with their env vars, a pointer to Atmosphere, and the `AuthProviderDescriptor` shape for third-party providers.
- `docs/src/content/docs/guides/atmosphere-auth.mdx` (new): full Atmosphere login guide. Covers install, allowlists (DID + handle, with how the handle DNS/HTTP verification works), `defaultRole`, first-user setup flow, the AT-Protocol-mandated `127.0.0.1` loopback for local dev, production behavior (`/.well-known/atproto-client-metadata.json`, `siteUrl` behind a proxy), and troubleshooting.
- `docs/src/content/docs/reference/configuration.mdx`: replaces the stale `auth.oauth` config block with the current top-level `authProviders` array.
- `docs/astro.config.mjs`: links the new Atmosphere page into the Guides sidebar.
- `packages/auth-atproto/README.md` (new): package README pointing at the guide. (Not in the published tarball — `package.json` `files` is `["src"]` — so no changeset needed.)

Terminology in the Atmosphere doc follows current Atmosphere/AT Protocol conventions (e.g. atmosphereaccount.com): "Atmosphere account", "handle", "provider"; technical identifiers like DID and PDS only appear where they're load-bearing for configuration.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (docs-only change; `astro check` clean)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — N/A, docs-only
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A, docs + non-shipped README only
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

`pnpm --silent lint:json | jq '.diagnostics | length'` → `0`
`pnpm astro check` (in `docs/`) → 0 errors / 0 warnings / 0 hints