### PR TITLE
fix(marketplace): allow content:afterPublish and content:afterUnpublish hooks

### DIFF
--- a/packages/marketplace/src/routes/author.ts
+++ b/packages/marketplace/src/routes/author.ts
@@ -766,6 +766,8 @@ const VALID_HOOKS = [
 	"content:afterSave",
 	"content:beforeDelete",
 	"content:afterDelete",
+	"content:afterPublish",
+	"content:afterUnpublish",
 	"media:beforeUpload",
 	"media:afterUpload",
 	"cron",


### PR DESCRIPTION
## What does this PR do?

The marketplace's `VALID_HOOKS` allowlist (in `packages/marketplace/src/routes/author.ts`) drifted out of sync with `HOOK_NAMES` in `packages/core/src/plugins/manifest-schema.ts`. Two hook names — `content:afterPublish` and `content:afterUnpublish` — were added to core but never copied over, so any plugin that registers them is rejected at publish time with `Invalid manifest: hooks.N: Invalid input`.

This caught the **atproto plugin's** seed-publish job on main: it registers `content:afterPublish` and was failing the post-merge `Seed Plugins` step. Local builds and the runtime hook system accept the hook fine, so it only surfaces at the marketplace boundary.

The file already has a comment that explicitly says "Must stay in sync with HOOK_NAMES in packages/core/src/plugins/manifest-schema.ts" — this PR brings it back in sync. Two lines added.

There's a separate question of whether to deduplicate the list (export `HOOK_NAMES` from core and import it in the marketplace, or assert equality in a snapshot test) so this can't drift again. Happy to do that as a follow-up if it's worth it; this PR is the minimal fix to unblock publishing.

Failing run for reference: https://github.com/emdash-cms/emdash/actions/runs/24978998995/job/73136789799

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`@emdash-cms/marketplace` typecheck clean)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes — `pnpm --filter @emdash-cms/marketplace test` 48/48 green
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — no new test; the existing publish-e2e suite covers the path. A guard test that asserts `VALID_HOOKS` matches core's `HOOK_NAMES` would be the right follow-up if we don't go the dedup route.
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A, server-side validator only
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A, `@emdash-cms/marketplace` is `private: true` (Worker, not published)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
> @emdash-cms/marketplace@0.0.1 test
Test Files  5 passed (5)
     Tests  48 passed (48)
```