### PR TITLE
feat(create-emdash): support scaffolding into current directory with `.`

### DIFF
--- a/.changeset/late-suits-rescue.md
+++ b/.changeset/late-suits-rescue.md
@@ -1,0 +1,5 @@
+---
+"create-emdash": minor
+---
+
+Adds support for positional directory argument, allowing `npm create emdash .` to scaffold into the current directory and `npm create emdash my-project` to skip the interactive name prompt.

--- a/packages/create-emdash/package.json
+++ b/packages/create-emdash/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
@@ -20,7 +21,8 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "keywords": [
     "create",

--- a/packages/create-emdash/src/index.ts
+++ b/packages/create-emdash/src/index.ts
@@ -3,12 +3,12 @@
  *
  * Interactive CLI for creating new EmDash projects
  *
- * Usage: npm create emdash@latest
+ * Usage: npm create emdash@latest [directory]
  */
 
 import { exec } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
@@ -17,7 +17,14 @@ import * as p from "@clack/prompts";
 import { downloadTemplate } from "giget";
 import pc from "picocolors";
 
-const PROJECT_NAME_PATTERN = /^[a-z0-9-]+$/;
+import {
+	PROJECT_NAME_PATTERN,
+	isDirNonEmpty,
+	parseTargetArg,
+	sanitizePackageName,
+} from "./utils.js";
+
+const targetArg = parseTargetArg(process.argv);
 
 const GITHUB_REPO = "emdash-cms/templates";
 
@@ -138,34 +145,78 @@ async function main() {
 	console.log(`\n  ${pc.bold(pc.cyan("— E M D A S H —"))}\n`);
 	p.intro("Create a new EmDash project");
 
-	const projectName = await p.text({
-		message: "Project name?",
-		placeholder: "my-site",
-		defaultValue: "my-site",
-		validate: (value) => {
-			if (!value) return "Project name is required";
-			if (!PROJECT_NAME_PATTERN.test(value))
-				return "Project name can only contain lowercase letters, numbers, and hyphens";
-			return undefined;
-		},
-	});
+	const isCurrentDir = targetArg === ".";
+	let projectName: string;
+	let projectDir: string;
 
-	if (p.isCancel(projectName)) {
-		p.cancel("Operation cancelled.");
-		process.exit(0);
-	}
+	if (isCurrentDir) {
+		// "npm create emdash ." — scaffold into the current directory
+		projectDir = process.cwd();
+		projectName = sanitizePackageName(basename(projectDir));
 
-	const projectDir = resolve(process.cwd(), projectName);
+		if (isDirNonEmpty(projectDir)) {
+			const proceed = await p.confirm({
+				message: "Current directory is not empty. Files may be overwritten. Continue?",
+				initialValue: false,
+			});
 
-	if (existsSync(projectDir)) {
-		const overwrite = await p.confirm({
-			message: `Directory ${projectName} already exists. Overwrite?`,
-			initialValue: false,
+			if (p.isCancel(proceed) || !proceed) {
+				p.cancel("Operation cancelled.");
+				process.exit(0);
+			}
+		}
+	} else if (targetArg) {
+		// "npm create emdash my-project" — use the argument as the project name
+		if (!PROJECT_NAME_PATTERN.test(targetArg)) {
+			p.cancel("Project name can only contain lowercase letters, numbers, and hyphens.");
+			process.exit(1);
+		}
+		projectName = targetArg;
+		projectDir = resolve(process.cwd(), projectName);
+
+		if (isDirNonEmpty(projectDir)) {
+			const overwrite = await p.confirm({
+				message: `Directory ${projectName} already exists and is not empty. Files may be overwritten. Continue?`,
+				initialValue: false,
+			});
+
+			if (p.isCancel(overwrite) || !overwrite) {
+				p.cancel("Operation cancelled.");
+				process.exit(0);
+			}
+		}
+	} else {
+		// No argument — interactive prompt
+		const name = await p.text({
+			message: "Project name?",
+			placeholder: "my-site",
+			defaultValue: "my-site",
+			validate: (value) => {
+				if (!value) return "Project name is required";
+				if (!PROJECT_NAME_PATTERN.test(value))
+					return "Project name can only contain lowercase letters, numbers, and hyphens";
+				return undefined;
+			},
 		});
 
-		if (p.isCancel(overwrite) || !overwrite) {
+		if (p.isCancel(name)) {
 			p.cancel("Operation cancelled.");
 			process.exit(0);
+		}
+
+		projectName = name;
+		projectDir = resolve(process.cwd(), projectName);
+
+		if (isDirNonEmpty(projectDir)) {
+			const overwrite = await p.confirm({
+				message: `Directory ${projectName} already exists and is not empty. Files may be overwritten. Continue?`,
+				initialValue: false,
+			});
+
+			if (p.isCancel(overwrite) || !overwrite) {
+				p.cancel("Operation cancelled.");
+				process.exit(0);
+			}
 		}
 	}
 
@@ -263,17 +314,26 @@ async function main() {
 				s.stop("Dependencies installed!");
 			} catch {
 				s.stop("Failed to install dependencies");
-				p.log.warn(`Run ${pc.cyan(`cd ${projectName} && ${installCmd}`)} manually`);
+				p.log.warn(
+					isCurrentDir
+						? `Run ${pc.cyan(installCmd)} manually`
+						: `Run ${pc.cyan(`cd ${projectName} && ${installCmd}`)} manually`,
+				);
 			}
 		}
 
-		const steps = [`cd ${projectName}`];
+		const steps: string[] = [];
+		if (!isCurrentDir) steps.push(`cd ${projectName}`);
 		if (!shouldInstall) steps.push(installCmd);
 		steps.push(runCmd("dev"));
 
 		p.note(steps.join("\n"), "Next steps");
 
-		p.outro(`${pc.green("Done!")} Your EmDash project is ready at ${pc.cyan(projectName)}`);
+		p.outro(
+			isCurrentDir
+				? `${pc.green("Done!")} Your EmDash project is ready in the current directory`
+				: `${pc.green("Done!")} Your EmDash project is ready at ${pc.cyan(projectName)}`,
+		);
 	} catch (error) {
 		s.stop("Failed to create project");
 		p.log.error(error instanceof Error ? error.message : String(error));

--- a/packages/create-emdash/src/utils.ts
+++ b/packages/create-emdash/src/utils.ts
@@ -1,0 +1,30 @@
+import { readdirSync } from "node:fs";
+
+export const PROJECT_NAME_PATTERN = /^[a-z0-9-]+$/;
+const INVALID_PKG_NAME_CHARS = /[^a-z0-9-]/g;
+const LEADING_TRAILING_HYPHENS = /^-+|-+$/g;
+
+/** Sanitise a directory basename into a valid npm package name */
+export function sanitizePackageName(name: string): string {
+	return (
+		name.toLowerCase().replace(INVALID_PKG_NAME_CHARS, "-").replace(LEADING_TRAILING_HYPHENS, "") ||
+		"my-site"
+	);
+}
+
+/** Check whether a directory exists and contains files */
+export function isDirNonEmpty(dir: string): boolean {
+	try {
+		return readdirSync(dir).length > 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Parse the first positional argument (not a flag) from an argv array.
+ * Returns undefined if no positional argument is found.
+ */
+export function parseTargetArg(argv: string[]): string | undefined {
+	return argv.slice(2).find((a) => !a.startsWith("-"));
+}

--- a/packages/create-emdash/tests/utils.test.ts
+++ b/packages/create-emdash/tests/utils.test.ts
@@ -1,0 +1,183 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	PROJECT_NAME_PATTERN,
+	isDirNonEmpty,
+	parseTargetArg,
+	sanitizePackageName,
+} from "../src/utils.js";
+
+// ---------------------------------------------------------------------------
+// sanitizePackageName
+// ---------------------------------------------------------------------------
+describe("sanitizePackageName", () => {
+	it("passes through a valid lowercase name unchanged", () => {
+		expect(sanitizePackageName("my-site")).toBe("my-site");
+	});
+
+	it("lowercases uppercase characters", () => {
+		expect(sanitizePackageName("My-Site")).toBe("my-site");
+	});
+
+	it("replaces spaces with hyphens", () => {
+		expect(sanitizePackageName("my cool site")).toBe("my-cool-site");
+	});
+
+	it("replaces dots with hyphens", () => {
+		expect(sanitizePackageName("my.site")).toBe("my-site");
+	});
+
+	it("replaces underscores with hyphens", () => {
+		expect(sanitizePackageName("my_site")).toBe("my-site");
+	});
+
+	it("strips leading hyphens", () => {
+		expect(sanitizePackageName("--my-site")).toBe("my-site");
+	});
+
+	it("strips trailing hyphens", () => {
+		expect(sanitizePackageName("my-site--")).toBe("my-site");
+	});
+
+	it("strips both leading and trailing hyphens", () => {
+		expect(sanitizePackageName("---my-site---")).toBe("my-site");
+	});
+
+	it("handles mixed invalid characters", () => {
+		expect(sanitizePackageName("My Cool Site!@#2024")).toBe("my-cool-site---2024");
+	});
+
+	it("handles a name that is entirely invalid characters", () => {
+		expect(sanitizePackageName("!!!")).toBe("my-site");
+	});
+
+	it("handles an empty string", () => {
+		expect(sanitizePackageName("")).toBe("my-site");
+	});
+
+	it("handles a single period (basename of root on some systems)", () => {
+		// basename("/") on some platforms can return "/" which sanitises to "my-site"
+		// but basename of a relative "." is ".", which becomes empty after stripping
+		expect(sanitizePackageName(".")).toBe("my-site");
+	});
+
+	it("handles names starting with numbers", () => {
+		expect(sanitizePackageName("123-project")).toBe("123-project");
+	});
+
+	it("handles unicode characters", () => {
+		expect(sanitizePackageName("mön-prøject")).toBe("m-n-pr-ject");
+	});
+
+	it("collapses multiple consecutive invalid chars into individual hyphens", () => {
+		// Each invalid char becomes a separate hyphen – no collapsing
+		expect(sanitizePackageName("a   b")).toBe("a---b");
+	});
+
+	it("handles CamelCase directory names", () => {
+		expect(sanitizePackageName("MyProject")).toBe("myproject");
+	});
+
+	it("handles paths that look like scoped packages", () => {
+		// The @ and / are both invalid, so they become hyphens
+		expect(sanitizePackageName("@scope/package")).toBe("scope-package");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PROJECT_NAME_PATTERN
+// ---------------------------------------------------------------------------
+describe("PROJECT_NAME_PATTERN", () => {
+	const valid = ["my-site", "blog", "a", "123", "my-cool-site-2"];
+	const invalid = ["My-Site", "my site", "my.site", "my_site", ".", ".hidden", "@scope/pkg", ""];
+
+	for (const name of valid) {
+		it(`accepts "${name}"`, () => {
+			expect(PROJECT_NAME_PATTERN.test(name)).toBe(true);
+		});
+	}
+
+	for (const name of invalid) {
+		it(`rejects "${name}"`, () => {
+			expect(PROJECT_NAME_PATTERN.test(name)).toBe(false);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// parseTargetArg
+// ---------------------------------------------------------------------------
+describe("parseTargetArg", () => {
+	it("returns undefined when no arguments are passed", () => {
+		// process.argv always has at least [node, script]
+		expect(parseTargetArg(["node", "script.js"])).toBeUndefined();
+	});
+
+	it('returns "." when a dot is the first positional argument', () => {
+		expect(parseTargetArg(["node", "script.js", "."])).toBe(".");
+	});
+
+	it("returns the project name when passed as a positional argument", () => {
+		expect(parseTargetArg(["node", "script.js", "my-project"])).toBe("my-project");
+	});
+
+	it("skips flags and returns the first positional argument", () => {
+		expect(parseTargetArg(["node", "script.js", "--verbose", "my-project"])).toBe("my-project");
+	});
+
+	it("skips all flags when no positional argument exists", () => {
+		expect(parseTargetArg(["node", "script.js", "--verbose", "--debug"])).toBeUndefined();
+	});
+
+	it("returns the first positional argument when multiple are passed", () => {
+		expect(parseTargetArg(["node", "script.js", "first", "second"])).toBe("first");
+	});
+
+	it("treats a single-hyphen flag as a flag, not a positional arg", () => {
+		expect(parseTargetArg(["node", "script.js", "-v", "my-project"])).toBe("my-project");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isDirNonEmpty
+// ---------------------------------------------------------------------------
+describe("isDirNonEmpty", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "create-emdash-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns false for an empty directory", () => {
+		expect(isDirNonEmpty(tempDir)).toBe(false);
+	});
+
+	it("returns true for a directory with files", () => {
+		writeFileSync(join(tempDir, "file.txt"), "hello");
+		expect(isDirNonEmpty(tempDir)).toBe(true);
+	});
+
+	it("returns true for a directory with subdirectories", () => {
+		mkdirSync(join(tempDir, "subdir"));
+		expect(isDirNonEmpty(tempDir)).toBe(true);
+	});
+
+	it("returns false for a non-existent path", () => {
+		expect(isDirNonEmpty(join(tempDir, "does-not-exist"))).toBe(false);
+	});
+
+	it("returns false for a path that is a file, not a directory", () => {
+		const filePath = join(tempDir, "a-file.txt");
+		writeFileSync(filePath, "content");
+		// readdirSync on a file throws ENOTDIR, which the catch handles
+		expect(isDirNonEmpty(filePath)).toBe(false);
+	});
+});

--- a/packages/create-emdash/vitest.config.ts
+++ b/packages/create-emdash/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 13.1.7(@types/node@24.10.13)(astro@6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(wrangler@4.80.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.8.2)
+        version: 13.1.7(@types/node@24.10.13)(astro@6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.8.2)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 5.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)
@@ -242,7 +242,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: 'catalog:'
-        version: 13.1.7(@types/node@24.10.13)(astro@6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(workerd@1.20260401.1)(wrangler@4.80.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.8.2)
+        version: 13.1.7(@types/node@24.10.13)(astro@6.0.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.55.2)(tsx@4.21.0)(typescript@6.0.0-beta)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(wrangler@4.80.0(@cloudflare/workers-types@4.20260305.1))(yaml@2.8.2)
       '@astrojs/react':
         specifier: 'catalog:'
         version: 5.0.0(@types/node@24.10.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)
@@ -1189,6 +1189,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@types/node@24.10.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/gutenberg-to-portable-text:
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Adds support for an optional positional directory argument to `create-emdash`, allowing users to scaffold a project into the current directory or skip the interactive name prompt. Inspired by `create-astro` which supports the same convention.

```bash
npm create emdash .          # scaffold into cwd
npm create emdash my-project # skip name prompt, use "my-project"
npm create emdash            # interactive prompt (unchanged)
```

When `.` is passed:
- The "Project name?" prompt is skipped entirely
- The `package.json` name is derived from the directory basename (sanitised to a valid npm name)
- If the directory is non-empty, a confirmation prompt asks "Current directory is not empty. Files may be overwritten. Continue?"
- "Next steps" omits the `cd` instruction since the user is already there
- The outro says "ready in the current directory" instead of "ready at `<name>`"

When a named argument is passed (e.g. `my-project`):
- The name prompt is skipped, the argument is validated against the existing pattern
- If the target directory already exists **and is non-empty**, a confirmation prompt is shown
- Empty existing directories are silently accepted (the user likely created it intentionally)

All three code paths (dot, named arg, interactive) now use `isDirNonEmpty` instead of `existsSync` for the overwrite check, so empty directories no longer trigger a misleading "already exists" prompt.

Closes https://github.com/emdash-cms/emdash/discussions/240

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/240

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
 ✓ tests/utils.test.ts (42 tests) 4ms

 Test Files  1 passed (1)
      Tests  42 passed (42)
   Start at  09:42:38
   Duration  233ms
```