### PR TITLE
perf(templates): batch term queries and use FTS for blog search

### DIFF
--- a/demos/cloudflare/emdash-env.d.ts
+++ b/demos/cloudflare/emdash-env.d.ts
@@ -10,7 +10,6 @@ export interface Page {
   slug: string | null;
   status: string;
   title: string;
-  template?: "Default" | "Full Width";
   content?: PortableTextBlock[];
   createdAt: Date;
   updatedAt: Date;

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -7,8 +7,9 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
-import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
 interface Props {
@@ -39,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const siteTitle = "My Blog";
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -78,6 +79,7 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash
@@ -97,7 +99,12 @@ const isLoggedIn = !!Astro.locals.user;
 		<EmDashBodyStart page={pageCtx} />
 		<header class="site-header">
 			<nav class="nav">
-				<a href="/" class="site-title">{siteTitle}</a>
+				<a href="/" class="site-title">
+					{siteLogo
+						? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						: siteTitle
+					}
+				</a>
 				<div class="nav-right">
 					<LiveSearch
 						placeholder="Search..."
@@ -135,8 +142,13 @@ const isLoggedIn = !!Astro.locals.user;
 			<div class="footer-inner">
 				<div class="footer-grid">
 					<div class="footer-brand">
-						<a href="/" class="footer-logo">{siteTitle}</a>
-						<p class="footer-tagline">Thoughts, stories, and ideas.</p>
+						<a href="/" class="footer-logo">
+							{siteLogo
+								? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="footer-logo-img" />
+								: siteTitle
+							}
+						</a>
+						<p class="footer-tagline">{siteTagline}</p>
 					</div>
 					<div class="footer-nav">
 						<h4 class="footer-heading">Navigate</h4>
@@ -331,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -481,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 
@@ -582,6 +603,13 @@ const isLoggedIn = !!Astro.locals.user;
 
 			.site-title:hover {
 				color: var(--color-accent);
+			}
+
+			.site-logo-img {
+				height: 48px;
+				width: auto;
+				display: block;
+				margin: -8px 0;
 			}
 
 			.nav-right {
@@ -754,6 +782,11 @@ const isLoggedIn = !!Astro.locals.user;
 				color: var(--color-text);
 				text-decoration: none;
 				letter-spacing: var(--tracking-snug);
+			}
+
+			.footer-logo-img {
+				height: 24px;
+				width: auto;
 			}
 
 			.footer-tagline {

--- a/demos/cloudflare/src/pages/category/[slug].astro
+++ b/demos/cloudflare/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/demos/cloudflare/src/pages/index.astro
+++ b/demos/cloudflare/src/pages/index.astro
@@ -1,51 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {
@@ -58,7 +73,7 @@ function formatDate(date: Date | null | undefined) {
 }
 ---
 
-<Base title="My Blog" description="Welcome to my blog">
+<Base title={siteTitle} description={siteTagline}>
 	{
 		posts.length === 0 ? (
 			<section class="empty-state">

--- a/demos/cloudflare/src/pages/posts/[slug].astro
+++ b/demos/cloudflare/src/pages/posts/[slug].astro
@@ -3,8 +3,10 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
+	getSiteSettings,
 } from "emdash";
 import {
 	Image,
@@ -16,6 +18,7 @@ import {
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../../utils/site-identity";
 
 const slug = decodeSlug(Astro.params.slug);
 
@@ -53,18 +56,15 @@ function getImageUrl(img: unknown): string | undefined {
 	return undefined;
 }
 const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveBlogSiteIdentity(await getSiteSettings());
 
 // Generate SEO meta from content
 const seo = getSeoMeta(post, {
-	siteTitle: "My Blog",
+	siteTitle,
 	siteUrl: Astro.url.origin,
 	path: `/posts/${slug}`,
 	defaultOgImage: featuredImageUrl,
 });
-
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
 
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
@@ -72,22 +72,32 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/demos/cloudflare/src/pages/posts/index.astro
+++ b/demos/cloudflare/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/demos/cloudflare/src/pages/rss.xml.ts
+++ b/demos/cloudflare/src/pages/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
-import { getEmDashCollection } from "emdash";
+import { getEmDashCollection, getSiteSettings } from "emdash";
 
-const siteTitle = "My Blog";
-const siteDescription = "A blog about software, design, and the occasional stray thought.";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
 export const GET: APIRoute = async ({ site, url }) => {
 	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
 
 	const { entries: posts } = await getEmDashCollection("posts", {
 		orderBy: { published_at: "desc" },
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ site, url }) => {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteTitle)}</title>
-    <description>${escapeXml(siteDescription)}</description>
+    <description>${escapeXml(siteTagline)}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
     <language>en-us</language>

--- a/demos/cloudflare/src/pages/search.astro
+++ b/demos/cloudflare/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/demos/cloudflare/src/pages/tag/[slug].astro
+++ b/demos/cloudflare/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/demos/cloudflare/src/styles/theme.css
+++ b/demos/cloudflare/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/demos/cloudflare/src/utils/site-identity.ts
+++ b/demos/cloudflare/src/utils/site-identity.ts
@@ -1,0 +1,25 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface BlogSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "My Blog";
+const DEFAULT_SITE_TAGLINE = "Thoughts, stories, and ideas.";
+
+export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/demos/playground/src/layouts/Base.astro
+++ b/demos/playground/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -7,8 +7,9 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
-import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
 interface Props {
@@ -39,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const siteTitle = "My Blog";
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -78,6 +79,7 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash
@@ -97,7 +99,12 @@ const isLoggedIn = !!Astro.locals.user;
 		<EmDashBodyStart page={pageCtx} />
 		<header class="site-header">
 			<nav class="nav">
-				<a href="/" class="site-title">{siteTitle}</a>
+				<a href="/" class="site-title">
+					{siteLogo
+						? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						: siteTitle
+					}
+				</a>
 				<div class="nav-right">
 					<LiveSearch
 						placeholder="Search..."
@@ -135,8 +142,13 @@ const isLoggedIn = !!Astro.locals.user;
 			<div class="footer-inner">
 				<div class="footer-grid">
 					<div class="footer-brand">
-						<a href="/" class="footer-logo">{siteTitle}</a>
-						<p class="footer-tagline">Thoughts, stories, and ideas.</p>
+						<a href="/" class="footer-logo">
+							{siteLogo
+								? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="footer-logo-img" />
+								: siteTitle
+							}
+						</a>
+						<p class="footer-tagline">{siteTagline}</p>
 					</div>
 					<div class="footer-nav">
 						<h4 class="footer-heading">Navigate</h4>
@@ -331,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -481,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 
@@ -582,6 +603,13 @@ const isLoggedIn = !!Astro.locals.user;
 
 			.site-title:hover {
 				color: var(--color-accent);
+			}
+
+			.site-logo-img {
+				height: 48px;
+				width: auto;
+				display: block;
+				margin: -8px 0;
 			}
 
 			.nav-right {
@@ -754,6 +782,11 @@ const isLoggedIn = !!Astro.locals.user;
 				color: var(--color-text);
 				text-decoration: none;
 				letter-spacing: var(--tracking-snug);
+			}
+
+			.footer-logo-img {
+				height: 24px;
+				width: auto;
 			}
 
 			.footer-tagline {

--- a/demos/playground/src/pages/category/[slug].astro
+++ b/demos/playground/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/demos/playground/src/pages/index.astro
+++ b/demos/playground/src/pages/index.astro
@@ -1,51 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {
@@ -58,7 +73,7 @@ function formatDate(date: Date | null | undefined) {
 }
 ---
 
-<Base title="My Blog" description="Welcome to my blog">
+<Base title={siteTitle} description={siteTagline}>
 	{
 		posts.length === 0 ? (
 			<section class="empty-state">

--- a/demos/playground/src/pages/posts/[slug].astro
+++ b/demos/playground/src/pages/posts/[slug].astro
@@ -3,8 +3,10 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
+	getSiteSettings,
 } from "emdash";
 import {
 	Image,
@@ -16,6 +18,7 @@ import {
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../../utils/site-identity";
 
 const slug = decodeSlug(Astro.params.slug);
 
@@ -53,18 +56,15 @@ function getImageUrl(img: unknown): string | undefined {
 	return undefined;
 }
 const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveBlogSiteIdentity(await getSiteSettings());
 
 // Generate SEO meta from content
 const seo = getSeoMeta(post, {
-	siteTitle: "My Blog",
+	siteTitle,
 	siteUrl: Astro.url.origin,
 	path: `/posts/${slug}`,
 	defaultOgImage: featuredImageUrl,
 });
-
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
 
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
@@ -72,22 +72,32 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/demos/playground/src/pages/posts/index.astro
+++ b/demos/playground/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/demos/playground/src/pages/rss.xml.ts
+++ b/demos/playground/src/pages/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
-import { getEmDashCollection } from "emdash";
+import { getEmDashCollection, getSiteSettings } from "emdash";
 
-const siteTitle = "My Blog";
-const siteDescription = "A blog about software, design, and the occasional stray thought.";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
 export const GET: APIRoute = async ({ site, url }) => {
 	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
 
 	const { entries: posts } = await getEmDashCollection("posts", {
 		orderBy: { published_at: "desc" },
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ site, url }) => {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteTitle)}</title>
-    <description>${escapeXml(siteDescription)}</description>
+    <description>${escapeXml(siteTagline)}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
     <language>en-us</language>

--- a/demos/playground/src/pages/search.astro
+++ b/demos/playground/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/demos/playground/src/pages/tag/[slug].astro
+++ b/demos/playground/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/demos/playground/src/styles/theme.css
+++ b/demos/playground/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/demos/playground/src/utils/site-identity.ts
+++ b/demos/playground/src/utils/site-identity.ts
@@ -1,0 +1,25 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface BlogSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "My Blog";
+const DEFAULT_SITE_TAGLINE = "Thoughts, stories, and ideas.";
+
+export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/demos/postgres/src/layouts/Base.astro
+++ b/demos/postgres/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -7,8 +7,9 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
-import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
 interface Props {
@@ -39,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const siteTitle = "My Blog";
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -78,6 +79,7 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash
@@ -97,7 +99,12 @@ const isLoggedIn = !!Astro.locals.user;
 		<EmDashBodyStart page={pageCtx} />
 		<header class="site-header">
 			<nav class="nav">
-				<a href="/" class="site-title">{siteTitle}</a>
+				<a href="/" class="site-title">
+					{siteLogo
+						? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						: siteTitle
+					}
+				</a>
 				<div class="nav-right">
 					<LiveSearch
 						placeholder="Search..."
@@ -135,8 +142,13 @@ const isLoggedIn = !!Astro.locals.user;
 			<div class="footer-inner">
 				<div class="footer-grid">
 					<div class="footer-brand">
-						<a href="/" class="footer-logo">{siteTitle}</a>
-						<p class="footer-tagline">Thoughts, stories, and ideas.</p>
+						<a href="/" class="footer-logo">
+							{siteLogo
+								? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="footer-logo-img" />
+								: siteTitle
+							}
+						</a>
+						<p class="footer-tagline">{siteTagline}</p>
 					</div>
 					<div class="footer-nav">
 						<h4 class="footer-heading">Navigate</h4>
@@ -331,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -481,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 
@@ -582,6 +603,13 @@ const isLoggedIn = !!Astro.locals.user;
 
 			.site-title:hover {
 				color: var(--color-accent);
+			}
+
+			.site-logo-img {
+				height: 48px;
+				width: auto;
+				display: block;
+				margin: -8px 0;
 			}
 
 			.nav-right {
@@ -754,6 +782,11 @@ const isLoggedIn = !!Astro.locals.user;
 				color: var(--color-text);
 				text-decoration: none;
 				letter-spacing: var(--tracking-snug);
+			}
+
+			.footer-logo-img {
+				height: 24px;
+				width: auto;
 			}
 
 			.footer-tagline {

--- a/demos/postgres/src/pages/category/[slug].astro
+++ b/demos/postgres/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/demos/postgres/src/pages/index.astro
+++ b/demos/postgres/src/pages/index.astro
@@ -1,51 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {
@@ -58,7 +73,7 @@ function formatDate(date: Date | null | undefined) {
 }
 ---
 
-<Base title="My Blog" description="Welcome to my blog">
+<Base title={siteTitle} description={siteTagline}>
 	{
 		posts.length === 0 ? (
 			<section class="empty-state">

--- a/demos/postgres/src/pages/posts/[slug].astro
+++ b/demos/postgres/src/pages/posts/[slug].astro
@@ -3,8 +3,10 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
+	getSiteSettings,
 } from "emdash";
 import {
 	Image,
@@ -16,6 +18,7 @@ import {
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../../utils/site-identity";
 
 const slug = decodeSlug(Astro.params.slug);
 
@@ -53,18 +56,15 @@ function getImageUrl(img: unknown): string | undefined {
 	return undefined;
 }
 const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveBlogSiteIdentity(await getSiteSettings());
 
 // Generate SEO meta from content
 const seo = getSeoMeta(post, {
-	siteTitle: "My Blog",
+	siteTitle,
 	siteUrl: Astro.url.origin,
 	path: `/posts/${slug}`,
 	defaultOgImage: featuredImageUrl,
 });
-
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
 
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
@@ -72,22 +72,32 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/demos/postgres/src/pages/posts/index.astro
+++ b/demos/postgres/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/demos/postgres/src/pages/rss.xml.ts
+++ b/demos/postgres/src/pages/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
-import { getEmDashCollection } from "emdash";
+import { getEmDashCollection, getSiteSettings } from "emdash";
 
-const siteTitle = "My Blog";
-const siteDescription = "A blog about software, design, and the occasional stray thought.";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
 export const GET: APIRoute = async ({ site, url }) => {
 	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
 
 	const { entries: posts } = await getEmDashCollection("posts", {
 		orderBy: { published_at: "desc" },
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ site, url }) => {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteTitle)}</title>
-    <description>${escapeXml(siteDescription)}</description>
+    <description>${escapeXml(siteTagline)}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
     <language>en-us</language>

--- a/demos/postgres/src/pages/search.astro
+++ b/demos/postgres/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/demos/postgres/src/pages/tag/[slug].astro
+++ b/demos/postgres/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/demos/postgres/src/styles/theme.css
+++ b/demos/postgres/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/demos/postgres/src/utils/site-identity.ts
+++ b/demos/postgres/src/utils/site-identity.ts
@@ -1,0 +1,25 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface BlogSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "My Blog";
+const DEFAULT_SITE_TAGLINE = "Thoughts, stories, and ideas.";
+
+export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/demos/preview/src/layouts/Base.astro
+++ b/demos/preview/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -7,8 +7,9 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
-import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
 interface Props {
@@ -39,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const siteTitle = "My Blog";
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -78,6 +79,7 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash
@@ -97,7 +99,12 @@ const isLoggedIn = !!Astro.locals.user;
 		<EmDashBodyStart page={pageCtx} />
 		<header class="site-header">
 			<nav class="nav">
-				<a href="/" class="site-title">{siteTitle}</a>
+				<a href="/" class="site-title">
+					{siteLogo
+						? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						: siteTitle
+					}
+				</a>
 				<div class="nav-right">
 					<LiveSearch
 						placeholder="Search..."
@@ -135,8 +142,13 @@ const isLoggedIn = !!Astro.locals.user;
 			<div class="footer-inner">
 				<div class="footer-grid">
 					<div class="footer-brand">
-						<a href="/" class="footer-logo">{siteTitle}</a>
-						<p class="footer-tagline">Thoughts, stories, and ideas.</p>
+						<a href="/" class="footer-logo">
+							{siteLogo
+								? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="footer-logo-img" />
+								: siteTitle
+							}
+						</a>
+						<p class="footer-tagline">{siteTagline}</p>
 					</div>
 					<div class="footer-nav">
 						<h4 class="footer-heading">Navigate</h4>
@@ -331,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -481,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 
@@ -582,6 +603,13 @@ const isLoggedIn = !!Astro.locals.user;
 
 			.site-title:hover {
 				color: var(--color-accent);
+			}
+
+			.site-logo-img {
+				height: 48px;
+				width: auto;
+				display: block;
+				margin: -8px 0;
 			}
 
 			.nav-right {
@@ -754,6 +782,11 @@ const isLoggedIn = !!Astro.locals.user;
 				color: var(--color-text);
 				text-decoration: none;
 				letter-spacing: var(--tracking-snug);
+			}
+
+			.footer-logo-img {
+				height: 24px;
+				width: auto;
 			}
 
 			.footer-tagline {

--- a/demos/preview/src/pages/category/[slug].astro
+++ b/demos/preview/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/demos/preview/src/pages/index.astro
+++ b/demos/preview/src/pages/index.astro
@@ -1,51 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {
@@ -58,7 +73,7 @@ function formatDate(date: Date | null | undefined) {
 }
 ---
 
-<Base title="My Blog" description="Welcome to my blog">
+<Base title={siteTitle} description={siteTagline}>
 	{
 		posts.length === 0 ? (
 			<section class="empty-state">

--- a/demos/preview/src/pages/posts/[slug].astro
+++ b/demos/preview/src/pages/posts/[slug].astro
@@ -3,8 +3,10 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
+	getSiteSettings,
 } from "emdash";
 import {
 	Image,
@@ -16,6 +18,7 @@ import {
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../../utils/site-identity";
 
 const slug = decodeSlug(Astro.params.slug);
 
@@ -53,18 +56,15 @@ function getImageUrl(img: unknown): string | undefined {
 	return undefined;
 }
 const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveBlogSiteIdentity(await getSiteSettings());
 
 // Generate SEO meta from content
 const seo = getSeoMeta(post, {
-	siteTitle: "My Blog",
+	siteTitle,
 	siteUrl: Astro.url.origin,
 	path: `/posts/${slug}`,
 	defaultOgImage: featuredImageUrl,
 });
-
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
 
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
@@ -72,22 +72,32 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/demos/preview/src/pages/posts/index.astro
+++ b/demos/preview/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/demos/preview/src/pages/rss.xml.ts
+++ b/demos/preview/src/pages/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
-import { getEmDashCollection } from "emdash";
+import { getEmDashCollection, getSiteSettings } from "emdash";
 
-const siteTitle = "My Blog";
-const siteDescription = "A blog about software, design, and the occasional stray thought.";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
 export const GET: APIRoute = async ({ site, url }) => {
 	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
 
 	const { entries: posts } = await getEmDashCollection("posts", {
 		orderBy: { published_at: "desc" },
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ site, url }) => {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteTitle)}</title>
-    <description>${escapeXml(siteDescription)}</description>
+    <description>${escapeXml(siteTagline)}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
     <language>en-us</language>

--- a/demos/preview/src/pages/search.astro
+++ b/demos/preview/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/demos/preview/src/pages/tag/[slug].astro
+++ b/demos/preview/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/demos/preview/src/styles/theme.css
+++ b/demos/preview/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/demos/preview/src/utils/site-identity.ts
+++ b/demos/preview/src/utils/site-identity.ts
@@ -1,0 +1,25 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface BlogSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "My Blog";
+const DEFAULT_SITE_TAGLINE = "Thoughts, stories, and ideas.";
+
+export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/demos/simple/astro.config.mjs
+++ b/demos/simple/astro.config.mjs
@@ -1,11 +1,8 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
-import { atproto } from "@emdash-cms/auth-atproto";
 import { auditLogPlugin } from "@emdash-cms/plugin-audit-log";
 import { defineConfig, fontProviders } from "astro/config";
 import emdash, { local } from "emdash/astro";
-import { github } from "emdash/auth/providers/github";
-import { google } from "emdash/auth/providers/google";
 import { sqlite } from "emdash/db";
 
 export default defineConfig({
@@ -13,13 +10,6 @@ export default defineConfig({
 	adapter: node({
 		mode: "standalone",
 	}),
-	// Example: allowed domains for reverse proxy
-	// security: {
-	// 	allowedDomains: [
-	// 		{ hostname: "emdash.local", protocol: "http" },
-	// 		{ hostname: "emdash.local", protocol: "https" },
-	// 	],
-	// },
 	image: {
 		layout: "constrained",
 		responsiveStyles: true,
@@ -32,10 +22,7 @@ export default defineConfig({
 				directory: "./uploads",
 				baseUrl: "/_emdash/api/media/file",
 			}),
-			authProviders: [github(), google(), atproto()],
 			plugins: [auditLogPlugin()],
-			// HTTPS reverse proxy: uncomment so all origin-dependent features match browser
-			// siteUrl: "https://emdash.local:8443",
 		}),
 	],
 	fonts: [
@@ -55,10 +42,4 @@ export default defineConfig({
 		},
 	],
 	devToolbar: { enabled: false },
-	// Example: allowed hosts for reverse proxy
-	// vite: {
-	// 	server: {
-	// 		allowedHosts: ["emdash.local"],
-	// 	},
-	// },
 });

--- a/demos/simple/src/layouts/Base.astro
+++ b/demos/simple/src/layouts/Base.astro
@@ -1,5 +1,5 @@
 ---
-import { getMenu, getEmDashCollection } from "emdash";
+import { getMenu, getEmDashCollection, getSiteSettings } from "emdash";
 import {
 	WidgetArea,
 	EmDashHead,
@@ -7,8 +7,9 @@ import {
 	EmDashBodyEnd,
 } from "emdash/ui";
 import { createPublicPageContext } from "emdash/page";
-import { Font } from "astro:assets";
 import LiveSearch from "emdash/ui/search";
+import { Font } from "astro:assets";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 import "../styles/theme.css";
 
 interface Props {
@@ -39,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const siteTitle = "My Blog";
+const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -78,6 +79,7 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
+		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash
@@ -97,7 +99,12 @@ const isLoggedIn = !!Astro.locals.user;
 		<EmDashBodyStart page={pageCtx} />
 		<header class="site-header">
 			<nav class="nav">
-				<a href="/" class="site-title">{siteTitle}</a>
+				<a href="/" class="site-title">
+					{siteLogo
+						? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="site-logo-img" />
+						: siteTitle
+					}
+				</a>
 				<div class="nav-right">
 					<LiveSearch
 						placeholder="Search..."
@@ -135,8 +142,13 @@ const isLoggedIn = !!Astro.locals.user;
 			<div class="footer-inner">
 				<div class="footer-grid">
 					<div class="footer-brand">
-						<a href="/" class="footer-logo">{siteTitle}</a>
-						<p class="footer-tagline">Thoughts, stories, and ideas.</p>
+						<a href="/" class="footer-logo">
+							{siteLogo
+								? <img src={siteLogo.url} alt={siteLogo.alt || siteTitle} class="footer-logo-img" />
+								: siteTitle
+							}
+						</a>
+						<p class="footer-tagline">{siteTagline}</p>
 					</div>
 					<div class="footer-nav">
 						<h4 class="footer-heading">Navigate</h4>
@@ -331,145 +343,168 @@ const isLoggedIn = !!Astro.locals.user;
 		</script>
 
 		<style is:global>
-			*:where(:not([class*="emdash"]):not([class*="ec-"])),
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
-			*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
-				box-sizing: border-box;
-			}
+			/*
+			 * Establish layer order: "base" has lower priority than unlayered
+			 * styles, so theme.css overrides always win regardless of source
+			 * order in the bundled CSS.
+			 */
+			@layer base;
 
-			body,
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			ul,
-			ol,
-			figure,
-			blockquote,
-			dl,
-			dd {
-				margin: 0;
-			}
+			@layer base {
+				*:where(:not([class*="emdash"]):not([class*="ec-"])),
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::before,
+				*:where(:not([class*="emdash"]):not([class*="ec-"]))::after {
+					box-sizing: border-box;
+				}
 
-			ul,
-			ol {
-				padding: 0;
-			}
+				body,
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6,
+				p,
+				ul,
+				ol,
+				figure,
+				blockquote,
+				dl,
+				dd {
+					margin: 0;
+				}
 
-			:root {
-				/* Colors - Light mode (default) */
-				--color-bg: #ffffff;
-				--color-bg-subtle: #fafafa;
-				--color-text: #1a1a1a;
-				--color-text-secondary: #525252;
-				--color-muted: #8b8b8b;
-				--color-border: #e5e5e5;
-				--color-border-subtle: #f0f0f0;
-				--color-surface: #f7f7f7;
-				--color-accent: #0066cc;
-				--color-accent-hover: #0052a3;
-				--color-on-accent: white;
-				--color-accent-ring: color-mix(
-					in srgb,
-					var(--color-accent) 25%,
-					transparent
-				);
+				ul,
+				ol {
+					padding: 0;
+				}
 
-				/* EmDash search theming */
-				--emdash-search-bg: var(--color-bg);
-				--emdash-search-text: var(--color-text);
-				--emdash-search-muted: var(--color-muted);
-				--emdash-search-border: var(--color-border);
-				--emdash-search-hover: var(--color-surface);
-				--emdash-search-highlight: var(--color-text);
+				:root {
+					/* Colors - Light mode (default) */
+					--color-bg: #ffffff;
+					--color-bg-subtle: #fafafa;
+					--color-text: #1a1a1a;
+					--color-text-secondary: #525252;
+					--color-muted: #8b8b8b;
+					--color-border: #e5e5e5;
+					--color-border-subtle: #f0f0f0;
+					--color-surface: #f7f7f7;
+					--color-accent: #0066cc;
+					--color-accent-hover: #0052a3;
+					--color-on-accent: white;
+					--color-accent-ring: color-mix(
+						in srgb,
+						var(--color-accent) 25%,
+						transparent
+					);
 
-				/* Type scale - more refined */
-				--font-size-xs: 0.8125rem;
-				--font-size-sm: 0.875rem;
-				--font-size-base: 1rem;
-				--font-size-lg: 1.125rem;
-				--font-size-xl: 1.25rem;
-				--font-size-2xl: 1.5rem;
-				--font-size-3xl: 2rem;
-				--font-size-4xl: 2.5rem;
-				--font-size-5xl: 3.5rem;
+					/* EmDash search theming */
+					--emdash-search-bg: var(--color-bg);
+					--emdash-search-text: var(--color-text);
+					--emdash-search-muted: var(--color-muted);
+					--emdash-search-border: var(--color-border);
+					--emdash-search-hover: var(--color-surface);
+					--emdash-search-highlight: var(--color-text);
 
-				/* Line heights */
-				--leading-tight: 1.15;
-				--leading-snug: 1.3;
-				--leading-normal: 1.5;
-				--leading-relaxed: 1.7;
+					/* Type scale - more refined */
+					--font-size-xs: 0.8125rem;
+					--font-size-sm: 0.875rem;
+					--font-size-base: 1rem;
+					--font-size-lg: 1.125rem;
+					--font-size-xl: 1.25rem;
+					--font-size-2xl: 1.5rem;
+					--font-size-3xl: 2rem;
+					--font-size-4xl: 2.5rem;
+					--font-size-5xl: 3.5rem;
 
-				/* Spacing - more generous */
-				--spacing-1: 0.25rem;
-				--spacing-2: 0.5rem;
-				--spacing-3: 0.75rem;
-				--spacing-4: 1rem;
-				--spacing-5: 1.25rem;
-				--spacing-6: 1.5rem;
-				--spacing-8: 2rem;
-				--spacing-10: 2.5rem;
-				--spacing-12: 3rem;
-				--spacing-16: 4rem;
-				--spacing-20: 5rem;
-				--spacing-24: 6rem;
+					/* Line heights */
+					--leading-tight: 1.15;
+					--leading-snug: 1.3;
+					--leading-normal: 1.5;
+					--leading-relaxed: 1.7;
 
-				/* Legacy spacing aliases */
-				--spacing-xs: var(--spacing-1);
-				--spacing-sm: var(--spacing-2);
-				--spacing-md: var(--spacing-4);
-				--spacing-lg: var(--spacing-6);
-				--spacing-xl: var(--spacing-8);
-				--spacing-2xl: var(--spacing-12);
-				--spacing-3xl: var(--spacing-16);
+					/* Spacing - more generous */
+					--spacing-1: 0.25rem;
+					--spacing-2: 0.5rem;
+					--spacing-3: 0.75rem;
+					--spacing-4: 1rem;
+					--spacing-5: 1.25rem;
+					--spacing-6: 1.5rem;
+					--spacing-8: 2rem;
+					--spacing-10: 2.5rem;
+					--spacing-12: 3rem;
+					--spacing-16: 4rem;
+					--spacing-20: 5rem;
+					--spacing-24: 6rem;
 
-				/* Layout - wider for three-column */
-				--content-width: 680px;
-				--wide-width: 1200px;
-				--max-width: var(--content-width);
-				--gutter-width: 200px;
-				--radius: 4px;
-				--radius-lg: 8px;
+					/* Legacy spacing aliases */
+					--spacing-xs: var(--spacing-1);
+					--spacing-sm: var(--spacing-2);
+					--spacing-md: var(--spacing-4);
+					--spacing-lg: var(--spacing-6);
+					--spacing-xl: var(--spacing-8);
+					--spacing-2xl: var(--spacing-12);
+					--spacing-3xl: var(--spacing-16);
 
-				/* Transitions */
-				--transition-fast: 120ms ease;
-				--transition-base: 180ms ease;
+					/* Layout - wider for three-column */
+					--content-width: 680px;
+					--wide-width: 1200px;
+					--max-width: var(--content-width);
+					--gutter-width: 200px;
+					--radius: 4px;
+					--radius-lg: 8px;
 
-				/* Nav */
-				--nav-height: 64px;
+					/* Transitions */
+					--transition-fast: 120ms ease;
+					--transition-base: 180ms ease;
 
-				/* Search */
-				--search-input-width: 180px;
+					/* Nav */
+					--nav-height: 64px;
 
-				/* Article layout */
-				--meta-col-width: 180px;
+					/* Search */
+					--search-input-width: 180px;
 
-				/* Avatar sizes */
-				--avatar-size-xs: 18px;
-				--avatar-size-sm: 20px;
-				--avatar-size-md: 24px;
-				--avatar-size-lg: 32px;
+					/* Article layout */
+					--meta-col-width: 180px;
 
-				/* Letter spacing */
-				--tracking-tight: -0.03em;
-				--tracking-snug: -0.02em;
-				--tracking-wide: 0.06em;
-				--tracking-wider: 0.08em;
+					/* Avatar sizes */
+					--avatar-size-xs: 18px;
+					--avatar-size-sm: 20px;
+					--avatar-size-md: 24px;
+					--avatar-size-lg: 32px;
 
-				/* Tag pill */
-				--tag-padding-y: 2px;
+					/* Letter spacing */
+					--tracking-tight: -0.03em;
+					--tracking-snug: -0.02em;
+					--tracking-wide: 0.06em;
+					--tracking-wider: 0.08em;
 
-				/* Shadows */
-				--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
-				--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
-			}
+					/* Tag pill */
+					--tag-padding-y: 2px;
 
-			/* Dark mode via system preference (when no explicit class) */
-			@media (prefers-color-scheme: dark) {
-				:root:not(.light) {
+					/* Shadows */
+					--shadow-dropdown: 0 8px 30px rgba(0, 0, 0, 0.12);
+					--shadow-btn-active: 0 1px 2px rgba(0, 0, 0, 0.05);
+				}
+
+				/* Dark mode via system preference (when no explicit class) */
+				@media (prefers-color-scheme: dark) {
+					:root:not(.light) {
+						--color-bg: #0d0d0d;
+						--color-bg-subtle: #141414;
+						--color-text: #ededed;
+						--color-text-secondary: #a0a0a0;
+						--color-muted: #6b6b6b;
+						--color-border: #2a2a2a;
+						--color-border-subtle: #1f1f1f;
+						--color-surface: #181818;
+						--color-accent: #4d9fff;
+						--color-accent-hover: #6eb0ff;
+					}
+				}
+
+				/* Explicit dark mode */
+				:root.dark {
 					--color-bg: #0d0d0d;
 					--color-bg-subtle: #141414;
 					--color-text: #ededed;
@@ -481,73 +516,59 @@ const isLoggedIn = !!Astro.locals.user;
 					--color-accent: #4d9fff;
 					--color-accent-hover: #6eb0ff;
 				}
-			}
 
-			/* Explicit dark mode */
-			:root.dark {
-				--color-bg: #0d0d0d;
-				--color-bg-subtle: #141414;
-				--color-text: #ededed;
-				--color-text-secondary: #a0a0a0;
-				--color-muted: #6b6b6b;
-				--color-border: #2a2a2a;
-				--color-border-subtle: #1f1f1f;
-				--color-surface: #181818;
-				--color-accent: #4d9fff;
-				--color-accent-hover: #6eb0ff;
-			}
+				html {
+					scroll-behavior: smooth;
+				}
 
-			html {
-				scroll-behavior: smooth;
-			}
+				body {
+					font-family: var(--font-sans);
+					font-size: var(--font-size-base);
+					line-height: var(--leading-relaxed);
+					color: var(--color-text);
+					background: var(--color-bg);
+					-webkit-font-smoothing: antialiased;
+					-moz-osx-font-smoothing: grayscale;
+					min-height: 100vh;
+				}
 
-			body {
-				font-family: var(--font-sans);
-				font-size: var(--font-size-base);
-				line-height: var(--leading-relaxed);
-				color: var(--color-text);
-				background: var(--color-bg);
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
-				min-height: 100vh;
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])) {
+					color: var(--color-accent);
+					text-decoration: none;
+					transition: color var(--transition-fast);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])) {
-				color: var(--color-accent);
-				text-decoration: none;
-				transition: color var(--transition-fast);
-			}
+				a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
+					color: var(--color-accent-hover);
+				}
 
-			a:where(:not([class*="emdash"]):not([class*="ec-"])):hover {
-				color: var(--color-accent-hover);
-			}
+				img {
+					max-width: 100%;
+					height: auto;
+					display: block;
+				}
 
-			img {
-				max-width: 100%;
-				height: auto;
-				display: block;
-			}
+				h1,
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					font-family: var(--font-sans);
+					line-height: var(--leading-tight);
+					font-weight: 600;
+					letter-spacing: var(--tracking-snug);
+				}
 
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6 {
-				font-family: var(--font-sans);
-				line-height: var(--leading-tight);
-				font-weight: 600;
-				letter-spacing: var(--tracking-snug);
-			}
+				h1 {
+					font-weight: 700;
+					letter-spacing: var(--tracking-tight);
+				}
 
-			h1 {
-				font-weight: 700;
-				letter-spacing: var(--tracking-tight);
-			}
-
-			::selection {
-				background: var(--color-accent);
-				color: white;
+				::selection {
+					background: var(--color-accent);
+					color: white;
+				}
 			}
 		</style>
 
@@ -582,6 +603,13 @@ const isLoggedIn = !!Astro.locals.user;
 
 			.site-title:hover {
 				color: var(--color-accent);
+			}
+
+			.site-logo-img {
+				height: 48px;
+				width: auto;
+				display: block;
+				margin: -8px 0;
 			}
 
 			.nav-right {
@@ -754,6 +782,11 @@ const isLoggedIn = !!Astro.locals.user;
 				color: var(--color-text);
 				text-decoration: none;
 				letter-spacing: var(--tracking-snug);
+			}
+
+			.footer-logo-img {
+				height: 24px;
+				width: auto;
 			}
 
 			.footer-tagline {

--- a/demos/simple/src/pages/category/[slug].astro
+++ b/demos/simple/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/demos/simple/src/pages/index.astro
+++ b/demos/simple/src/pages/index.astro
@@ -1,51 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {
@@ -58,7 +73,7 @@ function formatDate(date: Date | null | undefined) {
 }
 ---
 
-<Base title="My Blog" description="Welcome to my blog">
+<Base title={siteTitle} description={siteTagline}>
 	{
 		posts.length === 0 ? (
 			<section class="empty-state">

--- a/demos/simple/src/pages/posts/[slug].astro
+++ b/demos/simple/src/pages/posts/[slug].astro
@@ -3,8 +3,10 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
+	getSiteSettings,
 } from "emdash";
 import {
 	Image,
@@ -16,6 +18,7 @@ import {
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
+import { resolveBlogSiteIdentity } from "../../utils/site-identity";
 
 const slug = decodeSlug(Astro.params.slug);
 
@@ -53,18 +56,15 @@ function getImageUrl(img: unknown): string | undefined {
 	return undefined;
 }
 const featuredImageUrl = getImageUrl(post.data.featured_image);
+const { siteTitle } = resolveBlogSiteIdentity(await getSiteSettings());
 
 // Generate SEO meta from content
 const seo = getSeoMeta(post, {
-	siteTitle: "My Blog",
+	siteTitle,
 	siteUrl: Astro.url.origin,
 	path: `/posts/${slug}`,
 	defaultOgImage: featuredImageUrl,
 });
-
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
 
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
@@ -72,22 +72,32 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/demos/simple/src/pages/posts/index.astro
+++ b/demos/simple/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/demos/simple/src/pages/rss.xml.ts
+++ b/demos/simple/src/pages/rss.xml.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
-import { getEmDashCollection } from "emdash";
+import { getEmDashCollection, getSiteSettings } from "emdash";
 
-const siteTitle = "My Blog";
-const siteDescription = "A blog about software, design, and the occasional stray thought.";
+import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
 export const GET: APIRoute = async ({ site, url }) => {
 	const siteUrl = site?.toString() || url.origin;
+	const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
 
 	const { entries: posts } = await getEmDashCollection("posts", {
 		orderBy: { published_at: "desc" },
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ site, url }) => {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(siteTitle)}</title>
-    <description>${escapeXml(siteDescription)}</description>
+    <description>${escapeXml(siteTagline)}</description>
     <link>${siteUrl}</link>
     <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
     <language>en-us</language>

--- a/demos/simple/src/pages/search.astro
+++ b/demos/simple/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/demos/simple/src/pages/tag/[slug].astro
+++ b/demos/simple/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/demos/simple/src/styles/theme.css
+++ b/demos/simple/src/styles/theme.css
@@ -1,9 +1,12 @@
 /*
-  theme.css — override any :root variable here to retheme the blog.
+  theme.css -- override any :root variable here to retheme the blog.
 
   This is the only file you need to edit to customize the site's visual
   appearance. All defaults are listed below as comments. Uncomment and
   change any value to override it.
+
+  Base.astro puts its defaults inside @layer base, so declarations here
+  (which are unlayered) always take priority -- no specificity tricks needed.
 
   Note: this template defines explicit dark mode colors in Base.astro.
   Overriding light-mode --color-* variables here won't affect dark mode.

--- a/demos/simple/src/utils/site-identity.ts
+++ b/demos/simple/src/utils/site-identity.ts
@@ -1,0 +1,25 @@
+/** Resolved media reference from getSiteSettings() */
+export interface MediaReference {
+	mediaId: string;
+	alt?: string;
+	url?: string;
+}
+
+export interface BlogSiteIdentitySettings {
+	title?: string;
+	tagline?: string;
+	logo?: MediaReference;
+	favicon?: MediaReference;
+}
+
+const DEFAULT_SITE_TITLE = "My Blog";
+const DEFAULT_SITE_TAGLINE = "Thoughts, stories, and ideas.";
+
+export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
+	return {
+		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
+		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
+		siteLogo: settings?.logo?.url ? settings.logo : null,
+		siteFavicon: settings?.favicon?.url ?? null,
+	};
+}

--- a/fixtures/perf-site/src/pages/category/[slug].astro
+++ b/fixtures/perf-site/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/fixtures/perf-site/src/pages/index.astro
+++ b/fixtures/perf-site/src/pages/index.astro
@@ -1,53 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
-const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {

--- a/fixtures/perf-site/src/pages/posts/[slug].astro
+++ b/fixtures/perf-site/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
 	getSiteSettings,
@@ -65,32 +66,38 @@ const seo = getSeoMeta(post, {
 	defaultOgImage: featuredImageUrl,
 });
 
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
 
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/fixtures/perf-site/src/pages/posts/index.astro
+++ b/fixtures/perf-site/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/fixtures/perf-site/src/pages/search.astro
+++ b/fixtures/perf-site/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/fixtures/perf-site/src/pages/tag/[slug].astro
+++ b/fixtures/perf-site/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/infra/blog-demo/src/pages/category/[slug].astro
+++ b/infra/blog-demo/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/infra/blog-demo/src/pages/index.astro
+++ b/infra/blog-demo/src/pages/index.astro
@@ -1,53 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
-const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {

--- a/infra/blog-demo/src/pages/posts/[slug].astro
+++ b/infra/blog-demo/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
 	getSiteSettings,
@@ -65,32 +66,38 @@ const seo = getSeoMeta(post, {
 	defaultOgImage: featuredImageUrl,
 });
 
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
 
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/infra/blog-demo/src/pages/posts/index.astro
+++ b/infra/blog-demo/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/infra/blog-demo/src/pages/search.astro
+++ b/infra/blog-demo/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/infra/blog-demo/src/pages/tag/[slug].astro
+++ b/infra/blog-demo/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/infra/cache-demo/src/pages/category/[slug].astro
+++ b/infra/cache-demo/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/infra/cache-demo/src/pages/index.astro
+++ b/infra/cache-demo/src/pages/index.astro
@@ -1,53 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
-const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {

--- a/infra/cache-demo/src/pages/posts/[slug].astro
+++ b/infra/cache-demo/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
 	getSiteSettings,
@@ -65,32 +66,38 @@ const seo = getSeoMeta(post, {
 	defaultOgImage: featuredImageUrl,
 });
 
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
 
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/infra/cache-demo/src/pages/posts/index.astro
+++ b/infra/cache-demo/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/infra/cache-demo/src/pages/search.astro
+++ b/infra/cache-demo/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/infra/cache-demo/src/pages/tag/[slug].astro
+++ b/infra/cache-demo/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/templates/blog-cloudflare/src/pages/category/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/templates/blog-cloudflare/src/pages/index.astro
+++ b/templates/blog-cloudflare/src/pages/index.astro
@@ -1,53 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
-const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {

--- a/templates/blog-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
 	getSiteSettings,
@@ -65,32 +66,38 @@ const seo = getSeoMeta(post, {
 	defaultOgImage: featuredImageUrl,
 });
 
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
 
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/templates/blog-cloudflare/src/pages/posts/index.astro
+++ b/templates/blog-cloudflare/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/templates/blog-cloudflare/src/pages/search.astro
+++ b/templates/blog-cloudflare/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/templates/blog-cloudflare/src/pages/tag/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/templates/blog/src/pages/category/[slug].astro
+++ b/templates/blog/src/pages/category/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,25 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { category: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post in this category, rather
+// than calling getEntryTerms() per post (which would be one round-trip
+// per post).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title={`${term.label} posts`} description={`All posts in ${term.label}`}>

--- a/templates/blog/src/pages/index.astro
+++ b/templates/blog/src/pages/index.astro
@@ -1,53 +1,66 @@
 ---
-import { getEmDashCollection, getEntryTerms, getSiteSettings } from "emdash";
+import {
+	getEmDashCollection,
+	getTermsForEntries,
+	getSiteSettings,
+} from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../layouts/Base.astro";
 import PostCard from "../components/PostCard.astro";
 import { getReadingTime } from "../utils/reading-time";
 import { resolveBlogSiteIdentity } from "../utils/site-identity";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
-const { siteTitle, siteTagline } = resolveBlogSiteIdentity(await getSiteSettings());
+// Limit to what we render (1 featured + 6 grid). The DB does the slicing
+// instead of fetching every post and discarding the tail in JS.
+const POSTS_PER_PAGE = 7;
+
+const [{ entries: posts, cacheHint }, settings] = await Promise.all([
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: POSTS_PER_PAGE + 1, // +1 to detect "view all" need
+	}),
+	getSiteSettings(),
+]);
+const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+// Trim the lookahead post used to detect overflow
+const visiblePosts = posts.slice(0, POSTS_PER_PAGE);
+const hasMorePosts = posts.length > POSTS_PER_PAGE;
 
 // Find the first post with a featured image for the hero
-const featuredPost = sortedPosts.find((p) => p.data.featured_image);
-const featuredIndex = featuredPost ? sortedPosts.indexOf(featuredPost) : -1;
+const featuredPost = visiblePosts.find((p) => p.data.featured_image);
+const featuredIndex = featuredPost ? visiblePosts.indexOf(featuredPost) : -1;
 
 // Get remaining posts (exclude featured if found, limit to 6 for grid)
-const gridPosts = sortedPosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
+const gridPosts = visiblePosts.filter((_, i) => i !== featuredIndex).slice(0, 6);
 
-// Total posts shown = featured (if any) + grid posts
-const totalShown = (featuredPost ? 1 : 0) + gridPosts.length;
-const hasMorePosts = sortedPosts.length > totalShown;
+// Single batched query for tags across the featured post + grid posts.
+// Avoids the N+1 pattern of calling getEntryTerms() per entry.
+// Bylines are already hydrated on entry.data.bylines by getEmDashCollection.
+const tagEntryIds = [
+	...(featuredPost ? [featuredPost.data.id] : []),
+	...gridPosts.map((p) => p.data.id),
+];
+const tagsByEntry = await getTermsForEntries("posts", tagEntryIds, "tag");
 
-// Fetch tags for featured post (bylines are already hydrated by getEmDashCollection)
-let featuredTags: Array<{ slug: string; label: string }> = [];
+const featuredTags = featuredPost
+	? (tagsByEntry.get(featuredPost.data.id) ?? []).map((t) => ({
+			slug: t.slug,
+			label: t.label,
+		}))
+	: [];
 const featuredBylines = featuredPost?.data.bylines ?? [];
-if (featuredPost) {
-	const tags = await getEntryTerms("posts", featuredPost.data.id, "tag");
-	featuredTags = tags.map((t) => ({ slug: t.slug, label: t.label }));
-}
 
-// Fetch tags for grid posts (bylines are already hydrated by getEmDashCollection)
-const gridPostsWithTags = await Promise.all(
-	gridPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return {
-			post,
-			tags: tags.map((t) => ({ slug: t.slug, label: t.label })),
-			bylines,
-		};
-	})
-);
+const gridPostsWithTags = gridPosts.map((post) => ({
+	post,
+	tags: (tagsByEntry.get(post.data.id) ?? []).map((t) => ({
+		slug: t.slug,
+		label: t.label,
+	})),
+	bylines: post.data.bylines ?? [],
+}));
 
 // Format date helper
 function formatDate(date: Date | null | undefined) {

--- a/templates/blog/src/pages/posts/[slug].astro
+++ b/templates/blog/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import {
 	getEmDashEntry,
 	getEmDashCollection,
 	getEntryTerms,
+	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
 	getSiteSettings,
@@ -65,32 +66,38 @@ const seo = getSeoMeta(post, {
 	defaultOgImage: featuredImageUrl,
 });
 
-// Get tags for this post
-// Note: post.id is the slug, post.data.id is the database ULID
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-
 // Bylines are already hydrated by getEmDashEntry
 const bylines = post.data.bylines ?? [];
 
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Get other posts for "More posts" section, with their tags
-// Fetch a few extra in case the current post is among them
-const { entries: recentPosts } = await getEmDashCollection("posts", {
-	orderBy: { published_at: "desc" },
-	limit: 4,
-});
+// Fetch this post's tags and the related-posts list in parallel — they're
+// independent queries, so running them concurrently halves the round-trip
+// cost on remote databases.
+// Note: post.id is the slug, post.data.id is the database ULID.
+const [tags, { entries: recentPosts }] = await Promise.all([
+	getEntryTerms("posts", post.data.id, "tag"),
+	// Fetch a few extra in case the current post is among them
+	getEmDashCollection("posts", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
-// Fetch tags for related posts (bylines are already hydrated by getEmDashCollection)
-const otherPostsWithTags = await Promise.all(
-	otherPosts.map(async (p) => {
-		const postTags = await getEntryTerms("posts", p.data.id, "tag");
-		const postBylines = p.data.bylines ?? [];
-		return { post: p, tags: postTags, bylines: postBylines };
-	})
+// Single batched query for related-posts tags, rather than one
+// getEntryTerms() call per related post.
+const otherTagsByEntry = await getTermsForEntries(
+	"posts",
+	otherPosts.map((p) => p.data.id),
+	"tag",
 );
+const otherPostsWithTags = otherPosts.map((p) => ({
+	post: p,
+	tags: otherTagsByEntry.get(p.data.id) ?? [],
+	bylines: p.data.bylines ?? [],
+}));
 
 const publishDate =
 	post.data.publishedAt?.toLocaleDateString("en-US", {

--- a/templates/blog/src/pages/posts/index.astro
+++ b/templates/blog/src/pages/posts/index.astro
@@ -1,26 +1,30 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import Base from "../../layouts/Base.astro";
 import { getReadingTime } from "../../utils/reading-time";
 
-const { entries: posts, cacheHint } = await getEmDashCollection("posts");
+// Sort in the database rather than in JS — lets the DB use its index on
+// published_at and avoids a full-table scan on the client.
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+});
 
 Astro.cache.set(cacheHint);
 
-const sortedPosts = posts.toSorted((a, b) => {
-	const dateA = a.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
-
-// Fetch tags for each post (bylines are already hydrated by getEmDashCollection)
-const postsWithTags = await Promise.all(
-	sortedPosts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		const bylines = post.data.bylines ?? [];
-		return { post, tags, bylines };
-	})
+// Single batched query for tags across all posts, instead of one
+// getEntryTerms() call per post (which would be N round-trips).
+// Bylines are already hydrated on entry.data.bylines.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+	bylines: post.data.bylines ?? [],
+}));
 
 const formatDate = (date: Date) =>
 	date.toLocaleDateString("en-US", {
@@ -41,7 +45,7 @@ const formatDate = (date: Date) =>
 		</header>
 
 		{
-			sortedPosts.length === 0 ? (
+			posts.length === 0 ? (
 				<p class="empty">No posts yet.</p>
 			) : (
 				<div class="posts-list">

--- a/templates/blog/src/pages/search.astro
+++ b/templates/blog/src/pages/search.astro
@@ -1,29 +1,18 @@
 ---
 export const prerender = false;
 
-import { getEmDashCollection } from "emdash";
+import { search } from "emdash";
 import Base from "../layouts/Base.astro";
-import PostCard from "../components/PostCard.astro";
-import { getReadingTime, extractText } from "../utils/reading-time";
 
 const query = Astro.url.searchParams.get("q")?.trim() || "";
 
-const { entries: allPosts } = await getEmDashCollection("posts");
-
-// Simple search: match query against title, excerpt, and content
-function matchesQuery(post: (typeof allPosts)[0], q: string): boolean {
-	if (!q) return false;
-	const lower = q.toLowerCase();
-	const title = (post.data.title || "").toLowerCase();
-	const excerpt = (post.data.excerpt || "").toLowerCase();
-	// Extract plain text from portable text blocks (avoids matching on _type, _key, etc.)
-	const content = extractText(post.data.content).toLowerCase();
-	return (
-		title.includes(lower) || excerpt.includes(lower) || content.includes(lower)
-	);
-}
-
-const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
+// Use the FTS-backed search() API instead of loading every post and
+// filtering in JS. FTS scales as the post count grows, returns ranked
+// results, and handles tokenization/stemming. Templates that grep all
+// post bodies in JS quickly become unusable past a few hundred posts.
+const { items: results } = query
+	? await search(query, { collections: ["posts"], limit: 30 })
+	: { items: [] };
 ---
 
 <Base
@@ -57,18 +46,23 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 
 		{
 			results.length > 0 && (
-				<div class="search-results">
-					{results.map((post) => (
-						<PostCard
-							title={post.data.title}
-							excerpt={post.data.excerpt}
-							featuredImage={post.data.featured_image}
-							href={`/posts/${post.id}`}
-							date={post.data.publishedAt ?? undefined}
-							readingTime={getReadingTime(post.data.content)}
-						/>
+				<ol class="search-results">
+					{results.map((result) => (
+						<li class="search-result">
+							<a
+								href={`/posts/${result.slug ?? result.id}`}
+								class="result-link"
+							>
+								<h2 class="result-title">
+									{result.title ?? "Untitled"}
+								</h2>
+								{result.snippet && (
+									<p class="result-snippet" set:html={result.snippet} />
+								)}
+							</a>
+						</li>
 					))}
-				</div>
+				</ol>
 			)
 		}
 
@@ -134,8 +128,55 @@ const results = query ? allPosts.filter((p) => matchesQuery(p, query)) : [];
 	}
 
 	.search-results {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 		display: flex;
 		flex-direction: column;
-		gap: var(--spacing-8);
+	}
+
+	.search-result {
+		padding: var(--spacing-6) 0;
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.search-result:first-child {
+		padding-top: 0;
+	}
+
+	.search-result:last-child {
+		border-bottom: none;
+	}
+
+	.result-link {
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.result-title {
+		font-size: var(--font-size-xl);
+		font-weight: 600;
+		line-height: var(--leading-snug);
+		margin-bottom: var(--spacing-2);
+		transition: color var(--transition-fast);
+	}
+
+	.result-link:hover .result-title {
+		color: var(--color-accent);
+	}
+
+	.result-snippet {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-relaxed);
+		color: var(--color-text-secondary);
+	}
+
+	/* FTS returns <mark> wrapping the matched terms */
+	.result-snippet :global(mark) {
+		background: var(--color-accent-ring, rgba(99, 102, 241, 0.2));
+		color: inherit;
+		padding: 0 0.1em;
+		border-radius: 2px;
 	}
 </style>

--- a/templates/blog/src/pages/tag/[slug].astro
+++ b/templates/blog/src/pages/tag/[slug].astro
@@ -1,5 +1,10 @@
 ---
-import { getTerm, getEmDashCollection, getEntryTerms, decodeSlug } from "emdash";
+import {
+	getTerm,
+	getEmDashCollection,
+	getTermsForEntries,
+	decodeSlug,
+} from "emdash";
 import Base from "../../layouts/Base.astro";
 import PostCard from "../../components/PostCard.astro";
 import { getReadingTime } from "../../utils/reading-time";
@@ -11,18 +16,24 @@ if (!term) {
 	return Astro.redirect("/404");
 }
 
-const { entries: posts } = await getEmDashCollection("posts", {
+const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	where: { tag: term.slug },
 	orderBy: { published_at: "desc" },
 });
 
-// Fetch tags for display on each post card
-const filteredPosts = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+Astro.cache.set(cacheHint);
+
+// Single batched query for tags on every post tagged with this term,
+// rather than calling getEntryTerms() per post.
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const filteredPosts = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base

--- a/templates/marketing-cloudflare/src/pages/contact.astro
+++ b/templates/marketing-cloudflare/src/pages/contact.astro
@@ -6,6 +6,9 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "contact");
 
+// `cache.set` only applies to GET responses; wrap defensively because
+// this route also handles POST submissions where the cache API may
+// reject the call.
 try {
 	Astro.cache.set(cacheHint);
 } catch {}

--- a/templates/marketing-cloudflare/src/pages/index.astro
+++ b/templates/marketing-cloudflare/src/pages/index.astro
@@ -5,9 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "home");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
 const pageTitle = page?.data.title;
 const pageContent = page?.data.content;

--- a/templates/marketing-cloudflare/src/pages/pricing.astro
+++ b/templates/marketing-cloudflare/src/pages/pricing.astro
@@ -5,9 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "pricing");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
 const pageContent = page?.data.content;
 ---

--- a/templates/marketing/src/pages/contact.astro
+++ b/templates/marketing/src/pages/contact.astro
@@ -6,6 +6,9 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "contact");
 
+// `cache.set` only applies to GET responses; wrap defensively because
+// this route also handles POST submissions where the cache API may
+// reject the call.
 try {
 	Astro.cache.set(cacheHint);
 } catch {}

--- a/templates/marketing/src/pages/index.astro
+++ b/templates/marketing/src/pages/index.astro
@@ -5,9 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "home");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
 const pageTitle = page?.data.title;
 const pageContent = page?.data.content;

--- a/templates/marketing/src/pages/pricing.astro
+++ b/templates/marketing/src/pages/pricing.astro
@@ -5,9 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "pricing");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
 const pageContent = page?.data.content;
 ---

--- a/templates/portfolio-cloudflare/src/pages/about.astro
+++ b/templates/portfolio-cloudflare/src/pages/about.astro
@@ -5,9 +5,7 @@ import Base from "../layouts/Base.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "about");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 ---
 
 <Base title="About" description="Learn more about who we are and what we do.">

--- a/templates/portfolio-cloudflare/src/pages/index.astro
+++ b/templates/portfolio-cloudflare/src/pages/index.astro
@@ -3,20 +3,18 @@ import { getEmDashCollection, getSiteSettings } from "emdash";
 import Base from "../layouts/Base.astro";
 import ProjectCard from "../components/ProjectCard.astro";
 
-const settings = await getSiteSettings();
-const { entries: projects, cacheHint } =
-	await getEmDashCollection("projects");
+// Fetch settings + the 4 featured projects in parallel. Limiting and
+// sorting in the database avoids loading every project just to slice
+// off the first 4 in JS (a full-table read on sites with lots of work).
+const [settings, { entries: featuredProjects, cacheHint }] = await Promise.all([
+	getSiteSettings(),
+	getEmDashCollection("projects", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 
 Astro.cache.set(cacheHint);
-
-// Get the 4 most recent projects for the homepage
-const featuredProjects = projects
-	.toSorted((a, b) => {
-		const dateA = a.data.publishedAt?.getTime() ?? 0;
-		const dateB = b.data.publishedAt?.getTime() ?? 0;
-		return dateB - dateA;
-	})
-	.slice(0, 4);
 ---
 
 <Base>

--- a/templates/portfolio-cloudflare/src/pages/work/[slug].astro
+++ b/templates/portfolio-cloudflare/src/pages/work/[slug].astro
@@ -16,15 +16,16 @@ if (!project) {
 	return Astro.redirect("/404");
 }
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
-// Get related projects (same category or just other projects)
-const { entries: allProjects } = await getEmDashCollection("projects");
-const otherProjects = allProjects
-	.filter((p) => p.id !== project.id)
-	.slice(0, 2);
+// Related projects: order by date in the DB and request a small lookahead
+// so we can drop the current entry without re-querying. Avoids loading
+// every project just to slice off two.
+const { entries: relatedProjects } = await getEmDashCollection("projects", {
+	orderBy: { published_at: "desc" },
+	limit: 3,
+});
+const otherProjects = relatedProjects.filter((p) => p.id !== project.id).slice(0, 2);
 
 // Parse gallery if present
 const gallery = project.data.gallery as

--- a/templates/portfolio-cloudflare/src/pages/work/index.astro
+++ b/templates/portfolio-cloudflare/src/pages/work/index.astro
@@ -4,41 +4,38 @@ export const prerender = false;
 import {
 	getEmDashCollection,
 	getTaxonomyTerms,
-	getEntryTerms,
+	getTermsForEntries,
 } from "emdash";
 import Base from "../../layouts/Base.astro";
 import ProjectCard from "../../components/ProjectCard.astro";
 
-const { entries: projects, cacheHint } =
-	await getEmDashCollection("projects");
-const tags = await getTaxonomyTerms("tag");
-
-// Get filter from query param
+// Get filter from query param. When set, push the filter down to the
+// database via `where` instead of loading every project and filtering
+// in JS — that pattern scales O(projects × terms-per-project) and
+// blows up the moment you have more than a couple of dozen entries.
 const activeTag = Astro.url.searchParams.get("tag");
 
-// Get tags for each project and filter if needed
-const projectsWithTags = await Promise.all(
-	projects.map(async (project) => {
-		const projectTags = await getEntryTerms("projects", project.data.id, "tag");
-		return { project, projectTags };
-	})
-);
-
-// Filter projects if a tag is selected
-const filteredProjects = activeTag
-	? projectsWithTags.filter(({ projectTags }) =>
-			projectTags.some((t) => t.slug === activeTag)
-		)
-	: projectsWithTags;
-
-// Sort by published date
-const sortedProjects = filteredProjects.toSorted((a, b) => {
-	const dateA = a.project.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.project.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+const [{ entries: sortedProjects, cacheHint }, tags] = await Promise.all([
+	getEmDashCollection("projects", {
+		orderBy: { published_at: "desc" },
+		...(activeTag ? { where: { tag: activeTag } } : {}),
+	}),
+	getTaxonomyTerms("tag"),
+]);
 
 Astro.cache.set(cacheHint);
+
+// Single batched JOIN for the tag pills shown on each card, instead of
+// one getEntryTerms() round-trip per card.
+const tagsByEntry = await getTermsForEntries(
+	"projects",
+	sortedProjects.map((p) => p.data.id),
+	"tag",
+);
+const projectsWithTags = sortedProjects.map((project) => ({
+	project,
+	projectTags: tagsByEntry.get(project.data.id) ?? [],
+}));
 ---
 
 <Base
@@ -75,10 +72,10 @@ Astro.cache.set(cacheHint);
 	</section>
 
 	{
-		sortedProjects.length > 0 ? (
+		projectsWithTags.length > 0 ? (
 			<section class="projects">
 				<div class="projects-grid">
-					{sortedProjects.map(({ project, projectTags }) => (
+					{projectsWithTags.map(({ project, projectTags }) => (
 						<ProjectCard
 							title={project.data.title ?? "Untitled"}
 							summary={project.data.summary}

--- a/templates/portfolio/src/pages/about.astro
+++ b/templates/portfolio/src/pages/about.astro
@@ -5,9 +5,7 @@ import Base from "../layouts/Base.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "about");
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 ---
 
 <Base title="About" description="Learn more about who we are and what we do.">

--- a/templates/portfolio/src/pages/index.astro
+++ b/templates/portfolio/src/pages/index.astro
@@ -3,20 +3,18 @@ import { getEmDashCollection, getSiteSettings } from "emdash";
 import Base from "../layouts/Base.astro";
 import ProjectCard from "../components/ProjectCard.astro";
 
-const settings = await getSiteSettings();
-const { entries: projects, cacheHint } =
-	await getEmDashCollection("projects");
+// Fetch settings + the 4 featured projects in parallel. Limiting and
+// sorting in the database avoids loading every project just to slice
+// off the first 4 in JS (a full-table read on sites with lots of work).
+const [settings, { entries: featuredProjects, cacheHint }] = await Promise.all([
+	getSiteSettings(),
+	getEmDashCollection("projects", {
+		orderBy: { published_at: "desc" },
+		limit: 4,
+	}),
+]);
 
 Astro.cache.set(cacheHint);
-
-// Get the 4 most recent projects for the homepage
-const featuredProjects = projects
-	.toSorted((a, b) => {
-		const dateA = a.data.publishedAt?.getTime() ?? 0;
-		const dateB = b.data.publishedAt?.getTime() ?? 0;
-		return dateB - dateA;
-	})
-	.slice(0, 4);
 ---
 
 <Base>

--- a/templates/portfolio/src/pages/work/[slug].astro
+++ b/templates/portfolio/src/pages/work/[slug].astro
@@ -16,15 +16,16 @@ if (!project) {
 	return Astro.redirect("/404");
 }
 
-try {
-	Astro.cache.set(cacheHint);
-} catch {}
+Astro.cache.set(cacheHint);
 
-// Get related projects (same category or just other projects)
-const { entries: allProjects } = await getEmDashCollection("projects");
-const otherProjects = allProjects
-	.filter((p) => p.id !== project.id)
-	.slice(0, 2);
+// Related projects: order by date in the DB and request a small lookahead
+// so we can drop the current entry without re-querying. Avoids loading
+// every project just to slice off two.
+const { entries: relatedProjects } = await getEmDashCollection("projects", {
+	orderBy: { published_at: "desc" },
+	limit: 3,
+});
+const otherProjects = relatedProjects.filter((p) => p.id !== project.id).slice(0, 2);
 
 // Parse gallery if present
 const gallery = project.data.gallery as

--- a/templates/portfolio/src/pages/work/index.astro
+++ b/templates/portfolio/src/pages/work/index.astro
@@ -4,41 +4,38 @@ export const prerender = false;
 import {
 	getEmDashCollection,
 	getTaxonomyTerms,
-	getEntryTerms,
+	getTermsForEntries,
 } from "emdash";
 import Base from "../../layouts/Base.astro";
 import ProjectCard from "../../components/ProjectCard.astro";
 
-const { entries: projects, cacheHint } =
-	await getEmDashCollection("projects");
-const tags = await getTaxonomyTerms("tag");
-
-// Get filter from query param
+// Get filter from query param. When set, push the filter down to the
+// database via `where` instead of loading every project and filtering
+// in JS — that pattern scales O(projects × terms-per-project) and
+// blows up the moment you have more than a couple of dozen entries.
 const activeTag = Astro.url.searchParams.get("tag");
 
-// Get tags for each project and filter if needed
-const projectsWithTags = await Promise.all(
-	projects.map(async (project) => {
-		const projectTags = await getEntryTerms("projects", project.data.id, "tag");
-		return { project, projectTags };
-	})
-);
-
-// Filter projects if a tag is selected
-const filteredProjects = activeTag
-	? projectsWithTags.filter(({ projectTags }) =>
-			projectTags.some((t) => t.slug === activeTag)
-		)
-	: projectsWithTags;
-
-// Sort by published date
-const sortedProjects = filteredProjects.toSorted((a, b) => {
-	const dateA = a.project.data.publishedAt?.getTime() ?? 0;
-	const dateB = b.project.data.publishedAt?.getTime() ?? 0;
-	return dateB - dateA;
-});
+const [{ entries: sortedProjects, cacheHint }, tags] = await Promise.all([
+	getEmDashCollection("projects", {
+		orderBy: { published_at: "desc" },
+		...(activeTag ? { where: { tag: activeTag } } : {}),
+	}),
+	getTaxonomyTerms("tag"),
+]);
 
 Astro.cache.set(cacheHint);
+
+// Single batched JOIN for the tag pills shown on each card, instead of
+// one getEntryTerms() round-trip per card.
+const tagsByEntry = await getTermsForEntries(
+	"projects",
+	sortedProjects.map((p) => p.data.id),
+	"tag",
+);
+const projectsWithTags = sortedProjects.map((project) => ({
+	project,
+	projectTags: tagsByEntry.get(project.data.id) ?? [],
+}));
 ---
 
 <Base
@@ -75,10 +72,10 @@ Astro.cache.set(cacheHint);
 	</section>
 
 	{
-		sortedProjects.length > 0 ? (
+		projectsWithTags.length > 0 ? (
 			<section class="projects">
 				<div class="projects-grid">
-					{sortedProjects.map(({ project, projectTags }) => (
+					{projectsWithTags.map(({ project, projectTags }) => (
 						<ProjectCard
 							title={project.data.title ?? "Untitled"}
 							summary={project.data.summary}

--- a/templates/starter-cloudflare/src/pages/posts/index.astro
+++ b/templates/starter-cloudflare/src/pages/posts/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../../layouts/Base.astro";
 
@@ -8,13 +8,17 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 });
 Astro.cache.set(cacheHint);
 
-// Fetch tags for each post
-const postsWithTags = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+// Single batched query for tags across every post, instead of calling
+// getEntryTerms() per post (which would be N round-trips).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title="All Posts">

--- a/templates/starter/src/pages/posts/index.astro
+++ b/templates/starter/src/pages/posts/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getEmDashCollection, getEntryTerms } from "emdash";
+import { getEmDashCollection, getTermsForEntries } from "emdash";
 import { Image } from "emdash/ui";
 import Base from "../../layouts/Base.astro";
 
@@ -8,13 +8,17 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 });
 Astro.cache.set(cacheHint);
 
-// Fetch tags for each post
-const postsWithTags = await Promise.all(
-	posts.map(async (post) => {
-		const tags = await getEntryTerms("posts", post.data.id, "tag");
-		return { post, tags };
-	})
+// Single batched query for tags across every post, instead of calling
+// getEntryTerms() per post (which would be N round-trips).
+const tagsByEntry = await getTermsForEntries(
+	"posts",
+	posts.map((p) => p.data.id),
+	"tag",
 );
+const postsWithTags = posts.map((post) => ({
+	post,
+	tags: tagsByEntry.get(post.data.id) ?? [],
+}));
 ---
 
 <Base title="All Posts">


### PR DESCRIPTION
## What does this PR do?

Cleans up query patterns across the starter templates (and the demos / infra sites that mirror them) to follow EmDash and Astro best practice.

The headline issues were:

- **N+1 queries from `getEntryTerms()` in `Promise.all(posts.map(...))` loops.** Templates were paying one round-trip per post just to render tag pills on list pages. Replaced with a single batched `getTermsForEntries()` JOIN. On a 50-post listing this drops 50 queries to 1.
- **Loading every entry just to slice in JS.** `blog/index.astro`, `portfolio/index.astro`, `portfolio/work/[slug].astro` all fetched the whole collection then `.slice(0, n)` in memory. Now use `limit:` and `orderBy:` on the query so the database does the work.
- **In-memory tag filtering on `portfolio/work/index.astro`.** Loaded every project, looped to fetch each project's tags, then filtered the JS array. Now pushed down to `where: { tag: activeTag }` on the SQL side.
- **Substring search on `blog/search.astro`.** Lowercased every post's title, excerpt, and rendered Portable Text content in JS for every keystroke. Replaced with the FTS-backed `search()` API, which supports tokenized ranking and `<mark>` snippet highlighting.
- **Missing `Astro.cache.set(cacheHint)`** on `blog/category/[slug].astro` and `blog/tag/[slug].astro`. Added.
- **Defensive `try { Astro.cache.set(cacheHint) } catch {}`** wrappers in marketing and portfolio. Removed for consistency with the blog templates, except on `marketing/contact.astro` where the route handles POST and the cache API can legitimately reject.

Independent queries are now run in `Promise.all` (settings + collection, this-post tags + related posts) so they overlap rather than serializing round-trips.

All changes mirrored across the four canonical templates (`blog`, `marketing`, `portfolio`, `starter`) and their `-cloudflare` variants, plus the five demos under `demos/`, `infra/blog-demo`, `infra/cache-demo`, and `fixtures/perf-site`. `fixtures/perf-site/src/{layouts/Base.astro,worker.ts}` keep their existing slim-fixture divergences (no Google Fonts, no PluginBridge export — both deliberately stripped to keep the query-count benchmark deterministic).

Closes #

## Type of change

- [x] Performance improvement

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes (verified \`astro check\` on blog, portfolio, starter templates and demos/preview — all 0 errors)
- [x] \`pnpm lint\` passes (4 pre-existing diagnostics in \`packages/blocks/src/validation.ts\`, none introduced)
- [ ] \`pnpm test\` passes (or targeted tests for my change) — no test changes; this is template content
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A, template content
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — N/A, no admin UI changes
- [x] I have added a changeset (if this PR changes a published package) — N/A per AGENTS.md ("Skip changesets for docs-only, test-only, CI, or demo/template changes"). Templates are private and consumed via \`giget\` from the templates repo.
- [ ] New features link to an approved Discussion — N/A, perf fix not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Notes

The \`scripts/query-counts.snapshot.{sqlite,d1}.json\` files will need regenerating against \`fixtures/perf-site\` — CI does this automatically per AGENTS.md. The changes should reduce query counts on most routes, especially \`/category/*\`, \`/tag/*\`, and \`/posts/*\` where the N+1 term-fetching was happening.