### PR TITLE
feat(blocks): add accordion block for collapsible nested content

### DIFF
--- a/.changeset/blockkit-accordion.md
+++ b/.changeset/blockkit-accordion.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/blocks": minor
+---
+
+Adds an `accordion` Block Kit block: a collapsible container that wraps nested blocks under a labeled trigger. Open/closed state is local to the rendered component (with optional `default_open`), so plugin admin pages can hide advanced settings, FAQs, or auxiliary panels without paginating or round-tripping through `block_action`.

--- a/docs/src/content/docs/plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/block-kit.mdx
@@ -76,6 +76,7 @@ routes: {
 | `context` | Small muted help text |
 | `columns` | 2-3 column layout with nested blocks |
 | `empty` | Empty-state placeholder with icon, title, description, optional command line, and action buttons |
+| `accordion` | Collapsible section wrapping nested blocks |
 
 ## Element types
 

--- a/packages/blocks/src/blocks/accordion.tsx
+++ b/packages/blocks/src/blocks/accordion.tsx
@@ -1,0 +1,21 @@
+import { Collapsible } from "@cloudflare/kumo";
+import { useState } from "react";
+
+import { BlockRenderer } from "../renderer.js";
+import type { AccordionBlock, BlockInteraction } from "../types.js";
+
+export function AccordionBlockComponent({
+	block,
+	onAction,
+}: {
+	block: AccordionBlock;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	const [open, setOpen] = useState(block.default_open ?? false);
+
+	return (
+		<Collapsible label={block.label} open={open} onOpenChange={setOpen}>
+			<BlockRenderer blocks={block.blocks} onAction={onAction} />
+		</Collapsible>
+	);
+}

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -1,4 +1,5 @@
 import type {
+	AccordionBlock,
 	ActionsBlock,
 	BannerBlock,
 	Block,
@@ -442,6 +443,21 @@ function empty(opts: {
 	};
 }
 
+function accordion(opts: {
+	blockId?: string;
+	label: string;
+	blocks: Block[];
+	defaultOpen?: boolean;
+}): AccordionBlock {
+	return {
+		type: "accordion",
+		label: opts.label,
+		blocks: opts.blocks,
+		...(opts.defaultOpen !== undefined && { default_open: opts.defaultOpen }),
+		...(opts.blockId !== undefined && { block_id: opts.blockId }),
+	};
+}
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 export const blocks = {
@@ -462,6 +478,7 @@ export const blocks = {
 	meter,
 	code: codeBlock,
 	empty,
+	accordion,
 };
 
 export const elements = {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -52,6 +52,7 @@ export type {
 	BannerBlock,
 	MeterBlock,
 	EmptyBlock,
+	AccordionBlock,
 	Block,
 	// Interactions
 	BlockAction,

--- a/packages/blocks/src/renderer.tsx
+++ b/packages/blocks/src/renderer.tsx
@@ -1,3 +1,4 @@
+import { AccordionBlockComponent } from "./blocks/accordion.js";
 import { ActionsBlockComponent } from "./blocks/actions.js";
 import { BannerBlockComponent } from "./blocks/banner.js";
 import { ChartBlockComponent } from "./blocks/chart.js";
@@ -53,6 +54,8 @@ function renderBlock(
 			return <CodeBlockComponent block={block} />;
 		case "empty":
 			return <EmptyBlockComponent block={block} onAction={onAction} />;
+		case "accordion":
+			return <AccordionBlockComponent block={block} onAction={onAction} />;
 		default: {
 			const _exhaustive: never = block;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -330,6 +330,13 @@ export interface EmptyBlock extends BlockBase {
 	actions?: Element[];
 }
 
+export interface AccordionBlock extends BlockBase {
+	type: "accordion";
+	label: string;
+	blocks: Block[];
+	default_open?: boolean;
+}
+
 export type Block =
 	| HeaderBlock
 	| SectionBlock
@@ -346,7 +353,8 @@ export type Block =
 	| BannerBlock
 	| MeterBlock
 	| CodeBlock
-	| EmptyBlock;
+	| EmptyBlock
+	| AccordionBlock;
 
 // ── Interactions ─────────────────────────────────────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -15,6 +15,7 @@ const BLOCK_TYPES = new Set([
 	"meter",
 	"code",
 	"empty",
+	"accordion",
 ]);
 
 const EMPTY_SIZES = new Set(["sm", "base", "lg"]);
@@ -1125,6 +1126,31 @@ function validateBlock(value: unknown, path: string, errors: ValidationError[]):
 						validateElement(value.actions[i], `${path}.actions[${i}]`, errors);
 					}
 				}
+			}
+			break;
+		}
+		case "accordion": {
+			if (typeof value.label !== "string") {
+				errors.push({
+					path: `${path}.label`,
+					message: "Required field 'label' must be a string",
+				});
+			}
+			if (!Array.isArray(value.blocks)) {
+				errors.push({
+					path: `${path}.blocks`,
+					message: "Required field 'blocks' must be an array",
+				});
+			} else {
+				for (let i = 0; i < value.blocks.length; i++) {
+					validateBlock(value.blocks[i], `${path}.blocks[${i}]`, errors);
+				}
+			}
+			if (value.default_open !== undefined && typeof value.default_open !== "boolean") {
+				errors.push({
+					path: `${path}.default_open`,
+					message: "Field 'default_open' must be a boolean if provided",
+				});
 			}
 			break;
 		}

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -145,6 +145,14 @@ vi.mock("@cloudflare/kumo", () => ({
 			</label>
 		),
 	},
+	Collapsible: ({ children, label, open, onOpenChange }: any) => (
+		<div data-testid="collapsible" data-open={open ? "true" : "false"}>
+			<button type="button" onClick={() => onOpenChange?.(!open)}>
+				{label}
+			</button>
+			{open && <div data-testid="collapsible-content">{children}</div>}
+		</div>
+	),
 	Combobox: Object.assign(
 		({ children, label }: any) => (
 			<div data-testid="combobox">
@@ -467,6 +475,48 @@ describe("BlockRenderer", () => {
 	it("empty block omits contents when actions array is empty", () => {
 		const { container } = renderBlocks([{ type: "empty", title: "X", actions: [] }]);
 		expect(container.querySelectorAll("button").length).toBe(0);
+	});
+
+	it("accordion block renders label closed by default and reveals nested blocks on open", () => {
+		const { container } = renderBlocks([
+			{
+				type: "accordion",
+				label: "Advanced",
+				blocks: [{ type: "header", text: "Hidden heading" }],
+			},
+		]);
+
+		expect(screen.getByText("Advanced")).toBeTruthy();
+		expect(container.querySelector('[data-testid="collapsible"]')?.getAttribute("data-open")).toBe(
+			"false",
+		);
+		expect(screen.queryByText("Hidden heading")).toBeNull();
+
+		fireEvent.click(screen.getByText("Advanced"));
+		expect(screen.getByText("Hidden heading")).toBeTruthy();
+	});
+
+	it("accordion block respects default_open and forwards onAction from nested blocks", () => {
+		const onAction = vi.fn();
+		renderBlocks(
+			[
+				{
+					type: "accordion",
+					label: "Tools",
+					default_open: true,
+					blocks: [
+						{
+							type: "actions",
+							elements: [{ type: "button", action_id: "ping", label: "Ping" }],
+						},
+					],
+				},
+			],
+			onAction,
+		);
+
+		fireEvent.click(screen.getByText("Ping"));
+		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "ping" });
 	});
 
 	it("columns block renders blocks in columns", () => {

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -118,6 +118,23 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("accordion", () => {
+			const result = validateBlocks([
+				{
+					type: "accordion",
+					label: "Advanced settings",
+					default_open: false,
+					blocks: [{ type: "section", text: "Hidden content" }, { type: "divider" }],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("accordion with empty blocks array", () => {
+			const result = validateBlocks([{ type: "accordion", label: "Empty", blocks: [] }]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("repeater", () => {
 			const result = validateBlocks([
 				{
@@ -410,6 +427,32 @@ describe("validateBlocks", () => {
 			]);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]!.path).toBe("blocks[0].actions[0].style");
+		});
+
+		it("accordion missing label", () => {
+			const result = validateBlocks([{ type: "accordion", blocks: [] }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors.map((e) => e.path)).toContain("blocks[0].label");
+		});
+
+		it("accordion with invalid nested blocks reports correct path", () => {
+			const result = validateBlocks([
+				{
+					type: "accordion",
+					label: "Wrap",
+					blocks: [{ type: "header" }],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].blocks[0].text");
+		});
+
+		it("accordion with non-boolean default_open", () => {
+			const result = validateBlocks([
+				{ type: "accordion", label: "Wrap", blocks: [], default_open: "yes" },
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].default_open");
 		});
 
 		it("stats item missing label or value", () => {


### PR DESCRIPTION
## What does this PR do?

Adds a new `accordion` Block Kit block that wraps nested blocks under a labeled, expandable trigger. Maps directly to Kumo's `Collapsible` component. Plugin admin pages can now hide secondary content (advanced settings, FAQs, auxiliary panels) without paginating or round-tripping through `block_action`.

Open/closed state is local to the rendered React component (with optional `default_open`) — no new interaction type needed.

Discussion: https://github.com/emdash-cms/emdash/discussions/789

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (for `@emdash-cms/blocks` — the only package touched. A pre-existing typecheck failure in `@emdash-cms/admin/src/components/PortableTextEditor.tsx` exists on `main` and is unrelated to this PR.)
- [x] `pnpm lint` passes (lint:json diagnostic count unchanged from baseline)
- [x] `pnpm test` passes (`@emdash-cms/blocks`: 75 tests, all green)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (validation: 1 valid + 3 invalid cases; renderer: 2 cases covering toggle behavior and nested `onAction` propagation)
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A, no admin UI strings introduced
- [x] I have added a changeset (`@emdash-cms/blocks` minor — additive)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/789

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
✓ tests/validation.test.ts (48 tests) — includes new accordion valid + 3 invalid cases
✓ tests/renderer.test.tsx (21 tests) — includes new accordion default-closed + default_open + onAction propagation cases
✓ tests/form-conditions.test.tsx (6 tests)

Test Files  3 passed (3)
     Tests  75 passed (75)
```

### Design notes

- **Naming**: chose `accordion` over `collapsible` (the Kumo component name) because plugins typically stack several of them — "accordion" is the more familiar UX term. Easy to flip if maintainers prefer the Kumo name.
- **No state round-trip**: open/closed is local React state. `default_open` covers the "should this start expanded" case; rejected a `block_action`-based reactive variant as adding round-trips per toggle for negligible benefit.
- **Empty `blocks` allowed**: mirrors how an empty `section` is allowed; no minimum length enforced.
- **Recursive validation**: walks nested blocks so an invalid child reports the correct path (e.g. `blocks[0].blocks[2].text`).
