### PR TITLE
feat(blocks): add empty block for empty-state placeholders

### DIFF
--- a/.changeset/blockkit-empty.md
+++ b/.changeset/blockkit-empty.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/blocks": minor
+---
+
+Adds an `empty` Block Kit block: a styled empty-state placeholder with title, optional description, copyable shell command, size variant (`sm`/`base`/`lg`), and an optional list of action elements (CTAs). Plugin admin pages can now render proper empty states for lists, tables, and onboarding flows without rolling their own layout.

--- a/docs/src/content/docs/plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/block-kit.mdx
@@ -75,6 +75,7 @@ routes: {
 | `image` | Block-level image with caption |
 | `context` | Small muted help text |
 | `columns` | 2-3 column layout with nested blocks |
+| `empty` | Empty-state placeholder with icon, title, description, optional command line, and action buttons |
 
 ## Element types
 

--- a/packages/blocks/src/blocks/empty.tsx
+++ b/packages/blocks/src/blocks/empty.tsx
@@ -1,0 +1,33 @@
+import { Empty } from "@cloudflare/kumo";
+import { Package } from "@phosphor-icons/react";
+
+import { renderElement } from "../render-element.js";
+import type { BlockInteraction, EmptyBlock } from "../types.js";
+
+export function EmptyBlockComponent({
+	block,
+	onAction,
+}: {
+	block: EmptyBlock;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	const contents =
+		block.actions && block.actions.length > 0 ? (
+			<div className="flex flex-wrap justify-center gap-2">
+				{block.actions.map((el, i) => (
+					<div key={el.action_id ?? i}>{renderElement(el, onAction)}</div>
+				))}
+			</div>
+		) : undefined;
+
+	return (
+		<Empty
+			icon={<Package size={48} weight="duotone" />}
+			title={block.title}
+			description={block.description}
+			commandLine={block.command_line}
+			size={block.size}
+			contents={contents}
+		/>
+	);
+}

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -17,6 +17,7 @@ import type {
 	RepeaterSubField,
 	DividerBlock,
 	Element,
+	EmptyBlock,
 	FieldsBlock,
 	FormBlock,
 	FormField,
@@ -422,6 +423,25 @@ function codeBlock(opts: {
 	};
 }
 
+function empty(opts: {
+	blockId?: string;
+	title: string;
+	description?: string;
+	commandLine?: string;
+	size?: "sm" | "base" | "lg";
+	actions?: Element[];
+}): EmptyBlock {
+	return {
+		type: "empty",
+		title: opts.title,
+		...(opts.description !== undefined && { description: opts.description }),
+		...(opts.commandLine !== undefined && { command_line: opts.commandLine }),
+		...(opts.size !== undefined && { size: opts.size }),
+		...(opts.actions !== undefined && { actions: opts.actions }),
+		...(opts.blockId !== undefined && { block_id: opts.blockId }),
+	};
+}
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 export const blocks = {
@@ -441,6 +461,7 @@ export const blocks = {
 	banner: bannerBlock,
 	meter,
 	code: codeBlock,
+	empty,
 };
 
 export const elements = {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -51,6 +51,7 @@ export type {
 	CodeBlock,
 	BannerBlock,
 	MeterBlock,
+	EmptyBlock,
 	Block,
 	// Interactions
 	BlockAction,

--- a/packages/blocks/src/renderer.tsx
+++ b/packages/blocks/src/renderer.tsx
@@ -5,6 +5,7 @@ import { CodeBlockComponent } from "./blocks/code.js";
 import { ColumnsBlockComponent } from "./blocks/columns.js";
 import { ContextBlockComponent } from "./blocks/context.js";
 import { DividerBlockComponent } from "./blocks/divider.js";
+import { EmptyBlockComponent } from "./blocks/empty.js";
 import { FieldsBlockComponent } from "./blocks/fields.js";
 import { FormBlockComponent } from "./blocks/form.js";
 import { HeaderBlockComponent } from "./blocks/header.js";
@@ -50,6 +51,8 @@ function renderBlock(
 			return <BannerBlockComponent block={block} />;
 		case "code":
 			return <CodeBlockComponent block={block} />;
+		case "empty":
+			return <EmptyBlockComponent block={block} onAction={onAction} />;
 		default: {
 			const _exhaustive: never = block;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -321,6 +321,15 @@ export interface CodeBlock extends BlockBase {
 	language?: "ts" | "tsx" | "jsonc" | "bash" | "css";
 }
 
+export interface EmptyBlock extends BlockBase {
+	type: "empty";
+	title: string;
+	description?: string;
+	command_line?: string;
+	size?: "sm" | "base" | "lg";
+	actions?: Element[];
+}
+
 export type Block =
 	| HeaderBlock
 	| SectionBlock
@@ -336,7 +345,8 @@ export type Block =
 	| ChartBlock
 	| BannerBlock
 	| MeterBlock
-	| CodeBlock;
+	| CodeBlock
+	| EmptyBlock;
 
 // ── Interactions ─────────────────────────────────────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -14,7 +14,10 @@ const BLOCK_TYPES = new Set([
 	"banner",
 	"meter",
 	"code",
+	"empty",
 ]);
+
+const EMPTY_SIZES = new Set(["sm", "base", "lg"]);
 
 const ELEMENT_TYPES = new Set([
 	"button",
@@ -1080,6 +1083,48 @@ function validateBlock(value: unknown, path: string, errors: ValidationError[]):
 					path: `${path}.variant`,
 					message: `Field 'variant' must be one of: ${[...BANNER_VARIANTS].join(", ")}`,
 				});
+			}
+			break;
+		}
+		case "empty": {
+			if (typeof value.title !== "string") {
+				errors.push({
+					path: `${path}.title`,
+					message: "Required field 'title' must be a string",
+				});
+			}
+			if (value.description !== undefined && typeof value.description !== "string") {
+				errors.push({
+					path: `${path}.description`,
+					message: "Field 'description' must be a string if provided",
+				});
+			}
+			if (value.command_line !== undefined && typeof value.command_line !== "string") {
+				errors.push({
+					path: `${path}.command_line`,
+					message: "Field 'command_line' must be a string if provided",
+				});
+			}
+			if (
+				value.size !== undefined &&
+				(typeof value.size !== "string" || !EMPTY_SIZES.has(value.size))
+			) {
+				errors.push({
+					path: `${path}.size`,
+					message: `Field 'size' must be one of: ${[...EMPTY_SIZES].join(", ")}`,
+				});
+			}
+			if (value.actions !== undefined) {
+				if (!Array.isArray(value.actions)) {
+					errors.push({
+						path: `${path}.actions`,
+						message: "Field 'actions' must be an array if provided",
+					});
+				} else {
+					for (let i = 0; i < value.actions.length; i++) {
+						validateElement(value.actions[i], `${path}.actions[${i}]`, errors);
+					}
+				}
 			}
 			break;
 		}

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -108,6 +108,15 @@ vi.mock("@cloudflare/kumo", () => ({
 			<code>{code}</code>
 		</pre>
 	),
+	Empty: ({ title, description, commandLine, size, contents, icon }: any) => (
+		<div data-testid="empty" data-size={size ?? "base"}>
+			{icon}
+			<strong>{title}</strong>
+			{description && <p>{description}</p>}
+			{commandLine && <pre data-testid="empty-command">{commandLine}</pre>}
+			{contents}
+		</div>
+	),
 	Checkbox: {
 		Group: ({ children, legend }: any) => (
 			<fieldset data-testid="checkbox-group">
@@ -191,6 +200,7 @@ vi.mock("@phosphor-icons/react", () => ({
 	Info: () => <span data-testid="icon-info" />,
 	Warning: () => <span data-testid="icon-warning" />,
 	WarningCircle: () => <span data-testid="icon-warning-circle" />,
+	Package: () => <span data-testid="icon-package" />,
 }));
 
 afterEach(cleanup);
@@ -419,6 +429,44 @@ describe("BlockRenderer", () => {
 		const el = screen.getByText("Updated just now");
 		expect(el.tagName).toBe("P");
 		expect(el.className).toContain("text-sm");
+	});
+
+	it("empty block renders title and default icon", () => {
+		renderBlocks([{ type: "empty", title: "No items" }]);
+		expect(screen.getByText("No items")).toBeTruthy();
+		expect(screen.getByTestId("icon-package")).toBeTruthy();
+		expect(screen.getByTestId("empty").getAttribute("data-size")).toBe("base");
+	});
+
+	it("empty block renders description, command line, size, and action buttons", () => {
+		const onAction = vi.fn();
+		renderBlocks(
+			[
+				{
+					type: "empty",
+					title: "No webhooks yet",
+					description: "Create your first webhook.",
+					command_line: "emdash webhooks create",
+					size: "lg",
+					actions: [
+						{ type: "button", action_id: "create", label: "Create webhook", style: "primary" },
+					],
+				},
+			],
+			onAction,
+		);
+
+		expect(screen.getByText("Create your first webhook.")).toBeTruthy();
+		expect(screen.getByTestId("empty-command").textContent).toBe("emdash webhooks create");
+		expect(screen.getByTestId("empty").getAttribute("data-size")).toBe("lg");
+
+		fireEvent.click(screen.getByText("Create webhook"));
+		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "create" });
+	});
+
+	it("empty block omits contents when actions array is empty", () => {
+		const { container } = renderBlocks([{ type: "empty", title: "X", actions: [] }]);
+		expect(container.querySelectorAll("button").length).toBe(0);
 	});
 
 	it("columns block renders blocks in columns", () => {

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -96,6 +96,28 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("empty (minimal)", () => {
+			const result = validateBlocks([{ type: "empty", title: "No items" }]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("empty (full)", () => {
+			const result = validateBlocks([
+				{
+					type: "empty",
+					title: "No webhooks yet",
+					description: "Create your first webhook to receive notifications.",
+					command_line: "emdash webhooks create",
+					size: "lg",
+					actions: [
+						{ type: "button", action_id: "create", label: "Create webhook", style: "primary" },
+						{ type: "button", action_id: "import", label: "Import" },
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("repeater", () => {
 			const result = validateBlocks([
 				{
@@ -358,6 +380,36 @@ describe("validateBlocks", () => {
 			]);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]!.path).toBe("blocks[0].columns[1][0].text");
+		});
+
+		it("empty missing title", () => {
+			const result = validateBlocks([{ type: "empty" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].title");
+		});
+
+		it("empty with invalid size", () => {
+			const result = validateBlocks([{ type: "empty", title: "X", size: "huge" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].size");
+		});
+
+		it("empty with non-array actions", () => {
+			const result = validateBlocks([{ type: "empty", title: "X", actions: "nope" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].actions");
+		});
+
+		it("empty with invalid action element reports correct path", () => {
+			const result = validateBlocks([
+				{
+					type: "empty",
+					title: "X",
+					actions: [{ type: "button", action_id: "go", label: "Go", style: "neon" }],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].actions[0].style");
 		});
 
 		it("stats item missing label or value", () => {


### PR DESCRIPTION
## What does this PR do?

Adds a new `empty` Block Kit block: a styled empty-state placeholder with title, description, copyable shell command, size variant (`sm`/`base`/`lg`), and an optional list of action elements rendered below. Wraps Kumo's `Empty` component with a baked-in neutral `Package` icon.

Plugin admin pages can now render proper empty states for lists, tables, and onboarding flows without composing `header` + `section` + `actions`.

Discussion: https://github.com/emdash-cms/emdash/discussions/791

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (for `@emdash-cms/blocks` — the only package touched. A pre-existing typecheck failure in `@emdash-cms/admin/src/components/PortableTextEditor.tsx` exists on `main` and is unrelated to this PR.)
- [x] `pnpm lint` passes (lint:json diagnostic count unchanged from baseline)
- [x] `pnpm test` passes (`@emdash-cms/blocks`: 77 tests, all green)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (validation: 2 valid + 4 invalid cases; renderer: default + full + empty-actions cases including `onAction` propagation)
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A, no admin UI strings introduced
- [x] I have added a changeset (`@emdash-cms/blocks` minor — additive)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/791

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
✓ tests/validation.test.ts (49 tests) — includes new empty (minimal + full) + 4 invalid cases
✓ tests/renderer.test.tsx (22 tests) — includes new empty (default + full + empty-actions) cases
✓ tests/form-conditions.test.tsx (6 tests)

Test Files  3 passed (3)
     Tests  77 passed (77)
```

### Design notes

- **Baked-in icon**: uses `Package` from `@phosphor-icons/react` (matches Kumo's own example). Plugins cannot specify an icon — same philosophy as `BannerBlock`. Keeps the JSON serializable and avoids a string→component mapping table.
- **`actions: Element[]`**: chosen over `action?: Element` because empty states often pair primary + secondary CTAs ("Create" / "Import"). Validates each element recursively so an invalid action reports the correct path (e.g. `blocks[0].actions[1].style`).
- **`command_line`**: kept the Kumo `commandLine` slot — useful for "install the CLI" / "run this seed script" empty states.
- **Sizes**: `sm` / `base` / `lg`, matching Kumo. `base` is the default.
