### PR TITLE
fix(core): alias use-sync-external-store/shim to fix pnpm hydration

### DIFF
--- a/.changeset/fix-use-sync-external-store-shim.md
+++ b/.changeset/fix-use-sync-external-store-shim.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes hydration of the inline PortableText editor on pnpm projects by aliasing `use-sync-external-store/shim` to the main `use-sync-external-store` package. The shim is a CJS-only React<18 polyfill imported transitively by `@tiptap/react`; under pnpm's virtual store Vite cannot pre-bundle it, and the browser receives raw `module.exports` which fails to load as ESM (`SyntaxError: ... does not provide an export named 'useSyncExternalStore'`). The aliases redirect to React's built-in `useSyncExternalStore` (peer-dep floor is React 18), so users no longer need to add the workaround themselves in `astro.config.mjs`.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -325,6 +325,20 @@ export function createViteConfig(
 			alias: [
 				{ find: "@emdash-cms/admin/styles.css", replacement: resolve(adminDistPath, "styles.css") },
 				{ find: "@emdash-cms/admin", replacement: useSource ? adminSourcePath : adminDistPath },
+				// `use-sync-external-store/shim` is a React <18 polyfill that ships
+				// only as CJS. It's pulled in transitively by `@tiptap/react`. With
+				// pnpm's virtual store the file lives under .pnpm/, where Vite's
+				// dep scanner can't reach it for pre-bundling — so the browser is
+				// served raw `module.exports` and hydration fails with
+				// `SyntaxError: ... does not provide an export named
+				// 'useSyncExternalStore'`. Redirect both shim entry points to the
+				// main `use-sync-external-store` package, which on React >=18
+				// (our peer-dep floor) delegates to React's built-in hook.
+				{
+					find: "use-sync-external-store/shim/index.js",
+					replacement: "use-sync-external-store",
+				},
+				{ find: "use-sync-external-store/shim", replacement: "use-sync-external-store" },
 			],
 		},
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Monorepo has both vite 6 (docs) and vite 7 (core). tsgo resolves correctly.

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -77,3 +77,64 @@ describe("createViteConfig admin aliasing", () => {
 		expect(replacement).toMatch(adminDistPattern);
 	});
 });
+
+describe("createViteConfig use-sync-external-store shim aliasing", () => {
+	const externalProjectRoot = new URL("file:///workspace/emdash-site/");
+
+	function buildConfig(adapter: string) {
+		return createViteConfig(
+			{
+				serializableConfig: {},
+				resolvedConfig: {} as never,
+				pluginDescriptors: [],
+				astroConfig: {
+					root: externalProjectRoot,
+					adapter: { name: adapter },
+				} as AstroConfig,
+			},
+			"dev",
+		);
+	}
+
+	function getAlias(config: ReturnType<typeof createViteConfig>, find: string) {
+		const aliases = Array.isArray(config.resolve?.alias) ? config.resolve.alias : [];
+		return aliases.find(
+			(alias) =>
+				typeof alias === "object" && alias !== null && "find" in alias && alias.find === find,
+		);
+	}
+
+	// Regression: with pnpm + React 18+, @tiptap/react pulls in
+	// `use-sync-external-store/shim` (CJS). Vite can't pre-bundle from the
+	// virtual store, so browsers get raw CJS and InlinePortableTextEditor
+	// fails to hydrate. The aliases redirect the shim to the main package,
+	// which delegates to React's built-in hook on React >=18.
+	for (const adapter of ["@astrojs/node", "@astrojs/cloudflare"] as const) {
+		it(`redirects use-sync-external-store/shim to the main package on ${adapter}`, () => {
+			const config = buildConfig(adapter);
+
+			const indexAlias = getAlias(config, "use-sync-external-store/shim/index.js");
+			const shimAlias = getAlias(config, "use-sync-external-store/shim");
+
+			expect(indexAlias).toMatchObject({ replacement: "use-sync-external-store" });
+			expect(shimAlias).toMatchObject({ replacement: "use-sync-external-store" });
+		});
+
+		it(`lists the more-specific shim alias before the directory alias on ${adapter}`, () => {
+			const config = buildConfig(adapter);
+			const aliases = Array.isArray(config.resolve?.alias) ? config.resolve.alias : [];
+
+			const findIndex = (find: string) =>
+				aliases.findIndex(
+					(alias) =>
+						typeof alias === "object" && alias !== null && "find" in alias && alias.find === find,
+				);
+
+			const indexIdx = findIndex("use-sync-external-store/shim/index.js");
+			const shimIdx = findIndex("use-sync-external-store/shim");
+
+			expect(indexIdx).toBeGreaterThanOrEqual(0);
+			expect(shimIdx).toBeGreaterThan(indexIdx);
+		});
+	}
+});


### PR DESCRIPTION
## What does this PR do?

`@tiptap/react` transitively imports `use-sync-external-store/shim` — a CJS-only React<18 polyfill. Under pnpm's virtual store the shim lives in `.pnpm/`, where Vite's dependency scanner can't reach it for pre-bundling, so the browser receives raw `module.exports` and `InlinePortableTextEditor` fails to hydrate with:

```
SyntaxError: ... does not provide an export named 'useSyncExternalStore'
```

This adds two `resolve.alias` entries in the integration's `vite-config.ts` that redirect both shim entry points (`use-sync-external-store/shim` and `.../shim/index.js`) to the main `use-sync-external-store` package. On React >=18 (the peer-dep floor for `emdash` and `@emdash-cms/admin`) the main entry delegates to React's built-in `useSyncExternalStore`, so the shim is never needed and users no longer have to add the workaround manually in `astro.config.mjs`.

Closes #778

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
$ pnpm --filter emdash test
...
Test Files  176 passed (176)
     Tests  2916 passed (2916)
```

The 4 new test cases in `packages/core/tests/unit/astro/vite-config.test.ts` verify the alias is present and ordered correctly (more-specific entry first) for both Node and Cloudflare adapters.
