### PR TITLE
fix(core): sanitise FTS search snippets before returning

### DIFF
--- a/.changeset/solid-insects-hug.md
+++ b/.changeset/solid-insects-hug.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Sanitises the `snippet` field returned by the `search()` API so it is safe to render with `set:html` / `innerHTML`. Previously SQLite's FTS5 `snippet()` function spliced literal `<mark>` tags around matched terms but left the surrounding text unescaped, meaning a post title like `Hello <script>alert(1)</script>` would render as live markup. Templates and components rendering snippets directly were exposed; the in-tree `LiveSearch` component already worked around this client-side. Snippets now contain only HTML-escaped source text plus literal `<mark>...</mark>` highlight tags, matching the documented contract.

--- a/packages/core/src/components/LiveSearch.astro
+++ b/packages/core/src/components/LiveSearch.astro
@@ -109,13 +109,6 @@ const config = {
 </emdash-live-search>
 
 <script>
-	// Sanitization patterns for search snippets (allow only <mark> tags from FTS5)
-	const SNIPPET_AMP_RE = /&/g;
-	const SNIPPET_LT_RE = /</g;
-	const SNIPPET_GT_RE = />/g;
-	const SNIPPET_MARK_OPEN_RE = /&lt;mark&gt;/g;
-	const SNIPPET_MARK_CLOSE_RE = /&lt;\/mark&gt;/g;
-
 	interface SearchResult {
 		collection: string;
 		id: string;
@@ -396,17 +389,15 @@ const config = {
 						collectionEl.textContent = result.collection;
 					}
 
-					// Fill in snippet (sanitize to allow only <mark> tags from FTS5 highlighting)
+					// Snippets returned by /api/search are already sanitised
+					// server-side by sanitizeSnippet() — they contain only
+					// HTML-escaped text plus literal <mark>...</mark> tags
+					// around matched terms.
 					const snippetEl = link.querySelector(
 						".emdash-live-search-result-snippet"
 					);
 					if (snippetEl && this.config.showSnippets && result.snippet) {
-						snippetEl.innerHTML = result.snippet
-							.replace(SNIPPET_AMP_RE, "&amp;")
-							.replace(SNIPPET_LT_RE, "&lt;")
-							.replace(SNIPPET_GT_RE, "&gt;")
-							.replace(SNIPPET_MARK_OPEN_RE, "<mark>")
-							.replace(SNIPPET_MARK_CLOSE_RE, "</mark>");
+						snippetEl.innerHTML = result.snippet;
 					} else if (snippetEl) {
 						snippetEl.remove();
 					}

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -222,7 +222,7 @@ async function searchSingleCollection(
 			slug: string | null;
 			locale: string;
 			title: string | null;
-			snippet: string;
+			snippet: string | null;
 			score: number;
 		}>`
 		SELECT 
@@ -262,7 +262,12 @@ async function searchSingleCollection(
 		slug: row.slug,
 		locale: row.locale,
 		title: row.title ?? undefined,
-		snippet: sanitizeSnippet(row.snippet),
+		// SQLite's snippet() returns NULL when the targeted column is
+		// NULL for that row — even if the row matched via a different
+		// searchable column. Skip sanitization in that case so we don't
+		// throw on `null.replace`. The SearchResult.snippet field is
+		// already optional, so omitting it is the documented contract.
+		snippet: row.snippet === null ? undefined : sanitizeSnippet(row.snippet),
 		score: Math.abs(row.score), // bm25 returns negative scores
 	}));
 }

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -262,9 +262,44 @@ async function searchSingleCollection(
 		slug: row.slug,
 		locale: row.locale,
 		title: row.title ?? undefined,
-		snippet: row.snippet,
+		snippet: sanitizeSnippet(row.snippet),
 		score: Math.abs(row.score), // bm25 returns negative scores
 	}));
+}
+
+// Module-scope regexes so the engine doesn't recompile per call —
+// snippet sanitization runs on every search result.
+const SNIPPET_AMP_RE = /&/g;
+const SNIPPET_LT_RE = /</g;
+const SNIPPET_GT_RE = />/g;
+const SNIPPET_QUOT_RE = /"/g;
+const SNIPPET_APOS_RE = /'/g;
+
+/**
+ * Make an FTS5 snippet safe to render with `set:html` / `innerHTML`.
+ *
+ * SQLite's `snippet()` function splices literal `<mark>` and `</mark>`
+ * markers around matched terms but does not escape the surrounding
+ * source text. Posts that legitimately contain `<`, `>`, `&`, `"` or
+ * `'` would render as broken markup, and a `<script>` literal in a
+ * title (or any other indexed field) would execute when displayed.
+ *
+ * The fix: HTML-escape the whole string, which turns the markers into
+ * `&lt;mark&gt;` / `&lt;/mark&gt;`. Then restore those two patterns to
+ * their original tag form. The result is "the indexed text with all
+ * HTML metacharacters escaped, plus a small set of literal `<mark>`
+ * highlight tags around matched terms" — which matches the API's
+ * documented contract.
+ */
+function sanitizeSnippet(snippet: string): string {
+	return snippet
+		.replace(SNIPPET_AMP_RE, "&amp;")
+		.replace(SNIPPET_LT_RE, "&lt;")
+		.replace(SNIPPET_GT_RE, "&gt;")
+		.replace(SNIPPET_QUOT_RE, "&quot;")
+		.replace(SNIPPET_APOS_RE, "&#39;")
+		.replaceAll("&lt;mark&gt;", "<mark>")
+		.replaceAll("&lt;/mark&gt;", "</mark>");
 }
 
 /**

--- a/packages/core/src/search/types.ts
+++ b/packages/core/src/search/types.ts
@@ -58,7 +58,14 @@ export interface SearchResult {
 	locale: string;
 	/** Entry title (if available) */
 	title?: string;
-	/** Highlighted snippet showing match context */
+	/**
+	 * Highlighted snippet showing match context.
+	 *
+	 * Sanitized server-side to be safe for `set:html` / `innerHTML`:
+	 * all HTML metacharacters in the source text are escaped, and
+	 * matched terms are wrapped in literal `<mark>...</mark>` tags
+	 * (the only HTML the snippet is allowed to contain).
+	 */
 	snippet?: string;
 	/** Relevance score (higher = more relevant) */
 	score: number;

--- a/packages/core/tests/integration/search/snippet-sanitization.test.ts
+++ b/packages/core/tests/integration/search/snippet-sanitization.test.ts
@@ -91,6 +91,47 @@ describe("search snippet sanitization", () => {
 		expect(snippet).toContain("&lt;");
 	});
 
+	it("does not crash when the snippet column is NULL", async () => {
+		// FTS triggers insert raw column values with no COALESCE, so any
+		// row whose title (the column the snippet() call targets) is
+		// NULL produces a NULL snippet from SQLite — even when the row
+		// matched via a different searchable column. A regression that
+		// drops the null-guard throws "Cannot read properties of null
+		// (reading 'replace')" before these assertions can run.
+		const registry = new SchemaRegistry(db);
+		await registry.updateField("post", "content", { searchable: true });
+		const ftsManager = new FTSManager(db);
+		await ftsManager.enableSearch("post");
+
+		await repo.create(
+			createPostFixture({
+				slug: "no-title",
+				status: "published",
+				data: {
+					// Deliberately NULL title — matched via the content
+					// column so this row still surfaces in results.
+					title: null,
+					content: [
+						{
+							_type: "block",
+							style: "normal",
+							children: [{ _type: "span", text: "Quokka spotted today" }],
+						},
+					],
+				},
+			}),
+		);
+
+		const { items } = await searchWithDb(db, "Quokka", {
+			collections: ["post"],
+		});
+
+		expect(items).toHaveLength(1);
+		// Whether the snippet ends up as a string or undefined doesn't
+		// matter — the contract is "the search call must not throw".
+		expect(typeof items[0]!.snippet === "string" || items[0]!.snippet === undefined).toBe(true);
+	});
+
 	it("preserves `<mark>` highlight tags as live HTML", async () => {
 		// The whole point of returning a snippet is highlighting matches.
 		// Sanitization must not strip the markers we deliberately added.

--- a/packages/core/tests/integration/search/snippet-sanitization.test.ts
+++ b/packages/core/tests/integration/search/snippet-sanitization.test.ts
@@ -1,0 +1,117 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { FTSManager } from "../../../src/search/fts-manager.js";
+import { searchWithDb } from "../../../src/search/query.js";
+import { createPostFixture } from "../../utils/fixtures.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * Snippets returned by FTS5 splice literal `<mark>` markers around matched
+ * terms but never escape the surrounding text. If the indexed content
+ * contains characters that mean something in HTML (`<`, `>`, `&`, `"`,
+ * `'`) the resulting "snippet" is unsafe to render with set:html or
+ * innerHTML — both for visual integrity (broken markup, mojibake) and
+ * for security (a `<script>` literal in a title becomes executable).
+ *
+ * The shipped contract is "snippet is safe HTML containing only <mark>
+ * highlight tags." These tests pin that contract.
+ */
+describe("search snippet sanitization", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		const ftsManager = new FTSManager(db);
+		await registry.updateField("post", "title", { searchable: true });
+		await ftsManager.enableSearch("post");
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("escapes `<` and `>` in matched content so a `<script>` title cannot execute", async () => {
+		// A title containing a literal script tag — exactly the payload
+		// that an attacker would aim at a poorly-escaped highlighter.
+		await repo.create(
+			createPostFixture({
+				slug: "xss-attempt",
+				status: "published",
+				data: { title: "Hello <script>alert(1)</script> world" },
+			}),
+		);
+
+		const { items } = await searchWithDb(db, "alert", {
+			collections: ["post"],
+		});
+
+		expect(items).toHaveLength(1);
+		const snippet = items[0]!.snippet ?? "";
+
+		// The dangerous `<script>` substring must be escaped. The result
+		// is allowed to contain `<mark>...</mark>` highlights, so we
+		// can't just assert "no `<` chars" — we assert the script tag
+		// itself cannot appear as live markup.
+		expect(snippet).not.toContain("<script>");
+		expect(snippet).not.toContain("</script>");
+		expect(snippet).toContain("&lt;script&gt;");
+	});
+
+	it("escapes ampersands so `<3` and `&amp;` round-trip correctly", async () => {
+		await repo.create(
+			createPostFixture({
+				slug: "ampersand",
+				status: "published",
+				data: { title: "Tom & Jerry: 2 < 3 forever" },
+			}),
+		);
+
+		const { items } = await searchWithDb(db, "Jerry", {
+			collections: ["post"],
+		});
+
+		expect(items).toHaveLength(1);
+		const snippet = items[0]!.snippet ?? "";
+
+		// Bare `&` must be escaped to `&amp;` — otherwise a downstream
+		// HTML parser may interpret `& Jerry` as the start of an entity.
+		expect(snippet).toContain("&amp;");
+		expect(snippet).not.toMatch(/&(?!amp;|lt;|gt;|quot;|#39;)/);
+
+		// `<` from "2 < 3" must also be escaped, even though it's not
+		// adjacent to a tag-like structure.
+		expect(snippet).toContain("&lt;");
+	});
+
+	it("preserves `<mark>` highlight tags as live HTML", async () => {
+		// The whole point of returning a snippet is highlighting matches.
+		// Sanitization must not strip the markers we deliberately added.
+		await repo.create(
+			createPostFixture({
+				slug: "highlight",
+				status: "published",
+				data: { title: "The quick brown fox jumps" },
+			}),
+		);
+
+		const { items } = await searchWithDb(db, "fox", {
+			collections: ["post"],
+		});
+
+		expect(items).toHaveLength(1);
+		const snippet = items[0]!.snippet ?? "";
+
+		expect(snippet).toContain("<mark>");
+		expect(snippet).toContain("</mark>");
+		// And the highlighted token should be the matched word.
+		expect(snippet).toMatch(/<mark>fox<\/mark>/i);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Sanitises the `snippet` field returned by `search()` server-side, so it actually matches its documented contract of "safe HTML containing only `<mark>` highlight tags".

SQLite's FTS5 `snippet()` function splices literal `<mark>` and `</mark>` markers around matched terms but does **not** escape the surrounding source text. A post with a title like `Hello <script>alert(1)</script> world` -- or just plausible content like `2 < 3 forever`, `Tom & Jerry`, or a code snippet -- would render as broken (or actively malicious) markup in any caller that uses `set:html` or `innerHTML` on `result.snippet`.

The in-tree `LiveSearch` component already worked around this with a client-side regex pass; that pass is now redundant and is removed (otherwise it would double-escape). External templates rendering snippets directly were silently exposed -- this PR fixes them automatically without a template change.

The fix is the same trick `LiveSearch` was doing client-side, but applied once on the server: HTML-escape the whole snippet (which turns the markers into `&lt;mark&gt;` / `&lt;/mark&gt;`), then `replaceAll` those two specific patterns back to real `<mark>` tags. The result is exactly what the docs already claim: source text with all HTML metacharacters escaped, plus a small set of literal highlight tags around matched terms.

Discovered while reviewing the templates PR (#787, perf/template-batch-queries) -- Copilot flagged the `set:html={result.snippet}` use in the new blog search page. The right fix is centralised, not per-template, so it lives here.

Closes #

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes (\`pnpm --filter emdash typecheck\` clean; pre-existing failure in plugins/embeds is unrelated)
- [x] \`pnpm lint\` passes (4 pre-existing diagnostics in \`packages/blocks/src/validation.ts\`, none introduced)
- [x] \`pnpm test\` passes (2915 tests including 3 new integration tests pinning the contract)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes -- new \`packages/core/tests/integration/search/snippet-sanitization.test.ts\` with three TDD-written cases (red -> green): script-tag injection escaped, ampersands escaped, highlight tags preserved
- [x] User-visible strings in the admin UI are wrapped for translation -- N/A, no UI strings
- [x] I have added a changeset (\`patch\` bump on \`emdash\`)
- [ ] New features link to an approved Discussion -- N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Notes

**Compatibility note.** The shape of \`result.snippet\` is unchanged (still a string), but the contents are now what the docs said they were. Any external caller that was treating the snippet as plain text will now see literal \`<mark>\` tags in their output -- a minor visual regression, but the previous behaviour was already unsafe to render either way. Any caller that was doing the escape-and-restore dance themselves will now double-escape (their \`&\` becomes \`&amp;amp;\`); the changeset note flags this so anyone rolling their own sanitisation can drop it.

This PR pairs with #787. Either order is fine: this one fixes the underlying bug; #787 introduces the first in-tree consumer that renders snippets directly (the new blog \`search.astro\`).