### PR TITLE
fix: make migrations 034 and 035 idempotent for partial reapply

### DIFF
--- a/.changeset/safe-idempotent-migrations.md
+++ b/.changeset/safe-idempotent-migrations.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes migrations 034 and 035 so they can safely re-run when a previous attempt left the schema partially applied without recording it in `_emdash_migrations`. Resolves the "index already exists" error reported on upgrade from 0.1.1 to 0.6.0+.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -91,6 +91,56 @@ export async function tableExists(db: Kysely<any>, tableName: string): Promise<b
 }
 
 /**
+ * Check if an index exists in the database.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export async function indexExists(db: Kysely<any>, indexName: string): Promise<boolean> {
+	if (isPostgres(db)) {
+		const result = await sql<{ exists: boolean }>`
+			SELECT EXISTS(
+				SELECT 1 FROM pg_indexes
+				WHERE schemaname = current_schema() AND indexname = ${indexName}
+			) as exists
+		`.execute(db);
+		return result.rows[0]?.exists === true;
+	}
+
+	const result = await sql<{ name: string }>`
+		SELECT name FROM sqlite_master
+		WHERE type = 'index' AND name = ${indexName}
+	`.execute(db);
+	return result.rows.length > 0;
+}
+
+/**
+ * Check if a column exists in the database.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
+export async function columnExists(
+	db: Kysely<any>,
+	tableName: string,
+	columnName: string,
+): Promise<boolean> {
+	if (isPostgres(db)) {
+		const result = await sql<{ exists: boolean }>`
+			SELECT EXISTS(
+				SELECT 1 FROM information_schema.columns
+				WHERE table_schema = current_schema()
+					AND table_name = ${tableName}
+					AND column_name = ${columnName}
+			) as exists
+		`.execute(db);
+		return result.rows[0]?.exists === true;
+	}
+
+	const result = await sql<{ name: string }>`
+		SELECT name FROM pragma_table_info(${tableName})
+		WHERE name = ${columnName}
+	`.execute(db);
+	return result.rows.length > 0;
+}
+
+/**
  * List tables matching a LIKE pattern.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance

--- a/packages/core/src/database/migrations/034_published_at_index.ts
+++ b/packages/core/src/database/migrations/034_published_at_index.ts
@@ -10,7 +10,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 		const table = { name: tableName };
 
 		await sql`
-			CREATE INDEX ${sql.ref(`idx_${table.name}_deleted_published_id`)}
+			CREATE INDEX IF NOT EXISTS ${sql.ref(`idx_${table.name}_deleted_published_id`)}
 			ON ${sql.ref(table.name)} (deleted_at, published_at DESC, id DESC)
 		`.execute(db);
 	}

--- a/packages/core/src/database/migrations/035_bounded_404_log.ts
+++ b/packages/core/src/database/migrations/035_bounded_404_log.ts
@@ -1,6 +1,8 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import { columnExists } from "../dialect-helpers.js";
+
 /**
  * Migration: Bounded 404 logging
  *
@@ -19,16 +21,22 @@ import { sql } from "kysely";
  */
 
 export async function up(db: Kysely<unknown>): Promise<void> {
+	const hitsExists = await columnExists(db, "_emdash_404_log", "hits");
+
 	// 1. Add columns.
-	await db.schema
-		.alterTable("_emdash_404_log")
-		.addColumn("hits", "integer", (col) => col.notNull().defaultTo(1))
-		.execute();
+	if (!hitsExists) {
+		await db.schema
+			.alterTable("_emdash_404_log")
+			.addColumn("hits", "integer", (col) => col.notNull().defaultTo(1))
+			.execute();
+	}
 
 	// SQLite won't accept a non-constant default when adding a NOT NULL column
 	// to a table with existing rows, so backfill in two steps: add nullable,
 	// populate, then rely on the application layer / future inserts to set it.
-	await db.schema.alterTable("_emdash_404_log").addColumn("last_seen_at", "text").execute();
+	if (!(await columnExists(db, "_emdash_404_log", "last_seen_at"))) {
+		await db.schema.alterTable("_emdash_404_log").addColumn("last_seen_at", "text").execute();
+	}
 
 	// Backfill last_seen_at from created_at for existing rows.
 	await sql`
@@ -44,68 +52,77 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 	//    (3.25+, 2018) and Postgres. The previous GROUP BY approach was
 	//    accepted by SQLite but invalid on Postgres because `id` wasn't in
 	//    the GROUP BY or wrapped in an aggregate.
-	await sql`
-		WITH ranked AS (
-			SELECT
-				id,
-				path,
-				ROW_NUMBER() OVER (
-					PARTITION BY path
-					ORDER BY created_at DESC, id DESC
-				) AS rn,
-				COUNT(*) OVER (PARTITION BY path) AS path_count,
-				MAX(created_at) OVER (PARTITION BY path) AS latest_created_at
-			FROM _emdash_404_log
-		)
-		UPDATE _emdash_404_log
-		SET
-			hits = (SELECT path_count FROM ranked WHERE ranked.id = _emdash_404_log.id),
-			last_seen_at = (SELECT latest_created_at FROM ranked WHERE ranked.id = _emdash_404_log.id)
-		WHERE id IN (SELECT id FROM ranked WHERE rn = 1)
-	`.execute(db);
-
-	// Delete the non-keepers (every row except the freshest per path).
-	await sql`
-		DELETE FROM _emdash_404_log
-		WHERE id IN (
-			SELECT id FROM (
+	if (!hitsExists) {
+		await sql`
+			WITH ranked AS (
 				SELECT
 					id,
+					path,
 					ROW_NUMBER() OVER (
 						PARTITION BY path
 						ORDER BY created_at DESC, id DESC
-					) AS rn
+					) AS rn,
+					COUNT(*) OVER (PARTITION BY path) AS path_count,
+					MAX(created_at) OVER (PARTITION BY path) AS latest_created_at
 				FROM _emdash_404_log
-			) AS ranked
-			WHERE rn > 1
-		)
-	`.execute(db);
+			)
+			UPDATE _emdash_404_log
+			SET
+				hits = (SELECT path_count FROM ranked WHERE ranked.id = _emdash_404_log.id),
+				last_seen_at = (SELECT latest_created_at FROM ranked WHERE ranked.id = _emdash_404_log.id)
+			WHERE id IN (SELECT id FROM ranked WHERE rn = 1)
+		`.execute(db);
+
+		// Delete the non-keepers (every row except the freshest per path).
+		await sql`
+			DELETE FROM _emdash_404_log
+			WHERE id IN (
+				SELECT id FROM (
+					SELECT
+						id,
+						ROW_NUMBER() OVER (
+							PARTITION BY path
+							ORDER BY created_at DESC, id DESC
+						) AS rn
+					FROM _emdash_404_log
+				) AS ranked
+				WHERE rn > 1
+			)
+		`.execute(db);
+	}
 
 	// 3. Add unique index on path for upsert semantics.
 	await db.schema
 		.createIndex("idx_404_log_path_unique")
+		.ifNotExists()
 		.on("_emdash_404_log")
 		.column("path")
 		.unique()
 		.execute();
 
 	// Drop the old non-unique index; the unique one covers the same lookups.
-	await db.schema.dropIndex("idx_404_log_path").execute();
+	await db.schema.dropIndex("idx_404_log_path").ifExists().execute();
 
 	// 4. Index on last_seen_at for eviction ordering.
 	await db.schema
 		.createIndex("idx_404_log_last_seen")
+		.ifNotExists()
 		.on("_emdash_404_log")
 		.column("last_seen_at")
 		.execute();
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-	await db.schema.dropIndex("idx_404_log_last_seen").execute();
-	await db.schema.dropIndex("idx_404_log_path_unique").execute();
+	await db.schema.dropIndex("idx_404_log_last_seen").ifExists().execute();
+	await db.schema.dropIndex("idx_404_log_path_unique").ifExists().execute();
 
 	// Restore the original non-unique path index.
-	await db.schema.createIndex("idx_404_log_path").on("_emdash_404_log").column("path").execute();
+	await db.schema
+		.createIndex("idx_404_log_path")
+		.ifNotExists()
+		.on("_emdash_404_log")
+		.column("path")
+		.execute();
 
 	await db.schema.alterTable("_emdash_404_log").dropColumn("last_seen_at").execute();
 	await db.schema.alterTable("_emdash_404_log").dropColumn("hits").execute();

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -8,6 +8,7 @@ import {
 	MIGRATION_COUNT,
 } from "../../../src/database/migrations/runner.js";
 import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabaseWithCollections } from "../../utils/test-db.js";
 
 describe("Database Migrations (Integration)", () => {
 	let db: Kysely<Database>;
@@ -103,6 +104,24 @@ describe("Database Migrations (Integration)", () => {
 		const migrations = await db.selectFrom("_emdash_migrations").selectAll().execute();
 
 		// Should still only have the same number of migration records
+		expect(migrations).toHaveLength(MIGRATION_COUNT);
+	});
+
+	it("should re-run migrations 034 and 035 when schema changes were partially applied", async () => {
+		await db.destroy();
+		db = await setupTestDatabaseWithCollections();
+
+		await db
+			.deleteFrom("_emdash_migrations")
+			.where("name", "in", ["034_published_at_index", "035_bounded_404_log"])
+			.execute();
+
+		const { applied } = await runMigrations(db);
+
+		expect(applied).toContain("034_published_at_index");
+		expect(applied).toContain("035_bounded_404_log");
+
+		const migrations = await db.selectFrom("_emdash_migrations").selectAll().execute();
 		expect(migrations).toHaveLength(MIGRATION_COUNT);
 	});
 


### PR DESCRIPTION
## What does this PR do?

Closes #788

Migrations 034 and 035 weren't safe to rerun against a partially-applied schema. If a previous run's schema commit succeeded but the row write to `_emdash_migrations` failed (D1 subrequest limit, transient error mid-batch, Worker CPU limit), the next migration run reapplies the schema and crashes with `index already exists: SQLITE_ERROR (migration: 034_published_at_index)` — which is the exact failure the reporter hit upgrading from 0.1.1 to 0.6.0/0.7.0.

This makes both migrations safe to re-run on a partially-applied schema while preserving accumulated `_emdash_404_log` data.

- `034_published_at_index.ts`: `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS` so re-creating an existing per-table index is a no-op.
- `035_bounded_404_log.ts`: capture `hitsExists` once before the column adds. Guard `addColumn("hits")` and `addColumn("last_seen_at")` with `columnExists` checks. On rerun (when `hits` already exists), skip the dedup rollup `UPDATE`/`DELETE` block so live counters and `last_seen_at` aren't reset back to `COUNT(*) = 1` / `created_at`. Add `.ifNotExists()` to the new index creates and `.ifExists()` to the path-index drop (and the symmetric calls in `down()`).
- `dialect-helpers.ts`: add `columnExists` and `indexExists` helpers. Both branch on `isPostgres` and follow the same pattern as the existing `tableExists`. Use `pragma_table_info(table)` on SQLite, `information_schema.columns` / `pg_indexes` on Postgres.
- Added integration test `migrations.test.ts` that runs all migrations, deletes the rows for 034 and 035 from `_emdash_migrations`, and re-runs `runMigrations` against the partially-applied schema. Both names appear in `applied`, no error is thrown, and the migration table count returns to `MIGRATION_COUNT`.
- Patch-level changeset.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics)
- [x] `pnpm test` passes (`packages/core/tests/integration/database/migrations.test.ts` 15/15)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
Test Files  1 passed (1)
     Tests  15 passed (15)
  Duration  341ms
```

The new test exercises the partial-reapply path:

```ts
it("should re-run migrations 034 and 035 when schema changes were partially applied", async () => {
    await db.destroy();
    db = await setupTestDatabaseWithCollections();

    await db
        .deleteFrom("_emdash_migrations")
        .where("name", "in", ["034_published_at_index", "035_bounded_404_log"])
        .execute();

    const { applied } = await runMigrations(db);

    expect(applied).toContain("034_published_at_index");
    expect(applied).toContain("035_bounded_404_log");

    const migrations = await db.selectFrom("_emdash_migrations").selectAll().execute();
    expect(migrations).toHaveLength(MIGRATION_COUNT);
});
```

## Out of scope

The middleware behavior the reporter also flagged (auth middleware swallowing the migration error and falling through to a permissionless ghost user) is a separate failure mode in `auth.ts` and worth its own issue. Per CLAUDE.md's "no drive-by changes" rule, that's not addressed here.