### PR TITLE
feat(templates): make marketing blocks editable in admin

### DIFF
--- a/templates/marketing-cloudflare/astro.config.mjs
+++ b/templates/marketing-cloudflare/astro.config.mjs
@@ -52,6 +52,13 @@ export default defineConfig({
 		emdash({
 			database: d1({ binding: "DB", session: "auto" }),
 			storage: r2({ binding: "MEDIA" }),
+			plugins: [
+				{
+					id: "marketing-blocks",
+					version: "0.1.0",
+					entrypoint: "./src/plugins/marketing-blocks/index.ts",
+				},
+			],
 		}),
 	],
 	fonts: [

--- a/templates/marketing-cloudflare/astro.config.mjs
+++ b/templates/marketing-cloudflare/astro.config.mjs
@@ -56,7 +56,10 @@ export default defineConfig({
 				{
 					id: "marketing-blocks",
 					version: "0.1.0",
-					entrypoint: "./src/plugins/marketing-blocks/index.ts",
+					// Absolute file:// URL so the virtual emdash/plugins module
+					// can resolve this at build time (relative paths fail because
+					// the virtual module has no on-disk location to anchor them).
+					entrypoint: new URL("./src/plugins/marketing-blocks/index.ts", import.meta.url).href,
 				},
 			],
 		}),

--- a/templates/marketing-cloudflare/emdash-env.d.ts
+++ b/templates/marketing-cloudflare/emdash-env.d.ts
@@ -17,23 +17,8 @@ export interface Page {
   bylines?: ContentBylineCredit[];
 }
 
-export interface Post {
-  id: string;
-  slug: string | null;
-  status: string;
-  title: string;
-  featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number };
-  content?: PortableTextBlock[];
-  excerpt?: string;
-  createdAt: Date;
-  updatedAt: Date;
-  publishedAt: Date | null;
-  bylines?: ContentBylineCredit[];
-}
-
 declare module "emdash" {
   interface EmDashCollections {
     pages: Page;
-    posts: Post;
   }
 }

--- a/templates/marketing-cloudflare/seed/seed.json
+++ b/templates/marketing-cloudflare/seed/seed.json
@@ -60,8 +60,10 @@
 							"_key": "hero",
 							"headline": "Build products people actually want",
 							"subheadline": "The all-in-one platform for modern teams. Ship faster, collaborate better, and focus on what matters.",
-							"primaryCta": { "label": "Start Free Trial", "url": "/signup" },
-							"secondaryCta": { "label": "Watch Demo", "url": "/demo" }
+							"primaryCtaLabel": "Start Free Trial",
+							"primaryCtaUrl": "/signup",
+							"secondaryCtaLabel": "Watch Demo",
+							"secondaryCtaUrl": "/demo"
 						},
 						{
 							"_type": "marketing.features",
@@ -175,44 +177,27 @@
 									"price": "$0",
 									"period": "/month",
 									"description": "Perfect for trying things out",
-									"features": [
-										"Up to 3 team members",
-										"5 projects",
-										"Basic analytics",
-										"Community support",
-										"1GB storage"
-									],
-									"cta": { "label": "Get Started", "url": "/signup" }
+									"features": "Up to 3 team members\n5 projects\nBasic analytics\nCommunity support\n1GB storage",
+									"ctaLabel": "Get Started",
+									"ctaUrl": "/signup"
 								},
 								{
 									"name": "Pro",
 									"price": "$29",
 									"period": "/user/month",
 									"description": "For growing teams",
-									"features": [
-										"Unlimited team members",
-										"Unlimited projects",
-										"Advanced analytics",
-										"Priority support",
-										"100GB storage",
-										"Custom integrations",
-										"API access"
-									],
-									"cta": { "label": "Start Free Trial", "url": "/signup?plan=pro" },
+									"features": "Unlimited team members\nUnlimited projects\nAdvanced analytics\nPriority support\n100GB storage\nCustom integrations\nAPI access",
+									"ctaLabel": "Start Free Trial",
+									"ctaUrl": "/signup?plan=pro",
 									"highlighted": true
 								},
 								{
 									"name": "Enterprise",
 									"price": "Custom",
 									"description": "For large organizations",
-									"features": [
-										"Everything in Pro",
-										"Dedicated support",
-										"Custom contracts",
-										"SLA guarantee",
-										"Unlimited storage"
-									],
-									"cta": { "label": "Contact Sales", "url": "/contact" }
+									"features": "Everything in Pro\nDedicated support\nCustom contracts\nSLA guarantee\nUnlimited storage",
+									"ctaLabel": "Contact Sales",
+									"ctaUrl": "/contact"
 								}
 							]
 						},

--- a/templates/marketing-cloudflare/src/components/blocks/Hero.astro
+++ b/templates/marketing-cloudflare/src/components/blocks/Hero.astro
@@ -3,15 +3,28 @@ interface Props {
 	node: {
 		headline: string;
 		subheadline?: string;
-		primaryCta?: { label: string; url: string };
-		secondaryCta?: { label: string; url: string };
+		// CTAs are flattened to sibling fields because Block Kit has no
+		// object-group element. Empty strings mean "no CTA".
+		primaryCtaLabel?: string;
+		primaryCtaUrl?: string;
+		secondaryCtaLabel?: string;
+		secondaryCtaUrl?: string;
 		image?: { url: string; alt?: string };
 		centered?: boolean;
 	};
 }
 
 const { node } = Astro.props;
-const { headline, subheadline, primaryCta, secondaryCta, image, centered } = node;
+const { headline, subheadline, image, centered } = node;
+
+const primaryCta =
+	node.primaryCtaLabel && node.primaryCtaUrl
+		? { label: node.primaryCtaLabel, url: node.primaryCtaUrl }
+		: undefined;
+const secondaryCta =
+	node.secondaryCtaLabel && node.secondaryCtaUrl
+		? { label: node.secondaryCtaLabel, url: node.secondaryCtaUrl }
+		: undefined;
 ---
 
 <section class:list={["hero", { "hero-centered": centered, "hero-with-image": !!image }]}>

--- a/templates/marketing-cloudflare/src/components/blocks/Pricing.astro
+++ b/templates/marketing-cloudflare/src/components/blocks/Pricing.astro
@@ -1,21 +1,40 @@
 ---
+interface RawPlan {
+	name: string;
+	price: string;
+	period?: string;
+	description?: string;
+	// Features are stored as a newline-separated string (Block Kit has no
+	// list-of-strings element, so a multiline text input is the closest fit).
+	features?: string;
+	// CTAs are flattened to sibling fields because Block Kit has no
+	// object-group element.
+	ctaLabel?: string;
+	ctaUrl?: string;
+	highlighted?: boolean;
+}
+
 interface Props {
 	node: {
 		headline?: string;
-		plans: Array<{
-			name: string;
-			price: string;
-			period?: string;
-			description?: string;
-			features: string[];
-			cta: { label: string; url: string };
-			highlighted?: boolean;
-		}>;
+		plans: RawPlan[];
 	};
 }
 
 const { node } = Astro.props;
-const { headline, plans } = node;
+const { headline, plans: rawPlans } = node;
+
+const plans = rawPlans.map((plan) => ({
+	...plan,
+	features: (plan.features ?? "")
+		.split("\n")
+		.map((s) => s.trim())
+		.filter(Boolean),
+	cta: {
+		label: plan.ctaLabel ?? "",
+		url: plan.ctaUrl ?? "#",
+	},
+}));
 ---
 
 <section class="pricing section">

--- a/templates/marketing-cloudflare/src/plugins/marketing-blocks/index.ts
+++ b/templates/marketing-cloudflare/src/plugins/marketing-blocks/index.ts
@@ -1,0 +1,213 @@
+/**
+ * Marketing blocks plugin (inline, template-local).
+ *
+ * Registers the five marketing block types so editors can insert and edit them
+ * in the admin's Portable Text editor. Block Kit `fields` describe the form
+ * shown when inserting or editing a block.
+ *
+ * Constraints worth knowing:
+ *
+ * - Block Kit has no "object group" element, so nested object shapes (e.g. a
+ *   CTA's { label, url }) are flattened to sibling fields like ctaLabel and
+ *   ctaUrl. The site-side renderer reads the flat keys.
+ * - Repeater sub-fields are scalar only: text_input, number_input, select,
+ *   toggle. Nested repeaters are not allowed -- list-of-strings becomes a
+ *   single multiline text field, split on newline at render time (see
+ *   Pricing.astro for the pattern).
+ * - There is no media picker element in the editor's plugin-block modal yet,
+ *   so image fields (avatars, hero images) are URL strings entered by hand.
+ *
+ * Site-side rendering still goes through MarketingBlocks.astro --
+ * componentsEntry auto-wiring is a separate cleanup.
+ */
+
+import { definePlugin } from "emdash";
+import type { PluginDefinition } from "emdash";
+
+const ICON_OPTIONS = [
+	{ label: "Lightning", value: "zap" },
+	{ label: "Shield", value: "shield" },
+	{ label: "Users", value: "users" },
+	{ label: "Chart", value: "chart" },
+	{ label: "Code", value: "code" },
+	{ label: "Globe", value: "globe" },
+	{ label: "Heart", value: "heart" },
+	{ label: "Star", value: "star" },
+	{ label: "Check", value: "check" },
+	{ label: "Lock", value: "lock" },
+	{ label: "Clock", value: "clock" },
+	{ label: "Cloud", value: "cloud" },
+];
+
+const definition: PluginDefinition = {
+	id: "marketing-blocks",
+	version: "0.1.0",
+
+	admin: {
+		portableTextBlocks: [
+			{
+				type: "marketing.hero",
+				label: "Hero",
+				description: "Big headline section with optional CTAs",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "text_input",
+						action_id: "subheadline",
+						label: "Subheadline",
+						multiline: true,
+					},
+					{ type: "text_input", action_id: "primaryCtaLabel", label: "Primary CTA label" },
+					{ type: "text_input", action_id: "primaryCtaUrl", label: "Primary CTA URL" },
+					{
+						type: "text_input",
+						action_id: "secondaryCtaLabel",
+						label: "Secondary CTA label",
+					},
+					{ type: "text_input", action_id: "secondaryCtaUrl", label: "Secondary CTA URL" },
+					{ type: "toggle", action_id: "centered", label: "Center the layout" },
+				],
+			},
+
+			{
+				type: "marketing.features",
+				label: "Features",
+				description: "Grid of feature cards with icons",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "text_input",
+						action_id: "subheadline",
+						label: "Subheadline",
+						multiline: true,
+					},
+					{
+						type: "repeater",
+						action_id: "features",
+						label: "Features",
+						item_label: "Feature",
+						min_items: 1,
+						max_items: 12,
+						fields: [
+							{
+								type: "select",
+								action_id: "icon",
+								label: "Icon",
+								options: ICON_OPTIONS,
+							},
+							{ type: "text_input", action_id: "title", label: "Title" },
+							{
+								type: "text_input",
+								action_id: "description",
+								label: "Description",
+								multiline: true,
+							},
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.testimonials",
+				label: "Testimonials",
+				description: "Customer testimonial cards",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "testimonials",
+						label: "Testimonials",
+						item_label: "Testimonial",
+						min_items: 1,
+						fields: [
+							{ type: "text_input", action_id: "quote", label: "Quote", multiline: true },
+							{ type: "text_input", action_id: "author", label: "Author name" },
+							{ type: "text_input", action_id: "role", label: "Role / title" },
+							{ type: "text_input", action_id: "company", label: "Company" },
+							{ type: "text_input", action_id: "avatar", label: "Avatar URL" },
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.pricing",
+				label: "Pricing",
+				description: "Pricing plan comparison cards",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "plans",
+						label: "Plans",
+						item_label: "Plan",
+						min_items: 1,
+						max_items: 6,
+						fields: [
+							{ type: "text_input", action_id: "name", label: "Plan name" },
+							{
+								type: "text_input",
+								action_id: "price",
+								label: "Price",
+								placeholder: "$29 or Custom",
+							},
+							{
+								type: "text_input",
+								action_id: "period",
+								label: "Period",
+								placeholder: "/month",
+							},
+							{
+								type: "text_input",
+								action_id: "description",
+								label: "Description",
+								multiline: true,
+							},
+							{
+								type: "text_input",
+								action_id: "features",
+								label: "Features (one per line)",
+								multiline: true,
+								placeholder: "Unlimited projects\nPriority support\nSSO",
+							},
+							{ type: "text_input", action_id: "ctaLabel", label: "CTA label" },
+							{ type: "text_input", action_id: "ctaUrl", label: "CTA URL" },
+							{ type: "toggle", action_id: "highlighted", label: "Highlight this plan" },
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.faq",
+				label: "FAQ",
+				description: "Frequently asked questions",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "items",
+						label: "Questions",
+						item_label: "Question",
+						min_items: 1,
+						fields: [
+							{ type: "text_input", action_id: "question", label: "Question" },
+							{
+								type: "text_input",
+								action_id: "answer",
+								label: "Answer",
+								multiline: true,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+};
+
+export function createPlugin() {
+	return definePlugin(definition);
+}
+
+export default createPlugin;

--- a/templates/marketing/astro.config.mjs
+++ b/templates/marketing/astro.config.mjs
@@ -46,6 +46,13 @@ export default defineConfig({
 				directory: "./uploads",
 				baseUrl: "/_emdash/api/media/file",
 			}),
+			plugins: [
+				{
+					id: "marketing-blocks",
+					version: "0.1.0",
+					entrypoint: "./src/plugins/marketing-blocks/index.ts",
+				},
+			],
 		}),
 	],
 	fonts: [

--- a/templates/marketing/astro.config.mjs
+++ b/templates/marketing/astro.config.mjs
@@ -50,7 +50,10 @@ export default defineConfig({
 				{
 					id: "marketing-blocks",
 					version: "0.1.0",
-					entrypoint: "./src/plugins/marketing-blocks/index.ts",
+					// Absolute file:// URL so the virtual emdash/plugins module
+					// can resolve this at build time (relative paths fail because
+					// the virtual module has no on-disk location to anchor them).
+					entrypoint: new URL("./src/plugins/marketing-blocks/index.ts", import.meta.url).href,
 				},
 			],
 		}),

--- a/templates/marketing/seed/seed.json
+++ b/templates/marketing/seed/seed.json
@@ -60,8 +60,10 @@
 							"_key": "hero",
 							"headline": "Build products people actually want",
 							"subheadline": "The all-in-one platform for modern teams. Ship faster, collaborate better, and focus on what matters.",
-							"primaryCta": { "label": "Start Free Trial", "url": "/signup" },
-							"secondaryCta": { "label": "Watch Demo", "url": "/demo" }
+							"primaryCtaLabel": "Start Free Trial",
+							"primaryCtaUrl": "/signup",
+							"secondaryCtaLabel": "Watch Demo",
+							"secondaryCtaUrl": "/demo"
 						},
 						{
 							"_type": "marketing.features",
@@ -175,44 +177,27 @@
 									"price": "$0",
 									"period": "/month",
 									"description": "Perfect for trying things out",
-									"features": [
-										"Up to 3 team members",
-										"5 projects",
-										"Basic analytics",
-										"Community support",
-										"1GB storage"
-									],
-									"cta": { "label": "Get Started", "url": "/signup" }
+									"features": "Up to 3 team members\n5 projects\nBasic analytics\nCommunity support\n1GB storage",
+									"ctaLabel": "Get Started",
+									"ctaUrl": "/signup"
 								},
 								{
 									"name": "Pro",
 									"price": "$29",
 									"period": "/user/month",
 									"description": "For growing teams",
-									"features": [
-										"Unlimited team members",
-										"Unlimited projects",
-										"Advanced analytics",
-										"Priority support",
-										"100GB storage",
-										"Custom integrations",
-										"API access"
-									],
-									"cta": { "label": "Start Free Trial", "url": "/signup?plan=pro" },
+									"features": "Unlimited team members\nUnlimited projects\nAdvanced analytics\nPriority support\n100GB storage\nCustom integrations\nAPI access",
+									"ctaLabel": "Start Free Trial",
+									"ctaUrl": "/signup?plan=pro",
 									"highlighted": true
 								},
 								{
 									"name": "Enterprise",
 									"price": "Custom",
 									"description": "For large organizations",
-									"features": [
-										"Everything in Pro",
-										"Dedicated support",
-										"Custom contracts",
-										"SLA guarantee",
-										"Unlimited storage"
-									],
-									"cta": { "label": "Contact Sales", "url": "/contact" }
+									"features": "Everything in Pro\nDedicated support\nCustom contracts\nSLA guarantee\nUnlimited storage",
+									"ctaLabel": "Contact Sales",
+									"ctaUrl": "/contact"
 								}
 							]
 						},

--- a/templates/marketing/src/components/blocks/Hero.astro
+++ b/templates/marketing/src/components/blocks/Hero.astro
@@ -3,15 +3,28 @@ interface Props {
 	node: {
 		headline: string;
 		subheadline?: string;
-		primaryCta?: { label: string; url: string };
-		secondaryCta?: { label: string; url: string };
+		// CTAs are flattened to sibling fields because Block Kit has no
+		// object-group element. Empty strings mean "no CTA".
+		primaryCtaLabel?: string;
+		primaryCtaUrl?: string;
+		secondaryCtaLabel?: string;
+		secondaryCtaUrl?: string;
 		image?: { url: string; alt?: string };
 		centered?: boolean;
 	};
 }
 
 const { node } = Astro.props;
-const { headline, subheadline, primaryCta, secondaryCta, image, centered } = node;
+const { headline, subheadline, image, centered } = node;
+
+const primaryCta =
+	node.primaryCtaLabel && node.primaryCtaUrl
+		? { label: node.primaryCtaLabel, url: node.primaryCtaUrl }
+		: undefined;
+const secondaryCta =
+	node.secondaryCtaLabel && node.secondaryCtaUrl
+		? { label: node.secondaryCtaLabel, url: node.secondaryCtaUrl }
+		: undefined;
 ---
 
 <section class:list={["hero", { "hero-centered": centered, "hero-with-image": !!image }]}>

--- a/templates/marketing/src/components/blocks/Pricing.astro
+++ b/templates/marketing/src/components/blocks/Pricing.astro
@@ -1,21 +1,40 @@
 ---
+interface RawPlan {
+	name: string;
+	price: string;
+	period?: string;
+	description?: string;
+	// Features are stored as a newline-separated string (Block Kit has no
+	// list-of-strings element, so a multiline text input is the closest fit).
+	features?: string;
+	// CTAs are flattened to sibling fields because Block Kit has no
+	// object-group element.
+	ctaLabel?: string;
+	ctaUrl?: string;
+	highlighted?: boolean;
+}
+
 interface Props {
 	node: {
 		headline?: string;
-		plans: Array<{
-			name: string;
-			price: string;
-			period?: string;
-			description?: string;
-			features: string[];
-			cta: { label: string; url: string };
-			highlighted?: boolean;
-		}>;
+		plans: RawPlan[];
 	};
 }
 
 const { node } = Astro.props;
-const { headline, plans } = node;
+const { headline, plans: rawPlans } = node;
+
+const plans = rawPlans.map((plan) => ({
+	...plan,
+	features: (plan.features ?? "")
+		.split("\n")
+		.map((s) => s.trim())
+		.filter(Boolean),
+	cta: {
+		label: plan.ctaLabel ?? "",
+		url: plan.ctaUrl ?? "#",
+	},
+}));
 ---
 
 <section class="pricing section">

--- a/templates/marketing/src/plugins/marketing-blocks/index.ts
+++ b/templates/marketing/src/plugins/marketing-blocks/index.ts
@@ -1,0 +1,213 @@
+/**
+ * Marketing blocks plugin (inline, template-local).
+ *
+ * Registers the five marketing block types so editors can insert and edit them
+ * in the admin's Portable Text editor. Block Kit `fields` describe the form
+ * shown when inserting or editing a block.
+ *
+ * Constraints worth knowing:
+ *
+ * - Block Kit has no "object group" element, so nested object shapes (e.g. a
+ *   CTA's { label, url }) are flattened to sibling fields like ctaLabel and
+ *   ctaUrl. The site-side renderer reads the flat keys.
+ * - Repeater sub-fields are scalar only: text_input, number_input, select,
+ *   toggle. Nested repeaters are not allowed -- list-of-strings becomes a
+ *   single multiline text field, split on newline at render time (see
+ *   Pricing.astro for the pattern).
+ * - There is no media picker element in the editor's plugin-block modal yet,
+ *   so image fields (avatars, hero images) are URL strings entered by hand.
+ *
+ * Site-side rendering still goes through MarketingBlocks.astro --
+ * componentsEntry auto-wiring is a separate cleanup.
+ */
+
+import { definePlugin } from "emdash";
+import type { PluginDefinition } from "emdash";
+
+const ICON_OPTIONS = [
+	{ label: "Lightning", value: "zap" },
+	{ label: "Shield", value: "shield" },
+	{ label: "Users", value: "users" },
+	{ label: "Chart", value: "chart" },
+	{ label: "Code", value: "code" },
+	{ label: "Globe", value: "globe" },
+	{ label: "Heart", value: "heart" },
+	{ label: "Star", value: "star" },
+	{ label: "Check", value: "check" },
+	{ label: "Lock", value: "lock" },
+	{ label: "Clock", value: "clock" },
+	{ label: "Cloud", value: "cloud" },
+];
+
+const definition: PluginDefinition = {
+	id: "marketing-blocks",
+	version: "0.1.0",
+
+	admin: {
+		portableTextBlocks: [
+			{
+				type: "marketing.hero",
+				label: "Hero",
+				description: "Big headline section with optional CTAs",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "text_input",
+						action_id: "subheadline",
+						label: "Subheadline",
+						multiline: true,
+					},
+					{ type: "text_input", action_id: "primaryCtaLabel", label: "Primary CTA label" },
+					{ type: "text_input", action_id: "primaryCtaUrl", label: "Primary CTA URL" },
+					{
+						type: "text_input",
+						action_id: "secondaryCtaLabel",
+						label: "Secondary CTA label",
+					},
+					{ type: "text_input", action_id: "secondaryCtaUrl", label: "Secondary CTA URL" },
+					{ type: "toggle", action_id: "centered", label: "Center the layout" },
+				],
+			},
+
+			{
+				type: "marketing.features",
+				label: "Features",
+				description: "Grid of feature cards with icons",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "text_input",
+						action_id: "subheadline",
+						label: "Subheadline",
+						multiline: true,
+					},
+					{
+						type: "repeater",
+						action_id: "features",
+						label: "Features",
+						item_label: "Feature",
+						min_items: 1,
+						max_items: 12,
+						fields: [
+							{
+								type: "select",
+								action_id: "icon",
+								label: "Icon",
+								options: ICON_OPTIONS,
+							},
+							{ type: "text_input", action_id: "title", label: "Title" },
+							{
+								type: "text_input",
+								action_id: "description",
+								label: "Description",
+								multiline: true,
+							},
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.testimonials",
+				label: "Testimonials",
+				description: "Customer testimonial cards",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "testimonials",
+						label: "Testimonials",
+						item_label: "Testimonial",
+						min_items: 1,
+						fields: [
+							{ type: "text_input", action_id: "quote", label: "Quote", multiline: true },
+							{ type: "text_input", action_id: "author", label: "Author name" },
+							{ type: "text_input", action_id: "role", label: "Role / title" },
+							{ type: "text_input", action_id: "company", label: "Company" },
+							{ type: "text_input", action_id: "avatar", label: "Avatar URL" },
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.pricing",
+				label: "Pricing",
+				description: "Pricing plan comparison cards",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "plans",
+						label: "Plans",
+						item_label: "Plan",
+						min_items: 1,
+						max_items: 6,
+						fields: [
+							{ type: "text_input", action_id: "name", label: "Plan name" },
+							{
+								type: "text_input",
+								action_id: "price",
+								label: "Price",
+								placeholder: "$29 or Custom",
+							},
+							{
+								type: "text_input",
+								action_id: "period",
+								label: "Period",
+								placeholder: "/month",
+							},
+							{
+								type: "text_input",
+								action_id: "description",
+								label: "Description",
+								multiline: true,
+							},
+							{
+								type: "text_input",
+								action_id: "features",
+								label: "Features (one per line)",
+								multiline: true,
+								placeholder: "Unlimited projects\nPriority support\nSSO",
+							},
+							{ type: "text_input", action_id: "ctaLabel", label: "CTA label" },
+							{ type: "text_input", action_id: "ctaUrl", label: "CTA URL" },
+							{ type: "toggle", action_id: "highlighted", label: "Highlight this plan" },
+						],
+					},
+				],
+			},
+
+			{
+				type: "marketing.faq",
+				label: "FAQ",
+				description: "Frequently asked questions",
+				fields: [
+					{ type: "text_input", action_id: "headline", label: "Headline" },
+					{
+						type: "repeater",
+						action_id: "items",
+						label: "Questions",
+						item_label: "Question",
+						min_items: 1,
+						fields: [
+							{ type: "text_input", action_id: "question", label: "Question" },
+							{
+								type: "text_input",
+								action_id: "answer",
+								label: "Answer",
+								multiline: true,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+};
+
+export function createPlugin() {
+	return definePlugin(definition);
+}
+
+export default createPlugin;

--- a/templates/starter-cloudflare/emdash-env.d.ts
+++ b/templates/starter-cloudflare/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -14,7 +14,6 @@ export interface Page {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
-  bylines?: ContentBylineCredit[];
 }
 
 export interface Post {
@@ -28,7 +27,6 @@ export interface Post {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
-  bylines?: ContentBylineCredit[];
 }
 
 declare module "emdash" {


### PR DESCRIPTION
## What does this PR do?

Adds an inline plugin to the `marketing` and `marketing-cloudflare` templates that registers the five marketing block types (hero, features, testimonials, pricing, faq) with Block Kit field schemas. Editors can now insert and edit the blocks via the Portable Text editor's slash menu and modal, instead of seeing them as opaque `Marketing.*` entries with a URL fallback.

The plugin lives at `src/plugins/marketing-blocks/index.ts` and is wired via a relative `entrypoint` in `astro.config.mjs`. No new dependency.

### Shape changes in the seed

Block Kit's element vocabulary forced two on-disk shape changes:

- **CTAs are flattened to sibling fields** (`primaryCtaLabel`/`primaryCtaUrl`, `ctaLabel`/`ctaUrl`) because Block Kit has no object-group element. `Hero.astro` and `Pricing.astro` updated to read the flat shape.
- **Pricing plan features become a newline-separated string** because repeater sub-fields are scalar only (no nested repeaters). `Pricing.astro` splits on newline at render time.

Existing template users on prior versions are unaffected -- their data is already in their database. New users get editable blocks day one.

### Drive-bys (from the cloudflare-template sync script)

Running `scripts/sync-cloudflare-templates.sh` to mirror the changes also picked up two pre-existing dts inconsistencies:

- `templates/marketing-cloudflare/emdash-env.d.ts`: drops a stale `Post` type that didn't match the seed.
- `templates/starter-cloudflare/emdash-env.d.ts`: drops a stale `bylines` field.

Both were drifting from their base templates and would regenerate on first `pnpm dev` anyway -- now they match.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (4 pre-existing diagnostics in `packages/blocks/src/validation.ts`, unchanged from main)
- [x] `pnpm test` passes
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (template seed/render flow; smoke-tested via the dev admin -- agent-browser screenshots verified the modal renders and round-trips)
- [x] User-visible strings -- no admin UI strings introduced (block labels are template-author-facing config, not localised)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) -- N/A, template-only change
- [ ] New features link to an approved Discussion -- see note above

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

End-to-end smoke tested:

- Plugin appears in `/_emdash/api/manifest` as `plugins["marketing-blocks"].portableTextBlocks` with all five blocks and full `fields` arrays.
- Slash menu shows "Hero", "Features", "Testimonials", "Pricing", "FAQ" (registered labels, not type slugs).
- Edit modals render proper Block Kit forms (text inputs, multiline textareas, repeaters with drag/reorder, icon select, toggle).
- Existing seed data round-trips losslessly -- toggling `centered` and saving preserves all other fields including ones not in the form schema.
- Live `/` and `/pricing` pages render identically to before (verified visually).