### PR TITLE
fix(core): preserve plugin block payloads in visual-editing inline editor

### DIFF
--- a/.changeset/dull-jobs-argue.md
+++ b/.changeset/dull-jobs-argue.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes data loss in the visual-editing inline editor for plugin-contributed Portable Text block types. Previously, custom blocks like `marketing.hero` lost every field except `id` when the page was opened in edit mode, and the next save persisted the loss. Blocks now round-trip losslessly and render as a read-only placeholder labelled with the block type.

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -10,7 +10,7 @@
  */
 
 import { autoUpdate, flip, offset, shift, useFloating } from "@floating-ui/react";
-import { Extension, type JSONContent, type Range } from "@tiptap/core";
+import { Extension, Node, mergeAttributes, type JSONContent, type Range } from "@tiptap/core";
 import Focus from "@tiptap/extension-focus";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
@@ -202,12 +202,18 @@ function convertPMNode(node: PMNode): PTBlock | PTBlock[] | null {
 		}
 		case "horizontalRule":
 			return { _type: "break", _key: k(), style: "lineBreak" };
-		case "pluginBlock":
+		case "pluginBlock": {
+			// Spread the captured data back out so the block round-trips losslessly.
+			// `data` holds every field except _type / _key / id (which live on
+			// dedicated attrs).
+			const { blockType, id, data } = node.attrs ?? {};
 			return {
-				_type: attrStr(node.attrs, "blockType") || "embed",
+				...(data && typeof data === "object" ? data : {}),
+				_type: typeof blockType === "string" ? blockType : "embed",
 				_key: k(),
-				id: attrStr(node.attrs, "id"),
+				id: typeof id === "string" ? id : "",
 			};
+		}
 		default:
 			return null;
 	}
@@ -412,21 +418,23 @@ function convertPTBlock(block: PTBlock): JSONContent | null {
 			},
 		};
 	}
-	// Unknown block types — treat as plugin blocks if they have an id
-	const embedBlock = block as { _type: string; url?: string; id?: string };
-	if (embedBlock.id || embedBlock.url) {
-		return {
-			type: "pluginBlock",
-			attrs: {
-				blockType: block._type,
-				id: embedBlock.id || embedBlock.url || "",
-			},
-		};
-	}
-	// Truly unknown — render as code-marked text
+	// Unknown block types — treat as plugin blocks. Capture every field other
+	// than the well-known ones into `data` so the block round-trips losslessly,
+	// even if no plugin currently registers this type. Matches the admin
+	// editor's behaviour at PortableTextEditor.tsx:572-588.
+	const { _type, _key, id, url, ...rest } = block as { _type: string; _key: string } & Record<
+		string,
+		unknown
+	>;
+	// Filter out _-prefixed keys to prevent accumulation across edit cycles.
+	const data = Object.fromEntries(Object.entries(rest).filter(([key]) => !key.startsWith("_")));
 	return {
-		type: "paragraph",
-		content: [{ type: "text", text: `[${block._type}]`, marks: [{ type: "code" }] }],
+		type: "pluginBlock",
+		attrs: {
+			blockType: typeof _type === "string" ? _type : "embed",
+			id: typeof id === "string" ? id : typeof url === "string" ? url : "",
+			data,
+		},
 	};
 }
 
@@ -761,6 +769,61 @@ const initialSlashMenuState: SlashMenuState = {
 	clientRect: null,
 	range: null,
 };
+
+/**
+ * Minimal `pluginBlock` TipTap node for the inline (visual-editing) editor.
+ *
+ * Plugin-contributed Portable Text block types (e.g. `marketing.hero`) are
+ * editable in the admin via a Block Kit modal. The visual-editing surface
+ * deliberately does NOT offer that UX — it would need to fetch the manifest,
+ * mount the modal, and round-trip through plugin-block plumbing that lives in
+ * `@emdash-cms/admin`. Instead, the inline editor renders these blocks as a
+ * read-only placeholder so editors can see they exist and edit the surrounding
+ * content without losing the block's data.
+ *
+ * The full block payload is preserved on `data` and round-tripped losslessly
+ * through PT ↔ PM conversion (see convertPTBlock/convertPMNode). Without this
+ * extension, ProseMirror's schema would silently filter unknown nodes on load
+ * and the next save would persist the block's disappearance.
+ */
+const PluginBlockNode = Node.create({
+	name: "pluginBlock",
+	group: "block",
+	atom: true,
+	selectable: true,
+	draggable: true,
+
+	addAttributes() {
+		// All three attributes are stored on the ProseMirror node but not
+		// rendered as DOM attributes — they're metadata for the round-trip,
+		// not styling or behaviour the placeholder DOM needs to expose.
+		const noDom = { rendered: false, parseHTML: () => null };
+		return {
+			blockType: { default: "", ...noDom },
+			id: { default: "", ...noDom },
+			data: { default: {}, ...noDom },
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: 'div[data-emdash-plugin-block="true"]' }];
+	},
+
+	renderHTML({ HTMLAttributes, node }) {
+		const blockType = typeof node.attrs.blockType === "string" ? node.attrs.blockType : "";
+		const label = blockType || "Block";
+		return [
+			"div",
+			mergeAttributes(HTMLAttributes, {
+				"data-emdash-plugin-block": "true",
+				"data-block-type": blockType,
+				class: "emdash-plugin-block-placeholder",
+				contenteditable: "false",
+			}),
+			`Plugin block: ${label} (edit in admin)`,
+		];
+	},
+});
 
 function createSlashCommandsExtension(options: {
 	filterCommands: (query: string) => SlashCommandItem[];
@@ -1734,6 +1797,7 @@ export function InlinePortableTextEditor({
 				mode: "all",
 			}),
 			Typography,
+			PluginBlockNode,
 			slashCommandsExtension,
 		],
 		content: initialContent,
@@ -1932,7 +1996,29 @@ export function InlinePortableTextEditor({
 				.emdash-inline-editor:focus {
 					outline: none;
 				}
+				.emdash-plugin-block-placeholder {
+					margin: 0.75rem 0;
+					padding: 0.625rem 0.875rem;
+					border: 1px dashed #d1d5db;
+					border-radius: 0.5rem;
+					background: #f9fafb;
+					color: #4b5563;
+					font-size: 0.875rem;
+					font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+					user-select: none;
+				}
+				@media (prefers-color-scheme: dark) {
+					.emdash-plugin-block-placeholder {
+						border-color: #374151;
+						background: #111827;
+						color: #9ca3af;
+					}
+				}
 			`}</style>
 		</div>
 	);
 }
+
+// Test-only exports for unit tests of the conversion functions.
+export { pmToPortableText as _pmToPortableText };
+export { portableTextToPM as _portableTextToPM };

--- a/packages/core/tests/unit/components/inline-portable-text-plugin-block.test.ts
+++ b/packages/core/tests/unit/components/inline-portable-text-plugin-block.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Inline editor plugin-block round-trip tests.
+ *
+ * Regression tests for the bug where the visual-editing inline editor
+ * coerced unknown Portable Text block types (e.g. `marketing.hero`) into
+ * `pluginBlock` ProseMirror nodes that only carried `{ blockType, id }`,
+ * silently dropping every other field. On save, `pmToPortableText` then
+ * serialised the block back as `{ _type, _key, id }`, persisting the data
+ * loss.
+ *
+ * The fix preserves all non-well-known fields on a `data` attribute and
+ * spreads them back out during the PM → PT direction. See
+ * `InlinePortableTextEditor.tsx` `case "pluginBlock"` and the unknown-block
+ * fallback in `convertPTBlock`.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	_pmToPortableText as pmToPortableText,
+	_portableTextToPM as portableTextToPM,
+} from "../../../src/components/InlinePortableTextEditor.js";
+
+function pmDoc(...content: unknown[]) {
+	return { type: "doc", content };
+}
+
+describe("inline editor: PT → PM (unknown blocks)", () => {
+	it("captures every non-well-known field into data", () => {
+		const block = {
+			_type: "marketing.hero",
+			_key: "hero",
+			headline: "Build products people want",
+			subheadline: "The all-in-one platform",
+			primaryCtaLabel: "Sign up",
+			primaryCtaUrl: "/signup",
+			centered: true,
+		};
+
+		const pm = portableTextToPM([block]);
+		const node = pm.content?.[0] as {
+			type: string;
+			attrs: { blockType: string; id: string; data: Record<string, unknown> };
+		};
+
+		expect(node.type).toBe("pluginBlock");
+		expect(node.attrs.blockType).toBe("marketing.hero");
+		expect(node.attrs.id).toBe("");
+		expect(node.attrs.data).toEqual({
+			headline: "Build products people want",
+			subheadline: "The all-in-one platform",
+			primaryCtaLabel: "Sign up",
+			primaryCtaUrl: "/signup",
+			centered: true,
+		});
+	});
+
+	it("strips _-prefixed keys from data to prevent accumulation", () => {
+		const block = {
+			_type: "embed",
+			_key: "k1",
+			_internal: "should-strip",
+			caption: "should-keep",
+		};
+
+		const pm = portableTextToPM([block]);
+		const node = pm.content?.[0] as { attrs: { data: Record<string, unknown> } };
+
+		expect(node.attrs.data).toEqual({ caption: "should-keep" });
+		expect(node.attrs.data).not.toHaveProperty("_internal");
+	});
+
+	it("uses url as a fallback for id", () => {
+		const block = { _type: "youtube", _key: "k1", url: "https://youtu.be/abc" };
+
+		const pm = portableTextToPM([block]);
+		const node = pm.content?.[0] as { attrs: { id: string } };
+
+		expect(node.attrs.id).toBe("https://youtu.be/abc");
+	});
+});
+
+describe("inline editor: PM → PT (pluginBlock)", () => {
+	it("spreads data fields back into the PT block", () => {
+		const doc = pmDoc({
+			type: "pluginBlock",
+			attrs: {
+				blockType: "marketing.hero",
+				id: "",
+				data: { headline: "Hi", centered: true },
+			},
+		});
+
+		const blocks = pmToPortableText(doc);
+
+		expect(blocks[0]).toMatchObject({
+			_type: "marketing.hero",
+			id: "",
+			headline: "Hi",
+			centered: true,
+		});
+	});
+
+	it("data fields cannot overwrite _type or _key", () => {
+		const doc = pmDoc({
+			type: "pluginBlock",
+			attrs: {
+				blockType: "marketing.hero",
+				id: "",
+				data: { _type: "evil", _key: "evil", headline: "kept" },
+			},
+		});
+
+		const blocks = pmToPortableText(doc);
+
+		expect(blocks[0]!._type).toBe("marketing.hero");
+		expect(blocks[0]!._key).not.toBe("evil");
+		expect(blocks[0]).toMatchObject({ headline: "kept" });
+	});
+
+	it("falls back blockType to 'embed' when missing", () => {
+		const doc = pmDoc({
+			type: "pluginBlock",
+			attrs: { blockType: null, id: "u", data: {} },
+		});
+
+		const blocks = pmToPortableText(doc);
+
+		expect(blocks[0]!._type).toBe("embed");
+	});
+
+	it("handles non-object data gracefully", () => {
+		// Defensive: data could be malformed if persisted from a buggy source.
+		const doc = pmDoc({
+			type: "pluginBlock",
+			attrs: { blockType: "embed", id: "u", data: null },
+		});
+
+		const blocks = pmToPortableText(doc);
+
+		expect(blocks[0]).toMatchObject({ _type: "embed", id: "u" });
+	});
+});
+
+describe("inline editor: round-trip preserves plugin block payloads", () => {
+	it("a marketing.hero-shaped block survives PT → PM → PT intact", () => {
+		const original = {
+			_type: "marketing.hero",
+			_key: "hero",
+			headline: "Build products people want",
+			subheadline: "The all-in-one platform",
+			primaryCtaLabel: "Sign up",
+			primaryCtaUrl: "/signup",
+			secondaryCtaLabel: "Watch demo",
+			secondaryCtaUrl: "/demo",
+			centered: true,
+		};
+
+		const pm = portableTextToPM([original]);
+		const roundTripped = pmToPortableText(pm);
+
+		expect(roundTripped).toHaveLength(1);
+		expect(roundTripped[0]).toMatchObject({
+			_type: "marketing.hero",
+			headline: "Build products people want",
+			subheadline: "The all-in-one platform",
+			primaryCtaLabel: "Sign up",
+			primaryCtaUrl: "/signup",
+			secondaryCtaLabel: "Watch demo",
+			secondaryCtaUrl: "/demo",
+			centered: true,
+		});
+	});
+
+	it("nested objects in unknown fields survive round-trip", () => {
+		const original = {
+			_type: "marketing.hero",
+			_key: "hero",
+			primaryCta: { label: "Sign up", url: "/signup" },
+			image: { url: "/hero.png", alt: "Hero" },
+		};
+
+		const pm = portableTextToPM([original]);
+		const roundTripped = pmToPortableText(pm);
+
+		expect(roundTripped[0]).toMatchObject({
+			_type: "marketing.hero",
+			primaryCta: { label: "Sign up", url: "/signup" },
+			image: { url: "/hero.png", alt: "Hero" },
+		});
+	});
+
+	it("repeated round-trips are stable (no _-key leakage)", () => {
+		const original = {
+			_type: "marketing.faq",
+			_key: "faq",
+			items: [{ question: "Q?", answer: "A." }],
+		};
+
+		const rt1 = pmToPortableText(portableTextToPM([original]));
+		const rt2 = pmToPortableText(portableTextToPM(rt1));
+
+		expect(rt2[0]).toMatchObject({
+			_type: "marketing.faq",
+			items: [{ question: "Q?", answer: "A." }],
+		});
+		expect(Object.keys(rt2[0]!).filter((k) => k.startsWith("_"))).toEqual(["_type", "_key"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes silent data loss in the visual-editing inline editor (`InlinePortableTextEditor`) for plugin-contributed Portable Text block types.

### The bug

For any unknown PT block type (e.g. `marketing.hero` with `headline`/`subheadline`/CTAs etc.), opening a page in visual edit mode silently destroyed every field except `id`. Combined with the absence of a registered `pluginBlock` TipTap node, ProseMirror also filtered the node out of the document on load -- and the next save persisted the disappearance.

A `marketing.hero` block with seven fields became `{ _type, _key, id: "" }` after a single edit-mode visit + save.

### The fix

Three small changes, all in `packages/core/src/components/InlinePortableTextEditor.tsx`:

1. **Register a minimal `pluginBlock` TipTap node** so ProseMirror accepts it on load instead of filtering. Atom + `selectable: true` + `draggable: true`. Renders as a read-only placeholder ("Plugin block: marketing.hero (edit in admin)") with dashed border styling.
2. **Capture every non-well-known field into a `data` attribute on PT → PM** (filtering `_`-prefixed keys to prevent accumulation across edit cycles).
3. **Spread `data` back out on PM → PT** so the block round-trips losslessly.

This mirrors the lossless pattern already in the admin editor at `PortableTextEditor.tsx:572-588` (PT → PM) and `:298-305` (PM → PT). Closely related to #646's diagnosis, which correctly identified the bug for the inline editor specifically -- this PR ports the round-trip half of that proposal. Editing in visual mode remains intentionally out of scope (admin is the editing surface; visual editing just needs to not destroy data).

DOM attributes (`blockType`, `id`, `data`) are hidden from the rendered DOM via `rendered: false` so they live only on the PM node. Otherwise serialised `<div data="[object Object]" ...>` would leak into the page.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (4 pre-existing diagnostics in `packages/blocks/src/validation.ts`, unchanged from main)
- [x] `pnpm test` passes (4498 tests across all packages)
- [x] `pnpm format` has been run
- [x] I have added/updated tests -- 10 new unit tests in `tests/unit/components/inline-portable-text-plugin-block.test.ts` covering PT → PM, PM → PT, and full round-trip including a `marketing.hero`-shaped block, nested objects, and repeated round-trips
- [x] User-visible strings -- one new string ("Plugin block: \<type\> (edit in admin)") not localised; this surface is dev-facing while the editor surface is being designed (worth a follow-up if visual editing of plugin blocks is added later)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion -- N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Verified end-to-end with the marketing template's home page on the `feat/marketing-template-editable-blocks` branch (which has the marketing-blocks plugin):

- Before: visual edit mode on `/` shows nothing where the four marketing blocks should be -- they've been silently filtered. Next save would persist the disappearance.
- After: visual edit mode shows four read-only placeholder cards -- "Plugin block: marketing.hero (edit in admin)", and three more for features/testimonials/faq. Edits to the surrounding content don't disturb the blocks. The full block payload (headline, primaryCta, etc.) is preserved on the PM node and round-trips back to the API on save.

```
Tests: 10 new
✓ inline editor: PT → PM (unknown blocks)
  ✓ captures every non-well-known field into data
  ✓ strips _-prefixed keys from data to prevent accumulation
  ✓ uses url as a fallback for id
✓ inline editor: PM → PT (pluginBlock)
  ✓ spreads data fields back into the PT block
  ✓ data fields cannot overwrite _type or _key
  ✓ falls back blockType to 'embed' when missing
  ✓ handles non-object data gracefully
✓ inline editor: round-trip preserves plugin block payloads
  ✓ a marketing.hero-shaped block survives PT → PM → PT intact
  ✓ nested objects in unknown fields survive round-trip
  ✓ repeated round-trips are stable (no _-key leakage)
```