### PR TITLE
fix(admin): size plugin block modal based on field complexity

### DIFF
--- a/.changeset/large-birds-push.md
+++ b/.changeset/large-birds-push.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Sizes the plugin block edit modal based on field complexity so Block Kit forms have room to breathe. Simple URL embeds keep the previous compact dialog; forms with several fields get a wider one, and forms containing a repeater open at the largest size. Inputs inside the dialog now fill the available width.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1073,9 +1073,20 @@ function PluginBlockModal({
 		? hasPluginBlockFormData(formValues)
 		: typeof formValues.id === "string" && formValues.id.trim().length > 0;
 
+	// Size the dialog based on field complexity. The default `sm` is right for
+	// simple URL embeds (one field) but cramps Block Kit forms with several
+	// fields or a repeater, which need room for inline sub-field inputs.
+	const dialogSize = (() => {
+		if (!hasFields) return "sm";
+		const fields = block?.fields ?? [];
+		if (fields.some((f) => f.type === "repeater")) return "xl";
+		if (fields.length > 3) return "lg";
+		return "base";
+	})();
+
 	return (
 		<Dialog.Root open={!!block} onOpenChange={(open: boolean) => !open && onClose()}>
-			<Dialog className="p-6" size="sm">
+			<Dialog className="p-6" size={dialogSize}>
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
 						{isEditing ? "Edit" : "Insert"} {block?.label || ""}
@@ -1112,6 +1123,7 @@ function PluginBlockModal({
 							<Input
 								ref={inputRef}
 								type="url"
+								className="w-full"
 								placeholder={block?.placeholder || "Enter URL..."}
 								value={typeof formValues.id === "string" ? formValues.id : ""}
 								onChange={(e) => handleFieldChange("id", e.target.value)}
@@ -1165,6 +1177,7 @@ function BlockKitField({
 					) : (
 						<Input
 							type="text"
+							className="w-full"
 							placeholder={placeholder}
 							value={typeof value === "string" ? value : ""}
 							onChange={(e) => onChange(field.action_id, e.target.value)}
@@ -1181,6 +1194,7 @@ function BlockKitField({
 					<label className="text-sm font-medium mb-1.5 block">{field.label}</label>
 					<Input
 						type="number"
+						className="w-full"
 						min={min}
 						max={max}
 						value={typeof value === "number" ? String(value) : ""}


### PR DESCRIPTION
## What does this PR do?

The plugin block edit modal (the dialog that opens when clicking "edit" on a custom Portable Text block in the admin) was hardcoded to `size="sm"` (~288px min). That's the right size for the original embed-URL use case (one short URL field, e.g. YouTube), but it cramps Block Kit forms that have several fields or a repeater. Inputs got clipped, multiline textareas became 3 lines of ~23 chars, and repeater sub-fields didn't have room to lay out properly.

Concrete example, before this change: the marketing template's Features block opens with a Description textarea wide enough for "Built for speed from the" before wrapping. Each field looked truncated.

### The fix

Size the dialog adaptively based on the registered fields:

| Fields                         | Size     |
| ------------------------------ | -------- |
| None (simple URL embed)        | `sm`     |
| 1–3                            | `base`   |
| 4+                             | `lg`     |
| Any repeater                   | `xl`     |

Also adds `className="w-full"` to the dialog's `<Input>` calls so single-line text/number/url inputs fill the available width rather than relying on the input's intrinsic sizing. Multiline textareas already had `w-full` (line 1160). The `<select>` in `DynamicSelect` already had `w-full` (line 1594).

### Verified against

- **Hero block** (7 fields, no repeater) -- opens at `lg`. All seven fields visible: Headline, Subheadline (full sentence on 2 lines), Primary CTA label, Primary CTA URL, Secondary CTA label, Secondary CTA URL, Center the layout toggle.
- **Features block** (repeater with 6 items) -- opens at `xl`. Headline, Subheadline, "Features (6)" repeater with rows for Lightning Fast / Enterprise Security / Team Collaboration / Powerful Analytics / Developer Friendly / Global Scale. Expanded row shows full Icon select / Title input / Description textarea filling the width.
- **YouTube embed** (no fields, simple URL plugin) -- still `sm`, unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (4 pre-existing diagnostics in `packages/blocks/src/validation.ts`, unchanged from main)
- [x] `pnpm test` passes (all 796 admin tests, full workspace 4498 tests)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests -- this is a styling change visible only via screenshots; the modal's existing render-test coverage in `tests/editor/PortableTextEditor.test.tsx` is unaffected
- [x] User-visible strings -- no new strings introduced
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/admin: patch`)
- [ ] New features link to an approved Discussion -- N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Screenshots saved locally during verification (Hero modal at `lg`, Features modal at `xl` with repeater collapsed and expanded views). Happy to drop them into the PR via the web UI if useful for review.

The change is small enough to read directly: 6 lines for the size selector, 3 added `className="w-full"` props.