### PR TITLE
feat: rtl style improvements - direction visuals improvements and usage updates

### DIFF
--- a/.changeset/quiet-jokes-kick.md
+++ b/.changeset/quiet-jokes-kick.md
@@ -1,0 +1,9 @@
+---
+"@emdash-cms/plugin-ai-moderation": minor
+"@emdash-cms/plugin-color": minor
+"@emdash-cms/plugin-forms": minor
+"@emdash-cms/blocks": minor
+"@emdash-cms/admin": minor
+---
+
+rtl srtyle improvements and LTR/RTL compatible arrow/caret icons

--- a/packages/admin/src/components/ArrowIcons.tsx
+++ b/packages/admin/src/components/ArrowIcons.tsx
@@ -1,0 +1,23 @@
+import { ArrowRightIcon, CaretRightIcon, type IconProps } from "@phosphor-icons/react";
+
+import { cn } from "../lib/utils";
+
+/** Caret pointing in the "forward" direction — right in LTR, left in RTL. */
+export function CaretNext({ className, ...props }: IconProps) {
+	return <CaretRightIcon className={cn("rtl:-scale-x-100", className)} {...props} />;
+}
+
+/** Caret pointing in the "backward" direction — left in LTR, right in RTL. */
+export function CaretPrev({ className, ...props }: IconProps) {
+	return <CaretRightIcon className={cn("rotate-180 rtl:rotate-0", className)} {...props} />;
+}
+
+/** Arrow pointing in the "forward" direction — right in LTR, left in RTL. */
+export function ArrowNext({ className, ...props }: IconProps) {
+	return <ArrowRightIcon className={cn("rtl:-scale-x-100", className)} {...props} />;
+}
+
+/** Arrow pointing in the "backward" direction — left in LTR, right in RTL. */
+export function ArrowPrev({ className, ...props }: IconProps) {
+	return <ArrowRightIcon className={cn("rotate-180 rtl:rotate-0", className)} {...props} />;
+}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -13,7 +13,6 @@ import {
 } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	Check,
 	Eye,
 	Image as ImageIcon,
@@ -27,6 +26,8 @@ import {
 import { Link } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
+
+import { ArrowPrev } from "./ArrowIcons.js";
 
 import type {
 	BylineCreditInput,
@@ -535,7 +536,7 @@ export function ContentEditor({
 							aria-label={t`Back to ${collectionLabel} list`}
 							className={buttonVariants({ variant: "ghost", shape: "square" })}
 						>
-							<ArrowLeft className="h-5 w-5" aria-hidden="true" />
+							<ArrowPrev className="h-5 w-5" aria-hidden="true" />
 						</Link>
 					)}
 					{isDistractionFree && (

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -27,8 +27,6 @@ import { Link } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 
-import { ArrowPrev } from "./ArrowIcons.js";
-
 import type {
 	BylineCreditInput,
 	BylineSummary,
@@ -41,6 +39,7 @@ import { getPreviewUrl, getDraftStatus } from "../lib/api";
 import { usePluginAdmins } from "../lib/plugin-context.js";
 import { contentUrl } from "../lib/url.js";
 import { cn, slugify } from "../lib/utils";
+import { ArrowPrev } from "./ArrowIcons.js";
 import { BlockKitFieldWidget } from "./BlockKitFieldWidget.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { PluginFieldErrorBoundary } from "./PluginFieldErrorBoundary.js";

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -9,8 +9,6 @@ import {
 	ArrowSquareOut,
 	Copy,
 	MagnifyingGlass,
-	CaretLeft,
-	CaretRight,
 	CaretUp,
 	CaretDown,
 	CaretUpDown,
@@ -21,6 +19,7 @@ import * as React from "react";
 import type { ContentItem, TrashedContentItem } from "../lib/api";
 import { contentUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
+import { CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { LocaleSwitcher } from "./LocaleSwitcher";
 
 /** Sortable content list columns. Maps to the server's order field whitelist. */
@@ -297,7 +296,7 @@ export function ContentList({
 									onClick={() => setPage(page - 1)}
 									aria-label={t`Previous page`}
 								>
-									<CaretLeft className="h-4 w-4" aria-hidden="true" />
+									<CaretPrev className="h-4 w-4" aria-hidden="true" />
 								</Button>
 								<span className="text-sm">
 									{page + 1} / {totalPages}
@@ -309,7 +308,7 @@ export function ContentList({
 									onClick={() => setPage(page + 1)}
 									aria-label={t`Next page`}
 								>
-									<CaretRight className="h-4 w-4" aria-hidden="true" />
+									<CaretNext className="h-4 w-4" aria-hidden="true" />
 								</Button>
 							</div>
 						</div>

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -19,18 +19,9 @@ import { CSS } from "@dnd-kit/utilities";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import {
-	Plus,
-	DotsSixVertical,
-	Pencil,
-	Trash,
-	Database,
-	FileText,
-} from "@phosphor-icons/react";
+import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
-
-import { ArrowPrev } from "./ArrowIcons.js";
 
 import type {
 	SchemaCollectionWithFields,
@@ -40,6 +31,7 @@ import type {
 	UpdateCollectionInput,
 } from "../lib/api";
 import { cn } from "../lib/utils";
+import { ArrowPrev } from "./ArrowIcons.js";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { FieldEditor } from "./FieldEditor";
 

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -20,7 +20,6 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	Plus,
 	DotsSixVertical,
 	Pencil,
@@ -30,6 +29,8 @@ import {
 } from "@phosphor-icons/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
+
+import { ArrowPrev } from "./ArrowIcons.js";
 
 import type {
 	SchemaCollectionWithFields,
@@ -330,7 +331,7 @@ export function ContentTypeEditor({
 					aria-label="Back to Content Types"
 					className={buttonVariants({ variant: "ghost", shape: "square" })}
 				>
-					<ArrowLeft className="h-5 w-5" />
+					<ArrowPrev className="h-5 w-5" />
 				</Link>
 				<div className="flex-1">
 					<h1 className="text-2xl font-bold">{isNew ? "New Content Type" : collection?.label}</h1>

--- a/packages/admin/src/components/MarketplacePluginDetail.tsx
+++ b/packages/admin/src/components/MarketplacePluginDetail.tsx
@@ -13,16 +13,15 @@
 import { Badge, Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	DownloadSimple,
 	GithubLogo,
 	Globe,
 	ShieldCheck,
 	Warning,
-	CaretLeft,
-	CaretRight,
 	X,
 } from "@phosphor-icons/react";
+
+import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import DOMPurify from "dompurify";
@@ -398,7 +397,7 @@ function BackLink() {
 			to="/plugins/marketplace"
 			className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 		>
-			<ArrowLeft className="h-4 w-4" />
+			<ArrowPrev className="h-4 w-4" />
 			{t`Back to marketplace`}
 		</Link>
 	);
@@ -455,7 +454,7 @@ function ScreenshotLightbox({
 					className="absolute start-4 rounded-full bg-black/50 p-2 text-white hover:bg-black/70"
 					aria-label={t`Previous screenshot`}
 				>
-					<CaretLeft className="h-5 w-5" />
+					<CaretPrev className="h-5 w-5" />
 				</button>
 			)}
 
@@ -473,7 +472,7 @@ function ScreenshotLightbox({
 					className="absolute end-4 rounded-full bg-black/50 p-2 text-white hover:bg-black/70"
 					aria-label={t`Next screenshot`}
 				>
-					<CaretRight className="h-5 w-5" />
+					<CaretNext className="h-5 w-5" />
 				</button>
 			)}
 

--- a/packages/admin/src/components/MarketplacePluginDetail.tsx
+++ b/packages/admin/src/components/MarketplacePluginDetail.tsx
@@ -12,16 +12,7 @@
 
 import { Badge, Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	DownloadSimple,
-	GithubLogo,
-	Globe,
-	ShieldCheck,
-	Warning,
-	X,
-} from "@phosphor-icons/react";
-
-import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
+import { DownloadSimple, GithubLogo, Globe, ShieldCheck, Warning, X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import DOMPurify from "dompurify";
@@ -35,6 +26,7 @@ import {
 	describeCapability,
 } from "../lib/api/marketplace.js";
 import { SAFE_URL_RE, isSafeUrl, safeIconUrl } from "../lib/url.js";
+import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { getMutationError } from "./DialogError.js";
 import { AuditBadge } from "./MarketplaceBrowse.js";

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -19,8 +19,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
 
-import { ArrowPrev } from "./ArrowIcons.js";
-
 import {
 	fetchMenu,
 	createMenuItem,
@@ -29,6 +27,7 @@ import {
 	reorderMenuItems,
 	type MenuItem,
 } from "../lib/api";
+import { ArrowPrev } from "./ArrowIcons.js";
 import { ContentPickerModal } from "./ContentPickerModal";
 import { DialogError, getMutationError } from "./DialogError.js";
 

--- a/packages/admin/src/components/MenuEditor.tsx
+++ b/packages/admin/src/components/MenuEditor.tsx
@@ -12,13 +12,14 @@ import {
 	CaretUp,
 	CaretDown,
 	Link as LinkIcon,
-	ArrowLeft,
 	X,
 	File as FileIcon,
 } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
+
+import { ArrowPrev } from "./ArrowIcons.js";
 
 import {
 	fetchMenu,
@@ -218,7 +219,7 @@ export function MenuEditor() {
 						aria-label={t`Back`}
 						onClick={() => navigate({ to: "/menus" })}
 					>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 					<div>
 						<h1 className="text-3xl font-bold">{menu.label}</h1>

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -22,8 +22,6 @@ import {
 } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-
-import { CaretNext } from "./ArrowIcons.js";
 import * as React from "react";
 
 import {
@@ -42,6 +40,7 @@ import {
 } from "../lib/api/marketplace.js";
 import { safeIconUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
+import { CaretNext } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 
@@ -397,11 +396,7 @@ function PluginCard({
 							onClick={() => setExpanded(!expanded)}
 							aria-expanded={expanded}
 						>
-							{expanded ? (
-								<CaretDown className="h-4 w-4" />
-							) : (
-								<CaretNext className="h-4 w-4" />
-							)}
+							{expanded ? <CaretDown className="h-4 w-4" /> : <CaretNext className="h-4 w-4" />}
 							<span className="sr-only">
 								{expanded ? t`Collapse` : t`Expand`} {t`details`}
 							</span>

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -15,7 +15,6 @@ import {
 	SquaresFour,
 	WebhooksLogo,
 	CaretDown,
-	CaretRight,
 	ArrowsClockwise,
 	Storefront,
 	Trash,
@@ -23,6 +22,8 @@ import {
 } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+
+import { CaretNext } from "./ArrowIcons.js";
 import * as React from "react";
 
 import {
@@ -396,7 +397,11 @@ function PluginCard({
 							onClick={() => setExpanded(!expanded)}
 							aria-expanded={expanded}
 						>
-							{expanded ? <CaretDown className="h-4 w-4" /> : <CaretRight className="h-4 w-4" />}
+							{expanded ? (
+								<CaretDown className="h-4 w-4" />
+							) : (
+								<CaretNext className="h-4 w-4" />
+							)}
 							<span className="sr-only">
 								{expanded ? t`Collapse` : t`Expand`} {t`details`}
 							</span>

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -77,13 +77,12 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import Suggestion from "@tiptap/suggestion";
 import * as React from "react";
-
-import { CaretNext } from "./ArrowIcons.js";
 import { createPortal } from "react-dom";
 
 import type { MediaItem } from "../lib/api";
 import type { Section } from "../lib/api";
 import { cn } from "../lib/utils";
+import { CaretNext } from "./ArrowIcons.js";
 import { DragHandleWrapper } from "./editor/DragHandleWrapper";
 import { ImageExtension } from "./editor/ImageNode";
 import { MarkdownLinkExtension } from "./editor/MarkdownLinkExtension";

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -63,7 +63,6 @@ import {
 	Trash,
 	DotsSixVertical,
 	CaretDown,
-	CaretRight,
 	type Icon,
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
@@ -78,6 +77,8 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import Suggestion from "@tiptap/suggestion";
 import * as React from "react";
+
+import { CaretNext } from "./ArrowIcons.js";
 import { createPortal } from "react-dom";
 
 import type { MediaItem } from "../lib/api";
@@ -1470,12 +1471,12 @@ function BlockKitRepeaterItem({
 				</span>
 				<button
 					type="button"
-					className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+					className="flex items-center gap-2 flex-1 min-w-0 text-start cursor-pointer"
 					onClick={onToggleCollapse}
 					aria-expanded={!isCollapsed}
 				>
 					{isCollapsed ? (
-						<CaretRight className="h-4 w-4 text-kumo-subtle shrink-0" />
+						<CaretNext className="h-4 w-4 text-kumo-subtle shrink-0" />
 					) : (
 						<CaretDown className="h-4 w-4 text-kumo-subtle shrink-0" />
 					)}

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -2,7 +2,6 @@ import { Badge, Button, Dialog, Input, Label, Switch } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowRight,
 	MagnifyingGlass,
 	Plus,
 	ArrowsLeftRight,
@@ -28,6 +27,7 @@ import type {
 	UpdateRedirectInput,
 } from "../lib/api/redirects.js";
 import { cn } from "../lib/utils.js";
+import { ArrowNext } from "./ArrowIcons.js";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 
@@ -464,7 +464,7 @@ export function Redirects() {
 										{r.source}
 									</div>
 									<div className="w-8 text-center text-kumo-subtle">
-										<ArrowRight size={14} />
+										<ArrowNext size={14} />
 									</div>
 									<div className="flex-1 font-mono text-xs truncate" title={r.destination}>
 										{r.destination}

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -18,11 +18,10 @@ import { CSS } from "@dnd-kit/utilities";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, Trash, DotsSixVertical, CaretDown } from "@phosphor-icons/react";
-
-import { CaretNext } from "./ArrowIcons.js";
 import * as React from "react";
 
 import { cn } from "../lib/utils.js";
+import { CaretNext } from "./ArrowIcons.js";
 
 interface RepeaterSubFieldDef {
 	slug: string;

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -17,7 +17,9 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Plus, Trash, DotsSixVertical, CaretDown, CaretRight } from "@phosphor-icons/react";
+import { Plus, Trash, DotsSixVertical, CaretDown } from "@phosphor-icons/react";
+
+import { CaretNext } from "./ArrowIcons.js";
 import * as React from "react";
 
 import { cn } from "../lib/utils.js";
@@ -252,7 +254,7 @@ function SortableRepeaterItem({
 					onClick={(e) => e.stopPropagation()}
 				/>
 				{isCollapsed ? (
-					<CaretRight className="h-4 w-4 text-kumo-subtle shrink-0" />
+					<CaretNext className="h-4 w-4 text-kumo-subtle shrink-0" />
 				) : (
 					<CaretDown className="h-4 w-4 text-kumo-subtle shrink-0" />
 				)}

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -6,7 +6,8 @@
 
 import { Button, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { ArrowLeft } from "@phosphor-icons/react";
+
+import { ArrowPrev } from "./ArrowIcons.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
@@ -67,7 +68,7 @@ export function SectionEditor() {
 				<div className="flex items-center gap-4">
 					<Link to="/sections">
 						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
-							<ArrowLeft className="h-5 w-5" />
+							<ArrowPrev className="h-5 w-5" />
 						</Button>
 					</Link>
 					<h1 className="text-2xl font-bold">{t`Section Not Found`}</h1>
@@ -152,7 +153,7 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 				<div className="flex items-center gap-4">
 					<Link to="/sections">
 						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
-							<ArrowLeft className="h-5 w-5" />
+							<ArrowPrev className="h-5 w-5" />
 						</Button>
 					</Link>
 					<div>

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -6,14 +6,13 @@
 
 import { Button, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-
-import { ArrowPrev } from "./ArrowIcons.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSection, updateSection, type Section, type UpdateSectionInput } from "../lib/api";
 import { slugify } from "../lib/utils";
+import { ArrowPrev } from "./ArrowIcons.js";
 import { PortableTextEditor } from "./PortableTextEditor";
 import { SaveButton } from "./SaveButton";
 

--- a/packages/admin/src/components/Settings.tsx
+++ b/packages/admin/src/components/Settings.tsx
@@ -9,8 +9,9 @@ import {
 	GlobeSimple,
 	Key,
 	Envelope,
-	CaretRight,
 } from "@phosphor-icons/react";
+
+import { CaretNext } from "./ArrowIcons.js";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -39,7 +40,7 @@ function SettingsLink({ to, icon, title, description }: SettingsLinkProps) {
 					<div className="text-sm text-kumo-subtle">{description}</div>
 				</div>
 			</div>
-			<CaretRight className="h-5 w-5 text-kumo-subtle" />
+			<CaretNext className="h-5 w-5 text-kumo-subtle" />
 		</Link>
 	);
 }

--- a/packages/admin/src/components/Settings.tsx
+++ b/packages/admin/src/components/Settings.tsx
@@ -10,8 +10,6 @@ import {
 	Key,
 	Envelope,
 } from "@phosphor-icons/react";
-
-import { CaretNext } from "./ArrowIcons.js";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -19,6 +17,7 @@ import * as React from "react";
 import { fetchManifest } from "../lib/api";
 import { SUPPORTED_LOCALES } from "../locales/index.js";
 import { useLocale } from "../locales/useLocale.js";
+import { CaretNext } from "./ArrowIcons.js";
 
 interface SettingsLinkProps {
 	to: string;

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -409,7 +409,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 					{/* Content — collections + media (collapsible) */}
 					{visibleContent.length > 1 && (
 						<KumoSidebar.Group collapsible defaultOpen>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start">{t`Content`}</KumoSidebar.GroupLabel>
+							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Content`}</KumoSidebar.GroupLabel>
 							<KumoSidebar.GroupContent>
 								<KumoSidebar.Menu>
 									{renderNavItems(visibleContent.filter((i) => i.to !== "/"))}
@@ -423,7 +423,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 					{/* Manage — comments, menus, taxonomies, etc. (collapsible) */}
 					{visibleManage.length > 0 && (
 						<KumoSidebar.Group collapsible defaultOpen>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start">{t`Manage`}</KumoSidebar.GroupLabel>
+							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Manage`}</KumoSidebar.GroupLabel>
 							<KumoSidebar.GroupContent>
 								<KumoSidebar.Menu>{renderNavItems(visibleManage)}</KumoSidebar.Menu>
 							</KumoSidebar.GroupContent>
@@ -435,7 +435,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 					{/* Admin — content types, users, plugins, import (collapsible) */}
 					{visibleAdmin.length > 0 && (
 						<KumoSidebar.Group collapsible defaultOpen>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start">{t`Admin`}</KumoSidebar.GroupLabel>
+							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Admin`}</KumoSidebar.GroupLabel>
 							<KumoSidebar.GroupContent>
 								<KumoSidebar.Menu>{renderNavItems(visibleAdmin)}</KumoSidebar.Menu>
 							</KumoSidebar.GroupContent>
@@ -447,7 +447,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 						<>
 							<KumoSidebar.Separator />
 							<KumoSidebar.Group collapsible defaultOpen>
-								<KumoSidebar.GroupLabel className="[&>span]:text-start">{t`Plugins`}</KumoSidebar.GroupLabel>
+								<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Plugins`}</KumoSidebar.GroupLabel>
 								<KumoSidebar.GroupContent>
 									<KumoSidebar.Menu>{renderNavItems(visiblePlugins)}</KumoSidebar.Menu>
 								</KumoSidebar.GroupContent>

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -254,7 +254,7 @@ function TagInput({
 								type="button"
 								onClick={handleCreate}
 								disabled={isCreating}
-								className="w-full text-left px-3 py-2 text-sm hover:bg-kumo-tint text-kumo-accent flex items-center gap-1 border-t"
+								className="w-full text-start px-3 py-2 text-sm hover:bg-kumo-tint text-kumo-accent flex items-center gap-1 border-t"
 							>
 								<Plus className="w-3 h-3" />
 								{isCreating ? "Creating..." : `Create "${trimmedInput}"`}

--- a/packages/admin/src/components/ThemeMarketplaceDetail.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceDetail.tsx
@@ -11,17 +11,16 @@
 import { Badge, Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	ArrowSquareOut,
 	Eye,
 	GithubLogo,
 	Globe,
 	Palette,
 	ShieldCheck,
-	CaretLeft,
-	CaretRight,
 	X,
 } from "@phosphor-icons/react";
+
+import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -84,7 +83,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 					to={"/themes/marketplace" as "/"}
 					className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 				>
-					<ArrowLeft className="h-4 w-4" />
+				<ArrowPrev className="h-4 w-4" />
 					{t`Back to Themes`}
 				</Link>
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">
@@ -108,7 +107,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 				to={"/themes/marketplace" as "/"}
 				className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 			>
-				<ArrowLeft className="h-4 w-4" />
+				<ArrowPrev className="h-4 w-4" />
 				{t`Back to Themes`}
 			</Link>
 
@@ -313,14 +312,14 @@ function Lightbox({
 							className="absolute start-2 top-1/2 -translate-y-1/2 rounded-full bg-kumo-base/80 p-2 shadow hover:bg-kumo-base"
 							aria-label={t`Previous`}
 						>
-							<CaretLeft className="h-5 w-5" />
+							<CaretPrev className="h-5 w-5" />
 						</button>
 						<button
 							onClick={onNext}
 							className="absolute end-2 top-1/2 -translate-y-1/2 rounded-full bg-kumo-base/80 p-2 shadow hover:bg-kumo-base"
 							aria-label={t`Next`}
 						>
-							<CaretRight className="h-5 w-5" />
+							<CaretNext className="h-5 w-5" />
 						</button>
 					</>
 				)}

--- a/packages/admin/src/components/ThemeMarketplaceDetail.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceDetail.tsx
@@ -19,13 +19,12 @@ import {
 	ShieldCheck,
 	X,
 } from "@phosphor-icons/react";
-
-import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchTheme, generatePreviewUrl } from "../lib/api/theme-marketplace.js";
+import { ArrowPrev, CaretNext, CaretPrev } from "./ArrowIcons.js";
 
 /** Only allow safe URL protocols for external links */
 function isSafeUrl(url: string): boolean {
@@ -83,7 +82,7 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 					to={"/themes/marketplace" as "/"}
 					className="inline-flex items-center gap-1 text-sm text-kumo-subtle hover:text-kumo-default"
 				>
-				<ArrowPrev className="h-4 w-4" />
+					<ArrowPrev className="h-4 w-4" />
 					{t`Back to Themes`}
 				</Link>
 				<div className="rounded-lg border border-kumo-danger/50 bg-kumo-danger/10 p-6 text-center">

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -32,7 +32,9 @@ import { CSS } from "@dnd-kit/utilities";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Plus, DotsSixVertical, Trash, CaretDown, CaretRight } from "@phosphor-icons/react";
+import { Plus, DotsSixVertical, Trash, CaretDown } from "@phosphor-icons/react";
+
+import { CaretNext } from "./ArrowIcons.js";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -722,7 +724,11 @@ function WidgetItem({
 				</button>
 				<button onClick={onToggle} className="flex-1 text-start" aria-expanded={isExpanded}>
 					<div className="flex items-center gap-2">
-						{isExpanded ? <CaretDown className="h-4 w-4" /> : <CaretRight className="h-4 w-4" />}
+						{isExpanded ? (
+							<CaretDown className="h-4 w-4" />
+						) : (
+							<CaretNext className="h-4 w-4" />
+						)}
 						<span className="font-medium">{widget.title || "Untitled Widget"}</span>
 						<span className="text-xs text-kumo-subtle">({widget.type})</span>
 					</div>

--- a/packages/admin/src/components/Widgets.tsx
+++ b/packages/admin/src/components/Widgets.tsx
@@ -33,8 +33,6 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, DotsSixVertical, Trash, CaretDown } from "@phosphor-icons/react";
-
-import { CaretNext } from "./ArrowIcons.js";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -57,6 +55,7 @@ import {
 	type UpdateWidgetInput,
 } from "../lib/api";
 import { getPluginBlocks } from "../lib/pluginBlocks";
+import { CaretNext } from "./ArrowIcons.js";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
@@ -724,11 +723,7 @@ function WidgetItem({
 				</button>
 				<button onClick={onToggle} className="flex-1 text-start" aria-expanded={isExpanded}>
 					<div className="flex items-center gap-2">
-						{isExpanded ? (
-							<CaretDown className="h-4 w-4" />
-						) : (
-							<CaretNext className="h-4 w-4" />
-						)}
+						{isExpanded ? <CaretDown className="h-4 w-4" /> : <CaretNext className="h-4 w-4" />}
 						<span className="font-medium">{widget.title || "Untitled Widget"}</span>
 						<span className="text-xs text-kumo-subtle">({widget.type})</span>
 					</div>

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -23,8 +23,6 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import * as React from "react";
 
-import { CaretNext } from "./ArrowIcons.js";
-
 import {
 	analyzeWxr,
 	prepareWxrImport,
@@ -50,6 +48,7 @@ import {
 	type UserListItem,
 } from "../lib/api";
 import { cn } from "../lib/utils";
+import { CaretNext } from "./ArrowIcons.js";
 
 // ============================================================================
 // Constants

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -11,7 +11,6 @@ import {
 	Database,
 	FileText,
 	CaretDown,
-	CaretRight,
 	Image,
 	DownloadSimple,
 	Globe,
@@ -23,6 +22,8 @@ import {
 } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
 import * as React from "react";
+
+import { CaretNext } from "./ArrowIcons.js";
 
 import {
 	analyzeWxr,
@@ -1828,7 +1829,7 @@ function PostTypeRow({
 						{expanded ? (
 							<CaretDown className="h-4 w-4 text-kumo-subtle" />
 						) : (
-							<CaretRight className="h-4 w-4 text-kumo-subtle" />
+							<CaretNext className="h-4 w-4 text-kumo-subtle" />
 						)}
 						<div>
 							<p className="font-medium">{postType.name}</p>

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -18,7 +18,7 @@ import type {
 	BulkAction,
 } from "../../lib/api/comments.js";
 import { cn } from "../../lib/utils.js";
-import { CaretNext, CaretPrev } from "../ArrowIcons.js"
+import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 import { ConfirmDialog } from "../ConfirmDialog.js";
 import { CommentDetail } from "./CommentDetail.js";
 

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -8,16 +8,8 @@
 import { Badge, Button, Checkbox, Input, Select, Tabs } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import {
-	MagnifyingGlass,
-	Check,
-	Trash,
-	Warning,
-	ChatCircle,
-} from "@phosphor-icons/react";
+import { MagnifyingGlass, Check, Trash, Warning, ChatCircle } from "@phosphor-icons/react";
 import * as React from "react";
-
-import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 
 import type {
 	AdminComment,
@@ -26,6 +18,7 @@ import type {
 	BulkAction,
 } from "../../lib/api/comments.js";
 import { cn } from "../../lib/utils.js";
+import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 import { ConfirmDialog } from "../ConfirmDialog.js";
 import { CommentDetail } from "./CommentDetail.js";
 

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -13,11 +13,11 @@ import {
 	Check,
 	Trash,
 	Warning,
-	CaretLeft,
-	CaretRight,
 	ChatCircle,
 } from "@phosphor-icons/react";
 import * as React from "react";
+
+import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 
 import type {
 	AdminComment,
@@ -358,7 +358,7 @@ export function CommentInbox({
 							onClick={() => setPage(page - 1)}
 							aria-label={t`Previous page`}
 						>
-							<CaretLeft className="h-4 w-4" />
+							<CaretPrev className="h-4 w-4" />
 						</Button>
 						<span className="text-sm">
 							{page + 1} / {totalPages}
@@ -377,7 +377,7 @@ export function CommentInbox({
 							}}
 							aria-label={t`Next page`}
 						>
-							<CaretRight className="h-4 w-4" />
+							<CaretNext className="h-4 w-4" />
 						</Button>
 					</div>
 				</div>

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -18,7 +18,7 @@ import type {
 	BulkAction,
 } from "../../lib/api/comments.js";
 import { cn } from "../../lib/utils.js";
-import { CaretNext, CaretPrev } from "../ArrowIcons.js";
+import { CaretNext, CaretPrev } from "../ArrowIcons.js"
 import { ConfirmDialog } from "../ConfirmDialog.js";
 import { CommentDetail } from "./CommentDetail.js";
 

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -27,13 +27,13 @@ import {
 	ListNumbers,
 	Copy,
 	Trash,
-	CaretRight,
 	type Icon as PhosphorIcon,
 } from "@phosphor-icons/react";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 
+import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 import { useStableCallback } from "../../lib/hooks";
 import { cn } from "../../lib/utils";
 
@@ -250,7 +250,7 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 						className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-kumo-tint text-start"
 						onClick={() => setShowTransforms(false)}
 					>
-						<CaretRight className="h-4 w-4 rotate-180" />
+						<CaretPrev className="h-4 w-4" />
 						<span>Back</span>
 					</button>
 					<div className="h-px bg-kumo-line my-1" />
@@ -278,7 +278,7 @@ export function BlockMenu({ editor, anchorElement, isOpen, onClose }: BlockMenuP
 							<Paragraph className="h-4 w-4 text-kumo-subtle" />
 							<span>Turn into</span>
 						</span>
-						<CaretRight className="h-4 w-4 text-kumo-subtle" />
+						<CaretNext className="h-4 w-4 text-kumo-subtle" />
 					</button>
 					<button
 						type="button"

--- a/packages/admin/src/components/editor/BlockMenu.tsx
+++ b/packages/admin/src/components/editor/BlockMenu.tsx
@@ -33,9 +33,9 @@ import type { Editor } from "@tiptap/react";
 import * as React from "react";
 import { createPortal } from "react-dom";
 
-import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 import { useStableCallback } from "../../lib/hooks";
 import { cn } from "../../lib/utils";
+import { CaretNext, CaretPrev } from "../ArrowIcons.js";
 
 /**
  * Block transform options

--- a/packages/admin/src/components/editor/DocumentOutline.tsx
+++ b/packages/admin/src/components/editor/DocumentOutline.tsx
@@ -9,7 +9,9 @@
 
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { CaretDown, CaretRight, List } from "@phosphor-icons/react";
+import { CaretDown, List } from "@phosphor-icons/react";
+
+import { CaretNext } from "../ArrowIcons.js";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 
@@ -179,7 +181,11 @@ export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
 					<List className="h-4 w-4" />
 					<span className="font-semibold">{t`Outline`}</span>
 				</span>
-				{isExpanded ? <CaretDown className="h-4 w-4" /> : <CaretRight className="h-4 w-4" />}
+				{isExpanded ? (
+					<CaretDown className="h-4 w-4" />
+				) : (
+					<CaretNext className="h-4 w-4" />
+				)}
 			</Button>
 
 			{isExpanded && (

--- a/packages/admin/src/components/editor/DocumentOutline.tsx
+++ b/packages/admin/src/components/editor/DocumentOutline.tsx
@@ -10,12 +10,11 @@
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { CaretDown, List } from "@phosphor-icons/react";
-
-import { CaretNext } from "../ArrowIcons.js";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
+import { CaretNext } from "../ArrowIcons.js";
 
 function getIndentClass(level: number) {
 	switch (level) {
@@ -181,11 +180,7 @@ export function DocumentOutline({ editor, className }: DocumentOutlineProps) {
 					<List className="h-4 w-4" />
 					<span className="font-semibold">{t`Outline`}</span>
 				</span>
-				{isExpanded ? (
-					<CaretDown className="h-4 w-4" />
-				) : (
-					<CaretNext className="h-4 w-4" />
-				)}
+				{isExpanded ? <CaretDown className="h-4 w-4" /> : <CaretNext className="h-4 w-4" />}
 			</Button>
 
 			{isExpanded && (

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -14,13 +14,14 @@ import {
 	WarningCircle,
 	Trash,
 	Pencil,
-	ArrowLeft,
 	Info,
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
+
+import { ArrowPrev } from "../ArrowIcons.js";
 
 import {
 	fetchAllowedDomains,
@@ -166,7 +167,7 @@ export function AllowedDomainsSettings() {
 		<div className="flex items-center gap-3">
 			<Link to="/settings">
 				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-					<ArrowLeft className="h-4 w-4" />
+					<ArrowPrev className="h-4 w-4" />
 				</Button>
 			</Link>
 			<h1 className="text-2xl font-bold">{t`Self-Signup Domains`}</h1>

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -21,8 +21,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
-import { ArrowPrev } from "../ArrowIcons.js";
-
 import {
 	fetchAllowedDomains,
 	createAllowedDomain,
@@ -31,6 +29,7 @@ import {
 	fetchManifest,
 	type AllowedDomain,
 } from "../../lib/api";
+import { ArrowPrev } from "../ArrowIcons.js";
 import { useAllowedDomainsRolesConfig } from "./useAllowedDomainsRolesConfig.js";
 
 export function AllowedDomainsSettings() {

--- a/packages/admin/src/components/settings/ApiTokenSettings.tsx
+++ b/packages/admin/src/components/settings/ApiTokenSettings.tsx
@@ -8,17 +8,7 @@ import { Button, Checkbox, Input, Loader, Select } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import {
-	Copy,
-	Eye,
-	EyeSlash,
-	Key,
-	Plus,
-	Trash,
-	WarningCircle,
-} from "@phosphor-icons/react";
-
-import { ArrowPrev } from "../ArrowIcons.js";
+import { Copy, Eye, EyeSlash, Key, Plus, Trash, WarningCircle } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -31,6 +21,7 @@ import {
 	type ApiTokenCreateResult,
 	type ApiTokenScopeValue,
 } from "../../lib/api/api-tokens.js";
+import { ArrowPrev } from "../ArrowIcons.js";
 import { getMutationError } from "../DialogError.js";
 
 // =============================================================================

--- a/packages/admin/src/components/settings/ApiTokenSettings.tsx
+++ b/packages/admin/src/components/settings/ApiTokenSettings.tsx
@@ -9,7 +9,6 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	Copy,
 	Eye,
 	EyeSlash,
@@ -18,6 +17,8 @@ import {
 	Trash,
 	WarningCircle,
 } from "@phosphor-icons/react";
+
+import { ArrowPrev } from "../ArrowIcons.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -189,7 +190,7 @@ export function ApiTokenSettings() {
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
 					<Button variant="ghost" shape="square" aria-label={t(msg`Back to settings`)}>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 				</Link>
 				<div>

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -18,12 +18,12 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
-import { ArrowPrev } from "../ArrowIcons.js";
 import {
 	fetchEmailSettings,
 	sendTestEmail,
 	type EmailSettings as EmailSettingsData,
 } from "../../lib/api/email-settings.js";
+import { ArrowPrev } from "../ArrowIcons.js";
 import { getMutationError } from "../DialogError.js";
 
 export function EmailSettings() {

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -8,7 +8,6 @@
 import { Button, Input, Loader } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	CheckCircle,
 	Envelope,
 	PaperPlaneTilt,
@@ -19,6 +18,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
+import { ArrowPrev } from "../ArrowIcons.js";
 import {
 	fetchEmailSettings,
 	sendTestEmail,
@@ -84,7 +84,7 @@ export function EmailSettings() {
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
 						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowLeft className="h-4 w-4" />
+							<ArrowPrev className="h-4 w-4" />
 						</Button>
 					</Link>
 					<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
@@ -103,7 +103,7 @@ export function EmailSettings() {
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
 					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 				</Link>
 				<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -7,20 +7,13 @@
 
 import { Button, Input, Label } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	FloppyDisk,
-	CheckCircle,
-	WarningCircle,
-	Upload,
-	X,
-} from "@phosphor-icons/react";
+import { FloppyDisk, CheckCircle, WarningCircle, Upload, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
-import { ArrowPrev } from "../ArrowIcons.js";
-
 import { fetchSettings, updateSettings, type SiteSettings, type MediaItem } from "../../lib/api";
+import { ArrowPrev } from "../ArrowIcons.js";
 import { MediaPickerModal } from "../MediaPickerModal";
 
 export function GeneralSettings() {

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -8,7 +8,6 @@
 import { Button, Input, Label } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	FloppyDisk,
 	CheckCircle,
 	WarningCircle,
@@ -18,6 +17,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
+
+import { ArrowPrev } from "../ArrowIcons.js";
 
 import { fetchSettings, updateSettings, type SiteSettings, type MediaItem } from "../../lib/api";
 import { MediaPickerModal } from "../MediaPickerModal";
@@ -105,7 +106,7 @@ export function GeneralSettings() {
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
 						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowLeft className="h-4 w-4" />
+							<ArrowPrev className="h-4 w-4" />
 						</Button>
 					</Link>
 					<h1 className="text-2xl font-bold">{t`General Settings`}</h1>
@@ -123,7 +124,7 @@ export function GeneralSettings() {
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
 					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 				</Link>
 				<h1 className="text-2xl font-bold">{t`General Settings`}</h1>

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -8,13 +8,12 @@
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Shield, Plus, CheckCircle, WarningCircle, Info } from "@phosphor-icons/react";
-
-import { ArrowPrev } from "../ArrowIcons.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchPasskeys, renamePasskey, deletePasskey, fetchManifest } from "../../lib/api";
+import { ArrowPrev } from "../ArrowIcons.js";
 import { PasskeyRegistration } from "../auth/PasskeyRegistration";
 import { PasskeyList } from "./PasskeyList";
 

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -7,7 +7,9 @@
 
 import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Shield, Plus, CheckCircle, WarningCircle, ArrowLeft, Info } from "@phosphor-icons/react";
+import { Shield, Plus, CheckCircle, WarningCircle, Info } from "@phosphor-icons/react";
+
+import { ArrowPrev } from "../ArrowIcons.js";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -102,7 +104,7 @@ export function SecuritySettings() {
 		<div className="flex items-center gap-3">
 			<Link to="/settings">
 				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-					<ArrowLeft className="h-4 w-4" />
+					<ArrowPrev className="h-4 w-4" />
 				</Button>
 			</Link>
 			<h1 className="text-2xl font-bold">{t`Security Settings`}</h1>

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -6,18 +6,13 @@
 
 import { Button, Input, InputArea } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import {
-	FloppyDisk,
-	CheckCircle,
-	WarningCircle,
-	MagnifyingGlass,
-} from "@phosphor-icons/react";
+import { FloppyDisk, CheckCircle, WarningCircle, MagnifyingGlass } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
-import { ArrowPrev } from "../ArrowIcons.js";
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
+import { ArrowPrev } from "../ArrowIcons.js";
 
 export function SeoSettings() {
 	const { t } = useLingui();

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -7,7 +7,6 @@
 import { Button, Input, InputArea } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
-	ArrowLeft,
 	FloppyDisk,
 	CheckCircle,
 	WarningCircle,
@@ -17,6 +16,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
+import { ArrowPrev } from "../ArrowIcons.js";
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
 
 export function SeoSettings() {
@@ -81,7 +81,7 @@ export function SeoSettings() {
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
 						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowLeft className="h-4 w-4" />
+							<ArrowPrev className="h-4 w-4" />
 						</Button>
 					</Link>
 					<h1 className="text-2xl font-bold">{t`SEO Settings`}</h1>
@@ -99,7 +99,7 @@ export function SeoSettings() {
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
 					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 				</Link>
 				<h1 className="text-2xl font-bold">{t`SEO Settings`}</h1>

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -6,7 +6,9 @@
 
 import { Button, Input } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { ArrowLeft, FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
+import { FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
+
+import { ArrowPrev } from "../ArrowIcons.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
@@ -75,7 +77,7 @@ export function SocialSettings() {
 				<div className="flex items-center gap-3">
 					<Link to="/settings">
 						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowLeft className="h-4 w-4" />
+							<ArrowPrev className="h-4 w-4" />
 						</Button>
 					</Link>
 					<h1 className="text-2xl font-bold">{t`Social Links`}</h1>
@@ -93,7 +95,7 @@ export function SocialSettings() {
 			<div className="flex items-center gap-3">
 				<Link to="/settings">
 					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-						<ArrowLeft className="h-4 w-4" />
+						<ArrowPrev className="h-4 w-4" />
 					</Button>
 				</Link>
 				<h1 className="text-2xl font-bold">{t`Social Links`}</h1>

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -7,13 +7,12 @@
 import { Button, Input } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
-
-import { ArrowPrev } from "../ArrowIcons.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
+import { ArrowPrev } from "../ArrowIcons.js";
 
 export function SocialSettings() {
 	const { t } = useLingui();

--- a/packages/blocks/playground/src/Playground.tsx
+++ b/packages/blocks/playground/src/Playground.tsx
@@ -204,7 +204,7 @@ export function Playground() {
 			<header className="flex h-11 shrink-0 items-center gap-2 border-b border-kumo-line bg-kumo-bg px-3">
 				<span className="text-sm font-semibold text-kumo-text">Block Kit Playground</span>
 
-				<div className="ml-auto flex items-center gap-1.5">
+				<div className="ms-auto flex items-center gap-1.5">
 					{/* Template picker */}
 					<div className="relative" ref={templateMenuRef}>
 						<button
@@ -217,7 +217,7 @@ export function Playground() {
 						</button>
 						{templateMenuOpen && (
 							<div
-								className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-kumo-line p-1 shadow-lg"
+								className="absolute end-0 top-full z-50 mt-1 w-64 rounded-lg border border-kumo-line p-1 shadow-lg"
 								style={{ backgroundColor: "var(--kumo-bg, Canvas)" }}
 							>
 								{templates.map((t, i) => (
@@ -225,7 +225,7 @@ export function Playground() {
 										key={t.name}
 										type="button"
 										onClick={() => loadTemplate(i)}
-										className="flex w-full flex-col items-start rounded-md px-3 py-2 text-left hover:bg-kumo-tint"
+										className="flex w-full flex-col items-start rounded-md px-3 py-2 text-start hover:bg-kumo-tint"
 									>
 										<span className="text-sm font-medium text-kumo-text">{t.name}</span>
 										<span className="text-xs text-kumo-text-secondary">{t.description}</span>
@@ -272,7 +272,7 @@ export function Playground() {
 								key={entry.type}
 								type="button"
 								onClick={() => insertBlock(i)}
-								className="flex w-full items-start gap-2 rounded-md px-2.5 py-2 text-left hover:bg-kumo-tint"
+								className="flex w-full items-start gap-2 rounded-md px-2.5 py-2 text-start hover:bg-kumo-tint"
 							>
 								<Plus
 									size={14}
@@ -299,7 +299,7 @@ export function Playground() {
 							JSON Editor
 						</span>
 						{errorCount > 0 && (
-							<span className="ml-auto flex items-center gap-1 text-[11px] font-medium text-kumo-warning">
+							<span className="ms-auto flex items-center gap-1 text-[11px] font-medium text-kumo-warning">
 								<Warning size={12} weight="fill" />
 								{errorCount} {errorCount === 1 ? "error" : "errors"}
 							</span>
@@ -358,14 +358,14 @@ export function Playground() {
 							<span className="text-[11px] font-medium uppercase tracking-wide text-kumo-text-secondary">
 								Action Log
 							</span>
-							<span className="ml-1.5 rounded-full bg-kumo-tint px-1.5 py-0.5 text-[10px] font-medium text-kumo-text-secondary">
+							<span className="ms-1.5 rounded-full bg-kumo-tint px-1.5 py-0.5 text-[10px] font-medium text-kumo-text-secondary">
 								{actionLog.length}
 							</span>
 							{actionLog.length > 0 && (
 								<button
 									type="button"
 									onClick={() => setActionLog([])}
-									className="ml-auto rounded-md p-1 text-kumo-text-secondary hover:bg-kumo-tint"
+									className="ms-auto rounded-md p-1 text-kumo-text-secondary hover:bg-kumo-tint"
 									aria-label="Clear log"
 								>
 									<Trash size={12} />

--- a/packages/blocks/src/blocks/table.tsx
+++ b/packages/blocks/src/blocks/table.tsx
@@ -72,7 +72,7 @@ export function TableBlockComponent({
 
 	return (
 		<div className="overflow-x-auto">
-			<table className="w-full text-left text-sm">
+			<table className="w-full text-start text-sm">
 				<thead>
 					<tr className="border-b border-kumo-line">
 						{block.columns.map((col) => (

--- a/packages/plugins/ai-moderation/src/admin.tsx
+++ b/packages/plugins/ai-moderation/src/admin.tsx
@@ -386,7 +386,7 @@ function SettingsPage() {
 									</div>
 									<p className="text-sm text-muted-foreground mt-0.5 truncate">{cat.description}</p>
 								</div>
-								<div className="flex items-center gap-1 ml-4">
+								<div className="flex items-center gap-1 ms-4">
 									<button
 										onClick={() => setEditingCategory(cat)}
 										className="p-1.5 hover:bg-muted rounded"

--- a/packages/plugins/api-test/src/admin.tsx
+++ b/packages/plugins/api-test/src/admin.tsx
@@ -99,9 +99,9 @@ function ApiTestWidget() {
 							<Icon className="h-3.5 w-3.5 text-muted-foreground" />
 							<span className="text-muted-foreground">{name}</span>
 							{ok ? (
-								<CheckCircle className="h-3.5 w-3.5 text-green-500 ml-auto" />
+								<CheckCircle className="h-3.5 w-3.5 text-green-500 ms-auto" />
 							) : (
-								<XCircle className="h-3.5 w-3.5 text-red-500 ml-auto" />
+								<XCircle className="h-3.5 w-3.5 text-red-500 ms-auto" />
 							)}
 						</div>
 					))}
@@ -119,7 +119,7 @@ function ApiTestWidget() {
 				<button
 					onClick={runTests}
 					disabled={isRunning}
-					className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50 ml-auto"
+					className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50 ms-auto"
 				>
 					{isRunning ? (
 						<CircleNotch className="h-3.5 w-3.5 animate-spin" />

--- a/packages/plugins/color/src/admin.tsx
+++ b/packages/plugins/color/src/admin.tsx
@@ -50,7 +50,7 @@ function ColorPicker({ value, onChange, label, id, required, minimal }: FieldWid
 			{!minimal && (
 				<label htmlFor={id} className="text-sm font-medium leading-none mb-1.5 block">
 					{label}
-					{required && <span className="text-destructive ml-0.5">*</span>}
+					{required && <span className="text-destructive ms-0.5">*</span>}
 				</label>
 			)}
 			<div className="flex items-center gap-3">

--- a/packages/plugins/forms/src/admin.tsx
+++ b/packages/plugins/forms/src/admin.tsx
@@ -287,12 +287,12 @@ function FormsListPage() {
 					<table className="w-full text-sm">
 						<thead>
 							<tr className="border-b bg-muted/50">
-								<th className="text-left p-3 font-medium">Name</th>
-								<th className="text-left p-3 font-medium">Slug</th>
-								<th className="text-left p-3 font-medium">Status</th>
-								<th className="text-right p-3 font-medium">Submissions</th>
-								<th className="text-left p-3 font-medium">Last Submission</th>
-								<th className="text-right p-3 font-medium">Actions</th>
+								<th className="text-start p-3 font-medium">Name</th>
+								<th className="text-start p-3 font-medium">Slug</th>
+								<th className="text-start p-3 font-medium">Status</th>
+								<th className="text-end p-3 font-medium">Submissions</th>
+								<th className="text-start p-3 font-medium">Last Submission</th>
+								<th className="text-end p-3 font-medium">Actions</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -305,7 +305,7 @@ function FormsListPage() {
 											{form.status}
 										</Badge>
 									</td>
-									<td className="p-3 text-right tabular-nums">{form.submissionCount}</td>
+									<td className="p-3 text-end tabular-nums">{form.submissionCount}</td>
 									<td className="p-3 text-muted-foreground">
 										{form.lastSubmissionAt ? formatDate(form.lastSubmissionAt) : "Never"}
 									</td>
@@ -532,7 +532,7 @@ function FormEditor({
 		<div className="space-y-6">
 			<div className="flex items-center gap-3">
 				<Button variant="ghost" shape="square" onClick={onCancel} aria-label="Back">
-					<ArrowLeft className="h-5 w-5" />
+					<ArrowLeft className="h-5 w-5 rtl:-scale-x-100" />
 				</Button>
 				<div>
 					<h1 className="text-3xl font-bold">{form ? "Edit Form" : "New Form"}</h1>
@@ -808,7 +808,7 @@ function OptionsEditor({
 	const removeOption = (index: number) => onChange(options.filter((_, i) => i !== index));
 
 	return (
-		<div className="ml-8 space-y-1">
+		<div className="ms-8 space-y-1">
 			<span className="text-xs text-muted-foreground">Options:</span>
 			{options.map((opt, i) => (
 				<div key={i} className="flex items-center gap-2">
@@ -1054,10 +1054,10 @@ function SubmissionsPage() {
 								<thead>
 									<tr className="border-b bg-muted/50">
 										<th className="w-8 p-3" />
-										<th className="text-left p-3 font-medium">Date</th>
-										<th className="text-left p-3 font-medium">Preview</th>
-										<th className="text-left p-3 font-medium">Status</th>
-										<th className="text-right p-3 font-medium">Actions</th>
+										<th className="text-start p-3 font-medium">Date</th>
+										<th className="text-start p-3 font-medium">Preview</th>
+										<th className="text-start p-3 font-medium">Status</th>
+										<th className="text-end p-3 font-medium">Actions</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -1113,7 +1113,7 @@ function SubmissionsPage() {
 														{sub.status}
 													</Badge>
 												</td>
-												<td className="p-3 text-right">
+												<td className="p-3 text-end">
 													<div className="flex items-center justify-end gap-1">
 														<Button
 															variant="ghost"
@@ -1264,7 +1264,7 @@ function RecentSubmissionsWidget() {
 							<Badge variant={sub.status === "new" ? "success" : "default"}>{sub.status}</Badge>
 							<span className="truncate">{preview || formMap.get(sub.formId) || "Submission"}</span>
 						</div>
-						<span className="text-muted-foreground whitespace-nowrap ml-2">
+						<span className="text-muted-foreground whitespace-nowrap ms-2">
 							{formatDate(sub.createdAt)}
 						</span>
 					</div>


### PR DESCRIPTION
## What does this PR do?

General improvements for emdash admin and some other packages to be compatible with ltr/rtl direction. Related to this discussion: https://github.com/emdash-cms/emdash/discussions/145#discussioncomment-16551699

Also covers arrow and caret direction respecting chosen language direction.

So overall:

- Updates directional tailwind codes for left/right to start/end and related changes.
- Updates arrow and caret usage on left/right directions, to follow ltr/rtl directions.

## Type of change

- [ ] Bug fix
- [x] Feature (requires maintainer-approved)
- [x] Refactor (no behavior change)
- [ ] cms/emdash/discussions/categories/ideas))
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

Note: a little chore due to `ArrowLeft` and `CaretLeft` being deprecated; The updated usage is `ArrowLeftIcon` and `CaretLeftIcon`.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code (implementation in bits)

## Screenshots / Test Output

<img width="1225" height="925" alt="Screenshot 2026-04-28 at 19 23 34" src="https://github.com/user-attachments/assets/5f9d438e-88ec-4b2d-9484-748dd6cb5b78" />


---

<img width="1230" height="926" alt="Screenshot 2026-04-28 at 19 23 54" src="https://github.com/user-attachments/assets/d07a598b-f1c6-41cd-a20b-c3c530d8efe2" />


---

<img width="1216" height="935" alt="Screenshot 2026-04-28 at 19 24 21" src="https://github.com/user-attachments/assets/de682e99-94b5-4d37-9edf-4654d3ce12c5" />

