### PR TITLE
fix(admin): show loader instead of empty search message while content list loads

### DIFF
--- a/.changeset/real-beds-draw.md
+++ b/.changeset/real-beds-draw.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes content list loading state showing `No results for ""` instead of a loader while items are being fetched. The trash tab gets the same treatment.

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, buttonVariants, Dialog, Input, Tabs } from "@cloudflare/kumo";
+import { Badge, Button, buttonVariants, Dialog, Input, Loader, Tabs } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -238,7 +238,16 @@ export function ContentList({
 								</tr>
 							</thead>
 							<tbody>
-								{items.length === 0 && !isLoading ? (
+								{isLoading && items.length === 0 ? (
+									<tr>
+										<td colSpan={i18n ? 5 : 4} className="px-4 py-8 text-center text-kumo-subtle">
+											<span className="inline-flex items-center gap-2">
+												<Loader size="sm" />
+												{t`Loading...`}
+											</span>
+										</td>
+									</tr>
+								) : items.length === 0 ? (
 									<tr>
 										<td colSpan={i18n ? 5 : 4} className="px-4 py-8 text-center text-kumo-subtle">
 											{t`No ${collectionLabel.toLowerCase()} yet.`}{" "}
@@ -343,7 +352,16 @@ export function ContentList({
 								</tr>
 							</thead>
 							<tbody>
-								{trashedItems.length === 0 && !isTrashedLoading ? (
+								{isTrashedLoading && trashedItems.length === 0 ? (
+									<tr>
+										<td colSpan={3} className="px-4 py-8 text-center text-kumo-subtle">
+											<span className="inline-flex items-center gap-2">
+												<Loader size="sm" />
+												{t`Loading...`}
+											</span>
+										</td>
+									</tr>
+								) : trashedItems.length === 0 ? (
 									<tr>
 										<td colSpan={3} className="px-4 py-8 text-center text-kumo-subtle">
 											{t`Trash is empty`}


### PR DESCRIPTION
## What does this PR do?

The content list table briefly renders `No results for ""` while the initial fetch is in flight. The empty-state branch was gated on `!isLoading`, so loading + empty `items` fell through to the "no search results" branch with an empty `searchQuery`. Render a `<Loader>` row when `isLoading && items.length === 0`; applied the same fix to the trash tab (which was showing "Trash is empty" while loading).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

Manual verification: navigate to a content list page; the table now shows a spinner + "Loading..." while the first page is fetched, instead of `No results for ""`.