### PR TITLE
fix(core): fire redirect middleware for anonymous visitors

### DIFF
--- a/.changeset/anonymous-redirect-db.md
+++ b/.changeset/anonymous-redirect-db.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes redirect middleware silently skipping anonymous visitors. The anonymous fast path now exposes `locals.emdash.db`, so admin-defined redirects (exact-match and pattern) fire for logged-out users as the docs imply. Previously the middleware short-circuited on `!emdash?.db` for every public request and the visitor saw a 404 instead of the configured redirect.

--- a/e2e/tests/redirects.spec.ts
+++ b/e2e/tests/redirects.spec.ts
@@ -125,6 +125,50 @@ test.describe("Redirects", () => {
 		});
 	});
 
+	test.describe("Anonymous visitors", () => {
+		test("fires admin-defined redirects for logged-out users", async ({
+			page,
+			request,
+			serverInfo,
+		}) => {
+			const { baseUrl, token } = serverInfo;
+			const apiHeaders = {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+				"X-EmDash-Request": "1",
+				Origin: baseUrl,
+			};
+
+			// Create the redirect via the authenticated admin API.
+			const created = await page.request.post(`${baseUrl}/_emdash/api/redirects`, {
+				headers: apiHeaders,
+				data: { source: "/anon-redirect-test", destination: "/", type: 301 },
+			});
+			expect(created.ok(), await created.text()).toBe(true);
+			const id = (await created.json()).data.id;
+
+			try {
+				// Anonymous request via the worker-scoped request fixture (no
+				// browser cookies, no auth header). Pre-fix, the redirect
+				// middleware short-circuited on `!emdash.db` and the catch-all
+				// rendered 404. Post-fix it must emit 301 → /.
+				const res = await request.get(`${baseUrl}/anon-redirect-test`, {
+					maxRedirects: 0,
+				});
+				expect(res.status()).toBe(301);
+				expect(res.headers().location).toBe("/");
+			} finally {
+				await page.request
+					.delete(`${baseUrl}/_emdash/api/redirects/${id}`, {
+						headers: apiHeaders,
+					})
+					.catch(() => {
+						/* best-effort cleanup */
+					});
+			}
+		});
+	});
+
 	test.describe("404 Tracking", () => {
 		test("renders the 404 errors tab", async ({ admin, page }) => {
 			await admin.goto("/redirects");

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -308,6 +308,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				// getRuntime() is just a null-check. This enables SEO plugins to
 				// contribute meta tags for all visitors, not just logged-in editors.
 				const config = getConfig();
+				// Even on the anonymous fast path we ask the adapter for a per-request
+				// scoped db. For D1 with read replication this routes anonymous reads
+				// to the nearest replica; for other adapters it's a no-op. Hoisted
+				// above the runtime init so locals.emdash.db is populated for the
+				// redirect middleware (which runs before render and reads it directly).
+				const anonScoped = createRequestScopedDb({
+					config: config?.database?.config,
+					isAuthenticated: false,
+					isWrite: request.method !== "GET" && request.method !== "HEAD",
+					cookies,
+					url,
+				});
 				if (config) {
 					// Sub-phase timings are populated only on the cold init. Warm
 					// requests hit the cached runtime and leave this empty.
@@ -321,6 +333,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 							collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
 							collectPageFragments: runtime.collectPageFragments.bind(runtime),
 							getPublicMediaUrl: createPublicMediaUrlResolver(runtime.storage),
+							db: anonScoped?.db ?? runtime.db,
 						} as EmDashHandlers;
 					} catch {
 						// Non-fatal — EmDashHead will fall back to base SEO contributions
@@ -331,17 +344,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					// rt.sandbox, rt.market, rt.hooks, rt.cron).
 					for (const sub of initSubTimings) timings.push(sub);
 				}
-
-				// Even on the anonymous fast path we ask the adapter for a per-request
-				// scoped db. For D1 with read replication this routes anonymous reads
-				// to the nearest replica; for other adapters it's a no-op.
-				const anonScoped = createRequestScopedDb({
-					config: config?.database?.config,
-					isAuthenticated: false,
-					isWrite: request.method !== "GET" && request.method !== "HEAD",
-					cookies,
-					url,
-				});
 				const runAnon = async () => {
 					const t0 = performance.now();
 					const response = await next();


### PR DESCRIPTION
## What does this PR do?

Fires the bundled redirect middleware (`emdash/middleware/redirect`) for anonymous public visitors. It currently bails on `!locals.emdash?.db`, but the anonymous fast path in `packages/core/src/astro/middleware.ts` never assigned a `db` to `locals.emdash` — only `collectPageMetadata`, `collectPageFragments`, and `getPublicMediaUrl`. The request-scoped `anonScoped.db` was already created and threaded through `runWithContext`, just never exposed on locals where the redirect middleware reads it. Result: every public (logged-out) request short-circuits past the redirect lookup and admin-defined redirects silently 404. Editor sessions were unaffected because the slow path sets `locals.emdash.db = runtime.db` directly.

This hoists `createRequestScopedDb` above the runtime-init block on the fast path so its `db` can be exposed on `locals.emdash`, falling back to `runtime.db` for adapters that don't return a scoped wrapper. Fast-path intent is preserved (no manifest fetch, no handler bindings) so public-render latency is unchanged — `createRequestScopedDb` was already being invoked, this just moves it ~20 lines up.

**Repro before fix:** create an exact-match redirect via the admin UI (e.g. `/foo` → `/`), then `curl -sI http://localhost:4321/foo` from a clean shell — pre-fix returns 404 (`NotFoundShell`), post-fix returns 301 with `Location: /`.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
$ pnpm exec playwright test --grep "Redirects" --reporter=line
Running 10 tests using 1 worker

  10 passed (44.5s)
```

New test: `e2e/tests/redirects.spec.ts:129 › Redirects › Anonymous visitors › fires admin-defined redirects for logged-out users`. Creates a redirect via authenticated admin API, then asserts an anonymous request to the source path returns 301 with the configured `Location` header. Pre-fix it returns 404, post-fix 301.

`packages/core` unit suite: 3036/3036 passed.