### PR TITLE
test(admin): scope toolbar button queries to fix flaky CI

### DIFF
--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -123,6 +123,19 @@ async function focusAndSelectAll(screen: Awaited<ReturnType<typeof render>>) {
 	await userEvent.keyboard(`${mod}{a}${modUp}`);
 }
 
+/**
+ * Returns a locator scoped to the editor toolbar.
+ *
+ * The bubble menu (which appears when text is selected) renders buttons with
+ * the same accessible names as some toolbar buttons (Bold, Italic, Underline,
+ * Strikethrough). An unscoped `getByRole("button", { name: "Bold" })` after
+ * selecting text races with the bubble menu and produces a strict-mode
+ * violation in CI. Scoping to the toolbar via its aria-label avoids the race.
+ */
+function getToolbarButton(screen: Awaited<ReturnType<typeof render>>, name: string) {
+	return screen.getByRole("toolbar", { name: "Text formatting" }).getByRole("button", { name });
+}
+
 // =============================================================================
 // 1. Toolbar Presence and Structure
 // =============================================================================
@@ -205,7 +218,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Bold" });
+		const btn = getToolbarButton(screen, "Bold");
 		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
 		btn.element().click();
 
@@ -218,7 +231,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Italic" });
+		const btn = getToolbarButton(screen, "Italic");
 		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
 		btn.element().click();
 
@@ -231,7 +244,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Underline" });
+		const btn = getToolbarButton(screen, "Underline");
 		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
 		btn.element().click();
 
@@ -244,7 +257,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Strikethrough" });
+		const btn = getToolbarButton(screen, "Strikethrough");
 		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
 		btn.element().click();
 
@@ -257,7 +270,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Inline Code" });
+		const btn = getToolbarButton(screen, "Inline Code");
 		await expect.element(btn).toHaveAttribute("aria-pressed", "false");
 		btn.element().click();
 
@@ -357,7 +370,7 @@ describe("Formatting Button Toggle States", () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
 
-		const btn = screen.getByRole("button", { name: "Bold" });
+		const btn = getToolbarButton(screen, "Bold");
 
 		// First click: on
 		btn.element().click();
@@ -452,9 +465,9 @@ describe("Undo/Redo", () => {
 		await focusAndSelectAll(screen);
 
 		// Make a change - toggle bold
-		screen.getByRole("button", { name: "Bold" }).element().click();
+		getToolbarButton(screen, "Bold").element().click();
 
-		const undo = screen.getByRole("button", { name: "Undo" });
+		const undo = getToolbarButton(screen, "Undo");
 		await vi.waitFor(
 			() => {
 				expect(undo.element().disabled).toBe(false);
@@ -468,10 +481,10 @@ describe("Undo/Redo", () => {
 		await focusAndSelectAll(screen);
 
 		// Make a change
-		screen.getByRole("button", { name: "Bold" }).element().click();
+		getToolbarButton(screen, "Bold").element().click();
 
-		const undo = screen.getByRole("button", { name: "Undo" });
-		const redo = screen.getByRole("button", { name: "Redo" });
+		const undo = getToolbarButton(screen, "Undo");
+		const redo = getToolbarButton(screen, "Redo");
 
 		// Wait for undo to be enabled, then click it
 		await vi.waitFor(
@@ -495,10 +508,10 @@ describe("Undo/Redo", () => {
 		await focusAndSelectAll(screen);
 
 		// Make a change
-		screen.getByRole("button", { name: "Bold" }).element().click();
+		getToolbarButton(screen, "Bold").element().click();
 
-		const undo = screen.getByRole("button", { name: "Undo" });
-		const redo = screen.getByRole("button", { name: "Redo" });
+		const undo = getToolbarButton(screen, "Undo");
+		const redo = getToolbarButton(screen, "Redo");
 
 		// Undo
 		await vi.waitFor(


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky browser test in `packages/admin/tests/editor/toolbar.test.tsx`.

The `Undo/Redo > after undo, Redo becomes enabled` test failed intermittently in CI (e.g. https://github.com/emdash-cms/emdash/actions/runs/25114719499/job/73598330525) with a strict-mode locator violation:

\`\`\`
strict mode violation: getByTestId('__vitest_0__').getByRole('button', { name: 'Bold' }) resolved to 2 elements:
  1) toolbar Bold button
  2) bubble-menu Bold button (rendered after focusAndSelectAll)
\`\`\`

The editor toolbar and the bubble menu both expose buttons named Bold, Italic, Underline and Strikethrough. After `focusAndSelectAll()`, the bubble menu paints and the second `getByRole` evaluation can race it. The race was always present; CI load just made it surface here.

Adds a `getToolbarButton(screen, name)` test helper that scopes lookups to the editor toolbar via its `aria-label="Text formatting"`, and switches every toolbar test that selects text first (or queries a name shared with the bubble menu) to use it. Test-only change — no source modifications.

Verified locally: failing test passes 5/5 runs, full file passes 5/5 runs (46/46 each), `pnpm lint:json` reports 0 diagnostics, `pnpm format` is clean, admin `tsc --noEmit` is clean.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include \`messages.po\` changes except in translation PRs — a workflow extracts catalogs on merge to \`main\`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A, test-only change
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code