### PR TITLE
fix(migrations): make 035 dedup resumable after a partial failure

### DIFF
--- a/.changeset/migration-035-dedup-resume.md
+++ b/.changeset/migration-035-dedup-resume.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes migration `035_bounded_404_log` failing with `UNIQUE constraint failed: _emdash_404_log.path` when re-run after a partial first attempt. The dedup step was gated on `if (!hitsExists)`, so any retry that already had the `hits` column committed would skip dedup and crash on the unique-index creation. Gate dedup on the absence of the unique index instead, which is the actual invariant the index needs.

--- a/packages/core/src/database/migrations/035_bounded_404_log.ts
+++ b/packages/core/src/database/migrations/035_bounded_404_log.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
-import { columnExists } from "../dialect-helpers.js";
+import { columnExists, indexExists } from "../dialect-helpers.js";
 
 /**
  * Migration: Bounded 404 logging
@@ -22,6 +22,11 @@ import { columnExists } from "../dialect-helpers.js";
 
 export async function up(db: Kysely<unknown>): Promise<void> {
 	const hitsExists = await columnExists(db, "_emdash_404_log", "hits");
+	// Gate dedup on the unique index, not on `hits`. A previous attempt may
+	// have added the column and failed before completing dedup; gating on
+	// `hitsExists` would then silently skip dedup on retry and crash the
+	// unique-index step with `UNIQUE constraint failed`.
+	const uniqueIndexExists = await indexExists(db, "idx_404_log_path_unique");
 
 	// 1. Add columns.
 	if (!hitsExists) {
@@ -52,7 +57,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 	//    (3.25+, 2018) and Postgres. The previous GROUP BY approach was
 	//    accepted by SQLite but invalid on Postgres because `id` wasn't in
 	//    the GROUP BY or wrapped in an aggregate.
-	if (!hitsExists) {
+	if (!uniqueIndexExists) {
 		await sql`
 			WITH ranked AS (
 				SELECT

--- a/packages/core/tests/unit/database/migrations/035_bounded_404_log.test.ts
+++ b/packages/core/tests/unit/database/migrations/035_bounded_404_log.test.ts
@@ -1,0 +1,75 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createDatabase } from "../../../../src/database/connection.js";
+import { up } from "../../../../src/database/migrations/035_bounded_404_log.js";
+import type { Database } from "../../../../src/database/types.js";
+
+describe("035_bounded_404_log migration", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = createDatabase({ url: ":memory:" });
+
+		// Schema as it existed before 035: path is non-unique-indexed, no hits/last_seen_at.
+		await db.schema
+			.createTable("_emdash_404_log")
+			.addColumn("id", "integer", (col) => col.primaryKey().autoIncrement())
+			.addColumn("path", "text", (col) => col.notNull())
+			.addColumn("created_at", "text", (col) => col.notNull())
+			.execute();
+
+		await db.schema.createIndex("idx_404_log_path").on("_emdash_404_log").column("path").execute();
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it("dedups duplicate paths and creates the unique index on a fresh run", async () => {
+		await sql`
+			INSERT INTO _emdash_404_log (path, created_at) VALUES
+				('/a', '2026-01-01T00:00:00Z'),
+				('/a', '2026-01-02T00:00:00Z'),
+				('/b', '2026-01-01T00:00:00Z')
+		`.execute(db);
+
+		await up(db);
+
+		const rows = await sql<{ path: string; hits: number }>`
+			SELECT path, hits FROM _emdash_404_log ORDER BY path
+		`.execute(db);
+		expect(rows.rows).toEqual([
+			{ path: "/a", hits: 2 },
+			{ path: "/b", hits: 1 },
+		]);
+	});
+
+	// Regression: dedup was gated on `if (!hitsExists)`, so a retry after the
+	// `hits` column already committed would skip dedup and crash on the unique
+	// index. Gate dedup on the unique index instead.
+	it("dedups on retry when a previous attempt added `hits` but never deduped", async () => {
+		await sql`
+			INSERT INTO _emdash_404_log (path, created_at) VALUES
+				('/a', '2026-01-01T00:00:00Z'),
+				('/a', '2026-01-02T00:00:00Z')
+		`.execute(db);
+
+		// Simulate a partial first run: `hits` and `last_seen_at` are already
+		// present, but the unique index never got created because dedup
+		// crashed (or the row count grew between attempts).
+		await db.schema
+			.alterTable("_emdash_404_log")
+			.addColumn("hits", "integer", (col) => col.notNull().defaultTo(1))
+			.execute();
+		await db.schema.alterTable("_emdash_404_log").addColumn("last_seen_at", "text").execute();
+
+		await expect(up(db)).resolves.not.toThrow();
+
+		const rows = await sql<{ path: string }>`
+			SELECT path FROM _emdash_404_log
+		`.execute(db);
+		expect(rows.rows).toEqual([{ path: "/a" }]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Migration `035_bounded_404_log` gated its dedup step on `if (!hitsExists)`, so any retry after the `hits` column had been committed would skip dedup and abort at unique-index creation with `UNIQUE constraint failed: _emdash_404_log.path`. Gate dedup on the absence of the unique index instead — that is the actual invariant the index needs.

Surfaced on a deploy with heavy duplicate-path 404 traffic where a first attempt added the column and never finished dedup; the retry then crashed before the index could be created and the deploy could not recover without a manual `DELETE FROM _emdash_404_log`.

The fix is one helper read + one gate flip. No behavior change for fresh installs (the `hits` column is absent, `uniqueIndexExists` is false, dedup runs as before).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`pnpm --silent lint:json | jq '.diagnostics | length'` returns 0)
- [x] `pnpm test` passes (or targeted tests for my change) — full migration suite (35/35 incl. 4 new unit cases) green
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — N/A, no admin UI changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
 ✓ tests/unit/database/migrations/035_bounded_404_log.test.ts (4 tests)
   ✓ dedups duplicate paths and creates the unique index on a fresh run
   ✓ dedups on retry when a previous attempt added `hits` but never deduped
   ✓ dedups on retry when only `hits` was added before the previous attempt crashed
   ✓ is idempotent on full success (running twice in a row)

 ✓ tests/database/migrations.test.ts (14 tests)
 ✓ tests/integration/database/migrations.test.ts (15 tests)

 Test Files  4 passed (4)
      Tests  35 passed (35)
```

### Adversarial review notes (out of scope, flagged for future work)

- The original `_emdash_404_log` schema in `029_redirects.ts` does not enforce `created_at NOT NULL`. The application's `log404` always sets it and the column has a server-side default, so NULLs are unlikely; but the dedup `ROW_NUMBER() OVER (... ORDER BY created_at DESC)` would have undefined NULL ordering. Left as-is (matches existing migration behavior); could be tightened with `COALESCE(created_at, '')` in a follow-up.
- Concurrent writes to `_emdash_404_log` between dedup and unique-index creation could re-introduce duplicates. In the deploy entrypoint flow this runs before traffic is admitted, so the window is closed in practice.
- Tests run against in-memory SQLite only. The `indexExists` helper has a Postgres branch (`pg_indexes`) that isn't covered by repo's test infrastructure. Mirrors the rest of the migration suite.