### PR TITLE
ci: comment query-count snapshot diff on PRs

### DIFF
--- a/.github/workflows/query-counts-label.yml
+++ b/.github/workflows/query-counts-label.yml
@@ -42,3 +42,145 @@ jobs:
               issue_number: context.payload.pull_request.number,
               labels: [label],
             });
+
+      - name: Comment query-count diff
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.sha;
+            const headRef = pr.head.sha;
+
+            // Fetch a JSON file at a given ref. Returns {} if the file
+            // doesn't exist on that ref (e.g. snapshot added in this PR).
+            async function loadSnapshot(ref, path) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  ref,
+                  path,
+                });
+                if (Array.isArray(data) || data.type !== 'file' || !data.content) {
+                  return {};
+                }
+                const raw = Buffer.from(data.content, 'base64').toString('utf8');
+                return JSON.parse(raw);
+              } catch (err) {
+                if (err.status === 404) return {};
+                throw err;
+              }
+            }
+
+            function diffRows(before, after) {
+              const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+              const rows = [];
+              for (const key of [...keys].sort()) {
+                const b = before[key];
+                const a = after[key];
+                if (b === a) continue;
+                const bCell = b === undefined ? '—' : String(b);
+                const aCell = a === undefined ? '—' : String(a);
+                const delta = (a ?? 0) - (b ?? 0);
+                const deltaCell =
+                  a === undefined
+                    ? 'removed'
+                    : b === undefined
+                      ? 'added'
+                      : delta > 0
+                        ? `+${delta}`
+                        : String(delta);
+                rows.push(`| \`${key}\` | ${bCell} | ${aCell} | ${deltaCell} |`);
+              }
+              return rows;
+            }
+
+            const dialects = [
+              ['SQLite', 'scripts/query-counts.snapshot.sqlite.json'],
+              ['D1', 'scripts/query-counts.snapshot.d1.json'],
+            ];
+
+            const sections = [];
+            let totalDelta = 0;
+            let totalChanged = 0;
+
+            for (const [name, path] of dialects) {
+              const [before, after] = await Promise.all([
+                loadSnapshot(baseRef, path),
+                loadSnapshot(headRef, path),
+              ]);
+              const rows = diffRows(before, after);
+              if (rows.length === 0) continue;
+              totalChanged += rows.length;
+              for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+                const b = before[key] ?? 0;
+                const a = after[key] ?? 0;
+                if (a !== b) totalDelta += a - b;
+              }
+              sections.push(
+                [
+                  `### ${name}`,
+                  '',
+                  '| Route | Before | After | Δ |',
+                  '| --- | ---: | ---: | --- |',
+                  ...rows,
+                ].join('\n'),
+              );
+            }
+
+            const marker = '<!-- query-count-diff -->';
+
+            // Find an existing bot comment so we can upsert in place.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const prior = comments.find(
+              (c) => typeof c.body === 'string' && c.body.includes(marker),
+            );
+
+            if (sections.length === 0) {
+              // Snapshot files unchanged on this run; remove any stale comment
+              // (e.g. earlier push had a delta that has since been reverted).
+              if (prior) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: prior.id,
+                });
+              }
+              return;
+            }
+
+            const sign = totalDelta > 0 ? '+' : '';
+            const summary = `**${totalChanged}** route${totalChanged === 1 ? '' : 's'} changed, total Δ ${sign}${totalDelta} quer${Math.abs(totalDelta) === 1 ? 'y' : 'ies'}.`;
+
+            const body = [
+              marker,
+              '## Query-count snapshot changes',
+              '',
+              summary,
+              '',
+              ...sections,
+              '',
+              '<sub>Comparing snapshot files between base and head. Updated automatically on each push.</sub>',
+            ].join('\n');
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## What does this PR do?

When a PR's diff touches `scripts/query-counts.snapshot.{sqlite,d1}.json`, post a comment showing the per-route delta across both dialects. The existing `query-count changed` label step still runs as before; the comment is additive context so reviewers can see at a glance which routes regressed or improved without manually diffing the JSON.

The comment uses a hidden HTML marker (`<!-- query-count-diff -->`) and is upserted on each push. If a later push reverts all snapshot changes back to baseline, the prior comment is deleted so stale warnings don't sit on clean PRs.

Reads snapshots via the contents API at `pr.base.sha` and `pr.head.sha` -- no checkout needed. Same `pull_request_target` trigger as the label step, so it works on fork PRs (no untrusted code is executed; only API reads).

Example rendered output for a PR that adds two redirect-middleware queries to public routes:

> ## Query-count snapshot changes
>
> **6** routes changed, total Δ +12 queries.
>
> ### SQLite
>
> | Route | Before | After | Δ |
> | --- | ---: | ---: | --- |
> | \`GET / (cold)\` | 13 | 15 | +2 |
> | \`GET / (warm)\` | 13 | 15 | +2 |
> | ... | | | |

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes (no source changes)
- [x] \`pnpm lint\` passes (no source changes)
- [x] \`pnpm test\` passes (no source changes)
- [x] \`pnpm format\` has been run (workflow YAML untouched by formatter)
- [ ] I have added/updated tests for my changes (workflow logic; tested by running on this PR itself once merged)
- [x] User-visible strings in the admin UI are wrapped for translation (N/A)
- [x] I have added a changeset (N/A -- CI-only, no published package change)
- [x] New features link to an approved Discussion (N/A -- chore)

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

The workflow itself can't be exercised until it's on \`main\` (since \`pull_request_target\` runs from the base branch). The first PR that touches a snapshot after merge will be the live test. The script logic was reviewed for:

- 404 handling when a snapshot file is added/removed in the PR
- Empty-diff path (deletes prior comment instead of leaving stale)
- Fork PR safety (only API reads, no checkout, no script execution from head)
- Comment upsert via hidden marker