### PR TITLE
feat(core): make preview URL pattern locale-aware

### DIFF
--- a/.changeset/preview-url-locale-aware.md
+++ b/.changeset/preview-url-locale-aware.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Make the preview URL pattern locale-aware. `getPreviewUrl()` now accepts a `{locale}` placeholder and a `locale` option (empty string collapses adjacent slashes so default-locale entries on `prefixDefaultLocale: false` sites stay unprefixed). The `POST /_emdash/api/content/{collection}/{id}/preview-url` route resolves the locale automatically from the entry and the site's i18n config, and reads a project-wide default pattern from the new `EMDASH_PREVIEW_PATH_PATTERN` env var so the admin's "View on site" link can match locale-prefixed routes (e.g. `/{locale}/{id}`).

--- a/docs/src/content/docs/guides/preview.mdx
+++ b/docs/src/content/docs/guides/preview.mdx
@@ -118,6 +118,38 @@ const blogUrl = await getPreviewUrl({
 // Returns: /blog/my-draft-post?_preview=eyJjaWQ...
 ```
 
+### Locale-aware paths
+
+`pathPattern` also supports a `{locale}` placeholder. Pass an empty `locale`
+when the entry is in the default locale and `prefixDefaultLocale` is `false`;
+adjacent slashes left by the empty value are collapsed automatically.
+
+```ts
+await getPreviewUrl({
+	collection: "posts",
+	id: "hello",
+	secret,
+	pathPattern: "/{locale}/{id}",
+	locale: "pt-br",
+});
+// Returns: /pt-br/hello?_preview=...
+
+await getPreviewUrl({
+	collection: "posts",
+	id: "hello",
+	secret,
+	pathPattern: "/{locale}/{id}",
+	locale: "", // default locale, no prefix
+});
+// Returns: /hello?_preview=...
+```
+
+The admin's "View on site" link goes through `POST /_emdash/api/content/{collection}/{id}/preview-url`,
+which reads the entry's locale, looks up the site's i18n config and supplies
+the `locale` automatically. To change the default pattern used by that
+endpoint, set `EMDASH_PREVIEW_PATH_PATTERN` (e.g. `/{locale}/{id}`) — request
+bodies still win when they include their own `pathPattern`.
+
 ## Token Expiration
 
 Control how long preview links remain valid:
@@ -316,7 +348,8 @@ Generate a preview URL with a signed token.
 - `secret` — Signing secret (string)
 - `expiresIn` — Token validity duration (default: `"1h"`)
 - `baseUrl` — Optional base URL for absolute links
-- `pathPattern` — URL pattern with `{collection}` and `{id}` placeholders (default: `"/{collection}/{id}"`)
+- `pathPattern` — URL pattern with `{collection}`, `{id}` and `{locale}` placeholders (default: `"/{collection}/{id}"`)
+- `locale` — Value substituted for `{locale}`. Empty string omits the locale segment (slashes are collapsed).
 
 **Returns:** `Promise<string>`
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
@@ -6,7 +6,7 @@
  * Request body:
  * {
  *   expiresIn?: string | number;  // Default: "1h"
- *   pathPattern?: string;         // Default: "/{collection}/{id}"
+ *   pathPattern?: string;         // Default: "/{collection}/{id}" (or EMDASH_PREVIEW_PATH_PATTERN)
  * }
  *
  * Response:
@@ -24,6 +24,8 @@ import { parseOptionalBody, isParseError } from "#api/parse.js";
 import { contentPreviewUrlBody } from "#api/schemas.js";
 import { resolveSecretsCached } from "#config/secrets.js";
 import { getPreviewUrl } from "#preview/index.js";
+
+import { getI18nConfig } from "../../../../../../i18n/config.js";
 
 export const prerender = false;
 
@@ -46,10 +48,13 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 	// longer be silently disabled by a missing env var.
 	const { previewSecret } = await resolveSecretsCached(emdash.db);
 
-	// Verify the content exists (optional, but good for UX)
+	// Verify the content exists. The fetched item also yields the entry's
+	// locale, used below to resolve the `{locale}` placeholder.
+	let entryLocale: string | null = null;
 	if (emdash?.handleContentGet) {
 		const result = await emdash.handleContentGet(collection, id);
 		if (!result.success) return unwrapResult(result);
+		entryLocale = result.data?.item?.locale ?? null;
 	}
 
 	// Parse request body
@@ -57,7 +62,24 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 	if (isParseError(body)) return body;
 
 	const expiresIn = body.expiresIn || "1h";
-	const pathPattern = body.pathPattern;
+	// Allow a project-wide default `pathPattern` so the admin's "View on site"
+	// link can match the site's actual route shape without each call having
+	// to override the default `/{collection}/{id}`.
+	const defaultPathPattern =
+		import.meta.env.EMDASH_PREVIEW_PATH_PATTERN || "/{collection}/{id}";
+	const pathPattern = body.pathPattern || defaultPathPattern;
+
+	// Resolve the locale segment substituted for `{locale}`: empty when the
+	// entry is in the default locale and `prefixDefaultLocale` is `false`,
+	// the entry's own locale otherwise.
+	const i18n = getI18nConfig();
+	let localeSegment = "";
+	if (entryLocale && i18n) {
+		const isDefault = entryLocale === i18n.defaultLocale;
+		localeSegment = isDefault && !i18n.prefixDefaultLocale ? "" : entryLocale;
+	} else if (entryLocale) {
+		localeSegment = entryLocale;
+	}
 
 	// Calculate expiry timestamp
 	const expiresInSeconds = typeof expiresIn === "number" ? expiresIn : parseExpiresIn(expiresIn);
@@ -70,6 +92,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 			secret: previewSecret,
 			expiresIn,
 			pathPattern,
+			locale: localeSegment,
 		});
 
 		return apiSuccess({ url, expiresAt });

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/preview-url.ts
@@ -65,8 +65,7 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
 	// Allow a project-wide default `pathPattern` so the admin's "View on site"
 	// link can match the site's actual route shape without each call having
 	// to override the default `/{collection}/{id}`.
-	const defaultPathPattern =
-		import.meta.env.EMDASH_PREVIEW_PATH_PATTERN || "/{collection}/{id}";
+	const defaultPathPattern = import.meta.env.EMDASH_PREVIEW_PATH_PATTERN || "/{collection}/{id}";
 	const pathPattern = body.pathPattern || defaultPathPattern;
 
 	// Resolve the locale segment substituted for `{locale}`: empty when the

--- a/packages/core/src/preview/urls.ts
+++ b/packages/core/src/preview/urls.ts
@@ -20,8 +20,18 @@ export interface GetPreviewUrlOptions {
 	expiresIn?: string | number;
 	/** Base URL of the site. If not provided, returns a relative URL. */
 	baseUrl?: string;
-	/** Custom path pattern. Use {collection} and {id} as placeholders. Default: "/{collection}/{id}" */
+	/**
+	 * Custom path pattern. Supports `{collection}`, `{id}` and `{locale}`
+	 * placeholders. Default: `"/{collection}/{id}"`.
+	 */
 	pathPattern?: string;
+	/**
+	 * Locale segment substituted for the `{locale}` placeholder in `pathPattern`.
+	 * Pass an empty string to omit the locale prefix (e.g. for the default locale
+	 * when `prefixDefaultLocale` is `false`); adjacent slashes left by an empty
+	 * value are collapsed and any trailing slash is trimmed.
+	 */
+	locale?: string;
 }
 
 /**
@@ -65,6 +75,7 @@ export async function getPreviewUrl(options: GetPreviewUrlOptions): Promise<stri
 		expiresIn = "1h",
 		baseUrl,
 		pathPattern = "/{collection}/{id}",
+		locale = "",
 	} = options;
 
 	// Generate the signed token
@@ -74,8 +85,15 @@ export async function getPreviewUrl(options: GetPreviewUrlOptions): Promise<stri
 		secret,
 	});
 
-	// Build the path
-	const path = pathPattern.replace("{collection}", collection).replace("{id}", id);
+	// Build the path. `{locale}` may resolve to an empty string (default locale
+	// without a prefix); collapse the resulting double slashes and trim a
+	// trailing slash so the URL stays clean.
+	let path = pathPattern
+		.replace("{collection}", collection)
+		.replace("{id}", id)
+		.replace("{locale}", locale);
+	path = path.replace(/\/{2,}/g, "/");
+	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
 
 	// Add token as query parameter
 	const url = new URL(path, baseUrl || "http://placeholder");

--- a/packages/core/src/preview/urls.ts
+++ b/packages/core/src/preview/urls.ts
@@ -6,6 +6,8 @@
 
 import { generatePreviewToken } from "./tokens.js";
 
+const REPEATED_SLASHES = /\/{2,}/g;
+
 /**
  * Options for generating a preview URL
  */
@@ -92,7 +94,7 @@ export async function getPreviewUrl(options: GetPreviewUrlOptions): Promise<stri
 		.replace("{collection}", collection)
 		.replace("{id}", id)
 		.replace("{locale}", locale);
-	path = path.replace(/\/{2,}/g, "/");
+	path = path.replace(REPEATED_SLASHES, "/");
 	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
 
 	// Add token as query parameter

--- a/packages/core/tests/unit/preview/urls.test.ts
+++ b/packages/core/tests/unit/preview/urls.test.ts
@@ -76,6 +76,31 @@ describe("preview URLs", () => {
 			expect(token).not.toMatch(BASE64URL_INVALID_CHARS_REGEX);
 		});
 
+		it("substitutes {locale} placeholder", async () => {
+			const url = await getPreviewUrl({
+				collection: "posts",
+				id: "hello-world",
+				secret: testSecret,
+				pathPattern: "/{locale}/{id}",
+				locale: "pt-br",
+			});
+
+			expect(url).toMatch(/^\/pt-br\/hello-world\?_preview=/);
+		});
+
+		it("collapses empty {locale} segment", async () => {
+			const url = await getPreviewUrl({
+				collection: "posts",
+				id: "hello-world",
+				secret: testSecret,
+				pathPattern: "/{locale}/{id}",
+				locale: "",
+			});
+
+			// Empty locale should not leave a leading double slash.
+			expect(url).toMatch(/^\/hello-world\?_preview=/);
+		});
+
 		it("respects expiresIn option", async () => {
 			const shortUrl = await getPreviewUrl({
 				collection: "posts",


### PR DESCRIPTION
## Summary

`getPreviewUrl()` and the admin's preview-url endpoint hard-code a `/{collection}/{id}` shape. For sites using Astro i18n where post URLs live under `/<locale>/<slug>` (or any non-default route shape), the admin's "View on site" link points at a path that doesn't exist.

This PR makes the preview URL pattern locale-aware and project-configurable, while staying backward compatible.

## Changes

- **`getPreviewUrl()`** ([packages/core/src/preview/urls.ts](https://github.com/emdash-cms/emdash/blob/main/packages/core/src/preview/urls.ts))
  - New `{locale}` placeholder in `pathPattern`.
  - New `locale` option. An empty value collapses adjacent slashes so default-locale entries on `prefixDefaultLocale: false` sites stay at their unprefixed URL (e.g. `pathPattern: "/{locale}/{id}"` + `locale: ""` → `/hello`, not `//hello`).

- **Preview URL route** (`POST /_emdash/api/content/{collection}/{id}/preview-url`)
  - Reads `entry.locale` from the existing `handleContentGet` call and looks up the site's i18n config (`defaultLocale`, `prefixDefaultLocale`) to resolve the segment automatically — admins don't need to pass anything from the client.
  - Reads a project-wide default `pathPattern` from `EMDASH_PREVIEW_PATH_PATTERN` env var, so the admin's "View on site" button can match the site's real route shape without every caller having to override.

- **Tests**: two new cases covering `{locale}` substitution and empty-locale collapse. All 11 tests in `tests/unit/preview/urls.test.ts` pass locally.

- **Docs**: `docs/src/content/docs/guides/preview.mdx` updated with locale-aware examples and the env var.

## Backward compatibility

- Patterns without `{locale}` work unchanged.
- Calls to `getPreviewUrl()` without the `locale` option work unchanged.
- The endpoint default remains `/{collection}/{id}` when `EMDASH_PREVIEW_PATH_PATTERN` is unset.

## Test plan

- [x] `pnpm exec vitest run tests/unit/preview/urls.test.ts` (11/11 passing)
- [ ] Manual: admin "View on site" on a site with `astro.i18n.prefixDefaultLocale: false` and `EMDASH_PREVIEW_PATH_PATTERN=/{locale}/{id}` produces `/<slug>` for default locale and `/<locale>/<slug>` otherwise.

## Context

Discussed in a downstream site that uses `i18n: { defaultLocale: "en", locales: ["en", "pt-br", "es"], routing: { prefixDefaultLocale: false } }`. Without this change, the admin's preview link landed on a non-existent `/posts/<slug>` path; with `EMDASH_PREVIEW_PATH_PATTERN=/{locale}/{id}` the link goes to the correct locale-prefixed URL.