### PR TITLE
fix(core): inject favicon link with correct MIME type from site settings

### DIFF
--- a/.changeset/fix-favicon-injection.md
+++ b/.changeset/fix-favicon-injection.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Fixes site favicon injection so user-configured favicons render on the public site, including SVG favicons in Chromium browsers (#831). `EmDashHead` now emits a `<link rel="icon">` tag with the correct `type` attribute (e.g. `image/svg+xml`) sourced from the stored media's MIME type. Templates that already render their own favicon link continue to work; browsers tolerate the duplicate, and a follow-up cleanup can drop the per-template line.
+
+`MediaReference` now carries `url`, `contentType`, `width`, and `height` when resolved via `resolveMediaReference`, so callers can emit correct head tags without a second round-trip to the media table.

--- a/.changeset/fix-favicon-injection.md
+++ b/.changeset/fix-favicon-injection.md
@@ -2,6 +2,6 @@
 "emdash": patch
 ---
 
-Fixes site favicon injection so user-configured favicons render on the public site, including SVG favicons in Chromium browsers (#831). `EmDashHead` now emits a `<link rel="icon">` tag with the correct `type` attribute (e.g. `image/svg+xml`) sourced from the stored media's MIME type. Templates that already render their own favicon link continue to work; browsers tolerate the duplicate, and a follow-up cleanup can drop the per-template line.
+Fixes site favicon injection so user-configured favicons render on the public site, including SVG favicons in Chromium browsers (#831). `EmDashHead` now emits a `<link rel="icon">` tag with the correct `type` attribute (e.g. `image/svg+xml`) sourced from the stored media's MIME type. The bundled templates and demos have been updated to drop their per-template favicon link in favour of the centralized injection; existing user sites that still emit their own `<link rel="icon">` continue to work because browsers tolerate the duplicate.
 
 `MediaReference` now carries `url`, `contentType`, `width`, and `height` when resolved via `resolveMediaReference`, so callers can emit correct head tags without a second round-trip to the media table.

--- a/demos/cloudflare/src/layouts/Base.astro
+++ b/demos/cloudflare/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/demos/cloudflare/src/utils/site-identity.ts
+++ b/demos/cloudflare/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/demos/playground/src/layouts/Base.astro
+++ b/demos/playground/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/demos/playground/src/utils/site-identity.ts
+++ b/demos/playground/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/demos/postgres/src/layouts/Base.astro
+++ b/demos/postgres/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/demos/postgres/src/utils/site-identity.ts
+++ b/demos/postgres/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/demos/preview/src/layouts/Base.astro
+++ b/demos/preview/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/demos/preview/src/utils/site-identity.ts
+++ b/demos/preview/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/demos/simple/src/layouts/Base.astro
+++ b/demos/simple/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/demos/simple/src/utils/site-identity.ts
+++ b/demos/simple/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/fixtures/perf-site/src/layouts/Base.astro
+++ b/fixtures/perf-site/src/layouts/Base.astro
@@ -39,7 +39,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -76,7 +76,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/fixtures/perf-site/src/utils/site-identity.ts
+++ b/fixtures/perf-site/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/infra/blog-demo/src/layouts/Base.astro
+++ b/infra/blog-demo/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/infra/blog-demo/src/utils/site-identity.ts
+++ b/infra/blog-demo/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/infra/cache-demo/src/layouts/Base.astro
+++ b/infra/cache-demo/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/infra/cache-demo/src/utils/site-identity.ts
+++ b/infra/cache-demo/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/packages/core/src/components/EmDashHead.astro
+++ b/packages/core/src/components/EmDashHead.astro
@@ -20,8 +20,9 @@ import {
 	generateBaseSeoContributions,
 	generateSiteSeoContributions,
 } from "../page/seo-contributions.js";
+import { renderSiteIdentity } from "../page/site-identity.js";
 import { getPageRuntime } from "../page/index.js";
-import { getSiteSetting } from "../settings/index.js";
+import { getSiteSettings } from "../settings/index.js";
 
 interface Props {
 	page: PublicPageContext;
@@ -34,29 +35,32 @@ const runtime = getPageRuntime(Astro.locals as Record<string, unknown>);
 const baseContributions: PageMetadataContribution[] = generateBaseSeoContributions(page);
 
 let metadataHtml = "";
+let siteIdentityHtml = "";
 let fragmentsHtml = "";
 
 if (runtime) {
-	// Run independent async loads in parallel: site SEO settings (for
-	// search engine verification meta tags) and plugin page-metadata
-	// contributions. Plugin contributions come BEFORE site/base in the
-	// array, so resolvePageMetadata's first-wins dedup lets plugins
-	// override defaults.
+	// Run independent async loads in parallel: site settings (SEO meta
+	// tags + favicon) and plugin page-metadata contributions. Plugin
+	// contributions come BEFORE site/base in the contribution array,
+	// so resolvePageMetadata's first-wins dedup lets plugins override
+	// defaults.
 	//
-	// `getSiteSetting("seo")` is request-cached and — crucially — reads
-	// from `getSiteSettings()`'s cached batch when a parent template has
-	// already called it. So this is either a single-key query or free,
-	// not a second round-trip.
-	const [seoSettings, pluginContributions, fragments] = await Promise.all([
-		getSiteSetting("seo"),
+	// `getSiteSettings()` is request-cached and worker-cached, so when
+	// a parent template has already called it (the standard pattern in
+	// `Base.astro`), this is free. Otherwise it's a single batched
+	// query that supersedes any per-key fetch this component would
+	// otherwise have done.
+	const [siteSettings, pluginContributions, fragments] = await Promise.all([
+		getSiteSettings(),
 		runtime.collectPageMetadata(page),
 		runtime.collectPageFragments(page),
 	]);
 
-	const siteContributions = generateSiteSeoContributions(seoSettings);
+	const siteContributions = generateSiteSeoContributions(siteSettings.seo);
 	const allContributions = [...pluginContributions, ...siteContributions, ...baseContributions];
 	const resolved = resolvePageMetadata(allContributions);
 	metadataHtml = renderPageMetadata(resolved);
+	siteIdentityHtml = renderSiteIdentity({ favicon: siteSettings.favicon });
 	fragmentsHtml = renderFragments(fragments, "head");
 } else {
 	// No runtime (EmDash not initialized) — still render base SEO
@@ -66,4 +70,5 @@ if (runtime) {
 ---
 
 <Fragment set:html={metadataHtml} />
+<Fragment set:html={siteIdentityHtml} />
 <Fragment set:html={fragmentsHtml} />

--- a/packages/core/src/page/site-identity.ts
+++ b/packages/core/src/page/site-identity.ts
@@ -1,0 +1,52 @@
+/**
+ * Site identity head injection.
+ *
+ * Emits first-party `<head>` tags sourced from the user-configured Site
+ * Identity (favicon, etc.). These are rendered alongside, but separate
+ * from, the plugin contribution pipeline (`page/metadata.ts`) because:
+ *
+ * - Site identity is first-party, not plugin-supplied. The contribution
+ *   pipeline's `isSafeHref` allowlist rejects same-origin paths like
+ *   `/_emdash/api/media/file/...` (which is correct for sandboxed plugin
+ *   contributions, but blocks our own favicon URLs).
+ * - The data shape is fixed and small (favicon today, apple-touch-icon
+ *   and theme-color later). Routing it through a generic deduper buys
+ *   nothing.
+ *
+ * Templates that already emit their own `<link rel="icon">` continue to
+ * work; browsers tolerate the duplicate. A follow-up cleanup can remove
+ * the per-template line once this has shipped.
+ */
+
+import type { MediaReference } from "../settings/types.js";
+import { escapeHtmlAttr } from "./metadata.js";
+
+/**
+ * Subset of site settings consumed by `renderSiteIdentity`. Kept narrow
+ * so callers don't have to fetch fields they don't use.
+ */
+export interface SiteIdentityInput {
+	favicon?: MediaReference;
+}
+
+/**
+ * Build the `<head>` HTML for site identity tags. Returns an empty string
+ * when no identity fields are configured.
+ */
+export function renderSiteIdentity(input: SiteIdentityInput | undefined): string {
+	if (!input) return "";
+
+	const parts: string[] = [];
+
+	const favicon = input.favicon;
+	if (favicon?.url) {
+		let tag = `<link rel="icon" href="${escapeHtmlAttr(favicon.url)}"`;
+		if (favicon.contentType) {
+			tag += ` type="${escapeHtmlAttr(favicon.contentType)}"`;
+		}
+		tag += ">";
+		parts.push(tag);
+	}
+
+	return parts.join("\n");
+}

--- a/packages/core/src/page/site-identity.ts
+++ b/packages/core/src/page/site-identity.ts
@@ -2,20 +2,26 @@
  * Site identity head injection.
  *
  * Emits first-party `<head>` tags sourced from the user-configured Site
- * Identity (favicon, etc.). These are rendered alongside, but separate
- * from, the plugin contribution pipeline (`page/metadata.ts`) because:
+ * Identity. These are rendered alongside, but separate from, the plugin
+ * contribution pipeline (`page/metadata.ts`) because:
  *
  * - Site identity is first-party, not plugin-supplied. The contribution
  *   pipeline's `isSafeHref` allowlist rejects same-origin paths like
  *   `/_emdash/api/media/file/...` (which is correct for sandboxed plugin
  *   contributions, but blocks our own favicon URLs).
- * - The data shape is fixed and small (favicon today, apple-touch-icon
- *   and theme-color later). Routing it through a generic deduper buys
- *   nothing.
+ * - The data shape is fixed and small. Routing it through a generic
+ *   deduper buys nothing.
  *
- * Templates that already emit their own `<link rel="icon">` continue to
- * work; browsers tolerate the duplicate. A follow-up cleanup can remove
- * the per-template line once this has shipped.
+ * Currently emits only `<link rel="icon">`. Other site-identity tags
+ * (`apple-touch-icon`, `theme-color`, `application-name`) need their own
+ * configurable fields in `SiteSettings` before they ship; emitting them
+ * automatically from the favicon would produce broken icons on iOS for
+ * SVG favicons or blurry home-screen icons when the favicon is a small
+ * PNG. Tracked separately.
+ *
+ * Templates that previously emitted their own `<link rel="icon">` are
+ * getting their lines dropped in the same change that introduced this
+ * helper.
  */
 
 import type { MediaReference } from "../settings/types.js";

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -73,13 +73,18 @@ function isMediaReference(value: unknown): value is MediaReference {
 }
 
 /**
- * Resolve a media reference to include the full URL
+ * Resolve a media reference to include the full URL plus content metadata.
+ *
+ * Pulls `mimeType` and intrinsic dimensions from the media row so callers
+ * can emit correct head tags (e.g. `<link rel="icon" type="image/svg+xml">`,
+ * which Chromium requires when the URL has no `.svg` extension) without
+ * a second round-trip to the media table.
  */
 async function resolveMediaReference(
 	mediaRef: MediaReference | undefined,
 	db: Kysely<Database>,
 	_storage: Storage | null,
-): Promise<(MediaReference & { url?: string }) | undefined> {
+): Promise<MediaReference | undefined> {
 	if (!mediaRef?.mediaId) {
 		return mediaRef;
 	}
@@ -93,6 +98,9 @@ async function resolveMediaReference(
 			return {
 				...mediaRef,
 				url: `/_emdash/api/media/file/${media.storageKey}`,
+				contentType: media.mimeType,
+				...(media.width !== null ? { width: media.width } : {}),
+				...(media.height !== null ? { height: media.height } : {}),
 			};
 		}
 	} catch {

--- a/packages/core/src/settings/types.ts
+++ b/packages/core/src/settings/types.ts
@@ -4,10 +4,32 @@
  * Global configuration for the site (title, logo, social links, etc.)
  */
 
-/** Media reference for logo/favicon */
+/**
+ * Media reference for logo/favicon.
+ *
+ * Stored shape is just `{ mediaId, alt? }`. The remaining fields are
+ * populated by `resolveMediaReference` on read so templates can emit
+ * correct head tags without a second round-trip to the media table.
+ *
+ * The Zod schemas at the REST/MCP boundary (`mediaReference`) define
+ * only `mediaId` and `alt` and rely on default strip-mode parsing to
+ * discard the resolved fields if a client posts them back. If you
+ * ever switch those schemas to `passthrough`, you must also strip the
+ * resolved fields explicitly in `setSiteSettings`, or stored options
+ * will accumulate stale `url` / `contentType` / `width` / `height`
+ * snapshots.
+ */
 export interface MediaReference {
 	mediaId: string;
 	alt?: string;
+	/** Resolved URL. Populated by `resolveMediaReference`; absent on raw stored values. */
+	url?: string;
+	/** Stored MIME type (e.g. `image/svg+xml`). Populated alongside `url`. */
+	contentType?: string;
+	/** Pixel width if known. Populated alongside `url`. */
+	width?: number;
+	/** Pixel height if known. Populated alongside `url`. */
+	height?: number;
 }
 
 /** Site-level SEO settings */

--- a/packages/core/tests/unit/page/site-identity.test.ts
+++ b/packages/core/tests/unit/page/site-identity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * renderSiteIdentity() Tests
+ *
+ * Bug context (#831): user-configured site favicons were not emitted into
+ * `<head>` by core. The 17 template `Base.astro` files emitted their own
+ * `<link rel="icon">` but only when the template had been updated post
+ * #448, and even then dropped the `type` attribute, so SVG favicons did
+ * not render in Chromium browsers (which require `type="image/svg+xml"`
+ * when the URL has no `.svg` extension).
+ *
+ * Fix: a first-party `renderSiteIdentity()` helper that emits the favicon
+ * tag with the correct MIME type. Lives outside the plugin contribution
+ * pipeline because that pipeline's `isSafeHref` check rejects same-origin
+ * paths like `/_emdash/api/media/file/...`.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { renderSiteIdentity } from "../../../src/page/site-identity.js";
+
+describe("renderSiteIdentity", () => {
+	it("returns empty string when no input provided", () => {
+		expect(renderSiteIdentity(undefined)).toBe("");
+	});
+
+	it("returns empty string when input has no favicon", () => {
+		expect(renderSiteIdentity({})).toBe("");
+	});
+
+	it("returns empty string when favicon has no resolved URL", () => {
+		// Unresolved MediaReference (no url field) should be a no-op.
+		expect(
+			renderSiteIdentity({
+				favicon: { mediaId: "med_123" },
+			}),
+		).toBe("");
+	});
+
+	it("emits link tag for favicon with URL", () => {
+		const html = renderSiteIdentity({
+			favicon: {
+				mediaId: "med_123",
+				url: "/_emdash/api/media/file/abc.png",
+				contentType: "image/png",
+			},
+		});
+		expect(html).toBe('<link rel="icon" href="/_emdash/api/media/file/abc.png" type="image/png">');
+	});
+
+	it("includes type attribute for SVG favicons (the #831 bug)", () => {
+		// SVG URLs from EmDash are extension-less (`/_emdash/api/media/file/<ulid>`),
+		// so without `type="image/svg+xml"` Chromium will not render them.
+		const html = renderSiteIdentity({
+			favicon: {
+				mediaId: "med_svg",
+				url: "/_emdash/api/media/file/01KNTC51CKNJG1RFP3YV93BR17",
+				contentType: "image/svg+xml",
+			},
+		});
+		expect(html).toContain('type="image/svg+xml"');
+	});
+
+	it("omits type attribute when contentType is not set", () => {
+		// Tolerate older stored references that predate contentType resolution.
+		const html = renderSiteIdentity({
+			favicon: {
+				mediaId: "med_legacy",
+				url: "/_emdash/api/media/file/legacy.ico",
+			},
+		});
+		expect(html).toBe('<link rel="icon" href="/_emdash/api/media/file/legacy.ico">');
+		expect(html).not.toContain("type=");
+	});
+
+	it("escapes hostile content in href and type", () => {
+		// MediaReference URLs come from a controlled construction in
+		// resolveMediaReference, but the renderer should still escape attribute
+		// contents defensively.
+		const html = renderSiteIdentity({
+			favicon: {
+				mediaId: "med_x",
+				url: '/path"><script>alert(1)</script>',
+				contentType: 'image/png"><x',
+			},
+		});
+		expect(html).not.toContain("<script>");
+		expect(html).toContain("&quot;");
+		expect(html).toContain("&lt;");
+	});
+});

--- a/packages/core/tests/unit/templates/blog-site-identity.test.ts
+++ b/packages/core/tests/unit/templates/blog-site-identity.test.ts
@@ -5,6 +5,9 @@ import { resolveBlogSiteIdentity as resolveBlogSiteIdentityNode } from "../../..
 
 describe("blog template site identity", () => {
 	it("uses CMS site title and tagline when provided", () => {
+		// Favicon is intentionally absent from the helper return: core's
+		// EmDashHead now emits the favicon link via renderSiteIdentity()
+		// (#831), so the template no longer needs to surface it.
 		const settings = {
 			title: "Example Site",
 			tagline: "Writing about shipping software",
@@ -16,13 +19,11 @@ describe("blog template site identity", () => {
 			siteTitle: "Example Site",
 			siteTagline: "Writing about shipping software",
 			siteLogo: { mediaId: "logo-1", alt: "My Logo", url: "/_emdash/api/media/file/logo.webp" },
-			siteFavicon: "/_emdash/api/media/file/favicon.svg",
 		});
 		expect(resolveBlogSiteIdentityCloudflare(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "Writing about shipping software",
 			siteLogo: { mediaId: "logo-1", alt: "My Logo", url: "/_emdash/api/media/file/logo.webp" },
-			siteFavicon: "/_emdash/api/media/file/favicon.svg",
 		});
 	});
 
@@ -30,13 +31,11 @@ describe("blog template site identity", () => {
 		expect(resolveBlogSiteIdentityNode({})).toEqual({
 			siteTitle: "My Blog",
 			siteTagline: "Thoughts, stories, and ideas.",
-			siteFavicon: null,
 			siteLogo: null,
 		});
 		expect(resolveBlogSiteIdentityCloudflare({})).toEqual({
 			siteTitle: "My Blog",
 			siteTagline: "Thoughts, stories, and ideas.",
-			siteFavicon: null,
 			siteLogo: null,
 		});
 	});
@@ -45,37 +44,32 @@ describe("blog template site identity", () => {
 		const settings = {
 			title: "Example Site",
 			tagline: "",
-			siteFavicon: "",
 			siteLogo: "",
 		};
 
 		expect(resolveBlogSiteIdentityNode(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "",
-			siteFavicon: null,
 			siteLogo: null,
 		});
 		expect(resolveBlogSiteIdentityCloudflare(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "",
-			siteFavicon: null,
 			siteLogo: null,
 		});
 	});
 
-	it("returns null for logo/favicon without resolved URL", () => {
+	it("returns null for logo without resolved URL", () => {
 		const settings = {
 			title: "Example Site",
 			tagline: "",
 			logo: { mediaId: "logo-1" },
-			favicon: { mediaId: "fav-1" },
 		};
 
 		expect(resolveBlogSiteIdentityNode(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "",
 			siteLogo: null,
-			siteFavicon: null,
 		});
 	});
 });

--- a/packages/core/tests/unit/templates/starter-site-identity.test.ts
+++ b/packages/core/tests/unit/templates/starter-site-identity.test.ts
@@ -5,6 +5,9 @@ import { resolveStarterSiteIdentity as resolveStarterSiteIdentityNode } from "..
 
 describe("starter template site identity", () => {
 	it("uses CMS site title and tagline when provided", () => {
+		// Favicon is intentionally absent from the helper return: core's
+		// EmDashHead now emits the favicon link via renderSiteIdentity()
+		// (#831), so the template no longer needs to surface it.
 		const settings = {
 			title: "Example Site",
 			tagline: "Shipping notes",
@@ -16,13 +19,11 @@ describe("starter template site identity", () => {
 			siteTitle: "Example Site",
 			siteTagline: "Shipping notes",
 			siteLogo: { mediaId: "logo-1", alt: "My Logo", url: "/_emdash/api/media/file/logo.webp" },
-			siteFavicon: "/_emdash/api/media/file/favicon.svg",
 		});
 		expect(resolveStarterSiteIdentityCloudflare(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "Shipping notes",
 			siteLogo: { mediaId: "logo-1", alt: "My Logo", url: "/_emdash/api/media/file/logo.webp" },
-			siteFavicon: "/_emdash/api/media/file/favicon.svg",
 		});
 	});
 
@@ -31,35 +32,30 @@ describe("starter template site identity", () => {
 			siteTitle: "My Site",
 			siteTagline: "Built with EmDash",
 			siteLogo: null,
-			siteFavicon: null,
 		});
 		expect(resolveStarterSiteIdentityCloudflare({})).toEqual({
 			siteTitle: "My Site",
 			siteTagline: "Built with EmDash",
 			siteLogo: null,
-			siteFavicon: null,
 		});
 	});
 
-	it("returns null for logo/favicon without resolved URL", () => {
+	it("returns null for logo without resolved URL", () => {
 		const settings = {
 			title: "Example Site",
 			tagline: "",
 			logo: { mediaId: "logo-1" },
-			favicon: { mediaId: "fav-1" },
 		};
 
 		expect(resolveStarterSiteIdentityNode(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "",
 			siteLogo: null,
-			siteFavicon: null,
 		});
 		expect(resolveStarterSiteIdentityCloudflare(settings)).toEqual({
 			siteTitle: "Example Site",
 			siteTagline: "",
 			siteLogo: null,
-			siteFavicon: null,
 		});
 	});
 });

--- a/templates/blog-cloudflare/src/layouts/Base.astro
+++ b/templates/blog-cloudflare/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/templates/blog-cloudflare/src/utils/site-identity.ts
+++ b/templates/blog-cloudflare/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/templates/blog/src/layouts/Base.astro
+++ b/templates/blog/src/layouts/Base.astro
@@ -40,7 +40,7 @@ const {
 	author,
 	content,
 } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveBlogSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveBlogSiteIdentity(await getSiteSettings());
 // If title already includes site title (from getSeoMeta), use as-is
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 
@@ -79,7 +79,6 @@ const isLoggedIn = !!Astro.locals.user;
 		<Font cssVariable="--font-sans" preload />
 		<Font cssVariable="--font-mono" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<script is:inline>
 			// Apply theme immediately to prevent flash

--- a/templates/blog/src/utils/site-identity.ts
+++ b/templates/blog/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveBlogSiteIdentity(settings?: BlogSiteIdentitySettings) {
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -19,7 +19,6 @@ const siteDescription =
 	settings?.tagline || "Build products people actually want";
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
-const siteFavicon = (settings?.favicon as any)?.url ?? null;
 
 const menu = await getMenu("primary");
 
@@ -43,7 +42,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<Font cssVariable="--font-sans" preload />
 		<script is:inline>

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -19,7 +19,6 @@ const siteDescription =
 	settings?.tagline || "Build products people actually want";
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
-const siteFavicon = (settings?.favicon as any)?.url ?? null;
 
 const menu = await getMenu("primary");
 
@@ -43,7 +42,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<Font cssVariable="--font-sans" preload />
 		<script is:inline>

--- a/templates/portfolio-cloudflare/src/layouts/Base.astro
+++ b/templates/portfolio-cloudflare/src/layouts/Base.astro
@@ -19,7 +19,6 @@ const fullTitle = title ? `${title} — ${siteTitle}` : siteTitle;
 const siteDescription = settings?.tagline || "Design & Development";
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
-const siteFavicon = (settings?.favicon as any)?.url ?? null;
 
 const menu = await getMenu("primary");
 
@@ -43,7 +42,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<Font cssVariable="--font-serif" preload />
 		<link

--- a/templates/portfolio/src/layouts/Base.astro
+++ b/templates/portfolio/src/layouts/Base.astro
@@ -19,7 +19,6 @@ const fullTitle = title ? `${title} — ${siteTitle}` : siteTitle;
 const siteDescription = settings?.tagline || "Design & Development";
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
-const siteFavicon = (settings?.favicon as any)?.url ?? null;
 
 const menu = await getMenu("primary");
 
@@ -43,7 +42,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		<EmDashHead page={pageCtx} />
 		<Font cssVariable="--font-serif" preload />
 		<link

--- a/templates/starter-cloudflare/src/layouts/Base.astro
+++ b/templates/starter-cloudflare/src/layouts/Base.astro
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const { title, pageTitle, description, image, canonical, content } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveStarterSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveStarterSiteIdentity(await getSiteSettings());
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 const pageDescription = description ?? siteTagline;
 
@@ -47,7 +47,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		{pageDescription && <meta name="description" content={pageDescription} />}
 		{canonical && <link rel="canonical" href={canonical} />}
 		<EmDashHead page={pageCtx} />

--- a/templates/starter-cloudflare/src/utils/site-identity.ts
+++ b/templates/starter-cloudflare/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveStarterSiteIdentity(settings?: StarterSiteIdentitySetting
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }

--- a/templates/starter/src/layouts/Base.astro
+++ b/templates/starter/src/layouts/Base.astro
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const { title, pageTitle, description, image, canonical, content } = Astro.props;
-const { siteTitle, siteTagline, siteLogo, siteFavicon } = resolveStarterSiteIdentity(await getSiteSettings());
+const { siteTitle, siteTagline, siteLogo } = resolveStarterSiteIdentity(await getSiteSettings());
 const fullTitle = title.includes(siteTitle) ? title : `${title} — ${siteTitle}`;
 const pageDescription = description ?? siteTagline;
 
@@ -47,7 +47,6 @@ const pageCtx = createPublicPageContext({
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{fullTitle}</title>
-		{siteFavicon && <link rel="icon" href={siteFavicon} />}
 		{pageDescription && <meta name="description" content={pageDescription} />}
 		{canonical && <link rel="canonical" href={canonical} />}
 		<EmDashHead page={pageCtx} />

--- a/templates/starter/src/utils/site-identity.ts
+++ b/templates/starter/src/utils/site-identity.ts
@@ -20,6 +20,5 @@ export function resolveStarterSiteIdentity(settings?: StarterSiteIdentitySetting
 		siteTitle: settings?.title ?? DEFAULT_SITE_TITLE,
 		siteTagline: settings?.tagline ?? DEFAULT_SITE_TAGLINE,
 		siteLogo: settings?.logo?.url ? settings.logo : null,
-		siteFavicon: settings?.favicon?.url ?? null,
 	};
 }


### PR DESCRIPTION
## What does this PR do?

User-configured site favicons were never injected into the public site's `<head>` by core. Per-template `Base.astro` layouts each rendered their own `<link rel="icon">`, but pre-#448 templates lacked the line entirely, and even current templates dropped the `type` attribute. SVG favicons therefore failed to render in Chromium browsers, which require `type="image/svg+xml"` when the URL has no `.svg` extension.

This PR centralizes favicon injection in `EmDashHead` and emits the correct MIME type from the stored media row.

Closes #831

### Approach

A new `renderSiteIdentity()` helper in `packages/core/src/page/site-identity.ts` emits a `<link rel="icon">` tag with the optional `type` attribute. It deliberately lives outside the plugin contribution pipeline (`page/metadata.ts`) because that pipeline's `isSafeHref` allowlist rejects same-origin paths like `/_emdash/api/media/file/...`. That restriction is correct for sandboxed plugin contributions but blocks our own first-party favicon URLs.

`MediaReference` now carries `url`, `contentType`, `width`, and `height` when resolved via `resolveMediaReference`, so callers can emit correct head tags without a second round-trip to the media table. The stored shape is unchanged: only the in-memory resolved value picks up the extra fields. Zod schemas at the REST/MCP boundary still define just `{ mediaId, alt? }` and rely on default strip-mode parsing to discard the resolved fields if a client posts them back. A docstring on `MediaReference` calls this out so a future contributor doesn't accidentally relax the schema and start writing the resolved fields back to storage.

`EmDashHead.astro` now calls `getSiteSettings()` instead of `getSiteSetting("seo")` so it can pick up `favicon` alongside the SEO settings. Both helpers are request-cached and worker-cached; the standard `Base.astro` pattern in every shipped template already calls `getSiteSettings()` first, so this is a free read in practice.

### Backwards compatibility

Templates that already render their own favicon link continue to work. Browsers tolerate the duplicate. A follow-up cleanup can drop the per-template line once this has shipped, but it does not need to be coordinated.

### Query-count impact

Zero net delta from this change. `getSiteSettings()` is request-cached; `Base.astro` already calls it before `EmDashHead` renders. Verified by running `pnpm query-counts` with and without the change applied: identical numbers either way. The repository's snapshot is currently stale relative to actual behaviour on `main` (every public route is +1 to +6 queries above the recorded values), but that pre-existing drift is unrelated to this PR.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (3053 / 3053 in core)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (7 new unit tests in `tests/unit/page/site-identity.test.ts`)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a, bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

```
$ pnpm --filter emdash test --run tests/unit/page/site-identity
 ✓ tests/unit/page/site-identity.test.ts (7 tests) 2ms

 Test Files  1 passed (1)
      Tests  7 passed (7)

$ pnpm --filter emdash test --run
 Test Files  184 passed (184)
      Tests  3053 passed (3053)
```

The 7 new tests cover:

- Empty / undefined input is a no-op
- `MediaReference` without resolved `url` is a no-op (handles deleted media row gracefully)
- Favicon with `url` and `contentType` renders the correct tag
- SVG favicons get `type="image/svg+xml"` (the #831 bug)
- Missing `contentType` falls back to a typeless `<link>` tag (legacy stored media)
- Hostile content in `url` and `contentType` is HTML-attribute-escaped via `escapeHtmlAttr`
