### PR TITLE
fix(admin): round-trip datetime widget values through datetime-local input

### DIFF
--- a/.changeset/datetime-widget-roundtrip.md
+++ b/.changeset/datetime-widget-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the `datetime` field widget so existing values display in the editor and new values pass server validation. The widget passed raw ISO 8601 (`YYYY-MM-DDTHH:mm:ss.sssZ`) into `<input type="datetime-local">`, which silently rendered empty, and emitted `YYYY-MM-DDTHH:mm` on save, which the field's zod schema rejected. Strips the suffix for display, appends `:00.000Z` on save, and normalizes date-only stored values to UTC midnight for the input. Applies to the top-level `datetime` widget in the content editor and the `datetime` sub-field type inside `RepeaterField`.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -36,6 +36,7 @@ import type {
 	TranslationSummary,
 } from "../lib/api";
 import { getPreviewUrl, getDraftStatus } from "../lib/api";
+import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { usePluginAdmins } from "../lib/plugin-context.js";
 import { contentUrl } from "../lib/url.js";
 import { cn, slugify } from "../lib/utils";
@@ -1264,8 +1265,8 @@ function FieldRenderer({
 					label={label}
 					id={id}
 					type="datetime-local"
-					value={typeof value === "string" ? value : ""}
-					onChange={(e) => handleChange(e.target.value)}
+					value={toDatetimeLocalInputValue(value)}
+					onChange={(e) => handleChange(fromDatetimeLocalInputValue(e.target.value))}
 					required={field.required}
 				/>
 			);

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -20,6 +20,7 @@ import { useLingui } from "@lingui/react/macro";
 import { Plus, Trash, DotsSixVertical, CaretDown } from "@phosphor-icons/react";
 import * as React from "react";
 
+import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { cn } from "../lib/utils.js";
 import { CaretNext } from "./ArrowIcons.js";
 
@@ -348,8 +349,8 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 				<Input
 					label={subField.label}
 					type="datetime-local"
-					value={typeof value === "string" ? value : ""}
-					onChange={(e) => onChange(e.target.value)}
+					value={toDatetimeLocalInputValue(value)}
+					onChange={(e) => onChange(fromDatetimeLocalInputValue(e.target.value))}
 					required={subField.required}
 				/>
 			);

--- a/packages/admin/src/lib/datetime-local.ts
+++ b/packages/admin/src/lib/datetime-local.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for round-tripping `datetime` field values through
+ * `<input type="datetime-local">`.
+ *
+ * Stored field values are full ISO 8601 (`YYYY-MM-DDTHH:mm:ss.sssZ`) or
+ * date-only (`YYYY-MM-DD`) per the per-field zod schema in
+ * `packages/core/src/schema/zod-generator.ts`. The browser input only
+ * accepts `YYYY-MM-DDTHH:mm`, so widgets must convert in both directions.
+ *
+ * The widget treats the value as UTC for a stable round-trip. Using
+ * `new Date(...).toISOString()` (the convention in the publish-schedule
+ * UI in `ContentEditor.tsx`) would shift values by the local-UTC offset on
+ * every save, mutating the persisted time on each edit cycle.
+ */
+
+/** Format a stored datetime field value for the input. */
+export function toDatetimeLocalInputValue(value: unknown): string {
+	if (typeof value !== "string" || value === "") return "";
+	// `YYYY-MM-DD` (date-only branch of the schema): pad to UTC midnight.
+	if (value.length === 10) return `${value}T00:00`;
+	// Full ISO 8601: take the date + `HH:mm` prefix.
+	return value.slice(0, 16);
+}
+
+/** Convert an input value (`YYYY-MM-DDTHH:mm`) back to the stored ISO shape. */
+export function fromDatetimeLocalInputValue(value: string): string {
+	return value === "" ? "" : `${value}:00.000Z`;
+}

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -262,6 +262,65 @@ describe("ContentEditor", () => {
 			await expect.element(all[2]!).toBeChecked();
 		});
 
+		it("renders datetime fields as datetime-local inputs", async () => {
+			const screen = await renderEditor({
+				fields: { recall_date: { kind: "datetime", label: "Recall date" } },
+			});
+			const input = screen.getByLabelText("Recall date");
+			await expect.element(input).toHaveAttribute("type", "datetime-local");
+		});
+
+		it("displays a stored ISO datetime in the datetime-local input", async () => {
+			// The validator stores datetimes as full ISO 8601 with "Z" + millis,
+			// but <input type="datetime-local"> only accepts "YYYY-MM-DDTHH:mm".
+			// Without conversion the browser silently renders an empty input.
+			const item = makeItem({
+				data: { title: "Recall", recall_date: "2026-02-26T09:30:00.000Z" },
+			});
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				fields: {
+					title: { kind: "string", label: "Title", required: true },
+					recall_date: { kind: "datetime", label: "Recall date" },
+				},
+			});
+			const input = screen.getByLabelText("Recall date");
+			await expect.element(input).toHaveValue("2026-02-26T09:30");
+		});
+
+		it("saves datetime fields back as full ISO 8601 with Z and milliseconds", async () => {
+			// datetime-local emits "YYYY-MM-DDTHH:mm" which the field's
+			// `z.string().datetime().or(z.string().date())` schema rejects.
+			// The widget must round-trip the value back to a validator-accepted shape.
+			const onSave = vi.fn();
+			const screen = await renderEditor({
+				isNew: true,
+				onSave,
+				fields: {
+					title: { kind: "string", label: "Title", required: true },
+					recall_date: { kind: "datetime", label: "Recall date" },
+				},
+			});
+
+			const titleInput = screen.getByLabelText("Title");
+			await titleInput.fill("Recall");
+
+			const dtInput = screen.getByLabelText("Recall date");
+			await dtInput.fill("2026-02-26T09:30");
+
+			const saveBtn = screen.getByRole("button", { name: "Save" });
+			await saveBtn.click();
+
+			expect(onSave).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						recall_date: "2026-02-26T09:30:00.000Z",
+					}),
+				}),
+			);
+		});
+
 		it("renders json fields as a textarea", async () => {
 			const screen = await renderEditor({
 				fields: { metadata: { kind: "json", label: "Metadata" } },

--- a/packages/admin/tests/components/RepeaterField.test.tsx
+++ b/packages/admin/tests/components/RepeaterField.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import { RepeaterField } from "../../src/components/RepeaterField";
+import { render } from "../utils/render.tsx";
+
+describe("RepeaterField", () => {
+	describe("datetime sub-field", () => {
+		it("displays a stored ISO datetime in the datetime-local input", async () => {
+			// Mirrors the top-level datetime widget contract: full ISO 8601
+			// values must round-trip through `<input type="datetime-local">`,
+			// which only accepts `YYYY-MM-DDTHH:mm`.
+			const screen = await render(
+				<RepeaterField
+					label="Recalls"
+					id="recalls"
+					value={[{ recall_date: "2026-02-26T09:30:00.000Z" }]}
+					onChange={vi.fn()}
+					subFields={[{ slug: "recall_date", type: "datetime", label: "Recall date" }]}
+				/>,
+			);
+			const input = screen.getByLabelText("Recall date");
+			await expect.element(input).toHaveValue("2026-02-26T09:30");
+		});
+
+		it("emits a full ISO 8601 value with Z and milliseconds on change", async () => {
+			const onChange = vi.fn();
+			const screen = await render(
+				<RepeaterField
+					label="Recalls"
+					id="recalls"
+					value={[{ recall_date: "" }]}
+					onChange={onChange}
+					subFields={[{ slug: "recall_date", type: "datetime", label: "Recall date" }]}
+				/>,
+			);
+			const input = screen.getByLabelText("Recall date");
+			await input.fill("2026-02-26T09:30");
+
+			expect(onChange).toHaveBeenLastCalledWith([
+				expect.objectContaining({ recall_date: "2026-02-26T09:30:00.000Z" }),
+			]);
+		});
+	});
+});

--- a/packages/admin/tests/lib/datetime-local.test.ts
+++ b/packages/admin/tests/lib/datetime-local.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	fromDatetimeLocalInputValue,
+	toDatetimeLocalInputValue,
+} from "../../src/lib/datetime-local";
+
+describe("toDatetimeLocalInputValue", () => {
+	it("returns empty for non-string and empty values", () => {
+		expect(toDatetimeLocalInputValue(undefined)).toBe("");
+		expect(toDatetimeLocalInputValue(null)).toBe("");
+		expect(toDatetimeLocalInputValue(0)).toBe("");
+		expect(toDatetimeLocalInputValue("")).toBe("");
+	});
+
+	it("strips seconds/ms/Z from full ISO 8601", () => {
+		expect(toDatetimeLocalInputValue("2026-02-26T09:30:00.000Z")).toBe("2026-02-26T09:30");
+	});
+
+	it("pads date-only values to UTC midnight", () => {
+		expect(toDatetimeLocalInputValue("2026-02-26")).toBe("2026-02-26T00:00");
+	});
+
+	it("preserves a value already in datetime-local shape", () => {
+		expect(toDatetimeLocalInputValue("2026-02-26T09:30")).toBe("2026-02-26T09:30");
+	});
+});
+
+describe("fromDatetimeLocalInputValue", () => {
+	it("returns empty for empty input", () => {
+		expect(fromDatetimeLocalInputValue("")).toBe("");
+	});
+
+	it("appends seconds/ms/Z so the value matches the validator's ISO shape", () => {
+		expect(fromDatetimeLocalInputValue("2026-02-26T09:30")).toBe("2026-02-26T09:30:00.000Z");
+	});
+
+	it("round-trips a stored ISO value without drift", () => {
+		const stored = "2026-02-26T09:30:00.000Z";
+		expect(fromDatetimeLocalInputValue(toDatetimeLocalInputValue(stored))).toBe(stored);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the `datetime` field widget so existing values display in the editor and new values pass server validation. Two universal symptoms:

1. **Empty display.** The widget passed full ISO 8601 (`YYYY-MM-DDTHH:mm:ss.sssZ`) directly into `<input type="datetime-local">`, which only accepts `YYYY-MM-DDTHH:mm` and silently renders empty on anything else. Every existing datetime entry showed an empty input on edit.
2. **Save rejected.** `datetime-local` emits `YYYY-MM-DDTHH:mm`. The per-field zod schema in `packages/core/src/schema/zod-generator.ts` is `z.string().datetime().or(z.string().date())`, neither branch of which accepts that shape. Every save of a non-empty datetime was rejected.

The fix strips the seconds/ms/Z suffix for display and appends `:00.000Z` on save so the stored shape matches the validator's `datetime()` branch. Date-only stored values (`YYYY-MM-DD`, the schema's other accepted shape) are padded to UTC midnight for the input. The widget is treated as UTC for a stable round-trip — using `new Date().toISOString()` (the convention in the publish-schedule UI in the same file) would shift values by the local-UTC offset on every save, so each round-trip would mutate the persisted time.

The same bug existed on the `datetime` sub-field inside `RepeaterField`; fixed there in the same shape.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`pnpm --silent lint:json | jq '.diagnostics | length'` returns 0)
- [x] `pnpm test` passes (or targeted tests for my change) — `ContentEditor.test.tsx` (35/35) and new `RepeaterField.test.tsx` (2/2) green
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable). N/A — no new strings.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
 ✓ tests/components/ContentEditor.test.tsx (35 tests)
   ✓ field rendering > renders datetime fields as datetime-local inputs
   ✓ field rendering > displays a stored ISO datetime in the datetime-local input
   ✓ field rendering > saves datetime fields back as full ISO 8601 with Z and milliseconds
   ... (32 existing)

 ✓ tests/components/RepeaterField.test.tsx (2 tests)
   ✓ datetime sub-field > displays a stored ISO datetime in the datetime-local input
   ✓ datetime sub-field > emits a full ISO 8601 value with Z and milliseconds on change

 Test Files  2 passed (2)
      Tests  37 passed (37)
```

### Adversarial review notes (out of scope, flagged for future work)

- **Schedule picker (`ContentEditor.tsx:814`) uses `new Date().toISOString()` directly** for its datetime-local round-trip, which means a user entering a wall-clock time has it interpreted as local-TZ then converted to UTC for storage. This widget treats the field as UTC; the scheduler treats it as local. Two different conventions for the same input type in the same file. Not addressed here to keep the PR scoped to the reported bug; worth a follow-up Discussion to unify.
- **Stored values bearing a non-Z offset** (e.g. `2026-02-26T09:30:00+02:00`, valid per `z.string().datetime()`) display the bare 16-char prefix in the input, which the browser treats as local. Saving without changes would store `…+02:00` as `…Z` — a different moment. EmDash always stores `Z`-suffixed ISO today, so this only surfaces on data migrated from other systems. Not addressed.
- **Date-only stored values normalize to datetime on save.** A stored `2026-02-26` becomes `2026-02-26T00:00:00.000Z` after one round-trip through this widget. The validator accepts both shapes so persistence doesn't break, but downstream consumers that distinguish dates from datetimes by string shape would see a change. Documented in the changeset.