### PR TITLE
fix(schema): coerce SQLite-shaped numeric booleans in zod field schema

### DIFF
--- a/.changeset/zod-boolean-sqlite-coercion.md
+++ b/.changeset/zod-boolean-sqlite-coercion.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes content saves on collections with boolean fields. Boolean fields map to `INTEGER` columns and the repository writes booleans as `0/1`, but never converts them back on read, so a GET → edit → POST round-trip surfaced numbers where the per-collection zod schema expected booleans, and every save was rejected. The boolean field schema now coerces the `0/1` shape to real booleans at the validation boundary; other numbers and strings still fail validation as before.

--- a/packages/core/src/schema/zod-generator.ts
+++ b/packages/core/src/schema/zod-generator.ts
@@ -68,7 +68,15 @@ function getBaseSchema(type: FieldType, field: Field): ZodTypeAny {
 			return z.number().int();
 
 		case "boolean":
-			return z.boolean();
+			// Boolean fields map to `INTEGER` columns (`FIELD_TYPE_TO_COLUMN`
+			// in `schema/types.ts`) and `serializeValue` in
+			// `database/repositories/content.ts` writes booleans as 0/1.
+			// `deserializeValue` never converts them back, so reads return
+			// numbers. Coerce the stored 0/1 shape here so a GET → POST
+			// round-trip on a boolean field passes validation. Other inputs
+			// (strings, other numbers) fall through to `z.boolean()` and
+			// produce its standard rejection.
+			return z.preprocess((v) => (v === 0 || v === 1 ? Boolean(v) : v), z.boolean());
 
 		case "datetime":
 			return z.string().datetime().or(z.string().date());

--- a/packages/core/tests/unit/schema/zod-generator.test.ts
+++ b/packages/core/tests/unit/schema/zod-generator.test.ts
@@ -92,6 +92,95 @@ describe("Zod Generator", () => {
 			expect(() => schema.parse("yes")).toThrow();
 		});
 
+		it("should coerce stored 0/1 booleans to real booleans", () => {
+			// Boolean fields map to `INTEGER` columns (`FIELD_TYPE_TO_COLUMN`
+			// in `schema/types.ts`) and `serializeValue` in
+			// `database/repositories/content.ts` writes booleans as 0/1.
+			// `deserializeValue` never converts them back, so a GET → POST
+			// round-trip on a boolean field fails validation (`z.boolean()`
+			// rejects numbers) unless this schema accepts the integer shape.
+			const field: Field = {
+				id: "f1",
+				collectionId: "c1",
+				slug: "active",
+				label: "Active",
+				type: "boolean",
+				columnType: "INTEGER",
+				required: true,
+				unique: false,
+				sortOrder: 0,
+				createdAt: new Date().toISOString(),
+			};
+
+			const schema = generateFieldSchema(field);
+			expect(schema.parse(0)).toBe(false);
+			expect(schema.parse(1)).toBe(true);
+			// Other numbers must still fail — only the integer 0/1 shape is accepted.
+			expect(() => schema.parse(2)).toThrow();
+			expect(() => schema.parse(-1)).toThrow();
+			// Strings still fail.
+			expect(() => schema.parse("0")).toThrow();
+			expect(() => schema.parse("true")).toThrow();
+			// BigInt from drivers that return 64-bit ints is unsupported (no
+			// known driver currently does this for boolean columns); rejecting
+			// is safer than a silent coercion that could hide a real bug.
+			expect(() => schema.parse(BigInt(0))).toThrow();
+		});
+
+		it("should preserve `.default(false)` chaining through the boolean preprocess", () => {
+			const field: Field = {
+				id: "f1",
+				collectionId: "c1",
+				slug: "active",
+				label: "Active",
+				type: "boolean",
+				columnType: "INTEGER",
+				required: false,
+				unique: false,
+				sortOrder: 0,
+				defaultValue: false,
+				createdAt: new Date().toISOString(),
+			};
+
+			const schema = generateFieldSchema(field);
+			// default applies when the value is undefined.
+			expect(schema.parse(undefined)).toBe(false);
+			// Stored integer shape still coerces.
+			expect(schema.parse(1)).toBe(true);
+		});
+
+		it("should accept stored 0/1 booleans in partial-mode validation", () => {
+			// `validateContentData` in `api/handlers/validation.ts` calls
+			// `schema.partial()` for updates. Confirm that partial mode keeps
+			// the preprocess intact for the boolean field.
+			const collection: CollectionWithFields = {
+				id: "c1",
+				slug: "posts",
+				labelPlural: "Posts",
+				labelSingular: "Post",
+				updatedAt: new Date().toISOString(),
+				fields: [
+					{
+						id: "f1",
+						collectionId: "c1",
+						slug: "active",
+						label: "Active",
+						type: "boolean",
+						columnType: "INTEGER",
+						required: true,
+						unique: false,
+						sortOrder: 0,
+						createdAt: new Date().toISOString(),
+					},
+				],
+			};
+
+			const schema = generateZodSchema(collection).partial();
+			expect(schema.parse({ active: 0 })).toEqual({ active: false });
+			expect(schema.parse({ active: 1 })).toEqual({ active: true });
+			expect(schema.parse({})).toEqual({});
+		});
+
 		it("should generate url schema", () => {
 			const field: Field = {
 				id: "f1",


### PR DESCRIPTION
## What does this PR do?

Saving any content entry on a collection with a boolean field fails with a validation error after a GET → edit → POST round-trip. The repository converts booleans to `0/1` on write but never converts them back on read, so reads surface boolean columns as numbers. The per-field zod schema is `z.boolean()`, which rejects numbers. The admin re-includes untouched booleans in its form payload, so a user toggling one switch sees every other boolean field's `0/1` value re-submitted and rejected.

Trace:

- `packages/core/src/database/repositories/content.ts:54` (`serializeValue`) — boolean → `0/1`.
- `packages/core/src/database/repositories/content.ts:71` (`deserializeValue`) — only parses JSON, never coerces numerics.
- `packages/core/src/database/repositories/content.ts:1157` (`mapRow`) — runs every column through `deserializeValue`.
- `packages/core/src/schema/zod-generator.ts:70` — emits `z.boolean()` and rejects the read shape.
- `packages/core/src/api/handlers/validation.ts:71` — calls `generateZodSchema(...).partial()` for updates.

Wrap the boolean field schema in a `z.preprocess` that coerces the SQLite shape (`0/1`) to `false/true`, leaving every other input (other numbers, strings, `BigInt`) to fall through to `z.boolean()`'s standard rejection. Surgical fix at the validation boundary that restores symmetry with the write path without touching the repository contract or the existing `ContentRepository(db)` call sites that read `data.*` directly. Boolean fields map to `INTEGER` columns on every dialect via `FIELD_TYPE_TO_COLUMN` (`schema/types.ts:64`), so the fix covers SQLite and Postgres.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`pnpm --silent lint:json | jq '.diagnostics | length'` returns 0)
- [x] `pnpm test` passes (or targeted tests for my change) — full zod-generator suite (20/20 incl. 3 new cases) green; content-handlers suite (19/19) unaffected
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable). N/A — no admin UI changes.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code

## Screenshots / test output

```
 ✓ tests/unit/schema/zod-generator.test.ts (20 tests)
   ✓ generateFieldSchema > should generate boolean schema
   ✓ generateFieldSchema > should coerce SQLite-shaped numeric booleans (0/1) to real booleans
   ✓ generateFieldSchema > should preserve `.default(false)` chaining through the boolean preprocess
   ✓ generateFieldSchema > should accept SQLite-shaped booleans in partial-mode validation
   ... (16 existing)

 Test Files  1 passed (1)
      Tests  20 passed (20)
```

### Adversarial review notes (out of scope, flagged for future work)

- **Asymmetric serialization at the repo layer.** The root cause is that `deserializeValue` does not invert `serializeValue` for booleans. A more comprehensive fix would track per-collection field types in `mapRow` and coerce there, returning real booleans on `data.*` access. That changes the repository's read contract and would require an audit of every `ContentRepository(db)` consumer that currently reads `data.field as number` (no enforcement today, but easy to slip in). This PR keeps that contract intact and patches only the validation boundary.
- **Type-generation drift.** `generateTypeScript` emits `boolean` for boolean fields, but consumers reading `data.*` from `getEmDashEntry` / `getEmDashCollection` still see `0/1` until the repo-layer fix lands. This PR doesn't widen the emitted TS type, on the assumption that fixing the read path is preferable to documenting a `boolean | number` contract.
- **BigInt** rejection is intentional. No known SQLite driver returns BigInt for `INTEGER` columns containing 0/1, and silently coercing would mask a potential driver bug.