### PR TITLE
fix(admin): Wire image-settings sidebar in section editor

### DIFF
--- a/.changeset/section-editor-image-sidebar.md
+++ b/.changeset/section-editor-image-sidebar.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the image-settings icon in the Section editor so it actually opens `<ImageDetailPanel>` in the sidebar.

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -14,7 +14,8 @@ import { fetchSection, updateSection, type Section, type UpdateSectionInput } fr
 import { slugify } from "../lib/utils";
 import { ArrowPrev } from "./ArrowIcons.js";
 import { EditorHeader } from "./EditorHeader";
-import { PortableTextEditor } from "./PortableTextEditor";
+import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
+import { PortableTextEditor, type BlockSidebarPanel } from "./PortableTextEditor";
 import { SaveButton } from "./SaveButton";
 
 export function SectionEditor() {
@@ -131,6 +132,21 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 	);
 	const isDirty = currentData !== lastSavedData;
 
+	// Block sidebar state populated when a node view (e.g. ImageNode) requests
+	// sidebar space.
+	const [blockSidebarPanel, setBlockSidebarPanel] = React.useState<BlockSidebarPanel | null>(null);
+
+	const handleBlockSidebarOpen = React.useCallback((panel: BlockSidebarPanel) => {
+		setBlockSidebarPanel(panel);
+	}, []);
+
+	const handleBlockSidebarClose = React.useCallback(() => {
+		setBlockSidebarPanel((prev) => {
+			prev?.onClose();
+			return null;
+		});
+	}, []);
+
 	const handleSave = () => {
 		const keywordsArray = keywords
 			.split(",")
@@ -176,76 +192,98 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 						<PortableTextEditor
 							value={content as Parameters<typeof PortableTextEditor>[0]["value"]}
 							onChange={(value) => setContent(value as unknown[])}
+							onBlockSidebarOpen={handleBlockSidebarOpen}
+							onBlockSidebarClose={handleBlockSidebarClose}
 						/>
 					</div>
 				</div>
 
 				{/* Sidebar */}
 				<div className="col-span-4 space-y-6">
-					{/* Metadata */}
-					<div className="rounded-lg border bg-kumo-base p-6 space-y-4">
-						<h2 className="text-lg font-semibold">{t`Section Details`}</h2>
-
-						<Input
-							label={t`Title`}
-							value={title}
-							onChange={(e) => setTitle(e.target.value)}
-							placeholder={t`Section title`}
+					{blockSidebarPanel?.type === "image" ? (
+						<ImageDetailPanel
+							attributes={blockSidebarPanel.attrs as unknown as ImageAttributes}
+							onUpdate={(attrs) =>
+								blockSidebarPanel.onUpdate(attrs as unknown as Record<string, unknown>)
+							}
+							onReplace={(attrs) =>
+								blockSidebarPanel.onReplace(attrs as unknown as Record<string, unknown>)
+							}
+							onDelete={() => {
+								blockSidebarPanel.onDelete();
+								setBlockSidebarPanel(null);
+							}}
+							onClose={handleBlockSidebarClose}
+							inline
 						/>
+					) : (
+						<>
+							{/* Metadata */}
+							<div className="rounded-lg border bg-kumo-base p-6 space-y-4">
+								<h2 className="text-lg font-semibold">{t`Section Details`}</h2>
 
-						<div>
-							<Input
-								label={t`Slug`}
-								value={sectionSlug}
-								onChange={(e) => {
-									setSectionSlug(e.target.value);
-									setSlugTouched(true);
-								}}
-								placeholder="section-slug"
-								pattern="[a-z0-9\-]+"
-							/>
-							<p className="text-xs text-kumo-subtle mt-1">
-								{t`Used to identify this section. Lowercase letters, numbers, and hyphens only.`}
-							</p>
-						</div>
+								<Input
+									label={t`Title`}
+									value={title}
+									onChange={(e) => setTitle(e.target.value)}
+									placeholder={t`Section title`}
+								/>
 
-						<InputArea
-							label={t`Description`}
-							value={description}
-							onChange={(e) => setDescription(e.target.value)}
-							placeholder={t`Describe what this section is for...`}
-							rows={3}
-						/>
+								<div>
+									<Input
+										label={t`Slug`}
+										value={sectionSlug}
+										onChange={(e) => {
+											setSectionSlug(e.target.value);
+											setSlugTouched(true);
+										}}
+										placeholder="section-slug"
+										pattern="[a-z0-9\-]+"
+									/>
+									<p className="text-xs text-kumo-subtle mt-1">
+										{t`Used to identify this section. Lowercase letters, numbers, and hyphens only.`}
+									</p>
+								</div>
 
-						<div>
-							<Input
-								label={t`Keywords`}
-								value={keywords}
-								onChange={(e) => setKeywords(e.target.value)}
-								placeholder="hero, banner, cta"
-							/>
-							<p className="text-xs text-kumo-subtle mt-1">{t`Comma-separated keywords for search.`}</p>
-						</div>
-					</div>
+								<InputArea
+									label={t`Description`}
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									placeholder={t`Describe what this section is for...`}
+									rows={3}
+								/>
 
-					{/* Source info */}
-					<div className="rounded-lg border bg-kumo-base p-6">
-						<h2 className="text-lg font-semibold mb-2">{t`Source`}</h2>
-						<p className="text-sm text-kumo-subtle">
-							{section.source === "theme" && (
-								<>
-									{t`This section is provided by the theme. Editing will create a custom copy that overrides the theme version.`}
-								</>
-							)}
-							{section.source === "user" && <>{t`This is a custom section.`}</>}
-							{section.source === "import" && (
-								<>{t`This section was imported from another system.`}</>
-							)}
-						</p>
-						{section.themeId && (
-							<p className="text-xs text-kumo-subtle mt-2">{t`Theme ID: ${section.themeId}`}</p>
-						)}
-					</div>
+								<div>
+									<Input
+										label={t`Keywords`}
+										value={keywords}
+										onChange={(e) => setKeywords(e.target.value)}
+										placeholder="hero, banner, cta"
+									/>
+									<p className="text-xs text-kumo-subtle mt-1">{t`Comma-separated keywords for search.`}</p>
+								</div>
+							</div>
+
+							{/* Source info */}
+							<div className="rounded-lg border bg-kumo-base p-6">
+								<h2 className="text-lg font-semibold mb-2">{t`Source`}</h2>
+								<p className="text-sm text-kumo-subtle">
+									{section.source === "theme" && (
+										<>
+											{t`This section is provided by the theme. Editing will create a custom copy that overrides the theme version.`}
+										</>
+									)}
+									{section.source === "user" && <>{t`This is a custom section.`}</>}
+									{section.source === "import" && (
+										<>{t`This section was imported from another system.`}</>
+									)}
+								</p>
+								{section.themeId && (
+									<p className="text-xs text-kumo-subtle mt-2">{t`Theme ID: ${section.themeId}`}</p>
+								)}
+							</div>
+						</>
+					)}
 				</div>
 			</div>
 		</div>

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -13,8 +13,8 @@ import * as React from "react";
 import { fetchSection, updateSection, type Section, type UpdateSectionInput } from "../lib/api";
 import { slugify } from "../lib/utils";
 import { ArrowPrev } from "./ArrowIcons.js";
-import { EditorHeader } from "./EditorHeader";
 import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
+import { EditorHeader } from "./EditorHeader";
 import { PortableTextEditor, type BlockSidebarPanel } from "./PortableTextEditor";
 import { SaveButton } from "./SaveButton";
 

--- a/packages/admin/tests/components/SectionEditor.test.tsx
+++ b/packages/admin/tests/components/SectionEditor.test.tsx
@@ -1,0 +1,126 @@
+import { Toasty } from "@cloudflare/kumo";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { Section } from "../../src/lib/api";
+import { render } from "../utils/render.tsx";
+
+// Capture props passed to PortableTextEditor so the test can invoke the
+// block-sidebar callbacks the way the image node view does at runtime.
+const portableTextProps: { current: Record<string, unknown> | null } = { current: null };
+
+vi.mock("../../src/components/PortableTextEditor", () => ({
+	PortableTextEditor: (props: Record<string, unknown>) => {
+		portableTextProps.current = props;
+		return <div data-testid="portable-text-editor" />;
+	},
+}));
+
+vi.mock("../../src/components/MediaPickerModal", () => ({
+	MediaPickerModal: () => null,
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...(actual as Record<string, unknown>),
+		Link: ({ children, to, ...props }: { children: React.ReactNode; to?: string }) => (
+			<a href={String(to ?? "")} {...props}>
+				{children}
+			</a>
+		),
+		useParams: () => ({ slug: "footer" }),
+		useNavigate: () => vi.fn(),
+	};
+});
+
+const mockFetchSection = vi.fn<() => Promise<Section>>();
+const mockUpdateSection = vi.fn();
+
+vi.mock("../../src/lib/api", async () => {
+	const actual = await vi.importActual("../../src/lib/api");
+	return {
+		...(actual as Record<string, unknown>),
+		fetchSection: (...args: unknown[]) => mockFetchSection(...(args as [])),
+		updateSection: (...args: unknown[]) => mockUpdateSection(...(args as [])),
+	};
+});
+
+// Import after mocks so the module under test picks up the mocked deps.
+const { SectionEditor } = await import("../../src/components/SectionEditor");
+
+function makeSection(overrides: Partial<Section> = {}): Section {
+	return {
+		id: "sec_footer",
+		slug: "footer",
+		title: "Footer",
+		description: "All page footer",
+		keywords: [],
+		content: [],
+		source: "user",
+		createdAt: "2025-01-01T00:00:00Z",
+		updatedAt: "2025-01-02T00:00:00Z",
+		...overrides,
+	};
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return (
+		<QueryClientProvider client={qc}>
+			<Toasty>{children}</Toasty>
+		</QueryClientProvider>
+	);
+}
+
+describe("SectionEditor", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		portableTextProps.current = null;
+		mockFetchSection.mockResolvedValue(makeSection());
+	});
+
+	it("opens the image settings panel when a block requests the sidebar", async () => {
+		const screen = await render(<SectionEditor />, { wrapper: Wrapper });
+
+		// Editor must mount (and capture its props) before we can simulate.
+		await expect.element(screen.getByTestId("portable-text-editor")).toBeInTheDocument();
+
+		const onBlockSidebarOpen = portableTextProps.current?.onBlockSidebarOpen as
+			| ((panel: unknown) => void)
+			| undefined;
+		const onBlockSidebarClose = portableTextProps.current?.onBlockSidebarClose as
+			| (() => void)
+			| undefined;
+
+		// Both callbacks must be wired — without them, clicking the image-settings
+		// icon in the editor is a silent no-op (#845).
+		expect(typeof onBlockSidebarOpen).toBe("function");
+		expect(typeof onBlockSidebarClose).toBe("function");
+
+		// Simulate the image node view asking for sidebar space, the same shape
+		// it sends from ImageNode.openSidebar(). expect.element below polls until
+		// React flushes the state update, so we don't need an explicit act wrapper.
+		onBlockSidebarOpen!({
+			type: "image",
+			attrs: {
+				src: "https://example.com/logo.png",
+				alt: "Logo",
+				mediaId: "media-1",
+				width: 400,
+				height: 200,
+			},
+			onUpdate: vi.fn(),
+			onReplace: vi.fn(),
+			onDelete: vi.fn(),
+			onClose: vi.fn(),
+		});
+
+		// The Image Settings panel should now be rendered in the sidebar slot.
+		// The panel renders the image preview using the src we passed.
+		await expect.element(screen.getByRole("img", { name: "Logo" })).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #845

### The issue
Clicking the settings icon on an image inside a custom section was a silent no-op. As a result, images placed in sections couldn't be resized, recaptioned, or replaced through the UI. The resize controls live inside ImageDetailPanel, which never opened.

https://github.com/user-attachments/assets/f07ce767-2b74-49d8-b95a-bd1f5a0a1c1d

### The fix

Wires the block-sidebar callbacks in SectionEditor so the image "settings" (sliders) icon actually opens <ImageDetailPanel> in the sidebar.

The fix mirrors the existing wiring in ContentEditor: track the active block panel in component state, expose handlers that open/close it, and conditionally render <ImageDetailPanel inline /> in the sidebar slot.

https://github.com/user-attachments/assets/3dcce337-a1fa-4a7f-b681-c241a9b75aed

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
