### PR TITLE
chore(ci): pin node 22 floor, fix CLA and PR Compliance bot bypasses

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://www.cloudflare.com/cla/"
           branch: "cla-signatures"
-          allowlist: dependabot[bot],emdashbot[bot],copilot-swe-agent[bot],ask-bonk[bot]
+          allowlist: dependabot[bot],emdashbot[bot],copilot-swe-agent[bot],ask-bonk[bot],opencode
           lock-pullrequest-aftermerge: false
 
   label:

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -1,7 +1,7 @@
 name: PR Compliance
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, edited, synchronize]
 
@@ -12,7 +12,14 @@ permissions:
 jobs:
   check-pr:
     name: Validate PR
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'emdashbot[bot]' && github.actor != 'ask-bonk[bot]'
+    # Filter on the PR author, not github.actor: actor becomes a maintainer on
+    # synchronize/edited events triggered by pushes or merges into a bot branch,
+    # which lets bot PRs slip past an actor-based check.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'renovate[bot]'
+      && github.event.pull_request.user.login != 'emdashbot[bot]'
+      && github.event.pull_request.user.login != 'ask-bonk[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
 		"typescript": "6.0.0-beta"
 	},
 	"packageManager": "pnpm@10.28.0",
+	"engines": {
+		"node": ">=22"
+	},
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"better-sqlite3",


### PR DESCRIPTION
## What does this PR do?

Three small CI fixes, each independently verified against recent runs.

**1. Node 20 fallback in `review.yml` and `bonk.yml`.** Both use `node-version-file: package.json`, but root `package.json` has no `engines.node`, so `setup-node` warns *"Could not determine node version... Falling back"* and lands on Node 20.20.2 (run [25205003115](https://github.com/emdash-cms/emdash/actions/runs/25205003115/job/72165717879)). Other workflows pin `node-version: 22` explicitly. Adding `"engines": { "node": ">=22" }` resolves the fallback without touching workflows.

**2. CLA allowlist: `ask-bonk[bot]` never matched.** ask-bonk PRs are committed with git author `name: opencode` / `email: opencode@emdash.cms` — no GitHub user mapping, so `contributor-assistant`'s committer-identity check sees the literal name `opencode`, not `ask-bonk[bot]`. Run [25204750978](https://github.com/emdash-cms/emdash/actions/runs/25204750978) failed CLA on PR #869 with `ask-bonk[bot]` already in the list. Adding `opencode` to the allowlist fixes it.

**3. PR Compliance: comments fail and bot PRs leak through.**
- The comment step on PR #872 (from a fork) hit `403 Resource not accessible by integration` (run [25192888953](https://github.com/emdash-cms/emdash/actions/runs/25192888953)). `pull_request` gives a read-only `GITHUB_TOKEN` for fork PRs. Switching to `pull_request_target` restores write access. Safe here — the workflow only uses `actions/github-script` to read event payload, no PR code is checked out or executed.
- The `if:` filter checked `github.actor`, but on `synchronize`/`edited` events triggered by a maintainer pushing or merging into a bot branch, actor becomes the maintainer (e.g. run [25204322195](https://github.com/emdash-cms/emdash/actions/runs/25204322195) on the ask-bonk PR #869 had `actor: ascorbic`). Switching the check to `github.event.pull_request.user.login` filters on the PR author, which is stable across event types.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

CI-only — no published-package behavior changes, so no changeset.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

n/a — workflow changes only. The "Validate PR" check on this PR is itself the test for fix #3 (it should run, post a comment if anything's wrong, and pass).