### PR TITLE
fix: load seed/seed.json in seed virtual module

### DIFF
--- a/.changeset/seed-virtual-module-fallback.md
+++ b/.changeset/seed-virtual-module-fallback.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the seed virtual module to also look at the conventional `seed/seed.json` path when no `.emdash/seed.json` or `package.json#emdash.seed` pointer is configured. Without this fallback, a site that only had `seed/seed.json` would silently fall through to the built-in default seed -- the setup wizard would not offer demo content, and the wrong schema would be applied. The loader now warns when it falls through to the default seed so misconfiguration is loud during dev.

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -407,8 +407,14 @@ export function generateWaitUntilModule(adapterName: string | undefined): string
  *   3. `seed/seed.json` (conventional template path)
  *
  * Exports `userSeed` (user's seed or null) and `seed` (user's seed or default).
+ *
+ * When no user seed is found, falls back to the built-in default seed and
+ * (if `warnOnFallback` is true) logs a warning so misconfiguration is visible
+ * during `astro dev`. Build/preview/sync stay silent so sites that
+ * intentionally use the default seed (e.g. the blank template) don't
+ * generate noisy logs.
  */
-export function generateSeedModule(projectRoot: string): string {
+export function generateSeedModule(projectRoot: string, warnOnFallback = false): string {
 	let userSeedJson: string | null = null;
 
 	// Try .emdash/seed.json
@@ -455,10 +461,14 @@ export function generateSeedModule(projectRoot: string): string {
 		return [`export const userSeed = ${userSeedJson};`, `export const seed = userSeed;`].join("\n");
 	}
 
-	// No user seed — inline the default
-	console.warn(
-		"[emdash] No user seed found at .emdash/seed.json, package.json#emdash.seed, or seed/seed.json. Falling back to the built-in default seed; the setup wizard will not offer demo content for this site.",
-	);
+	// No user seed — inline the default. Caller (the Vite plugin) gates this
+	// to dev-only so production builds stay quiet for sites that intentionally
+	// rely on the default seed.
+	if (warnOnFallback) {
+		console.warn(
+			"[emdash] No user seed found at .emdash/seed.json, package.json#emdash.seed, or seed/seed.json. Falling back to the built-in default seed; the setup wizard will not offer demo content for this site.",
+		);
+	}
 	return [
 		`export const userSeed = null;`,
 		`export const seed = ${JSON.stringify(defaultSeed)};`,

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -401,6 +401,11 @@ export function generateWaitUntilModule(adapterName: string | undefined): string
  * Reads the user's seed file at build time (in Node context) and embeds it,
  * so the runtime doesn't need filesystem access (required for workerd).
  *
+ * Search order:
+ *   1. `.emdash/seed.json`
+ *   2. `package.json` → `emdash.seed` reference
+ *   3. `seed/seed.json` (conventional template path)
+ *
  * Exports `userSeed` (user's seed or null) and `seed` (user's seed or default).
  */
 export function generateSeedModule(projectRoot: string): string {
@@ -434,11 +439,26 @@ export function generateSeedModule(projectRoot: string): string {
 		}
 	}
 
+	// Try conventional seed/seed.json fallback
+	if (!userSeedJson) {
+		try {
+			const seedPath = resolve(projectRoot, "seed", "seed.json");
+			const content = readFileSync(seedPath, "utf-8");
+			JSON.parse(content); // validate
+			userSeedJson = content;
+		} catch {
+			// Not found
+		}
+	}
+
 	if (userSeedJson) {
 		return [`export const userSeed = ${userSeedJson};`, `export const seed = userSeed;`].join("\n");
 	}
 
 	// No user seed — inline the default
+	console.warn(
+		"[emdash] No user seed found at .emdash/seed.json, package.json#emdash.seed, or seed/seed.json. Falling back to the built-in default seed; the setup wizard will not offer demo content for this site.",
+	);
 	return [
 		`export const userSeed = null;`,
 		`export const seed = ${JSON.stringify(defaultSeed)};`,

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -156,8 +156,13 @@ export interface VitePluginOptions {
 export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 	const { serializableConfig, resolvedConfig, pluginDescriptors, astroConfig } = options;
 
+	let viteCommand: "build" | "serve" | undefined;
+
 	return {
 		name: "emdash-virtual-modules",
+		configResolved(config) {
+			viteCommand = config.command;
+		},
 		resolveId(id: string) {
 			if (id === VIRTUAL_CONFIG_ID) {
 				return RESOLVED_VIRTUAL_CONFIG_ID;
@@ -259,7 +264,7 @@ export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 			// Generate seed module — embeds user seed or default at build time
 			if (id === RESOLVED_VIRTUAL_SEED_ID) {
 				const projectRoot = fileURLToPath(astroConfig.root);
-				return generateSeedModule(projectRoot);
+				return generateSeedModule(projectRoot, viteCommand === "serve");
 			}
 			// Generate wait-until module — re-exports cloudflare:workers'
 			// waitUntil under the Cloudflare adapter, undefined otherwise.

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	generateConfigModule,
 	generateDialectModule,
+	generateSeedModule,
 } from "../../../../src/astro/integration/virtual-modules.js";
 
 describe("generateConfigModule", () => {
@@ -59,5 +64,85 @@ describe("generateDialectModule", () => {
 			supportsRequestScope: false,
 		});
 		expect(out).toContain(`export const dialectType = "postgres"`);
+	});
+});
+
+describe("generateSeedModule", () => {
+	let projectRoot: string;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		projectRoot = mkdtempSync(join(tmpdir(), "emdash-seed-test-"));
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		rmSync(projectRoot, { recursive: true, force: true });
+		warnSpy.mockRestore();
+	});
+
+	const sampleSeed = (name: string) => ({
+		version: "1",
+		meta: { name },
+		collections: [],
+	});
+
+	it("prefers .emdash/seed.json over package.json#emdash.seed and seed/seed.json", () => {
+		mkdirSync(join(projectRoot, ".emdash"));
+		writeFileSync(
+			join(projectRoot, ".emdash", "seed.json"),
+			JSON.stringify(sampleSeed("dot-emdash")),
+		);
+
+		writeFileSync(
+			join(projectRoot, "package.json"),
+			JSON.stringify({ name: "x", emdash: { seed: "custom-seed.json" } }),
+		);
+		writeFileSync(join(projectRoot, "custom-seed.json"), JSON.stringify(sampleSeed("pkg-pointer")));
+
+		mkdirSync(join(projectRoot, "seed"));
+		writeFileSync(
+			join(projectRoot, "seed", "seed.json"),
+			JSON.stringify(sampleSeed("conventional")),
+		);
+
+		const out = generateSeedModule(projectRoot);
+		expect(out).toContain(`"name":"dot-emdash"`);
+		expect(out).toContain("export const seed = userSeed;");
+	});
+
+	it("uses package.json#emdash.seed when .emdash/seed.json is absent", () => {
+		writeFileSync(
+			join(projectRoot, "package.json"),
+			JSON.stringify({ name: "x", emdash: { seed: "seed/seed.json" } }),
+		);
+		mkdirSync(join(projectRoot, "seed"));
+		writeFileSync(join(projectRoot, "seed", "seed.json"), JSON.stringify(sampleSeed("via-pkg")));
+
+		const out = generateSeedModule(projectRoot);
+		expect(out).toContain(`"name":"via-pkg"`);
+	});
+
+	it("falls back to seed/seed.json when no pointer is configured", () => {
+		writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ name: "x" }));
+		mkdirSync(join(projectRoot, "seed"));
+		writeFileSync(
+			join(projectRoot, "seed", "seed.json"),
+			JSON.stringify(sampleSeed("conventional-fallback")),
+		);
+
+		const out = generateSeedModule(projectRoot);
+		expect(out).toContain(`"name":"conventional-fallback"`);
+		expect(out).toContain("export const seed = userSeed;");
+	});
+
+	it("falls through to the default seed and warns when no user seed is found", () => {
+		writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ name: "x" }));
+
+		const out = generateSeedModule(projectRoot);
+		expect(out).toContain("export const userSeed = null;");
+		expect(out).toContain("export const seed = ");
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/No user seed found/);
 	});
 });

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
 	generateConfigModule,
@@ -69,16 +69,13 @@ describe("generateDialectModule", () => {
 
 describe("generateSeedModule", () => {
 	let projectRoot: string;
-	let warnSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		projectRoot = mkdtempSync(join(tmpdir(), "emdash-seed-test-"));
-		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
 		rmSync(projectRoot, { recursive: true, force: true });
-		warnSpy.mockRestore();
 	});
 
 	const sampleSeed = (name: string) => ({
@@ -136,13 +133,11 @@ describe("generateSeedModule", () => {
 		expect(out).toContain("export const seed = userSeed;");
 	});
 
-	it("falls through to the default seed and warns when no user seed is found", () => {
+	it("falls through to the default seed when no user seed is found", () => {
 		writeFileSync(join(projectRoot, "package.json"), JSON.stringify({ name: "x" }));
 
 		const out = generateSeedModule(projectRoot);
 		expect(out).toContain("export const userSeed = null;");
 		expect(out).toContain("export const seed = ");
-		expect(warnSpy).toHaveBeenCalledTimes(1);
-		expect(warnSpy.mock.calls[0]?.[0]).toMatch(/No user seed found/);
 	});
 });

--- a/templates/blog-cloudflare/package.json
+++ b/templates/blog-cloudflare/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.3",
 	"private": true,
 	"type": "module",
+	"emdash": {
+		"seed": "seed/seed.json"
+	},
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/templates/marketing-cloudflare/package.json
+++ b/templates/marketing-cloudflare/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.3",
 	"private": true,
 	"type": "module",
+	"emdash": {
+		"seed": "seed/seed.json"
+	},
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/templates/starter-cloudflare/package.json
+++ b/templates/starter-cloudflare/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.3",
 	"private": true,
 	"type": "module",
+	"emdash": {
+		"seed": "seed/seed.json"
+	},
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.3",
   "private": true,
   "type": "module",
+  "emdash": {
+    "seed": "seed/seed.json"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## What does this PR do?

Four of the nine templates (\`marketing-cloudflare\`, \`blog-cloudflare\`, \`starter-cloudflare\`, \`starter\`) were missing the \`package.json#emdash.seed\` pointer. Without it, the seed virtual module fell back to the built-in default seed instead of the template's own \`seed/seed.json\`. Symptoms when running these templates:

- Setup wizard didn't offer the "Include sample content" toggle (status endpoint reported \`seedInfo: null\`).
- Wrong schema was applied to the database -- e.g. running marketing-cloudflare gave you the default seed's \`pages\` + \`posts\` collections instead of just the marketing \`pages\` collection.
- After completing the wizard, the admin had no content because the wizard's \`applySeed\` ran against the default seed, which has no demo content.

This PR:

1. Adds the missing \`"emdash": { "seed": "seed/seed.json" }\` pointers to the four affected templates.
2. Adds a third fallback in \`generateSeedModule\` that searches for \`seed/seed.json\` (the conventional path documented in every template's AGENTS.md) before giving up to the default seed. This makes the loader robust against future template misconfiguration.
3. Logs a \`console.warn\` when falling through to the built-in default seed, naming all three search paths, so this kind of footgun is loud during dev.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include \`messages.po\` changes except in translation PRs -- a workflow extracts catalogs on merge to \`main\`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7

## Screenshots / test output

\`pnpm test\`: 3086 passed (3086) across 190 test files. Four new tests in \`virtual-modules.test.ts\` cover the search-order precedence, the new \`seed/seed.json\` fallback, and the warn-on-fallthrough behavior.

\`pnpm --silent lint:json | jq '.diagnostics | length'\`: \`0\`.