### PR TITLE
fix(i18n): correct malformed ICU plural syntax in Indonesian translation

### DIFF
--- a/.changeset/full-mangos-sell.md
+++ b/.changeset/full-mangos-sell.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes malformed ICU plural syntax in Indonesian (id) locale — ContentList item count now renders correctly

--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -143,7 +143,7 @@ msgstr "{0, plural, other {# pengguna}}"
 #. placeholder {2}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:295
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
-msgstr "{0, plural, other {{#}{2} item}}"
+msgstr "{0, plural, one {#{1} item} other {#{2} item}}"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1133


### PR DESCRIPTION
## What does this PR do?

Fixes a malformed ICU MessageFormat plural in the Indonesian (id) locale file — `packages/admin/src/locales/id/messages.po:146`. The broken `msgstr` used `{#}` (which renders the numeric count) instead of the literal `#` symbol that the `msgid` expects, and was missing the `one` plural form.

Closes #886

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — N/A (`.po` file only)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes — N/A (translation string fix, no behavior change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) — N/A (already translated; this is a fix to an existing translation)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion: N/A

## AI-generated code disclosure

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->