### PR TITLE
fix(admin): preserve translation content when switching between locales

### DIFF
--- a/.changeset/fix-translation-switch-stale-editor.md
+++ b/.changeset/fix-translation-switch-stale-editor.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes stale content shown in the Portable Text editor when switching between translations of the same content. Previously, navigating from one locale's editor to another (e.g. from the English version of a post to the French version) kept the previous locale's body in the editor, and any subsequent edit would silently overwrite the new translation's content. The form now resets synchronously when the underlying content item changes, and field editors are keyed by item id so they remount cleanly on a translation switch.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -274,6 +274,39 @@ export function ContentEditor({
 	);
 	const pendingAutosaveStateRef = React.useRef<string | null>(null);
 
+	// Synchronously reset form state when the underlying item changes (e.g. a
+	// translation switch where TanStack Router keeps ContentEditor mounted but
+	// swaps `item` for a different id). The post-render useEffect below also
+	// syncs item -> formData, but it runs *after* the first render with the new
+	// item, leaving children (notably PortableTextEditor, which freezes its
+	// initial content on mount) one render behind. This is the React-recommended
+	// "store info from previous renders" idiom -- see
+	// https://react.dev/reference/react/useState#storing-information-from-previous-renders
+	//
+	// We also reset lastSavedData here (not just in the post-render effect) so
+	// that isDirty stays false through the switch -- otherwise SaveButton would
+	// briefly flip from "Saved" -> "Save" -> "Saved" within a single tick.
+	const [previousItemId, setPreviousItemId] = React.useState<string | null>(item?.id ?? null);
+	if (item && item.id !== previousItemId) {
+		setPreviousItemId(item.id);
+		setFormData(item.data);
+		setSlug(item.slug || "");
+		setSlugTouched(!!item.slug);
+		setStatus(item.status);
+		const nextBylines =
+			item.bylines?.map((entry) => ({ bylineId: entry.byline.id, roleLabel: entry.roleLabel })) ??
+			[];
+		setInternalBylines(nextBylines);
+		setLastSavedData(
+			serializeEditorState({
+				data: item.data,
+				slug: item.slug || "",
+				bylines: nextBylines,
+			}),
+		);
+		pendingAutosaveStateRef.current = null;
+	}
+
 	// Update form and last saved state when item changes (e.g., after save or restore)
 	// Stringify the data for comparison since objects are compared by reference
 	const itemDataString = React.useMemo(() => (item ? JSON.stringify(item.data) : ""), [item?.data]);
@@ -702,9 +735,16 @@ export function ContentEditor({
 					>
 						<div className="space-y-4">
 							{Object.entries(fields).map(([name, field]) => {
+								// Key by item id so all field editors remount cleanly when the
+								// underlying content item changes (e.g. switching translations).
+								// PortableTextEditor in particular freezes its initial content on
+								// mount; without this key, navigating between translations leaves
+								// the previous locale's body in the editor and silently overwrites
+								// the new translation on the next edit.
+								const fieldKey = `${name}:${item?.id ?? "new"}`;
 								const fieldEl = (
 									<FieldRenderer
-										key={name}
+										key={fieldKey}
 										name={name}
 										field={field}
 										value={formData[name]}
@@ -733,7 +773,10 @@ export function ContentEditor({
 									onSeoChange
 								) {
 									return (
-										<div key={`${name}-with-seo`} className="grid grid-cols-1 gap-6 md:grid-cols-2">
+										<div
+											key={`${fieldKey}-with-seo`}
+											className="grid grid-cols-1 gap-6 md:grid-cols-2"
+										>
 											<div>{fieldEl}</div>
 											<div>
 												<SeoImageField seo={item?.seo} onChange={onSeoChange} />

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1086,8 +1086,9 @@ interface FieldRendererProps {
 	field: FieldDescriptor;
 	value: unknown;
 	onChange: (name: string, value: unknown) => void;
-	/** Callback when a portableText editor is ready */
-	onEditorReady?: (editor: Editor) => void;
+	/** Callback when a portableText editor is ready.
+	 * Called with the editor on mount, and with `null` on unmount. */
+	onEditorReady?: (editor: Editor | null) => void;
 	/** Minimal chrome - hides toolbar, fades labels, removes borders (distraction-free mode) */
 	minimal?: boolean;
 	/** Plugin block types available for insertion in Portable Text fields */

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1707,8 +1707,10 @@ export interface PortableTextEditorProps {
 	focusMode?: FocusMode;
 	/** Callback when focus mode changes */
 	onFocusModeChange?: (mode: FocusMode) => void;
-	/** Callback to receive the editor instance for external integrations */
-	onEditorReady?: (editor: Editor) => void;
+	/** Callback to receive the editor instance for external integrations.
+	 * Called with the editor on mount, and with `null` on unmount so consumers
+	 * can clear stale references (e.g. before the next instance mounts). */
+	onEditorReady?: (editor: Editor | null) => void;
 	/** Minimal chrome - hides toolbar, border, footer (distraction-free mode) */
 	minimal?: boolean;
 	/** Callback when a block node requests sidebar space (e.g. image settings) */
@@ -1952,11 +1954,17 @@ export function PortableTextEditor({
 		},
 	});
 
-	// Notify when editor is ready
+	// Notify when editor is ready, and on unmount so consumers can clear the
+	// reference before TipTap destroys the instance (e.g. when keying by item.id
+	// to switch translations).
 	React.useEffect(() => {
 		if (editor && onEditorReady) {
 			onEditorReady(editor);
+			return () => {
+				onEditorReady(null);
+			};
 		}
+		return undefined;
 	}, [editor, onEditorReady]);
 
 	// Register plugin blocks into editor storage so the node view can look up metadata

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -9,11 +9,30 @@ import {
 import type { ContentItem } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
 
-// Mock child components that have complex dependencies
+// Mock child components that have complex dependencies.
+// The mock simulates the real editor's behaviour of freezing initial content on mount:
+// it captures `value` once via useState initializer and never re-reads it.
+// This is what makes the translation-switch bug observable in tests — the displayed
+// content stays stale unless the component is forced to remount via a fresh `key`.
+let portableTextMountCount = 0;
 vi.mock("../../src/components/PortableTextEditor", () => ({
-	PortableTextEditor: ({ placeholder }: any) => (
-		<div data-testid="portable-text-editor">{placeholder}</div>
-	),
+	PortableTextEditor: ({ value, placeholder }: any) => {
+		// Mirror the real component: capture initial value once, never update.
+		const [initialValue] = React.useState(() => value);
+		React.useEffect(() => {
+			portableTextMountCount++;
+		}, []);
+		const text = Array.isArray(initialValue)
+			? initialValue
+					.map((b: any) => b?.children?.map((c: any) => c?.text ?? "").join("") ?? "")
+					.join("\n")
+			: "";
+		return (
+			<div data-testid="portable-text-editor" data-content={text}>
+				{placeholder}
+			</div>
+		);
+	},
 }));
 
 vi.mock("../../src/components/RevisionHistory", () => ({
@@ -88,6 +107,7 @@ function renderEditor(props: Partial<ContentEditorProps> = {}) {
 describe("ContentEditor", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		portableTextMountCount = 0;
 	});
 
 	describe("slug generation", () => {
@@ -616,6 +636,85 @@ describe("ContentEditor", () => {
 			const item = makeItem();
 			const screen = await renderEditor({ isNew: false, item, collectionLabel: "Post" });
 			await expect.element(screen.getByText("Edit Post")).toBeInTheDocument();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Bug: translation switch leaves stale content in PortableTextEditor.
+	//
+	// When navigating between translations of the same content (e.g. /en post ->
+	// /fr post), TanStack Router keeps ContentEditor mounted and only the `item`
+	// prop changes. The PortableTextEditor (TipTap) freezes its content via
+	// useMemo([], ...) on mount and has no effect to reconcile incoming `value`
+	// changes, so it keeps showing the previous locale's body.
+	//
+	// Worse: any subsequent edit fires onUpdate with the stale content, silently
+	// overwriting the new translation's body in formData.
+	//
+	// Fix: key <FieldRenderer> by `${name}:${item?.id ?? "new"}` so all field
+	// editors remount cleanly when the underlying content item changes.
+	// ---------------------------------------------------------------------------
+	describe("translation / item switch", () => {
+		function buildPtItem(id: string, text: string): ContentItem {
+			return makeItem({
+				id,
+				slug: id,
+				data: {
+					title: text,
+					body: [
+						{
+							_type: "block",
+							_key: `block-${id}`,
+							style: "normal",
+							children: [{ _type: "span", _key: `span-${id}`, text, marks: [] }],
+							markDefs: [],
+						},
+					],
+				},
+			});
+		}
+
+		const ptFields: Record<string, FieldDescriptor> = {
+			title: { kind: "string", label: "Title", required: true },
+			body: { kind: "portableText", label: "Body" },
+		};
+
+		it("remounts the portable text editor when item.id changes (translation switch)", async () => {
+			const itemEn = buildPtItem("post-en", "English body");
+			const itemFr = buildPtItem("post-fr", "French body");
+
+			// Use a wrapper so we can swap items without unmounting ContentEditor.
+			function Switcher({ item }: { item: ContentItem }) {
+				return (
+					<ContentEditor
+						collection="posts"
+						collectionLabel="Post"
+						fields={ptFields}
+						isNew={false}
+						item={item}
+						onSave={vi.fn()}
+					/>
+				);
+			}
+
+			const screen = await render(<Switcher item={itemEn} />);
+
+			// Initial mount: editor shows the English body.
+			const editor = screen.getByTestId("portable-text-editor");
+			await expect.element(editor).toHaveAttribute("data-content", "English body");
+			expect(portableTextMountCount).toBe(1);
+
+			// Simulate translation switch by rerendering with a different item id.
+			// The fix (keying FieldRenderer by item.id) must force a fresh mount
+			// so the editor reads the new locale's body.
+			await screen.rerender(<Switcher item={itemFr} />);
+
+			const editorAfter = screen.getByTestId("portable-text-editor");
+			await expect.element(editorAfter).toHaveAttribute("data-content", "French body");
+
+			// A new mount means the FieldRenderer was keyed by id and remounted.
+			// Without the fix, mountCount stays at 1 and content stays stale.
+			expect(portableTextMountCount).toBeGreaterThanOrEqual(2);
 		});
 	});
 });

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -14,14 +14,35 @@ import { render } from "../utils/render.tsx";
 // it captures `value` once via useState initializer and never re-reads it.
 // This is what makes the translation-switch bug observable in tests — the displayed
 // content stays stale unless the component is forced to remount via a fresh `key`.
+//
+// It also mirrors the real component's onEditorReady contract: called with a stub
+// editor on mount and with `null` on unmount, so consumers can clear stale refs
+// before the next instance mounts.
 let portableTextMountCount = 0;
+type EditorReadyCall = { mockId: number | null };
+let onEditorReadyCalls: EditorReadyCall[] = [];
 vi.mock("../../src/components/PortableTextEditor", () => ({
-	PortableTextEditor: ({ value, placeholder }: any) => {
+	PortableTextEditor: ({ value, placeholder, onEditorReady }: any) => {
 		// Mirror the real component: capture initial value once, never update.
 		const [initialValue] = React.useState(() => value);
+		const mountIdRef = React.useRef<number>(0);
 		React.useEffect(() => {
 			portableTextMountCount++;
+			mountIdRef.current = portableTextMountCount;
 		}, []);
+		React.useEffect(() => {
+			if (onEditorReady) {
+				const id = mountIdRef.current || portableTextMountCount + 1;
+				const stubEditor = { __mockId: id } as unknown;
+				onEditorReadyCalls.push({ mockId: id });
+				onEditorReady(stubEditor);
+				return () => {
+					onEditorReadyCalls.push({ mockId: null });
+					onEditorReady(null);
+				};
+			}
+			return undefined;
+		}, [onEditorReady]);
 		const text = Array.isArray(initialValue)
 			? initialValue
 					.map((b: any) => b?.children?.map((c: any) => c?.text ?? "").join("") ?? "")
@@ -108,6 +129,7 @@ describe("ContentEditor", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		portableTextMountCount = 0;
+		onEditorReadyCalls = [];
 	});
 
 	describe("slug generation", () => {
@@ -715,6 +737,102 @@ describe("ContentEditor", () => {
 			// A new mount means the FieldRenderer was keyed by id and remounted.
 			// Without the fix, mountCount stays at 1 and content stays stale.
 			expect(portableTextMountCount).toBeGreaterThanOrEqual(2);
+		});
+
+		it("wires onEditorReady through for the 'content' field so DocumentOutline tracks remounts", async () => {
+			// ContentEditor only wires `onEditorReady` to its `setPortableTextEditor`
+			// slot when the field name is exactly "content" (see ContentEditor.tsx,
+			// where the conditional onEditorReady prop is set). On a translation
+			// switch, the FieldRenderer is keyed by item.id so the editor remounts;
+			// the corresponding cleanup call flows through, clearing the stale ref
+			// in the parent before the new instance mounts.
+			//
+			// The actual cleanup behaviour of PortableTextEditor (calling
+			// onEditorReady(null) on unmount) is exercised against the real
+			// component in tests/editor/PortableTextEditor.test.tsx — this test
+			// only verifies that ContentEditor wires the callback in the first place.
+			const ptFieldsForContent: Record<string, FieldDescriptor> = {
+				title: { kind: "string", label: "Title", required: true },
+				// "content" is the magic field name that wires onEditorReady through
+				// to ContentEditor's setPortableTextEditor (see ContentEditor.tsx).
+				content: { kind: "portableText", label: "Body" },
+			};
+
+			const itemEn = makeItem({
+				id: "post-en",
+				slug: "post-en",
+				data: {
+					title: "EN",
+					content: [
+						{
+							_type: "block",
+							_key: "block-en",
+							style: "normal",
+							children: [{ _type: "span", _key: "span-en", text: "English", marks: [] }],
+							markDefs: [],
+						},
+					],
+				},
+			});
+			const itemFr = makeItem({
+				id: "post-fr",
+				slug: "post-fr",
+				data: {
+					title: "FR",
+					content: [
+						{
+							_type: "block",
+							_key: "block-fr",
+							style: "normal",
+							children: [{ _type: "span", _key: "span-fr", text: "French", marks: [] }],
+							markDefs: [],
+						},
+					],
+				},
+			});
+
+			function Switcher({ item }: { item: ContentItem }) {
+				return (
+					<ContentEditor
+						collection="posts"
+						collectionLabel="Post"
+						fields={ptFieldsForContent}
+						isNew={false}
+						item={item}
+						onSave={vi.fn()}
+					/>
+				);
+			}
+
+			const screen = await render(<Switcher item={itemEn} />);
+			await expect
+				.element(screen.getByTestId("portable-text-editor"))
+				.toHaveAttribute("data-content", "English");
+
+			// Initial mount fired exactly one onEditorReady call with a non-null editor.
+			expect(onEditorReadyCalls).toHaveLength(1);
+			expect(onEditorReadyCalls[0]?.mockId).not.toBeNull();
+
+			await screen.rerender(<Switcher item={itemFr} />);
+			await expect
+				.element(screen.getByTestId("portable-text-editor"))
+				.toHaveAttribute("data-content", "French");
+
+			// After the switch we expect the call sequence:
+			//   1. mount (en) -> non-null
+			//   2. cleanup (en) -> null   <-- the M1 fix
+			//   3. mount (fr) -> non-null
+			// Without the cleanup in PortableTextEditor's onEditorReady effect,
+			// step 2 is missing and the stale en-editor reference lingers in
+			// ContentEditor's state during the remount window.
+			const nullCallIndex = onEditorReadyCalls.findIndex((c) => c.mockId === null);
+			expect(nullCallIndex).toBeGreaterThan(-1);
+
+			// The null call must come before the final mount (otherwise the slot
+			// would end up null after a fresh editor was reported ready).
+			const lastCall = onEditorReadyCalls.at(-1);
+			expect(lastCall?.mockId).not.toBeNull();
+			expect(nullCallIndex).toBeLessThan(onEditorReadyCalls.length - 1);
 		});
 	});
 });

--- a/packages/admin/tests/editor/PortableTextEditor.test.tsx
+++ b/packages/admin/tests/editor/PortableTextEditor.test.tsx
@@ -570,6 +570,27 @@ describe("Editor component behaviour", () => {
 		expect(typeof editorArg.chain).toBe("function");
 	});
 
+	it("calls onEditorReady with null on unmount so consumers can clear stale references", async () => {
+		// Without this cleanup, ContentEditor's `portableTextEditor` slot keeps
+		// pointing at a destroyed TipTap instance during the brief remount window
+		// when switching translations (FieldRenderer is re-keyed by item.id),
+		// causing DocumentOutline to render against a destroyed editor.
+		const onEditorReady = vi.fn();
+		const screen = await render(
+			<PortableTextEditor onEditorReady={onEditorReady} value={[textBlock("Mount/unmount")]} />,
+		);
+		await waitForEditor();
+
+		await vi.waitFor(() => expect(onEditorReady).toHaveBeenCalledTimes(1), { timeout: 2000 });
+		expect(onEditorReady.mock.calls[0]![0]).toBeTruthy();
+
+		// Unmount and verify the cleanup fires onEditorReady(null).
+		await screen.unmount();
+
+		await vi.waitFor(() => expect(onEditorReady).toHaveBeenCalledTimes(2), { timeout: 2000 });
+		expect(onEditorReady.mock.calls[1]![0]).toBeNull();
+	});
+
 	it("shows word count and character count in footer", async () => {
 		await render(<PortableTextEditor value={[textBlock("One two three")]} />);
 		await waitForEditor();


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where switching between translations of the same content in the admin editor (e.g. clicking "Edit" on a French translation while viewing the English version) would leave the previous locale's body in the Portable Text editor. Worse: any subsequent edit silently overwrote the new translation's content in `formData`, corrupting it on autosave.

**Root cause** (two layers):

1. `PortableTextEditor` freezes its initial content via `useMemo(() => ..., [])` on mount and has no effect to reconcile incoming `value` changes. This is intentional — re-creating the TipTap instance on every render caused infinite loops with the Suggestion plugin.
2. `ContentEditor` reused the same `<FieldRenderer>` instance on translation switch (key was just `name`), and the `formData` reset for the new item happened in a post-render `useEffect` — one render behind, so even if a remount were forced it would capture stale data.

Translations switch via TanStack Router `<Link>` to `/content/$collection/$id` with a different `id`. The route component stays mounted; only the `item` prop changes.

**Fix** (two parts in `ContentEditor.tsx`):

- Added React's "store info from previous renders" idiom: a `previousItemId` state gate that synchronously resets `formData`, `slug`, `slugTouched`, `status`, `internalBylines`, `lastSavedData`, and clears `pendingAutosaveStateRef` when `item.id` changes during render. Including `lastSavedData` in the synchronous reset keeps `isDirty` stable through the switch (no `Saved -> Save -> Saved` SaveButton flicker).
- Keyed `<FieldRenderer>` by \`\${name}:\${item?.id ?? "new"}\` so all field editors remount cleanly on item id change. Sidesteps the deliberate \`useMemo([])\` memoization in PortableTextEditor without unwinding it.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (or targeted tests for my change)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include \`messages.po\` changes except in translation PRs — a workflow extracts catalogs on merge to \`main\`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (OpenCode)

## Screenshots / test output

TDD: wrote a failing test first that mocks \`PortableTextEditor\` to mirror the real freeze behaviour (captures initial \`value\` once via \`useState\` initializer, never reconciles), then renders a wrapper that swaps \`item\` between two locales without unmounting \`ContentEditor\`. The test asserts both that the displayed content updates and that the editor remounts (\`mountCount >= 2\`). Verified empirically that reverting either half of the fix (the synchronous reset OR the \`key={item.id}\` change) makes the test fail — both halves are required.

Adversarial review pass: ran the \`adversarial-reviewer\` agent against the fix; no critical or high-severity findings. Three medium/low items raised — applied the in-scope ones (avoid \`isDirty\` flicker by including \`lastSavedData\` in the synchronous reset; reset mock mount counter in \`beforeEach\`). Skipped one out-of-scope latent issue (stale \`portableTextEditor\` ref across remount window — pre-existing, separate fix).

\`\`\`
Test Files  60 passed (60)
     Tests  839 passed (839)
\`\`\`