### PR TITLE
feat(mcp): publishedAt on content_publish, seo/bylines/publishedAt on content_update

### DIFF
--- a/.changeset/mcp-publish-update-fields.md
+++ b/.changeset/mcp-publish-update-fields.md
@@ -1,0 +1,9 @@
+---
+"emdash": minor
+---
+
+Adds `publishedAt` to `content_publish` (MCP and REST) and exposes `seo`, `bylines`, and `publishedAt` on the MCP `content_update` tool.
+
+`content_publish` now accepts an optional ISO 8601 `publishedAt` to backdate a publish, which is useful when migrating content from another CMS or correcting a historical publish date. The override requires the `content:publish_any` permission. Without it, the existing `published_at` is preserved on re-publish (idempotent) and falls back to the current time on first publish.
+
+The MCP `content_update` tool previously dropped `seo`, `bylines`, and `publishedAt` even though the underlying handler accepted them. Callers had to fall back to raw SQL against `_emdash_seo` and `_emdash_content_bylines` to set these fields. They now flow through the MCP tool and are persisted in the same transaction as field updates. Setting `publishedAt` requires `content:publish_any`, mirroring the REST PUT route. Closes #621 and #622.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -1124,12 +1124,13 @@ export async function handleContentPublish(
 	db: Kysely<Database>,
 	collection: string,
 	id: string,
+	options: { publishedAt?: string } = {},
 ): Promise<ApiResult<ContentResponse>> {
 	try {
 		const item = await withTransaction(db, async (trx) => {
 			const repo = new ContentRepository(trx);
 			const resolvedId = (await resolveId(repo, collection, id)) ?? id;
-			return repo.publish(collection, resolvedId);
+			return repo.publish(collection, resolvedId, options.publishedAt);
 		});
 
 		const hasSeo = await collectionHasSeo(db, collection);

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -72,6 +72,15 @@ export const contentScheduleBody = z
 	})
 	.meta({ id: "ContentScheduleBody" });
 
+export const contentPublishBody = z
+	.object({
+		publishedAt: contentDateOverride.meta({
+			description:
+				"Optional ISO 8601 datetime to backdate the publish (e.g. when migrating content). Requires content:publish_any permission. Without this, existing published_at is preserved on re-publish.",
+		}),
+	})
+	.meta({ id: "ContentPublishBody" });
+
 export const contentPreviewUrlBody = z
 	.object({
 		expiresIn: z.union([z.string(), z.number()]).optional(),

--- a/packages/core/src/api/schemas/content.ts
+++ b/packages/core/src/api/schemas/content.ts
@@ -74,10 +74,18 @@ export const contentScheduleBody = z
 
 export const contentPublishBody = z
 	.object({
-		publishedAt: contentDateOverride.meta({
-			description:
-				"Optional ISO 8601 datetime to backdate the publish (e.g. when migrating content). Requires content:publish_any permission. Without this, existing published_at is preserved on re-publish.",
-		}),
+		// .optional() rather than .nullish(): publishing has no semantic
+		// meaning for `null` (you can't "clear" a publish timestamp by
+		// publishing). Tightening the schema here means callers either
+		// pass a valid datetime or omit the field, and the route doesn't
+		// have to silently drop a null that snuck through.
+		publishedAt: z.iso
+			.datetime({ offset: true, message: "must be an ISO 8601 datetime" })
+			.optional()
+			.meta({
+				description:
+					"Optional ISO 8601 datetime to backdate the publish (e.g. when migrating content). Requires content:publish_any permission. Without this, existing published_at is preserved on re-publish.",
+			}),
 	})
 	.meta({ id: "ContentPublishBody" });
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
@@ -2,16 +2,25 @@
  * Publish content - promotes draft to live
  *
  * POST /_emdash/api/content/{collection}/{id}/publish
+ *
+ * Optional JSON body: { publishedAt?: string }
+ *   publishedAt — ISO 8601 datetime to backdate the publish (e.g. when
+ *   migrating content). Writing publishedAt requires content:publish_any.
+ *   Without it, the existing published_at is preserved on re-publish and
+ *   falls back to the current time on first publish.
  */
 
+import { hasPermission } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requireOwnerPerm } from "#api/authorize.js";
 import { apiError, mapErrorStatus, unwrapResult } from "#api/error.js";
+import { isParseError, parseOptionalBody } from "#api/parse.js";
+import { contentPublishBody } from "#api/schemas.js";
 
 export const prerender = false;
 
-export const POST: APIRoute = async ({ params, locals, cache }) => {
+export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 	const id = params.id!;
@@ -19,6 +28,11 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 	if (!emdash?.handleContentPublish || !emdash?.handleContentGet) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
+
+	// Body is optional — empty body means use the legacy behavior (preserve
+	// or default published_at). Pass `publishedAt` to backdate.
+	const body = await parseOptionalBody(request, contentPublishBody, {});
+	if (isParseError(body)) return body;
 
 	// Fetch item to check ownership
 	const existing = await emdash.handleContentGet(collection, id);
@@ -44,9 +58,21 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 	const denied = requireOwnerPerm(user, authorId, "content:publish_own", "content:publish_any");
 	if (denied) return denied;
 
+	// Backdating overwrites historical record — gate behind publish_any
+	// regardless of ownership.
+	if (body?.publishedAt !== undefined && !hasPermission(user, "content:publish_any")) {
+		return apiError(
+			"FORBIDDEN",
+			"Setting publishedAt requires content:publish_any permission",
+			403,
+		);
+	}
+
 	const resolvedId = typeof existingItem?.id === "string" ? existingItem.id : id;
 
-	const result = await emdash.handleContentPublish(collection, resolvedId);
+	const result = await emdash.handleContentPublish(collection, resolvedId, {
+		publishedAt: body?.publishedAt ?? undefined,
+	});
 
 	if (!result.success) return unwrapResult(result);
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
@@ -58,9 +58,13 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const denied = requireOwnerPerm(user, authorId, "content:publish_own", "content:publish_any");
 	if (denied) return denied;
 
+	// Schema narrows `publishedAt` to `string | undefined`; null is rejected
+	// at the schema layer (publish has no semantic meaning for "clear").
+	const publishedAt = body?.publishedAt;
+
 	// Backdating overwrites historical record — gate behind publish_any
 	// regardless of ownership.
-	if (body?.publishedAt !== undefined && !hasPermission(user, "content:publish_any")) {
+	if (publishedAt !== undefined && !hasPermission(user, "content:publish_any")) {
 		return apiError(
 			"FORBIDDEN",
 			"Setting publishedAt requires content:publish_any permission",
@@ -71,7 +75,7 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 	const resolvedId = typeof existingItem?.id === "string" ? existingItem.id : id;
 
 	const result = await emdash.handleContentPublish(collection, resolvedId, {
-		publishedAt: body?.publishedAt ?? undefined,
+		publishedAt,
 	});
 
 	if (!result.success) return unwrapResult(result);

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -228,6 +228,15 @@ export interface EmDashHandlers {
 			slug?: string;
 			status?: string;
 			authorId?: string | null;
+			bylines?: Array<{ bylineId: string; roleLabel?: string | null }>;
+			seo?: {
+				title?: string | null;
+				description?: string | null;
+				image?: string | null;
+				canonical?: string | null;
+				noIndex?: boolean;
+			};
+			publishedAt?: string | null;
 			_rev?: string;
 		},
 	) => Promise<HandlerResponse>;
@@ -255,7 +264,11 @@ export interface EmDashHandlers {
 	) => Promise<HandlerResponse>;
 
 	// Publishing & Scheduling handlers
-	handleContentPublish: (collection: string, id: string) => Promise<HandlerResponse>;
+	handleContentPublish: (
+		collection: string,
+		id: string,
+		options?: { publishedAt?: string },
+	) => Promise<HandlerResponse>;
 
 	handleContentUnpublish: (collection: string, id: string) => Promise<HandlerResponse>;
 

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -917,8 +917,14 @@ export class ContentRepository {
 	 * Syncs the draft revision's data into the content table columns so the
 	 * content table always reflects the published version.
 	 * If no draft revision exists, creates one from current data and publishes it.
+	 *
+	 * `publishedAt` (optional) overrides the publication timestamp. If omitted,
+	 * the existing `published_at` is preserved (idempotent re-publish keeps the
+	 * original date) and falls back to the current time on first publish. Pass
+	 * an explicit value to backdate a publish (e.g. when migrating content from
+	 * another CMS).
 	 */
-	async publish(type: string, id: string): Promise<ContentItem> {
+	async publish(type: string, id: string, publishedAt?: string): Promise<ContentItem> {
 		const tableName = getTableName(type);
 		const now = new Date().toISOString();
 
@@ -956,17 +962,35 @@ export class ContentRepository {
 			}
 		}
 
-		await sql`
-			UPDATE ${sql.ref(tableName)}
-			SET live_revision_id = ${revisionToPublish},
-				draft_revision_id = NULL,
-				status = 'published',
-				scheduled_at = NULL,
-				published_at = COALESCE(published_at, ${now}),
-				updated_at = ${now}
-			WHERE id = ${id}
-			AND deleted_at IS NULL
-		`.execute(this.db);
+		if (publishedAt !== undefined) {
+			// Caller supplied an explicit timestamp, so we overwrite published_at
+			// directly (used to backdate a publish, e.g. for content migrations).
+			await sql`
+				UPDATE ${sql.ref(tableName)}
+				SET live_revision_id = ${revisionToPublish},
+					draft_revision_id = NULL,
+					status = 'published',
+					scheduled_at = NULL,
+					published_at = ${publishedAt},
+					updated_at = ${now}
+				WHERE id = ${id}
+				AND deleted_at IS NULL
+			`.execute(this.db);
+		} else {
+			// No timestamp supplied — preserve existing published_at on
+			// idempotent re-publish, fall back to `now` on first publish.
+			await sql`
+				UPDATE ${sql.ref(tableName)}
+				SET live_revision_id = ${revisionToPublish},
+					draft_revision_id = NULL,
+					status = 'published',
+					scheduled_at = NULL,
+					published_at = COALESCE(published_at, ${now}),
+					updated_at = ${now}
+				WHERE id = ${id}
+				AND deleted_at IS NULL
+			`.execute(this.db);
+		}
 
 		const updated = await this.findById(type, id);
 		if (!updated) {

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1799,6 +1799,14 @@ export class EmDashRuntime {
 			status?: string;
 			authorId?: string | null;
 			bylines?: Array<{ bylineId: string; roleLabel?: string | null }>;
+			seo?: {
+				title?: string | null;
+				description?: string | null;
+				image?: string | null;
+				canonical?: string | null;
+				noIndex?: boolean;
+			};
+			publishedAt?: string | null;
 			/** Skip revision creation (used by autosave) */
 			skipRevision?: boolean;
 			_rev?: string;
@@ -2025,8 +2033,12 @@ export class EmDashRuntime {
 	// Publishing & Scheduling Handlers
 	// =========================================================================
 
-	async handleContentPublish(collection: string, id: string) {
-		const result = await handleContentPublish(this.db, collection, id);
+	async handleContentPublish(
+		collection: string,
+		id: string,
+		options: { publishedAt?: string } = {},
+	) {
+		const result = await handleContentPublish(this.db, collection, id, options);
 
 		// Run afterPublish hooks (fire-and-forget)
 		if (result.success && result.data) {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -14,6 +14,8 @@ import { canActOnOwn, hasPermission, Role } from "@emdash-cms/auth";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { contentBylineInputSchema, contentSeoInput } from "#api/schemas.js";
+
 import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
 
@@ -623,7 +625,10 @@ export function createMcpServer(): McpServer {
 				"Update an existing content item. Only include fields you want to change " +
 				"in the 'data' object — unspecified fields are left unchanged. Pass the " +
 				"_rev token from content_get to enable optimistic concurrency checking " +
-				"(the update fails if the item was modified since you read it).",
+				"(the update fails if the item was modified since you read it). " +
+				"`seo` and `bylines` are persisted alongside the field updates in a " +
+				"single transaction. `publishedAt` requires the content:publish_any " +
+				"permission and is useful for migrations or correcting historical dates.",
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug"),
 				id: z.string().describe("Content item ID or slug"),
@@ -638,6 +643,28 @@ export function createMcpServer(): McpServer {
 					.describe(
 						"New status. Setting to 'published' requires publish permission. Setting to 'draft' unpublishes the item and also requires publish permission.",
 					),
+				// Reuse the REST schema rather than redefining inline. The REST schema's
+				// `canonical` field is gated through `httpUrl` (validates the URL parses
+				// AND has an http(s) scheme) which rejects javascript:/data: URIs that
+				// would otherwise become stored XSS in the rendered <link rel="canonical">.
+				// Inlining a looser shape here would let MCP callers bypass that.
+				seo: contentSeoInput
+					.optional()
+					.describe(
+						"Per-content SEO metadata. Only valid for collections with SEO enabled (see schema_get_collection.hasSeo). Fields not included are left unchanged; pass null to clear.",
+					),
+				bylines: z
+					.array(contentBylineInputSchema)
+					.optional()
+					.describe(
+						"Replace the byline list for this item. The first entry becomes the primary byline. Pass an empty array to clear all bylines.",
+					),
+				publishedAt: z.iso
+					.datetime({ offset: true, message: "must be an ISO 8601 datetime" })
+					.nullish()
+					.describe(
+						"Override the publication timestamp (ISO 8601). Requires content:publish_any permission. Pass null to clear. Useful for content migrations.",
+					),
 				_rev: z
 					.string()
 					.optional()
@@ -647,35 +674,48 @@ export function createMcpServer(): McpServer {
 		async (args, extra) => {
 			requireScope(extra, "content:write");
 			requireRole(extra, Role.AUTHOR);
-			const { emdash, userId } = getExtra(extra);
+			const { emdash, userId, userRole } = getExtra(extra);
 
 			// Fetch item to check ownership
 			const existing = await emdash.handleContentGet(args.collection, args.id);
 			if (!existing.success) {
 				return unwrap(existing);
 			}
-			requireOwnership(
-				extra,
-				extractContentAuthorId(existing.data),
-				"content:edit_own",
-				"content:edit_any",
-			);
+			const ownerId = extractContentAuthorId(existing.data);
+			requireOwnership(extra, ownerId, "content:edit_own", "content:edit_any");
+
+			// Writing publishedAt directly (incl. clearing to null) overwrites
+			// historical record — gate behind publish_any, mirroring the REST PUT
+			// route. Status-driven publishes are gated separately below.
+			if (args.publishedAt !== undefined) {
+				const user = { id: userId, role: userRole };
+				if (!hasPermission(user, "content:publish_any" as Permission)) {
+					throw new EmDashAuthError(
+						"Setting publishedAt requires content:publish_any permission",
+						"INSUFFICIENT_PERMISSIONS",
+					);
+				}
+			}
 
 			const resolvedId = extractContentId(existing.data) ?? args.id;
 
 			// Status transitions route through dedicated handlers for proper revision management
 			if (args.status === "published") {
-				requireOwnership(
-					extra,
-					extractContentAuthorId(existing.data),
-					"content:publish_own",
-					"content:publish_any",
-				);
-				if (args.data || args.slug) {
+				requireOwnership(extra, ownerId, "content:publish_own", "content:publish_any");
+				if (
+					args.data ||
+					args.slug ||
+					args.seo !== undefined ||
+					args.bylines !== undefined ||
+					args.publishedAt !== undefined
+				) {
 					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
 						data: args.data,
 						slug: args.slug,
 						authorId: userId,
+						seo: args.seo,
+						bylines: args.bylines,
+						publishedAt: args.publishedAt,
 						_rev: args._rev,
 					});
 					if (!updateResult.success) return unwrap(updateResult);
@@ -684,17 +724,21 @@ export function createMcpServer(): McpServer {
 			}
 
 			if (args.status === "draft") {
-				requireOwnership(
-					extra,
-					extractContentAuthorId(existing.data),
-					"content:publish_own",
-					"content:publish_any",
-				);
-				if (args.data || args.slug) {
+				requireOwnership(extra, ownerId, "content:publish_own", "content:publish_any");
+				if (
+					args.data ||
+					args.slug ||
+					args.seo !== undefined ||
+					args.bylines !== undefined ||
+					args.publishedAt !== undefined
+				) {
 					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
 						data: args.data,
 						slug: args.slug,
 						authorId: userId,
+						seo: args.seo,
+						bylines: args.bylines,
+						publishedAt: args.publishedAt,
 						_rev: args._rev,
 					});
 					if (!updateResult.success) return unwrap(updateResult);
@@ -707,6 +751,9 @@ export function createMcpServer(): McpServer {
 					data: args.data,
 					slug: args.slug,
 					authorId: userId,
+					seo: args.seo,
+					bylines: args.bylines,
+					publishedAt: args.publishedAt,
 					_rev: args._rev,
 				}),
 			);
@@ -809,31 +856,53 @@ export function createMcpServer(): McpServer {
 			description:
 				"Publish a content item, making it live on the site. Creates a published " +
 				"revision from the current draft. Further edits create a new draft without " +
-				"affecting the live version until re-published.",
+				"affecting the live version until re-published. Pass `publishedAt` to " +
+				"backdate (e.g. when migrating content from another CMS) — this requires " +
+				"the content:publish_any permission. Without `publishedAt`, the existing " +
+				"`published_at` is preserved on re-publish (idempotent) and falls back to " +
+				"the current time on first publish.",
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug"),
 				id: z.string().describe("Content item ID or slug"),
+				publishedAt: z.iso
+					.datetime({ offset: true, message: "must be an ISO 8601 datetime" })
+					.optional()
+					.describe(
+						"Override publication timestamp (ISO 8601). Requires content:publish_any permission. Useful when importing content with original publish dates.",
+					),
 			}),
 		},
 		async (args, extra) => {
 			requireScope(extra, "content:write");
 			requireRole(extra, Role.AUTHOR);
-			const ec = getEmDash(extra);
+			const { emdash, userId, userRole } = getExtra(extra);
 
 			// Fetch item to check ownership
-			const existing = await ec.handleContentGet(args.collection, args.id);
+			const existing = await emdash.handleContentGet(args.collection, args.id);
 			if (!existing.success) {
 				return unwrap(existing);
 			}
-			requireOwnership(
-				extra,
-				extractContentAuthorId(existing.data),
-				"content:publish_own",
-				"content:publish_any",
-			);
+			const ownerId = extractContentAuthorId(existing.data);
+			requireOwnership(extra, ownerId, "content:publish_own", "content:publish_any");
+
+			// Backdating overwrites historical record — gate behind publish_any
+			// regardless of ownership (mirrors the REST PUT route's publishedAt gate).
+			if (args.publishedAt !== undefined) {
+				const user = { id: userId, role: userRole };
+				if (!hasPermission(user, "content:publish_any" as Permission)) {
+					throw new EmDashAuthError(
+						"Setting publishedAt requires content:publish_any permission",
+						"INSUFFICIENT_PERMISSIONS",
+					);
+				}
+			}
 
 			const resolvedId = extractContentId(existing.data) ?? args.id;
-			return unwrap(await ec.handleContentPublish(args.collection, resolvedId));
+			return unwrap(
+				await emdash.handleContentPublish(args.collection, resolvedId, {
+					publishedAt: args.publishedAt,
+				}),
+			);
 		},
 	);
 

--- a/packages/core/tests/integration/mcp/publish-update-fields.test.ts
+++ b/packages/core/tests/integration/mcp/publish-update-fields.test.ts
@@ -1,0 +1,560 @@
+/**
+ * MCP content_publish + content_update field-coverage tests.
+ *
+ * Pins the contracts for:
+ *
+ * - **#622** `content_publish` accepts an optional `publishedAt` ISO 8601
+ *   datetime that overrides the publication timestamp. The behavior is
+ *   gated on `content:publish_any` because backdating overwrites historical
+ *   record. Without `publishedAt`, idempotent re-publish preserves the
+ *   existing timestamp (regression guard for the COALESCE behavior).
+ *
+ * - **#621** `content_update` persists `seo`, `bylines`, and `publishedAt`
+ *   alongside field updates. The MCP tool exposes the same fields the REST
+ *   API has accepted since #777; before this PR the tool's input schema
+ *   silently dropped them.
+ *
+ * Failure modes covered:
+ *   - non-admin (AUTHOR) trying to set `publishedAt` -> INSUFFICIENT_PERMISSIONS
+ *   - SEO on a collection that doesn't have SEO enabled -> VALIDATION_ERROR
+ *   - bylines pointing at a non-existent byline ID -> handler-level FK error
+ */
+
+import { Role } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { BylineRepository } from "../../../src/database/repositories/byline.js";
+import type { Database } from "../../../src/database/types.js";
+import {
+	connectMcpHarness,
+	extractJson,
+	extractText,
+	isErrorResult,
+	type McpHarness,
+} from "../../utils/mcp-runtime.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+const ADMIN_ID = "user_admin";
+const AUTHOR_ID = "user_author";
+
+// ---------------------------------------------------------------------------
+// content_publish — publishedAt override (#622)
+// ---------------------------------------------------------------------------
+
+describe("MCP content_publish — publishedAt override (#622)", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("backdates publishedAt when caller passes an explicit ISO timestamp", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Imported post" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const PAST = "2020-01-15T10:00:00.000Z";
+		const result = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id, publishedAt: PAST },
+		});
+		expect(result.isError, extractText(result)).toBeFalsy();
+
+		const item = extractJson<{ item: { publishedAt: string | null; status: string } }>(result).item;
+		expect(item.status).toBe("published");
+		// Repository normalizes to ISO so we compare via Date round-trip.
+		expect(new Date(item.publishedAt!).toISOString()).toBe(PAST);
+	});
+
+	it("re-publishing with a new publishedAt overwrites the previous timestamp", async () => {
+		// First publish without an override — gets a current timestamp.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const first = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+		const firstTs = extractJson<{ item: { publishedAt: string } }>(first).item.publishedAt;
+		expect(firstTs).toBeTruthy();
+
+		// Re-publish with explicit override — should overwrite.
+		const PAST = "2019-06-01T00:00:00.000Z";
+		const second = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id, publishedAt: PAST },
+		});
+		const secondItem = extractJson<{ item: { publishedAt: string | null } }>(second).item;
+		expect(new Date(secondItem.publishedAt!).toISOString()).toBe(PAST);
+		expect(secondItem.publishedAt).not.toBe(firstTs);
+	});
+
+	it("rejects non-ISO-8601 publishedAt at the schema layer", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const result = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id, publishedAt: "yesterday" },
+		});
+		// Schema validation produces an isError envelope. We assert the schema's
+		// own message wording — not just that the field name appears anywhere
+		// (which would let an echoed input or stack trace satisfy the test for
+		// the wrong reason).
+		expect(isErrorResult(result)).toBe(true);
+		expect(extractText(result)).toContain("must be an ISO 8601 datetime");
+	});
+
+	it("accepts ISO 8601 with explicit timezone offset (offset: true)", async () => {
+		// Positive companion to the rejection test: pins that the schema's
+		// `offset: true` actually accepts non-Z offsets, not just Z.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const result = await harness.client.callTool({
+			name: "content_publish",
+			arguments: {
+				collection: "post",
+				id,
+				publishedAt: "2020-01-15T10:00:00+05:30",
+			},
+		});
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const item = extractJson<{ item: { publishedAt: string | null } }>(result).item;
+		// Date round-trip normalizes the offset to UTC.
+		expect(new Date(item.publishedAt!).toISOString()).toBe(
+			new Date("2020-01-15T10:00:00+05:30").toISOString(),
+		);
+	});
+
+	it("requires content:publish_any to set publishedAt — AUTHOR (owner) is denied", async () => {
+		// Switch to AUTHOR role: AUTHOR has publish_own but NOT publish_any.
+		await harness.cleanup();
+		harness = await connectMcpHarness({ db, userId: AUTHOR_ID, userRole: Role.AUTHOR });
+
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Author's post" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		// Plain publish (no publishedAt) — AUTHOR can do this for their own item.
+		const ok = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+		expect(ok.isError, extractText(ok)).toBeFalsy();
+
+		// Publish with backdated publishedAt — AUTHOR is denied even on their
+		// own item, because backdating overwrites historical record.
+		const denied = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id, publishedAt: "2020-01-01T00:00:00.000Z" },
+		});
+		expect(isErrorResult(denied)).toBe(true);
+		expect(extractText(denied)).toContain("INSUFFICIENT_PERMISSIONS");
+		expect(extractText(denied).toLowerCase()).toContain("publish_any");
+	});
+
+	it("AUTHOR cannot publish someone else's item with publishedAt (ownership denies first)", async () => {
+		// First create as ADMIN so the item belongs to a different user.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Admin's post" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		// Switch to AUTHOR — now they're not the owner.
+		await harness.cleanup();
+		harness = await connectMcpHarness({ db, userId: AUTHOR_ID, userRole: Role.AUTHOR });
+
+		const denied = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id, publishedAt: "2020-01-01T00:00:00.000Z" },
+		});
+		// Whichever check fires first (ownership or publishedAt gate), the
+		// denial is the correct outcome. We pin the structural failure shape,
+		// not the specific code, because either order is correct.
+		expect(isErrorResult(denied)).toBe(true);
+		expect(extractText(denied)).toContain("INSUFFICIENT_PERMISSIONS");
+	});
+
+	it("idempotent re-publish without publishedAt preserves the original timestamp", async () => {
+		// Regression guard: the COALESCE preserve-on-re-publish behavior
+		// shouldn't change just because the repo signature now accepts an
+		// optional override.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const first = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+		const firstTs = extractJson<{ item: { publishedAt: string } }>(first).item.publishedAt;
+
+		// Wait so a regression that always uses `now` would surface as a new ts.
+		await new Promise((r) => setTimeout(r, 5));
+
+		const second = await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+		const secondTs = extractJson<{ item: { publishedAt: string } }>(second).item.publishedAt;
+		expect(secondTs).toBe(firstTs);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// content_update — seo / bylines / publishedAt (#621)
+// ---------------------------------------------------------------------------
+
+describe("MCP content_update — seo / bylines / publishedAt (#621)", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+	let bylineId: string;
+	let bylineId2: string;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		// Enable SEO on the post collection (mirrors integration/seo/seo.test.ts).
+		await db
+			.updateTable("_emdash_collections")
+			.set({ has_seo: 1 })
+			.where("slug", "=", "post")
+			.execute();
+
+		// Pre-create two bylines so we can attach them via content_update.
+		const bylineRepo = new BylineRepository(db);
+		const b1 = await bylineRepo.create({
+			slug: "jane-doe",
+			displayName: "Jane Doe",
+			isGuest: false,
+		});
+		const b2 = await bylineRepo.create({
+			slug: "john-smith",
+			displayName: "John Smith",
+			isGuest: false,
+		});
+		bylineId = b1.id;
+		bylineId2 = b2.id;
+
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("rejects SEO canonical URL with non-http scheme (XSS guard)", async () => {
+		// Pins that the MCP `content_update.seo` schema reuses the REST
+		// `contentSeoInput` schema, which validates `canonical` through
+		// `httpUrl` (rejects javascript:/data: URIs that would otherwise
+		// become stored XSS in the rendered <link rel="canonical">).
+		// A regression that swapped this back to a plain `z.string()` would
+		// silently accept the malicious URL and persist it.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const result = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				seo: { canonical: "javascript:alert(1)" },
+			},
+		});
+		expect(isErrorResult(result)).toBe(true);
+	});
+
+	it("persists SEO fields passed to content_update", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				seo: {
+					title: "SEO Title",
+					description: "SEO description goes here.",
+					noIndex: true,
+				},
+			},
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		// Round-trip via content_get — confirms persistence, not just the
+		// echo from the update response.
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{
+			item: {
+				seo?: {
+					title: string | null;
+					description: string | null;
+					noIndex: boolean;
+				};
+			};
+		}>(got).item;
+		expect(item.seo?.title).toBe("SEO Title");
+		expect(item.seo?.description).toBe("SEO description goes here.");
+		expect(item.seo?.noIndex).toBe(true);
+	});
+
+	it("persists bylines passed to content_update and sets primary byline", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				bylines: [
+					{ bylineId, roleLabel: "Author" },
+					{ bylineId: bylineId2, roleLabel: "Editor" },
+				],
+			},
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		// Round-trip via content_get rather than relying on the update response
+		// echoing the input — confirms persistence rather than just the in-memory
+		// pass-through. (A regression that silently dropped the DB write but
+		// echoed the byline list in the response would still pass an
+		// update-response-only assertion.)
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{
+			item: {
+				primaryBylineId: string | null;
+				bylines?: Array<{ byline: { id: string }; roleLabel: string | null }>;
+			};
+		}>(got).item;
+
+		// First entry becomes the primary byline.
+		expect(item.primaryBylineId).toBe(bylineId);
+		expect(item.bylines).toHaveLength(2);
+		expect(item.bylines?.[0]?.byline.id).toBe(bylineId);
+		expect(item.bylines?.[0]?.roleLabel).toBe("Author");
+		expect(item.bylines?.[1]?.byline.id).toBe(bylineId2);
+	});
+
+	it("backdates publishedAt when content_update receives one", async () => {
+		// Publish first (so the item has a published_at to overwrite).
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+		await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+
+		const PAST = "2018-03-15T12:00:00.000Z";
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: { collection: "post", id, publishedAt: PAST },
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		// Round-trip via content_get to confirm persistence.
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{ item: { publishedAt: string | null } }>(got).item;
+		expect(new Date(item.publishedAt!).toISOString()).toBe(PAST);
+	});
+
+	it("AUTHOR (owner) cannot set publishedAt via content_update", async () => {
+		await harness.cleanup();
+		harness = await connectMcpHarness({ db, userId: AUTHOR_ID, userRole: Role.AUTHOR });
+
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Author's post" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		// AUTHOR owns this item, so ownership passes — the publishedAt gate
+		// fires next and denies. This pins that the gate fires regardless of
+		// ownership (backdating overwrites historical record).
+		const denied = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				publishedAt: "2020-01-01T00:00:00.000Z",
+			},
+		});
+		expect(isErrorResult(denied)).toBe(true);
+		expect(extractText(denied)).toContain("INSUFFICIENT_PERMISSIONS");
+		expect(extractText(denied).toLowerCase()).toContain("publish_any");
+	});
+
+	it("AUTHOR cannot set publishedAt on someone else's item via content_update", async () => {
+		// Create as ADMIN so the item belongs to someone else.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Admin's post" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		// Switch to AUTHOR — now they're not the owner.
+		await harness.cleanup();
+		harness = await connectMcpHarness({ db, userId: AUTHOR_ID, userRole: Role.AUTHOR });
+
+		const denied = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				publishedAt: "2020-01-01T00:00:00.000Z",
+			},
+		});
+		// Either ownership or the publishedAt gate denies — whichever fires
+		// first. Both produce INSUFFICIENT_PERMISSIONS so the cross-product is
+		// pinned without depending on check order.
+		expect(isErrorResult(denied)).toBe(true);
+		expect(extractText(denied)).toContain("INSUFFICIENT_PERMISSIONS");
+	});
+
+	it("rejects SEO on a collection without SEO enabled", async () => {
+		// page collection from the test fixture does NOT have SEO.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "page", data: { title: "Page" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const result = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "page",
+				id,
+				seo: { title: "Should fail" },
+			},
+		});
+		expect(isErrorResult(result)).toBe(true);
+		expect(extractText(result)).toContain("VALIDATION_ERROR");
+	});
+
+	it("content_update with status='published' + publishedAt publishes AND backdates", async () => {
+		// Pins the interaction between the status='published' branch and the
+		// publishedAt override. The branch calls handleContentUpdate (which
+		// writes published_at to the column) and then handleContentPublish
+		// (which preserves the column via COALESCE). If either side regresses,
+		// the backdated timestamp won't survive the publish.
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const PAST = "2017-04-20T00:00:00.000Z";
+		const result = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				status: "published",
+				publishedAt: PAST,
+			},
+		});
+		expect(result.isError, extractText(result)).toBeFalsy();
+
+		// Round-trip via content_get to confirm both status AND backdated
+		// timestamp landed.
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{ item: { status: string; publishedAt: string | null } }>(got).item;
+		expect(item.status).toBe("published");
+		expect(new Date(item.publishedAt!).toISOString()).toBe(PAST);
+	});
+
+	it("seo / bylines / publishedAt and field updates apply atomically", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Original" } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+		await harness.client.callTool({
+			name: "content_publish",
+			arguments: { collection: "post", id },
+		});
+
+		const PAST = "2021-06-01T00:00:00.000Z";
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				data: { title: "Updated" },
+				seo: { title: "SEO" },
+				bylines: [{ bylineId }],
+				publishedAt: PAST,
+			},
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{
+			item: {
+				data: { title?: string };
+				publishedAt: string | null;
+				primaryBylineId: string | null;
+				seo?: { title: string | null };
+			};
+		}>(got).item;
+
+		// All four updates landed.
+		expect(item.data.title).toBe("Updated");
+		expect(item.seo?.title).toBe("SEO");
+		expect(item.primaryBylineId).toBe(bylineId);
+		expect(new Date(item.publishedAt!).toISOString()).toBe(PAST);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Closes #621 and #622.

The MCP \`content_update\` tool previously dropped \`seo\`, \`bylines\`, and \`publishedAt\` even though the underlying handler accepted them (added in #777). Callers had to fall back to raw SQL against \`_emdash_seo\` and \`_emdash_content_bylines\` to set these fields, breaking MCP-first workflows.

\`content_publish\` (and the equivalent REST route) now accept an optional ISO 8601 \`publishedAt\` to backdate a publish, useful when migrating content from another CMS or correcting a historical publish date. The override requires \`content:publish_any\`. Without it, the existing \`COALESCE(published_at, now())\` preserve-on-re-publish behavior is unchanged.

The MCP \`content_update\` \`inputSchema\` now reuses the REST \`contentSeoInput\` and \`contentBylineInputSchema\` rather than redefining inline. The first adversarial review pass caught that an inline \`z.string()\` shape on \`seo.canonical\` would have bypassed the REST schema's \`httpUrl\` refinement (which rejects \`javascript:\` and \`data:\` URIs), letting an LLM-driven MCP client write a stored XSS into the rendered \`<link rel=\"canonical\">\`. Reusing the REST schemas closes that gap and keeps the layers in lockstep going forward.

Taxonomies (the third item in #621) are not in this PR. The handler doesn't yet wire taxonomies through \`handleContentUpdate\`; that's a separate piece of work and gets its own PR.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

The new MCP fields fill capability gaps where the handler already supported the behavior. Filed as bug fix per the same logic #777 used for similar gaps.

## Notable changes

- **\`repo.publish(type, id, publishedAt?)\`** \u2014 optional override. When provided, written directly. When omitted, the COALESCE preserve branch runs unchanged. Two SQL branches rather than one to keep the override semantically explicit.
- **\`handleContentPublish\`** runtime/handler/REST/MCP all gain an optional \`publishedAt\`. REST publish now accepts an optional JSON body via \`parseOptionalBody\`; empty body keeps the previous behavior. \`publishedAt\` writes are gated on \`content:publish_any\` regardless of ownership at all four layers.
- **MCP \`content_update\`** exposes \`seo\`, \`bylines\`, \`publishedAt\`. The status='published' and status='draft' branches forward the new fields through the underlying \`handleContentUpdate\` call. The \`publishedAt\` gate fires regardless of ownership (mirrors the REST PUT route at \`[id].ts:103-110\`).
- **\`EmDashHandlers\` interface** in \`astro/types.ts\` extended for both \`handleContentPublish\` and \`handleContentUpdate\` to match the runtime signatures.
- **New \`contentPublishBody\`** Zod schema in \`api/schemas/content.ts\`.
- **16 new MCP integration tests** covering positive, negative, ownership, permission, and atomicity paths.

## Adversarial review

Two review cycles. The first pass caught a stored-XSS gap (inline SEO schema bypassing the REST canonical-URL refinement), three test-quality issues (passes-for-the-wrong-reason patterns), and the AI-trope em dashes in the changeset. Second pass confirmed the fixes hold and flagged one missing positive test for the C1 fix, which I added (\`rejects SEO canonical URL with non-http scheme\`). Two leftover LOW items deferred:

- REST \`contentPublishBody.publishedAt\` is \`.nullish()\` (inherited from the shared \`contentDateOverride\`) but \`null\` is silently dropped by the route. Behavior-preserving; not in scope.
- Per-tool \`as Permission\` casts on the new \`hasPermission\` calls match the pre-existing pattern at \`mcp/server.ts:587\`. Removing only the new ones would create inconsistency; touching the old one is a drive-by.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (0 diagnostics)
- [x] \`pnpm test\` passes (282/282 MCP integration, 3097/3097 core)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are wrapped for translation \u2014 N/A (no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion \u2014 N/A, this is a bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code \u2014 model/tool: Claude Opus 4.7

Driven by Claude with manual oversight at each adversarial review cycle. Each fix was verified against a failing test, and tests were re-checked across review passes for tautologies and assertions that pass for the wrong reason.

## Test output

\`\`\`
Test Files  17 passed (17)
     Tests  282 passed (282)
\`\`\`

(MCP integration suite. Full core suite: 3097/3097.)