### PR TITLE
fix: dashboard 500 on D1 with many title-bearing collections (#895)

### DIFF
--- a/.changeset/fix-dashboard-d1-compound-select.md
+++ b/.changeset/fix-dashboard-d1-compound-select.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes 500 error on `GET /_emdash/api/dashboard` when running on Cloudflare D1 with many title-bearing collections. `fetchRecentItems` now issues one query per collection in parallel and merges results in JS instead of building a single chained `UNION ALL`, which trips D1's `SQLITE_LIMIT_COMPOUND_SELECT` cap once enough collections are present (#895).

--- a/packages/core/src/api/handlers/dashboard.ts
+++ b/packages/core/src/api/handlers/dashboard.ts
@@ -140,21 +140,22 @@ async function fetchRecentItems(
 
 	const collectionsWithTitle = new Set(titleFields.map((r) => r.collection_slug));
 
-	// Build a UNION ALL query across all content tables.
-	// Each branch is wrapped in SELECT * FROM (...) so the inner
-	// ORDER BY + LIMIT is valid SQLite (bare ORDER BY inside UNION
-	// branches is a syntax error in SQLite).
-	const subQueries = collections.map((col) => {
-		validateIdentifier(col.slug);
-		const table = `ec_${col.slug}`;
-		const hasTitle = collectionsWithTitle.has(col.slug);
+	// Issue one query per collection in parallel, then merge in JS.
+	// A single UNION ALL across N collections trips D1's
+	// SQLITE_LIMIT_COMPOUND_SELECT cap when N is large enough (#895);
+	// per-collection queries side-step that. Each query fetches at most
+	// 10 rows, so the merge handles at most N * 10 rows before slicing.
+	const perCollection = await Promise.all(
+		collections.map(async (col) => {
+			validateIdentifier(col.slug);
+			const table = `ec_${col.slug}`;
+			const hasTitle = collectionsWithTitle.has(col.slug);
 
-		// Use title column if it exists, otherwise fall back to slug → id.
-		// All output uses snake_case to avoid SQLite quoting issues on D1.
-		const titleExpr = hasTitle ? sql`COALESCE(title, slug, id)` : sql`COALESCE(slug, id)`;
+			// Use title column if it exists, otherwise fall back to slug, id.
+			// All output uses snake_case to avoid SQLite quoting issues on D1.
+			const titleExpr = hasTitle ? sql`COALESCE(title, slug, id)` : sql`COALESCE(slug, id)`;
 
-		return sql<RecentItemRow>`
-			SELECT * FROM (
+			const result = await sql<RecentItemRow>`
 				SELECT
 					id,
 					${sql.lit(col.slug)} AS collection,
@@ -168,27 +169,19 @@ async function fetchRecentItems(
 				WHERE deleted_at IS NULL
 				ORDER BY updated_at DESC
 				LIMIT 10
-			)
-		`;
-	});
+			`.execute(db);
+			return result.rows;
+		}),
+	);
 
-	// Combine with UNION ALL
-	// eslint-disable-next-line typescript-eslint(no-unnecessary-type-assertion) -- noUncheckedIndexedAccess
-	let combined = subQueries[0]!;
-	for (let i = 1; i < subQueries.length; i++) {
-		// eslint-disable-next-line typescript-eslint(no-unnecessary-type-assertion) -- noUncheckedIndexedAccess
-		combined = sql<RecentItemRow>`${combined} UNION ALL ${subQueries[i]!}`;
-	}
+	// Merge across collections, sort by updated_at desc, take top 10.
+	const merged = perCollection
+		.flat()
+		.toSorted((a, b) => (a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0))
+		.slice(0, 10);
 
-	// Final sort + limit across all branches
-	const result = await sql<RecentItemRow>`
-		SELECT * FROM (${combined})
-		ORDER BY updated_at DESC
-		LIMIT 10
-	`.execute(db);
-
-	// Map snake_case DB rows → camelCase API shape
-	return result.rows.map((row) => ({
+	// Map snake_case DB rows to camelCase API shape
+	return merged.map((row) => ({
 		id: row.id,
 		collection: row.collection,
 		collectionLabel: row.collection_label,

--- a/packages/core/tests/unit/api/dashboard-handlers.test.ts
+++ b/packages/core/tests/unit/api/dashboard-handlers.test.ts
@@ -214,6 +214,54 @@ describe("Dashboard Handlers", () => {
 			expect(postStats!.total).toBe(1);
 		});
 
+		it("merges recent items across many title-bearing collections (#895)", async () => {
+			// Regression for #895: with enough title-bearing collections, the
+			// previous chained UNION ALL query exceeded D1's compound-SELECT cap
+			// and returned a 500. The per-collection fan-out path must merge,
+			// sort, and slice to 10 across all collections regardless of count.
+			db = await setupTestDatabase();
+			const registry = new SchemaRegistry(db);
+			const contentRepo = new ContentRepository(db);
+
+			const collectionCount = 12;
+			const slugs: string[] = [];
+			for (let i = 0; i < collectionCount; i++) {
+				const slug = `coll_${String(i).padStart(2, "0")}`;
+				slugs.push(slug);
+				await registry.createCollection({
+					slug,
+					label: `Collection ${i}`,
+					labelSingular: `Item ${i}`,
+				});
+				await registry.createField(slug, { slug: "title", label: "Title", type: "string" });
+			}
+
+			// One entry per collection, with monotonically increasing updated_at
+			// so we can deterministically assert ordering.
+			for (let i = 0; i < collectionCount; i++) {
+				await contentRepo.create({
+					type: slugs[i]!,
+					slug: `entry-${String(i).padStart(2, "0")}`,
+					data: { title: `Title ${i}` },
+					status: "draft",
+				});
+				await new Promise((r) => setTimeout(r, 5));
+			}
+
+			const result = await handleDashboardStats(db);
+
+			expect(result.success).toBe(true);
+			const { recentItems } = result.data!;
+
+			// Capped at 10 even when 12 collections each have an entry
+			expect(recentItems).toHaveLength(10);
+
+			// Newest 10 are the last 10 created, in reverse-creation order.
+			const expected = slugs.slice(-10).toReversed();
+			expect(recentItems.map((i) => i.collection)).toEqual(expected);
+			expect(recentItems[0]!.title).toBe(`Title ${collectionCount - 1}`);
+		});
+
 		it("returns camelCase keys in recent items", async () => {
 			db = await setupTestDatabaseWithCollections();
 			const contentRepo = new ContentRepository(db);


### PR DESCRIPTION
## What does this PR do?

Fixes the `GET /_emdash/api/dashboard` 500 error on Cloudflare D1 (and the miniflare D1 emulator) when a project has enough title-bearing collections. The admin dashboard fails to render for every authenticated user once the threshold is crossed (reproduced at 9 arms in the issue).

**Root cause:** `fetchRecentItems` in `packages/core/src/api/handlers/dashboard.ts` composes a single chained `UNION ALL` across every title-bearing collection and wraps it in an outer `SELECT * FROM (combined) ORDER BY updated_at DESC LIMIT 10`. D1 enforces a `SQLITE_LIMIT_COMPOUND_SELECT` cap that is tighter than upstream SQLite's default of 500, so the query fails on D1 even though the same SQL runs fine against `better-sqlite3`. This is a 0.7.0 → 0.8.0 regression and is unchanged in 0.9.0.

**Fix:** Replace the chained `UNION ALL` with N per-collection queries fired in parallel via `Promise.all`, then merge / sort / slice in JS. Equivalent semantics, no schema changes, no D1-specific branching, and at most `N * 10` rows materialized before the final `slice(0, 10)`. Per-arm `sql.lit(label)` interpolation is preserved (kept on the outer side of each per-collection query, identical to the previous arm shape).

This patch was developed and validated in production at https://github.com/cristianuibar/wishday-web (12 collections, 9 title-bearing) by running `pnpm patch emdash@0.8.0` against the affected file. The dashboard has rendered cleanly under that patch through staging deploys; this PR upstreams the same change.

Closes #895

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics introduced; pre-existing main-branch warnings unchanged)
- [x] `pnpm test` passes (or targeted tests for my change) — `tests/unit/api/dashboard-handlers.test.ts` 11/11 pass; the 8 pre-existing failures in `vite-config.test.ts`, `wordpress-slug-sanitization.test.ts`, and `wp-prepare-invalidate.test.ts` reproduce on `origin/main` and are unrelated to this change
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. _N/A — no admin UI strings touched._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — `.changeset/fix-dashboard-d1-compound-select.md`, `emdash: patch`
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _N/A — bug fix._

### Test notes

The added regression test (`merges recent items across many title-bearing collections (#895)`) creates 12 collections each with a `title` field and one entry, then asserts the merged top-10 contract: count = 10, ordered by `updated_at` desc, drawn across all collections.

Caveat — the original D1 `SQLITE_LIMIT_COMPOUND_SELECT` cap cannot be reproduced under `better-sqlite3` (its compound-SELECT limit is upstream SQLite's default of 500), so this test will not _fail_ against the previous `UNION ALL` code path. It exists as a behavioral regression guard for the per-collection merge contract introduced by this fix and would catch a future revert. The actual 500 was reproduced and fixed against live Cloudflare D1 in https://github.com/cristianuibar/wishday-web via `pnpm patch`; the patch shipped here is equivalent.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (1M context) via Claude Code

## Screenshots / test output

```
$ cd packages/core && pnpm exec vitest run tests/unit/api/dashboard-handlers.test.ts
 ✓ tests/unit/api/dashboard-handlers.test.ts (11 tests) 463ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
```