### PR TITLE
fix(create-emdash): accept "." in the Project name? prompt

### DIFF
--- a/.changeset/olive-loops-change.md
+++ b/.changeset/olive-loops-change.md
@@ -1,0 +1,5 @@
+---
+"create-emdash": patch
+---
+
+Fixes interactive `Project name?` prompt to accept `.` for the current directory. The flag-positional path already accepted `.` (validated by `validateProjectName`), but the prompt's inline regex check rejected it, so users running `npm create emdash@latest` with no arguments could not scaffold into the current directory. The prompt now uses `validateProjectName` directly for parity, and its message hints at the `.` option.

--- a/packages/create-emdash/src/index.ts
+++ b/packages/create-emdash/src/index.ts
@@ -31,12 +31,7 @@ import {
 	validateProjectName,
 	wantsHelp,
 } from "./flags.js";
-import {
-	PROJECT_NAME_PATTERN,
-	isDirNonEmpty,
-	sanitizePackageName,
-	writeEncryptionKey,
-} from "./utils.js";
+import { isDirNonEmpty, sanitizePackageName, writeEncryptionKey } from "./utils.js";
 
 const GITHUB_REPO = "emdash-cms/templates";
 
@@ -179,10 +174,30 @@ async function resolveProjectLocation(
 		}
 	}
 
-	const target = flags.name;
-	const isCurrentDir = target === ".";
+	let target = flags.name;
 
-	if (isCurrentDir) {
+	if (target === undefined) {
+		if (flags.yes) {
+			// --yes with no positional: fall back to the documented default
+			// rather than silently dropping into the (broken-in-non-TTY) prompt.
+			// This is the contract documented in flags.ts and HELP_TEXT.
+			target = DEFAULT_PROJECT_NAME;
+		} else {
+			const name = await p.text({
+				message: 'Project name? (use "." for current directory)',
+				placeholder: DEFAULT_PROJECT_NAME,
+				defaultValue: DEFAULT_PROJECT_NAME,
+				validate: (value) => {
+					if (!value) return "Project name is required";
+					return validateProjectName(value);
+				},
+			});
+			if (p.isCancel(name)) return null;
+			target = name;
+		}
+	}
+
+	if (target === ".") {
 		const projectDir = process.cwd();
 		const projectName = sanitizePackageName(basename(projectDir));
 		if (isDirNonEmpty(projectDir)) {
@@ -205,30 +220,7 @@ async function resolveProjectLocation(
 		return { projectName, projectDir, isCurrentDir: true };
 	}
 
-	let projectName: string;
-	if (target !== undefined) {
-		projectName = target;
-	} else if (flags.yes) {
-		// --yes with no positional: fall back to the documented default
-		// rather than silently dropping into the (broken-in-non-TTY) prompt.
-		// This is the contract documented in flags.ts and HELP_TEXT.
-		projectName = DEFAULT_PROJECT_NAME;
-	} else {
-		const name = await p.text({
-			message: "Project name?",
-			placeholder: DEFAULT_PROJECT_NAME,
-			defaultValue: DEFAULT_PROJECT_NAME,
-			validate: (value) => {
-				if (!value) return "Project name is required";
-				if (!PROJECT_NAME_PATTERN.test(value))
-					return "Project name can only contain lowercase letters, numbers, and hyphens";
-				return undefined;
-			},
-		});
-		if (p.isCancel(name)) return null;
-		projectName = name;
-	}
-
+	const projectName = target;
 	const projectDir = resolve(process.cwd(), projectName);
 	if (isDirNonEmpty(projectDir)) {
 		if (flags.yes && !flags.force) {


### PR DESCRIPTION
## What does this PR do?

Closes #894

The interactive `Project name?` prompt in `create-emdash` rejected `.` as a project name, even though the flag-positional path (e.g. `npm create emdash@latest .`) already accepted it via `validateProjectName`. Users who ran `npm create emdash@latest` without arguments had no way to scaffold into the current directory from the prompt.

The prompt validator now delegates to the same `validateProjectName` helper the flag path uses, and the prompt message gains a hint about `.`. Behavior on every other path (flag positional, `--yes`, `--yes --force`, non-empty cwd confirm) is unchanged -- the `target === "."` branch in `resolveProjectLocation` already handles current-directory scaffolding.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`packages/create-emdash`)
- [x] `pnpm lint` passes -- diagnostic count unchanged (45 on `main`, 45 on this branch; all pre-existing)
- [x] `pnpm test` passes (`103 passed` in `create-emdash`)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation -- N/A, this is the CLI scaffolder, not the admin UI
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) -- `.changeset/olive-loops-change.md`, `create-emdash: patch`
- [ ] New features link to an approved Discussion -- N/A (bug fix)

### Tests

`packages/create-emdash/tests/flags.test.ts` already exercises `validateProjectName(".")` returning `undefined` ("returns undefined for `.` (current-dir sentinel)"). The fix is precisely "make the prompt validator call this same helper", so the existing test now also covers the prompt path's accept-of-`.` behavior. No new test was added because the validator is the unit under test and was already covered.

If reviewers prefer an explicit prompt-path test, happy to add one -- it would mock `@clack/prompts.text` and assert that `validateProjectName` is the validate fn.

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7

## Screenshots / test output

```
$ pnpm test
 ✓ tests/flags.test.ts (51 tests) 4ms
 ✓ tests/utils.test.ts (52 tests) 6ms
 Test Files  2 passed (2)
      Tests  103 passed (103)
```