### PR TITLE
templates+demos: drop init/seed scripts and stale D1 setup steps

### DIFF
--- a/demos/cloudflare/README.md
+++ b/demos/cloudflare/README.md
@@ -6,33 +6,15 @@ Uses Astro 6 + `@astrojs/cloudflare` v13 which runs the real `workerd` runtime i
 
 ## Setup
 
-1. Create a D1 database:
-
-```bash
-pnpm db:create
-```
-
-2. Copy the database ID from the output and update `wrangler.jsonc`:
-
-```jsonc
-"d1_databases": [
-  {
-    "binding": "DB",
-    "database_name": "emdash-demo",
-    "database_id": "YOUR_DATABASE_ID_HERE"
-  }
-]
-```
-
-3. Start the dev server:
+1. Start the dev server:
 
 ```bash
 pnpm dev
 ```
 
-EmDash runs migrations automatically on first request — no manual migration step needed.
+EmDash runs migrations automatically on first request — no manual migration or DB-create step needed. Wrangler provisions the D1 database on first deploy.
 
-4. Open http://localhost:4321/\_emdash/admin
+2. Open http://localhost:4321/\_emdash/admin
 
 ## Preview
 

--- a/demos/cloudflare/package.json
+++ b/demos/cloudflare/package.json
@@ -9,7 +9,6 @@
     "build:all": "pnpm run --filter @emdash-cms/demo-cloudflare... build",
     "preview": "astro preview",
     "deploy": "pnpm build:all && wrangler deploy",
-    "db:create": "wrangler d1 create emdash-demo",
     "db:reset:remote": "./scripts/reset-db.sh",
     "typecheck": "astro check"
   },

--- a/demos/plugins-demo/package.json
+++ b/demos/plugins-demo/package.json
@@ -8,7 +8,6 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
-    "seed": "emdash seed",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/demos/simple/package.json
+++ b/demos/simple/package.json
@@ -11,8 +11,6 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
-    "bootstrap": "emdash init && emdash seed",
-    "seed": "emdash seed",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/docs/src/content/docs/themes/seed-files.mdx
+++ b/docs/src/content/docs/themes/seed-files.mdx
@@ -659,6 +659,9 @@ Validation checks:
 The seed file at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty. To export an existing site's schema (and optionally its content) as a seed file:
 
 ```bash
+# `mkdir -p` because .emdash/ may not exist yet on a fresh project
+mkdir -p .emdash
+
 # Export the current schema as a seed file
 npx emdash export-seed > .emdash/seed.json
 

--- a/skills/building-emdash-site/SKILL.md
+++ b/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/skills/building-emdash-site/references/configuration.md
+++ b/skills/building-emdash-site/references/configuration.md
@@ -97,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/skills/building-emdash-site/references/schema-and-seed.md
+++ b/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/skills/emdash-cli/SKILL.md
+++ b/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/skills/emdash-cli/SKILL.md
+++ b/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation

--- a/skills/wordpress-plugin-to-emdash/SKILL.md
+++ b/skills/wordpress-plugin-to-emdash/SKILL.md
@@ -229,9 +229,7 @@ WordPress plugins that call `wp_insert_term()`, `register_nav_menu()`, or insert
 }
 ```
 
-```bash
-npx emdash seed .emdash/seed.json
-```
+Save to `.emdash/seed.json` (or wire up via `package.json#emdash.seed`); the runtime applies it on the next first-boot when the database is empty.
 
 Use `redirects` for legacy WordPress URLs that still receive traffic after migration.
 

--- a/skills/wordpress-theme-to-emdash/SKILL.md
+++ b/skills/wordpress-theme-to-emdash/SKILL.md
@@ -63,12 +63,11 @@ Port WordPress themes to EmDash in six phases. **Read the phase file before star
 
 ### Phase 5: Seed
 
-- [ ] Seed file created with demo images
-- [ ] Validates: `emdash seed --validate`
+- [ ] Seed file created with demo images at `.emdash/seed.json` (or wired up via `package.json#emdash.seed`)
 
 ### Phase 6: Verify
 
-- [ ] Seed applied
+- [ ] Dev server applied seed cleanly on first request (no validation errors in logs)
 - [ ] Output screenshots captured
 - [ ] Visual comparison done
 - [ ] Build succeeds: `pnpm build`

--- a/skills/wordpress-theme-to-emdash/phases/5-seed.md
+++ b/skills/wordpress-theme-to-emdash/phases/5-seed.md
@@ -18,12 +18,9 @@ Combine all theme features into a seed file with sample content.
    }
    ```
 
-## 5.2 Validate Before Applying
+## 5.2 Validation
 
-```bash
-# Validate without applying
-emdash seed --validate
-```
+The seed is applied automatically on the first request when the database is empty (and no setup wizard run yet). Validation runs at apply time — errors show up in the dev server logs. Restart the dev server after fixing them.
 
 The validator catches common mistakes:
 

--- a/skills/wordpress-theme-to-emdash/phases/6-verify.md
+++ b/skills/wordpress-theme-to-emdash/phases/6-verify.md
@@ -2,24 +2,19 @@
 
 Seed content, run the dev server, compare screenshots, and iterate until pages match.
 
-## 6.1 Apply the Seed
+## 6.1 Start Dev Server
 
-```bash
-# Validate first
-emdash seed --validate
-
-# Apply seed with content
-emdash seed
-```
-
-## 6.2 Start Dev Server
+The seed is applied on the first request when the database is empty. If you've already run the dev server against an existing database, delete `data.db` first so the seed reapplies.
 
 Kill any existing server first:
 
 ```bash
 lsof -ti:4321 | xargs kill -9 2>/dev/null || true
+rm -f data.db   # only if you need a clean slate
 pnpm dev
 ```
+
+Watch the logs for any seed validation errors and fix them before continuing.
 
 ## 6.3 Screenshot Each Page Type
 

--- a/skills/wordpress-theme-to-emdash/references/emdash-api.md
+++ b/skills/wordpress-theme-to-emdash/references/emdash-api.md
@@ -380,37 +380,16 @@ import { PortableText } from "emdash/ui";
 
 ## CLI Commands
 
-### Seed Validation
+### Apply Seed
 
-Validate seed files before applying:
+The seed is inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed. Validation runs at apply time — errors surface in the dev server logs. To re-seed during iteration, delete `data.db` and restart the dev server.
 
-```bash
-# Validate default seed file (.emdash/seed.json)
-emdash seed --validate
-
-# Validate a specific file
-emdash seed path/to/seed.json --validate
-```
-
-Catches common mistakes:
+Common validation errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
-
-### Apply Seed
-
-```bash
-# Apply seed with content
-emdash seed
-
-# Apply seed without sample content
-emdash seed --no-content
-
-# Specify database path
-emdash seed --database ./my-data.db
-```
 
 ### Export Seed
 

--- a/skills/wordpress-theme-to-emdash/scaffold/CHECKLIST.md
+++ b/skills/wordpress-theme-to-emdash/scaffold/CHECKLIST.md
@@ -77,11 +77,10 @@ Use this checklist to track progress when porting a WordPress theme to EmDash.
   - [ ] Posts (3-5 with varied content)
   - [ ] Pages (About, Contact, etc.)
 - [ ] Images use `$media` syntax with `discovery/images/` files
-- [ ] Seed validates: `emdash seed --validate`
 
 ## Phase 6: Verify & Iterate
 
-- [ ] Seed applied successfully: `emdash seed`
+- [ ] Dev server applied seed cleanly on first request (no validation errors in logs)
 - [ ] Dev server running: `pnpm dev`
 - [ ] Output screenshots captured to `output/`:
   - [ ] Homepage

--- a/templates/blank/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blank/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/blank/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/blank/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/blank/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/blank/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/blank/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/blank/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/blank/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/blank/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blank/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/blank/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blank/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/blank/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blank/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/blank/AGENTS.md
+++ b/templates/blank/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -8,7 +8,6 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
-    "bootstrap": "emdash init",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/blog-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/blog-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blog-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/blog-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blog-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/blog-cloudflare/AGENTS.md
+++ b/templates/blog-cloudflare/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/blog-cloudflare/package.json
+++ b/templates/blog-cloudflare/package.json
@@ -11,9 +11,7 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"deploy": "astro build && wrangler deploy",
-		"typecheck": "astro check",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed"
+		"typecheck": "astro check"
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "catalog:",

--- a/templates/blog-cloudflare/wrangler.jsonc
+++ b/templates/blog-cloudflare/wrangler.jsonc
@@ -8,8 +8,6 @@
 		{
 			"binding": "DB",
 			"database_name": "my-emdash-site",
-			// Run `wrangler d1 create my-emdash-site` and paste the real ID here for deploy
-			"database_id": "local",
 		},
 	],
 	"r2_buckets": [

--- a/templates/blog/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/blog/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/blog/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/blog/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/blog/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/blog/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/blog/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/blog/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/blog/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/blog/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blog/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/blog/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blog/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/blog/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/blog/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/blog/AGENTS.md
+++ b/templates/blog/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/blog/package.json
+++ b/templates/blog/package.json
@@ -11,8 +11,6 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
-    "bootstrap": "emdash init && emdash seed",
-    "seed": "emdash seed",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/marketing-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/marketing-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/marketing-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/marketing-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/marketing-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/marketing-cloudflare/AGENTS.md
+++ b/templates/marketing-cloudflare/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/marketing-cloudflare/package.json
+++ b/templates/marketing-cloudflare/package.json
@@ -11,9 +11,7 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"deploy": "astro build && wrangler deploy",
-		"typecheck": "astro check",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed"
+		"typecheck": "astro check"
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "catalog:",

--- a/templates/marketing-cloudflare/wrangler.jsonc
+++ b/templates/marketing-cloudflare/wrangler.jsonc
@@ -8,8 +8,6 @@
 		{
 			"binding": "DB",
 			"database_name": "my-marketing-site",
-			// Run `wrangler d1 create my-marketing-site` and paste the real ID here for deploy
-			"database_id": "local",
 		},
 	],
 	"r2_buckets": [

--- a/templates/marketing/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/marketing/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/marketing/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/marketing/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/marketing/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/marketing/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/marketing/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/marketing/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/marketing/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/marketing/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/marketing/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/marketing/AGENTS.md
+++ b/templates/marketing/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/marketing/package.json
+++ b/templates/marketing/package.json
@@ -11,8 +11,6 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"start": "node ./dist/server/entry.mjs",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed",
 		"typecheck": "astro check"
 	},
 	"dependencies": {

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/portfolio-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/portfolio-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/portfolio-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/portfolio-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/portfolio-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/portfolio-cloudflare/AGENTS.md
+++ b/templates/portfolio-cloudflare/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/portfolio-cloudflare/package.json
+++ b/templates/portfolio-cloudflare/package.json
@@ -11,9 +11,7 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"deploy": "astro build && wrangler deploy",
-		"typecheck": "astro check",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed"
+		"typecheck": "astro check"
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "catalog:",

--- a/templates/portfolio-cloudflare/wrangler.jsonc
+++ b/templates/portfolio-cloudflare/wrangler.jsonc
@@ -8,8 +8,6 @@
 		{
 			"binding": "DB",
 			"database_name": "my-portfolio-site",
-			// Run `wrangler d1 create my-portfolio-site` and paste the real ID here for deploy
-			"database_id": "local",
 		},
 	],
 	"r2_buckets": [

--- a/templates/portfolio/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/portfolio/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/portfolio/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/portfolio/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/portfolio/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/portfolio/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/portfolio/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/portfolio/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/portfolio/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/portfolio/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/portfolio/AGENTS.md
+++ b/templates/portfolio/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/portfolio/package.json
+++ b/templates/portfolio/package.json
@@ -11,8 +11,6 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"start": "node ./dist/server/entry.mjs",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed",
 		"typecheck": "astro check"
 	},
 	"dependencies": {

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/starter-cloudflare/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/starter-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/starter-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/starter-cloudflare/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/starter-cloudflare/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/starter-cloudflare/AGENTS.md
+++ b/templates/starter-cloudflare/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/starter-cloudflare/package.json
+++ b/templates/starter-cloudflare/package.json
@@ -11,9 +11,7 @@
 		"build": "astro build",
 		"preview": "astro preview",
 		"deploy": "astro build && wrangler deploy",
-		"typecheck": "astro check",
-		"bootstrap": "emdash init && emdash seed",
-		"seed": "emdash seed"
+		"typecheck": "astro check"
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "catalog:",

--- a/templates/starter-cloudflare/wrangler.jsonc
+++ b/templates/starter-cloudflare/wrangler.jsonc
@@ -8,8 +8,6 @@
 		{
 			"binding": "DB",
 			"database_name": "my-emdash-site",
-			// Run `wrangler d1 create my-emdash-site` and paste the real ID here for deploy
-			"database_id": "local",
 		},
 	],
 	"r2_buckets": [

--- a/templates/starter/.agents/skills/building-emdash-site/SKILL.md
+++ b/templates/starter/.agents/skills/building-emdash-site/SKILL.md
@@ -59,11 +59,7 @@ Read **[references/site-features.md](references/site-features.md)** for site set
 
 ### 5. Create the seed file
 
-Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content. Validate with:
-
-```bash
-npx emdash seed seed/seed.json --validate
-```
+Write `seed/seed.json` with collections, fields, taxonomies, menus, widgets, and sample content.
 
 ### 6. Run and verify
 

--- a/templates/starter/.agents/skills/building-emdash-site/references/configuration.md
+++ b/templates/starter/.agents/skills/building-emdash-site/references/configuration.md
@@ -32,6 +32,32 @@ export default defineConfig({
 });
 ```
 
+### Reverse proxy
+
+When behind a TLS-terminating reverse proxy, `Astro.url` returns the internal address (e.g. `http://localhost:4321`) instead of the public one (`https://mysite.example.com`). This breaks passkeys, CSRF, OAuth, redirects, and more.
+
+**Step 1:** Declare allowed public hosts via [`security.allowedDomains`](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) so Astro reconstructs the URL from `X-Forwarded-*` headers. In dev, add matching **`vite.server.allowedHosts`** or Vite rejects the proxy `Host`.
+
+**Step 2:** If the reconstructed URL still disagrees with the browser (common with TLS termination), set **`siteUrl`**:
+
+```javascript
+emdash({
+	siteUrl: "https://mysite.example.com",
+	// ...
+});
+```
+
+Or via environment variable (useful for container deployments):
+
+```bash
+EMDASH_SITE_URL=https://mysite.example.com
+# or: SITE_URL=https://mysite.example.com
+```
+
+`siteUrl` replaces `passkeyPublicOrigin` (which only fixed passkeys). It applies to passkeys, CSRF origin matching, OAuth redirects, login redirects, MCP discovery, snapshot exports, sitemap, robots.txt, and JSON-LD structured data.
+
+With TLS terminated in front, **`astro dev --host 127.0.0.1`** (loopback) is usually enough: the proxy reaches the dev server locally while **`siteUrl`** matches the browser’s HTTPS origin -- without opening the Node port on the LAN.
+
 ### Cloudflare (D1 + R2)
 
 ```javascript
@@ -71,7 +97,6 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 		{
 			"binding": "DB",
 			"database_name": "my-site",
-			"database_id": "", // from `wrangler d1 create my-site`
 		},
 	],
 	"r2_buckets": [

--- a/templates/starter/.agents/skills/building-emdash-site/references/schema-and-seed.md
+++ b/templates/starter/.agents/skills/building-emdash-site/references/schema-and-seed.md
@@ -1,6 +1,6 @@
 # Schema and Seed Files
 
-The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's applied on first run or via `npx emdash seed seed/seed.json`.
+The seed file (`seed/seed.json`) defines the site's entire schema and optional demo content. It's inlined into the build and applied automatically on the first request when the database is empty and the setup wizard hasn't been completed.
 
 ## Seed File Structure
 
@@ -440,25 +440,18 @@ Set `"status": "draft"` to create unpublished content:
 }
 ```
 
-## Validation
+## Applying Seeds
 
-```bash
-npx emdash seed seed/seed.json --validate
-```
+The seed at `.emdash/seed.json`, `package.json#emdash.seed`, or `seed/seed.json` is inlined into the build and applied on the first request when the database is empty and the setup wizard hasn't been completed. Existing data is never overwritten.
 
-Catches:
+Validation runs at apply time. Common errors caught:
 
 - Image fields with raw URLs (should use `$media`)
 - Reference fields with raw IDs (should use `$ref:id`)
 - PortableText not an array or missing `_type`
 - Type mismatches (string vs number, etc.)
 
-## Applying Seeds
-
-```bash
-npx emdash seed seed/seed.json              # Apply with content
-npx emdash seed seed/seed.json --no-content  # Schema only (no sample content)
-```
+If the seed is invalid, the first request fails and the error is logged. Restart the dev server after fixing it.
 
 ## Exporting Seeds
 

--- a/templates/starter/.agents/skills/creating-plugins/SKILL.md
+++ b/templates/starter/.agents/skills/creating-plugins/SKILL.md
@@ -132,14 +132,14 @@ EmDash has two execution modes. Plugin code is identical in both — only the en
 
 Trusted plugins are npm packages or local files added in `astro.config.mjs`. They run in-process with your Astro site.
 
-- **Capabilities are documentation only.** Declaring `["read:content"]` documents intent but isn't enforced — the plugin has full process access.
+- **Capabilities are documentation only.** Declaring `["content:read"]` documents intent but isn't enforced — the plugin has full process access.
 - Only install from sources you trust. A malicious trusted plugin has the same access as your application code.
 
 ### Sandboxed Mode
 
 Sandboxed plugins run in isolated V8 isolates on Cloudflare Workers via [Dynamic Worker Loader](https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/). Each plugin gets its own isolate.
 
-- **Capabilities are enforced.** If a plugin declares `["read:content"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
+- **Capabilities are enforced.** If a plugin declares `["content:read"]`, it can only call `ctx.content.get()` and `ctx.content.list()`. Attempting `ctx.content.create()` throws a permission error.
 - **Network is blocked by default.** Direct `fetch()` calls fail. Plugins must use `ctx.http.fetch()`, which validates against `allowedHosts`.
 - **Storage is scoped.** A plugin can only access its own KV and storage collections.
 - **Admin UI uses Block Kit.** Sandboxed plugins describe their UI as JSON blocks -- no plugin JavaScript runs in the browser. See [Block Kit reference](./references/block-kit.md).
@@ -161,7 +161,7 @@ export default definePlugin({
 	hooks: {
 		"content:afterSave": {
 			handler: async (event: any, ctx: PluginContext) => {
-				// Trusted: ctx.http present because descriptor declares network:fetch
+				// Trusted: ctx.http present because descriptor declares network:request
 				// Sandboxed: ctx.http present and enforced via RPC bridge
 				if (!ctx.http) return;
 				await ctx.http.fetch("https://api.analytics.example.com/track", {
@@ -180,25 +180,27 @@ Key constraint for sandbox compatibility: **no Node.js built-ins** (`fs`, `path`
 
 Capabilities control what APIs are available on `ctx`. Always declare what your plugin needs — even in trusted mode, they document intent and are required for sandboxed execution.
 
-| Capability        | Grants                                                                 | `ctx` property |
-| ----------------- | ---------------------------------------------------------------------- | -------------- |
-| `read:content`    | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
-| `write:content`   | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
-| `read:media`      | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
-| `write:media`     | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
-| `network:fetch`   | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
-| `read:users`      | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
-| `email:send`      | `ctx.email.send()` — send email through the pipeline                   | `email`        |
-| `email:provide`   | Can register `email:deliver` exclusive hook (transport provider)       | —              |
-| `email:intercept` | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| Capability                       | Grants                                                                 | `ctx` property |
+| -------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| `content:read`                   | `ctx.content.get()`, `ctx.content.list()`                              | `content`      |
+| `content:write`                  | `ctx.content.create()`, `ctx.content.update()`, `ctx.content.delete()` | `content`      |
+| `media:read`                     | `ctx.media.get()`, `ctx.media.list()`                                  | `media`        |
+| `media:write`                    | `ctx.media.getUploadUrl()`, `ctx.media.delete()`                       | `media`        |
+| `network:request`                | `ctx.http.fetch()` (restricted to `allowedHosts`)                      | `http`         |
+| `network:request:unrestricted`   | `ctx.http.fetch()` (unrestricted — for user-configured URLs)           | `http`         |
+| `users:read`                     | `ctx.users.get()`, `ctx.users.list()`, `ctx.users.getByEmail()`        | `users`        |
+| `email:send`                     | `ctx.email.send()` — send email through the pipeline                   | `email`        |
+| `hooks.email-transport:register` | Can register `email:deliver` exclusive hook (transport provider)       | —              |
+| `hooks.email-events:register`    | Can register `email:beforeSend` / `email:afterSend` hooks              | —              |
+| `hooks.page-fragments:register`  | Can register `page:fragments` hook (inject scripts/styles into pages)  | —              |
 
 Storage (`ctx.storage`) and KV (`ctx.kv`) are **always available** — no capability needed. They're automatically scoped to the plugin.
 
 **Email capabilities are distinct:**
 
 - `email:send` — for plugins that _consume_ email (call `ctx.email.send()`)
-- `email:provide` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
-- `email:intercept` — for plugins that _observe or transform_ email (middleware hooks)
+- `hooks.email-transport:register` — for plugins that _deliver_ email (implement the transport, e.g. Resend, SMTP)
+- `hooks.email-events:register` — for plugins that _observe or transform_ email (middleware hooks)
 
 ```typescript
 // In the descriptor (index.ts)
@@ -209,7 +211,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com", "*.googleapis.com"], // Wildcards supported
 	};
 }
@@ -296,7 +298,7 @@ export function submissionsPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/plugin-submissions/sandbox",
 		options: {},
-		capabilities: ["read:content"],
+		capabilities: ["content:read"],
 		storage: {
 			submissions: {
 				indexes: ["formId", "status", "createdAt"],
@@ -415,10 +417,10 @@ interface PluginContext {
 	storage: Record<string, StorageCollection>; // Declared collections
 	kv: KVAccess; // Key-value store
 	log: LogAccess; // Structured logger
-	content?: ContentAccess; // If "read:content" capability
-	media?: MediaAccess; // If "read:media" capability
-	http?: HttpAccess; // If "network:fetch" capability
-	users?: UserAccess; // If "read:users" capability
+	content?: ContentAccess; // If "content:read" capability
+	media?: MediaAccess; // If "media:read" capability
+	http?: HttpAccess; // If "network:request" capability
+	users?: UserAccess; // If "users:read" capability
 	cron?: CronAccess; // Always available — scoped to plugin
 	email?: EmailAccess; // If "email:send" capability AND a provider is configured
 }
@@ -435,7 +437,7 @@ export function myPlugin(): PluginDescriptor {
 		format: "standard",
 		entrypoint: "@my-org/my-plugin/sandbox",
 		options: {},
-		capabilities: ["read:content", "network:fetch"],
+		capabilities: ["content:read", "network:request"],
 		allowedHosts: ["api.example.com"],
 		storage: { events: { indexes: ["timestamp"] } },
 	};

--- a/templates/starter/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/api-routes.md
@@ -215,11 +215,11 @@ routes: {
 
 ### External API Proxy
 
-Requires `network:fetch` capability and `allowedHosts`:
+Requires `network:request` capability and `allowedHosts`:
 
 ```typescript
 definePlugin({
-	capabilities: ["network:fetch"],
+	capabilities: ["network:request"],
 	allowedHosts: ["api.weather.example.com"],
 
 	routes: {

--- a/templates/starter/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/hooks.md
@@ -424,12 +424,12 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
 | `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
 | `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
-| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
-| `content:afterSave`      | After save           | —                                | `void`                       |
-| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
-| `content:afterDelete`    | After delete         | —                                | `void`                       |
-| `content:afterPublish`   | After publish        | —                                | `void`                       |
-| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | `content:write`                  | Modified content or `void`   |
+| `content:afterSave`      | After save           | `content:read`                   | `void`                       |
+| `content:beforeDelete`   | Before delete        | `content:read`                   | `false` to cancel            |
+| `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
+| `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
+| `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/starter/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/hooks.md
@@ -163,6 +163,32 @@ Runs after successful delete.
 Event: `{ id: string, collection: string }`
 Returns: `void`
 
+### `content:afterPublish`
+
+Runs after content is published (promoted from draft to live). Side effects only.
+
+```typescript
+"content:afterPublish": async (event, ctx) => {
+	ctx.log.info(`Published ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
+### `content:afterUnpublish`
+
+Runs after content is unpublished (reverted to draft). Side effects only.
+
+```typescript
+"content:afterUnpublish": async (event, ctx) => {
+	ctx.log.info(`Unpublished ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -207,14 +233,14 @@ Email hooks require specific capabilities. Without the required capability, hook
 
 ### `email:beforeSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs before email delivery. Return modified message, or `false` to cancel delivery. Handlers are chained — each receives the output of the previous one.
 
 ```typescript
 definePlugin({
 	id: "email-footer",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:beforeSend": async (event, ctx) => {
 			return { ...event.message, text: event.message.text + "\n\n-- Sent via EmDash" };
@@ -228,14 +254,14 @@ Returns: `EmailMessage | false`
 
 ### `email:deliver`
 
-**Requires:** `email:provide` capability. **Exclusive hook** — exactly one provider is active.
+**Requires:** `hooks.email-transport:register` capability. **Exclusive hook** — exactly one provider is active.
 
 Implements email transport (e.g. Resend, SMTP, SES). Selected by the admin in Settings > Email.
 
 ```typescript
 definePlugin({
 	id: "emdash-resend",
-	capabilities: ["email:provide", "network:fetch"],
+	capabilities: ["hooks.email-transport:register", "network:request"],
 	allowedHosts: ["api.resend.com"],
 	hooks: {
 		"email:deliver": {
@@ -258,14 +284,14 @@ Returns: `void`
 
 ### `email:afterSend`
 
-**Requires:** `email:intercept` capability.
+**Requires:** `hooks.email-events:register` capability.
 
 Runs after successful delivery. Fire-and-forget — errors are logged but don't propagate.
 
 ```typescript
 definePlugin({
 	id: "email-logger",
-	capabilities: ["email:intercept"],
+	capabilities: ["hooks.email-events:register"],
 	hooks: {
 		"email:afterSend": async (event, ctx) => {
 			ctx.log.info(`Email sent to ${event.message.to}`, { source: event.source });
@@ -392,21 +418,23 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 
 ## Quick Reference
 
-| Hook                   | Trigger              | Capability Required | Return                       |
-| ---------------------- | -------------------- | ------------------- | ---------------------------- |
-| `plugin:install`       | First install        | —                   | `void`                       |
-| `plugin:activate`      | Plugin enabled       | —                   | `void`                       |
-| `plugin:deactivate`    | Plugin disabled      | —                   | `void`                       |
-| `plugin:uninstall`     | Plugin removed       | —                   | `void`                       |
-| `content:beforeSave`   | Before save          | —                   | Modified content or `void`   |
-| `content:afterSave`    | After save           | —                   | `void`                       |
-| `content:beforeDelete` | Before delete        | —                   | `false` to cancel            |
-| `content:afterDelete`  | After delete         | —                   | `void`                       |
-| `media:beforeUpload`   | Before upload        | —                   | Modified file info or `void` |
-| `media:afterUpload`    | After upload         | —                   | `void`                       |
-| `email:beforeSend`     | Before email send    | `email:intercept`   | Modified message or `false`  |
-| `email:deliver`        | Email delivery       | `email:provide`     | `void` (exclusive)           |
-| `email:afterSend`      | After email send     | `email:intercept`   | `void`                       |
-| `cron`                 | Scheduled task fires | —                   | `void`                       |
-| `page:metadata`        | Page render          | —                   | Metadata contributions       |
-| `page:fragments`       | Page render          | — (trusted only)    | Fragment contributions       |
+| Hook                     | Trigger              | Capability Required              | Return                       |
+| ------------------------ | -------------------- | -------------------------------- | ---------------------------- |
+| `plugin:install`         | First install        | —                                | `void`                       |
+| `plugin:activate`        | Plugin enabled       | —                                | `void`                       |
+| `plugin:deactivate`      | Plugin disabled      | —                                | `void`                       |
+| `plugin:uninstall`       | Plugin removed       | —                                | `void`                       |
+| `content:beforeSave`     | Before save          | —                                | Modified content or `void`   |
+| `content:afterSave`      | After save           | —                                | `void`                       |
+| `content:beforeDelete`   | Before delete        | —                                | `false` to cancel            |
+| `content:afterDelete`    | After delete         | —                                | `void`                       |
+| `content:afterPublish`   | After publish        | —                                | `void`                       |
+| `content:afterUnpublish` | After unpublish      | —                                | `void`                       |
+| `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
+| `media:afterUpload`      | After upload         | —                                | `void`                       |
+| `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |
+| `email:deliver`          | Email delivery       | `hooks.email-transport:register` | `void` (exclusive)           |
+| `email:afterSend`        | After email send     | `hooks.email-events:register`    | `void`                       |
+| `cron`                   | Scheduled task fires | —                                | `void`                       |
+| `page:metadata`          | Page render          | —                                | Metadata contributions       |
+| `page:fragments`         | Page render          | — (trusted only)                 | Fragment contributions       |

--- a/templates/starter/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/starter/.agents/skills/emdash-cli/SKILL.md
@@ -80,6 +80,9 @@ npx emdash dev
 npx emdash dev --types
 
 # Export an existing database as a seed file
+# (the runtime auto-discovers .emdash/seed.json on first boot;
+# `mkdir -p` because the directory may not exist yet)
+mkdir -p .emdash
 npx emdash export-seed > .emdash/seed.json
 npx emdash export-seed --with-content > .emdash/seed.json
 ```

--- a/templates/starter/.agents/skills/emdash-cli/SKILL.md
+++ b/templates/starter/.agents/skills/emdash-cli/SKILL.md
@@ -70,22 +70,18 @@ npx emdash login --url https://example.com -H "X-API-Key: secret123"
 
 ### Database Setup
 
-```bash
-# Initialize database with migrations
-npx emdash init
+Migrations and seed application happen automatically inside the runtime — there's no separate init/seed step. Just start the dev server (or deploy) and the first request runs pending migrations and applies the bundled seed if the database is empty.
 
-# Start dev server (runs migrations, starts Astro)
+```bash
+# Start dev server (runs migrations, applies seed on empty DB, starts Astro)
 npx emdash dev
 
 # Start dev server and generate types from remote
 npx emdash dev --types
 
-# Apply a seed file
-npx emdash seed .emdash/seed.json
-
-# Export database as seed
-npx emdash export-seed > seed.json
-npx emdash export-seed --with-content > seed.json
+# Export an existing database as a seed file
+npx emdash export-seed > .emdash/seed.json
+npx emdash export-seed --with-content > .emdash/seed.json
 ```
 
 ### Type Generation
@@ -177,7 +173,7 @@ npx emdash schema add-field posts featured --type boolean --required
 npx emdash schema remove-field posts featured
 ```
 
-Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `image`, `reference`, `portableText`, `json`.
+Field types: `string`, `text`, `number`, `integer`, `boolean`, `datetime`, `select`, `multiSelect`, `image`, `file`, `reference`, `portableText`, `json`, `slug`, `url`. See `FIELD_TYPE_TO_COLUMN` in `packages/core/src/schema/types.ts` for the authoritative list.
 
 ### Media
 

--- a/templates/starter/AGENTS.md
+++ b/templates/starter/AGENTS.md
@@ -5,7 +5,6 @@ This is an EmDash site -- a CMS built on Astro with a full admin UI.
 ```bash
 npx emdash dev        # Start dev server (runs migrations, seeds, generates types)
 npx emdash types      # Regenerate TypeScript types from schema
-npx emdash seed seed/seed.json --validate  # Validate seed file
 ```
 
 The admin UI is at `http://localhost:4321/_emdash/admin`.

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -11,7 +11,6 @@
     "build": "astro build",
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
-    "bootstrap": "emdash init",
     "typecheck": "astro check"
   },
   "dependencies": {


### PR DESCRIPTION
## What does this PR do?

Brings the templates and demos in line with the runtime + deployment-doc behaviour landed in #899: the runtime auto-applies migrations and seeds on the first request, and Wrangler provisions D1 databases on first deploy when `database_id` is omitted. The templates and demos still pointed users at the old `emdash init` / `emdash seed` flow and the explicit `wrangler d1 create` + paste-the-id step.

Per-template/demo changes (the user-facing scope):

- **Drop `bootstrap` and `seed` scripts** from every template `package.json` (Node + Cloudflare) and from `demos/simple`, `demos/plugins-demo`. They wrapped `emdash init && emdash seed`, which the runtime now does itself.
- **Drop `database_id: "local"` and the "Run wrangler d1 create … and paste the real ID here" comment** from every Cloudflare template's `wrangler.jsonc`. Matches the shape `demos/cloudflare/wrangler.jsonc` already uses.
- **Drop the `db:create` script** from `demos/cloudflare/package.json` and **rewrite the Setup section** in `demos/cloudflare/README.md` to match: just `pnpm dev`, no manual create or paste step.

Skill / agent-doc changes (canonical sources, then synced):

- **`skills/building-emdash-site/`** — drop the `emdash seed --validate` step and the `database_id` placeholder comment in the Cloudflare config example. Rewrite "Applying Seeds" to describe runtime auto-apply.
- **`skills/emdash-cli/SKILL.md`** — replace the "Database Setup" recipe to point at `emdash dev` (which kicks off auto-migration + auto-seed) instead of separate `emdash init` / `emdash seed` calls.
- **`skills/wordpress-theme-to-emdash/`** and **`skills/wordpress-plugin-to-emdash/`** — same treatment in phases/5-seed.md, phases/6-verify.md, references/emdash-api.md, scaffold/CHECKLIST.md, and both `SKILL.md` files. Validation now happens at apply time; errors surface in dev server logs.
- **`templates/starter/AGENTS.md`** (canonical AGENTS.md per `scripts/sync-template-skills.sh`) — drop the `emdash seed --validate` line.

I then ran `scripts/sync-template-skills.sh` to propagate the canonical skill + AGENTS.md updates to all 8 templates. The sync also picked up pre-existing drift in the `creating-plugins` skill (capability rename `read:content` → `content:read`, `network:fetch` → `network:request`). Those are correct and overdue, so I included them rather than leaving more drift; flagging here so they don't surprise a reviewer.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (no code changes)
- [x] `pnpm lint` passes (no code changes)
- [x] `pnpm test` passes (or targeted tests for my change) — n/a, templates/skills/demos only
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, all templates/demos/skills are private workspace packages
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

n/a — config + prose changes only. Verified by re-running the audit grep across `templates/`, `demos/`, and `skills/` for `emdash init`, `emdash seed`, `wrangler d1 create`, and `database_id` after the edits — returns no hits.