### PR TITLE
cli: prompt for plugin format and align scaffolds with docs

### DIFF
--- a/.changeset/plugin-init-format-prompt.md
+++ b/.changeset/plugin-init-format-prompt.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+`emdash plugin init` now prompts for the plugin format (sandboxed or native) when run interactively, and the scaffolded boilerplate matches the canonical patterns from the docs. Both formats now ship a `dist/` build via tsdown, declare a sample `storage` collection, and demonstrate a hook plus an API route. The sandboxed entry uses an explicitly typed `ContentSaveEvent`; the native entry forwards options through `createPlugin`. The descriptor `id` is now derived from the slug instead of the full scoped package name, so scoped names like `@org/my-plugin` produce a runtime-valid id. Pass `--format=sandboxed`, `--format=native`, or `--native` to skip the prompt; non-TTY runs continue to default to sandboxed.

--- a/packages/core/src/cli/commands/plugin-init.ts
+++ b/packages/core/src/cli/commands/plugin-init.ts
@@ -119,10 +119,20 @@ async function resolveFormat(
 ): Promise<PluginFormat | null> {
 	if (formatArg) {
 		const normalized = formatArg.toLowerCase();
-		if (normalized === "native") return "native";
-		if (normalized === "sandboxed" || normalized === "standard") return "standard";
-		consola.error(`Invalid --format "${formatArg}". Use "sandboxed" or "native".`);
-		process.exit(1);
+		let parsed: PluginFormat;
+		if (normalized === "native") {
+			parsed = "native";
+		} else if (normalized === "sandboxed" || normalized === "standard") {
+			parsed = "standard";
+		} else {
+			consola.error(`Invalid --format "${formatArg}". Use "sandboxed" or "native".`);
+			process.exit(1);
+		}
+		if (nativeFlag && parsed !== "native") {
+			consola.error(`Conflicting flags: --native and --format=${formatArg}. Pass only one.`);
+			process.exit(1);
+		}
+		return parsed;
 	}
 	if (nativeFlag) return "native";
 
@@ -244,7 +254,7 @@ export function ${fnName}Plugin(): PluginDescriptor {
 \t\tformat: "standard",
 \t\tentrypoint: "${pluginName}/sandbox",
 
-\t\tcapabilities: [],
+\t\tcapabilities: ["content:read"],
 \t\tstorage: {
 \t\t\tevents: { indexes: ["timestamp"] },
 \t\t},
@@ -285,7 +295,10 @@ export default definePlugin({
 \troutes: {
 \t\trecent: {
 \t\t\thandler: async (_routeCtx, ctx: PluginContext) => {
-\t\t\t\tconst result = await ctx.storage.events.query({ limit: 10 });
+\t\t\t\tconst result = await ctx.storage.events.query({
+\t\t\t\t\torderBy: { timestamp: "desc" },
+\t\t\t\t\tlimit: 10,
+\t\t\t\t});
 \t\t\t\treturn { events: result.items };
 \t\t\t},
 \t\t},
@@ -353,7 +366,7 @@ export interface ${typeName}Options {
 \tenabled?: boolean;
 }
 
-export function ${fnName}Plugin(options: ${typeName}Options = {}): PluginDescriptor {
+export function ${fnName}Plugin(options: ${typeName}Options = {}): PluginDescriptor<${typeName}Options> {
 \treturn {
 \t\tid: "${slug}",
 \t\tversion: "0.1.0",
@@ -368,6 +381,7 @@ export function createPlugin(options: ${typeName}Options = {}) {
 \t\tid: "${slug}",
 \t\tversion: "0.1.0",
 
+\t\tcapabilities: ["content:read"],
 \t\tstorage: {
 \t\t\tevents: { indexes: ["createdAt"] },
 \t\t},
@@ -386,7 +400,10 @@ export function createPlugin(options: ${typeName}Options = {}) {
 \t\troutes: {
 \t\t\trecent: {
 \t\t\t\thandler: async (ctx) => {
-\t\t\t\t\tconst result = await ctx.storage.events.query({ limit: 10 });
+\t\t\t\t\tconst result = await ctx.storage.events.query({
+\t\t\t\t\t\torderBy: { createdAt: "desc" },
+\t\t\t\t\t\tlimit: 10,
+\t\t\t\t\t});
 \t\t\t\t\treturn { events: result.items };
 \t\t\t\t},
 \t\t\t},

--- a/packages/core/src/cli/commands/plugin-init.ts
+++ b/packages/core/src/cli/commands/plugin-init.ts
@@ -1,13 +1,15 @@
 /**
  * emdash plugin init
  *
- * Scaffold a new EmDash plugin. Generates the standard-format boilerplate:
+ * Scaffold a new EmDash plugin. Generates the sandboxed-format boilerplate:
  *   src/index.ts         -- descriptor factory
  *   src/sandbox-entry.ts -- definePlugin({ hooks, routes })
  *   package.json
  *   tsconfig.json
  *
- * Use --native to generate native-format boilerplate instead (createPlugin + React admin).
+ * Use --format=native (or --native) to generate native-format boilerplate
+ * instead (createPlugin + React admin). When neither is passed and stdout
+ * is a TTY, the user is prompted to choose.
  *
  */
 
@@ -21,6 +23,8 @@ import { fileExists } from "./bundle-utils.js";
 
 const SLUG_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 const SCOPE_RE = /^@[^/]+\//;
+
+type PluginFormat = "standard" | "native";
 
 export const pluginInitCommand = defineCommand({
 	meta: {
@@ -37,15 +41,27 @@ export const pluginInitCommand = defineCommand({
 			type: "string",
 			description: "Plugin name/id (e.g. my-plugin or @org/my-plugin)",
 		},
+		format: {
+			type: "string",
+			description:
+				"Plugin format: sandboxed or native. Prompts when running interactively if not set.",
+			valueHint: "sandboxed|native",
+		},
 		native: {
 			type: "boolean",
-			description: "Generate native-format plugin (createPlugin + React admin)",
+			description: "Shortcut for --format=native",
 			default: false,
 		},
 	},
 	async run({ args }) {
 		const targetDir = resolve(args.dir);
-		const isNative = args.native;
+
+		const format = await resolveFormat(args.format, args.native);
+		if (!format) {
+			consola.info("Cancelled");
+			return;
+		}
+		const isNative = format === "native";
 
 		// Derive plugin name from --name or directory name
 		let pluginName = args.name || basename(targetDir);
@@ -71,7 +87,7 @@ export const pluginInitCommand = defineCommand({
 			process.exit(1);
 		}
 
-		consola.start(`Scaffolding ${isNative ? "native" : "standard"} plugin: ${pluginName}`);
+		consola.start(`Scaffolding ${isNative ? "native" : "sandboxed"} plugin: ${pluginName}`);
 
 		await mkdir(srcDir, { recursive: true });
 
@@ -83,22 +99,89 @@ export const pluginInitCommand = defineCommand({
 
 		consola.success(`Plugin scaffolded in ${targetDir}`);
 		consola.info("Next steps:");
-		if (args.dir !== ".") {
-			consola.info(`  1. cd ${args.dir}`);
-		}
-		consola.info(`  ${args.dir !== "." ? "2" : "1"}. pnpm install`);
-		if (isNative) {
-			consola.info(`  ${args.dir !== "." ? "3" : "2"}. Edit src/index.ts to add hooks and routes`);
-		} else {
-			consola.info(
-				`  ${args.dir !== "." ? "3" : "2"}. Edit src/sandbox-entry.ts to add hooks and routes`,
-			);
-		}
-		consola.info(`  ${args.dir !== "." ? "4" : "3"}. emdash plugin validate --dir .`);
+		const steps: string[] = [];
+		if (args.dir !== ".") steps.push(`cd ${args.dir}`);
+		steps.push("pnpm install");
+		steps.push(
+			isNative
+				? "Edit src/index.ts to add hooks and routes"
+				: "Edit src/sandbox-entry.ts to add hooks and routes",
+		);
+		steps.push("pnpm build");
+		if (!isNative) steps.push("emdash plugin validate --dir .");
+		steps.forEach((step, i) => consola.info(`  ${i + 1}. ${step}`));
 	},
 });
 
-// ── Standard format scaffolding ──────────────────────────────────
+async function resolveFormat(
+	formatArg: string | undefined,
+	nativeFlag: boolean,
+): Promise<PluginFormat | null> {
+	if (formatArg) {
+		const normalized = formatArg.toLowerCase();
+		if (normalized === "native") return "native";
+		if (normalized === "sandboxed" || normalized === "standard") return "standard";
+		consola.error(`Invalid --format "${formatArg}". Use "sandboxed" or "native".`);
+		process.exit(1);
+	}
+	if (nativeFlag) return "native";
+
+	if (!process.stdout.isTTY) return "standard";
+
+	const choice = await consola.prompt("Which plugin format?", {
+		type: "select",
+		initial: "standard",
+		options: [
+			{
+				label: "Sandboxed",
+				value: "standard",
+				hint: "runs in an isolated sandbox; safe to install from the marketplace",
+			},
+			{
+				label: "Native",
+				value: "native",
+				hint: "full runtime access; install from npm",
+			},
+		],
+		cancel: "null",
+	});
+	if (choice === null) return null;
+	return choice as PluginFormat;
+}
+
+function camelCase(slug: string): string {
+	return slug
+		.split("-")
+		.map((s, i) => (i === 0 ? s : s[0].toUpperCase() + s.slice(1)))
+		.join("");
+}
+
+function pascalCase(slug: string): string {
+	return slug
+		.split("-")
+		.map((s) => s[0].toUpperCase() + s.slice(1))
+		.join("");
+}
+
+const TSCONFIG = {
+	compilerOptions: {
+		target: "ES2022",
+		module: "preserve",
+		moduleResolution: "bundler",
+		strict: true,
+		esModuleInterop: true,
+		declaration: true,
+		outDir: "./dist",
+		rootDir: "./src",
+	},
+	include: ["src/**/*"],
+	exclude: ["node_modules", "dist"],
+} as const;
+
+const TSDOWN_VERSION = "^0.20.0";
+const TYPESCRIPT_VERSION = "^5.9.0";
+
+// ── Sandboxed format scaffolding ─────────────────────────────────
 
 async function scaffoldStandard(
 	targetDir: string,
@@ -106,13 +189,8 @@ async function scaffoldStandard(
 	pluginName: string,
 	slug: string,
 ): Promise<void> {
-	// Derive the camelCase function name from slug
-	const fnName = slug
-		.split("-")
-		.map((s, i) => (i === 0 ? s : s[0].toUpperCase() + s.slice(1)))
-		.join("");
+	const fnName = camelCase(slug);
 
-	// package.json
 	await writeFile(
 		join(targetDir, "package.json"),
 		JSON.stringify(
@@ -120,74 +198,95 @@ async function scaffoldStandard(
 				name: pluginName,
 				version: "0.1.0",
 				type: "module",
+				main: "./dist/index.mjs",
 				exports: {
-					".": "./src/index.ts",
-					"./sandbox": "./src/sandbox-entry.ts",
+					".": {
+						types: "./dist/index.d.mts",
+						import: "./dist/index.mjs",
+					},
+					"./sandbox": {
+						types: "./dist/sandbox-entry.d.mts",
+						import: "./dist/sandbox-entry.mjs",
+					},
 				},
-				files: ["src"],
+				files: ["dist"],
+				scripts: {
+					build: "tsdown src/index.ts src/sandbox-entry.ts --format esm --dts --clean",
+					dev: "tsdown src/index.ts src/sandbox-entry.ts --format esm --dts --watch",
+					typecheck: "tsc --noEmit",
+				},
+				keywords: ["emdash", "emdash-plugin"],
+				license: "MIT",
 				peerDependencies: {
 					emdash: "*",
 				},
-			},
-			null,
-			"\t",
-		) + "\n",
-	);
-
-	// tsconfig.json
-	await writeFile(
-		join(targetDir, "tsconfig.json"),
-		JSON.stringify(
-			{
-				compilerOptions: {
-					target: "ES2022",
-					module: "preserve",
-					moduleResolution: "bundler",
-					strict: true,
-					esModuleInterop: true,
-					declaration: true,
-					outDir: "./dist",
-					rootDir: "./src",
+				devDependencies: {
+					emdash: "*",
+					tsdown: TSDOWN_VERSION,
+					typescript: TYPESCRIPT_VERSION,
 				},
-				include: ["src/**/*"],
-				exclude: ["node_modules", "dist"],
 			},
 			null,
 			"\t",
 		) + "\n",
 	);
 
-	// src/index.ts -- descriptor factory
+	await writeFile(join(targetDir, "tsconfig.json"), JSON.stringify(TSCONFIG, null, "\t") + "\n");
+
 	await writeFile(
 		join(srcDir, "index.ts"),
 		`import type { PluginDescriptor } from "emdash";
 
 export function ${fnName}Plugin(): PluginDescriptor {
 \treturn {
-\t\tid: "${pluginName}",
+\t\tid: "${slug}",
 \t\tversion: "0.1.0",
 \t\tformat: "standard",
 \t\tentrypoint: "${pluginName}/sandbox",
+
 \t\tcapabilities: [],
+\t\tstorage: {
+\t\t\tevents: { indexes: ["timestamp"] },
+\t\t},
 \t};
 }
 `,
 	);
 
-	// src/sandbox-entry.ts -- plugin definition
 	await writeFile(
 		join(srcDir, "sandbox-entry.ts"),
 		`import { definePlugin } from "emdash";
 import type { PluginContext } from "emdash";
 
+interface ContentSaveEvent {
+\tcollection: string;
+\tcontent: { id: string };
+\tisNew: boolean;
+}
+
 export default definePlugin({
 \thooks: {
 \t\t"content:afterSave": {
-\t\t\thandler: async (event: any, ctx: PluginContext) => {
+\t\t\thandler: async (event: ContentSaveEvent, ctx: PluginContext) => {
 \t\t\t\tctx.log.info("Content saved", {
 \t\t\t\t\tcollection: event.collection,
 \t\t\t\t\tid: event.content.id,
 \t\t\t\t});
+
+\t\t\t\tawait ctx.storage.events.put(\`save-\${Date.now()}\`, {
+\t\t\t\t\ttimestamp: new Date().toISOString(),
+\t\t\t\t\tcollection: event.collection,
+\t\t\t\t\tcontentId: event.content.id,
+\t\t\t\t});
+\t\t\t},
+\t\t},
+\t},
+
+\troutes: {
+\t\trecent: {
+\t\t\thandler: async (_routeCtx, ctx: PluginContext) => {
+\t\t\t\tconst result = await ctx.storage.events.query({ limit: 10 });
+\t\t\t\treturn { events: result.items };
 \t\t\t},
 \t\t},
 \t},
@@ -204,12 +303,9 @@ async function scaffoldNative(
 	pluginName: string,
 	slug: string,
 ): Promise<void> {
-	const fnName = slug
-		.split("-")
-		.map((s, i) => (i === 0 ? s : s[0].toUpperCase() + s.slice(1)))
-		.join("");
+	const fnName = camelCase(slug);
+	const typeName = pascalCase(slug);
 
-	// package.json
 	await writeFile(
 		join(targetDir, "package.json"),
 		JSON.stringify(
@@ -217,69 +313,82 @@ async function scaffoldNative(
 				name: pluginName,
 				version: "0.1.0",
 				type: "module",
+				main: "./dist/index.mjs",
 				exports: {
-					".": "./src/index.ts",
+					".": {
+						types: "./dist/index.d.mts",
+						import: "./dist/index.mjs",
+					},
 				},
-				files: ["src"],
+				files: ["dist"],
+				scripts: {
+					build: "tsdown src/index.ts --format esm --dts --clean",
+					dev: "tsdown src/index.ts --format esm --dts --watch",
+					typecheck: "tsc --noEmit",
+				},
+				keywords: ["emdash", "emdash-plugin"],
+				license: "MIT",
 				peerDependencies: {
 					emdash: "*",
 				},
-			},
-			null,
-			"\t",
-		) + "\n",
-	);
-
-	// tsconfig.json
-	await writeFile(
-		join(targetDir, "tsconfig.json"),
-		JSON.stringify(
-			{
-				compilerOptions: {
-					target: "ES2022",
-					module: "preserve",
-					moduleResolution: "bundler",
-					strict: true,
-					esModuleInterop: true,
-					declaration: true,
-					outDir: "./dist",
-					rootDir: "./src",
+				devDependencies: {
+					emdash: "*",
+					tsdown: TSDOWN_VERSION,
+					typescript: TYPESCRIPT_VERSION,
 				},
-				include: ["src/**/*"],
-				exclude: ["node_modules", "dist"],
 			},
 			null,
 			"\t",
 		) + "\n",
 	);
 
-	// src/index.ts -- descriptor + createPlugin
+	await writeFile(join(targetDir, "tsconfig.json"), JSON.stringify(TSCONFIG, null, "\t") + "\n");
+
 	await writeFile(
 		join(srcDir, "index.ts"),
 		`import { definePlugin } from "emdash";
 import type { PluginDescriptor } from "emdash";
 
-export function ${fnName}Plugin(): PluginDescriptor {
+export interface ${typeName}Options {
+\tenabled?: boolean;
+}
+
+export function ${fnName}Plugin(options: ${typeName}Options = {}): PluginDescriptor {
 \treturn {
-\t\tid: "${pluginName}",
+\t\tid: "${slug}",
 \t\tversion: "0.1.0",
 \t\tformat: "native",
 \t\tentrypoint: "${pluginName}",
-\t\toptions: {},
+\t\toptions,
 \t};
 }
 
-export function createPlugin() {
+export function createPlugin(options: ${typeName}Options = {}) {
 \treturn definePlugin({
-\t\tid: "${pluginName}",
+\t\tid: "${slug}",
 \t\tversion: "0.1.0",
+
+\t\tstorage: {
+\t\t\tevents: { indexes: ["createdAt"] },
+\t\t},
 
 \t\thooks: {
 \t\t\t"content:afterSave": async (event, ctx) => {
-\t\t\t\tctx.log.info("Content saved", {
+\t\t\t\tif (options.enabled === false) return;
+\t\t\t\tawait ctx.storage.events.put(\`evt_\${Date.now()}\`, {
 \t\t\t\t\tcollection: event.collection,
-\t\t\t\t\tid: event.content.id,
+\t\t\t\t\tcontentId: event.content.id,
+\t\t\t\t\tcreatedAt: new Date().toISOString(),
 \t\t\t\t});
+\t\t\t},
+\t\t},
+
+\t\troutes: {
+\t\t\trecent: {
+\t\t\t\thandler: async (ctx) => {
+\t\t\t\t\tconst result = await ctx.storage.events.query({ limit: 10 });
+\t\t\t\t\treturn { events: result.items };
+\t\t\t\t},
 \t\t\t},
 \t\t},
 \t});


### PR DESCRIPTION
## What does this PR do?

`emdash plugin init` previously always scaffolded the standard (sandboxed) format, with `--native` as the only escape hatch. Users who didn't already know the two formats existed had no signal that they had a choice.

This PR:

- Adds an interactive prompt when stdout is a TTY and neither `--format` nor `--native` is set. Options are **Sandboxed** (default; "runs in an isolated sandbox; safe to install from the marketplace") and **Native** ("full runtime access; install from npm").
- Adds `--format=sandboxed` / `--format=native` to skip the prompt explicitly. `--native` is kept as a shortcut for `--format=native`. Non-TTY runs continue to default to sandboxed, so scripted usage is unchanged.
- Rewrites both scaffolds to match the canonical patterns from `docs/src/content/docs/plugins/creating-plugins/your-first-plugin.mdx` and `creating-native-plugins/your-first-native-plugin.mdx`:
  - `package.json` ships a tsdown build (`build`/`dev`/`typecheck` scripts), `main` + conditional `exports` pointing at `dist/`, `files: ["dist"]`, `keywords`, `license: "MIT"`, and `devDependencies` for `emdash`/`tsdown`/`typescript`.
  - The sandboxed `src/sandbox-entry.ts` drops `event: any`, defines a typed `ContentSaveEvent`, writes to `ctx.storage.events`, and demonstrates a `recent` route using the standard two-arg `(routeCtx, ctx)` signature.
  - The native `src/index.ts` adds an `Options` interface, forwards the options through `createPlugin`, declares storage, demonstrates an options-aware hook, and exposes a `recent` route using the native single-arg `(ctx)` signature.
- Fixes a latent bug in both scaffolds: descriptor `id` was being set to the raw `pluginName`, which fails the runtime regex `/^[a-z][a-z0-9_-]*$/` when given a scoped name like `@org/foo`. It now uses the stripped slug.
- Updates the next-steps printout to add `pnpm build` and skip `emdash plugin validate` for native plugins (validate is part of the marketplace bundle flow, which only applies to sandboxed plugins).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Claude Code)

## Screenshots / test output

Smoke-tested locally by scaffolding both formats with a scoped name (`@my-org/test-sandboxed` and `@my-org/test-native`) and verifying the generated `package.json`, `tsconfig.json`, and `src/*.ts` files match the canonical examples from the docs and produce a runtime-valid descriptor `id`.

```
$ emdash plugin init --dir ./test-sandboxed --name @my-org/test-sandboxed --format sandboxed
◐ Scaffolding sandboxed plugin: @my-org/test-sandboxed
✔ Plugin scaffolded in ./test-sandboxed
ℹ Next steps:
ℹ   1. cd ./test-sandboxed
ℹ   2. pnpm install
ℹ   3. Edit src/sandbox-entry.ts to add hooks and routes
ℹ   4. pnpm build
ℹ   5. emdash plugin validate --dir .
```