### PR TITLE
fix(revisions): store new revision created_at as ISO UTC

### DIFF
--- a/.changeset/thick-toes-find.md
+++ b/.changeset/thick-toes-find.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes new revision timestamps to be stored as explicit UTC ISO-8601 strings so admin time displays are correct across timezones.

--- a/packages/core/src/database/repositories/revision.ts
+++ b/packages/core/src/database/repositories/revision.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import { monotonicFactory } from "ulidx";
 
-import type { Database, RevisionTable } from "../types.js";
+import type { Database } from "../types.js";
 
 const monotonic = monotonicFactory();
 
@@ -36,12 +36,13 @@ export class RevisionRepository {
 	async create(input: CreateRevisionInput): Promise<Revision> {
 		const id = monotonic();
 
-		const row: Omit<RevisionTable, "created_at"> = {
+		const row = {
 			id,
 			collection: input.collection,
 			entry_id: input.entryId,
 			data: JSON.stringify(input.data),
 			author_id: input.authorId ?? null,
+			created_at: new Date().toISOString(),
 		};
 
 		await this.db.insertInto("revisions").values(row).execute();

--- a/packages/core/src/database/repositories/revision.ts
+++ b/packages/core/src/database/repositories/revision.ts
@@ -1,7 +1,7 @@
 import type { Kysely } from "kysely";
 import { monotonicFactory } from "ulidx";
 
-import type { Database } from "../types.js";
+import type { Database, RevisionTable } from "../types.js";
 
 const monotonic = monotonicFactory();
 

--- a/packages/core/src/database/repositories/revision.ts
+++ b/packages/core/src/database/repositories/revision.ts
@@ -36,7 +36,7 @@ export class RevisionRepository {
 	async create(input: CreateRevisionInput): Promise<Revision> {
 		const id = monotonic();
 
-		const row = {
+		const row: RevisionTable = {
 			id,
 			collection: input.collection,
 			entry_id: input.entryId,

--- a/packages/core/tests/unit/api/revision-handlers.test.ts
+++ b/packages/core/tests/unit/api/revision-handlers.test.ts
@@ -128,6 +128,29 @@ describe("Revision Handlers", () => {
 			expect(result.data?.item.data.title).toBe("Test Revision");
 		});
 
+		it("stores and returns createdAt as explicit UTC ISO timestamp for new revisions", async () => {
+			const content = await contentRepo.create(createPostFixture());
+			const revision = await revisionRepo.create({
+				collection: "post",
+				entryId: content.id,
+				data: { title: "Timestamp test" },
+			});
+
+			const stored = await db
+				.selectFrom("revisions")
+				.select("created_at")
+				.where("id", "=", revision.id)
+				.executeTakeFirstOrThrow();
+
+			const result = await handleRevisionGet(db, revision.id);
+
+			expect(result.success).toBe(true);
+			expect(stored.created_at).toMatch(/T/);
+			expect(stored.created_at).toMatch(/Z$/);
+			expect(result.data?.item.createdAt).toMatch(/Z$/);
+			expect(new Date(result.data!.item.createdAt).toISOString()).toBe(result.data!.item.createdAt);
+		});
+
 		it("should return NOT_FOUND for non-existent revision", async () => {
 			const result = await handleRevisionGet(db, "nonexistent-id");
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
Revisions were displaying an incorrect `created_at` timestamp (observed in `plugins-demo` admin UI). Other code paths store dates differently (see `packages/core/src/database/repositories/content.ts`), so revisions were updated to use the same date storage approach for consistency.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code: 5.3-Codex  <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->

It shows "2 hours ago" before the bugfix and "just now" after.
<img width="476" height="464" alt="Screenshot 2026-05-03 at 20 44 02" src="https://github.com/user-attachments/assets/12e6b7af-494f-4e97-bc3f-d97525e4c7ec" />
