### PR TITLE
Add Block Kit card grid block

### DIFF
--- a/.changeset/blockkit-card-grid.md
+++ b/.changeset/blockkit-card-grid.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/blocks": patch
+---
+
+Adds a `card_grid` Block Kit block for rendering responsive grids of cards with optional media, metadata, badges, and button actions.

--- a/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
@@ -92,6 +92,7 @@ The standard-format route handler takes two arguments: `routeCtx` (with `input`,
 | `columns`   | 2–3 column layout with nested blocks                                                    |
 | `empty`     | Empty-state placeholder with icon, title, description, optional command line, and action buttons |
 | `accordion` | Collapsible section wrapping nested blocks                                              |
+| `card_grid` | Responsive card grid for integrations, resources, launchers, and marketplace-style lists |
 
 ## Element types
 

--- a/packages/blocks/src/blocks/card-grid.tsx
+++ b/packages/blocks/src/blocks/card-grid.tsx
@@ -10,6 +10,20 @@ const COLUMN_CLASSES: Record<NonNullable<CardGridBlock["columns"]>, string> = {
 	3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
 };
 
+function getSafePreviewSrc(url: string): string | null {
+	const trimmed = url.trim();
+
+	if (trimmed.startsWith("//")) return null;
+	if (trimmed.startsWith("/")) return trimmed;
+
+	try {
+		const parsed = new URL(trimmed);
+		return parsed.protocol === "http:" || parsed.protocol === "https:" ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
 export function CardGridBlockComponent({
 	block,
 	onAction,
@@ -23,37 +37,44 @@ export function CardGridBlockComponent({
 
 	return (
 		<div className={cn("grid gap-3", COLUMN_CLASSES[block.columns ?? 3])}>
-			{block.cards.map((card, i) => (
-				<article
-					key={`${card.title}-${i}`}
-					className="overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
-				>
-					{card.image_url && (
-						<img
-							src={card.image_url}
-							alt={card.image_alt ?? ""}
-							className="h-32 w-full object-cover"
-						/>
-					)}
-					<div className="flex h-full flex-col gap-3 p-4">
-						<div className="flex items-start justify-between gap-3">
-							<div className="min-w-0">
-								<h3 className="text-sm font-semibold text-kumo-default">{card.title}</h3>
-								{card.meta && <p className="mt-1 text-xs text-kumo-subtle">{card.meta}</p>}
-							</div>
-							{card.badge && <Badge>{card.badge}</Badge>}
-						</div>
-						{card.description && <p className="text-sm text-kumo-subtle">{card.description}</p>}
-						{card.actions && card.actions.length > 0 && (
-							<div className="mt-auto flex flex-wrap gap-2">
-								{card.actions.map((action, actionIndex) => (
-									<div key={action.action_id ?? actionIndex}>{renderElement(action, onAction)}</div>
-								))}
-							</div>
+			{block.cards.map((card, i) => {
+				const previewSrc = card.image_url ? getSafePreviewSrc(card.image_url) : null;
+				return (
+					<article
+						key={`${card.title}-${i}`}
+						className="overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
+					>
+						{previewSrc && (
+							<img
+								src={previewSrc}
+								alt={card.image_alt ?? ""}
+								className="h-32 w-full object-cover"
+								referrerPolicy="no-referrer"
+								loading="lazy"
+							/>
 						)}
-					</div>
-				</article>
-			))}
+						<div className="flex h-full flex-col gap-3 p-4">
+							<div className="flex items-start justify-between gap-3">
+								<div className="min-w-0">
+									<h3 className="text-sm font-semibold text-kumo-default">{card.title}</h3>
+									{card.meta && <p className="mt-1 text-xs text-kumo-subtle">{card.meta}</p>}
+								</div>
+								{card.badge && <Badge>{card.badge}</Badge>}
+							</div>
+							{card.description && <p className="text-sm text-kumo-subtle">{card.description}</p>}
+							{card.actions && card.actions.length > 0 && (
+								<div className="mt-auto flex flex-wrap gap-2">
+									{card.actions.map((action, actionIndex) => (
+										<div key={action.action_id ?? actionIndex}>
+											{renderElement(action, onAction)}
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+					</article>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/blocks/src/blocks/card-grid.tsx
+++ b/packages/blocks/src/blocks/card-grid.tsx
@@ -42,7 +42,7 @@ export function CardGridBlockComponent({
 				return (
 					<article
 						key={`${card.title}-${i}`}
-						className="overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
+						className="flex flex-col overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
 					>
 						{previewSrc && (
 							<img
@@ -53,7 +53,7 @@ export function CardGridBlockComponent({
 								loading="lazy"
 							/>
 						)}
-						<div className="flex h-full flex-col gap-3 p-4">
+						<div className="flex flex-1 flex-col gap-3 p-4">
 							<div className="flex items-start justify-between gap-3">
 								<div className="min-w-0">
 									<h3 className="text-sm font-semibold text-kumo-default">{card.title}</h3>

--- a/packages/blocks/src/blocks/card-grid.tsx
+++ b/packages/blocks/src/blocks/card-grid.tsx
@@ -1,0 +1,55 @@
+import { Badge } from "@cloudflare/kumo";
+
+import { renderElement } from "../render-element.js";
+import type { BlockInteraction, CardGridBlock } from "../types.js";
+import { cn } from "../utils.js";
+
+const COLUMN_CLASSES: Record<NonNullable<CardGridBlock["columns"]>, string> = {
+	1: "grid-cols-1",
+	2: "grid-cols-1 sm:grid-cols-2",
+	3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+};
+
+export function CardGridBlockComponent({
+	block,
+	onAction,
+}: {
+	block: CardGridBlock;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	if (block.cards.length === 0 && block.empty_text) {
+		return <p className="py-4 text-center text-sm text-kumo-subtle">{block.empty_text}</p>;
+	}
+
+	return (
+		<div className={cn("grid gap-3", COLUMN_CLASSES[block.columns ?? 3])}>
+			{block.cards.map((card, i) => (
+				<article
+					key={`${card.title}-${i}`}
+					className="overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
+				>
+					{card.image_url && (
+						<img src={card.image_url} alt={card.image_alt ?? ""} className="h-32 w-full object-cover" />
+					)}
+					<div className="flex h-full flex-col gap-3 p-4">
+						<div className="flex items-start justify-between gap-3">
+							<div className="min-w-0">
+								<h3 className="text-sm font-semibold text-kumo-default">{card.title}</h3>
+								{card.meta && <p className="mt-1 text-xs text-kumo-subtle">{card.meta}</p>}
+							</div>
+							{card.badge && <Badge>{card.badge}</Badge>}
+						</div>
+						{card.description && <p className="text-sm text-kumo-subtle">{card.description}</p>}
+						{card.actions && card.actions.length > 0 && (
+							<div className="mt-auto flex flex-wrap gap-2">
+								{card.actions.map((action, actionIndex) => (
+									<div key={action.action_id ?? actionIndex}>{renderElement(action, onAction)}</div>
+								))}
+							</div>
+						)}
+					</div>
+				</article>
+			))}
+		</div>
+	);
+}

--- a/packages/blocks/src/blocks/card-grid.tsx
+++ b/packages/blocks/src/blocks/card-grid.tsx
@@ -29,7 +29,11 @@ export function CardGridBlockComponent({
 					className="overflow-hidden rounded-md border border-kumo-line bg-kumo-surface"
 				>
 					{card.image_url && (
-						<img src={card.image_url} alt={card.image_alt ?? ""} className="h-32 w-full object-cover" />
+						<img
+							src={card.image_url}
+							alt={card.image_alt ?? ""}
+							className="h-32 w-full object-cover"
+						/>
 					)}
 					<div className="flex h-full flex-col gap-3 p-4">
 						<div className="flex items-start justify-between gap-3">

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -4,6 +4,8 @@ import type {
 	BannerBlock,
 	Block,
 	ButtonElement,
+	CardGridBlock,
+	CardGridItem,
 	CheckboxElement,
 	ChartBlock,
 	ChartSeries,
@@ -495,6 +497,21 @@ function accordion(opts: {
 	};
 }
 
+function cardGrid(opts: {
+	blockId?: string;
+	cards: CardGridItem[];
+	columns?: 1 | 2 | 3;
+	emptyText?: string;
+}): CardGridBlock {
+	return {
+		type: "card_grid",
+		cards: opts.cards,
+		...(opts.columns !== undefined && { columns: opts.columns }),
+		...(opts.emptyText !== undefined && { empty_text: opts.emptyText }),
+		...(opts.blockId !== undefined && { block_id: opts.blockId }),
+	};
+}
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 export const blocks = {
@@ -517,6 +534,7 @@ export const blocks = {
 	tab: tabBlock,
 	empty,
 	accordion,
+	cardGrid,
 };
 
 export const elements = {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -32,6 +32,7 @@ export type {
 	// Block sub-types
 	TableColumn,
 	StatItem,
+	CardGridItem,
 	ChartSeries,
 	ChartConfig,
 	TimeseriesChartConfig,
@@ -56,6 +57,7 @@ export type {
 	MeterBlock,
 	EmptyBlock,
 	AccordionBlock,
+	CardGridBlock,
 	Block,
 	// Interactions
 	BlockAction,

--- a/packages/blocks/src/renderer.tsx
+++ b/packages/blocks/src/renderer.tsx
@@ -1,6 +1,7 @@
 import { AccordionBlockComponent } from "./blocks/accordion.js";
 import { ActionsBlockComponent } from "./blocks/actions.js";
 import { BannerBlockComponent } from "./blocks/banner.js";
+import { CardGridBlockComponent } from "./blocks/card-grid.js";
 import { ChartBlockComponent } from "./blocks/chart.js";
 import { CodeBlockComponent } from "./blocks/code.js";
 import { ColumnsBlockComponent } from "./blocks/columns.js";
@@ -59,6 +60,8 @@ function renderBlock(
 			return <EmptyBlockComponent block={block} onAction={onAction} />;
 		case "accordion":
 			return <AccordionBlockComponent block={block} onAction={onAction} />;
+		case "card_grid":
+			return <CardGridBlockComponent block={block} onAction={onAction} />;
 		default: {
 			const _exhaustive: never = block;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -201,6 +201,16 @@ export interface StatItem {
 	trend?: "up" | "down" | "neutral";
 }
 
+export interface CardGridItem {
+	title: string;
+	description?: string;
+	image_url?: string;
+	image_alt?: string;
+	badge?: string;
+	meta?: string;
+	actions?: ButtonElement[];
+}
+
 /** A single data series for a timeseries chart. */
 export interface ChartSeries {
 	/** Display name shown in tooltips and legends */
@@ -364,6 +374,13 @@ export interface AccordionBlock extends BlockBase {
 	default_open?: boolean;
 }
 
+export interface CardGridBlock extends BlockBase {
+	type: "card_grid";
+	cards: CardGridItem[];
+	columns?: 1 | 2 | 3;
+	empty_text?: string;
+}
+
 export type Block =
 	| HeaderBlock
 	| SectionBlock
@@ -382,7 +399,8 @@ export type Block =
 	| CodeBlock
 	| TabBlock
 	| EmptyBlock
-	| AccordionBlock;
+	| AccordionBlock
+	| CardGridBlock;
 
 // ── Interactions ─────────────────────────────────────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -16,6 +16,7 @@ const BLOCK_TYPES = new Set([
 	"code",
 	"empty",
 	"accordion",
+	"card_grid",
 ]);
 
 const EMPTY_SIZES = new Set(["sm", "base", "lg"]);
@@ -44,6 +45,7 @@ const CODE_LANGUAGES = new Set(["ts", "tsx", "jsonc", "bash", "css"]);
 const BUTTON_STYLES = new Set(["primary", "danger", "secondary"]);
 const TREND_VALUES = new Set(["up", "down", "neutral"]);
 const BANNER_VARIANTS = new Set(["default", "alert", "error"]);
+const CARD_GRID_COLUMNS = new Set([1, 2, 3]);
 
 /**
  * RFC 6838-style image MIME type or image-prefix.
@@ -610,6 +612,17 @@ function validateFormField(value: unknown, path: string, errors: ValidationError
 			});
 		}
 	}
+}
+
+function validateButtonAction(value: unknown, path: string, errors: ValidationError[]): void {
+	if (isRecord(value) && value.type !== "button") {
+		errors.push({
+			path: `${path}.type`,
+			message: "Action must be a button element",
+		});
+		return;
+	}
+	validateElement(value, path, errors);
 }
 
 const CHART_TYPES = new Set(["timeseries", "custom"]);
@@ -1193,6 +1206,61 @@ function validateBlock(value: unknown, path: string, errors: ValidationError[]):
 				errors.push({
 					path: `${path}.default_open`,
 					message: "Field 'default_open' must be a boolean if provided",
+				});
+			}
+			break;
+		}
+		case "card_grid": {
+			if (!Array.isArray(value.cards)) {
+				errors.push({
+					path: `${path}.cards`,
+					message: "Required field 'cards' must be an array",
+				});
+			} else {
+				for (let i = 0; i < value.cards.length; i++) {
+					const card = value.cards[i] as unknown;
+					if (!isRecord(card)) {
+						errors.push({ path: `${path}.cards[${i}]`, message: "Card must be an object" });
+						continue;
+					}
+					if (typeof card.title !== "string") {
+						errors.push({
+							path: `${path}.cards[${i}].title`,
+							message: "Required field 'title' must be a string",
+						});
+					}
+					for (const key of ["description", "image_url", "image_alt", "badge", "meta"]) {
+						if (card[key] !== undefined && typeof card[key] !== "string") {
+							errors.push({
+								path: `${path}.cards[${i}].${key}`,
+								message: `Field '${key}' must be a string if provided`,
+							});
+						}
+					}
+					if (card.actions !== undefined) {
+						if (!Array.isArray(card.actions)) {
+							errors.push({
+								path: `${path}.cards[${i}].actions`,
+								message: "Field 'actions' must be an array if provided",
+							});
+						} else {
+							for (let j = 0; j < card.actions.length; j++) {
+								validateButtonAction(card.actions[j], `${path}.cards[${i}].actions[${j}]`, errors);
+							}
+						}
+					}
+				}
+			}
+			if (value.columns !== undefined && !CARD_GRID_COLUMNS.has(value.columns as number)) {
+				errors.push({
+					path: `${path}.columns`,
+					message: "Field 'columns' must be one of: 1, 2, 3",
+				});
+			}
+			if (value.empty_text !== undefined && typeof value.empty_text !== "string") {
+				errors.push({
+					path: `${path}.empty_text`,
+					message: "Field 'empty_text' must be a string if provided",
 				});
 			}
 			break;

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -533,6 +533,47 @@ describe("BlockRenderer", () => {
 		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "ping" });
 	});
 
+	it("card_grid block renders cards with metadata, images, badges, and actions", () => {
+		const onAction = vi.fn();
+		renderBlocks(
+			[
+				{
+					type: "card_grid",
+					columns: 2,
+					cards: [
+						{
+							title: "Stripe",
+							description: "Sync payment events.",
+							image_url: "https://example.com/stripe.png",
+							image_alt: "Stripe logo",
+							badge: "Connected",
+							meta: "Payments",
+							actions: [{ type: "button", action_id: "configure", label: "Configure" }],
+						},
+					],
+				},
+			],
+			onAction,
+		);
+
+		expect(screen.getByText("Stripe")).toBeTruthy();
+		expect(screen.getByText("Sync payment events.")).toBeTruthy();
+		expect(screen.getByText("Payments")).toBeTruthy();
+		expect(screen.getByText("Connected")).toBeTruthy();
+		expect(screen.getByAltText("Stripe logo")).toBeTruthy();
+
+		fireEvent.click(screen.getByText("Configure"));
+		expect(onAction).toHaveBeenCalledWith({
+			type: "block_action",
+			action_id: "configure",
+		});
+	});
+
+	it("card_grid block renders empty_text for empty card arrays", () => {
+		renderBlocks([{ type: "card_grid", cards: [], empty_text: "No integrations found" }]);
+		expect(screen.getByText("No integrations found")).toBeTruthy();
+	});
+
 	it("columns block renders blocks in columns", () => {
 		renderBlocks([
 			{

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -574,6 +574,16 @@ describe("BlockRenderer", () => {
 		expect(screen.getByText("No integrations found")).toBeTruthy();
 	});
 
+	it("card_grid block does not render unsafe image URLs", () => {
+		const { container } = renderBlocks([
+			{
+				type: "card_grid",
+				cards: [{ title: "Unsafe", image_url: "data:image/svg+xml;base64,PHN2Zy8+" }],
+			},
+		]);
+		expect(container.querySelector("img")).toBeNull();
+	});
+
 	it("columns block renders blocks in columns", () => {
 		renderBlocks([
 			{

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -135,6 +135,33 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("card_grid", () => {
+			const result = validateBlocks([
+				{
+					type: "card_grid",
+					columns: 2,
+					empty_text: "No cards",
+					cards: [
+						{
+							title: "Analytics",
+							description: "Review site traffic.",
+							image_url: "/analytics.png",
+							image_alt: "Analytics chart",
+							badge: "New",
+							meta: "Reports",
+							actions: [{ type: "button", action_id: "open", label: "Open" }],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("card_grid with empty cards array", () => {
+			const result = validateBlocks([{ type: "card_grid", cards: [] }]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("repeater", () => {
 			const result = validateBlocks([
 				{
@@ -499,6 +526,30 @@ describe("validateBlocks", () => {
 			]);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]!.path).toBe("blocks[0].default_open");
+		});
+
+		it("card_grid missing cards", () => {
+			const result = validateBlocks([{ type: "card_grid" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].cards");
+		});
+
+		it("card_grid validates card fields", () => {
+			const result = validateBlocks([
+				{
+					type: "card_grid",
+					cards: [{ description: 42, actions: [{ type: "select", action_id: "x", label: "X" }] }],
+					columns: 4,
+					empty_text: false,
+				},
+			]);
+			expect(result.valid).toBe(false);
+			const paths = result.errors.map((e) => e.path);
+			expect(paths).toContain("blocks[0].cards[0].title");
+			expect(paths).toContain("blocks[0].cards[0].description");
+			expect(paths).toContain("blocks[0].cards[0].actions[0].type");
+			expect(paths).toContain("blocks[0].columns");
+			expect(paths).toContain("blocks[0].empty_text");
 		});
 
 		it("stats item missing label or value", () => {


### PR DESCRIPTION
## What does this PR do?

Adds the `card_grid` Block Kit block to `@emdash-cms/blocks`.

This block renders a responsive grid of cards for capability summaries, integrations, plugin cards, setup areas, and other compact operational summaries. Each card supports a title, optional description, image preview, badge, metadata, and nested `ButtonElement` actions routed through the existing `block_action` interaction path.

Discussion: https://github.com/emdash-cms/emdash/discussions/904

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/904

Draft status note: Discussion #904 has been opened and linked above. This PR should stay draft until maintainers approve or waive the Discussion requirement.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex GPT-5.5 via RepoPrompt orchestrate/agents; Codex GPT-5 local coding agent

## Screenshots / test output

- `pnpm --silent lint:quick` passed on this branch.
- `pnpm --filter @emdash-cms/blocks test` passed on this branch.
- `pnpm --filter @emdash-cms/blocks typecheck` passed on this branch.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm typecheck`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm format:check`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks test` with 136 tests.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks-playground build`.
- Integration browser verification rendered all five proposed blocks together and confirmed nested `block_action` events.
- GitHub CI is passing, including Typecheck, Lint, Tests, Integration Tests, Browser Tests, Smoke Tests, E2E shards, Format, Version Check, Validate Plugins, and Validate PR.

