### PR TITLE
Add Block Kit timeline block

### DIFF
--- a/.changeset/tidy-timelines-sparkle.md
+++ b/.changeset/tidy-timelines-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/blocks": patch
+---
+
+Adds a timeline Block Kit block for chronological status histories.

--- a/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
@@ -92,6 +92,7 @@ The standard-format route handler takes two arguments: `routeCtx` (with `input`,
 | `columns`   | 2–3 column layout with nested blocks                                                    |
 | `empty`     | Empty-state placeholder with icon, title, description, optional command line, and action buttons |
 | `accordion` | Collapsible section wrapping nested blocks                                              |
+| `timeline`  | Chronological status history with optional action buttons                               |
 
 ## Element types
 

--- a/packages/blocks/src/blocks/timeline.tsx
+++ b/packages/blocks/src/blocks/timeline.tsx
@@ -1,0 +1,54 @@
+import { renderElement } from "../render-element.js";
+import type { BlockInteraction, TimelineBlock, TimelineItem } from "../types.js";
+import { cn } from "../utils.js";
+
+const statusDotClasses: Record<NonNullable<TimelineItem["status"]>, string> = {
+	default: "border-kumo-line bg-kumo-tint",
+	success: "border-kumo-success bg-kumo-success",
+	warning: "border-kumo-warning bg-kumo-warning",
+	error: "border-kumo-danger bg-kumo-danger",
+};
+
+export function TimelineBlockComponent({
+	block,
+	onAction,
+}: {
+	block: TimelineBlock;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	if (block.items.length === 0) {
+		return block.empty_text ? (
+			<p className="py-4 text-center text-sm text-kumo-subtle">{block.empty_text}</p>
+		) : null;
+	}
+
+	return (
+		<ol className="ms-3 border-s border-kumo-line">
+			{block.items.map((item, i) => (
+				<li key={i} className="relative pb-5 ps-6 last:pb-0">
+					<span
+						aria-hidden="true"
+						className={cn(
+							"absolute start-[-0.4375rem] top-1.5 h-3.5 w-3.5 rounded-full border-2",
+							statusDotClasses[item.status ?? "default"],
+						)}
+					/>
+					<div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+						<h3 className="font-medium text-kumo-default">{item.title}</h3>
+						<time className="shrink-0 text-sm text-kumo-subtle" dateTime={item.timestamp}>
+							{item.timestamp}
+						</time>
+					</div>
+					{item.description && <p className="mt-1 text-sm text-kumo-subtle">{item.description}</p>}
+					{item.actions && item.actions.length > 0 && (
+						<div className="mt-3 flex flex-wrap gap-2">
+							{item.actions.map((action, actionIndex) => (
+								<div key={action.action_id ?? actionIndex}>{renderElement(action, onAction)}</div>
+							))}
+						</div>
+					)}
+				</li>
+			))}
+		</ol>
+	);
+}

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -38,6 +38,8 @@ import type {
 	ToggleElement,
 	TabBlock,
 	TabPanel,
+	TimelineBlock,
+	TimelineItem,
 } from "./types.js";
 
 // ── Block Builders ───────────────────────────────────────────────────────────
@@ -495,6 +497,19 @@ function accordion(opts: {
 	};
 }
 
+function timeline(opts: {
+	blockId?: string;
+	items: TimelineItem[];
+	emptyText?: string;
+}): TimelineBlock {
+	return {
+		type: "timeline",
+		items: opts.items,
+		...(opts.emptyText !== undefined && { empty_text: opts.emptyText }),
+		...(opts.blockId !== undefined && { block_id: opts.blockId }),
+	};
+}
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 export const blocks = {
@@ -517,6 +532,7 @@ export const blocks = {
 	tab: tabBlock,
 	empty,
 	accordion,
+	timeline,
 };
 
 export const elements = {

--- a/packages/blocks/src/renderer.tsx
+++ b/packages/blocks/src/renderer.tsx
@@ -16,6 +16,7 @@ import { SectionBlockComponent } from "./blocks/section.js";
 import { StatsBlockComponent } from "./blocks/stats.js";
 import { TabBlockComponent } from "./blocks/tab.js";
 import { TableBlockComponent } from "./blocks/table.js";
+import { TimelineBlockComponent } from "./blocks/timeline.js";
 import type { Block, BlockInteraction } from "./types.js";
 
 function renderBlock(
@@ -59,6 +60,8 @@ function renderBlock(
 			return <EmptyBlockComponent block={block} onAction={onAction} />;
 		case "accordion":
 			return <AccordionBlockComponent block={block} onAction={onAction} />;
+		case "timeline":
+			return <TimelineBlockComponent block={block} onAction={onAction} />;
 		default: {
 			const _exhaustive: never = block;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -201,6 +201,14 @@ export interface StatItem {
 	trend?: "up" | "down" | "neutral";
 }
 
+export interface TimelineItem {
+	title: string;
+	timestamp: string;
+	description?: string;
+	status?: "default" | "success" | "warning" | "error";
+	actions?: ButtonElement[];
+}
+
 /** A single data series for a timeseries chart. */
 export interface ChartSeries {
 	/** Display name shown in tooltips and legends */
@@ -364,6 +372,12 @@ export interface AccordionBlock extends BlockBase {
 	default_open?: boolean;
 }
 
+export interface TimelineBlock extends BlockBase {
+	type: "timeline";
+	items: TimelineItem[];
+	empty_text?: string;
+}
+
 export type Block =
 	| HeaderBlock
 	| SectionBlock
@@ -382,7 +396,8 @@ export type Block =
 	| CodeBlock
 	| TabBlock
 	| EmptyBlock
-	| AccordionBlock;
+	| AccordionBlock
+	| TimelineBlock;
 
 // ── Interactions ─────────────────────────────────────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -16,6 +16,7 @@ const BLOCK_TYPES = new Set([
 	"code",
 	"empty",
 	"accordion",
+	"timeline",
 ]);
 
 const EMPTY_SIZES = new Set(["sm", "base", "lg"]);
@@ -44,6 +45,7 @@ const CODE_LANGUAGES = new Set(["ts", "tsx", "jsonc", "bash", "css"]);
 const BUTTON_STYLES = new Set(["primary", "danger", "secondary"]);
 const TREND_VALUES = new Set(["up", "down", "neutral"]);
 const BANNER_VARIANTS = new Set(["default", "alert", "error"]);
+const TIMELINE_STATUSES = new Set(["default", "success", "warning", "error"]);
 
 /**
  * RFC 6838-style image MIME type or image-prefix.
@@ -584,6 +586,17 @@ function validateElement(value: unknown, path: string, errors: ValidationError[]
 			break;
 		}
 	}
+}
+
+function validateButtonAction(value: unknown, path: string, errors: ValidationError[]): void {
+	if (isRecord(value) && value.type !== undefined && value.type !== "button") {
+		errors.push({
+			path: `${path}.type`,
+			message: "Timeline actions must be button elements",
+		});
+		return;
+	}
+	validateElement(value, path, errors);
 }
 
 function validateFormField(value: unknown, path: string, errors: ValidationError[]): void {
@@ -1193,6 +1206,69 @@ function validateBlock(value: unknown, path: string, errors: ValidationError[]):
 				errors.push({
 					path: `${path}.default_open`,
 					message: "Field 'default_open' must be a boolean if provided",
+				});
+			}
+			break;
+		}
+		case "timeline": {
+			if (!Array.isArray(value.items)) {
+				errors.push({
+					path: `${path}.items`,
+					message: "Required field 'items' must be an array",
+				});
+			} else {
+				for (let i = 0; i < value.items.length; i++) {
+					const item = value.items[i] as unknown;
+					const itemPath = `${path}.items[${i}]`;
+					if (!isRecord(item)) {
+						errors.push({ path: itemPath, message: "Timeline item must be an object" });
+						continue;
+					}
+					if (typeof item.title !== "string") {
+						errors.push({
+							path: `${itemPath}.title`,
+							message: "Required field 'title' must be a string",
+						});
+					}
+					if (typeof item.timestamp !== "string") {
+						errors.push({
+							path: `${itemPath}.timestamp`,
+							message: "Required field 'timestamp' must be a string",
+						});
+					}
+					if (item.description !== undefined && typeof item.description !== "string") {
+						errors.push({
+							path: `${itemPath}.description`,
+							message: "Field 'description' must be a string if provided",
+						});
+					}
+					if (
+						item.status !== undefined &&
+						(typeof item.status !== "string" || !TIMELINE_STATUSES.has(item.status))
+					) {
+						errors.push({
+							path: `${itemPath}.status`,
+							message: `Field 'status' must be one of: ${[...TIMELINE_STATUSES].join(", ")}`,
+						});
+					}
+					if (item.actions !== undefined) {
+						if (!Array.isArray(item.actions)) {
+							errors.push({
+								path: `${itemPath}.actions`,
+								message: "Field 'actions' must be an array if provided",
+							});
+						} else {
+							for (let j = 0; j < item.actions.length; j++) {
+								validateButtonAction(item.actions[j], `${itemPath}.actions[${j}]`, errors);
+							}
+						}
+					}
+				}
+			}
+			if (value.empty_text !== undefined && typeof value.empty_text !== "string") {
+				errors.push({
+					path: `${path}.empty_text`,
+					message: "Field 'empty_text' must be a string if provided",
 				});
 			}
 			break;

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -533,6 +533,56 @@ describe("BlockRenderer", () => {
 		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "ping" });
 	});
 
+	it("timeline block renders items with timestamps and descriptions", () => {
+		renderBlocks([
+			{
+				type: "timeline",
+				items: [
+					{
+						title: "Import started",
+						timestamp: "2026-05-03 10:00",
+						description: "Queued 25 records.",
+						status: "success",
+					},
+					{ title: "Import warning", timestamp: "2026-05-03 10:02", status: "warning" },
+				],
+			},
+		]);
+
+		expect(screen.getByText("Import started")).toBeTruthy();
+		expect(screen.getByText("2026-05-03 10:00")).toBeTruthy();
+		expect(screen.getByText("Queued 25 records.")).toBeTruthy();
+		expect(screen.getByText("Import warning")).toBeTruthy();
+	});
+
+	it("timeline block renders empty_text when items are empty", () => {
+		renderBlocks([{ type: "timeline", items: [], empty_text: "No history yet" }]);
+		expect(screen.getByText("No history yet")).toBeTruthy();
+	});
+
+	it("timeline block renders nested action buttons", () => {
+		const onAction = vi.fn();
+		renderBlocks(
+			[
+				{
+					type: "timeline",
+					items: [
+						{
+							title: "Deploy failed",
+							timestamp: "2026-05-03 10:10",
+							status: "error",
+							actions: [{ type: "button", action_id: "retry", label: "Retry" }],
+						},
+					],
+				},
+			],
+			onAction,
+		);
+
+		fireEvent.click(screen.getByText("Retry"));
+		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "retry" });
+	});
+
 	it("columns block renders blocks in columns", () => {
 		renderBlocks([
 			{

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -135,6 +135,30 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("timeline", () => {
+			const result = validateBlocks([
+				{
+					type: "timeline",
+					empty_text: "No history yet",
+					items: [
+						{
+							title: "Deploy completed",
+							timestamp: "2026-05-03T10:00:00Z",
+							description: "Production deploy finished.",
+							status: "success",
+							actions: [{ type: "button", action_id: "view", label: "View deploy" }],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("timeline with empty items array", () => {
+			const result = validateBlocks([{ type: "timeline", items: [] }]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("repeater", () => {
 			const result = validateBlocks([
 				{
@@ -499,6 +523,46 @@ describe("validateBlocks", () => {
 			]);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]!.path).toBe("blocks[0].default_open");
+		});
+
+		it("timeline missing items", () => {
+			const result = validateBlocks([{ type: "timeline" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].items");
+		});
+
+		it("timeline item missing title or timestamp", () => {
+			const result = validateBlocks([{ type: "timeline", items: [{ description: "Started" }] }]);
+			expect(result.valid).toBe(false);
+			const paths = result.errors.map((e) => e.path);
+			expect(paths).toContain("blocks[0].items[0].title");
+			expect(paths).toContain("blocks[0].items[0].timestamp");
+		});
+
+		it("timeline item with invalid status", () => {
+			const result = validateBlocks([
+				{ type: "timeline", items: [{ title: "X", timestamp: "now", status: "paused" }] },
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].items[0].status");
+		});
+
+		it("timeline actions must be button elements", () => {
+			const result = validateBlocks([
+				{
+					type: "timeline",
+					items: [
+						{
+							title: "X",
+							timestamp: "now",
+							actions: [{ type: "text_input", action_id: "note", label: "Note" }],
+						},
+					],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].items[0].actions[0].type");
+			expect(result.errors[0]!.message).toContain("button elements");
 		});
 
 		it("stats item missing label or value", () => {


### PR DESCRIPTION
## What does this PR do?

Adds the `timeline` Block Kit block to `@emdash-cms/blocks`.

This block renders chronological operational event lists for import history, deploy history, audit summaries, webhook delivery history, and similar plugin/admin workflows. Timeline items support a title, optional description, timestamp, status, and nested `ButtonElement` actions routed through the existing `block_action` interaction path.

Discussion: https://github.com/emdash-cms/emdash/discussions/904

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/904

Draft status note: Discussion #904 has been opened and linked above. This PR should stay draft until maintainers approve or waive the Discussion requirement.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex GPT-5.5 via RepoPrompt orchestrate/agents; Codex GPT-5 local coding agent

## Screenshots / test output

- `pnpm --silent lint:quick` passed on this branch.
- `pnpm --filter @emdash-cms/blocks test` passed on this branch.
- `pnpm --filter @emdash-cms/blocks typecheck` passed on this branch.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm typecheck`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm format:check`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks test` with 136 tests.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks-playground build`.
- Integration browser verification rendered all five proposed blocks together and confirmed nested `block_action` events.
- GitHub CI is passing, including Typecheck, Lint, Tests, Integration Tests, Browser Tests, Smoke Tests, E2E shards, Format, Version Check, Validate Plugins, and Validate PR.

