### PR TITLE
Add Block Kit media grid block

### DIFF
--- a/.changeset/media-grid-block.md
+++ b/.changeset/media-grid-block.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/blocks": minor
+---
+
+Adds a `media_grid` Block Kit block for rendering media preview grids with safe image URL handling.

--- a/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/block-kit.mdx
@@ -88,6 +88,7 @@ The standard-format route handler takes two arguments: `routeCtx` (with `input`,
 | `stats`     | Dashboard metric cards with trend indicators                                            |
 | `form`      | Input fields with conditional visibility and submit                                     |
 | `image`     | Block-level image with caption                                                          |
+| `media_grid` | Grid of media previews with safe image URL handling and optional item actions            |
 | `context`   | Small muted help text                                                                   |
 | `columns`   | 2–3 column layout with nested blocks                                                    |
 | `empty`     | Empty-state placeholder with icon, title, description, optional command line, and action buttons |

--- a/packages/blocks/src/blocks/media-grid.tsx
+++ b/packages/blocks/src/blocks/media-grid.tsx
@@ -1,0 +1,87 @@
+import { Badge } from "@cloudflare/kumo";
+
+import { renderElement } from "../render-element.js";
+import type { BlockInteraction, MediaGridBlock, MediaGridItem } from "../types.js";
+import { cn } from "../utils.js";
+
+const columnClass = {
+	2: "sm:grid-cols-2",
+	3: "sm:grid-cols-2 lg:grid-cols-3",
+	4: "sm:grid-cols-2 lg:grid-cols-4",
+} as const;
+
+function getSafePreviewSrc(url: string): string | null {
+	const trimmed = url.trim();
+
+	if (trimmed.startsWith("//")) return null;
+	if (trimmed.startsWith("/")) return trimmed;
+
+	try {
+		const parsed = new URL(trimmed);
+		return parsed.protocol === "http:" || parsed.protocol === "https:" ? trimmed : null;
+	} catch {
+		return null;
+	}
+}
+
+function MediaGridItemCard({
+	item,
+	onAction,
+}: {
+	item: MediaGridItem;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	const previewSrc = getSafePreviewSrc(item.url);
+
+	return (
+		<article className="overflow-hidden rounded-lg border border-kumo-line bg-kumo-base">
+			<div className="aspect-video bg-kumo-tint">
+				{previewSrc ? (
+					<img src={previewSrc} alt={item.alt} className="h-full w-full object-cover" />
+				) : (
+					<div className="flex h-full items-center justify-center px-4 text-center text-sm text-kumo-subtle">
+						Preview unavailable
+					</div>
+				)}
+			</div>
+			{(item.badge || item.title || item.description || item.actions?.length) && (
+				<div className="space-y-3 p-4">
+					{item.badge && <Badge>{item.badge}</Badge>}
+					{(item.title || item.description) && (
+						<div className="space-y-1">
+							{item.title && <h3 className="font-medium text-kumo-default">{item.title}</h3>}
+							{item.description && <p className="text-sm text-kumo-subtle">{item.description}</p>}
+						</div>
+					)}
+					{item.actions && item.actions.length > 0 && (
+						<div className="flex flex-wrap gap-2">
+							{item.actions.map((action, i) => (
+								<div key={action.action_id ?? i}>{renderElement(action, onAction)}</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+		</article>
+	);
+}
+
+export function MediaGridBlockComponent({
+	block,
+	onAction,
+}: {
+	block: MediaGridBlock;
+	onAction: (interaction: BlockInteraction) => void;
+}) {
+	if (block.items.length === 0 && block.empty_text) {
+		return <p className="py-4 text-center text-sm text-kumo-subtle">{block.empty_text}</p>;
+	}
+
+	return (
+		<div className={cn("grid gap-4", columnClass[block.columns ?? 3])}>
+			{block.items.map((item, i) => (
+				<MediaGridItemCard key={`${item.url}:${i}`} item={item} onAction={onAction} />
+			))}
+		</div>
+	);
+}

--- a/packages/blocks/src/builders.ts
+++ b/packages/blocks/src/builders.ts
@@ -24,6 +24,8 @@ import type {
 	FormField,
 	HeaderBlock,
 	ImageBlock,
+	MediaGridBlock,
+	MediaGridItem,
 	MediaPickerElement,
 	MeterBlock,
 	NumberInputElement,
@@ -495,6 +497,21 @@ function accordion(opts: {
 	};
 }
 
+function mediaGrid(opts: {
+	blockId?: string;
+	items: MediaGridItem[];
+	columns?: 2 | 3 | 4;
+	emptyText?: string;
+}): MediaGridBlock {
+	return {
+		type: "media_grid",
+		items: opts.items,
+		...(opts.columns !== undefined && { columns: opts.columns }),
+		...(opts.emptyText !== undefined && { empty_text: opts.emptyText }),
+		...(opts.blockId !== undefined && { block_id: opts.blockId }),
+	};
+}
+
 // ── Exports ──────────────────────────────────────────────────────────────────
 
 export const blocks = {
@@ -517,6 +534,7 @@ export const blocks = {
 	tab: tabBlock,
 	empty,
 	accordion,
+	mediaGrid,
 };
 
 export const elements = {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -32,6 +32,7 @@ export type {
 	// Block sub-types
 	TableColumn,
 	StatItem,
+	MediaGridItem,
 	ChartSeries,
 	ChartConfig,
 	TimeseriesChartConfig,
@@ -56,6 +57,7 @@ export type {
 	MeterBlock,
 	EmptyBlock,
 	AccordionBlock,
+	MediaGridBlock,
 	Block,
 	// Interactions
 	BlockAction,

--- a/packages/blocks/src/renderer.tsx
+++ b/packages/blocks/src/renderer.tsx
@@ -11,6 +11,7 @@ import { FieldsBlockComponent } from "./blocks/fields.js";
 import { FormBlockComponent } from "./blocks/form.js";
 import { HeaderBlockComponent } from "./blocks/header.js";
 import { ImageBlockComponent } from "./blocks/image.js";
+import { MediaGridBlockComponent } from "./blocks/media-grid.js";
 import { MeterBlockComponent } from "./blocks/meter.js";
 import { SectionBlockComponent } from "./blocks/section.js";
 import { StatsBlockComponent } from "./blocks/stats.js";
@@ -59,6 +60,8 @@ function renderBlock(
 			return <EmptyBlockComponent block={block} onAction={onAction} />;
 		case "accordion":
 			return <AccordionBlockComponent block={block} onAction={onAction} />;
+		case "media_grid":
+			return <MediaGridBlockComponent block={block} onAction={onAction} />;
 		default: {
 			const _exhaustive: never = block;
 			return null;

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -201,6 +201,15 @@ export interface StatItem {
 	trend?: "up" | "down" | "neutral";
 }
 
+export interface MediaGridItem {
+	url: string;
+	alt: string;
+	title?: string;
+	description?: string;
+	badge?: string;
+	actions?: ButtonElement[];
+}
+
 /** A single data series for a timeseries chart. */
 export interface ChartSeries {
 	/** Display name shown in tooltips and legends */
@@ -364,6 +373,13 @@ export interface AccordionBlock extends BlockBase {
 	default_open?: boolean;
 }
 
+export interface MediaGridBlock extends BlockBase {
+	type: "media_grid";
+	items: MediaGridItem[];
+	columns?: 2 | 3 | 4;
+	empty_text?: string;
+}
+
 export type Block =
 	| HeaderBlock
 	| SectionBlock
@@ -382,7 +398,8 @@ export type Block =
 	| CodeBlock
 	| TabBlock
 	| EmptyBlock
-	| AccordionBlock;
+	| AccordionBlock
+	| MediaGridBlock;
 
 // ── Interactions ─────────────────────────────────────────────────────────────
 

--- a/packages/blocks/src/validation.ts
+++ b/packages/blocks/src/validation.ts
@@ -16,6 +16,7 @@ const BLOCK_TYPES = new Set([
 	"code",
 	"empty",
 	"accordion",
+	"media_grid",
 ]);
 
 const EMPTY_SIZES = new Set(["sm", "base", "lg"]);
@@ -44,6 +45,7 @@ const CODE_LANGUAGES = new Set(["ts", "tsx", "jsonc", "bash", "css"]);
 const BUTTON_STYLES = new Set(["primary", "danger", "secondary"]);
 const TREND_VALUES = new Set(["up", "down", "neutral"]);
 const BANNER_VARIANTS = new Set(["default", "alert", "error"]);
+const MEDIA_GRID_COLUMNS = new Set([2, 3, 4]);
 
 /**
  * RFC 6838-style image MIME type or image-prefix.
@@ -584,6 +586,18 @@ function validateElement(value: unknown, path: string, errors: ValidationError[]
 			break;
 		}
 	}
+}
+
+function validateButtonElement(value: unknown, path: string, errors: ValidationError[]): void {
+	if (isRecord(value) && value.type !== "button") {
+		errors.push({
+			path: `${path}.type`,
+			message: "Action must be a button element",
+		});
+		return;
+	}
+
+	validateElement(value, path, errors);
 }
 
 function validateFormField(value: unknown, path: string, errors: ValidationError[]): void {
@@ -1193,6 +1207,81 @@ function validateBlock(value: unknown, path: string, errors: ValidationError[]):
 				errors.push({
 					path: `${path}.default_open`,
 					message: "Field 'default_open' must be a boolean if provided",
+				});
+			}
+			break;
+		}
+		case "media_grid": {
+			if (!Array.isArray(value.items)) {
+				errors.push({
+					path: `${path}.items`,
+					message: "Required field 'items' must be an array",
+				});
+			} else {
+				for (let i = 0; i < value.items.length; i++) {
+					const item = value.items[i] as unknown;
+					const itemPath = `${path}.items[${i}]`;
+					if (!isRecord(item)) {
+						errors.push({ path: itemPath, message: "Media grid item must be an object" });
+						continue;
+					}
+					if (typeof item.url !== "string") {
+						errors.push({
+							path: `${itemPath}.url`,
+							message: "Required field 'url' must be a string",
+						});
+					}
+					if (typeof item.alt !== "string") {
+						errors.push({
+							path: `${itemPath}.alt`,
+							message: "Required field 'alt' must be a string",
+						});
+					}
+					if (item.title !== undefined && typeof item.title !== "string") {
+						errors.push({
+							path: `${itemPath}.title`,
+							message: "Field 'title' must be a string if provided",
+						});
+					}
+					if (item.description !== undefined && typeof item.description !== "string") {
+						errors.push({
+							path: `${itemPath}.description`,
+							message: "Field 'description' must be a string if provided",
+						});
+					}
+					if (item.badge !== undefined && typeof item.badge !== "string") {
+						errors.push({
+							path: `${itemPath}.badge`,
+							message: "Field 'badge' must be a string if provided",
+						});
+					}
+					if (item.actions !== undefined) {
+						if (!Array.isArray(item.actions)) {
+							errors.push({
+								path: `${itemPath}.actions`,
+								message: "Field 'actions' must be an array if provided",
+							});
+						} else {
+							for (let j = 0; j < item.actions.length; j++) {
+								validateButtonElement(item.actions[j], `${itemPath}.actions[${j}]`, errors);
+							}
+						}
+					}
+				}
+			}
+			if (
+				value.columns !== undefined &&
+				(typeof value.columns !== "number" || !MEDIA_GRID_COLUMNS.has(value.columns))
+			) {
+				errors.push({
+					path: `${path}.columns`,
+					message: `Field 'columns' must be one of: ${[...MEDIA_GRID_COLUMNS].join(", ")}`,
+				});
+			}
+			if (value.empty_text !== undefined && typeof value.empty_text !== "string") {
+				errors.push({
+					path: `${path}.empty_text`,
+					message: "Field 'empty_text' must be a string if provided",
 				});
 			}
 			break;

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -446,6 +446,68 @@ describe("BlockRenderer", () => {
 		expect(img.src).toBe("https://example.com/photo.jpg");
 	});
 
+	it("media_grid block renders media cards and nested actions", () => {
+		const onAction = vi.fn();
+		renderBlocks(
+			[
+				{
+					type: "media_grid",
+					columns: 4,
+					items: [
+						{
+							url: "https://example.com/photo.jpg",
+							alt: "A product screenshot",
+							title: "Product screenshot",
+							description: "Shows the dashboard.",
+							badge: "Featured",
+							actions: [{ type: "button", action_id: "view", label: "View" }],
+						},
+					],
+				},
+			],
+			onAction,
+		);
+
+		const img = screen.getByAltText("A product screenshot") as HTMLImageElement;
+		expect(img.src).toBe("https://example.com/photo.jpg");
+		expect(screen.getByText("Product screenshot")).toBeTruthy();
+		expect(screen.getByText("Shows the dashboard.")).toBeTruthy();
+		expect(screen.getByTestId("badge").textContent).toBe("Featured");
+
+		fireEvent.click(screen.getByText("View"));
+		expect(onAction).toHaveBeenCalledWith({ type: "block_action", action_id: "view" });
+	});
+
+	it("media_grid block shows empty_text when items are empty", () => {
+		renderBlocks([{ type: "media_grid", items: [], empty_text: "No media yet" }]);
+		expect(screen.getByText("No media yet")).toBeTruthy();
+	});
+
+	it("media_grid block previews root-relative URLs", () => {
+		renderBlocks([{ type: "media_grid", items: [{ url: "/uploads/photo.jpg", alt: "Upload" }] }]);
+		const img = screen.getByAltText("Upload") as HTMLImageElement;
+		expect(img.getAttribute("src")).toBe("/uploads/photo.jpg");
+	});
+
+	it("media_grid block does not use unsafe URLs as img src", () => {
+		const unsafeUrls = [
+			"//example.com/image.jpg",
+			"javascript:alert(1)",
+			"data:image/svg+xml,<svg></svg>",
+			"ftp://example.com/image.jpg",
+		];
+
+		const { container } = renderBlocks([
+			{
+				type: "media_grid",
+				items: unsafeUrls.map((url, i) => ({ url, alt: `Unsafe ${i}` })),
+			},
+		]);
+
+		expect(container.querySelectorAll("img").length).toBe(0);
+		expect(screen.getAllByText("Preview unavailable").length).toBe(unsafeUrls.length);
+	});
+
 	it("context block renders small muted text", () => {
 		renderBlocks([{ type: "context", text: "Updated just now" }]);
 		const el = screen.getByText("Updated just now");

--- a/packages/blocks/tests/validation.test.ts
+++ b/packages/blocks/tests/validation.test.ts
@@ -135,6 +135,32 @@ describe("validateBlocks", () => {
 			expect(result).toEqual({ valid: true, errors: [] });
 		});
 
+		it("media_grid", () => {
+			const result = validateBlocks([
+				{
+					type: "media_grid",
+					columns: 3,
+					empty_text: "No media",
+					items: [
+						{
+							url: "https://example.com/photo.jpg",
+							alt: "Photo",
+							title: "Photo title",
+							description: "Photo description",
+							badge: "New",
+							actions: [{ type: "button", action_id: "view", label: "View" }],
+						},
+					],
+				},
+			]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
+		it("media_grid with empty items array", () => {
+			const result = validateBlocks([{ type: "media_grid", items: [] }]);
+			expect(result).toEqual({ valid: true, errors: [] });
+		});
+
 		it("repeater", () => {
 			const result = validateBlocks([
 				{
@@ -499,6 +525,44 @@ describe("validateBlocks", () => {
 			]);
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]!.path).toBe("blocks[0].default_open");
+		});
+
+		it("media_grid missing items", () => {
+			const result = validateBlocks([{ type: "media_grid" }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].items");
+		});
+
+		it("media_grid item missing required url or alt", () => {
+			const result = validateBlocks([{ type: "media_grid", items: [{}] }]);
+			expect(result.valid).toBe(false);
+			const paths = result.errors.map((e) => e.path);
+			expect(paths).toContain("blocks[0].items[0].url");
+			expect(paths).toContain("blocks[0].items[0].alt");
+		});
+
+		it("media_grid rejects invalid columns", () => {
+			const result = validateBlocks([{ type: "media_grid", columns: 5, items: [] }]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].columns");
+		});
+
+		it("media_grid actions must be button elements", () => {
+			const result = validateBlocks([
+				{
+					type: "media_grid",
+					items: [
+						{
+							url: "/uploads/photo.jpg",
+							alt: "Photo",
+							actions: [{ type: "select", action_id: "pick", label: "Pick", options: [] }],
+						},
+					],
+				},
+			]);
+			expect(result.valid).toBe(false);
+			expect(result.errors[0]!.path).toBe("blocks[0].items[0].actions[0].type");
+			expect(result.errors[0]!.message).toContain("button");
 		});
 
 		it("stats item missing label or value", () => {


### PR DESCRIPTION
## What does this PR do?

Adds the `media_grid` Block Kit block to `@emdash-cms/blocks`.

This block renders small media preview grids for asset review, import previews, generated media, moderation queues, and gallery-like plugin workflows. Media items support a required URL and alt text plus optional title, description, badge, and nested `ButtonElement` actions.

Preview rendering is intentionally restricted to root-relative paths and `http(s)` URLs. Protocol-relative, `javascript:`, and `data:` preview URLs are rejected and rendered as unavailable previews.

Discussion: https://github.com/emdash-cms/emdash/discussions/904

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/904

Draft status note: Discussion #904 has been opened and linked above. This PR should stay draft until maintainers approve or waive the Discussion requirement.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex GPT-5.5 via RepoPrompt orchestrate/agents; Codex GPT-5 local coding agent

## Screenshots / test output

- `pnpm --silent lint:quick` passed on this branch.
- `pnpm --filter @emdash-cms/blocks test` passed on this branch.
- `pnpm --filter @emdash-cms/blocks typecheck` passed on this branch.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm typecheck`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm format:check`.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks test` with 136 tests.
- Integration branch `codex/blockkit-all-five-integration` passed `pnpm --filter @emdash-cms/blocks-playground build`.
- Integration browser verification rendered all five proposed blocks together, confirmed unsafe media previews are suppressed, and confirmed nested `block_action` events.
- GitHub CI is passing, including Typecheck, Lint, Tests, Integration Tests, Browser Tests, Smoke Tests, E2E shards, Format, Version Check, Validate Plugins, and Validate PR.

