### PR TITLE
Fix D1 dashboard recent items query

### DIFF
--- a/.changeset/stale-actors-sneeze.md
+++ b/.changeset/stale-actors-sneeze.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes dashboard recent items on D1 by avoiding compound SELECT queries that can exceed D1 limits on sites with many collections.

--- a/packages/core/src/api/handlers/dashboard.ts
+++ b/packages/core/src/api/handlers/dashboard.ts
@@ -117,8 +117,9 @@ interface RecentItemRow {
 /**
  * Fetch the 10 most recently updated items across all collections.
  *
- * Uses UNION ALL over each ec_* table. The query is safe because
- * collection slugs come from the system table and are validated.
+ * Queries each collection separately instead of building a single UNION ALL.
+ * D1 has a low compound SELECT limit, and sites with many collections can
+ * exceed it before SQLite does.
  *
  * `title` is not a standard column — it's a user-defined field. We query
  * `_emdash_fields` to discover which collections have one and fall back
@@ -140,25 +141,21 @@ async function fetchRecentItems(
 
 	const collectionsWithTitle = new Set(titleFields.map((r) => r.collection_slug));
 
-	// Build a UNION ALL query across all content tables.
-	// Each branch is wrapped in SELECT * FROM (...) so the inner
-	// ORDER BY + LIMIT is valid SQLite (bare ORDER BY inside UNION
-	// branches is a syntax error in SQLite).
-	const subQueries = collections.map((col) => {
-		validateIdentifier(col.slug);
-		const table = `ec_${col.slug}`;
-		const hasTitle = collectionsWithTitle.has(col.slug);
+	const rowsByCollection = await Promise.all(
+		collections.map(async (col) => {
+			validateIdentifier(col.slug);
+			const table = `ec_${col.slug}`;
+			const hasTitle = collectionsWithTitle.has(col.slug);
 
-		// Use title column if it exists, otherwise fall back to slug → id.
-		// All output uses snake_case to avoid SQLite quoting issues on D1.
-		const titleExpr = hasTitle ? sql`COALESCE(title, slug, id)` : sql`COALESCE(slug, id)`;
+			// Use title column if it exists, otherwise fall back to slug -> id.
+			// All output uses snake_case to avoid SQLite quoting issues on D1.
+			const titleExpr = hasTitle ? sql`COALESCE(title, slug, id)` : sql`COALESCE(slug, id)`;
 
-		return sql<RecentItemRow>`
-			SELECT * FROM (
+			const result = await sql<RecentItemRow>`
 				SELECT
 					id,
-					${sql.lit(col.slug)} AS collection,
-					${sql.lit(col.label)} AS collection_label,
+					${col.slug} AS collection,
+					${col.label} AS collection_label,
 					${titleExpr} AS title,
 					slug,
 					status,
@@ -168,27 +165,19 @@ async function fetchRecentItems(
 				WHERE deleted_at IS NULL
 				ORDER BY updated_at DESC
 				LIMIT 10
-			)
-		`;
-	});
+			`.execute(db);
 
-	// Combine with UNION ALL
-	// eslint-disable-next-line typescript-eslint(no-unnecessary-type-assertion) -- noUncheckedIndexedAccess
-	let combined = subQueries[0]!;
-	for (let i = 1; i < subQueries.length; i++) {
-		// eslint-disable-next-line typescript-eslint(no-unnecessary-type-assertion) -- noUncheckedIndexedAccess
-		combined = sql<RecentItemRow>`${combined} UNION ALL ${subQueries[i]!}`;
-	}
+			return result.rows;
+		}),
+	);
 
-	// Final sort + limit across all branches
-	const result = await sql<RecentItemRow>`
-		SELECT * FROM (${combined})
-		ORDER BY updated_at DESC
-		LIMIT 10
-	`.execute(db);
+	const rows = rowsByCollection
+		.flat()
+		.toSorted((a, b) => b.updated_at.localeCompare(a.updated_at))
+		.slice(0, 10);
 
-	// Map snake_case DB rows → camelCase API shape
-	return result.rows.map((row) => ({
+	// Map snake_case DB rows -> camelCase API shape
+	return rows.map((row) => ({
 		id: row.id,
 		collection: row.collection,
 		collectionLabel: row.collection_label,

--- a/packages/core/tests/unit/api/dashboard-handlers.test.ts
+++ b/packages/core/tests/unit/api/dashboard-handlers.test.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import type { Kysely, KyselyPlugin } from "kysely";
 import { describe, it, expect, afterEach } from "vitest";
 
 import { handleDashboardStats } from "../../../src/api/handlers/dashboard.js";
@@ -11,6 +11,19 @@ import {
 	setupTestDatabaseWithCollections,
 	teardownTestDatabase,
 } from "../../utils/test-db.js";
+
+const rejectCompoundSelectPlugin = {
+	transformQuery(args) {
+		if (JSON.stringify(args.node).includes(" UNION ALL ")) {
+			throw new Error("D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR");
+		}
+
+		return args.node;
+	},
+	async transformResult(args) {
+		return args.result;
+	},
+} satisfies KyselyPlugin;
 
 describe("Dashboard Handlers", () => {
 	describe("handleDashboardStats", () => {
@@ -93,6 +106,39 @@ describe("Dashboard Handlers", () => {
 			expect(recentItems[1]!.collection).toBe("post");
 			expect(recentItems[1]!.collectionLabel).toBe("Posts");
 			expect(recentItems[1]!.slug).toBe("post-1");
+		});
+
+		it("does not use a compound recent-items query that exceeds D1 limits", async () => {
+			db = await setupTestDatabase();
+			const registry = new SchemaRegistry(db);
+			const contentRepo = new ContentRepository(db);
+
+			for (let i = 0; i < 12; i++) {
+				const slug = `section_${String(i).padStart(2, "0")}`;
+				await registry.createCollection({
+					slug,
+					label: `Section ${i}`,
+					labelSingular: "Section",
+				});
+				await registry.createField(slug, {
+					slug: "title",
+					label: "Title",
+					type: "string",
+				});
+				await contentRepo.create({
+					type: slug,
+					slug: `item-${i}`,
+					data: { title: `Item ${i}` },
+					status: "draft",
+				});
+			}
+
+			const d1LikeDb = db.withPlugin(rejectCompoundSelectPlugin);
+			const result = await handleDashboardStats(d1LikeDb);
+
+			expect(result.success).toBe(true);
+			expect(result.data!.recentItems).toHaveLength(10);
+			expect(result.data!.recentItems.every((item) => item.collection.startsWith("section_"))).toBe(true);
 		});
 
 		it("recent items use title field when available", async () => {

--- a/packages/core/tests/unit/api/dashboard-handlers.test.ts
+++ b/packages/core/tests/unit/api/dashboard-handlers.test.ts
@@ -138,7 +138,9 @@ describe("Dashboard Handlers", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.data!.recentItems).toHaveLength(10);
-			expect(result.data!.recentItems.every((item) => item.collection.startsWith("section_"))).toBe(true);
+			expect(result.data!.recentItems.every((item) => item.collection.startsWith("section_"))).toBe(
+				true,
+			);
 		});
 
 		it("recent items use title field when available", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the D1 dashboard 500 from recent-items loading by replacing the single cross-collection `UNION ALL` query with per-collection capped queries that are merged and limited in JS. This preserves the dashboard API shape while avoiding D1's low compound SELECT limit on sites with many collections.

Closes #895

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A — bug fix

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Not visual.

Local targeted checks:

```text
pnpm --silent lint:quick
=> { "diagnostics": [] }

cd packages/core && pnpm exec vitest run tests/unit/api/dashboard-handlers.test.ts
=> Test Files 1 passed; Tests 11 passed

pnpm --filter emdash typecheck
=> passed

pnpm format
=> passed
```

GitHub CI is passing, including Typecheck, Lint, Tests, Integration Tests, Browser Tests, Smoke Tests, E2E shards, Format, Version Check, Validate Plugins, and Validate PR.

Additional review:

```text
Adversarial review cycle 1: found flaky test assertion on tied timestamps.
Fix applied: removed ordering-sensitive assertion from the D1 regression test.
Adversarial review cycle 2: No bugs found.
```
