### PR TITLE
fix(core): permanent delete is missing trash guard and uses unrelated permission

### DIFF
--- a/.changeset/eighty-rabbits-deny.md
+++ b/.changeset/eighty-rabbits-deny.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/auth": patch
+"emdash": patch
+---
+
+Permanent-delete API now refuses to remove live (non-trashed) rows and uses a content-domain `content:delete_permanent` permission instead of the unrelated `import:execute`. Existing audience (ADMIN-only) is unchanged.

--- a/packages/auth/src/rbac.ts
+++ b/packages/auth/src/rbac.ts
@@ -21,6 +21,10 @@ export const Permissions = {
 	"content:edit_any": Role.EDITOR,
 	"content:delete_own": Role.AUTHOR,
 	"content:delete_any": Role.EDITOR,
+	// Permanent deletion (empty trash) is irreversible and bypasses the
+	// soft-delete safety net, so it sits at the same authorization tier as
+	// other destructive system actions (schema:manage, comments:delete).
+	"content:delete_permanent": Role.ADMIN,
 	"content:publish_own": Role.AUTHOR,
 	"content:publish_any": Role.EDITOR,
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
@@ -16,7 +16,7 @@ export const DELETE: APIRoute = async ({ params, locals, cache }) => {
 	const collection = params.collection!;
 	const id = params.id!;
 
-	const denied = requirePerm(user, "import:execute");
+	const denied = requirePerm(user, "content:delete_permanent");
 	if (denied) return denied;
 
 	if (!emdash?.handleContentPermanentDelete) {

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -637,12 +637,23 @@ export class ContentRepository {
 	/**
 	 * Permanently delete content (cannot be undone)
 	 */
+	/**
+	 * Permanently delete a soft-deleted content row.
+	 *
+	 * Returns `true` only when a soft-deleted (trashed) row was removed.
+	 * Returns `false` when no row exists OR when the row exists but is live —
+	 * the caller is responsible for distinguishing these cases (typically via
+	 * a follow-up `findByIdOrSlugIncludingTrashed` to surface NOT_FOUND vs
+	 * NOT_TRASHED). The `AND deleted_at IS NOT NULL` clause is the safety net
+	 * that prevents permanent delete from bypassing the trash workflow.
+	 */
 	async permanentDelete(type: string, id: string): Promise<boolean> {
 		const tableName = getTableName(type);
 
 		const result = await sql`
 			DELETE FROM ${sql.ref(tableName)}
 			WHERE id = ${id}
+			AND deleted_at IS NOT NULL
 		`.execute(this.db);
 
 		return (result.numAffectedRows ?? 0n) > 0n;

--- a/packages/core/tests/integration/content/permanent-delete.test.ts
+++ b/packages/core/tests/integration/content/permanent-delete.test.ts
@@ -1,0 +1,77 @@
+/**
+ * handleContentPermanentDelete must enforce the trash-state contract:
+ * permanent deletion is "empty trash", not "skip soft-delete". Calling it
+ * on a live (non-trashed) item bypasses the soft-delete safety net and
+ * leaves no recovery path, so the handler must refuse the deletion and
+ * leave the row intact.
+ */
+
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { handleContentPermanentDelete } from "../../../src/api/handlers/content.js";
+import { createDatabase } from "../../../src/database/connection.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+
+describe("handleContentPermanentDelete — trash-state guard", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = createDatabase({ url: ":memory:" });
+		await runMigrations(db);
+		repo = new ContentRepository(db);
+		const registry = new SchemaRegistry(db);
+
+		await registry.createCollection({
+			slug: "post",
+			label: "Posts",
+			labelSingular: "Post",
+		});
+		await registry.createField("post", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+		});
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it("refuses to permanently delete a live (non-trashed) item", async () => {
+		const item = await repo.create({ type: "post", data: { title: "Live post" } });
+
+		const result = await handleContentPermanentDelete(db, "post", item.id);
+
+		expect(result.success).toBe(false);
+
+		// The key invariant: the row must remain in the database. Permanent
+		// delete on a live row must not silently succeed and bypass the trash
+		// safety net, regardless of which error code surfaces to the caller.
+		const survivor = await repo.findById("post", item.id);
+		expect(survivor?.id).toBe(item.id);
+	});
+
+	it("fails for a nonexistent id without touching the database", async () => {
+		const result = await handleContentPermanentDelete(db, "post", "01HZZZZZZZZZZZZZZZZZZZZZZZ");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("permanently deletes a trashed item (happy path preserved)", async () => {
+		const item = await repo.create({ type: "post", data: { title: "To trash" } });
+		const softDeleted = await repo.delete("post", item.id);
+		expect(softDeleted).toBe(true);
+
+		const result = await handleContentPermanentDelete(db, "post", item.id);
+
+		expect(result.success).toBe(true);
+
+		const survivor = await repo.findByIdOrSlugIncludingTrashed("post", item.id);
+		expect(survivor).toBeNull();
+	});
+});

--- a/packages/core/tests/unit/astro/content-routes-authz.test.ts
+++ b/packages/core/tests/unit/astro/content-routes-authz.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import { GET as getItem } from "../../../src/astro/routes/api/content/[collection]/[id].js";
 import { GET as getCompare } from "../../../src/astro/routes/api/content/[collection]/[id]/compare.js";
+import { DELETE as deletePermanent } from "../../../src/astro/routes/api/content/[collection]/[id]/permanent.js";
 import { POST as postPreviewUrl } from "../../../src/astro/routes/api/content/[collection]/[id]/preview-url.js";
 import { GET as getRevisions } from "../../../src/astro/routes/api/content/[collection]/[id]/revisions.js";
 import { GET as getTranslations } from "../../../src/astro/routes/api/content/[collection]/[id]/translations.js";
@@ -37,7 +38,9 @@ interface StubUser {
 
 const subscriber: StubUser = { id: "u-sub", role: Role.SUBSCRIBER };
 const contributor: StubUser = { id: "u-con", role: Role.CONTRIBUTOR };
+const author: StubUser = { id: "u-auth", role: Role.AUTHOR };
 const editor: StubUser = { id: "u-edit", role: Role.EDITOR };
+const admin: StubUser = { id: "u-admin", role: Role.ADMIN };
 
 interface StubItem {
 	id: string;
@@ -128,6 +131,11 @@ function buildEmdash(
 		data: opts.compare ?? { hasChanges: false, live: null, draft: null },
 	}));
 
+	const handleContentPermanentDelete = vi.fn(async () => ({
+		success: true as const,
+		data: { deleted: true as const },
+	}));
+
 	return {
 		handleContentList,
 		handleContentGet,
@@ -135,6 +143,7 @@ function buildEmdash(
 		handleContentListTrashed,
 		handleRevisionList,
 		handleContentCompare,
+		handleContentPermanentDelete,
 	};
 }
 
@@ -154,6 +163,7 @@ function ctx(opts: {
 			user: opts.user,
 			emdash: opts.emdash,
 		},
+		cache: { enabled: false, invalidate: vi.fn() },
 		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- minimal stub for tests
 	} as unknown as APIContext;
 }
@@ -359,5 +369,62 @@ describe("GET /content/:collection/:id/translations", () => {
 			data: { translations: Array<{ id: string; status: string }> };
 		};
 		expect(body.data.translations).toHaveLength(3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /content/:collection/:id/permanent — must be ADMIN-only and gated on
+// the content domain. Permanent deletion is irreversible and bypasses the
+// trash safety net, so it sits at the same authorization tier as other
+// destructive system actions (schema:manage, comments:delete, users:manage).
+// Lower roles soft-delete via DELETE /:id (delete_own / delete_any); only
+// ADMIN can empty the trash.
+// ---------------------------------------------------------------------------
+
+describe("DELETE /content/:collection/:id/permanent", () => {
+	function permanentCtx(user: StubUser | null, emdash: ReturnType<typeof buildEmdash>) {
+		const url = "http://localhost/";
+		return ctx({
+			user,
+			emdash,
+			params: { collection: "post", id: "p1" },
+			url,
+			request: new Request(url, { method: "DELETE" }),
+		});
+	}
+
+	it("allows ADMIN to permanently delete (passes through to handler)", async () => {
+		const emdash = buildEmdash();
+		const res = await deletePermanent(permanentCtx(admin, emdash));
+		expect(res.status).toBe(200);
+		expect(emdash.handleContentPermanentDelete).toHaveBeenCalledWith("post", "p1");
+	});
+
+	it("denies EDITOR (handler must not be called)", async () => {
+		const emdash = buildEmdash();
+		const res = await deletePermanent(permanentCtx(editor, emdash));
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentPermanentDelete).not.toHaveBeenCalled();
+	});
+
+	it("denies AUTHOR (handler must not be called)", async () => {
+		const emdash = buildEmdash();
+		const res = await deletePermanent(permanentCtx(author, emdash));
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentPermanentDelete).not.toHaveBeenCalled();
+	});
+
+	it("denies CONTRIBUTOR (handler must not be called)", async () => {
+		const emdash = buildEmdash();
+		const res = await deletePermanent(permanentCtx(contributor, emdash));
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentPermanentDelete).not.toHaveBeenCalled();
+	});
+
+	it("denies SUBSCRIBER (handler must not be called)", async () => {
+		const emdash = buildEmdash();
+		const res = await deletePermanent(permanentCtx(subscriber, emdash));
+		expect(res.status).toBe(403);
+		expect(emdash.handleContentPermanentDelete).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What does this PR do?

`DELETE /content/:collection/:id/permanent` had two issues:

1. **No trash-state guard.** The SQL was `DELETE FROM ${table} WHERE id = ?`, so live rows could be permanently removed without going through soft-delete first. The query now requires `deleted_at IS NOT NULL`.

2. **Wrong permission domain.** The route gated on `import:execute`, an unrelated permission that happens to be ADMIN-only. Replaced with a new `content:delete_permanent` (also ADMIN-only — no audience change).

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
