### PR TITLE
fix(registry-cli): granular OAuth scopes, error reporting, exit hang

### DIFF
--- a/.changeset/registry-cli-exit-hang.md
+++ b/.changeset/registry-cli-exit-hang.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-cli": patch
+---
+
+Fixes the CLI hanging indefinitely after a successful `login` or `logout`. `run()` was returning correctly, but something in the OAuth path left a ref'd handle alive that prevented Node's event loop from draining. Workaround: force-exit at the top level once `runMain` resolves. The underlying handle leak is unidentified.

--- a/.changeset/registry-cli-granular-scopes.md
+++ b/.changeset/registry-cli-granular-scopes.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-cli": patch
+---
+
+Switches the login flow to request granular OAuth scopes derived from the `@emdash-cms/registry-lexicons` lexicon set instead of the broad `transition:generic`: `repo:` for every record-shaped lexicon (package profile, package release, publisher profile, publisher verification) and `rpc:<nsid>?aud=*` for every aggregator query (`getLatestRelease`, `getPackage`, `listReleases`, `resolvePackage`, `searchPackages`). Display name resolution no longer goes through `com.atproto.server.getSession`; the handle is read from the DID document via `LocalActorResolver` so the CLI doesn't need an `rpc:com.atproto.*` scope and isn't affected by PDS-side DPoP/Bearer compatibility quirks. If the PDS rejects the granular scopes with `invalid_scope`, login automatically retries once with `transition:generic` and prints a notice. Existing sessions continue working with their original scope until they're revoked or re-issued.

--- a/.changeset/registry-cli-login-error.md
+++ b/.changeset/registry-cli-login-error.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-cli": patch
+---
+
+Improves `login` error reporting for OAuth response failures. Previously, transient PDS errors surfaced as a bare `unknown_error` with a stack trace; the CLI now prints the HTTP status, endpoint, OAuth error code/description, a body snippet when the response wasn't OAuth-shaped JSON, and a hint to retry on 5xx responses.

--- a/.changeset/registry-lexicons-nsid-lists.md
+++ b/.changeset/registry-lexicons-nsid-lists.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/registry-lexicons": minor
+---
+
+Adds `RECORD_NSIDS` and `QUERY_NSIDS` const arrays alongside the existing `NSID` map. They enumerate the record-shaped and query-shaped lexicons in this package so consumers (e.g. tooling that builds OAuth `repo:` / `rpc:` scopes) can derive their list from the lexicon set instead of hand-rolling one that drifts.

--- a/packages/registry-cli/src/commands/login.ts
+++ b/packages/registry-cli/src/commands/login.ts
@@ -12,7 +12,7 @@
  */
 
 import { isHandle } from "@atcute/lexicons/syntax";
-import { OAuthResponseError } from "@atcute/oauth-node-client";
+import { OAuthCallbackError, OAuthResponseError } from "@atcute/oauth-node-client";
 import { FileCredentialStore } from "@emdash-cms/registry-client";
 import { defineCommand } from "citty";
 import { consola } from "consola";
@@ -121,6 +121,13 @@ export const loginCommand = defineCommand({
 		} catch (error) {
 			if (error instanceof OAuthResponseError) {
 				await reportOAuthFailure(error);
+				process.exit(1);
+			}
+			if (error instanceof OAuthCallbackError) {
+				consola.error(`Login failed: ${error.errorDescription ?? error.error}`);
+				if (error.errorDescription && error.error !== error.errorDescription) {
+					consola.info(`Error code: ${error.error}`);
+				}
 				process.exit(1);
 			}
 			throw error;

--- a/packages/registry-cli/src/commands/login.ts
+++ b/packages/registry-cli/src/commands/login.ts
@@ -12,6 +12,7 @@
  */
 
 import { isHandle } from "@atcute/lexicons/syntax";
+import { OAuthResponseError } from "@atcute/oauth-node-client";
 import { FileCredentialStore } from "@emdash-cms/registry-client";
 import { defineCommand } from "citty";
 import { consola } from "consola";
@@ -19,6 +20,62 @@ import pc from "picocolors";
 
 import { runInteractiveLogin } from "../oauth.js";
 import { resolveAtprotoProfile } from "../profile.js";
+
+const BODY_SNIPPET_MAX_CHARS = 200;
+const WHITESPACE_RUN = /\s+/g;
+
+/**
+ * Read up to `BODY_SNIPPET_MAX_CHARS` of the response body, collapsed to a
+ * single line. Returns null if the body is empty or can't be read. Used to
+ * surface what the PDS actually returned when the OAuth library couldn't
+ * extract an `error` / `error_description` from the JSON body and fell back
+ * to its `unknown_error` placeholder.
+ */
+async function readBodySnippet(response: Response): Promise<string | null> {
+	try {
+		const text = await response.clone().text();
+		if (!text) return null;
+		const oneLine = text.replace(WHITESPACE_RUN, " ").trim();
+		if (!oneLine) return null;
+		return oneLine.length > BODY_SNIPPET_MAX_CHARS
+			? `${oneLine.slice(0, BODY_SNIPPET_MAX_CHARS)}…`
+			: oneLine;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Render an OAuth response error as a clean CLI message. The atcute library
+ * surfaces these as `OAuthResponseError` with `error: "unknown_error"` whenever
+ * the AS response wasn't an OAuth-shaped JSON body — most often a transient
+ * gateway/PDS hiccup. Without this, users just see "ERROR unknown_error" and a
+ * stack trace, which doesn't help them tell "PDS hiccup" from "config issue".
+ */
+async function reportOAuthFailure(error: OAuthResponseError): Promise<void> {
+	const { status } = error;
+	const statusText = error.response.statusText;
+	const endpoint = error.response.url;
+
+	const statusLine = statusText ? `HTTP ${status} ${statusText}` : `HTTP ${status}`;
+	consola.error(`Login failed: PDS responded with ${statusLine}`);
+	if (endpoint) consola.info(`Endpoint: ${pc.dim(endpoint)}`);
+
+	if (error.errorDescription) {
+		consola.info(`Reason: ${error.errorDescription}`);
+	} else if (error.error && error.error !== "unknown_error") {
+		consola.info(`Reason: ${error.error}`);
+	}
+
+	if (error.error === "unknown_error") {
+		const snippet = await readBodySnippet(error.response);
+		if (snippet) consola.info(`Body: ${pc.dim(snippet)}`);
+	}
+
+	if (status >= 500) {
+		consola.info("This looks like a transient server error — try again in a moment.");
+	}
+}
 
 export const loginCommand = defineCommand({
 	meta: {
@@ -41,16 +98,33 @@ export const loginCommand = defineCommand({
 
 		consola.start(`Logging in as ${pc.bold(identifier)}...`);
 
-		const result = await runInteractiveLogin({
-			identifier,
-			onUrl: (url) => {
-				console.log();
-				consola.info("Open your browser to:");
-				console.log(`  ${pc.cyan(pc.bold(url.toString()))}`);
-				console.log();
-				consola.info("Waiting for authorization...");
-			},
-		});
+		let result: Awaited<ReturnType<typeof runInteractiveLogin>>;
+		try {
+			result = await runInteractiveLogin({
+				identifier,
+				onUrl: (url) => {
+					console.log();
+					consola.info("Open your browser to:");
+					console.log(`  ${pc.cyan(pc.bold(url.toString()))}`);
+					console.log();
+					consola.info("Waiting for authorization...");
+				},
+				onLegacyScopeFallback: () => {
+					consola.warn(
+						"Your PDS rejected the granular OAuth scopes; falling back to legacy `transition:generic`.",
+					);
+					consola.info(
+						"This grants the CLI broader permissions than it needs. Ask your PDS operator to update to a build that supports the atproto granular permission spec.",
+					);
+				},
+			});
+		} catch (error) {
+			if (error instanceof OAuthResponseError) {
+				await reportOAuthFailure(error);
+				process.exit(1);
+			}
+			throw error;
+		}
 
 		const { displayName, handle, pds } = await resolveAtprotoProfile(result.session);
 

--- a/packages/registry-cli/src/index.ts
+++ b/packages/registry-cli/src/index.ts
@@ -46,4 +46,12 @@ const main = defineCommand({
 	},
 });
 
-void runMain(main);
+// citty's `runMain` only force-exits on error or `--help`; on normal
+// completion it just resolves and lets the event loop drain. After a
+// successful `login` the success message prints, `run()` returns, but
+// something inside atcute / the loopback HTTP path leaves a ref'd handle
+// alive indefinitely -- the CLI hangs forever instead of returning to the
+// shell. (The same is true for `logout`'s revocation flow.) Force-exit on
+// success so users get an immediate prompt back; non-success paths already
+// `process.exit` themselves.
+void runMain(main).then(() => process.exit(0));

--- a/packages/registry-cli/src/oauth.ts
+++ b/packages/registry-cli/src/oauth.ts
@@ -240,10 +240,10 @@ export interface OAuthClientFactoryOptions {
 	 */
 	redirectUri: `http://127.0.0.1:${number}/callback`;
 	/**
-	 * Scopes to request. Defaults to {@link DEFAULT_CLI_SCOPE} — granular per
-	 * the atproto OAuth permission spec, scoped to the two record collections
-	 * the CLI publishes plus an `rpc:com.atproto.server.getSession` for handle
-	 * resolution.
+	 * Scopes to request. Defaults to {@link DEFAULT_CLI_SCOPE}: `atproto` plus
+	 * `repo:<nsid>` for every record-shaped lexicon in
+	 * `@emdash-cms/registry-lexicons` and `rpc:<nsid>?aud=*` for every
+	 * aggregator query.
 	 */
 	scope?: string;
 }

--- a/packages/registry-cli/src/oauth.ts
+++ b/packages/registry-cli/src/oauth.ts
@@ -37,12 +37,50 @@ import {
 	type LoopbackClientMetadata,
 	type OAuthSession,
 	OAuthClient,
+	OAuthResponseError,
 	type Store,
 	type StoredSession,
 	type StoredState,
 } from "@atcute/oauth-node-client";
+import { QUERY_NSIDS, RECORD_NSIDS } from "@emdash-cms/registry-lexicons";
 
 import { DEFAULT_OAUTH_DIR } from "./config.js";
+
+/**
+ * Default OAuth scope for the registry CLI. Granular per the atproto OAuth
+ * permission spec, derived from the lexicon set in `@emdash-cms/registry-lexicons`:
+ *
+ *   - `atproto`: base requirement (DID-bound DPoP session, identity).
+ *   - `repo:<nsid>` for every record-shaped lexicon: write profile, release,
+ *     publisher profile, and verification records via `applyWrites`. Repo
+ *     reads of public records don't require a scope, and embedded objects
+ *     (`releaseExtension`) ride inside their parent record.
+ *   - `rpc:<nsid>?aud=*` for every query-shaped lexicon: cover the
+ *     aggregator XRPC methods even though the publish CLI doesn't call them
+ *     yet — granting them at login means future tooling that resumes the
+ *     stored session can call the aggregator without forcing a re-login.
+ *     `aud=*` because the aggregator's service DID isn't pinned today.
+ *
+ * `transition:generic` is intentionally not included. PDSes accept granular
+ * scopes at PAR even when their `scopes_supported` metadata still lists only
+ * the transitional shims, so requesting only what we need keeps the consent
+ * screen honest.
+ */
+const DEFAULT_CLI_SCOPE = [
+	"atproto",
+	...RECORD_NSIDS.map((nsid) => `repo:${nsid}`),
+	...QUERY_NSIDS.map((nsid) => `rpc:${nsid}?aud=*`),
+].join(" ");
+
+/**
+ * Legacy fallback scope used when the AS returns `invalid_scope` for the
+ * granular request. `transition:generic` predates the granular permission
+ * spec and every atproto OAuth server has supported it since OAuth shipped,
+ * so it's the safe re-try shape. The publish flow doesn't get any narrower
+ * permissions out of this path -- it's purely a compatibility shim for
+ * publishers on un-upgraded PDSes.
+ */
+const LEGACY_FALLBACK_SCOPE = "atproto transition:generic";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Filesystem-backed Store<K, V>
@@ -202,10 +240,36 @@ export interface OAuthClientFactoryOptions {
 	 */
 	redirectUri: `http://127.0.0.1:${number}/callback`;
 	/**
-	 * Scopes to request. Defaults to `atproto transition:generic`, which is
-	 * what the publishing CLI needs to put records in the publisher's repo.
+	 * Scopes to request. Defaults to {@link DEFAULT_CLI_SCOPE} — granular per
+	 * the atproto OAuth permission spec, scoped to the two record collections
+	 * the CLI publishes plus an `rpc:com.atproto.server.getSession` for handle
+	 * resolution.
 	 */
 	scope?: string;
+}
+
+/**
+ * Build a `LocalActorResolver` for atproto identity lookups (handle <-> DID,
+ * DID document, PDS endpoint). Shared by the OAuth client and post-login
+ * profile resolution so they agree on handle/DID round-trip rules.
+ */
+export function createActorResolver(): LocalActorResolver {
+	return new LocalActorResolver({
+		handleResolver: new CompositeHandleResolver({
+			methods: {
+				dns: new DohJsonHandleResolver({
+					dohUrl: "https://cloudflare-dns.com/dns-query",
+				}),
+				http: new WellKnownHandleResolver(),
+			},
+		}),
+		didDocumentResolver: new CompositeDidDocumentResolver({
+			methods: {
+				plc: new PlcDidDocumentResolver(),
+				web: new WebDidDocumentResolver(),
+			},
+		}),
+	});
 }
 
 /**
@@ -222,22 +286,7 @@ export function createCliOAuthClient(options: OAuthClientFactoryOptions): OAuthC
 	const sessions = new FileStore<StoredSession>(join(stateDir, "sessions.json"));
 	const states = new FileStore<StoredState>(join(stateDir, "states.json"));
 
-	const actorResolver = new LocalActorResolver({
-		handleResolver: new CompositeHandleResolver({
-			methods: {
-				dns: new DohJsonHandleResolver({
-					dohUrl: "https://cloudflare-dns.com/dns-query",
-				}),
-				http: new WellKnownHandleResolver(),
-			},
-		}),
-		didDocumentResolver: new CompositeDidDocumentResolver({
-			methods: {
-				plc: new PlcDidDocumentResolver(),
-				web: new WebDidDocumentResolver(),
-			},
-		}),
-	});
+	const actorResolver = createActorResolver();
 
 	// Loopback public client per RFC 8252: no client_id, no JWKS, no
 	// confidential auth. The PDS derives metadata from the client_id URL
@@ -246,7 +295,7 @@ export function createCliOAuthClient(options: OAuthClientFactoryOptions): OAuthC
 	// loopbackRedirectUriSchema.
 	const metadata: LoopbackClientMetadata = {
 		redirect_uris: [options.redirectUri],
-		scope: options.scope ?? "atproto transition:generic",
+		scope: options.scope ?? DEFAULT_CLI_SCOPE,
 	};
 
 	return new OAuthClient({
@@ -514,11 +563,61 @@ export interface RunInteractiveLoginOptions {
 	timeoutMs?: number;
 	/** Hook for printing the verification URL when the browser-open fails. */
 	onUrl?: (url: URL) => void;
+	/**
+	 * Hook fired when the AS rejected the granular scope request and the
+	 * flow is retrying with the legacy `transition:generic` fallback. The
+	 * CLI uses this to print a notice so the user knows their PDS is
+	 * granting broader permissions than the spec-compliant path would.
+	 */
+	onLegacyScopeFallback?: () => void;
 }
 
 export interface RunInteractiveLoginResult {
 	session: OAuthSession;
 	did: Did;
+}
+
+/**
+ * Build an OAuth client, call `authorize`, and on `invalid_scope` retry once
+ * with the legacy `transition:generic` shim. Returns whichever client actually
+ * pushed an authorization request, so the caller hands the same client to
+ * `callback()` (the second client owns the persisted state).
+ *
+ * `invalid_scope` is the well-defined RFC 6749 §5.2 error the AS returns when
+ * a requested scope isn't supported. The retry path doesn't fire on any other
+ * OAuth error -- a `bad_request`, `server_error`, etc. all bubble up so the
+ * login command can render them via its `OAuthResponseError` handler.
+ */
+async function authorizeWithLegacyFallback(input: {
+	stateDir: string | undefined;
+	redirectUri: `http://127.0.0.1:${number}/callback`;
+	identifier: ActorIdentifier;
+	onLegacyScopeFallback: (() => void) | undefined;
+}): Promise<{ client: OAuthClient; url: URL }> {
+	const granular = createCliOAuthClient({
+		stateDir: input.stateDir,
+		redirectUri: input.redirectUri,
+	});
+	try {
+		const { url } = await granular.authorize({
+			target: { type: "account", identifier: input.identifier },
+		});
+		return { client: granular, url };
+	} catch (error) {
+		if (!(error instanceof OAuthResponseError) || error.error !== "invalid_scope") {
+			throw error;
+		}
+		input.onLegacyScopeFallback?.();
+		const legacy = createCliOAuthClient({
+			stateDir: input.stateDir,
+			redirectUri: input.redirectUri,
+			scope: LEGACY_FALLBACK_SCOPE,
+		});
+		const { url } = await legacy.authorize({
+			target: { type: "account", identifier: input.identifier },
+		});
+		return { client: legacy, url };
+	}
 }
 
 /**
@@ -535,14 +634,12 @@ export async function runInteractiveLogin(
 ): Promise<RunInteractiveLoginResult> {
 	const server = await bindLoopbackServer(options.timeoutMs);
 	try {
-		const client = createCliOAuthClient({
+		const identifier = parseActorIdentifier(options.identifier);
+		const { client, url } = await authorizeWithLegacyFallback({
 			stateDir: options.stateDir,
 			redirectUri: server.redirectUri,
-		});
-
-		const identifier = parseActorIdentifier(options.identifier);
-		const { url } = await client.authorize({
-			target: { type: "account", identifier },
+			identifier,
+			onLegacyScopeFallback: options.onLegacyScopeFallback,
 		});
 
 		options.onUrl?.(url);

--- a/packages/registry-cli/src/profile.ts
+++ b/packages/registry-cli/src/profile.ts
@@ -8,12 +8,15 @@
  *      resource server URL the session is bound to -- exactly the PDS the
  *      session can actually talk to. Always populated for authenticated
  *      sessions; never empty.
- *   2. Handle: `com.atproto.server.getSession`. Best-effort; falls back
- *      to the DID on failure. The DID is then surfaced as a placeholder
- *      handle that the caller is expected to detect (`isHandle()`) and
- *      treat as null for storage.
- *   3. Display name: `app.bsky.actor.profile` (rkey `self`). Optional;
- *      absent profile records are not an error.
+ *   2. Handle: resolved from the DID document via `LocalActorResolver`.
+ *      `alsoKnownAs` is read off the DID doc and the handle is verified to
+ *      round-trip back to the same DID before it's accepted. No PDS XRPC
+ *      involved -- this works regardless of how the PDS handles OAuth/DPoP
+ *      tokens, and doesn't need an `rpc:` scope. Falls back to the DID on
+ *      failure; the caller detects that via `isHandle()`.
+ *   3. Display name: `app.bsky.actor.profile` (rkey `self`) via
+ *      `getRecord` -- a public repo read that doesn't require auth. Absent
+ *      profile records are not an error.
  *
  * The PDS URL is no longer best-effort: a session without a usable PDS
  * is unrecoverable, so we throw rather than persist an empty string and
@@ -22,9 +25,7 @@
 
 import type { OAuthSession } from "@atcute/oauth-node-client";
 
-interface GetSessionResponse {
-	handle?: string;
-}
+import { createActorResolver } from "./oauth.js";
 
 export interface AtprotoProfile {
 	handle: string;
@@ -56,10 +57,12 @@ export async function resolveAtprotoProfile(session: OAuthSession): Promise<Atpr
 	let displayName: string | null = null;
 
 	try {
-		const res = await session.handle("/xrpc/com.atproto.server.getSession");
-		if (res.ok) {
-			const data = pickGetSession(await res.json());
-			if (data.handle) handle = data.handle;
+		const resolved = await createActorResolver().resolve(did);
+		// `LocalActorResolver` returns `'handle.invalid'` when the
+		// alsoKnownAs handle doesn't round-trip back to this DID. Treat
+		// that as "no handle" and fall back to the DID.
+		if (resolved.handle && resolved.handle !== "handle.invalid") {
+			handle = resolved.handle;
 		}
 	} catch {
 		// best-effort; fall through to DID as handle
@@ -77,13 +80,6 @@ export async function resolveAtprotoProfile(session: OAuthSession): Promise<Atpr
 	}
 
 	return { handle, displayName, pds };
-}
-
-function pickGetSession(input: unknown): GetSessionResponse {
-	if (!input || typeof input !== "object") return {};
-	const out: GetSessionResponse = {};
-	if ("handle" in input && typeof input.handle === "string") out.handle = input.handle;
-	return out;
 }
 
 function pickDisplayName(input: unknown): string | null {

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -88,7 +88,6 @@ export const QUERY_NSIDS = [
 
 import type * as PackageProfileNs from "./generated/types/com/emdashcms/experimental/package/profile.js";
 import type * as PackageReleaseNs from "./generated/types/com/emdashcms/experimental/package/release.js";
-import type * as PackageReleaseExtensionNs from "./generated/types/com/emdashcms/experimental/package/releaseExtension.js";
 import type * as PublisherProfileNs from "./generated/types/com/emdashcms/experimental/publisher/profile.js";
 import type * as PublisherVerificationNs from "./generated/types/com/emdashcms/experimental/publisher/verification.js";
 
@@ -97,13 +96,13 @@ import type * as PublisherVerificationNs from "./generated/types/com/emdashcms/e
  * to its PDS. Used by `PublishingClient.putRecord` (and any other typed-write
  * helper) to ensure callers pass a record matching the collection's lexicon.
  *
- * Query / procedure NSIDs (the `aggregator.*` ones) are deliberately absent --
- * they aren't records.
+ * Embedded objects (`releaseExtension`, which lives inside a release record's
+ * `extensions` map) and query/procedure NSIDs (the `aggregator.*` ones) are
+ * deliberately absent -- they aren't standalone repo collections.
  */
 export interface RegistryRecords {
 	"com.emdashcms.experimental.package.profile": PackageProfileNs.Main;
 	"com.emdashcms.experimental.package.release": PackageReleaseNs.Main;
-	"com.emdashcms.experimental.package.releaseExtension": PackageReleaseExtensionNs.Main;
 	"com.emdashcms.experimental.publisher.profile": PublisherProfileNs.Main;
 	"com.emdashcms.experimental.publisher.verification": PublisherVerificationNs.Main;
 }

--- a/packages/registry-lexicons/src/index.ts
+++ b/packages/registry-lexicons/src/index.ts
@@ -56,6 +56,36 @@ export const NSID = {
 
 export type NSIDValue = (typeof NSID)[keyof typeof NSID];
 
+/**
+ * NSIDs of record-shaped lexicons in this package (one row per NSID in the
+ * publisher's repo). Embedded objects (`releaseExtension`) and shared defs
+ * (`aggregator.defs`) are excluded — they don't address their own collection.
+ *
+ * Useful for consumers building OAuth `repo:` scopes or enumerating writable
+ * collections without hand-rolling a list that drifts from the lexicons.
+ */
+export const RECORD_NSIDS = [
+	NSID.packageProfile,
+	NSID.packageRelease,
+	NSID.publisherProfile,
+	NSID.publisherVerification,
+] as const;
+
+/**
+ * NSIDs of query-shaped lexicons in this package (read-only XRPC methods on
+ * the aggregator). Procedures and shared defs are excluded.
+ *
+ * Useful for consumers building OAuth `rpc:` scopes or enumerating callable
+ * AppView endpoints.
+ */
+export const QUERY_NSIDS = [
+	NSID.aggregatorGetLatestRelease,
+	NSID.aggregatorGetPackage,
+	NSID.aggregatorListReleases,
+	NSID.aggregatorResolvePackage,
+	NSID.aggregatorSearchPackages,
+] as const;
+
 import type * as PackageProfileNs from "./generated/types/com/emdashcms/experimental/package/profile.js";
 import type * as PackageReleaseNs from "./generated/types/com/emdashcms/experimental/package/release.js";
 import type * as PackageReleaseExtensionNs from "./generated/types/com/emdashcms/experimental/package/releaseExtension.js";


### PR DESCRIPTION
## What does this PR do?

Four related improvements to the `@emdash-cms/registry-cli` login flow, surfaced while logging in to `mk.gg`:

1. **Granular OAuth scopes.** `transition:generic` is replaced with the narrowest scope set derived from `@emdash-cms/registry-lexicons`:

   - `atproto`
   - `repo:<nsid>` for every record-shaped lexicon (package profile, package release, publisher profile, publisher verification)
   - `rpc:<nsid>?aud=*` for every aggregator query (the publish CLI doesn't call them yet, but granting them at login means future tooling that resumes the stored session can call the aggregator without forcing a re-login).

   If the AS rejects the granular request with `invalid_scope`, login automatically retries once with `transition:generic` and prints a notice — keeps publishers on un-upgraded PDSes unblocked.

2. **OAuth error reporting.** `OAuthResponseError` is caught in the login command and rendered with HTTP status, endpoint, OAuth error code/description, and a body snippet when the AS response wasn't OAuth-shaped JSON. The original symptom was a bare `unknown_error` plus a stack trace whenever the PDS hiccuped at PAR — users had no way to tell "transient PDS issue" from "config problem."

3. **Display name / handle resolution.** Post-login handle resolution moved off `com.atproto.server.getSession` (which 401s on cirrus PDSes that only accept `Authorization: Bearer ...`, since atcute sends `Authorization: DPoP ...` for OAuth sessions) onto `LocalActorResolver.resolve(did)`. The handle is read from the DID document's `alsoKnownAs` and round-tripped through DNS/well-known to verify it points back. No PDS XRPC, no DPoP/Bearer compatibility, no `rpc:com.atproto.*` scope needed.

4. **Login/logout exit hang.** After a successful `login` or `logout`, `run()` was returning correctly but the CLI hung indefinitely. Root cause is a ref'd handle somewhere in the OAuth path (atcute, undici, or the loopback server) that prevents Node's event loop from draining. Workaround: force-exit at the top level once `runMain` resolves. The underlying handle leak is unidentified — flagged in the changeset and the source comment.

Bonus: `@emdash-cms/registry-lexicons` now exports `RECORD_NSIDS` and `QUERY_NSIDS` so other consumers can derive permission/scope lists from the lexicon set instead of hand-rolling one that drifts.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — _no tests added; the changes are presentation, scope strings, and a top-level workaround. The existing 83 tests in the package still pass._
- [ ] User-visible strings in the admin UI are wrapped for translation — _N/A; this is the CLI._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (four changesets — three patches on `@emdash-cms/registry-cli`, one minor on `@emdash-cms/registry-lexicons` for the new exports)
- [ ] New features link to an approved Discussion — _N/A; this is a bug fix bundle._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

`node packages/registry-cli/dist/index.mjs login mk.gg` before this PR (the actual symptom that prompted the work):

```
ℹ Waiting for authorization...
✔ Logged in as did:plc:uwbl4k3tza7eyjv3morkrld2 (Matt Kane)
ℹ PDS: https://mk.pds.mk.gg/
^C   <-- CLI never returned to the shell prompt
```

After this PR: handle resolves to `mk.gg` (via DID doc, no PDS XRPC), and the prompt returns immediately after `PDS:` prints.