### PR TITLE
chore(templates): make marketing footer links editable via menus

### DIFF
--- a/templates/marketing-cloudflare/seed/seed.json
+++ b/templates/marketing-cloudflare/seed/seed.json
@@ -52,6 +52,33 @@
 					"url": "/contact"
 				}
 			]
+		},
+		{
+			"name": "footer_product",
+			"label": "Footer: Product",
+			"items": [
+				{ "type": "custom", "label": "Features", "url": "/#features" },
+				{ "type": "custom", "label": "Pricing", "url": "/pricing" },
+				{ "type": "custom", "label": "Changelog", "url": "/changelog" }
+			]
+		},
+		{
+			"name": "footer_company",
+			"label": "Footer: Company",
+			"items": [
+				{ "type": "custom", "label": "About", "url": "/about" },
+				{ "type": "custom", "label": "Blog", "url": "/blog" },
+				{ "type": "custom", "label": "Careers", "url": "/careers" }
+			]
+		},
+		{
+			"name": "footer_support",
+			"label": "Footer: Support",
+			"items": [
+				{ "type": "custom", "label": "Documentation", "url": "/docs" },
+				{ "type": "custom", "label": "Contact", "url": "/contact" },
+				{ "type": "custom", "label": "Status", "url": "/status" }
+			]
 		}
 	],
 	"content": {

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -117,7 +117,10 @@ const pageCtx = createPublicPageContext({
 							<div class="footer-col">
 								<h4>{col.heading}</h4>
 								{col.menu!.items.map((item) => (
-									<a href={item.url} target={item.target}>
+									<a
+										href={item.url}
+										target={item.target}
+										rel={item.target ? "noopener noreferrer" : undefined}>
 										{item.label}
 									</a>
 								))}

--- a/templates/marketing-cloudflare/src/layouts/Base.astro
+++ b/templates/marketing-cloudflare/src/layouts/Base.astro
@@ -20,7 +20,18 @@ const siteDescription =
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
 
-const menu = await getMenu("primary");
+const [menu, footerProduct, footerCompany, footerSupport] = await Promise.all([
+	getMenu("primary"),
+	getMenu("footer_product"),
+	getMenu("footer_company"),
+	getMenu("footer_support"),
+]);
+
+const footerColumns = [
+	{ heading: "Product", menu: footerProduct },
+	{ heading: "Company", menu: footerCompany },
+	{ heading: "Support", menu: footerSupport },
+].filter((col) => col.menu && col.menu.items.length > 0);
 
 const pageCtx = createPublicPageContext({
 	Astro,
@@ -101,24 +112,18 @@ const pageCtx = createPublicPageContext({
 					</p>
 				</div>
 				<div class="footer-links">
-					<div class="footer-col">
-						<h4>Product</h4>
-						<a href="/#features">Features</a>
-						<a href="/pricing">Pricing</a>
-						<a href="/changelog">Changelog</a>
-					</div>
-					<div class="footer-col">
-						<h4>Company</h4>
-						<a href="/about">About</a>
-						<a href="/blog">Blog</a>
-						<a href="/careers">Careers</a>
-					</div>
-					<div class="footer-col">
-						<h4>Support</h4>
-						<a href="/docs">Documentation</a>
-						<a href="/contact">Contact</a>
-						<a href="/status">Status</a>
-					</div>
+					{
+						footerColumns.map((col) => (
+							<div class="footer-col">
+								<h4>{col.heading}</h4>
+								{col.menu!.items.map((item) => (
+									<a href={item.url} target={item.target}>
+										{item.label}
+									</a>
+								))}
+							</div>
+						))
+					}
 				</div>
 			</div>
 			<div class="footer-bottom">

--- a/templates/marketing/seed/seed.json
+++ b/templates/marketing/seed/seed.json
@@ -52,6 +52,33 @@
 					"url": "/contact"
 				}
 			]
+		},
+		{
+			"name": "footer_product",
+			"label": "Footer: Product",
+			"items": [
+				{ "type": "custom", "label": "Features", "url": "/#features" },
+				{ "type": "custom", "label": "Pricing", "url": "/pricing" },
+				{ "type": "custom", "label": "Changelog", "url": "/changelog" }
+			]
+		},
+		{
+			"name": "footer_company",
+			"label": "Footer: Company",
+			"items": [
+				{ "type": "custom", "label": "About", "url": "/about" },
+				{ "type": "custom", "label": "Blog", "url": "/blog" },
+				{ "type": "custom", "label": "Careers", "url": "/careers" }
+			]
+		},
+		{
+			"name": "footer_support",
+			"label": "Footer: Support",
+			"items": [
+				{ "type": "custom", "label": "Documentation", "url": "/docs" },
+				{ "type": "custom", "label": "Contact", "url": "/contact" },
+				{ "type": "custom", "label": "Status", "url": "/status" }
+			]
 		}
 	],
 	"content": {

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -117,7 +117,10 @@ const pageCtx = createPublicPageContext({
 							<div class="footer-col">
 								<h4>{col.heading}</h4>
 								{col.menu!.items.map((item) => (
-									<a href={item.url} target={item.target}>
+									<a
+										href={item.url}
+										target={item.target}
+										rel={item.target ? "noopener noreferrer" : undefined}>
 										{item.label}
 									</a>
 								))}

--- a/templates/marketing/src/layouts/Base.astro
+++ b/templates/marketing/src/layouts/Base.astro
@@ -20,7 +20,18 @@ const siteDescription =
 const siteLogo = (settings?.logo as any)?.url ? settings.logo as
 	{ mediaId: string; alt?: string; url: string } : null;
 
-const menu = await getMenu("primary");
+const [menu, footerProduct, footerCompany, footerSupport] = await Promise.all([
+	getMenu("primary"),
+	getMenu("footer_product"),
+	getMenu("footer_company"),
+	getMenu("footer_support"),
+]);
+
+const footerColumns = [
+	{ heading: "Product", menu: footerProduct },
+	{ heading: "Company", menu: footerCompany },
+	{ heading: "Support", menu: footerSupport },
+].filter((col) => col.menu && col.menu.items.length > 0);
 
 const pageCtx = createPublicPageContext({
 	Astro,
@@ -101,24 +112,18 @@ const pageCtx = createPublicPageContext({
 					</p>
 				</div>
 				<div class="footer-links">
-					<div class="footer-col">
-						<h4>Product</h4>
-						<a href="/#features">Features</a>
-						<a href="/pricing">Pricing</a>
-						<a href="/changelog">Changelog</a>
-					</div>
-					<div class="footer-col">
-						<h4>Company</h4>
-						<a href="/about">About</a>
-						<a href="/blog">Blog</a>
-						<a href="/careers">Careers</a>
-					</div>
-					<div class="footer-col">
-						<h4>Support</h4>
-						<a href="/docs">Documentation</a>
-						<a href="/contact">Contact</a>
-						<a href="/status">Status</a>
-					</div>
+					{
+						footerColumns.map((col) => (
+							<div class="footer-col">
+								<h4>{col.heading}</h4>
+								{col.menu!.items.map((item) => (
+									<a href={item.url} target={item.target}>
+										{item.label}
+									</a>
+								))}
+							</div>
+						))
+					}
 				</div>
 			</div>
 			<div class="footer-bottom">


### PR DESCRIPTION
## What does this PR do?

Makes the footer links in the \`marketing\` template editable from the admin UI rather than hard-coded in \`Base.astro\`. Adds three menus (\`footer_product\`, \`footer_company\`, \`footer_support\`) to the seed and renders them dynamically. Columns hide automatically when their menu is empty, so editors can shrink the footer to one or two columns without touching code. Cloudflare variant kept in sync via \`scripts/sync-cloudflare-templates.sh\`.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [x] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (0 errors; 21 pre-existing warnings on \`main\` unchanged by this PR)
- [ ] \`pnpm test\` passes (or targeted tests for my change) -- not run; template-only change, no tests cover this
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (if applicable) -- N/A
- [ ] User-visible strings in the admin UI are wrapped for translation -- N/A, no admin UI changes
- [ ] I have added a changeset -- N/A, marketing templates are in \`.changeset/config.json\` \`ignore\` list
- [ ] New features link to an approved Discussion -- N/A, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7 (OpenCode)

## Screenshots / test output

\`pnpm astro check\` in \`templates/marketing\`: 0 errors, 0 warnings, 0 hints across 17 files.