### PR TITLE
fix(admin): standardise button and link patterns across admin UI

### DIFF
--- a/.changeset/legal-doodles-move.md
+++ b/.changeset/legal-doodles-move.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes button and link inconsistencies across the admin UI. Standardises on Kumo's `Button` `icon` prop and `LinkButton` (with `external` for new-tab links) instead of manual icon spacing and raw anchor styling, removes a `<Link><Button>` invalid HTML nesting in the plugin manager, and translates two stray English strings in the user list empty state.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -6,6 +6,7 @@ import {
 	Input,
 	InputArea,
 	Label,
+	LinkButton,
 	Loader,
 	Select,
 	Switch,
@@ -658,7 +659,7 @@ export function ContentEditor({
 								<Dialog.Root>
 									<Dialog.Trigger
 										render={(p) => (
-											<Button {...p} type="button" variant="outline" size="sm" icon={<X />}>
+											<Button {...p} type="button" variant="outline" icon={<X />}>
 												{t`Discard changes`}
 											</Button>
 										)}
@@ -707,15 +708,14 @@ export function ContentEditor({
 								</Button>
 							)}
 							{isLive && item?.slug && (
-								<a
+								<LinkButton
 									href={contentUrl(collection, item.slug, urlPattern)}
-									target="_blank"
-									rel="noopener noreferrer"
-									className={buttonVariants({ variant: "outline" })}
+									external
+									variant="outline"
+									icon={<ArrowSquareOut />}
 								>
-									<ArrowSquareOut className="me-2 h-4 w-4" aria-hidden="true" />
 									{t`Live View`}
-								</a>
+								</LinkButton>
 							)}
 						</>
 					)}

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1,4 +1,13 @@
-import { Badge, Button, buttonVariants, Dialog, Input, Loader, Tabs } from "@cloudflare/kumo";
+import {
+	Badge,
+	Button,
+	buttonVariants,
+	Dialog,
+	Input,
+	LinkButton,
+	Loader,
+	Tabs,
+} from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -509,15 +518,14 @@ function ContentListItem({
 			<td className="px-4 py-3 text-end">
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (
-						<a
+						<LinkButton
 							href={contentUrl(collection, item.slug, urlPattern)}
-							target="_blank"
-							rel="noopener noreferrer"
+							external
+							variant="ghost"
+							shape="square"
 							aria-label={t`View published ${title}`}
-							className={buttonVariants({ variant: "ghost", shape: "square" })}
-						>
-							<ArrowSquareOut className="h-4 w-4" aria-hidden="true" />
-						</a>
+							icon={<ArrowSquareOut />}
+						/>
 					)}
 					<Link
 						to="/content/$collection/$id"

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -137,8 +137,12 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 					<p className="mt-1 text-sm text-kumo-subtle">
 						{error instanceof Error ? error.message : t`An error occurred`}
 					</p>
-					<Button variant="ghost" className="mt-4" onClick={() => void refetch()}>
-						<ArrowsClockwise className="me-2 h-4 w-4" />
+					<Button
+						variant="ghost"
+						className="mt-4"
+						onClick={() => void refetch()}
+						icon={<ArrowsClockwise />}
+					>
 						{t`Retry`}
 					</Button>
 				</div>

--- a/packages/admin/src/components/MarketplacePluginDetail.tsx
+++ b/packages/admin/src/components/MarketplacePluginDetail.tsx
@@ -189,8 +189,7 @@ export function MarketplacePluginDetail({
 							<span className="text-xs text-kumo-danger">{t`Failed security audit`}</span>
 						</div>
 					) : (
-						<Button onClick={() => setShowConsent(true)}>
-							<DownloadSimple className="me-2 h-4 w-4" />
+						<Button onClick={() => setShowConsent(true)} icon={<DownloadSimple />}>
 							{t`Install`}
 						</Button>
 					)}

--- a/packages/admin/src/components/MenuList.tsx
+++ b/packages/admin/src/components/MenuList.tsx
@@ -220,7 +220,7 @@ export function MenuList() {
 									search={{ locale: menu.locale }}
 									className={buttonVariants({ variant: "outline", size: "sm" })}
 								>
-									<Pencil className="h-4 w-4 me-2" />
+									<Pencil className="me-2 h-4 w-4" aria-hidden="true" />
 									{t`Edit`}
 								</Link>
 								<Button

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -6,7 +6,7 @@
  * update/uninstall for marketplace-installed plugins.
  */
 
-import { Badge, Button, Switch, Toast } from "@cloudflare/kumo";
+import { Badge, Button, buttonVariants, Switch, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	PuzzlePiece,
@@ -147,19 +147,15 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 							variant="ghost"
 							onClick={() => void refetchUpdates()}
 							disabled={isCheckingUpdates}
+							icon={<ArrowsClockwise className={cn(isCheckingUpdates && "animate-spin")} />}
 						>
-							<ArrowsClockwise
-								className={cn("me-2 h-4 w-4", isCheckingUpdates && "animate-spin")}
-							/>
 							{t`Check for updates`}
 						</Button>
 					)}
 					{hasMarketplace && (
-						<Link to="/plugins/marketplace">
-							<Button variant="ghost">
-								<Storefront className="me-2 h-4 w-4" />
-								{t`Marketplace`}
-							</Button>
+						<Link to="/plugins/marketplace" className={buttonVariants({ variant: "ghost" })}>
+							<Storefront className="me-2 h-4 w-4" aria-hidden="true" />
+							{t`Marketplace`}
 						</Link>
 					)}
 					<span className="text-sm text-kumo-subtle">{t`${plugins?.length ?? 0} plugins`}</span>
@@ -479,8 +475,8 @@ function PluginCard({
 									className="text-kumo-danger hover:text-kumo-danger"
 									onClick={() => setShowUninstallConfirm(true)}
 									disabled={uninstallMutation.isPending}
+									icon={<Trash />}
 								>
-									<Trash className="me-2 h-4 w-4" />
 									{t`Uninstall`}
 								</Button>
 							</div>

--- a/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
@@ -115,8 +115,12 @@ export function ThemeMarketplaceBrowse() {
 					<p className="mt-1 text-sm text-kumo-subtle">
 						{error instanceof Error ? error.message : t`An error occurred`}
 					</p>
-					<Button variant="ghost" className="mt-4" onClick={() => void refetch()}>
-						<ArrowsClockwise className="me-2 h-4 w-4" />
+					<Button
+						variant="ghost"
+						className="mt-4"
+						onClick={() => void refetch()}
+						icon={<ArrowsClockwise />}
+					>
 						{t`Retry`}
 					</Button>
 				</div>

--- a/packages/admin/src/components/ThemeMarketplaceDetail.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceDetail.tsx
@@ -8,7 +8,7 @@
  * - Demo + repository links
  */
 
-import { Badge, Button } from "@cloudflare/kumo";
+import { Badge, Button, LinkButton } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	ArrowSquareOut,
@@ -138,18 +138,14 @@ export function ThemeMarketplaceDetail({ themeId }: ThemeMarketplaceDetailProps)
 						variant="primary"
 						onClick={() => previewMutation.mutate()}
 						disabled={previewMutation.isPending}
+						icon={<Eye />}
 					>
-						<Eye className="me-2 h-4 w-4" />
 						{previewMutation.isPending ? t`Loading...` : t`Try with my data`}
 					</Button>
 					{theme.demoUrl && isSafeUrl(theme.demoUrl) && (
-						<Button
-							variant="outline"
-							onClick={() => window.open(theme.demoUrl!, "_blank", "noopener")}
-						>
-							<ArrowSquareOut className="me-2 h-4 w-4" />
+						<LinkButton href={theme.demoUrl} external variant="outline" icon={<ArrowSquareOut />}>
 							{t`Demo`}
-						</Button>
+						</LinkButton>
 					)}
 				</div>
 			</div>

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -1359,10 +1359,10 @@ function PluginAuthStep({
 							href={`${siteUrl}/wp-admin/profile.php#application-passwords-section`}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="mt-2 inline-flex items-center gap-1 text-blue-600 hover:underline"
+							className="mt-2 inline-flex items-center gap-1 text-kumo-brand hover:underline"
 						>
 							{t`Open WordPress Profile`}
-							<ArrowSquareOut className="h-3 w-3" />
+							<ArrowSquareOut className="h-3 w-3" aria-hidden="true" />
 						</a>
 					</div>
 				</div>

--- a/packages/admin/src/components/users/UserList.tsx
+++ b/packages/admin/src/components/users/UserList.tsx
@@ -119,20 +119,25 @@ export function UserList({
 										<>
 											No users found matching your filters.{" "}
 											<button
+												type="button"
 												className="text-kumo-brand underline"
 												onClick={() => {
 													onSearchChange("");
 													onRoleFilterChange(undefined);
 												}}
 											>
-												Clear filters
+												{t`Clear filters`}
 											</button>
 										</>
 									) : (
 										<>
 											No users yet.{" "}
-											<button className="text-kumo-brand underline" onClick={onInviteUser}>
-												Invite your first team member
+											<button
+												type="button"
+												className="text-kumo-brand underline"
+												onClick={onInviteUser}
+											>
+												{t`Invite your first team member`}
 											</button>
 										</>
 									)}


### PR DESCRIPTION
## What does this PR do?

Cleans up button and link inconsistencies across the admin UI. Started from a single \`size=\"sm\"\` mismatch on the content editor toolbar's *Discard changes* button and expanded into a focused audit of related patterns.

Changes by file:

- **\`ContentEditor.tsx\`** — Drop \`size=\"sm\"\` on the *Discard changes* trigger (it sat next to default-sized buttons). Convert the *Live View* link from a raw \`<a target=\"_blank\">\` styled with \`buttonVariants\` to \`<LinkButton external icon={...}>\`.
- **\`ContentList.tsx\`** — Convert the published-content view link (icon-only) from raw anchor to \`<LinkButton external shape=\"square\">\`.
- **\`PluginManager.tsx\`** — Fix invalid \`<Link><Button>\` nesting (renders \`<a><button>\`) by switching the Marketplace link to \`<Link className={buttonVariants(...)}>\`, matching the convention already used in \`ContentList\` / \`ContentTypeList\`. Also convert three buttons from manual \`<Icon className=\"me-2 h-4 w-4\" />\` children to the \`icon\` prop.
- **\`ThemeMarketplaceDetail.tsx\`** — Convert the *Demo* button from \`<Button onClick={() => window.open(...)}>\` to a real \`<LinkButton href external>\` (gives middle-click + open-in-new-tab behaviour). Convert *Try with my data* to use the \`icon\` prop.
- **\`MarketplacePluginDetail.tsx\`**, **\`MarketplaceBrowse.tsx\`**, **\`ThemeMarketplaceBrowse.tsx\`** — Convert remaining \`<Icon className=\"me-2 h-4 w-4\" />\` patterns to the \`icon\` prop.
- **\`WordPressImport.tsx\`** — Replace hard-coded \`text-blue-600\` with the \`text-kumo-brand\` semantic token (was bypassing dark mode); add missing \`aria-hidden\` on a decorative icon.
- **\`MenuList.tsx\`** — Class order nit on a decorative icon (\`h-4 w-4 me-2\` -> \`me-2 h-4 w-4\`); add missing \`aria-hidden\`.
- **\`users/UserList.tsx\`** — Two bare \`<button>\`s in the empty state had English string literals (\"Clear filters\", \"Invite your first team member\") that bypassed Lingui. Wrapped in \`t\`\`\` and added \`type=\"button\"\` (was missing — would default to \`submit\` if ever placed inside a form).

I deliberately scoped the i18n fix to just the two flagged buttons. \`UserList.tsx\` has many more untranslated strings (table headers, search placeholder, etc.); those should be a separate translation PR per the AGENTS.md \"don't make bulk/spray changes\" rule.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (no new diagnostics for touched files)
- [x] \`pnpm test\` passes (admin: 858/858)
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (if applicable) — not applicable, all changes are 1:1 visual/markup substitutions of existing components
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include \`messages.po\` changes except in translation PRs — a workflow extracts catalogs on merge to \`main\`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (OpenCode)

## Screenshots / test output

The visible behaviour change in this PR is uniformity — all toolbar buttons now share the default \`size=\"base\"\` and Kumo's icon spacing. *Live View* and the *Demo* link now render as Kumo \`LinkButton\`s with proper \`external\` semantics (\`target=\"_blank\" rel=\"noopener noreferrer\"\`) and middle-click support. The *Marketplace* link in the plugin manager no longer renders invalid \`<a><button>\` nested HTML.