### PR TITLE
chore(lexicons): skip formatting for generated lexicon types

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,6 +6,7 @@
 		"**/node_modules/**",
 		"**/*.mdx",
 		"**/package.json",
-		"**/emdash-env.d.ts"
+		"**/emdash-env.d.ts",
+		"packages/registry-lexicons/src/generated/**"
 	]
 }

--- a/packages/registry-lexicons/src/generated/index.ts
+++ b/packages/registry-lexicons/src/generated/index.ts
@@ -1,0 +1,11 @@
+export * as ComEmdashcmsExperimentalAggregatorDefs from "./types/com/emdashcms/experimental/aggregator/defs.js";
+export * as ComEmdashcmsExperimentalAggregatorGetLatestRelease from "./types/com/emdashcms/experimental/aggregator/getLatestRelease.js";
+export * as ComEmdashcmsExperimentalAggregatorGetPackage from "./types/com/emdashcms/experimental/aggregator/getPackage.js";
+export * as ComEmdashcmsExperimentalAggregatorListReleases from "./types/com/emdashcms/experimental/aggregator/listReleases.js";
+export * as ComEmdashcmsExperimentalAggregatorResolvePackage from "./types/com/emdashcms/experimental/aggregator/resolvePackage.js";
+export * as ComEmdashcmsExperimentalAggregatorSearchPackages from "./types/com/emdashcms/experimental/aggregator/searchPackages.js";
+export * as ComEmdashcmsExperimentalPackageProfile from "./types/com/emdashcms/experimental/package/profile.js";
+export * as ComEmdashcmsExperimentalPackageRelease from "./types/com/emdashcms/experimental/package/release.js";
+export * as ComEmdashcmsExperimentalPackageReleaseExtension from "./types/com/emdashcms/experimental/package/releaseExtension.js";
+export * as ComEmdashcmsExperimentalPublisherProfile from "./types/com/emdashcms/experimental/publisher/profile.js";
+export * as ComEmdashcmsExperimentalPublisherVerification from "./types/com/emdashcms/experimental/publisher/verification.js";

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/defs.ts
@@ -1,10 +1,12 @@
-import * as ComAtprotoLabelDefs from "@atcute/atproto/types/label/defs";
 import type {} from "@atcute/lexicons";
 import * as v from "@atcute/lexicons/validations";
+import * as ComAtprotoLabelDefs from "@atcute/atproto/types/label/defs";
 
 const _packageViewSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.aggregator.defs#packageView"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.aggregator.defs#packageView",
+		),
 	),
 	/**
 	 * CID of the profile record content the aggregator indexed. Lets clients confirm they're working with the same bytes the aggregator did.
@@ -28,9 +30,10 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 	 */
 	get labels() {
 		return /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema), [
-				/*#__PURE__*/ v.arrayLength(0, 64),
-			]),
+			/*#__PURE__*/ v.constrain(
+				/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+				[/*#__PURE__*/ v.arrayLength(0, 64)],
+			),
 		);
 	},
 	/**
@@ -38,7 +41,9 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 	 * @maxLength 64
 	 */
 	latestVersion: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 64)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 64),
+		]),
 	),
 	/**
 	 * The signed profile record verbatim, passed through from the publisher's repo (carrying its $type, all required fields, etc.).
@@ -49,7 +54,9 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 	 * @minLength 1
 	 * @maxLength 64
 	 */
-	slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(1, 64)]),
+	slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+		/*#__PURE__*/ v.stringLength(1, 64),
+	]),
 	/**
 	 * AT URI of the profile record the aggregator indexed. Pins exactly which record version this view describes.
 	 */
@@ -57,7 +64,9 @@ const _packageViewSchema = /*#__PURE__*/ v.object({
 });
 const _releaseViewSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.aggregator.defs#releaseView"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.aggregator.defs#releaseView",
+		),
 	),
 	/**
 	 * CID of the release record content the aggregator indexed.
@@ -77,9 +86,10 @@ const _releaseViewSchema = /*#__PURE__*/ v.object({
 	 */
 	get labels() {
 		return /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema), [
-				/*#__PURE__*/ v.arrayLength(0, 64),
-			]),
+			/*#__PURE__*/ v.constrain(
+				/*#__PURE__*/ v.array(ComAtprotoLabelDefs.labelSchema),
+				[/*#__PURE__*/ v.arrayLength(0, 64)],
+			),
 		);
 	},
 	/**

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getLatestRelease.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getLatestRelease.ts
@@ -1,7 +1,6 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
-
+import type {} from "@atcute/lexicons/ambient";
 import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
 
 const _mainSchema = /*#__PURE__*/ v.query(

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPackage.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/getPackage.ts
@@ -1,31 +1,33 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
-
+import type {} from "@atcute/lexicons/ambient";
 import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
 
-const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator.getPackage", {
-	params: /*#__PURE__*/ v.object({
-		/**
-		 * Publisher DID.
-		 */
-		did: /*#__PURE__*/ v.didString(),
-		/**
-		 * Package slug.
-		 * @minLength 1
-		 * @maxLength 64
-		 */
-		slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
-			/*#__PURE__*/ v.stringLength(1, 64),
-		]),
-	}),
-	output: {
-		type: "lex",
-		get schema() {
-			return ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema;
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.getPackage",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * Publisher DID.
+			 */
+			did: /*#__PURE__*/ v.didString(),
+			/**
+			 * Package slug.
+			 * @minLength 1
+			 * @maxLength 64
+			 */
+			slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema;
+			},
 		},
 	},
-});
+);
 
 type main$schematype = typeof _mainSchema;
 

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/listReleases.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/listReleases.ts
@@ -1,46 +1,14 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
-
+import type {} from "@atcute/lexicons/ambient";
 import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
 
-const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator.listReleases", {
-	params: /*#__PURE__*/ v.object({
-		/**
-		 * Pagination cursor from a previous response.
-		 * @maxLength 1024
-		 */
-		cursor: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 1024)]),
-		),
-		/**
-		 * Publisher DID.
-		 */
-		did: /*#__PURE__*/ v.didString(),
-		/**
-		 * Max results to return.
-		 * @minimum 1
-		 * @maximum 100
-		 * @default 25
-		 */
-		limit: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 100)]),
-			25,
-		),
-		/**
-		 * Parent package slug.
-		 * @minLength 1
-		 * @maxLength 64
-		 */
-		package: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
-			/*#__PURE__*/ v.stringLength(1, 64),
-		]),
-	}),
-	output: {
-		type: "lex",
-		schema: /*#__PURE__*/ v.object({
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.listReleases",
+	{
+		params: /*#__PURE__*/ v.object({
 			/**
-			 * Cursor to fetch the next page. Absent when there are no more results.
+			 * Pagination cursor from a previous response.
 			 * @maxLength 1024
 			 */
 			cursor: /*#__PURE__*/ v.optional(
@@ -49,17 +17,57 @@ const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator
 				]),
 			),
 			/**
-			 * @maxLength 100
+			 * Publisher DID.
 			 */
-			get releases() {
-				return /*#__PURE__*/ v.constrain(
-					/*#__PURE__*/ v.array(ComEmdashcmsExperimentalAggregatorDefs.releaseViewSchema),
-					[/*#__PURE__*/ v.arrayLength(0, 100)],
-				);
-			},
+			did: /*#__PURE__*/ v.didString(),
+			/**
+			 * Max results to return.
+			 * @minimum 1
+			 * @maximum 100
+			 * @default 25
+			 */
+			limit: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+					/*#__PURE__*/ v.integerRange(1, 100),
+				]),
+				25,
+			),
+			/**
+			 * Parent package slug.
+			 * @minLength 1
+			 * @maxLength 64
+			 */
+			package: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
 		}),
+		output: {
+			type: "lex",
+			schema: /*#__PURE__*/ v.object({
+				/**
+				 * Cursor to fetch the next page. Absent when there are no more results.
+				 * @maxLength 1024
+				 */
+				cursor: /*#__PURE__*/ v.optional(
+					/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+						/*#__PURE__*/ v.stringLength(0, 1024),
+					]),
+				),
+				/**
+				 * @maxLength 100
+				 */
+				get releases() {
+					return /*#__PURE__*/ v.constrain(
+						/*#__PURE__*/ v.array(
+							ComEmdashcmsExperimentalAggregatorDefs.releaseViewSchema,
+						),
+						[/*#__PURE__*/ v.arrayLength(0, 100)],
+					);
+				},
+			}),
+		},
 	},
-});
+);
 
 type main$schematype = typeof _mainSchema;
 

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/resolvePackage.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/resolvePackage.ts
@@ -1,31 +1,33 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
-
+import type {} from "@atcute/lexicons/ambient";
 import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
 
-const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator.resolvePackage", {
-	params: /*#__PURE__*/ v.object({
-		/**
-		 * Publisher's handle (e.g. 'example.dev').
-		 */
-		handle: /*#__PURE__*/ v.handleString(),
-		/**
-		 * Package slug.
-		 * @minLength 1
-		 * @maxLength 64
-		 */
-		slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
-			/*#__PURE__*/ v.stringLength(1, 64),
-		]),
-	}),
-	output: {
-		type: "lex",
-		get schema() {
-			return ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema;
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.resolvePackage",
+	{
+		params: /*#__PURE__*/ v.object({
+			/**
+			 * Publisher's handle (e.g. 'example.dev').
+			 */
+			handle: /*#__PURE__*/ v.handleString(),
+			/**
+			 * Package slug.
+			 * @minLength 1
+			 * @maxLength 64
+			 */
+			slug: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
+		}),
+		output: {
+			type: "lex",
+			get schema() {
+				return ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema;
+			},
 		},
 	},
-});
+);
 
 type main$schematype = typeof _mainSchema;
 

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/searchPackages.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/searchPackages.ts
@@ -1,48 +1,23 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
-
+import type {} from "@atcute/lexicons/ambient";
 import * as ComEmdashcmsExperimentalAggregatorDefs from "./defs.js";
 
-const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator.searchPackages", {
-	params: /*#__PURE__*/ v.object({
-		/**
-		 * Optional filter: only return packages that declare this access category (e.g. 'email', 'network'). Compares against the latest release's declaredAccess top-level keys.
-		 * @maxLength 64
-		 */
-		capability: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 64)]),
-		),
-		/**
-		 * Pagination cursor from a previous response.
-		 * @maxLength 1024
-		 */
-		cursor: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 1024)]),
-		),
-		/**
-		 * Max results to return.
-		 * @minimum 1
-		 * @maximum 100
-		 * @default 25
-		 */
-		limit: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 100)]),
-			25,
-		),
-		/**
-		 * Free-text search query. Matches against name, description, keywords, and authors. Empty or absent returns all packages.
-		 * @maxLength 256
-		 */
-		q: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
-		),
-	}),
-	output: {
-		type: "lex",
-		schema: /*#__PURE__*/ v.object({
+const _mainSchema = /*#__PURE__*/ v.query(
+	"com.emdashcms.experimental.aggregator.searchPackages",
+	{
+		params: /*#__PURE__*/ v.object({
 			/**
-			 * Cursor to fetch the next page. Absent when there are no more results.
+			 * Optional filter: only return packages that declare this access category (e.g. 'email', 'network'). Compares against the latest release's declaredAccess top-level keys.
+			 * @maxLength 64
+			 */
+			capability: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+					/*#__PURE__*/ v.stringLength(0, 64),
+				]),
+			),
+			/**
+			 * Pagination cursor from a previous response.
 			 * @maxLength 1024
 			 */
 			cursor: /*#__PURE__*/ v.optional(
@@ -51,17 +26,54 @@ const _mainSchema = /*#__PURE__*/ v.query("com.emdashcms.experimental.aggregator
 				]),
 			),
 			/**
-			 * @maxLength 100
+			 * Max results to return.
+			 * @minimum 1
+			 * @maximum 100
+			 * @default 25
 			 */
-			get packages() {
-				return /*#__PURE__*/ v.constrain(
-					/*#__PURE__*/ v.array(ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema),
-					[/*#__PURE__*/ v.arrayLength(0, 100)],
-				);
-			},
+			limit: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+					/*#__PURE__*/ v.integerRange(1, 100),
+				]),
+				25,
+			),
+			/**
+			 * Free-text search query. Matches against name, description, keywords, and authors. Empty or absent returns all packages.
+			 * @maxLength 256
+			 */
+			q: /*#__PURE__*/ v.optional(
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+					/*#__PURE__*/ v.stringLength(0, 256),
+				]),
+			),
 		}),
+		output: {
+			type: "lex",
+			schema: /*#__PURE__*/ v.object({
+				/**
+				 * Cursor to fetch the next page. Absent when there are no more results.
+				 * @maxLength 1024
+				 */
+				cursor: /*#__PURE__*/ v.optional(
+					/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+						/*#__PURE__*/ v.stringLength(0, 1024),
+					]),
+				),
+				/**
+				 * @maxLength 100
+				 */
+				get packages() {
+					return /*#__PURE__*/ v.constrain(
+						/*#__PURE__*/ v.array(
+							ComEmdashcmsExperimentalAggregatorDefs.packageViewSchema,
+						),
+						[/*#__PURE__*/ v.arrayLength(0, 100)],
+					);
+				},
+			}),
+		},
 	},
-});
+);
 
 type main$schematype = typeof _mainSchema;
 

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/profile.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/profile.ts
@@ -1,16 +1,20 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
 
 const _authorSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.profile#author"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.profile#author",
+		),
 	),
 	/**
 	 * @maxLength 256
 	 */
 	email: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
 	),
 	/**
 	 * @maxLength 256
@@ -31,13 +35,17 @@ const _authorSchema = /*#__PURE__*/ v.object({
 });
 const _contactSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.profile#contact"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.profile#contact",
+		),
 	),
 	/**
 	 * @maxLength 256
 	 */
 	email: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
 	),
 	/**
 	 * @maxLength 1024
@@ -51,7 +59,9 @@ const _contactSchema = /*#__PURE__*/ v.object({
 const _mainSchema = /*#__PURE__*/ v.record(
 	/*#__PURE__*/ v.string(),
 	/*#__PURE__*/ v.object({
-		$type: /*#__PURE__*/ v.literal("com.emdashcms.experimental.package.profile"),
+		$type: /*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.profile",
+		),
 		/**
 		 * At least one author. Vendors SHOULD specify at least one of url or email per author.
 		 * @minLength 1
@@ -136,20 +146,25 @@ const _mainSchema = /*#__PURE__*/ v.record(
 		 * @maxLength 64
 		 */
 		slug: /*#__PURE__*/ v.optional(
-			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(1, 64)]),
+			/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+				/*#__PURE__*/ v.stringLength(1, 64),
+			]),
 		),
 		/**
 		 * Package type from FAIR's type registry. EmDash plugins use 'emdash-plugin'. Custom types use the 'x-' prefix.
 		 * @maxLength 64
 		 */
-		type: /*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string<"emdash-plugin" | (string & {})>(), [
-			/*#__PURE__*/ v.stringLength(0, 64),
-		]),
+		type: /*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.string<"emdash-plugin" | (string & {})>(),
+			[/*#__PURE__*/ v.stringLength(0, 64)],
+		),
 	}),
 );
 const _sectionsSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.profile#sections"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.profile#sections",
+		),
 	),
 	/**
 	 * @maxLength 20000

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/release.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/release.ts
@@ -1,10 +1,12 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
 
 const _artifactSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.release#artifact"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.release#artifact",
+		),
 	),
 	/**
 	 * Multibase-encoded multihash of the artifact bytes. EmDash clients MUST support sha2-256 (multihash code 0x12) and SHOULD support sha2-512 (0x13) and blake3 (0x1e). Recommended base prefix: base32 ('b'). Clients reject artifacts whose checksum uses an unsupported hash function rather than skipping verification.
@@ -18,7 +20,9 @@ const _artifactSchema = /*#__PURE__*/ v.object({
 	 * @maxLength 256
 	 */
 	contentType: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
 	),
 	/**
 	 * Pixel height, for image artifacts.
@@ -26,14 +30,18 @@ const _artifactSchema = /*#__PURE__*/ v.object({
 	 * @maximum 8192
 	 */
 	height: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 8192)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+			/*#__PURE__*/ v.integerRange(1, 8192),
+		]),
 	),
 	/**
 	 * Unique ID within the artifact type.
 	 * @maxLength 128
 	 */
 	id: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 128)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 128),
+		]),
 	),
 	/**
 	 * BCP 47 language tag for localised artifacts (icon, screenshot).
@@ -52,7 +60,9 @@ const _artifactSchema = /*#__PURE__*/ v.object({
 	 * @maxLength 1024
 	 */
 	signature: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 1024)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 1024),
+		]),
 	),
 	/**
 	 * URL where the artifact can be downloaded.
@@ -67,12 +77,16 @@ const _artifactSchema = /*#__PURE__*/ v.object({
 	 * @maximum 8192
 	 */
 	width: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [/*#__PURE__*/ v.integerRange(1, 8192)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.integer(), [
+			/*#__PURE__*/ v.integerRange(1, 8192),
+		]),
 	),
 });
 const _artifactsSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.release#artifacts"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.release#artifacts",
+		),
 	),
 	get banner() {
 		return /*#__PURE__*/ v.optional(artifactSchema);
@@ -93,7 +107,9 @@ const _artifactsSchema = /*#__PURE__*/ v.object({
 const _mainSchema = /*#__PURE__*/ v.record(
 	/*#__PURE__*/ v.string(),
 	/*#__PURE__*/ v.object({
-		$type: /*#__PURE__*/ v.literal("com.emdashcms.experimental.package.release"),
+		$type: /*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.release",
+		),
 		/**
 		 * Map of artifact type to artifact object. MUST have at least one entry. The 'package' entry (installable bundle) is required.
 		 */
@@ -162,16 +178,19 @@ const _sbomSchema = /*#__PURE__*/ v.object({
 	 * @maxLength 256
 	 */
 	checksum: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
 	),
 	/**
 	 * SBOM format identifier.
 	 * @maxLength 32
 	 */
 	format: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string<"cyclonedx" | "spdx" | (string & {})>(), [
-			/*#__PURE__*/ v.stringLength(0, 32),
-		]),
+		/*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.string<"cyclonedx" | "spdx" | (string & {})>(),
+			[/*#__PURE__*/ v.stringLength(0, 32)],
+		),
 	),
 	/**
 	 * URL where the SBOM document can be fetched.

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/releaseExtension.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/releaseExtension.ts
@@ -3,7 +3,9 @@ import * as v from "@atcute/lexicons/validations";
 
 const _contentAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension#contentAccess"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#contentAccess",
+		),
 	),
 	/**
 	 * Plugin may read content records.
@@ -34,7 +36,9 @@ const _contentWriteConstraintsSchema = /*#__PURE__*/ v.object({
 });
 const _declaredAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension#declaredAccess"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#declaredAccess",
+		),
 	),
 	/**
 	 * Access to site content (posts, pages, custom collections).
@@ -63,7 +67,9 @@ const _declaredAccessSchema = /*#__PURE__*/ v.object({
 });
 const _emailAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension#emailAccess"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#emailAccess",
+		),
 	),
 	/**
 	 * Plugin may send mail.
@@ -81,7 +87,9 @@ const _emailSendConstraintsSchema = /*#__PURE__*/ v.object({
 });
 const _mainSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension",
+		),
 	),
 	/**
 	 * Structured per-category access manifest. The sandbox enforces every operation declared here at runtime.
@@ -92,7 +100,9 @@ const _mainSchema = /*#__PURE__*/ v.object({
 });
 const _mediaAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension#mediaAccess"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#mediaAccess",
+		),
 	),
 	/**
 	 * Plugin may read media metadata and fetch media bytes.
@@ -123,7 +133,9 @@ const _mediaWriteConstraintsSchema = /*#__PURE__*/ v.object({
 });
 const _networkAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.package.releaseExtension#networkAccess"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#networkAccess",
+		),
 	),
 	/**
 	 * Plugin may make outbound HTTP requests. Constraints scope the access; an empty object grants unrestricted requests.
@@ -146,7 +158,9 @@ const _networkRequestConstraintsSchema = /*#__PURE__*/ v.object({
 	allowedHosts: /*#__PURE__*/ v.optional(
 		/*#__PURE__*/ v.constrain(
 			/*#__PURE__*/ v.array(
-				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+					/*#__PURE__*/ v.stringLength(0, 256),
+				]),
 			),
 			[/*#__PURE__*/ v.arrayLength(1, 64)],
 		),
@@ -164,7 +178,8 @@ type mediaAccess$schematype = typeof _mediaAccessSchema;
 type mediaReadConstraints$schematype = typeof _mediaReadConstraintsSchema;
 type mediaWriteConstraints$schematype = typeof _mediaWriteConstraintsSchema;
 type networkAccess$schematype = typeof _networkAccessSchema;
-type networkRequestConstraints$schematype = typeof _networkRequestConstraintsSchema;
+type networkRequestConstraints$schematype =
+	typeof _networkRequestConstraintsSchema;
 
 export interface contentAccessSchema extends contentAccess$schematype {}
 export interface contentReadConstraintsSchema extends contentReadConstraints$schematype {}
@@ -184,31 +199,48 @@ export const contentReadConstraintsSchema =
 	_contentReadConstraintsSchema as contentReadConstraintsSchema;
 export const contentWriteConstraintsSchema =
 	_contentWriteConstraintsSchema as contentWriteConstraintsSchema;
-export const declaredAccessSchema = _declaredAccessSchema as declaredAccessSchema;
+export const declaredAccessSchema =
+	_declaredAccessSchema as declaredAccessSchema;
 export const emailAccessSchema = _emailAccessSchema as emailAccessSchema;
-export const emailSendConstraintsSchema = _emailSendConstraintsSchema as emailSendConstraintsSchema;
+export const emailSendConstraintsSchema =
+	_emailSendConstraintsSchema as emailSendConstraintsSchema;
 export const mainSchema = _mainSchema as mainSchema;
 export const mediaAccessSchema = _mediaAccessSchema as mediaAccessSchema;
-export const mediaReadConstraintsSchema = _mediaReadConstraintsSchema as mediaReadConstraintsSchema;
+export const mediaReadConstraintsSchema =
+	_mediaReadConstraintsSchema as mediaReadConstraintsSchema;
 export const mediaWriteConstraintsSchema =
 	_mediaWriteConstraintsSchema as mediaWriteConstraintsSchema;
 export const networkAccessSchema = _networkAccessSchema as networkAccessSchema;
 export const networkRequestConstraintsSchema =
 	_networkRequestConstraintsSchema as networkRequestConstraintsSchema;
 
-export interface ContentAccess extends v.InferInput<typeof contentAccessSchema> {}
-export interface ContentReadConstraints extends v.InferInput<typeof contentReadConstraintsSchema> {}
+export interface ContentAccess extends v.InferInput<
+	typeof contentAccessSchema
+> {}
+export interface ContentReadConstraints extends v.InferInput<
+	typeof contentReadConstraintsSchema
+> {}
 export interface ContentWriteConstraints extends v.InferInput<
 	typeof contentWriteConstraintsSchema
 > {}
-export interface DeclaredAccess extends v.InferInput<typeof declaredAccessSchema> {}
+export interface DeclaredAccess extends v.InferInput<
+	typeof declaredAccessSchema
+> {}
 export interface EmailAccess extends v.InferInput<typeof emailAccessSchema> {}
-export interface EmailSendConstraints extends v.InferInput<typeof emailSendConstraintsSchema> {}
+export interface EmailSendConstraints extends v.InferInput<
+	typeof emailSendConstraintsSchema
+> {}
 export interface Main extends v.InferInput<typeof mainSchema> {}
 export interface MediaAccess extends v.InferInput<typeof mediaAccessSchema> {}
-export interface MediaReadConstraints extends v.InferInput<typeof mediaReadConstraintsSchema> {}
-export interface MediaWriteConstraints extends v.InferInput<typeof mediaWriteConstraintsSchema> {}
-export interface NetworkAccess extends v.InferInput<typeof networkAccessSchema> {}
+export interface MediaReadConstraints extends v.InferInput<
+	typeof mediaReadConstraintsSchema
+> {}
+export interface MediaWriteConstraints extends v.InferInput<
+	typeof mediaWriteConstraintsSchema
+> {}
+export interface NetworkAccess extends v.InferInput<
+	typeof networkAccessSchema
+> {}
 export interface NetworkRequestConstraints extends v.InferInput<
 	typeof networkRequestConstraintsSchema
 > {}

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/publisher/profile.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/publisher/profile.ts
@@ -1,25 +1,30 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
 
 const _contactSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.literal("com.emdashcms.experimental.publisher.profile#contact"),
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.publisher.profile#contact",
+		),
 	),
 	/**
 	 * @maxLength 256
 	 */
 	email: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [/*#__PURE__*/ v.stringLength(0, 256)]),
+		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
+			/*#__PURE__*/ v.stringLength(0, 256),
+		]),
 	),
 	/**
 	 * Channel role. 'general' for ordinary contact, 'security' for vulnerability reporting.
 	 * @maxLength 32
 	 */
 	kind: /*#__PURE__*/ v.optional(
-		/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string<"general" | "security" | (string & {})>(), [
-			/*#__PURE__*/ v.stringLength(0, 32),
-		]),
+		/*#__PURE__*/ v.constrain(
+			/*#__PURE__*/ v.string<"general" | "security" | (string & {})>(),
+			[/*#__PURE__*/ v.stringLength(0, 32)],
+		),
 	),
 	/**
 	 * @maxLength 1024
@@ -33,7 +38,9 @@ const _contactSchema = /*#__PURE__*/ v.object({
 const _mainSchema = /*#__PURE__*/ v.record(
 	/*#__PURE__*/ v.literal("self"),
 	/*#__PURE__*/ v.object({
-		$type: /*#__PURE__*/ v.literal("com.emdashcms.experimental.publisher.profile"),
+		$type: /*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.publisher.profile",
+		),
 		/**
 		 * Identity-level contact channels for the publisher (general / security). Per-package security contacts on package profile records remain authoritative for their respective packages; this list is for the publisher entity itself.
 		 * @maxLength 8

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/publisher/verification.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/publisher/verification.ts
@@ -1,11 +1,13 @@
 import type {} from "@atcute/lexicons";
-import type {} from "@atcute/lexicons/ambient";
 import * as v from "@atcute/lexicons/validations";
+import type {} from "@atcute/lexicons/ambient";
 
 const _mainSchema = /*#__PURE__*/ v.record(
 	/*#__PURE__*/ v.tidString(),
 	/*#__PURE__*/ v.object({
-		$type: /*#__PURE__*/ v.literal("com.emdashcms.experimental.publisher.verification"),
+		$type: /*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.publisher.verification",
+		),
 		/**
 		 * When the verification was issued.
 		 */


### PR DESCRIPTION
## What does this PR do?

The auto-generated lexicon types were being formatted by oxfmt, meaning they were showing as changed every time a build was run. This fixes that by ignoring them, and commits the files as-generated.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) and `pnpm locale:extract` has been run (if applicable)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
