### PR TITLE
fix(auth): quote reserved "window" column in rate-limit SQL for Postgres

### DIFF
--- a/.changeset/sweet-toys-matter.md
+++ b/.changeset/sweet-toys-matter.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Postgres rate-limit queries by quoting the reserved `window` column name.

--- a/packages/core/src/auth/rate-limit.ts
+++ b/packages/core/src/auth/rate-limit.ts
@@ -63,9 +63,9 @@ export async function checkRateLimit(
 
 	// Atomic upsert: insert or increment, return current count
 	const result = await sql<{ count: number }>`
-		INSERT INTO _emdash_rate_limits (key, window, count)
+		INSERT INTO _emdash_rate_limits (key, "window", count)
 		VALUES (${key}, ${windowStart}, 1)
-		ON CONFLICT (key, window)
+		ON CONFLICT (key, "window")
 		DO UPDATE SET count = _emdash_rate_limits.count + 1
 		RETURNING count
 	`.execute(db);
@@ -179,7 +179,7 @@ export async function cleanupExpiredRateLimits(
 	const cutoff = new Date(Date.now() - maxAgeSeconds * 1000).toISOString();
 
 	const result = await sql`
-		DELETE FROM _emdash_rate_limits WHERE window < ${cutoff}
+		DELETE FROM _emdash_rate_limits WHERE "window" < ${cutoff}
 	`.execute(db);
 
 	return Number(result.numAffectedRows ?? 0);


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/emdash-cms/emdash/issues/935 by quoting Postgres reserved keyword `window`.
<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes (fails but unrelated)
- [ ] `pnpm lint` passes (fails but unrelated)
- [ ] `pnpm test` passes (or targeted tests for my change) (fails but unrelated)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
