### PR TITLE
perf: add db.* and cache.* Server-Timing fields

### DIFF
--- a/.changeset/server-timing-metrics.md
+++ b/.changeset/server-timing-metrics.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds always-on `db.*` and `cache.*` Server-Timing fields so render-phase performance is diagnosable in production. Each request now emits `db.total` (cumulative DB ms), `db.count` (query count), `db.first` / `db.last` (first/last query offset from request start), and `cache.hit` / `cache.miss` (request-scoped cache stats). The Kysely log hook is now always installed so counters work without setting `EMDASH_QUERY_LOG`.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -47,7 +47,12 @@ import { createPublicMediaUrlResolver } from "../media/url.js";
 import type { SandboxRunner } from "../plugins/sandbox/types.js";
 import type { ResolvedPlugin } from "../plugins/types.js";
 import { invalidateUrlPatternCache } from "../query.js";
-import { getRequestContext, runWithContext } from "../request-context.js";
+import {
+	createRequestMetrics,
+	getRequestContext,
+	type RequestMetrics,
+	runWithContext,
+} from "../request-context.js";
 import type { EmDashConfig } from "./integration/runtime.js";
 import type { EmDashHandlers } from "./types.js";
 
@@ -209,6 +214,33 @@ function finalizeResponse(
 	return res;
 }
 
+/**
+ * Append always-on counters (db.*, cache.*) to the Server-Timing list.
+ *
+ * dur values for `count`, `hit`, `miss` are integer counts — Server-Timing
+ * spec only models milliseconds, but browsers show whatever number is given,
+ * which is the convention most projects use for non-time samples.
+ */
+function pushMetricsTimings(
+	timings: Array<{ name: string; dur: number; desc?: string }>,
+	metrics: RequestMetrics,
+): void {
+	if (metrics.dbCount > 0) {
+		timings.push({ name: "db.total", dur: metrics.dbTotalMs, desc: "DB total" });
+		timings.push({ name: "db.count", dur: metrics.dbCount, desc: "Query count" });
+		if (metrics.dbFirstOffset !== null) {
+			timings.push({ name: "db.first", dur: metrics.dbFirstOffset, desc: "First query at" });
+		}
+		if (metrics.dbLastOffset !== null) {
+			timings.push({ name: "db.last", dur: metrics.dbLastOffset, desc: "Last query at" });
+		}
+	}
+	if (metrics.cacheHits + metrics.cacheMisses > 0) {
+		timings.push({ name: "cache.hit", dur: metrics.cacheHits, desc: "Cache hits" });
+		timings.push({ name: "cache.miss", dur: metrics.cacheMisses, desc: "Cache misses" });
+	}
+}
+
 /** Public routes that require the runtime (sitemap, robots.txt, etc.) */
 const PUBLIC_RUNTIME_ROUTES = new Set(["/sitemap.xml", "/robots.txt"]);
 const SITEMAP_COLLECTION_RE = /^\/sitemap-[a-z][a-z0-9_]*\.xml$/;
@@ -251,6 +283,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 	const queryRecorder = isInstrumentationEnabled()
 		? createRecorder(url.pathname, request.method, request.headers.get("x-perf-phase") ?? "default")
 		: undefined;
+
+	const metrics = createRequestMetrics(performance.now());
 
 	const run = async (): Promise<Response> => {
 		// Process /_emdash routes and public routes with an active session
@@ -355,13 +389,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					const response = await next();
 					timings.push({ name: "render", dur: performance.now() - t0, desc: "Page render" });
 					timings.push({ name: "mw", dur: performance.now() - mwStart, desc: "Total middleware" });
+					pushMetricsTimings(timings, metrics);
 					return finalizeResponse(response, timings);
 				};
 				if (anonScoped) {
 					const parent = getRequestContext();
 					const ctx = parent
 						? { ...parent, db: anonScoped.db }
-						: { editMode: false, db: anonScoped.db };
+						: { editMode: false, db: anonScoped.db, metrics };
 					return runWithContext(ctx, async () => {
 						const response = await runAnon();
 						anonScoped.commit();
@@ -516,12 +551,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				const response = await next();
 				timings.push({ name: "render", dur: performance.now() - t0, desc: "Page render" });
 				timings.push({ name: "mw", dur: performance.now() - mwStart, desc: "Total middleware" });
+				pushMetricsTimings(timings, metrics);
 				return finalizeResponse(response, timings);
 			};
 
 			if (scoped) {
 				const parent = getRequestContext();
-				const ctx = parent ? { ...parent, db: scoped.db } : { editMode: false, db: scoped.db };
+				const ctx = parent
+					? { ...parent, db: scoped.db }
+					: { editMode: false, db: scoped.db, metrics };
 				return runWithContext(ctx, async () => {
 					const response = await renderAndFinalize();
 					scoped.commit();
@@ -542,20 +580,17 @@ export const onRequest = defineMiddleware(async (context, next) => {
 			const parent = getRequestContext();
 			const ctx = parent
 				? { ...parent, editMode, db: playgroundDb, dbIsIsolated: true }
-				: { editMode, db: playgroundDb, dbIsIsolated: true };
+				: { editMode, db: playgroundDb, dbIsIsolated: true, metrics };
 			return runWithContext(ctx, doInit);
 		}
 		return doInit();
 	};
 
-	if (queryRecorder) {
-		try {
-			return await runWithContext({ editMode: false, queryRecorder }, run);
-		} finally {
-			flushRecorder(queryRecorder);
-		}
+	try {
+		return await runWithContext({ editMode: false, queryRecorder, metrics }, run);
+	} finally {
+		if (queryRecorder) flushRecorder(queryRecorder);
 	}
-	return run();
 });
 
 export default onRequest;

--- a/packages/core/src/database/instrumentation.ts
+++ b/packages/core/src/database/instrumentation.ts
@@ -83,16 +83,30 @@ export function isInstrumentationEnabled(): boolean {
 
 function kyselyLog(event: LogEvent): void {
 	if (event.level !== "query") return;
-	const rec = getRequestContext()?.queryRecorder;
-	if (!rec) return;
-	recordEvent(rec, event.query.sql, event.query.parameters, event.queryDurationMillis);
+	const ctx = getRequestContext();
+	if (!ctx) return;
+	const dur = event.queryDurationMillis;
+	if (ctx.metrics) {
+		const m = ctx.metrics;
+		m.dbCount += 1;
+		m.dbTotalMs += dur;
+		const finishedAt = performance.now() - m.start;
+		const startedAt = finishedAt - dur;
+		if (m.dbFirstOffset === null) m.dbFirstOffset = startedAt;
+		m.dbLastOffset = finishedAt;
+	}
+	if (ctx.queryRecorder) {
+		recordEvent(ctx.queryRecorder, event.query.sql, event.query.parameters, dur);
+	}
 }
 
 /**
- * Returns a Kysely `log` option when instrumentation is enabled, or undefined.
- * Pass as `new Kysely({ dialect, log: kyselyLogOption() })` so disabled mode
- * has zero overhead — Kysely skips query timing entirely when `log` is absent.
+ * Returns a Kysely `log` callback. Always returns a function so per-request
+ * counters (db.count, db.total, db.first, db.last) and the optional NDJSON
+ * recorder both get fed. The cost over the previous "undefined when off"
+ * behaviour is one `performance.now()` pair per query inside Kysely, which
+ * is in the noise compared to any real query.
  */
-export function kyselyLogOption(): Logger | undefined {
-	return isInstrumentationEnabled() ? kyselyLog : undefined;
+export function kyselyLogOption(): Logger {
+	return kyselyLog;
 }

--- a/packages/core/src/request-cache.ts
+++ b/packages/core/src/request-cache.ts
@@ -48,8 +48,12 @@ export function requestCached<T>(key: string, fn: () => Promise<T>): Promise<T> 
 	}
 
 	const existing = cache.get(key);
-	// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- heterogeneous cache; key namespacing guarantees the stored promise resolves to T
-	if (existing) return existing as Promise<T>;
+	if (existing) {
+		if (ctx.metrics) ctx.metrics.cacheHits += 1;
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- heterogeneous cache; key namespacing guarantees the stored promise resolves to T
+		return existing as Promise<T>;
+	}
+	if (ctx.metrics) ctx.metrics.cacheMisses += 1;
 
 	const promise = Promise.resolve()
 		.then(fn)

--- a/packages/core/src/request-context.ts
+++ b/packages/core/src/request-context.ts
@@ -5,8 +5,10 @@
  * without requiring explicit parameter passing. The middleware wraps next()
  * in als.run(), making the context available to all code during rendering.
  *
- * For logged-out users with no CMS signals (no edit cookie, no preview param),
- * the middleware skips ALS entirely — zero overhead for normal traffic.
+ * Middleware always wraps each request in a context so per-request
+ * metrics (db.*, cache.*) can be surfaced via Server-Timing. The cost is
+ * one ALS frame per request — sub-microsecond, negligible compared to
+ * any real work.
  *
  * The AsyncLocalStorage instance is stored on globalThis with a Symbol key
  * to guarantee a singleton even when bundlers duplicate this module across
@@ -18,6 +20,38 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import type { QueryRecorder } from "./database/instrumentation.js";
+
+/**
+ * Lightweight always-on counters surfaced in Server-Timing.
+ *
+ * Bumped by the Kysely log hook (db queries) and by `requestCached`
+ * (cache hits/misses). Read by middleware after the response is
+ * generated to emit `db.*` and `cache.*` Server-Timing fields.
+ *
+ * Offsets are milliseconds from `start` (the request's entry into
+ * middleware), captured via `performance.now()`.
+ */
+export interface RequestMetrics {
+	start: number;
+	dbCount: number;
+	dbTotalMs: number;
+	dbFirstOffset: number | null;
+	dbLastOffset: number | null;
+	cacheHits: number;
+	cacheMisses: number;
+}
+
+export function createRequestMetrics(start: number): RequestMetrics {
+	return {
+		start,
+		dbCount: 0,
+		dbTotalMs: 0,
+		dbFirstOffset: null,
+		dbLastOffset: null,
+		cacheHits: 0,
+		cacheMisses: 0,
+	};
+}
 
 export interface EmDashRequestContext {
 	/** Whether the current request is in visual editing mode */
@@ -54,6 +88,12 @@ export interface EmDashRequestContext {
 	 * to NDJSON after the response.
 	 */
 	queryRecorder?: QueryRecorder;
+	/**
+	 * Per-request metrics for Server-Timing. Always attached by middleware
+	 * for requests that emit timing headers; bumped by the Kysely log hook
+	 * and `requestCached`.
+	 */
+	metrics?: RequestMetrics;
 }
 
 const ALS_KEY = Symbol.for("emdash:request-context");

--- a/packages/core/tests/unit/metrics.test.ts
+++ b/packages/core/tests/unit/metrics.test.ts
@@ -1,0 +1,81 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, sql } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { kyselyLogOption } from "../../src/database/instrumentation.js";
+import { requestCached } from "../../src/request-cache.js";
+import {
+	createRequestMetrics,
+	type RequestMetrics,
+	runWithContext,
+} from "../../src/request-context.js";
+
+function freshKysely() {
+	return new Kysely<Record<string, unknown>>({
+		dialect: new SqliteDialect({ database: new Database(":memory:") }),
+		log: kyselyLogOption(),
+	});
+}
+
+async function withMetrics<T>(metrics: RequestMetrics, fn: () => Promise<T>): Promise<T> {
+	return runWithContext({ editMode: false, metrics }, fn);
+}
+
+describe("request metrics — Kysely log hook", () => {
+	it("counts queries and accumulates total duration", async () => {
+		const db = freshKysely();
+		const metrics = createRequestMetrics(performance.now());
+		await withMetrics(metrics, async () => {
+			await sql`SELECT 1`.execute(db);
+			await sql`SELECT 2`.execute(db);
+			await sql`SELECT 3`.execute(db);
+		});
+		expect(metrics.dbCount).toBe(3);
+		expect(metrics.dbTotalMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("captures first and last query offsets", async () => {
+		const db = freshKysely();
+		const metrics = createRequestMetrics(performance.now());
+		await withMetrics(metrics, async () => {
+			await sql`SELECT 1`.execute(db);
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			await sql`SELECT 2`.execute(db);
+		});
+		expect(metrics.dbFirstOffset).not.toBeNull();
+		expect(metrics.dbLastOffset).not.toBeNull();
+		expect(metrics.dbLastOffset!).toBeGreaterThan(metrics.dbFirstOffset!);
+	});
+
+	it("does nothing outside a request context", async () => {
+		const db = freshKysely();
+		const metrics = createRequestMetrics(performance.now());
+		await sql`SELECT 1`.execute(db);
+		expect(metrics.dbCount).toBe(0);
+		expect(metrics.dbFirstOffset).toBeNull();
+	});
+});
+
+describe("request metrics — request-cache", () => {
+	it("counts misses on first lookup and hits on subsequent lookups", async () => {
+		const metrics = createRequestMetrics(performance.now());
+		await withMetrics(metrics, async () => {
+			await requestCached("k", async () => "v");
+			await requestCached("k", async () => "v");
+			await requestCached("k", async () => "v");
+			await requestCached("other", async () => "v");
+		});
+		expect(metrics.cacheMisses).toBe(2);
+		expect(metrics.cacheHits).toBe(2);
+	});
+
+	it("does not bump counters when no metrics on context", async () => {
+		const metrics = createRequestMetrics(performance.now());
+		await runWithContext({ editMode: false }, async () => {
+			await requestCached("k", async () => "v");
+			await requestCached("k", async () => "v");
+		});
+		expect(metrics.cacheHits).toBe(0);
+		expect(metrics.cacheMisses).toBe(0);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds always-on per-request counters to `Server-Timing` so the render phase is diagnosable in production without enabling `EMDASH_QUERY_LOG`.

New fields on every response:

- `db.total` — cumulative ms spent in DB queries
- `db.count` — number of queries
- `db.first` / `db.last` — offset (ms from request start) of the first and last query
- `cache.hit` / `cache.miss` — request-scoped cache stats from `requestCached`

Together with the existing `rt`/`render`/`mw` fields, you can now tell at a glance whether a slow render is I/O-bound (high `db.total`/`db.count`), CPU-bound (high `render`, low `db.total`), or held up by a sequential query chain (`db.last` close to `render`). Background: on `blog-demo.emdashcms.com` the warm-isolate `render` is 100–170ms with no breakdown today; on D1 each query is 10–20ms, so the new counters point straight at the dominant cost.

### Implementation

- `packages/core/src/request-context.ts` — adds `RequestMetrics` (counts, offsets, request start time) and `createRequestMetrics`. Optional field on `EmDashRequestContext`.
- `packages/core/src/database/instrumentation.ts` — `kyselyLogOption()` now always returns a `Logger`. The hook bumps metrics when present and still feeds the existing `queryRecorder` when `EMDASH_QUERY_LOG=1`. The previous "zero overhead when off" promise drops a `performance.now()` pair per query inside Kysely — in the noise compared to any real query.
- `packages/core/src/request-cache.ts` — bumps `cacheHits` / `cacheMisses` in `requestCached`.
- `packages/core/src/astro/middleware.ts` — always wraps the request in `runWithContext({ ..., metrics })` so the Kysely log and the cache see the same metrics object. Pushes `db.*` / `cache.*` entries into the timing list before `finalizeResponse`. The previous "skip ALS for the logged-out anonymous fast path" optimisation is dropped — cost is one ALS frame per request, sub-microsecond.

### Verified locally

```
server-timing: rt;dur=0;desc="Runtime init",
               render;dur=54;desc="Page render",
               mw;dur=54;desc="Total middleware",
               db.total;dur=2;desc="DB total",
               db.count;dur=8;desc="Query count",
               db.first;dur=0;desc="First query at",
               db.last;dur=54;desc="Last query at",
               cache.hit;dur=1;desc="Cache hits",
               cache.miss;dur=4;desc="Cache misses"
```

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics in changed files; 23 pre-existing warnings unchanged)
- [x] `pnpm test` passes (3149 tests, including 5 new ones for this change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

```
Test Files  196 passed (196)
Tests       3149 passed (3149)
```