### PR TITLE
fix(admin): introduce RouterLinkButton, fix invalid <Link><Button> HTML nesting

### DIFF
--- a/.changeset/modern-maps-remain.md
+++ b/.changeset/modern-maps-remain.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes invalid `<a><button>` HTML produced by `<Link><Button>...</Button></Link>` patterns across the admin UI. Replaces them with `<Link className={buttonVariants(...)}>...</Link>` (TanStack Router `Link` doesn't compose with `LinkButton`). Extracts the duplicated "Back to settings" header link into a shared `BackToSettingsLink` component.

--- a/.changeset/modern-maps-remain.md
+++ b/.changeset/modern-maps-remain.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Fixes invalid `<a><button>` HTML produced by `<Link><Button>...</Button></Link>` patterns across the admin UI. Replaces them with `<Link className={buttonVariants(...)}>...</Link>` (TanStack Router `Link` doesn't compose with `LinkButton`). Extracts the duplicated "Back to settings" header link into a shared `BackToSettingsLink` component.
+Fixes invalid `<a><button>` HTML produced by `<Link><Button>...</Button></Link>` patterns across the admin UI. Introduces a `RouterLinkButton` component that wraps TanStack Router's `<Link>` with Kumo button styling (`variant`, `size`, `shape`, `icon` props), and migrates all existing `<Link className={buttonVariants(...)}>` usages to use it. Extracts the duplicated "Back to settings" header link into a shared `BackToSettingsLink` component.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,12 +387,12 @@ Common imports: `Button`, `LinkButton`, `Dialog`, `Input`, `InputArea`, `Select`
 
 #### Buttons and links: pick the right component
 
-| Need                                       | Component                                                |
-| ------------------------------------------ | -------------------------------------------------------- |
-| In-place action (submit, toggle, open)     | `Button`                                                 |
-| External link styled as a button           | `LinkButton href="..." external`                         |
-| Internal router-aware link as a button     | `RouterLinkButton to="..."` (in `components/`)           |
-| Non-button element needing button classes  | `buttonVariants(...)` (e.g. file-upload `<span>` inside `<label>`) |
+| Need                                      | Component                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| In-place action (submit, toggle, open)    | `Button`                                                           |
+| External link styled as a button          | `LinkButton href="..." external`                                   |
+| Internal router-aware link as a button    | `RouterLinkButton to="..."` (in `components/`)                     |
+| Non-button element needing button classes | `buttonVariants(...)` (e.g. file-upload `<span>` inside `<label>`) |
 
 `RouterLinkButton` is our wrapper around TanStack Router's `<Link>` styled with Kumo button classes. Use it for any internal navigation that should look like a button -- typed `to`/`params`/`search`/`preload` props pass through. Never write `<Link><Button>...</Button></Link>` (renders invalid `<a><button>` HTML, breaks a11y). Never write `<a>` with hand-rolled button styling.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,68 +374,55 @@ after(async () => {
 
 ### Admin UI: Use Kumo Components
 
-The admin UI is built on [Kumo](https://github.com/cloudflare/kumo) (Cloudflare's design system). Use Kumo components for all standard UI elements -- never roll your own buttons, inputs, dialogs, selects, etc. This gives us consistent styling, dark mode, accessibility, and RTL support for free.
+The admin UI is built on [Kumo](https://github.com/cloudflare/kumo) (Cloudflare's design system). Never roll your own buttons, inputs, dialogs, selects, etc. -- use Kumo. This gives consistent styling, dark mode, accessibility, and RTL support for free.
 
-**Look up component docs from the CLI** -- don't guess at props:
+**Always look up component docs from the CLI before reaching for an element**:
 
 ```bash
 npx @cloudflare/kumo doc Button    # docs for a specific component
-npx @cloudflare/kumo ls            # list all available components
-npx @cloudflare/kumo docs          # docs for everything
+npx @cloudflare/kumo ls            # list all components
 ```
 
-Key components (all from `@cloudflare/kumo`):
+Common imports: `Button`, `LinkButton`, `Dialog`, `Input`, `InputArea`, `Select`, `Checkbox`, `Switch`, `Loader`, `Badge`, `Toast`/`Toasty`, `Popover`, `Dropdown`, `Tooltip`, `Label`, `CommandPalette`. For confirm/cancel modals use our `ConfirmDialog` wrapper, not raw `Dialog`.
 
-- **`Button`** -- all clickable actions. Supports `variant`, `size`, `icon`, and `loading`.
-- **`LinkButton`** -- anchor styled as a button. Use for navigation, never `<a>` with manual styling. Supports `external` prop for new-tab links.
-- **`Dialog`** -- all modals. Use `ConfirmDialog` (ours) for simple confirm/cancel flows.
-- **`Input`**, **`InputArea`**, **`Select`**, **`Checkbox`**, **`Switch`** -- form controls.
-- **`Toast`** / **`Toasty`** -- notifications.
-- **`Loader`** -- loading spinners.
-- **`Badge`** -- status labels, counts.
-- **`Popover`**, **`Dropdown`**, **`Tooltip`** -- overlays.
-- **`CommandPalette`** -- the admin command palette.
-- **`Label`** -- form labels (pairs with inputs).
+#### Buttons and links: pick the right component
 
-```typescript
+| Need                                       | Component                                                |
+| ------------------------------------------ | -------------------------------------------------------- |
+| In-place action (submit, toggle, open)     | `Button`                                                 |
+| External link styled as a button           | `LinkButton href="..." external`                         |
+| Internal router-aware link as a button     | `RouterLinkButton to="..."` (in `components/`)           |
+| Non-button element needing button classes  | `buttonVariants(...)` (e.g. file-upload `<span>` inside `<label>`) |
+
+`RouterLinkButton` is our wrapper around TanStack Router's `<Link>` styled with Kumo button classes. Use it for any internal navigation that should look like a button -- typed `to`/`params`/`search`/`preload` props pass through. Never write `<Link><Button>...</Button></Link>` (renders invalid `<a><button>` HTML, breaks a11y). Never write `<a>` with hand-rolled button styling.
+
+```tsx
 import { Button, LinkButton, Loader } from "@cloudflare/kumo";
+import { RouterLinkButton } from "./RouterLinkButton.js"; // path varies by file location
 
-// loading prop -- shows spinner and disables interaction automatically
-<Button variant="primary" loading={mutation.isPending}>
-	{t`Save`}
-</Button>
-
-// icon prop with conditional Loader -- use when the icon itself changes per state
-// (e.g. different icons for idle/pending/done -- see SaveButton.tsx for the full pattern)
-<Button
-	variant={isSaved ? "secondary" : "primary"}
-	icon={isSaving ? <Loader size="sm" /> : isSaved ? <Check /> : <FloppyDisk />}
-	disabled={isSaving || isSaved}
-	aria-busy={isSaving}
->
-	{isSaving ? t`Saving...` : isSaved ? t`Saved` : t`Save`}
-</Button>
-
-// icon prop -- pass a Phosphor icon component or React element
+// In-place actions
+<Button variant="primary" loading={mutation.isPending}>{t`Save`}</Button>
 <Button variant="secondary" icon={PlusIcon}>{t`Add item`}</Button>
-
-// icon-only buttons require shape + aria-label
 <Button shape="square" icon={TrashIcon} aria-label={t`Delete`} variant="ghost" />
 
-// LinkButton for navigation -- never use <a> with manual button classes
-<LinkButton href="/_emdash/admin" variant="ghost" icon={HouseIcon}>
-	{t`Dashboard`}
-</LinkButton>
+// Internal navigation
+<RouterLinkButton to="/settings" variant="ghost" shape="square"
+  aria-label={t`Back to settings`} icon={<ArrowPrev />} />
+<RouterLinkButton to="/posts/$id" params={{ id }} variant="primary">
+  {t`Edit post`}
+</RouterLinkButton>
 
-// external links open in new tab with rel="noopener noreferrer"
+// External link
 <LinkButton href="https://docs.example.com" external>{t`Docs`}</LinkButton>
 ```
 
-**Styling rules:**
+For state-dependent icons (idle/pending/done), pass a conditional element to `icon`. See `SaveButton.tsx` for the canonical pattern.
 
-- **Use semantic color tokens**, not raw Tailwind colors. `bg-kumo-brand` not `bg-blue-500`. `text-kumo-subtle` not `text-gray-500`. The full token list is in the Kumo styles.
-- **Never use `dark:` prefixes.** Kumo's semantic tokens use CSS `light-dark()` to handle dark mode automatically. If you're writing `dark:bg-something`, you're bypassing the design system.
-- Don't reach for raw HTML elements or Tailwind-only solutions when a Kumo component exists. If you need a button, use `Button`. If you need a link that looks like a button, use `LinkButton`. If you need `buttonVariants()` classes on a non-button element, import `buttonVariants` from `@cloudflare/kumo`.
+#### Styling rules
+
+- **Use semantic tokens**: `bg-kumo-brand`, `text-kumo-subtle`, etc. Never raw Tailwind colors like `bg-blue-500`.
+- **Never use `dark:` prefixes.** Kumo's tokens use CSS `light-dark()` -- writing `dark:bg-something` bypasses the design system.
+- **Never duplicate component styles.** If you find yourself writing `bg-kumo-brand text-white rounded-md px-3 py-2` on a `<button>`, you're recreating Kumo's `Button` -- use the component instead.
 
 ### Admin UI: Localization (Lingui)
 

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -10,7 +10,6 @@ import {
 	Loader,
 	Select,
 	Switch,
-	buttonVariants,
 } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -48,6 +47,7 @@ import { BlockKitFieldWidget } from "./BlockKitFieldWidget.js";
 import { DocumentOutline } from "./editor/DocumentOutline";
 import { PluginFieldErrorBoundary } from "./PluginFieldErrorBoundary.js";
 import { RepeaterField } from "./RepeaterField.js";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 /** Autosave debounce delay in milliseconds */
 const AUTOSAVE_DELAY = 2000;
@@ -578,15 +578,15 @@ export function ContentEditor({
 			>
 				<div className="flex items-center space-x-4">
 					{!isDistractionFree && (
-						<Link
+						<RouterLinkButton
 							to="/content/$collection"
 							params={{ collection }}
 							search={{ locale: undefined }}
 							aria-label={t`Back to ${collectionLabel} list`}
-							className={buttonVariants({ variant: "ghost", shape: "square" })}
-						>
-							<ArrowPrev className="h-5 w-5" aria-hidden="true" />
-						</Link>
+							variant="ghost"
+							shape="square"
+							icon={<ArrowPrev />}
+						/>
 					)}
 					{isDistractionFree && (
 						<Button

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1,13 +1,4 @@
-import {
-	Badge,
-	Button,
-	buttonVariants,
-	Dialog,
-	Input,
-	LinkButton,
-	Loader,
-	Tabs,
-} from "@cloudflare/kumo";
+import { Badge, Button, Dialog, Input, LinkButton, Loader, Tabs } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -30,6 +21,7 @@ import { contentUrl } from "../lib/url.js";
 import { cn } from "../lib/utils";
 import { CaretNext, CaretPrev } from "./ArrowIcons.js";
 import { LocaleSwitcher } from "./LocaleSwitcher";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 /** Sortable content list columns. Maps to the server's order field whitelist. */
 export type ContentListSortField = "title" | "status" | "locale" | "updatedAt";
@@ -158,15 +150,14 @@ export function ContentList({
 						/>
 					)}
 				</div>
-				<Link
+				<RouterLinkButton
 					to="/content/$collection/new"
 					params={{ collection }}
 					search={{ locale: activeLocale }}
-					className={buttonVariants()}
+					icon={<Plus />}
 				>
-					<Plus className="me-2 h-4 w-4" aria-hidden="true" />
 					{t`Add New`}
-				</Link>
+				</RouterLinkButton>
 			</div>
 
 			{/* Search */}
@@ -527,14 +518,14 @@ function ContentListItem({
 							icon={<ArrowSquareOut />}
 						/>
 					)}
-					<Link
+					<RouterLinkButton
 						to="/content/$collection/$id"
 						params={{ collection, id: item.id }}
 						aria-label={t`Edit ${title}`}
-						className={buttonVariants({ variant: "ghost", shape: "square" })}
-					>
-						<Pencil className="h-4 w-4" aria-hidden="true" />
-					</Link>
+						variant="ghost"
+						shape="square"
+						icon={<Pencil />}
+					/>
 					<Button
 						variant="ghost"
 						shape="square"

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Input, InputArea, Label, Select, buttonVariants } from "@cloudflare/kumo";
+import { Badge, Button, Input, InputArea, Label, Select } from "@cloudflare/kumo";
 import {
 	DndContext,
 	closestCenter,
@@ -20,7 +20,7 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import * as React from "react";
 
 import type {
@@ -35,6 +35,7 @@ import { ArrowPrev } from "./ArrowIcons.js";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { EditorHeader } from "./EditorHeader";
 import { FieldEditor } from "./FieldEditor";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 import { SaveButton } from "./SaveButton";
 
 // Regex patterns for slug generation
@@ -330,13 +331,13 @@ export function ContentTypeEditor({
 			    so DOM order still ends with a submit control. */}
 			<EditorHeader
 				leading={
-					<Link
+					<RouterLinkButton
 						to="/content-types"
 						aria-label={t`Back to Content Types`}
-						className={buttonVariants({ variant: "ghost", shape: "square" })}
-					>
-						<ArrowPrev className="h-5 w-5" />
-					</Link>
+						variant="ghost"
+						shape="square"
+						icon={<ArrowPrev />}
+					/>
 				}
 				actions={
 					!isFromCode && !isNew ? (

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, buttonVariants } from "@cloudflare/kumo";
+import { Badge, Button } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, Pencil, Trash, Database, FileText, Warning, Check } from "@phosphor-icons/react";
@@ -8,6 +8,7 @@ import * as React from "react";
 import type { SchemaCollection, OrphanedTable } from "../lib/api";
 import { cn } from "../lib/utils";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 export interface ContentTypeListProps {
 	collections: SchemaCollection[];
@@ -39,10 +40,9 @@ export function ContentTypeList({
 					<h1 className="text-2xl font-bold">{t`Content Types`}</h1>
 					<p className="text-kumo-subtle text-sm">{t`Define the structure of your content`}</p>
 				</div>
-				<Link to="/content-types/new" className={buttonVariants()}>
-					<Plus className="me-2 h-4 w-4" aria-hidden="true" />
+				<RouterLinkButton to="/content-types/new" icon={<Plus />}>
 					{t`New Content Type`}
-				</Link>
+				</RouterLinkButton>
 			</div>
 
 			{/* Orphaned Tables Warning */}
@@ -214,14 +214,14 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 			</td>
 			<td className="px-4 py-3 text-end">
 				<div className="flex items-center justify-end space-x-1">
-					<Link
+					<RouterLinkButton
 						to="/content-types/$slug"
 						params={{ slug: collection.slug }}
 						aria-label={t`Edit ${collection.label}`}
-						className={buttonVariants({ variant: "ghost", shape: "square" })}
-					>
-						<Pencil className="h-4 w-4" aria-hidden="true" />
-					</Link>
+						variant="ghost"
+						shape="square"
+						icon={<Pencil />}
+					/>
 					{!isFromCode && (
 						<Button
 							variant="ghost"

--- a/packages/admin/src/components/InviteAcceptPage.tsx
+++ b/packages/admin/src/components/InviteAcceptPage.tsx
@@ -3,16 +3,16 @@
  * Validates an invite token, then registers a passkey to complete signup.
  */
 
-import { buttonVariants, Input, Loader } from "@cloudflare/kumo";
+import { Input, Loader } from "@cloudflare/kumo";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
-import { Link, useSearch } from "@tanstack/react-router";
+import { useSearch } from "@tanstack/react-router";
 import * as React from "react";
 
 import { validateInviteToken, type InviteVerifyResult } from "../lib/api";
-import { cn } from "../lib/utils";
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { LogoLockup } from "./Logo.js";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 type InviteStep = "verify" | "register" | "error";
 
@@ -126,16 +126,17 @@ function ErrorStep({ message, code }: ErrorStepProps) {
 
 			<div className="space-y-2">
 				{code === "USER_EXISTS" ? (
-					<Link to="/login" className={cn(buttonVariants(), "w-full")}>{t`Sign in instead`}</Link>
+					<RouterLinkButton to="/login" className="w-full">{t`Sign in instead`}</RouterLinkButton>
 				) : (
 					<>
 						<p className="text-sm text-kumo-subtle">
 							{t`Please ask your administrator to send a new invite.`}
 						</p>
-						<Link
+						<RouterLinkButton
 							to="/login"
-							className={cn(buttonVariants({ variant: "ghost" }), "w-full")}
-						>{t`Back to login`}</Link>
+							variant="ghost"
+							className="w-full"
+						>{t`Back to login`}</RouterLinkButton>
 					</>
 				)}
 			</div>

--- a/packages/admin/src/components/InviteAcceptPage.tsx
+++ b/packages/admin/src/components/InviteAcceptPage.tsx
@@ -3,13 +3,14 @@
  * Validates an invite token, then registers a passkey to complete signup.
  */
 
-import { Button, Input, Loader } from "@cloudflare/kumo";
+import { buttonVariants, Input, Loader } from "@cloudflare/kumo";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Link, useSearch } from "@tanstack/react-router";
 import * as React from "react";
 
 import { validateInviteToken, type InviteVerifyResult } from "../lib/api";
+import { cn } from "../lib/utils";
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { LogoLockup } from "./Logo.js";
 
@@ -125,19 +126,16 @@ function ErrorStep({ message, code }: ErrorStepProps) {
 
 			<div className="space-y-2">
 				{code === "USER_EXISTS" ? (
-					<Link to="/login">
-						<Button className="w-full">{t`Sign in instead`}</Button>
-					</Link>
+					<Link to="/login" className={cn(buttonVariants(), "w-full")}>{t`Sign in instead`}</Link>
 				) : (
 					<>
 						<p className="text-sm text-kumo-subtle">
 							{t`Please ask your administrator to send a new invite.`}
 						</p>
-						<Link to="/login">
-							<Button variant="ghost" className="w-full">
-								{t`Back to login`}
-							</Button>
-						</Link>
+						<Link
+							to="/login"
+							className={cn(buttonVariants({ variant: "ghost" }), "w-full")}
+						>{t`Back to login`}</Link>
 					</>
 				)}
 			</div>

--- a/packages/admin/src/components/MenuList.tsx
+++ b/packages/admin/src/components/MenuList.tsx
@@ -4,7 +4,7 @@
  * Displays all menus with ability to create, edit, and delete.
  */
 
-import { Button, Dialog, Input, Toast, buttonVariants } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Toast } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -19,6 +19,7 @@ import { fetchManifest } from "../lib/api/client.js";
 import { ConfirmDialog } from "./ConfirmDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
 import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 export function MenuList() {
 	const { t } = useLingui();
@@ -219,15 +220,16 @@ export function MenuList() {
 								</div>
 							</Link>
 							<div className="flex gap-2">
-								<Link
+								<RouterLinkButton
 									to="/menus/$name"
 									params={{ name: menu.name }}
 									search={{ locale: menu.locale }}
-									className={buttonVariants({ variant: "outline", size: "sm" })}
+									variant="outline"
+									size="sm"
+									icon={<Pencil />}
 								>
-									<Pencil className="me-2 h-4 w-4" aria-hidden="true" />
 									{t`Edit`}
-								</Link>
+								</RouterLinkButton>
 								<Button
 									variant="outline"
 									size="sm"

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -361,20 +361,25 @@ function PluginCard({
 						)}
 
 						{isMarketplace && hasMarketplace && (
-							<Link to="/plugins/marketplace/$pluginId" params={{ pluginId: plugin.id }}>
-								<Button variant="ghost" size="sm">
-									<Storefront className="me-1.5 h-3.5 w-3.5" />
-									{t`View in Marketplace`}
-								</Button>
+							<Link
+								to="/plugins/marketplace/$pluginId"
+								params={{ pluginId: plugin.id }}
+								className={buttonVariants({ variant: "ghost", size: "sm" })}
+							>
+								<Storefront className="me-1.5 h-3.5 w-3.5" />
+								{t`View in Marketplace`}
 							</Link>
 						)}
 
 						{plugin.hasAdminPages && plugin.enabled && (
-							<Link to="/plugins/$pluginId/$" params={{ pluginId: plugin.id, _splat: "" }}>
-								<Button variant="ghost" shape="square" aria-label={t`Settings`}>
-									<Gear className="h-4 w-4" />
-									<span className="sr-only">{t`Settings`}</span>
-								</Button>
+							<Link
+								to="/plugins/$pluginId/$"
+								params={{ pluginId: plugin.id, _splat: "" }}
+								aria-label={t`Settings`}
+								className={buttonVariants({ variant: "ghost", shape: "square" })}
+							>
+								<Gear className="h-4 w-4" />
+								<span className="sr-only">{t`Settings`}</span>
 							</Link>
 						)}
 

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -6,7 +6,7 @@
  * update/uninstall for marketplace-installed plugins.
  */
 
-import { Badge, Button, buttonVariants, Switch, Toast } from "@cloudflare/kumo";
+import { Badge, Button, Switch, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	PuzzlePiece,
@@ -43,6 +43,7 @@ import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
 import { CapabilityConsentDialog } from "./CapabilityConsentDialog.js";
 import { DialogError, getMutationError } from "./DialogError.js";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 export interface PluginManagerProps {
 	/** Admin manifest — used to check if marketplace is configured */
@@ -153,10 +154,9 @@ export function PluginManager({ manifest }: PluginManagerProps) {
 						</Button>
 					)}
 					{hasMarketplace && (
-						<Link to="/plugins/marketplace" className={buttonVariants({ variant: "ghost" })}>
-							<Storefront className="me-2 h-4 w-4" aria-hidden="true" />
+						<RouterLinkButton to="/plugins/marketplace" variant="ghost" icon={<Storefront />}>
 							{t`Marketplace`}
-						</Link>
+						</RouterLinkButton>
 					)}
 					<span className="text-sm text-kumo-subtle">{t`${plugins?.length ?? 0} plugins`}</span>
 				</div>
@@ -361,26 +361,26 @@ function PluginCard({
 						)}
 
 						{isMarketplace && hasMarketplace && (
-							<Link
+							<RouterLinkButton
 								to="/plugins/marketplace/$pluginId"
 								params={{ pluginId: plugin.id }}
-								className={buttonVariants({ variant: "ghost", size: "sm" })}
+								variant="ghost"
+								size="sm"
+								icon={<Storefront />}
 							>
-								<Storefront className="me-1.5 h-3.5 w-3.5" />
 								{t`View in Marketplace`}
-							</Link>
+							</RouterLinkButton>
 						)}
 
 						{plugin.hasAdminPages && plugin.enabled && (
-							<Link
+							<RouterLinkButton
 								to="/plugins/$pluginId/$"
 								params={{ pluginId: plugin.id, _splat: "" }}
 								aria-label={t`Settings`}
-								className={buttonVariants({ variant: "ghost", shape: "square" })}
-							>
-								<Gear className="h-4 w-4" />
-								<span className="sr-only">{t`Settings`}</span>
-							</Link>
+								variant="ghost"
+								shape="square"
+								icon={<Gear />}
+							/>
 						)}
 
 						<Switch

--- a/packages/admin/src/components/RouterLinkButton.tsx
+++ b/packages/admin/src/components/RouterLinkButton.tsx
@@ -1,0 +1,71 @@
+/**
+ * Router-aware anchor styled as a Kumo button.
+ *
+ * Wraps TanStack Router's `Link` so it routes client-side, but matches the
+ * Kumo `Button` API surface for `variant` / `size` / `shape` / `icon`. Use
+ * this anywhere you'd reach for `<Link><Button>...</Button></Link>` (which
+ * is invalid HTML — renders `<a><button>`).
+ *
+ * Inherits TanStack Router's typed `to` / `params` / `search` / `preload`
+ * props by spreading them through to the underlying `<Link>`.
+ *
+ * @example
+ * ```tsx
+ * <RouterLinkButton to="/settings" variant="ghost" shape="square"
+ *   aria-label={t`Back to settings`} icon={<ArrowPrev />} />
+ *
+ * <RouterLinkButton to="/posts/$id" params={{ id }} variant="primary">
+ *   {t`Edit post`}
+ * </RouterLinkButton>
+ * ```
+ *
+ * For external links (or anything that needs `target="_blank"`), use Kumo's
+ * `LinkButton` directly with `external`.
+ */
+
+import { type LinkButtonProps, buttonVariants } from "@cloudflare/kumo";
+import { type Icon } from "@phosphor-icons/react";
+import { Link, type LinkProps } from "@tanstack/react-router";
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+type ButtonStyleProps = Pick<LinkButtonProps, "variant" | "size" | "shape" | "icon">;
+
+export type RouterLinkButtonProps = Omit<LinkProps, "children"> &
+	ButtonStyleProps & {
+		className?: string;
+		children?: React.ReactNode;
+	};
+
+export function RouterLinkButton({
+	className,
+	variant,
+	size,
+	shape,
+	icon,
+	children,
+	...linkProps
+}: RouterLinkButtonProps) {
+	const iconNode = renderIcon(icon);
+	return (
+		<Link
+			{...(linkProps as LinkProps)}
+			className={cn(
+				buttonVariants({ variant, size, shape }),
+				"flex items-center no-underline!",
+				className,
+			)}
+		>
+			{iconNode}
+			{children}
+		</Link>
+	);
+}
+
+function renderIcon(icon: Icon | React.ReactNode | undefined): React.ReactNode {
+	if (!icon) return null;
+	if (React.isValidElement(icon)) return icon;
+	const Comp = icon as React.ComponentType<Record<string, unknown>>;
+	return <Comp />;
+}

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -4,10 +4,10 @@
  * Edit a section's content and metadata.
  */
 
-import { buttonVariants, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
+import { Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link, useParams, useNavigate } from "@tanstack/react-router";
+import { useParams, useNavigate } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSection, updateSection, type Section, type UpdateSectionInput } from "../lib/api";
@@ -16,6 +16,7 @@ import { ArrowPrev } from "./ArrowIcons.js";
 import { ImageDetailPanel, type ImageAttributes } from "./editor/ImageDetailPanel";
 import { EditorHeader } from "./EditorHeader";
 import { PortableTextEditor, type BlockSidebarPanel } from "./PortableTextEditor";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 import { SaveButton } from "./SaveButton";
 
 export function SectionEditor() {
@@ -67,13 +68,13 @@ export function SectionEditor() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-4">
-					<Link
+					<RouterLinkButton
 						to="/sections"
 						aria-label={t`Back to sections`}
-						className={buttonVariants({ variant: "ghost", shape: "square" })}
-					>
-						<ArrowPrev className="h-5 w-5" />
-					</Link>
+						variant="ghost"
+						shape="square"
+						icon={<ArrowPrev />}
+					/>
 					<h1 className="text-2xl font-bold">{t`Section Not Found`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
@@ -170,13 +171,13 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 			    long PortableText content. */}
 			<EditorHeader
 				leading={
-					<Link
+					<RouterLinkButton
 						to="/sections"
 						aria-label={t`Back to sections`}
-						className={buttonVariants({ variant: "ghost", shape: "square" })}
-					>
-						<ArrowPrev className="h-5 w-5" />
-					</Link>
+						variant="ghost"
+						shape="square"
+						icon={<ArrowPrev />}
+					/>
 				}
 				actions={<SaveButton isSaving={isSaving} isDirty={isDirty} onClick={handleSave} />}
 			>

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -4,7 +4,7 @@
  * Edit a section's content and metadata.
  */
 
-import { Button, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
+import { buttonVariants, Input, InputArea, Label, Loader, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams, useNavigate } from "@tanstack/react-router";
@@ -67,10 +67,12 @@ export function SectionEditor() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-4">
-					<Link to="/sections">
-						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
-							<ArrowPrev className="h-5 w-5" />
-						</Button>
+					<Link
+						to="/sections"
+						aria-label={t`Back to sections`}
+						className={buttonVariants({ variant: "ghost", shape: "square" })}
+					>
+						<ArrowPrev className="h-5 w-5" />
 					</Link>
 					<h1 className="text-2xl font-bold">{t`Section Not Found`}</h1>
 				</div>
@@ -168,10 +170,12 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 			    long PortableText content. */}
 			<EditorHeader
 				leading={
-					<Link to="/sections">
-						<Button variant="ghost" shape="square" aria-label={t`Back to sections`}>
-							<ArrowPrev className="h-5 w-5" />
-						</Button>
+					<Link
+						to="/sections"
+						aria-label={t`Back to sections`}
+						className={buttonVariants({ variant: "ghost", shape: "square" })}
+					>
+						<ArrowPrev className="h-5 w-5" />
 					</Link>
 				}
 				actions={<SaveButton isSaving={isSaving} isDirty={isDirty} onClick={handleSave} />}

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -10,12 +10,13 @@
  * 3. After clicking email link: Passkey registration
  */
 
-import { Button, Input, Loader } from "@cloudflare/kumo";
+import { Button, buttonVariants, Input, Loader } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { requestSignup, verifySignupToken, type SignupVerifyResult } from "../lib/api";
+import { cn } from "../lib/utils";
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { LogoLockup } from "./Logo.js";
 
@@ -265,9 +266,7 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 
 			<div className="space-y-2">
 				{code === "user_exists" ? (
-					<Link to="/login">
-						<Button className="w-full">{t`Sign in instead`}</Button>
-					</Link>
+					<Link to="/login" className={cn(buttonVariants(), "w-full")}>{t`Sign in instead`}</Link>
 				) : (
 					onRetry && (
 						<Button onClick={onRetry} className="w-full">
@@ -275,11 +274,10 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 						</Button>
 					)
 				)}
-				<Link to="/login">
-					<Button variant="ghost" className="w-full">
-						{t`Back to login`}
-					</Button>
-				</Link>
+				<Link
+					to="/login"
+					className={cn(buttonVariants({ variant: "ghost" }), "w-full")}
+				>{t`Back to login`}</Link>
 			</div>
 		</div>
 	);

--- a/packages/admin/src/components/SignupPage.tsx
+++ b/packages/admin/src/components/SignupPage.tsx
@@ -10,15 +10,15 @@
  * 3. After clicking email link: Passkey registration
  */
 
-import { Button, buttonVariants, Input, Loader } from "@cloudflare/kumo";
+import { Button, Input, Loader } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { requestSignup, verifySignupToken, type SignupVerifyResult } from "../lib/api";
-import { cn } from "../lib/utils";
 import { PasskeyRegistration } from "./auth/PasskeyRegistration";
 import { LogoLockup } from "./Logo.js";
+import { RouterLinkButton } from "./RouterLinkButton.js";
 
 // ============================================================================
 // Types
@@ -266,7 +266,7 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 
 			<div className="space-y-2">
 				{code === "user_exists" ? (
-					<Link to="/login" className={cn(buttonVariants(), "w-full")}>{t`Sign in instead`}</Link>
+					<RouterLinkButton to="/login" className="w-full">{t`Sign in instead`}</RouterLinkButton>
 				) : (
 					onRetry && (
 						<Button onClick={onRetry} className="w-full">
@@ -274,10 +274,11 @@ function ErrorStep({ message, code, onRetry }: ErrorStepProps) {
 						</Button>
 					)
 				)}
-				<Link
+				<RouterLinkButton
 					to="/login"
-					className={cn(buttonVariants({ variant: "ghost" }), "w-full")}
-				>{t`Back to login`}</Link>
+					variant="ghost"
+					className="w-full"
+				>{t`Back to login`}</RouterLinkButton>
 			</div>
 		</div>
 	);

--- a/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
+++ b/packages/admin/src/components/settings/AllowedDomainsSettings.tsx
@@ -18,7 +18,6 @@ import {
 } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import {
@@ -29,7 +28,7 @@ import {
 	fetchManifest,
 	type AllowedDomain,
 } from "../../lib/api";
-import { ArrowPrev } from "../ArrowIcons.js";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 import { useAllowedDomainsRolesConfig } from "./useAllowedDomainsRolesConfig.js";
 
 export function AllowedDomainsSettings() {
@@ -164,11 +163,7 @@ export function AllowedDomainsSettings() {
 
 	const settingsHeader = (
 		<div className="flex items-center gap-3">
-			<Link to="/settings">
-				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-					<ArrowPrev className="h-4 w-4" />
-				</Button>
-			</Link>
+			<BackToSettingsLink />
 			<h1 className="text-2xl font-bold">{t`Self-Signup Domains`}</h1>
 		</div>
 	);

--- a/packages/admin/src/components/settings/ApiTokenSettings.tsx
+++ b/packages/admin/src/components/settings/ApiTokenSettings.tsx
@@ -10,7 +10,6 @@ import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Copy, Eye, EyeSlash, Key, Plus, Trash, WarningCircle } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import {
@@ -21,8 +20,8 @@ import {
 	type ApiTokenCreateResult,
 	type ApiTokenScopeValue,
 } from "../../lib/api/api-tokens.js";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { getMutationError } from "../DialogError.js";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 // =============================================================================
 // Expiry options
@@ -179,11 +178,7 @@ export function ApiTokenSettings() {
 		<div className="space-y-6">
 			{/* Header */}
 			<div className="flex items-center gap-3">
-				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label={t(msg`Back to settings`)}>
-						<ArrowPrev className="h-4 w-4" />
-					</Button>
-				</Link>
+				<BackToSettingsLink />
 				<div>
 					<h1 className="text-2xl font-bold">{t(msg`API Tokens`)}</h1>
 					<p className="text-sm text-kumo-subtle">

--- a/packages/admin/src/components/settings/BackToSettingsLink.tsx
+++ b/packages/admin/src/components/settings/BackToSettingsLink.tsx
@@ -1,0 +1,24 @@
+import { buttonVariants } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { Link } from "@tanstack/react-router";
+
+import { ArrowPrev } from "../ArrowIcons.js";
+
+/**
+ * Shared "Back to settings" link, used in the header of each settings sub-page.
+ *
+ * Renders as a single anchor element styled as a Kumo ghost square button.
+ * Avoids the invalid `<a><button>` HTML produced by `<Link><Button>`.
+ */
+export function BackToSettingsLink() {
+	const { t } = useLingui();
+	return (
+		<Link
+			to="/settings"
+			aria-label={t`Back to settings`}
+			className={buttonVariants({ variant: "ghost", shape: "square" })}
+		>
+			<ArrowPrev className="h-4 w-4" />
+		</Link>
+	);
+}

--- a/packages/admin/src/components/settings/BackToSettingsLink.tsx
+++ b/packages/admin/src/components/settings/BackToSettingsLink.tsx
@@ -1,24 +1,23 @@
-import { buttonVariants } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
-import { Link } from "@tanstack/react-router";
 
 import { ArrowPrev } from "../ArrowIcons.js";
+import { RouterLinkButton } from "../RouterLinkButton.js";
 
 /**
  * Shared "Back to settings" link, used in the header of each settings sub-page.
  *
  * Renders as a single anchor element styled as a Kumo ghost square button.
- * Avoids the invalid `<a><button>` HTML produced by `<Link><Button>`.
+ * Routes through TanStack Router (client-side navigation, no full page reload).
  */
 export function BackToSettingsLink() {
 	const { t } = useLingui();
 	return (
-		<Link
+		<RouterLinkButton
 			to="/settings"
+			variant="ghost"
+			shape="square"
 			aria-label={t`Back to settings`}
-			className={buttonVariants({ variant: "ghost", shape: "square" })}
-		>
-			<ArrowPrev className="h-4 w-4" />
-		</Link>
+			icon={<ArrowPrev />}
+		/>
 	);
 }

--- a/packages/admin/src/components/settings/EmailSettings.tsx
+++ b/packages/admin/src/components/settings/EmailSettings.tsx
@@ -15,7 +15,6 @@ import {
 	WarningCircle,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import {
@@ -23,8 +22,8 @@ import {
 	sendTestEmail,
 	type EmailSettings as EmailSettingsData,
 } from "../../lib/api/email-settings.js";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { getMutationError } from "../DialogError.js";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 export function EmailSettings() {
 	const { t } = useLingui();
@@ -82,11 +81,7 @@ export function EmailSettings() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
+					<BackToSettingsLink />
 					<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
 				</div>
 				<div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200">
@@ -101,11 +96,7 @@ export function EmailSettings() {
 		<div className="space-y-6">
 			{/* Header */}
 			<div className="flex items-center gap-3">
-				<Link to="/settings">
-					<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-						<ArrowPrev className="h-4 w-4" />
-					</Button>
-				</Link>
+				<BackToSettingsLink />
 				<h1 className="text-2xl font-bold">{t`Email Settings`}</h1>
 			</div>
 

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -9,13 +9,12 @@ import { Button, Input, Label } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { FloppyDisk, CheckCircle, WarningCircle, Upload, X } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSettings, updateSettings, type SiteSettings, type MediaItem } from "../../lib/api";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { EditorHeader } from "../EditorHeader";
 import { MediaPickerModal } from "../MediaPickerModal";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 export function GeneralSettings() {
 	const { t } = useLingui();
@@ -98,11 +97,7 @@ export function GeneralSettings() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
+					<BackToSettingsLink />
 					<h1 className="text-2xl font-bold">{t`General Settings`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
@@ -119,13 +114,7 @@ export function GeneralSettings() {
 			    below so the natural last-control DOM order works for keyboard
 			    and screen-reader users. */}
 			<EditorHeader
-				leading={
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
-				}
+				leading={<BackToSettingsLink />}
 				actions={
 					<Button
 						type="submit"

--- a/packages/admin/src/components/settings/SecuritySettings.tsx
+++ b/packages/admin/src/components/settings/SecuritySettings.tsx
@@ -9,12 +9,11 @@ import { Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Shield, Plus, CheckCircle, WarningCircle, Info } from "@phosphor-icons/react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchPasskeys, renamePasskey, deletePasskey, fetchManifest } from "../../lib/api";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { PasskeyRegistration } from "../auth/PasskeyRegistration";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 import { PasskeyList } from "./PasskeyList";
 
 export function SecuritySettings() {
@@ -101,11 +100,7 @@ export function SecuritySettings() {
 
 	const settingsHeader = (
 		<div className="flex items-center gap-3">
-			<Link to="/settings">
-				<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-					<ArrowPrev className="h-4 w-4" />
-				</Button>
-			</Link>
+			<BackToSettingsLink />
 			<h1 className="text-2xl font-bold">{t`Security Settings`}</h1>
 		</div>
 	);

--- a/packages/admin/src/components/settings/SeoSettings.tsx
+++ b/packages/admin/src/components/settings/SeoSettings.tsx
@@ -8,12 +8,11 @@ import { Button, Input, InputArea } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { FloppyDisk, CheckCircle, WarningCircle, MagnifyingGlass } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { EditorHeader } from "../EditorHeader";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 export function SeoSettings() {
 	const { t } = useLingui();
@@ -75,11 +74,7 @@ export function SeoSettings() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
+					<BackToSettingsLink />
 					<h1 className="text-2xl font-bold">{t`SEO Settings`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
@@ -93,13 +88,7 @@ export function SeoSettings() {
 		<div className="space-y-6">
 			{/* Sticky header — see GeneralSettings for the same pattern. */}
 			<EditorHeader
-				leading={
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
-				}
+				leading={<BackToSettingsLink />}
 				actions={
 					<Button
 						type="submit"

--- a/packages/admin/src/components/settings/SocialSettings.tsx
+++ b/packages/admin/src/components/settings/SocialSettings.tsx
@@ -8,12 +8,11 @@ import { Button, Input } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { FloppyDisk, CheckCircle, WarningCircle } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import * as React from "react";
 
 import { fetchSettings, updateSettings, type SiteSettings } from "../../lib/api";
-import { ArrowPrev } from "../ArrowIcons.js";
 import { EditorHeader } from "../EditorHeader";
+import { BackToSettingsLink } from "./BackToSettingsLink.js";
 
 export function SocialSettings() {
 	const { t } = useLingui();
@@ -75,11 +74,7 @@ export function SocialSettings() {
 		return (
 			<div className="space-y-6">
 				<div className="flex items-center gap-3">
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
+					<BackToSettingsLink />
 					<h1 className="text-2xl font-bold">{t`Social Links`}</h1>
 				</div>
 				<div className="rounded-lg border bg-kumo-base p-6">
@@ -93,13 +88,7 @@ export function SocialSettings() {
 		<div className="space-y-6">
 			{/* Sticky header — see GeneralSettings for the same pattern. */}
 			<EditorHeader
-				leading={
-					<Link to="/settings">
-						<Button variant="ghost" shape="square" aria-label={t`Back to settings`}>
-							<ArrowPrev className="h-4 w-4" />
-						</Button>
-					</Link>
-				}
+				leading={<BackToSettingsLink />}
 				actions={
 					<Button
 						type="submit"

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -4,7 +4,7 @@
  * Defines all admin routes and their components.
  */
 
-import { Loader, Toast } from "@cloudflare/kumo";
+import { Button, Loader, Toast } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { QueryClient } from "@tanstack/react-query";
@@ -1721,12 +1721,9 @@ function ErrorScreen({ error }: { error: string }) {
 			<div className="text-center">
 				<h1 className="text-xl font-bold text-kumo-danger">{t`Error`}</h1>
 				<p className="mt-2 text-kumo-subtle">{error}</p>
-				<button
-					onClick={() => window.location.reload()}
-					className="mt-4 px-4 py-2 bg-kumo-brand text-white rounded-md"
-				>
+				<Button onClick={() => window.location.reload()} className="mt-4">
 					{t`Retry`}
-				</button>
+				</Button>
 			</div>
 		</div>
 	);

--- a/packages/admin/tests/components/PluginManager.test.tsx
+++ b/packages/admin/tests/components/PluginManager.test.tsx
@@ -179,8 +179,8 @@ describe("PluginManager", () => {
 			</Wrapper>,
 		);
 		await expect.element(screen.getByText("Audit Log")).toBeInTheDocument();
-		const settingsButtons = screen.getByRole("button", { name: "Settings" }).all();
-		expect(settingsButtons.length).toBe(1);
+		const settingsLinks = screen.getByRole("link", { name: "Settings" }).all();
+		expect(settingsLinks.length).toBe(1);
 	});
 
 	it("settings link points to the plugin root, not a /settings sub-path", async () => {
@@ -190,13 +190,12 @@ describe("PluginManager", () => {
 			</Wrapper>,
 		);
 		await expect.element(screen.getByText("Audit Log")).toBeInTheDocument();
-		const settingsButton = screen.getByRole("button", { name: "Settings" });
-		await expect.element(settingsButton).toBeInTheDocument();
-		const anchor = settingsButton.element().closest("a");
-		expect(anchor).not.toBeNull();
+		const settingsLink = screen.getByRole("link", { name: "Settings" });
+		await expect.element(settingsLink).toBeInTheDocument();
+		const anchor = settingsLink.element() as HTMLAnchorElement;
 		// Plugins are not required to expose a `/settings` sub-page; the gear
 		// icon should land on the plugin's primary admin page.
-		expect(anchor!.getAttribute("href")).toMatch(/^\/plugins\/audit-log\/?$/);
+		expect(anchor.getAttribute("href")).toMatch(/^\/plugins\/audit-log\/?$/);
 	});
 
 	it("expand/collapse shows plugin details", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes invalid `<a><button>` HTML produced by `<Link><Button>...</Button></Link>` patterns across the admin UI, and introduces a `RouterLinkButton` component to make this kind of router-aware-button reusable.

`<Link><Button>` renders as `<a><button>`, which is invalid HTML — screen readers see two interactive elements, keyboard navigation breaks, and the rendered DOM doesn't match the semantics the developer wrote.

### Approach

Two commits, intentionally separated for review clarity:

1. **First commit**: Initial fix using the documented `<Link className={buttonVariants(...)}>` pattern. Also extracts the duplicated "Back to settings" header link into a shared `BackToSettingsLink` component used by all 7 settings sub-pages, and fixes a raw `<button>` Retry control in `router.tsx` ErrorScreen (which was using inline `bg-kumo-brand text-white` classes that bypassed Kumo's state styling).

2. **Second commit**: Introduces a `RouterLinkButton` component that wraps TanStack Router's `<Link>` with Kumo button styling (`variant`, `size`, `shape`, `icon`, `className` props passing through). Migrates all 16+ `<Link className={buttonVariants(...)}>` usages — both the ones added in the first commit and 10 pre-existing ones across `ContentEditor`, `ContentList`, `ContentTypeEditor`, `ContentTypeList`, `MenuList`, `PluginManager`, `SectionEditor`, etc. — to use it. The result: a single, consistent way to render a router-aware button.

### Why not Kumo's `LinkButton` + `LinkProvider`?

Considered and rejected. Kumo's `LinkProvider` wires a custom anchor component for `LinkButton`, but its `LinkComponentProps` type only accepts plain anchor attrs + optional `to: string`. TanStack Router's typed routes require `params`, `search`, `preload`, etc. — props that don't fit through Kumo's provider interface. Going via `LinkProvider` would lose TanStack's type safety, link preloading, active states, and forces a runtime branching adapter.

`RouterLinkButton` keeps the full TanStack Router `Link` API intact and just composes Kumo's button-variant classes onto it. Implementation note: I tried using TanStack's `createLink()` helper first, but it broke the existing test suite (153 failures) because tests mock `@tanstack/react-router` as a stub anchor and `createLink` calls `useRouter()` internally which fails without the real router context. Using `<Link>` directly inside the wrapper means tests' existing mock substitutes correctly.

### Files changed

**New:**
- `packages/admin/src/components/RouterLinkButton.tsx` — the component
- `packages/admin/src/components/settings/BackToSettingsLink.tsx` — shared back-to-settings link

**Migrated (12 files):**
- Settings pages (`ApiTokenSettings`, `GeneralSettings`, `SeoSettings`, `EmailSettings`, `SocialSettings`, `SecuritySettings`, `AllowedDomainsSettings`) — use `BackToSettingsLink`
- Content editing flow (`ContentEditor`, `ContentList`, `ContentTypeEditor`, `ContentTypeList`, `SectionEditor`)
- Plugin/menu UI (`MenuList`, `PluginManager`)
- Auth flow (`SignupPage`, `InviteAcceptPage`)
- `router.tsx` — Retry button → Kumo `<Button>`
- `tests/components/PluginManager.test.tsx` — query by `role=link` instead of `role=button` (the element is now correctly a link)

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (admin: 858/858)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (PluginManager test query updated to match new semantic role)
- [x] User-visible strings in the admin UI are wrapped for translation
- [x] I have added a changeset
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (orchestration) + Claude Haiku 4.5 (sub-agents) via OpenCode

## Screenshots / test output

No visual change — `RouterLinkButton` produces the same Tailwind classes as the `<Link className={buttonVariants(...)}>` pattern. The fix is structural (DOM no longer has `<a><button>`), affecting screen readers and keyboard navigation rather than visible UI.

Stack: `main` → #934 (merged) → #937 (merged) → #940 (merged) → **this PR** → (next: aria-labels) → (next: RTL safety) → (next: semantic tokens) → (last: ESLint enforcement)