### PR TITLE
fix(admin): replace raw <select> and <input type="search"> with Kumo components

### DIFF
--- a/.changeset/tall-oranges-appear.md
+++ b/.changeset/tall-oranges-appear.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Replaces raw `<select>` and `<input type="search">` elements across the admin UI with Kumo's `Select` and `Input` components. This gives consistent styling, proper focus rings, accessibility (label association via the Field wrapper), and dark-mode handling for free instead of relying on hand-rolled Tailwind classes that bypassed the design system.

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -83,11 +83,14 @@ test.describe("Bylines", () => {
 			.getByRole("heading", { name: "Bylines" })
 			.locator("xpath=ancestor::div[contains(@class,'p-4')]")
 			.first();
-		const bylineSelect = bylinesSidebar.locator("select").first();
-		await bylineSelect.selectOption({ value: firstBylineId });
+		// Kumo's Select renders as a combobox button + popover, not a native <select>.
+		const bylineCombobox = bylinesSidebar.getByRole("combobox").first();
+		await bylineCombobox.click();
+		await page.getByRole("option", { name: primaryName }).click();
 		await bylinesSidebar.getByRole("button", { name: "Add" }).click();
 
-		await bylineSelect.selectOption({ value: secondBylineId });
+		await bylineCombobox.click();
+		await page.getByRole("option", { name: secondaryName }).click();
 		await bylinesSidebar.getByRole("button", { name: "Add" }).click();
 
 		await page.getByLabel("Role label").nth(1).fill("Co-author");

--- a/packages/admin/src/components/BlockKitFieldWidget.tsx
+++ b/packages/admin/src/components/BlockKitFieldWidget.tsx
@@ -104,7 +104,10 @@ function BlockKitFieldElement({
 					label={element.label}
 					value={typeof value === "string" ? value : ""}
 					onValueChange={(v) => onChange(element.action_id, v ?? "")}
-					items={Object.fromEntries(options.map((opt) => [opt.value, opt.label]))}
+					items={{
+						"": t`Select...`,
+						...Object.fromEntries(options.map((opt) => [opt.value, opt.label])),
+					}}
 				/>
 			);
 		}

--- a/packages/admin/src/components/BlockKitFieldWidget.tsx
+++ b/packages/admin/src/components/BlockKitFieldWidget.tsx
@@ -1,4 +1,4 @@
-import { Input, Switch } from "@cloudflare/kumo";
+import { Input, Select, Switch } from "@cloudflare/kumo";
 import type { Element } from "@emdash-cms/blocks";
 import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
@@ -100,21 +100,12 @@ function BlockKitFieldElement({
 		case "select": {
 			const options = Array.isArray(element.options) ? element.options : [];
 			return (
-				<div>
-					<label className="text-sm font-medium mb-1.5 block">{element.label}</label>
-					<select
-						className="flex w-full rounded-md border border-kumo-line bg-transparent px-3 py-2 text-sm"
-						value={typeof value === "string" ? value : ""}
-						onChange={(e) => onChange(element.action_id, e.target.value)}
-					>
-						<option value="">{t`Select...`}</option>
-						{options.map((opt) => (
-							<option key={opt.value} value={opt.value}>
-								{opt.label}
-							</option>
-						))}
-					</select>
-				</div>
+				<Select
+					label={element.label}
+					value={typeof value === "string" ? value : ""}
+					onValueChange={(v) => onChange(element.action_id, v ?? "")}
+					items={Object.fromEntries(options.map((opt) => [opt.value, opt.label]))}
+				/>
 			);
 		}
 		case "media_picker":

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1890,18 +1890,16 @@ function BylineCreditsEditor({
 	return (
 		<div className="space-y-3">
 			<div className="flex gap-2">
-				<select
+				<Select
 					value={selectedBylineId}
-					onChange={(e) => setSelectedBylineId(e.target.value)}
-					className="w-full rounded border bg-kumo-base px-3 py-2 text-sm"
-				>
-					<option value="">{t`Select byline...`}</option>
-					{availableToAdd.map((b) => (
-						<option key={b.id} value={b.id}>
-							{b.displayName}
-						</option>
-					))}
-				</select>
+					onValueChange={(v) => setSelectedBylineId(v ?? "")}
+					items={{
+						"": t`Select byline...`,
+						...Object.fromEntries(availableToAdd.map((b) => [b.id, b.displayName])),
+					}}
+					aria-label={t`Select byline`}
+					className="w-full"
+				/>
 				<Button
 					type="button"
 					variant="secondary"

--- a/packages/admin/src/components/ContentPickerModal.tsx
+++ b/packages/admin/src/components/ContentPickerModal.tsx
@@ -5,7 +5,7 @@
  * Uses cursor pagination to allow browsing beyond the initial page.
  */
 
-import { Button, Dialog, Input, Loader } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Loader, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { MagnifyingGlass, FolderOpen, X } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -145,21 +145,16 @@ export function ContentPickerModal({ open, onOpenChange, onSelect }: ContentPick
 							autoFocus
 						/>
 					</div>
-					<select
+					<Select
 						value={selectedCollection}
-						onChange={(e) => {
-							setSelectedCollection(e.target.value);
+						onValueChange={(v) => {
+							setSelectedCollection(v ?? "");
 							setAllItems([]);
 							setNextCursor(undefined);
 						}}
-						className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-kumo-ring focus:ring-offset-2"
-					>
-						{collections.map((col) => (
-							<option key={col.slug} value={col.slug}>
-								{col.label}
-							</option>
-						))}
-					</select>
+						items={Object.fromEntries(collections.map((col) => [col.slug, col.label]))}
+						aria-label={t`Collection`}
+					/>
 				</div>
 
 				{/* Content list */}

--- a/packages/admin/src/components/FieldEditor.tsx
+++ b/packages/admin/src/components/FieldEditor.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, Input, InputArea } from "@cloudflare/kumo";
+import { Button, Dialog, Input, InputArea, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	TextT,
@@ -568,25 +568,25 @@ export function FieldEditor({ open, onOpenChange, field, onSave, isSaving }: Fie
 													placeholder={t`Field label`}
 												/>
 												<div>
-													<label className="text-sm font-medium">{t`Type`}</label>
-													<select
-														className="w-full mt-1 rounded-md border px-3 py-2 text-sm"
+													<Select
+														label={t`Type`}
 														value={sf.type}
-														onChange={(e) => {
+														onValueChange={(v) => {
 															const updated = [...formState.subFields];
-															updated[i] = { ...sf, type: e.target.value };
+															updated[i] = { ...sf, type: v ?? "string" };
 															setFormState((prev) => ({ ...prev, subFields: updated }));
 														}}
-													>
-														<option value="string">{t`Short Text`}</option>
-														<option value="text">{t`Long Text`}</option>
-														<option value="number">{t`Number`}</option>
-														<option value="integer">{t`Integer`}</option>
-														<option value="boolean">{t`Boolean`}</option>
-														<option value="datetime">{t`Date & Time`}</option>
-														<option value="select">{t`Select`}</option>
-														<option value="url">{t`URL`}</option>
-													</select>
+														items={{
+															string: t`Short Text`,
+															text: t`Long Text`,
+															number: t`Number`,
+															integer: t`Integer`,
+															boolean: t`Boolean`,
+															datetime: t`Date & Time`,
+															select: t`Select`,
+															url: t`URL`,
+														}}
+													/>
 												</div>
 											</div>
 											<label className="flex items-center gap-2 text-sm">

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -5,7 +5,7 @@
  * Navigates to plugin detail on card click.
  */
 
-import { Badge, Button } from "@cloudflare/kumo";
+import { Badge, Button, Input, Select } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -92,42 +92,36 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 				<div className="relative flex-1">
 					<MagnifyingGlass className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
-					<input
+					<Input
 						type="search"
 						placeholder={t`Search plugins...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
-						className="w-full rounded-md border bg-kumo-base px-3 py-2 ps-9 text-sm placeholder:text-kumo-subtle focus:outline-none focus:ring-2 focus:ring-kumo-ring"
+						className="ps-9"
+						aria-label={t`Search plugins`}
 					/>
 				</div>
-				<select
+				<Select
 					value={capability}
-					onChange={(e) => setCapability(e.target.value)}
-					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
-					aria-label={t`Filter by capability`}
-				>
-					<option value="">{t`All capabilities`}</option>
-					{Object.entries(CAPABILITY_LABELS).map(([value, label]) => (
-						<option key={value} value={value}>
-							{label}
-						</option>
-					))}
-				</select>
-				<select
-					value={sort}
-					onChange={(e) => {
-						const v = e.target.value;
-						if (isSortOption(v)) setSort(v);
+					onValueChange={(v) => setCapability(v ?? "")}
+					items={{
+						"": t`All capabilities`,
+						...Object.fromEntries(
+							Object.entries(CAPABILITY_LABELS).map(([value, label]) => [value, t`${label}`]),
+						),
 					}}
-					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
+					aria-label={t`Filter by capability`}
+				/>
+				<Select
+					value={sort}
+					onValueChange={(v) => {
+						if (v && isSortOption(v)) setSort(v);
+					}}
+					items={Object.fromEntries(
+						Object.entries(SORT_LABELS).map(([value, label]) => [value, t(label)]),
+					)}
 					aria-label={t`Sort plugins`}
-				>
-					{Object.entries(SORT_LABELS).map(([value, label]) => (
-						<option key={value} value={value}>
-							{t(label)}
-						</option>
-					))}
-				</select>
+				/>
 			</div>
 
 			{/* Error state */}

--- a/packages/admin/src/components/MarketplaceBrowse.tsx
+++ b/packages/admin/src/components/MarketplaceBrowse.tsx
@@ -107,7 +107,7 @@ export function MarketplaceBrowse({ installedPluginIds = new Set() }: Marketplac
 					items={{
 						"": t`All capabilities`,
 						...Object.fromEntries(
-							Object.entries(CAPABILITY_LABELS).map(([value, label]) => [value, t`${label}`]),
+							Object.entries(CAPABILITY_LABELS).map(([value, label]) => [value, t(label)]),
 						),
 					}}
 					aria-label={t`Filter by capability`}

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -338,7 +338,12 @@ function PluginCard({
 							{plugin.capabilities.length > 0 && (
 								<span
 									className="flex items-center gap-1"
-									title={plugin.capabilities.map((c) => CAPABILITY_LABELS[c] ?? c).join(", ")}
+									title={plugin.capabilities
+										.map((c) => {
+											const label = CAPABILITY_LABELS[c];
+											return label ? t(label) : c;
+										})
+										.join(", ")}
 								>
 									<ShieldCheck className="h-3 w-3" />
 									{t`${plugin.capabilities.length} permission${plugin.capabilities.length !== 1 ? "s" : ""}`}
@@ -415,15 +420,19 @@ function PluginCard({
 									{t`Capabilities`}
 								</h4>
 								<div className="flex flex-wrap gap-1">
-									{plugin.capabilities.map((cap) => (
-										<span
-											key={cap}
-											className="inline-flex items-center rounded-md bg-kumo-tint px-2 py-0.5 text-xs"
-											title={CAPABILITY_LABELS[cap]}
-										>
-											{CAPABILITY_LABELS[cap] ?? cap}
-										</span>
-									))}
+									{plugin.capabilities.map((cap) => {
+										const label = CAPABILITY_LABELS[cap];
+										const text = label ? t(label) : cap;
+										return (
+											<span
+												key={cap}
+												className="inline-flex items-center rounded-md bg-kumo-tint px-2 py-0.5 text-xs"
+												title={text}
+											>
+												{text}
+											</span>
+										);
+									})}
 								</div>
 							</div>
 						)}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -11,7 +11,7 @@
  * - Floating menu on empty lines
  */
 
-import { Button, Dialog, Input } from "@cloudflare/kumo";
+import { Button, Dialog, Input, Select } from "@cloudflare/kumo";
 import {
 	DndContext,
 	KeyboardSensor,
@@ -1754,18 +1754,12 @@ function DynamicSelect({
 			{loading ? (
 				<div className="flex h-10 items-center px-3 text-sm text-kumo-subtle">{t`Loading...`}</div>
 			) : (
-				<select
-					className="flex h-10 w-full rounded-md border border-kumo-line bg-transparent px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kumo-ring focus-visible:ring-offset-2"
+				<Select
+					aria-label={field.label}
 					value={typeof value === "string" ? value : ""}
-					onChange={(e) => onChange(field.action_id, e.target.value)}
-				>
-					<option value="">{t`Select...`}</option>
-					{options.map((opt) => (
-						<option key={opt.value} value={opt.value}>
-							{opt.label}
-						</option>
-					))}
-				</select>
+					onValueChange={(v) => onChange(field.action_id, v ?? "")}
+					items={Object.fromEntries(options.map((opt) => [opt.value, opt.label]))}
+				/>
 			)}
 		</div>
 	);

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1758,7 +1758,10 @@ function DynamicSelect({
 					aria-label={field.label}
 					value={typeof value === "string" ? value : ""}
 					onValueChange={(v) => onChange(field.action_id, v ?? "")}
-					items={Object.fromEntries(options.map((opt) => [opt.value, opt.label]))}
+					items={{
+						"": t`Select...`,
+						...Object.fromEntries(options.map((opt) => [opt.value, opt.label])),
+					}}
 				/>
 			)}
 		</div>

--- a/packages/admin/src/components/Redirects.tsx
+++ b/packages/admin/src/components/Redirects.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Dialog, Input, Label, Switch } from "@cloudflare/kumo";
+import { Badge, Button, Dialog, Input, Label, Select, Switch } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -142,18 +142,17 @@ function RedirectFormDialog({
 
 					<div className="grid grid-cols-2 gap-4">
 						<div>
-							<Label htmlFor="redirect-type">{t`Status code`}</Label>
-							<select
-								id="redirect-type"
+							<Select
+								label={t`Status code`}
 								value={type}
-								onChange={(e) => setType(e.target.value)}
-								className="flex h-10 w-full rounded-md border border-kumo-line bg-kumo-base px-3 py-2 text-sm"
-							>
-								<option value="301">{t`301 Permanent`}</option>
-								<option value="302">{t`302 Temporary`}</option>
-								<option value="307">{t`307 Temporary (Strict)`}</option>
-								<option value="308">{t`308 Permanent (Strict)`}</option>
-							</select>
+								onValueChange={(v) => setType(v ?? "301")}
+								items={{
+									"301": t`301 Permanent`,
+									"302": t`302 Temporary`,
+									"307": t`307 Temporary (Strict)`,
+									"308": t`308 Permanent (Strict)`,
+								}}
+							/>
 						</div>
 
 						<Input
@@ -387,24 +386,18 @@ export function Redirects() {
 								onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
 							/>
 						</div>
-						<select
+						<Select
 							value={filterEnabled}
-							onChange={(e) => setFilterEnabled(e.target.value)}
-							className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 text-sm"
-						>
-							<option value="all">{t`All statuses`}</option>
-							<option value="true">{t`Enabled`}</option>
-							<option value="false">{t`Disabled`}</option>
-						</select>
-						<select
+							onValueChange={(v) => setFilterEnabled(v ?? "all")}
+							items={{ all: t`All statuses`, true: t`Enabled`, false: t`Disabled` }}
+							aria-label={t`Filter by status`}
+						/>
+						<Select
 							value={filterAuto}
-							onChange={(e) => setFilterAuto(e.target.value)}
-							className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 text-sm"
-						>
-							<option value="all">{t`All types`}</option>
-							<option value="false">{t`Manual`}</option>
-							<option value="true">{t`Auto (slug change)`}</option>
-						</select>
+							onValueChange={(v) => setFilterAuto(v ?? "all")}
+							items={{ all: t`All types`, false: t`Manual`, true: t`Auto (slug change)` }}
+							aria-label={t`Filter by type`}
+						/>
 					</div>
 
 					{/* Loop warning banner */}

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -360,7 +360,10 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 					label={subField.label}
 					value={typeof value === "string" ? value : ""}
 					onValueChange={(v) => onChange(v ?? "")}
-					items={Object.fromEntries((subField.options ?? []).map((opt) => [opt, opt]))}
+					items={{
+						"": t`Select...`,
+						...Object.fromEntries((subField.options ?? []).map((opt) => [opt, opt])),
+					}}
 				/>
 			);
 		default:

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -5,7 +5,7 @@
  * Items can be added, removed, and reordered via drag-and-drop.
  */
 
-import { Button, Input, InputArea } from "@cloudflare/kumo";
+import { Button, Input, InputArea, Select } from "@cloudflare/kumo";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import {
@@ -356,22 +356,12 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 			);
 		case "select":
 			return (
-				<div>
-					<label className="text-sm font-medium">{subField.label}</label>
-					<select
-						className="w-full mt-1 rounded-md border px-3 py-2 text-sm"
-						value={typeof value === "string" ? value : ""}
-						onChange={(e) => onChange(e.target.value)}
-						required={subField.required}
-					>
-						<option value="">{t`Select...`}</option>
-						{subField.options?.map((opt) => (
-							<option key={opt} value={opt}>
-								{opt}
-							</option>
-						))}
-					</select>
-				</div>
+				<Select
+					label={subField.label}
+					value={typeof value === "string" ? value : ""}
+					onValueChange={(v) => onChange(v ?? "")}
+					items={Object.fromEntries((subField.options ?? []).map((opt) => [opt, opt]))}
+				/>
 			);
 		default:
 			return (

--- a/packages/admin/src/components/Sections.tsx
+++ b/packages/admin/src/components/Sections.tsx
@@ -4,7 +4,7 @@
  * Browse, create, and manage reusable content sections (block patterns).
  */
 
-import { Button, Dialog, Input, InputArea, Toast } from "@cloudflare/kumo";
+import { Button, Dialog, Input, InputArea, Select, Toast } from "@cloudflare/kumo";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
@@ -231,19 +231,19 @@ export function Sections() {
 				</div>
 
 				{/* Source filter */}
-				<select
-					value={selectedSource || ""}
-					onChange={(e) => {
-						const val = e.target.value;
-						setSelectedSource(val === "theme" || val === "user" || val === "import" ? val : null);
+				<Select
+					value={selectedSource ?? ""}
+					onValueChange={(v) => {
+						setSelectedSource(v === "theme" || v === "user" || v === "import" ? v : null);
 					}}
-					className="h-10 rounded-md border border-kumo-line bg-kumo-base px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-kumo-ring focus:ring-offset-2"
-				>
-					<option value="">{t`All Sources`}</option>
-					<option value="theme">{t`Theme`}</option>
-					<option value="user">{t`Custom`}</option>
-					<option value="import">{t`Imported`}</option>
-				</select>
+					items={{
+						"": t`All Sources`,
+						...Object.fromEntries(
+							Object.entries(sourceLabels).map(([key, label]) => [key, t(label)]),
+						),
+					}}
+					aria-label={t`Filter by source`}
+				/>
 			</div>
 
 			{/* Section Grid */}

--- a/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
@@ -6,6 +6,8 @@
  */
 
 import { Button, Input, Select } from "@cloudflare/kumo";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
@@ -29,10 +31,10 @@ import {
 
 type SortOption = "updated" | "created" | "name";
 
-const SORT_LABELS: Record<SortOption, string> = {
-	updated: "Recently Updated",
-	created: "Newest",
-	name: "Name",
+const SORT_LABELS: Record<SortOption, MessageDescriptor> = {
+	updated: msg`Recently Updated`,
+	created: msg`Newest`,
+	name: msg`Name`,
 };
 
 const VALID_SORTS = new Set<string>(["updated", "created", "name"]);
@@ -97,7 +99,7 @@ export function ThemeMarketplaceBrowse() {
 						if (v && isSortOption(v)) setSort(v);
 					}}
 					items={Object.fromEntries(
-						Object.entries(SORT_LABELS).map(([value, label]) => [value, t`${label}`]),
+						Object.entries(SORT_LABELS).map(([value, label]) => [value, t(label)]),
 					)}
 					aria-label={t`Sort themes`}
 				/>

--- a/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
+++ b/packages/admin/src/components/ThemeMarketplaceBrowse.tsx
@@ -5,7 +5,7 @@
  * Navigates to theme detail on card click.
  */
 
-import { Button } from "@cloudflare/kumo";
+import { Button, Input, Select } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	MagnifyingGlass,
@@ -82,29 +82,25 @@ export function ThemeMarketplaceBrowse() {
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 				<div className="relative flex-1">
 					<MagnifyingGlass className="absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-kumo-subtle" />
-					<input
+					<Input
 						type="search"
 						placeholder={t`Search themes...`}
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
-						className="w-full rounded-md border bg-kumo-base px-3 py-2 ps-9 text-sm placeholder:text-kumo-subtle focus:outline-none focus:ring-2 focus:ring-kumo-ring"
+						className="ps-9"
+						aria-label={t`Search themes`}
 					/>
 				</div>
-				<select
+				<Select
 					value={sort}
-					onChange={(e) => {
-						const v = e.target.value;
-						if (isSortOption(v)) setSort(v);
+					onValueChange={(v) => {
+						if (v && isSortOption(v)) setSort(v);
 					}}
-					className="rounded-md border bg-kumo-base px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-kumo-ring"
+					items={Object.fromEntries(
+						Object.entries(SORT_LABELS).map(([value, label]) => [value, t`${label}`]),
+					)}
 					aria-label={t`Sort themes`}
-				>
-					{Object.entries(SORT_LABELS).map(([value, label]) => (
-						<option key={value} value={value}>
-							{label}
-						</option>
-					))}
-				</select>
+				/>
 			</div>
 
 			{/* Error state */}

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -2333,6 +2333,7 @@ function AuthorMappingStep({
 										),
 									}}
 									aria-label={t`Map WordPress user ${mapping.wpLogin} to EmDash user`}
+									className="w-48"
 								/>
 							</div>
 						</div>

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -2326,15 +2326,14 @@ function AuthorMappingStep({
 								<Select
 									value={mapping.emdashUserId || ""}
 									onValueChange={(v) => onMappingChange(mapping.wpLogin, v || null)}
+									items={{
+										"": t`Leave unassigned`,
+										...Object.fromEntries(
+											emdashUsers.map((user) => [user.id, user.name || user.email]),
+										),
+									}}
 									aria-label={t`Map WordPress user ${mapping.wpLogin} to EmDash user`}
-								>
-									<Select.Option value="">{t`Leave unassigned`}</Select.Option>
-									{emdashUsers.map((user) => (
-										<Select.Option key={user.id} value={user.id}>
-											{user.name || user.email}
-										</Select.Option>
-									))}
-								</Select>
+								/>
 							</div>
 						</div>
 					))}

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Input, LinkButton, Loader, buttonVariants } from "@cloudflare/kumo";
+import { Badge, Button, Input, LinkButton, Loader, Select, buttonVariants } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
@@ -2323,18 +2323,18 @@ function AuthorMappingStep({
 							</div>
 							<div className="flex items-center gap-2">
 								<span className="text-kumo-subtle">→</span>
-								<select
+								<Select
 									value={mapping.emdashUserId || ""}
-									onChange={(e) => onMappingChange(mapping.wpLogin, e.target.value || null)}
-									className="w-48 px-3 py-2 rounded-md border bg-kumo-base text-sm"
+									onValueChange={(v) => onMappingChange(mapping.wpLogin, v || null)}
+									aria-label={t`Map WordPress user ${mapping.wpLogin} to EmDash user`}
 								>
-									<option value="">{t`Leave unassigned`}</option>
+									<Select.Option value="">{t`Leave unassigned`}</Select.Option>
 									{emdashUsers.map((user) => (
-										<option key={user.id} value={user.id}>
+										<Select.Option key={user.id} value={user.id}>
 											{user.name || user.email}
-										</option>
+										</Select.Option>
 									))}
-								</select>
+								</Select>
 							</div>
 						</div>
 					))}

--- a/packages/admin/src/lib/api/marketplace.ts
+++ b/packages/admin/src/lib/api/marketplace.ts
@@ -215,23 +215,25 @@ export async function checkPluginUpdates(): Promise<PluginUpdateInfo[]> {
  * Canonical names are the keys; legacy names alias to the same labels so
  * old manifests still render meaningful copy until they're republished.
  */
-export const CAPABILITY_LABELS: Record<string, string> = {
+import type { MessageDescriptor } from "@lingui/core";
+
+export const CAPABILITY_LABELS: Record<string, MessageDescriptor> = {
 	// Canonical
-	"content:read": "Read your content",
-	"content:write": "Create, update, and delete content",
-	"media:read": "Access your media library",
-	"media:write": "Upload and manage media",
-	"users:read": "Read user accounts",
-	"network:request": "Make network requests",
-	"network:request:unrestricted": "Make network requests to any host (unrestricted)",
+	"content:read": msg`Read your content`,
+	"content:write": msg`Create, update, and delete content`,
+	"media:read": msg`Access your media library`,
+	"media:write": msg`Upload and manage media`,
+	"users:read": msg`Read user accounts`,
+	"network:request": msg`Make network requests`,
+	"network:request:unrestricted": msg`Make network requests to any host (unrestricted)`,
 	// Legacy aliases (still emitted by older installed manifests)
-	"read:content": "Read your content",
-	"write:content": "Create, update, and delete content",
-	"read:media": "Access your media library",
-	"write:media": "Upload and manage media",
-	"read:users": "Read user accounts",
-	"network:fetch": "Make network requests",
-	"network:fetch:any": "Make network requests to any host (unrestricted)",
+	"read:content": msg`Read your content`,
+	"write:content": msg`Create, update, and delete content`,
+	"read:media": msg`Access your media library`,
+	"write:media": msg`Upload and manage media`,
+	"read:users": msg`Read user accounts`,
+	"network:fetch": msg`Make network requests`,
+	"network:fetch:any": msg`Make network requests to any host (unrestricted)`,
 };
 
 /** Capability names that grant scoped network access (legacy + canonical). */
@@ -240,11 +242,17 @@ const NETWORK_REQUEST_CAPABILITIES = new Set(["network:request", "network:fetch"
 /**
  * Get a human-readable description for a capability.
  * For scoped network capabilities, appends the allowed hosts if provided.
+ *
+ * Module-scope so calls outside React components work; uses the global i18n
+ * instance for translation. Components that have access to `useLingui` can
+ * also resolve `CAPABILITY_LABELS[capability]` directly with `t(...)` if they
+ * need the translated string without the host suffix.
  */
 export function describeCapability(capability: string, allowedHosts?: string[]): string {
-	const base = CAPABILITY_LABELS[capability] ?? capability;
+	const descriptor = CAPABILITY_LABELS[capability];
+	const base = descriptor ? i18n._(descriptor) : capability;
 	if (NETWORK_REQUEST_CAPABILITIES.has(capability) && allowedHosts && allowedHosts.length > 0) {
-		return `${base} to: ${allowedHosts.join(", ")}`;
+		return i18n._(msg`${base} to: ${allowedHosts.join(", ")}`);
 	}
 	return base;
 }

--- a/packages/admin/src/routes/bylines.tsx
+++ b/packages/admin/src/routes/bylines.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, InputArea, Loader, Switch } from "@cloudflare/kumo";
+import { Button, Input, InputArea, Loader, Select, Switch } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
@@ -183,16 +183,16 @@ export function BylinesPage() {
 						onChange={(e) => setSearch(e.target.value)}
 					/>
 					<div className="flex items-center gap-2">
-						<select
+						<Select
 							aria-label={t`Filter byline type`}
 							value={guestFilter}
-							onChange={(e) => setGuestFilter(e.target.value as "all" | "guest" | "linked")}
-							className="w-full rounded border bg-kumo-base px-3 py-2 text-sm"
+							onValueChange={(v) => setGuestFilter((v as "all" | "guest" | "linked") ?? "all")}
+							className="w-full"
 						>
-							<option value="all">{t`All bylines`}</option>
-							<option value="guest">{t`Guest only`}</option>
-							<option value="linked">{t`Linked only`}</option>
-						</select>
+							<Select.Option value="all">{t`All bylines`}</Select.Option>
+							<Select.Option value="guest">{t`Guest only`}</Select.Option>
+							<Select.Option value="linked">{t`Linked only`}</Select.Option>
+						</Select>
 						<Button
 							variant="secondary"
 							onClick={() => {
@@ -266,27 +266,25 @@ export function BylinesPage() {
 						onChange={(e) => setForm((prev) => ({ ...prev, bio: e.target.value }))}
 						rows={5}
 					/>
-					<div>
-						<label className="text-sm font-medium">{t`Linked user`}</label>
-						<select
-							value={form.userId ?? ""}
-							onChange={(e) =>
-								setForm((prev) => ({
-									...prev,
-									userId: e.target.value || null,
-									isGuest: e.target.value ? false : prev.isGuest,
-								}))
-							}
-							className="mt-1 w-full rounded border bg-kumo-base px-3 py-2 text-sm"
-						>
-							<option value="">{t`No linked user`}</option>
-							{users.map((user) => (
-								<option key={user.id} value={user.id}>
-									{getUserLabel(user)}
-								</option>
-							))}
-						</select>
-					</div>
+					<Select
+						label={t`Linked user`}
+						value={form.userId ?? ""}
+						onValueChange={(v) => {
+							const val = (v as string) || null;
+							setForm((prev) => ({
+								...prev,
+								userId: val,
+								isGuest: val ? false : prev.isGuest,
+							}));
+						}}
+					>
+						<Select.Option value="">{t`No linked user`}</Select.Option>
+						{users.map((u) => (
+							<Select.Option key={u.id} value={u.id}>
+								{getUserLabel(u)}
+							</Select.Option>
+						))}
+					</Select>
 					<Switch
 						label={t`Guest byline`}
 						checked={form.isGuest}

--- a/packages/admin/src/routes/bylines.tsx
+++ b/packages/admin/src/routes/bylines.tsx
@@ -183,16 +183,19 @@ export function BylinesPage() {
 						onChange={(e) => setSearch(e.target.value)}
 					/>
 					<div className="flex items-center gap-2">
-						<Select
-							aria-label={t`Filter byline type`}
-							value={guestFilter}
-							onValueChange={(v) => setGuestFilter((v as "all" | "guest" | "linked") ?? "all")}
-							className="w-full"
-						>
-							<Select.Option value="all">{t`All bylines`}</Select.Option>
-							<Select.Option value="guest">{t`Guest only`}</Select.Option>
-							<Select.Option value="linked">{t`Linked only`}</Select.Option>
-						</Select>
+						<div className="flex-1">
+							<Select
+								aria-label={t`Filter byline type`}
+								value={guestFilter}
+								onValueChange={(v) => setGuestFilter((v as "all" | "guest" | "linked") ?? "all")}
+								items={{
+									all: t`All bylines`,
+									guest: t`Guest only`,
+									linked: t`Linked only`,
+								}}
+								className="w-full"
+							/>
+						</div>
 						<Button
 							variant="secondary"
 							onClick={() => {
@@ -277,14 +280,12 @@ export function BylinesPage() {
 								isGuest: val ? false : prev.isGuest,
 							}));
 						}}
-					>
-						<Select.Option value="">{t`No linked user`}</Select.Option>
-						{users.map((u) => (
-							<Select.Option key={u.id} value={u.id}>
-								{getUserLabel(u)}
-							</Select.Option>
-						))}
-					</Select>
+						items={{
+							"": t`No linked user`,
+							...Object.fromEntries(users.map((u) => [u.id, getUserLabel(u)])),
+						}}
+						className="w-full"
+					/>
 					<Switch
 						label={t`Guest byline`}
 						checked={form.isGuest}


### PR DESCRIPTION
## What does this PR do?

Migrates 11 raw `<select>` elements and 2 `<input type="search">` elements across the admin UI to Kumo's `Select` and `Input`. These were using hand-rolled Tailwind classes (`rounded-md border bg-kumo-base px-3 py-2 ...`) that duplicated and sometimes conflicted with what Kumo provides automatically — including focus rings, label association via the Field wrapper, dark-mode tokens, and disabled states.

### Files migrated

**Selects:**
- `MarketplaceBrowse.tsx` — capability filter + sort dropdown
- `ThemeMarketplaceBrowse.tsx` — sort dropdown
- `Sections.tsx` — source filter (re-uses existing `sourceLabels` MessageDescriptor map)
- `Redirects.tsx` — status code form select (paired `<Label>` removed in favour of `Select`'s `label` prop), status filter, type filter
- `ContentEditor.tsx` — byline picker
- `ContentPickerModal.tsx` — collection picker
- `FieldEditor.tsx` — sub-field type picker
- `RepeaterField.tsx` — repeater sub-field renderer (dynamic options from field def)
- `PortableTextEditor.tsx` (`DynamicSelect`) — plugin field renderer (plugin-supplied labels passed through, not `t``-wrapped)
- `BlockKitFieldWidget.tsx` — block-kit `select` element renderer (same)
- `WordPressImport.tsx` — per-user mapping select (one rendered per WP user being imported)
- `routes/bylines.tsx` — filter type + linked-user form select

**Search inputs:**
- `MarketplaceBrowse.tsx` and `ThemeMarketplaceBrowse.tsx`

### Approach decisions

- **`items` prop vs `Select.Option` children**: used `items` for fixed translatable option sets (e.g. sort modes), and `Select.Option` children for dynamic data (user lists, plugin-supplied options) where each option needs runtime values rather than a static map.
- **Plugin-supplied labels**: passed through as plain strings rather than wrapped in `t``` since they come from external runtime data, not catalog entries.
- **Paired `<label>` elements**: removed where a `<Select>` could carry the label via its `label` prop, dropping the `<div>` wrapper noise.
- **`LocaleSwitcher.tsx` is intentionally custom** — its small/medium size variants don't map cleanly to Kumo's `Select` API. Left as-is per the original audit recommendation.

### What's not in this PR

- The remaining `~20 <input type="checkbox">` elements (some better as `Switch`) — design pass first, separate PR.
- Tab-style buttons (`MediaPickerModal`, `MediaLibrary`, `Redirects` filter tabs) — separate refactor.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (admin: 858/858)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes — not applicable, all changes are 1:1 component substitutions; existing tests cover the rendered output.
- [x] User-visible strings are wrapped for translation
- [x] I have added a changeset
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (orchestration) + Claude Haiku 4.5 (`simple-tasks` sub-agents) via OpenCode

## Screenshots / test output

Visual change is minor: focus rings, hover states, and label rendering now go through Kumo's tokens. The selects and search inputs render at the same physical sizes (existing width classes preserved).

Stack: `main` → #934 (merged) → #937 (merged) → #940 (merged) → #949 (merged) → **this PR** → (next: checkboxes/switches) → (next: aria-labels) → (next: RTL safety) → (next: semantic tokens) → (last: ESLint enforcement)