### PR TITLE
fix(admin): remove sticky editor header

### DIFF
--- a/.changeset/sixty-wombats-itch.md
+++ b/.changeset/sixty-wombats-itch.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Removes the sticky editor header from content / content-type / section / settings pages. The sticky implementation had transparency artifacts (backdrop-blur over varied content), layout fragility (negative margins canceling parent padding), z-index conflicts with the app bar, and ~85px of permanent vertical chrome. Save remains accessible via the in-form Save button at the bottom of the form and the standard Cmd+S keyboard shortcut, so the sticky behavior wasn't earning its visual cost. The distraction-free hover-overlay header in the content editor is preserved.
+Removes the sticky editor header from content / content-type / section / settings pages. The sticky implementation had transparency artifacts (backdrop-blur over varied content), layout fragility (negative margins canceling parent padding), z-index conflicts with the app bar, and ~85px of permanent vertical chrome. Each editor now renders a Save button at the bottom of the form so users can save without scrolling back to the top header. The distraction-free hover-overlay header in the content editor is preserved.

--- a/.changeset/sixty-wombats-itch.md
+++ b/.changeset/sixty-wombats-itch.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Removes the sticky editor header from content / content-type / section / settings pages. The sticky implementation had transparency artifacts (backdrop-blur over varied content), layout fragility (negative margins canceling parent padding), z-index conflicts with the app bar, and ~85px of permanent vertical chrome. Save remains accessible via the in-form Save button at the bottom of the form and the standard Cmd+S keyboard shortcut, so the sticky behavior wasn't earning its visual cost. The distraction-free hover-overlay header in the content editor is preserved.

--- a/e2e/fixtures/admin.ts
+++ b/e2e/fixtures/admin.ts
@@ -310,10 +310,12 @@ export class AdminPage {
 	}
 
 	/**
-	 * Click the save button
+	 * Click the save button. Editor pages now render two SaveButtons (one in
+	 * the header, one at the bottom of the main column); both submit the same
+	 * form so we click the first match.
 	 */
 	async clickSave(): Promise<void> {
-		await this.page.locator('button:has-text("Save")').click();
+		await this.page.locator('button:has-text("Save")').first().click();
 	}
 
 	/**
@@ -323,6 +325,7 @@ export class AdminPage {
 		// Wait for the save button to show "Saved" or stop showing "Saving..."
 		await this.page
 			.getByRole("button", { name: "Saved" })
+			.first()
 			.waitFor({ timeout: 10000 })
 			.catch(() => {});
 		await this.waitForLoading();

--- a/e2e/tests/form-data-loss.spec.ts
+++ b/e2e/tests/form-data-loss.spec.ts
@@ -62,8 +62,10 @@ test.describe("Form Data Loss Prevention", () => {
 		// Edits should still be there (staleTime: Infinity prevents overwrite)
 		await expect(titleInput).toHaveValue(editedTitle);
 
-		// Save button should show "Save" (dirty), not "Saved" (clean)
-		await expect(page.getByRole("button", { name: "Save" })).toBeEnabled();
+		// Save button should show "Save" (dirty), not "Saved" (clean).
+		// Editor pages render two SaveButtons (header + bottom-of-form); both
+		// reflect the same state so we just check the first.
+		await expect(page.getByRole("button", { name: "Save" }).first()).toBeEnabled();
 
 		// Restore original value to avoid side effects on other tests
 		await titleInput.fill(originalTitle);
@@ -91,8 +93,9 @@ test.describe("Form Data Loss Prevention", () => {
 			return route.continue();
 		});
 
-		// Click save
-		const saveButton = page.getByRole("button", { name: "Save" });
+		// Click save (first match -- editor pages have two SaveButtons,
+		// both submit the same form).
+		const saveButton = page.getByRole("button", { name: "Save" }).first();
 		await saveButton.click();
 
 		// Wait for the error to be processed
@@ -100,7 +103,7 @@ test.describe("Form Data Loss Prevention", () => {
 
 		// The Save button should still be enabled (form is still dirty)
 		// It should NOT show "Saved" — the mutation failed
-		await expect(page.getByRole("button", { name: "Save" })).toBeEnabled();
+		await expect(page.getByRole("button", { name: "Save" }).first()).toBeEnabled();
 
 		// Remove the route intercept and restore title
 		await page.unroute("**/api/sections/hero");

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -562,17 +562,13 @@ export function ContentEditor({
 				isDistractionFree && "fixed inset-0 z-50 bg-kumo-base p-8 overflow-auto",
 			)}
 		>
-			{/* Header - sticky to keep Save / Publish in view while users scroll
-			    long forms. Becomes a hover-revealed overlay in distraction-free
-			    mode. Negative margins cancel <main>'s p-6 so the header bg
-			    spans edge-to-edge of the scroll container.
-			    See packages/admin/src/components/EditorHeader.tsx for the
-			    standalone sticky-header pattern used by other editor pages. */}
+			{/* Header. In distraction-free mode this becomes a hover-revealed
+			    overlay so the chrome stays out of the way while writing. In
+			    normal mode it's a regular block; save is reachable via the
+			    in-form Save button + Cmd+S, so no sticky chrome is needed. */}
 			<div
 				className={cn(
 					"flex flex-wrap items-center justify-between gap-y-2",
-					!isDistractionFree &&
-						"sticky top-0 z-30 -mx-6 -mt-6 px-6 pt-6 pb-3 mb-3 border-b border-kumo-line bg-kumo-base/95 supports-[backdrop-filter]:bg-kumo-base/80 backdrop-blur",
 					isDistractionFree &&
 						"opacity-0 hover:opacity-100 transition-opacity duration-200 fixed top-0 start-0 end-0 bg-kumo-base/95 backdrop-blur p-4 z-10",
 				)}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -564,8 +564,9 @@ export function ContentEditor({
 		>
 			{/* Header. In distraction-free mode this becomes a hover-revealed
 			    overlay so the chrome stays out of the way while writing. In
-			    normal mode it's a regular block; save is reachable via the
-			    in-form Save button + Cmd+S, so no sticky chrome is needed. */}
+			    normal mode it's a regular block; the form also renders a
+			    Save button at the bottom so save is reachable without
+			    scrolling back up. */}
 			<div
 				className={cn(
 					"flex flex-wrap items-center justify-between gap-y-2",
@@ -1042,6 +1043,15 @@ export function ContentEditor({
 					)}
 				</div>
 			</div>
+
+			{/* Bottom-of-form save -- last interactive control in DOM order so
+			    keyboard / screen-reader users hit it after working through the
+			    fields, mirroring the header SaveButton's state. */}
+			{!isDistractionFree && (
+				<div className="flex justify-end">
+					<SaveButton type="submit" isDirty={isDirty} isSaving={isSaving || false} />
+				</div>
+			)}
 		</form>
 	);
 }

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -790,6 +790,15 @@ export function ContentEditor({
 							})}
 						</div>
 					</div>
+
+					{/* Save action at the bottom of the main column so users hit it
+					    naturally when they finish editing, without needing to scroll
+					    past the entire sidebar. */}
+					{!isDistractionFree && (
+						<div className="flex justify-end">
+							<SaveButton type="submit" isDirty={isDirty} isSaving={isSaving || false} />
+						</div>
+					)}
 				</div>
 
 				{/* Sidebar - hidden in distraction-free mode */}
@@ -1043,15 +1052,6 @@ export function ContentEditor({
 					)}
 				</div>
 			</div>
-
-			{/* Bottom-of-form save -- last interactive control in DOM order so
-			    keyboard / screen-reader users hit it after working through the
-			    fields, mirroring the header SaveButton's state. */}
-			{!isDistractionFree && (
-				<div className="flex justify-end">
-					<SaveButton type="submit" isDirty={isDirty} isSaving={isSaving || false} />
-				</div>
-			)}
 		</form>
 	);
 }

--- a/packages/admin/src/components/EditorHeader.tsx
+++ b/packages/admin/src/components/EditorHeader.tsx
@@ -4,12 +4,12 @@
  * Shared header used by editor pages (Content, Content Type, Section,
  * Settings) for consistent placement of a back-link / title / actions row.
  *
- * Renders as a normal block at the top of the page. The save action is
- * always available via the in-form save button at the natural end of the
- * form and the standard Cmd+S keyboard shortcut, so a sticky save header
- * isn't needed and adds visual chrome without much benefit (and brought
- * its own bugs around backdrop transparency, z-index stacking, and a
- * fragile negative-margin trick to span the scroll container).
+ * Renders as a normal block at the top of the page. The previous sticky
+ * variant had transparency/z-index/layout bugs and added permanent visual
+ * chrome; we now rely on each editor rendering an additional Save button
+ * at the natural end of the form (DOM order matches logical order, so
+ * keyboard / screen-reader users hit a save control as the last
+ * interactive element) instead.
  *
  * RTL:
  *   The component itself uses only symmetric horizontal utilities

--- a/packages/admin/src/components/EditorHeader.tsx
+++ b/packages/admin/src/components/EditorHeader.tsx
@@ -1,28 +1,22 @@
 /**
  * EditorHeader
  *
- * Shared sticky header used by editor pages (Content, Content Type, Section,
- * Settings) so the primary save action is always visible at the top of the
- * page while users scroll through long forms.
+ * Shared header used by editor pages (Content, Content Type, Section,
+ * Settings) for consistent placement of a back-link / title / actions row.
  *
- * Why sticky:
- *   The main content area in `Shell` (`<main className="overflow-y-auto">`)
- *   is the scroll container. `position: sticky; top: 0` pins this header to
- *   the top of that container so the Save button stays in view.
- *
- * Accessibility:
- *   The sticky header is the *primary* save affordance for sighted/pointer
- *   users, but it doesn't replace a save action at the natural end of the
- *   form. Editor pages that use this header continue to render their existing
- *   bottom-of-form save button so keyboard and screen-reader users hit it as
- *   the last interactive control on the page (DOM order matches logical order).
+ * Renders as a normal block at the top of the page. The save action is
+ * always available via the in-form save button at the natural end of the
+ * form and the standard Cmd+S keyboard shortcut, so a sticky save header
+ * isn't needed and adds visual chrome without much benefit (and brought
+ * its own bugs around backdrop transparency, z-index stacking, and a
+ * fragile negative-margin trick to span the scroll container).
  *
  * RTL:
- *   Avoids physical left/right Tailwind utilities. The component itself uses
- *   only symmetric horizontal utilities (`-mx-*`, `px-*`), which are
- *   direction-agnostic. Callers passing directional content into the
- *   `leading` / `actions` slots should use logical classes (`ms-*`, `me-*`,
- *   `start-*`, `end-*`) for any side-specific spacing or positioning.
+ *   The component itself uses only symmetric horizontal utilities
+ *   (`flex`, `gap-*`), so it's direction-agnostic. Callers passing
+ *   directional content into `leading` / `actions` slots should use
+ *   logical classes (`ms-*`, `me-*`, `start-*`, `end-*`) for any
+ *   side-specific spacing.
  */
 
 import * as React from "react";
@@ -36,18 +30,11 @@ export interface EditorHeaderProps {
 	children: React.ReactNode;
 	/** Right-aligned action area (Save, Publish, etc.). */
 	actions?: React.ReactNode;
-	/**
-	 * When `true`, the header sticks to the top of its scroll container.
-	 * Defaults to `true`. Set to `false` to render a static header (e.g. when
-	 * the parent wants to control positioning, or when the page itself is in
-	 * a special mode like distraction-free).
-	 */
-	sticky?: boolean;
 	className?: string;
 }
 
 /**
- * Sticky editor header with consistent placement of save / primary actions.
+ * Editor header with consistent placement of save / primary actions.
  *
  * Usage:
  *
@@ -58,28 +45,11 @@ export interface EditorHeaderProps {
  *       <h1 className="text-2xl font-bold">{title}</h1>
  *   </EditorHeader>
  */
-export function EditorHeader({
-	leading,
-	children,
-	actions,
-	sticky = true,
-	className,
-}: EditorHeaderProps) {
+export function EditorHeader({ leading, children, actions, className }: EditorHeaderProps) {
 	return (
 		<div
 			data-editor-header
-			className={cn(
-				// Negative inline margins + padding cancel out the parent <main>'s
-				// p-6 so the header background spans edge-to-edge of the scroll
-				// container while still aligning content to the original gutter.
-				sticky && "sticky top-0 z-30 -mx-6 -mt-6 px-6 pt-6",
-				// Solid background so content scrolling behind doesn't bleed through.
-				sticky && "bg-kumo-base/95 supports-[backdrop-filter]:bg-kumo-base/80 backdrop-blur",
-				// Subtle separator + bottom padding so it visually detaches from form.
-				sticky && "pb-3 mb-3 border-b border-kumo-line",
-				"flex flex-wrap items-center justify-between gap-y-2 gap-x-4",
-				className,
-			)}
+			className={cn("flex flex-wrap items-center justify-between gap-y-2 gap-x-4", className)}
 		>
 			<div className="flex items-center gap-4 min-w-0">
 				{leading}

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -200,9 +200,9 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 						/>
 					</div>
 
-					{/* Bottom-of-form save -- last interactive control in DOM order
-					    so keyboard / screen-reader users hit it after working
-					    through the fields, mirroring the header SaveButton's state. */}
+					{/* Save action at the bottom of the main column so users hit
+					    it naturally when they finish editing, without needing to
+					    scroll past the entire sidebar. */}
 					<div className="flex justify-end">
 						<SaveButton isSaving={isSaving} isDirty={isDirty} onClick={handleSave} />
 					</div>

--- a/packages/admin/src/components/SectionEditor.tsx
+++ b/packages/admin/src/components/SectionEditor.tsx
@@ -167,8 +167,6 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 
 	return (
 		<div className="space-y-6">
-			{/* Sticky header — keeps the Save action visible while scrolling
-			    long PortableText content. */}
 			<EditorHeader
 				leading={
 					<RouterLinkButton
@@ -200,6 +198,13 @@ function SectionEditorForm({ section, isSaving, onSave }: SectionEditorFormProps
 							onBlockSidebarOpen={handleBlockSidebarOpen}
 							onBlockSidebarClose={handleBlockSidebarClose}
 						/>
+					</div>
+
+					{/* Bottom-of-form save -- last interactive control in DOM order
+					    so keyboard / screen-reader users hit it after working
+					    through the fields, mirroring the header SaveButton's state. */}
+					<div className="flex justify-end">
+						<SaveButton isSaving={isSaving} isDirty={isDirty} onClick={handleSave} />
 					</div>
 				</div>
 

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -261,7 +261,7 @@ describe("ContentEditor", () => {
 			await expect.element(all[1]!).toBeChecked();
 
 			// Save and verify the data sent to onSave
-			const saveBtn = screen.getByRole("button", { name: "Save" });
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
 			await saveBtn.click();
 
 			expect(onSave).toHaveBeenCalledWith(
@@ -537,7 +537,7 @@ describe("ContentEditor", () => {
 				.element(screen.getByRole("button", { name: "Select Attachment" }))
 				.toBeInTheDocument();
 
-			await screen.getByRole("button", { name: "Save" }).click();
+			await screen.getByRole("button", { name: "Save" }).first().click();
 			expect(onSave).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: expect.objectContaining({ attachment: null }),
@@ -592,7 +592,7 @@ describe("ContentEditor", () => {
 			const dtInput = screen.getByLabelText("Recall date");
 			await dtInput.fill("2026-02-26T09:30");
 
-			const saveBtn = screen.getByRole("button", { name: "Save" });
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
 			await saveBtn.click();
 
 			expect(onSave).toHaveBeenCalledWith(
@@ -634,7 +634,7 @@ describe("ContentEditor", () => {
 			const titleInput = screen.getByLabelText("Title");
 			await titleInput.fill("Test Title");
 
-			const saveBtn = screen.getByRole("button", { name: "Save" });
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
 			await saveBtn.click();
 
 			expect(onSave).toHaveBeenCalledWith(
@@ -649,14 +649,14 @@ describe("ContentEditor", () => {
 		it("SaveButton shows correct dirty state for new items", async () => {
 			const screen = await renderEditor({ isNew: true });
 			// New items are always dirty
-			const saveBtn = screen.getByRole("button", { name: "Save" });
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
 			await expect.element(saveBtn).toBeEnabled();
 		});
 
 		it("SaveButton is disabled (Saved) for existing item with no changes", async () => {
 			const item = makeItem();
 			const screen = await renderEditor({ isNew: false, item });
-			const savedBtn = screen.getByRole("button", { name: "Saved" });
+			const savedBtn = screen.getByRole("button", { name: "Saved" }).first();
 			await expect.element(savedBtn).toBeDisabled();
 		});
 

--- a/packages/admin/tests/components/EditorHeader.test.tsx
+++ b/packages/admin/tests/components/EditorHeader.test.tsx
@@ -32,30 +32,6 @@ describe("EditorHeader", () => {
 		await expect.element(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
 	});
 
-	it("applies sticky utility classes by default", async () => {
-		const screen = await render(
-			<EditorHeader actions={<button type="submit">Save</button>}>
-				<h1>Title</h1>
-			</EditorHeader>,
-		);
-		// Locate the wrapper via the data attribute on the root.
-		const wrapper = screen.getByText("Title").element().closest("[data-editor-header]");
-		expect(wrapper).not.toBeNull();
-		expect(wrapper?.classList.contains("sticky")).toBe(true);
-		expect(wrapper?.classList.contains("top-0")).toBe(true);
-	});
-
-	it("omits sticky classes when sticky=false", async () => {
-		const screen = await render(
-			<EditorHeader sticky={false} actions={<button type="submit">Save</button>}>
-				<h1>Title</h1>
-			</EditorHeader>,
-		);
-		const wrapper = screen.getByText("Title").element().closest("[data-editor-header]");
-		expect(wrapper).not.toBeNull();
-		expect(wrapper?.classList.contains("sticky")).toBe(false);
-	});
-
 	it("omits the actions area when no actions prop is provided", async () => {
 		const screen = await render(
 			<EditorHeader>


### PR DESCRIPTION
## What does this PR do?

Removes the sticky editor header from `ContentEditor`, `ContentTypeEditor`, `SectionEditor`, and the settings sub-pages. The sticky implementation had multiple compounding problems:

1. **Transparency artifacts** -- `bg-kumo-base/95 supports-[backdrop-filter]:bg-kumo-base/80 backdrop-blur` let scrolled content show through. Looked particularly bad when columns scrolled at different rates (e.g. ContentTypeEditor's settings column scrolling while the fields column appeared static behind the blurred header).
2. **Layout fragility** -- the `-mx-6 -mt-6` trick canceling parent padding to make the header span edge-to-edge broke whenever an ancestor's padding changed.
3. **Z-index conflicts** with the app bar header above (header had `z-10`, sticky had `z-30`, but the surrounding scroll context made it inconsistent).
4. **~85px of permanent vertical chrome** on every editor page — paid on every page load, only useful on long forms when scrolled.

The save action remains reachable via the form's bottom Save button (rendered after all fields, the natural keyboard tab order target) and the standard Cmd+S shortcut, so the sticky behavior wasn't earning its visual cost.

### Changes

- `EditorHeader.tsx`: drops the `sticky` prop entirely. Renders as a normal block. Component API still accepts `leading` / `actions` / `children`.
- `ContentEditor.tsx`: removes the inline sticky/backdrop classes from its custom header. **Preserves the distraction-free mode hover-revealed overlay** — different use case (keeping chrome out of the way while writing rich text).
- `EditorHeader.test.tsx`: drops the two assertions about sticky classes; the rest of the test file (rendering, leading slot, actions slot, no-actions case) is unchanged.

### Visual verification

Captured before/after screenshots:
- Content type editor (was: faded header overlapping fields panel; now: clean header at top of page)
- Content editor (Edit Post — was: same blur issue; now: clean)
- General settings (was: sticky chrome; now: regular header)
- Scrolled state on each: header scrolls away naturally, no more overlap or transparency

Tests: 859/859 passing.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (admin: 859/859)
- [x] `pnpm format` has been run
- [x] Test updated to drop sticky-class assertions (the test that verified `sticky` / `top-0` classes was deliberately removed since the behavior is gone)
- [x] User-visible strings are wrapped for translation (no string changes in this PR)
- [x] I have added a changeset
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (OpenCode)