### PR TITLE
fix(admin): show OG image picker for any SEO-enabled collection

### DIFF
--- a/.changeset/seo-og-image-in-panel.md
+++ b/.changeset/seo-og-image-in-panel.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the OG image picker in the content editor only appearing for collections with a field literally named `featured_image`. The OG image control now lives in the SEO sidebar panel alongside the other SEO fields, so any collection with `seo` enabled can set a social preview image regardless of whether it has a featured image field.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -75,7 +75,6 @@ import {
 } from "./PortableTextEditor";
 import { RevisionHistory } from "./RevisionHistory";
 import { SaveButton } from "./SaveButton";
-import { SeoImageField } from "./SeoImageField";
 import { SeoPanel } from "./SeoPanel";
 import { TaxonomySidebar } from "./TaxonomySidebar";
 import { TranslationsPanel } from "./TranslationsPanel.js";
@@ -770,25 +769,6 @@ export function ContentEditor({
 										manifest={manifest}
 									/>
 								);
-								if (
-									name === "featured_image" &&
-									field.kind === "image" &&
-									hasSeo &&
-									!isNew &&
-									onSeoChange
-								) {
-									return (
-										<div
-											key={`${fieldKey}-with-seo`}
-											className="grid grid-cols-1 gap-6 md:grid-cols-2"
-										>
-											<div>{fieldEl}</div>
-											<div>
-												<SeoImageField seo={item?.seo} onChange={onSeoChange} />
-											</div>
-										</div>
-									);
-								}
 								return fieldEl;
 							})}
 						</div>

--- a/packages/admin/src/components/SeoPanel.tsx
+++ b/packages/admin/src/components/SeoPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * SEO Panel for Content Editor Sidebar
  *
- * Shows SEO metadata fields (title, description, OG image, canonical URL,
+ * Shows SEO metadata fields (OG image, title, description, canonical URL,
  * noIndex) when the collection has `hasSeo` enabled. Changes are sent
  * alongside content updates via the `seo` field on the update body.
  */
@@ -11,6 +11,7 @@ import { useLingui } from "@lingui/react/macro";
 import * as React from "react";
 
 import type { ContentSeo, ContentSeoInput } from "../lib/api";
+import { SeoImageField } from "./SeoImageField";
 
 export interface SeoPanelProps {
 	contentKey: string;
@@ -147,6 +148,8 @@ export function SeoPanel({ contentKey, seo, onChange }: SeoPanelProps) {
 
 	return (
 		<div className="space-y-3">
+			<SeoImageField seo={seo} onChange={onChange} />
+
 			<Input
 				label={t`SEO Title`}
 				description={t`Overrides the page title in search engine results`}

--- a/packages/admin/src/components/SeoPanel.tsx
+++ b/packages/admin/src/components/SeoPanel.tsx
@@ -148,7 +148,7 @@ export function SeoPanel({ contentKey, seo, onChange }: SeoPanelProps) {
 
 	return (
 		<div className="space-y-3">
-			<SeoImageField seo={seo} onChange={onChange} />
+			<SeoImageField key={contentKey} seo={seo} onChange={onChange} />
 
 			<Input
 				label={t`SEO Title`}

--- a/packages/admin/tests/components/SeoPanel.test.tsx
+++ b/packages/admin/tests/components/SeoPanel.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { userEvent } from "vitest/browser";
@@ -5,20 +6,79 @@ import { userEvent } from "vitest/browser";
 import { SeoPanel } from "../../src/components/SeoPanel";
 import { render } from "../utils/render";
 
+// SeoPanel renders SeoImageField, which uses MediaPickerModal -- that hooks
+// into react-query. Tests need a QueryClient in scope even when the modal is
+// not opened, because the hook is called on the initial render.
+function QueryWrapper({ children }: { children: React.ReactNode }) {
+	const queryClient = React.useMemo(
+		() =>
+			new QueryClient({
+				defaultOptions: { queries: { retry: false } },
+			}),
+		[],
+	);
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
 describe("SeoPanel", () => {
 	beforeEach(() => {
 		vi.useRealTimers();
+	});
+
+	it("renders an OG image control regardless of collection fields", async () => {
+		// The OG image picker used to live next to a `featured_image` content
+		// field, so collections without that field (e.g. typical Pages) had no
+		// way to set it. It now lives inside SeoPanel itself.
+		const screen = await render(
+			<QueryWrapper>
+				<SeoPanel
+					contentKey="page-1"
+					seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+					onChange={() => {}}
+				/>
+			</QueryWrapper>,
+		);
+
+		screen.getByText("OG Image");
+		screen.getByRole("button", { name: "Select OG image" });
+	});
+
+	it("renders the existing OG image preview when set", async () => {
+		const screen = await render(
+			<QueryWrapper>
+				<SeoPanel
+					contentKey="page-1"
+					seo={{
+						title: null,
+						description: null,
+						image: "https://example.com/og.jpg",
+						canonical: null,
+						noIndex: false,
+					}}
+					onChange={() => {}}
+				/>
+			</QueryWrapper>,
+		);
+
+		// The decorative <img> has alt="" so it doesn't have role="img" --
+		// query the DOM directly after confirming the panel rendered.
+		screen.getByText("OG Image");
+		const img = document.querySelector("img");
+		expect(img).not.toBeNull();
+		expect(img?.getAttribute("src")).toBe("https://example.com/og.jpg");
 	});
 
 	it("debounces text field saves", async () => {
 		const onChange = vi.fn();
 
 		const screen = await render(
-			<SeoPanel
-				contentKey="post-1"
-				seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
-				onChange={onChange}
-			/>,
+			<QueryWrapper>
+				<SeoPanel
+					contentKey="post-1"
+					seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+					onChange={onChange}
+				/>
+			</QueryWrapper>,
 		);
 
 		const titleInput = screen.getByLabelText("SEO Title");
@@ -45,11 +105,13 @@ describe("SeoPanel", () => {
 		const onChange = vi.fn();
 
 		const screen = await render(
-			<SeoPanel
-				contentKey="post-1"
-				seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
-				onChange={onChange}
-			/>,
+			<QueryWrapper>
+				<SeoPanel
+					contentKey="post-1"
+					seo={{ title: "", description: null, image: null, canonical: null, noIndex: false }}
+					onChange={onChange}
+				/>
+			</QueryWrapper>,
 		);
 
 		await userEvent.click(screen.getByRole("switch"));
@@ -95,7 +157,11 @@ describe("SeoPanel", () => {
 			);
 		}
 
-		const screen = await render(<Host />);
+		const screen = await render(
+			<QueryWrapper>
+				<Host />
+			</QueryWrapper>,
+		);
 		const titleInput = screen.getByLabelText("SEO Title");
 		await userEvent.clear(titleInput);
 		await userEvent.type(titleInput, "Newest local value");
@@ -144,7 +210,11 @@ describe("SeoPanel", () => {
 			);
 		}
 
-		const screen = await render(<Host />);
+		const screen = await render(
+			<QueryWrapper>
+				<Host />
+			</QueryWrapper>,
+		);
 		const titleInput = screen.getByLabelText("SEO Title");
 		await userEvent.clear(titleInput);
 		await userEvent.type(titleInput, "Unsaved local edit");
@@ -185,7 +255,11 @@ describe("SeoPanel", () => {
 			);
 		}
 
-		const screen = await render(<Host />);
+		const screen = await render(
+			<QueryWrapper>
+				<Host />
+			</QueryWrapper>,
+		);
 		const titleInput = screen.getByLabelText("SEO Title");
 		await userEvent.type(titleInput, "SEO title");
 


### PR DESCRIPTION
## What does this PR do?

The OG image control was rendered inline next to a content field whose slug had to be literally `featured_image`. Collections without that exact field (e.g. typical Pages) had no way to set a social preview image even with SEO enabled in the schema -- the `SeoPanel` sidebar only shows Title / Description / Canonical / NoIndex.

This PR moves the OG image picker into `SeoPanel` itself so it appears in the sidebar alongside the other SEO fields, decoupled from the schema. Any collection with `seo: true` in supports now gets the picker, regardless of which fields it has.

The picker is the same `SeoImageField` component as before; only its mount point changed. Server-side handling is unchanged -- `SeoImageField` still emits a partial `{ image: url }`, and the existing `SeoRepository.upsert` correctly preserves other columns when `image` is the only key.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (warning count unchanged from main baseline)
- [x] `pnpm test` passes (admin: 863/863, including 2 new SeoPanel tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs -- a workflow extracts catalogs on merge to `main`. (No new strings; existing `OG Image` / `Select OG image` already localized in `SeoImageField`.)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a -- bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7 (OpenCode)

## Screenshots / test output

Visual check confirmed by maintainer locally.

Test output:
```
✓ tests/components/SeoPanel.test.tsx (7 tests)
   ✓ renders an OG image control regardless of collection fields
   ✓ renders the existing OG image preview when set
   ✓ debounces text field saves
   ✓ saves noindex changes immediately
   ✓ does not overwrite newer local text when stale props arrive
   ✓ resets when switching to a different content item
   ✓ flushes pending text changes on unmount
```