### PR TITLE
fix(admin): give list and card surfaces an explicit background

### DIFF
--- a/.changeset/admin-panel-surfaces.md
+++ b/.changeset/admin-panel-surfaces.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes admin lists, tables and info cards rendering as transparent against the page background. Card containers in the content list, content type list, content type editor, media library, comments, users and device authorization views now have an explicit `bg-kumo-base` surface so they're visually distinct from the body.
+
+Also fixes column header labels in content list tables ("Title", "Status", etc.) rendering pale because of an undefined Tailwind class (`text-kumo-fg`) -- they now use the default text color and rely on the sort indicator icon to signal active state.

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -236,7 +236,7 @@ export function ContentList({
 									</th>
 								</tr>
 							</thead>
-							<tbody>
+							<tbody className="divide-y divide-kumo-line">
 								{isLoading && items.length === 0 ? (
 									<tr>
 										<td colSpan={i18n ? 5 : 4} className="px-4 py-8 text-center text-kumo-subtle">
@@ -350,7 +350,7 @@ export function ContentList({
 									</th>
 								</tr>
 							</thead>
-							<tbody>
+							<tbody className="divide-y divide-kumo-line">
 								{isTrashedLoading && trashedItems.length === 0 ? (
 									<tr>
 										<td colSpan={3} className="px-4 py-8 text-center text-kumo-subtle">
@@ -481,7 +481,7 @@ function ContentListItem({
 	const date = new Date(item.updatedAt || item.createdAt);
 
 	return (
-		<tr className="border-b hover:bg-kumo-tint/25">
+		<tr className="hover:bg-kumo-tint/25">
 			<td className="px-4 py-3">
 				<Link
 					to="/content/$collection/$id"
@@ -587,7 +587,7 @@ function TrashedListItem({ item, onRestore, onPermanentDelete }: TrashedListItem
 	const deletedDate = new Date(item.deletedAt);
 
 	return (
-		<tr className="border-b hover:bg-kumo-tint/25">
+		<tr className="hover:bg-kumo-tint/25">
 			<td className="px-4 py-3">
 				<span className="font-medium text-kumo-subtle">{title}</span>
 			</td>

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -201,7 +201,7 @@ export function ContentList({
 			{activeTab === "all" ? (
 				<>
 					{/* Table */}
-					<div className="rounded-md border overflow-x-auto">
+					<div className="rounded-md border bg-kumo-base overflow-x-auto">
 						<table className="w-full">
 							<thead>
 								<tr className="border-b bg-kumo-tint/50">
@@ -335,7 +335,7 @@ export function ContentList({
 			) : (
 				<>
 					{/* Trash Table */}
-					<div className="rounded-md border overflow-x-auto">
+					<div className="rounded-md border bg-kumo-base overflow-x-auto">
 						<table className="w-full">
 							<thead>
 								<tr className="border-b bg-kumo-tint/50">
@@ -448,9 +448,8 @@ function SortableTh({ field, sort, onSortChange, label }: SortableThProps) {
 				type="button"
 				onClick={handleClick}
 				className={cn(
-					"inline-flex items-center gap-1 rounded hover:text-kumo-brand",
+					"inline-flex items-center gap-1 rounded text-kumo-default hover:text-kumo-brand",
 					"focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-kumo-brand",
-					isActive ? "text-kumo-fg" : "text-kumo-subtle",
 				)}
 			>
 				<span>{label}</span>

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -379,7 +379,7 @@ export function ContentTypeEditor({
 				{/* Settings form */}
 				<div className="lg:col-span-1">
 					<form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4">
-						<div className="rounded-lg border p-4 space-y-4">
+						<div className="rounded-lg border bg-kumo-base p-4 space-y-4">
 							<h2 className="font-semibold">{t`Settings`}</h2>
 
 							<Input
@@ -483,7 +483,7 @@ export function ContentTypeEditor({
 
 						{/* Comments settings — only for existing collections */}
 						{!isNew && (
-							<div className="rounded-lg border p-4 space-y-4">
+							<div className="rounded-lg border bg-kumo-base p-4 space-y-4">
 								<h2 className="font-semibold">{t`Comments`}</h2>
 
 								<Switch
@@ -566,7 +566,7 @@ export function ContentTypeEditor({
 				{/* Fields section - only show for existing collections */}
 				{!isNew && (
 					<div className="lg:col-span-2">
-						<div className="rounded-lg border">
+						<div className="rounded-lg border bg-kumo-base">
 							<div className="flex items-center justify-between p-4 border-b">
 								<div>
 									<h2 className="font-semibold">{t`Fields`}</h2>
@@ -585,11 +585,11 @@ export function ContentTypeEditor({
 							</div>
 
 							{/* System fields - always shown */}
-							<div className="border-b bg-kumo-tint/30">
-								<div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider">
+							<div>
+								<div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b">
 									{t`System Fields`}
 								</div>
-								<div className="divide-y divide-kumo-line/50">
+								<div className="divide-y divide-kumo-line/50 border-b">
 									{SYSTEM_FIELDS.map((field) => (
 										<SystemFieldRow key={field.slug} field={field} />
 									))}
@@ -610,7 +610,7 @@ export function ContentTypeEditor({
 								</div>
 							) : (
 								<>
-									<div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider border-b">
+									<div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b">
 										{t`Custom Fields`}
 									</div>
 									<DndContext

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -86,7 +86,7 @@ export function ContentTypeList({
 			)}
 
 			{/* Table */}
-			<div className="rounded-md border overflow-x-auto">
+			<div className="rounded-md border bg-kumo-base overflow-x-auto">
 				<table className="w-full">
 					<thead>
 						<tr className="border-b bg-kumo-tint/50">

--- a/packages/admin/src/components/ContentTypeList.tsx
+++ b/packages/admin/src/components/ContentTypeList.tsx
@@ -107,7 +107,7 @@ export function ContentTypeList({
 							</th>
 						</tr>
 					</thead>
-					<tbody>
+					<tbody className="divide-y divide-kumo-line">
 						{isLoading ? (
 							<tr>
 								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
@@ -170,7 +170,7 @@ function ContentTypeRow({ collection, onRequestDelete }: ContentTypeRowProps) {
 	const isFromCode = collection.source === "code";
 
 	return (
-		<tr className="border-b hover:bg-kumo-tint/25">
+		<tr className="hover:bg-kumo-tint/25">
 			<td className="px-4 py-3">
 				<div className="flex items-center space-x-3">
 					<div

--- a/packages/admin/src/components/DeviceAuthorizePage.tsx
+++ b/packages/admin/src/components/DeviceAuthorizePage.tsx
@@ -193,7 +193,7 @@ export function DeviceAuthorizePage() {
 
 				{/* Denied state */}
 				{pageState === "denied" && (
-					<div className="rounded-lg border border-kumo-line p-6 text-center">
+					<div className="rounded-lg border border-kumo-line bg-kumo-base p-6 text-center">
 						<h2 className="font-medium">{t`Authorization denied`}</h2>
 						<p className="text-sm text-kumo-subtle mt-1">{t`The device will not be granted access.`}</p>
 						<Button

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -419,7 +419,7 @@ export function MediaLibrary({
 								<th className="px-4 py-3 text-end text-sm font-medium">{t`Actions`}</th>
 							</tr>
 						</thead>
-						<tbody>
+						<tbody className="divide-y divide-kumo-line">
 							{activeProvider === "local"
 								? currentItems.map((item) => (
 										<MediaListItem
@@ -584,7 +584,7 @@ function MediaListItem({ item, selected, onClick }: MediaListItemProps) {
 	return (
 		<tr
 			className={cn(
-				"border-b cursor-pointer transition-colors",
+				"cursor-pointer transition-colors",
 				selected ? "bg-kumo-brand/10" : "hover:bg-kumo-tint/25",
 			)}
 			onClick={onClick}
@@ -638,7 +638,7 @@ function ProviderListItem({ item, selected, onClick, onDimensionsLoaded }: Provi
 	return (
 		<tr
 			className={cn(
-				"border-b cursor-pointer transition-colors",
+				"cursor-pointer transition-colors",
 				selected ? "bg-kumo-brand/10" : "hover:bg-kumo-tint/25",
 			)}
 			onClick={onClick}

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -408,7 +408,7 @@ export function MediaLibrary({
 							))}
 				</div>
 			) : (
-				<div className="rounded-md border overflow-x-auto">
+				<div className="rounded-md border bg-kumo-base overflow-x-auto">
 					<table className="w-full">
 						<thead>
 							<tr className="border-b bg-kumo-tint/50">

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -66,7 +66,7 @@ function TermRow({
 	const { t } = useLingui();
 	return (
 		<>
-			<div className="flex items-center gap-4 py-2 px-4 border-b hover:bg-kumo-tint/50">
+			<div className="flex items-center gap-4 py-2 px-4 hover:bg-kumo-tint/50">
 				<div style={{ marginInlineStart: `${level * 1.5}rem` }} className="flex-1">
 					<span className="font-medium">{term.label}</span>
 					<span className="text-sm text-kumo-subtle ms-2">({term.slug})</span>
@@ -828,7 +828,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 						{t`No ${taxonomyDef.label.toLowerCase()} yet. Create one to get started.`}
 					</div>
 				) : (
-					<div>
+					<div className="divide-y divide-kumo-line">
 						{terms.map((term) => (
 							<TermRow
 								key={term.id}

--- a/packages/admin/src/components/WordPressImport.tsx
+++ b/packages/admin/src/components/WordPressImport.tsx
@@ -1024,9 +1024,9 @@ function FeatureComparison() {
 							<th className="text-center p-3 font-medium whitespace-nowrap">{t`Plugin`}</th>
 						</tr>
 					</thead>
-					<tbody>
+					<tbody className="divide-y divide-kumo-line">
 						{FEATURE_COMPARISON.map((item) => (
-							<tr key={item.feature} className="border-b last:border-0">
+							<tr key={item.feature}>
 								<td className="p-3 text-kumo-subtle">{item.feature}</td>
 								<td className="p-3 text-center">
 									<FeatureStatus status={item.wxr} note={item.wxrNote} />

--- a/packages/admin/src/components/comments/CommentDetail.tsx
+++ b/packages/admin/src/components/comments/CommentDetail.tsx
@@ -72,7 +72,7 @@ export function CommentDetail({
 					</div>
 
 					{/* Author info */}
-					<div className="rounded-lg border p-4 space-y-3">
+					<div className="rounded-lg border bg-kumo-base p-4 space-y-3">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
 							{t`Author`}
 						</h3>
@@ -90,7 +90,7 @@ export function CommentDetail({
 					</div>
 
 					{/* Comment body */}
-					<div className="rounded-lg border p-4 space-y-3">
+					<div className="rounded-lg border bg-kumo-base p-4 space-y-3">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
 							{t`Comment`}
 						</h3>
@@ -98,7 +98,7 @@ export function CommentDetail({
 					</div>
 
 					{/* Content reference */}
-					<div className="rounded-lg border p-4 space-y-2">
+					<div className="rounded-lg border bg-kumo-base p-4 space-y-2">
 						<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
 							{t`Content`}
 						</h3>
@@ -124,7 +124,7 @@ export function CommentDetail({
 
 					{/* Moderation metadata */}
 					{comment.moderationMetadata && Object.keys(comment.moderationMetadata).length > 0 && (
-						<div className="rounded-lg border p-4 space-y-3">
+						<div className="rounded-lg border bg-kumo-base p-4 space-y-3">
 							<h3 className="text-sm font-semibold text-kumo-subtle uppercase tracking-wider">
 								{t`Moderation Signals`}
 							</h3>

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -300,7 +300,7 @@ export function CommentInbox({
 							</th>
 						</tr>
 					</thead>
-					<tbody>
+					<tbody className="divide-y divide-kumo-line">
 						{isLoading && comments.length === 0 ? (
 							<tr>
 								<td colSpan={6} className="px-4 py-8 text-center text-kumo-subtle">
@@ -448,7 +448,7 @@ function CommentRow({
 	const excerpt = comment.body.length > 120 ? comment.body.slice(0, 120) + "..." : comment.body;
 
 	return (
-		<tr className={cn("border-b hover:bg-kumo-tint/25", isSelected && "bg-kumo-tint/40")}>
+		<tr className={cn("hover:bg-kumo-tint/25", isSelected && "bg-kumo-tint/40")}>
 			<td className="w-10 px-3 py-3">
 				<Checkbox
 					checked={isSelected}

--- a/packages/admin/src/components/comments/CommentInbox.tsx
+++ b/packages/admin/src/components/comments/CommentInbox.tsx
@@ -272,7 +272,7 @@ export function CommentInbox({
 			)}
 
 			{/* Table */}
-			<div className="rounded-md border overflow-x-auto">
+			<div className="rounded-md border bg-kumo-base overflow-x-auto">
 				<table className="w-full">
 					<thead>
 						<tr className="border-b bg-kumo-tint/50">

--- a/packages/admin/src/components/users/UserDetail.tsx
+++ b/packages/admin/src/components/users/UserDetail.tsx
@@ -212,7 +212,7 @@ export function UserDetail({
 								{/* Info cards */}
 								<div className="grid gap-4">
 									{/* Timestamps */}
-									<div className="rounded-lg border p-4">
+									<div className="rounded-lg border bg-kumo-base p-4">
 										<h4 className="text-sm font-medium text-kumo-subtle mb-3">{t`Account Info`}</h4>
 										<div className="space-y-2 text-sm">
 											<div className="flex justify-between">
@@ -239,7 +239,7 @@ export function UserDetail({
 									</div>
 
 									{/* Passkeys */}
-									<div className="rounded-lg border p-4">
+									<div className="rounded-lg border bg-kumo-base p-4">
 										<h4 className="text-sm font-medium text-kumo-subtle mb-3 flex items-center gap-2">
 											<Key className="h-4 w-4" aria-hidden="true" />
 											{t`Passkeys (${user.credentials.length})`}
@@ -270,7 +270,7 @@ export function UserDetail({
 
 									{/* OAuth accounts */}
 									{user.oauthAccounts.length > 0 && (
-										<div className="rounded-lg border p-4">
+										<div className="rounded-lg border bg-kumo-base p-4">
 											<h4 className="text-sm font-medium text-kumo-subtle mb-3 flex items-center gap-2">
 												<ArrowSquareOut className="h-4 w-4" aria-hidden="true" />
 												{t`Linked Accounts (${user.oauthAccounts.length})`}
@@ -365,7 +365,7 @@ function UserDetailSkeleton() {
 
 			{/* Cards skeleton */}
 			{Array.from({ length: 2 }, (_, i) => (
-				<div key={i} className="rounded-lg border p-4 space-y-3">
+				<div key={i} className="rounded-lg border bg-kumo-base p-4 space-y-3">
 					<div className="h-4 w-24 bg-kumo-tint rounded" />
 					<div className="space-y-2">
 						<div className="h-4 w-full bg-kumo-tint rounded" />

--- a/packages/admin/src/components/users/UserList.tsx
+++ b/packages/admin/src/components/users/UserList.tsx
@@ -111,7 +111,7 @@ export function UserList({
 							</th>
 						</tr>
 					</thead>
-					<tbody>
+					<tbody className="divide-y divide-kumo-line">
 						{users.length === 0 && !isLoading ? (
 							<tr>
 								<td colSpan={5} className="px-4 py-8 text-center text-kumo-subtle">
@@ -185,7 +185,7 @@ function UserListRow({ user, onSelect }: UserListRowProps) {
 	const lastLogin = user.lastLogin ? new Date(user.lastLogin).toLocaleDateString() : t`Never`;
 
 	return (
-		<tr className="border-b hover:bg-kumo-tint/25 cursor-pointer" onClick={onSelect}>
+		<tr className="hover:bg-kumo-tint/25 cursor-pointer" onClick={onSelect}>
 			<td className="px-4 py-3">
 				<div className="flex items-center gap-3">
 					{/* Avatar */}
@@ -249,11 +249,13 @@ export function UserListSkeleton() {
 				<div className="border-b bg-kumo-tint/50 px-4 py-3">
 					<div className="h-4 w-full bg-kumo-tint animate-pulse rounded" />
 				</div>
-				{Array.from({ length: 5 }, (_, i) => (
-					<div key={i} className="border-b px-4 py-4">
-						<div className="h-8 w-full bg-kumo-tint animate-pulse rounded" />
-					</div>
-				))}
+				<div className="divide-y divide-kumo-line">
+					{Array.from({ length: 5 }, (_, i) => (
+						<div key={i} className="px-4 py-4">
+							<div className="h-8 w-full bg-kumo-tint animate-pulse rounded" />
+						</div>
+					))}
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/admin/src/components/users/UserList.tsx
+++ b/packages/admin/src/components/users/UserList.tsx
@@ -90,7 +90,7 @@ export function UserList({
 			</div>
 
 			{/* Table */}
-			<div className="rounded-md border overflow-x-auto">
+			<div className="rounded-md border bg-kumo-base overflow-x-auto">
 				<table className="w-full">
 					<thead>
 						<tr className="border-b bg-kumo-tint/50">
@@ -245,7 +245,7 @@ export function UserListSkeleton() {
 			</div>
 
 			{/* Table skeleton */}
-			<div className="rounded-md border">
+			<div className="rounded-md border bg-kumo-base">
 				<div className="border-b bg-kumo-tint/50 px-4 py-3">
 					<div className="h-4 w-full bg-kumo-tint animate-pulse rounded" />
 				</div>


### PR DESCRIPTION
## What does this PR do?

Card containers across the admin used `rounded-md/lg border` without any `bg-*` class. The body's `--color-kumo-elevated` (`#f0f0f1`) showed straight through, so cards visually merged with the page background and any internal section strips (`bg-kumo-tint/30` etc.) read as accidental shading rather than as headers.

This affected the posts/pages list, content types list, content type editor (Settings + Fields cards), media library list view, comments inbox & detail, users list & detail, and the device authorization page.

Changes:

- Add `bg-kumo-base` to every list/info card surface.
- In `ContentTypeEditor`, the SYSTEM FIELDS wrapper had `bg-kumo-tint/30` on the whole section, which tinted the system field rows themselves. Move the tint to the header strip only and apply the same treatment to the CUSTOM FIELDS strip so they read as symmetric section headers (header tinted, rows not).
- Fix `SortableTh` referencing a non-existent `text-kumo-fg` class, which silently rendered inactive sortable column labels in `text-kumo-subtle` (pale grey -- `#787c82`). The labels are now always `text-kumo-default` and the caret icon (`CaretUpDown` -> `CaretUp`/`CaretDown`) signals active sort state.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (warning count unchanged from main baseline -- 28 pre-existing)
- [x] `pnpm test` passes (admin: 861/861)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) -- visual changes verified manually; existing tests cover the components' behavior
- [x] User-visible strings in the admin UI are wrapped for translation -- no string changes
- [x] I have added a changeset
- [ ] New features link to an approved Discussion -- n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7 (OpenCode)

## Screenshots / test output

Before -- the table card has no surface; rows blend into the page bg:
> Posts list: header strip subtle, rows transparent on grey body
> Content types list: same; "card" reads as a single bar
> Content type editor: SYSTEM FIELDS rows tinted, CUSTOM FIELDS rows not (asymmetric); both Settings and Fields cards transparent

After -- white card surface, symmetric section headers, readable column labels:
> Posts list: white card, dark Title/Status/Date headers, dark sort caret on active column
> Content types list: clearly framed white card with rows on it
> Content type editor: Settings (left) and Fields (right) on white surfaces; SYSTEM/CUSTOM strip headers both tinted, rows uniform white