### PR TITLE
feat(cli): enforce sandboxed plugin bundle size caps

### DIFF
--- a/.changeset/cli-bundle-size-caps.md
+++ b/.changeset/cli-bundle-size-caps.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/registry-cli": minor
+"emdash": minor
+---
+
+Enforces the sandboxed plugin bundle size caps from RFC 0001 §"Bundle size limits" in both the `bundle` and `publish` CLI flows: total decompressed ≤ 256 KB, per-file decompressed ≤ 128 KB, and at most 20 files per bundle. The previous bundle command capped only the total at 5 MB; the publish command now also re-validates the decompressed tarball before signing the release record so a publisher hits the same cap locally that aggregators enforce at ingest. Bundles between 256 KB and the old 5 MB ceiling will now be rejected — usually a sign the plugin is bundling host-provided dependencies or assets that belong in a CDN rather than the plugin payload.

--- a/packages/core/src/cli/commands/bundle-utils.ts
+++ b/packages/core/src/cli/commands/bundle-utils.ts
@@ -22,7 +22,12 @@ import type {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-export const MAX_BUNDLE_SIZE = 5 * 1024 * 1024;
+// Bundle size caps per RFC 0001 §"Bundle size limits". These are decompressed
+// sizes; the gzipped tarball is typically a fraction of MAX_BUNDLE_SIZE.
+export const MAX_BUNDLE_SIZE = 256 * 1024;
+export const MAX_FILE_SIZE = 128 * 1024;
+export const MAX_FILE_COUNT = 20;
+
 export const MAX_SCREENSHOTS = 5;
 export const MAX_SCREENSHOT_WIDTH = 1920;
 export const MAX_SCREENSHOT_HEIGHT = 1080;
@@ -251,21 +256,91 @@ export function findSourceExports(
 // ── Directory helpers ────────────────────────────────────────────────────────
 
 /**
- * Recursively calculate the total size of all files in a directory.
+ * One file in a bundle: a tarball-relative path and its byte length.
+ * Produced by `collectBundleEntries` (from a staging dir) or by the publish
+ * flow (from tarball entries); consumed by `validateBundleSize`.
  */
-export async function calculateDirectorySize(dir: string): Promise<number> {
-	let total = 0;
+export interface BundleFileEntry {
+	name: string;
+	bytes: number;
+}
+
+/**
+ * Recursively walk a staging directory and return a flat list of all files
+ * with sizes. Names are relative to `dir` so they match what would appear
+ * as the tarball entry name.
+ */
+export async function collectBundleEntries(dir: string): Promise<BundleFileEntry[]> {
+	const entries: BundleFileEntry[] = [];
+	await walkBundle(dir, "", entries);
+	return entries;
+}
+
+async function walkBundle(dir: string, prefix: string, into: BundleFileEntry[]): Promise<void> {
 	const items = await readdir(dir, { withFileTypes: true });
 	for (const item of items) {
 		const fullPath = join(dir, item.name);
+		const relPath = prefix ? `${prefix}/${item.name}` : item.name;
 		if (item.isFile()) {
 			const s = await stat(fullPath);
-			total += s.size;
+			into.push({ name: relPath, bytes: s.size });
 		} else if (item.isDirectory()) {
-			total += await calculateDirectorySize(fullPath);
+			await walkBundle(fullPath, relPath, into);
 		}
 	}
+}
+
+/**
+ * Sum the byte sizes of all entries.
+ */
+export function totalBundleBytes(entries: readonly BundleFileEntry[]): number {
+	let total = 0;
+	for (const e of entries) total += e.bytes;
 	return total;
+}
+
+/**
+ * Check a bundle against the three size caps from RFC 0001:
+ *   - total decompressed ≤ MAX_BUNDLE_SIZE
+ *   - per-file decompressed ≤ MAX_FILE_SIZE
+ *   - file count ≤ MAX_FILE_COUNT
+ *
+ * Returns a list of violation messages (empty if the bundle is within all
+ * caps). Messages are deterministic per input — the total/count violations
+ * come first, then oversized files in alphabetical order — so the same
+ * bundle always produces the same error text.
+ */
+export function validateBundleSize(entries: readonly BundleFileEntry[]): string[] {
+	const violations: string[] = [];
+	const total = totalBundleBytes(entries);
+	if (total > MAX_BUNDLE_SIZE) {
+		violations.push(
+			`Bundle size ${formatBytes(total)} exceeds maximum of ${formatBytes(MAX_BUNDLE_SIZE)}.`,
+		);
+	}
+	if (entries.length > MAX_FILE_COUNT) {
+		violations.push(
+			`Bundle contains ${entries.length} files, exceeds maximum of ${MAX_FILE_COUNT}.`,
+		);
+	}
+	const oversized = entries
+		.filter((e) => e.bytes > MAX_FILE_SIZE)
+		.toSorted((a, b) => a.name.localeCompare(b.name));
+	for (const e of oversized) {
+		violations.push(
+			`File ${e.name} is ${formatBytes(e.bytes)}, exceeds per-file maximum of ${formatBytes(MAX_FILE_SIZE)}.`,
+		);
+	}
+	return violations;
+}
+
+/**
+ * Render a byte count as a human-friendly string (e.g. "256.0 KB").
+ */
+export function formatBytes(n: number): string {
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / 1024 / 1024).toFixed(2)} MB`;
 }
 
 // ── Tarball creation ─────────────────────────────────────────────────────────

--- a/packages/core/src/cli/commands/bundle.ts
+++ b/packages/core/src/cli/commands/bundle.ts
@@ -23,20 +23,22 @@ import consola from "consola";
 import { CAPABILITY_RENAMES, isDeprecatedCapability } from "../../plugins/types.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import {
-	fileExists,
-	readImageDimensions,
-	extractManifest,
-	findNodeBuiltinImports,
-	findBuildOutput,
-	findSourceExports,
-	resolveSourceEntry,
-	calculateDirectorySize,
+	collectBundleEntries,
 	createTarball,
-	MAX_BUNDLE_SIZE,
+	extractManifest,
+	fileExists,
+	findBuildOutput,
+	findNodeBuiltinImports,
+	findSourceExports,
+	formatBytes,
+	ICON_SIZE,
 	MAX_SCREENSHOTS,
 	MAX_SCREENSHOT_WIDTH,
 	MAX_SCREENSHOT_HEIGHT,
-	ICON_SIZE,
+	readImageDimensions,
+	resolveSourceEntry,
+	totalBundleBytes,
+	validateBundleSize,
 } from "./bundle-utils.js";
 
 const TS_EXT_RE = /\.(tsx?|[mc]?js)$/;
@@ -596,15 +598,16 @@ export const bundleCommand = defineCommand({
 				}
 			}
 
-			// Calculate total bundle size
-			const totalSize = await calculateDirectorySize(bundleDir);
-			if (totalSize > MAX_BUNDLE_SIZE) {
-				const sizeMB = (totalSize / 1024 / 1024).toFixed(2);
-				consola.error(`Bundle size ${sizeMB}MB exceeds maximum of 5MB`);
+			// Bundle size caps (RFC 0001 §"Bundle size limits").
+			const bundleEntries = await collectBundleEntries(bundleDir);
+			const sizeViolations = validateBundleSize(bundleEntries);
+			if (sizeViolations.length > 0) {
+				for (const v of sizeViolations) consola.error(v);
 				hasErrors = true;
 			} else {
-				const sizeKB = (totalSize / 1024).toFixed(1);
-				consola.info(`Bundle size: ${sizeKB}KB`);
+				consola.info(
+					`Bundle size: ${formatBytes(totalBundleBytes(bundleEntries))} across ${bundleEntries.length} file${bundleEntries.length === 1 ? "" : "s"}`,
+				);
 			}
 
 			if (hasErrors) {

--- a/packages/registry-cli/src/bundle/api.ts
+++ b/packages/registry-cli/src/bundle/api.ts
@@ -45,20 +45,22 @@ import {
 	type ResolvedPlugin,
 } from "./types.js";
 import {
-	calculateDirectorySize,
+	collectBundleEntries,
 	createTarball,
 	extractManifest,
 	fileExists,
 	findBuildOutput,
 	findNodeBuiltinImports,
 	findSourceExports,
+	formatBytes,
 	ICON_SIZE,
-	MAX_BUNDLE_SIZE,
 	MAX_SCREENSHOTS,
 	MAX_SCREENSHOT_HEIGHT,
 	MAX_SCREENSHOT_WIDTH,
 	readImageDimensions,
 	resolveSourceEntry,
+	totalBundleBytes,
+	validateBundleSize,
 } from "./utils.js";
 
 const TS_EXT_RE = /\.(tsx?|[mc]?js)$/;
@@ -374,14 +376,15 @@ export async function bundlePlugin(options: BundleOptions): Promise<BundleResult
 			}
 		}
 
-		// Bundle size.
-		const totalSize = await calculateDirectorySize(bundleDir);
-		if (totalSize > MAX_BUNDLE_SIZE) {
-			const sizeMB = (totalSize / 1024 / 1024).toFixed(2);
-			validationErrors.push(`Bundle size ${sizeMB}MB exceeds maximum of 5MB.`);
+		// Bundle size caps (RFC 0001 §"Bundle size limits").
+		const bundleEntries = await collectBundleEntries(bundleDir);
+		const sizeViolations = validateBundleSize(bundleEntries);
+		if (sizeViolations.length > 0) {
+			validationErrors.push(...sizeViolations);
 		} else {
-			const sizeKB = (totalSize / 1024).toFixed(1);
-			log.info?.(`Bundle size: ${sizeKB}KB`);
+			log.info?.(
+				`Bundle size: ${formatBytes(totalBundleBytes(bundleEntries))} across ${bundleEntries.length} file${bundleEntries.length === 1 ? "" : "s"}`,
+			);
 		}
 
 		if (validationErrors.length > 0) {

--- a/packages/registry-cli/src/bundle/utils.ts
+++ b/packages/registry-cli/src/bundle/utils.ts
@@ -19,7 +19,12 @@ import type { ManifestHookEntry, PluginManifest, ResolvedPlugin } from "./types.
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-export const MAX_BUNDLE_SIZE = 5 * 1024 * 1024;
+// Bundle size caps per RFC 0001 §"Bundle size limits". These are decompressed
+// sizes; the gzipped tarball is typically a fraction of MAX_BUNDLE_SIZE.
+export const MAX_BUNDLE_SIZE = 256 * 1024;
+export const MAX_FILE_SIZE = 128 * 1024;
+export const MAX_FILE_COUNT = 20;
+
 export const MAX_SCREENSHOTS = 5;
 export const MAX_SCREENSHOT_WIDTH = 1920;
 export const MAX_SCREENSHOT_HEIGHT = 1080;
@@ -246,21 +251,92 @@ export function findSourceExports(
 // ── Directory helpers ────────────────────────────────────────────────────────
 
 /**
- * Recursively calculate the total size of all files in a directory.
+ * One file in a bundle: a tarball-relative path and its byte length.
+ * Produced by `collectBundleEntries` (from a staging dir) or by the publish
+ * flow (from tarball entries); consumed by `validateBundleSize`.
  */
-export async function calculateDirectorySize(dir: string): Promise<number> {
-	let total = 0;
+export interface BundleFileEntry {
+	name: string;
+	bytes: number;
+}
+
+/**
+ * Recursively walk a staging directory and return a flat list of all files
+ * with sizes. Names are relative to `dir` so they match what would appear
+ * as the tarball entry name.
+ */
+export async function collectBundleEntries(dir: string): Promise<BundleFileEntry[]> {
+	const entries: BundleFileEntry[] = [];
+	await walkBundle(dir, "", entries);
+	return entries;
+}
+
+async function walkBundle(dir: string, prefix: string, into: BundleFileEntry[]): Promise<void> {
 	const items = await readdir(dir, { withFileTypes: true });
 	for (const item of items) {
 		const fullPath = join(dir, item.name);
+		const relPath = prefix ? `${prefix}/${item.name}` : item.name;
 		if (item.isFile()) {
 			const s = await stat(fullPath);
-			total += s.size;
+			into.push({ name: relPath, bytes: s.size });
 		} else if (item.isDirectory()) {
-			total += await calculateDirectorySize(fullPath);
+			await walkBundle(fullPath, relPath, into);
 		}
 	}
+}
+
+/**
+ * Sum the byte sizes of all entries.
+ */
+export function totalBundleBytes(entries: readonly BundleFileEntry[]): number {
+	let total = 0;
+	for (const e of entries) total += e.bytes;
 	return total;
+}
+
+/**
+ * Check a bundle against the three size caps from RFC 0001:
+ *   - total decompressed ≤ MAX_BUNDLE_SIZE
+ *   - per-file decompressed ≤ MAX_FILE_SIZE
+ *   - file count ≤ MAX_FILE_COUNT
+ *
+ * Returns a list of violation messages (empty if the bundle is within all
+ * caps). Messages are deterministic per input — the total/count violations
+ * come first, then oversized files in alphabetical order — so the same
+ * bundle always produces the same error text.
+ */
+export function validateBundleSize(entries: readonly BundleFileEntry[]): string[] {
+	const violations: string[] = [];
+	const total = totalBundleBytes(entries);
+	if (total > MAX_BUNDLE_SIZE) {
+		violations.push(
+			`Bundle size ${formatBytes(total)} exceeds maximum of ${formatBytes(MAX_BUNDLE_SIZE)}.`,
+		);
+	}
+	if (entries.length > MAX_FILE_COUNT) {
+		violations.push(
+			`Bundle contains ${entries.length} files, exceeds maximum of ${MAX_FILE_COUNT}.`,
+		);
+	}
+	const oversized = entries
+		.filter((e) => e.bytes > MAX_FILE_SIZE)
+		.toSorted((a, b) => a.name.localeCompare(b.name));
+	for (const e of oversized) {
+		violations.push(
+			`File ${e.name} is ${formatBytes(e.bytes)}, exceeds per-file maximum of ${formatBytes(MAX_FILE_SIZE)}.`,
+		);
+	}
+	return violations;
+}
+
+/**
+ * Render a byte count as a human-friendly string. Mirrors the format used
+ * by the publish CLI's user-facing error messages (e.g. "256.0 KB").
+ */
+export function formatBytes(n: number): string {
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / 1024 / 1024).toFixed(2)} MB`;
 }
 
 // ── Tarball creation ─────────────────────────────────────────────────────────

--- a/packages/registry-cli/src/commands/publish.ts
+++ b/packages/registry-cli/src/commands/publish.ts
@@ -28,6 +28,7 @@ import { defineCommand } from "citty";
 import consola from "consola";
 import pc from "picocolors";
 
+import { formatBytes, MAX_BUNDLE_SIZE, validateBundleSize } from "../bundle/utils.js";
 import { sha256Multihash } from "../multihash.js";
 import { resumeSession } from "../oauth.js";
 import {
@@ -37,8 +38,14 @@ import {
 	type PublishLogger,
 } from "../publish/api.js";
 
-/** Hard cap on tarball size we'll buffer into memory. Mirrors MAX_BUNDLE_SIZE. */
-const MAX_TARBALL_BYTES = 5 * 1024 * 1024;
+/**
+ * Hard cap on the gzipped tarball we'll buffer into memory. Sized for the
+ * decompressed bundle cap from RFC 0001 (MAX_BUNDLE_SIZE = 256 KB) plus
+ * tar headers and worst-case gzip overhead. Anything larger is rejected at
+ * fetch time before decompression. The decompressed bundle is then re-checked
+ * against the per-file and total caps via `validateBundleSize`.
+ */
+const MAX_TARBALL_BYTES = 384 * 1024;
 
 export const publishCommand = defineCommand({
 	meta: {
@@ -349,12 +356,6 @@ function redirectConsolaToStderr(): () => void {
 	};
 }
 
-function formatBytes(n: number): string {
-	if (n < 1024) return `${n} B`;
-	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-	return `${(n / 1024 / 1024).toFixed(2)} MB`;
-}
-
 /**
  * Validate the publish URL before any network access. Returns an error message
  * to print, or `null` if the URL is acceptable.
@@ -489,6 +490,7 @@ async function validateResolvedHost(host: string): Promise<string | null> {
 // guard is the FIRST line of defence -- the redirect loop additionally runs
 // a DNS-resolved check (`validateResolvedHost`) so a public hostname
 // pointing at a private IP is also caught.
+const TAR_LEADING_DOT_SLASH_RE = /^\.\//;
 const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
 // IPv6 ULA (fc00::/7), link-local (fe80::/10). Bracket-stripped form.
 const IPV6_ULA_FC_RE = /^fc[0-9a-f]{2}(?::|$)/i;
@@ -655,6 +657,20 @@ function validateStringFlags(flags: Record<string, string | undefined>): string 
  * that 302s to `http://169.254.169.254/...` (cloud metadata) or to a
  * `localhost` victim, defeating the publish-side allow-list.
  */
+/**
+ * Build the error message for the gzipped-fetch cap. The cap itself is an
+ * implementation detail of the fetch buffer (sized to fit any bundle that
+ * meets the published RFC 0001 caps); the user-facing constraint is the
+ * decompressed total — surface that here so the next attempt aims at the
+ * right number.
+ */
+function oversizedFetchError(url: string, fetched: number): string {
+	return (
+		`tarball at ${url} is ${formatBytes(fetched)} (gzipped), exceeding the ${formatBytes(MAX_TARBALL_BYTES)} fetch cap. ` +
+		`Sandboxed plugin bundles must decompress to at most ${formatBytes(MAX_BUNDLE_SIZE)} (RFC 0001).`
+	);
+}
+
 async function fetchTarball(url: string): Promise<Uint8Array> {
 	const MAX_REDIRECTS = 10;
 	let currentUrl = url;
@@ -715,18 +731,14 @@ async function fetchTarball(url: string): Promise<Uint8Array> {
 	if (contentLength) {
 		const len = Number(contentLength);
 		if (Number.isFinite(len) && len > MAX_TARBALL_BYTES) {
-			throw new Error(
-				`tarball at ${url} is ${formatBytes(len)} which exceeds the ${formatBytes(MAX_TARBALL_BYTES)} limit`,
-			);
+			throw new Error(oversizedFetchError(url, len));
 		}
 	}
 
 	if (!res.body) {
 		const buf = await res.arrayBuffer();
 		if (buf.byteLength > MAX_TARBALL_BYTES) {
-			throw new Error(
-				`tarball at ${url} is ${formatBytes(buf.byteLength)} which exceeds the ${formatBytes(MAX_TARBALL_BYTES)} limit`,
-			);
+			throw new Error(oversizedFetchError(url, buf.byteLength));
 		}
 		return new Uint8Array(buf);
 	}
@@ -743,7 +755,7 @@ async function fetchTarball(url: string): Promise<Uint8Array> {
 			total += value.length;
 			if (total > MAX_TARBALL_BYTES) {
 				await reader.cancel();
-				throw new Error(`tarball at ${url} exceeds the ${formatBytes(MAX_TARBALL_BYTES)} limit`);
+				throw new Error(oversizedFetchError(url, total));
 			}
 			chunks.push(value);
 		}
@@ -764,10 +776,20 @@ async function fetchTarball(url: string): Promise<Uint8Array> {
  * Accepts both `manifest.json` and `./manifest.json` since modern-tar's
  * exact naming behaviour isn't pinned in our contract.
  *
+ * Enforces the bundle size caps from RFC 0001 against the decompressed
+ * entries — total decompressed size, per-file size, and file count. The
+ * gzipped fetch is already capped at MAX_TARBALL_BYTES upstream; this is
+ * the post-decompression check that matches what aggregators enforce at
+ * ingest, so a publisher who would be rejected at the registry sees the
+ * same error locally first.
+ *
  * Validates the parsed JSON shape against the contract before returning,
  * so downstream code (which iterates `capabilities`, indexes `allowedHosts`,
  * etc.) doesn't TypeError on garbage input from a malicious tarball.
  */
+// Exported for unit tests; not part of the public CLI surface.
+export const extractManifestFromTarballForTest = extractManifestFromTarball;
+
 async function extractManifestFromTarball(bytes: Uint8Array): Promise<PluginManifest> {
 	const { unpackTar, createGzipDecoder } = await import("modern-tar");
 	const source = new ReadableStream<Uint8Array>({
@@ -784,6 +806,24 @@ async function extractManifestFromTarball(bytes: Uint8Array): Promise<PluginMani
 		throw new Error(
 			`tarball at the URL is not a valid gzipped tar archive: ${error instanceof Error ? error.message : String(error)}`,
 			{ cause: error },
+		);
+	}
+	// The bundle size caps apply to regular files only: directories,
+	// symlinks, hardlinks, devices, and FIFOs all carry no content and
+	// shouldn't appear in a sandboxed plugin bundle anyway. Filtering by
+	// header.type matches what `collectBundleEntries` does for the staging
+	// dir (where `item.isFile()` already excludes non-files), so the bundle
+	// command and the publish command agree on what counts.
+	const fileEntries = entries
+		.filter((e) => (e.header.type ?? "file") === "file")
+		.map((e) => ({
+			name: e.header.name.replace(TAR_LEADING_DOT_SLASH_RE, ""),
+			bytes: e.data?.byteLength ?? 0,
+		}));
+	const sizeViolations = validateBundleSize(fileEntries);
+	if (sizeViolations.length > 0) {
+		throw new Error(
+			`tarball at the URL violates bundle size caps:\n  - ${sizeViolations.join("\n  - ")}`,
 		);
 	}
 	const manifestEntry = entries.find((e) => {

--- a/packages/registry-cli/tests/bundle-utils.test.ts
+++ b/packages/registry-cli/tests/bundle-utils.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ResolvedPlugin } from "../src/bundle/types.js";
-import { extractManifest, findNodeBuiltinImports, findSourceExports } from "../src/bundle/utils.js";
+import {
+	collectBundleEntries,
+	extractManifest,
+	findNodeBuiltinImports,
+	findSourceExports,
+	formatBytes,
+	MAX_FILE_COUNT,
+	MAX_FILE_SIZE,
+	totalBundleBytes,
+	validateBundleSize,
+} from "../src/bundle/utils.js";
 
 const minimalResolved = (overrides: Partial<ResolvedPlugin> = {}): ResolvedPlugin => ({
 	id: "test-plugin",
@@ -143,5 +157,165 @@ describe("findSourceExports", () => {
 				"./empty": null,
 			}),
 		).toEqual([]);
+	});
+});
+
+describe("validateBundleSize", () => {
+	it("accepts an empty bundle (boundary: zero files)", () => {
+		expect(validateBundleSize([])).toEqual([]);
+	});
+
+	it("accepts a bundle that sits exactly at every cap", () => {
+		// 19 small files + one file at the per-file cap. Total stays under
+		// MAX_BUNDLE_SIZE because per-file cap × file count is much larger
+		// than the bundle cap; we deliberately undershoot the total.
+		const entries = [
+			{ name: "backend.js", bytes: MAX_FILE_SIZE },
+			...Array.from({ length: MAX_FILE_COUNT - 1 }, (_, i) => ({
+				name: `extra-${i}.js`,
+				bytes: 100,
+			})),
+		];
+		expect(validateBundleSize(entries)).toEqual([]);
+	});
+
+	it("flags total bundle size when it exceeds MAX_BUNDLE_SIZE without tripping per-file cap", () => {
+		// Three files at exactly MAX_FILE_SIZE each — per-file cap is satisfied
+		// (`>` not `>=`), but the sum (3 × 128 KB = 384 KB) exceeds the 256 KB
+		// total cap. Isolates the total-size assertion from per-file noise.
+		const entries = [
+			{ name: "a.js", bytes: MAX_FILE_SIZE },
+			{ name: "b.js", bytes: MAX_FILE_SIZE },
+			{ name: "c.js", bytes: MAX_FILE_SIZE },
+		];
+		const violations = validateBundleSize(entries);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toMatch(/Bundle size .* exceeds maximum of/);
+	});
+
+	it("does not flag a bundle exactly at MAX_BUNDLE_SIZE", () => {
+		// Use MAX_FILE_SIZE-bounded files so per-file cap is satisfied too.
+		// MAX_BUNDLE_SIZE / MAX_FILE_SIZE = 256/128 = 2 files.
+		const entries = [
+			{ name: "a.js", bytes: MAX_FILE_SIZE },
+			{ name: "b.js", bytes: MAX_FILE_SIZE },
+		];
+		expect(validateBundleSize(entries)).toEqual([]);
+	});
+
+	it("flags file count when it exceeds MAX_FILE_COUNT", () => {
+		const entries = Array.from({ length: MAX_FILE_COUNT + 1 }, (_, i) => ({
+			name: `f-${i}.js`,
+			bytes: 10,
+		}));
+		const violations = validateBundleSize(entries);
+		expect(violations).toContainEqual(
+			expect.stringMatching(new RegExp(`contains ${MAX_FILE_COUNT + 1} files`)),
+		);
+	});
+
+	it("flags every oversized file individually", () => {
+		const entries = [
+			{ name: "ok.js", bytes: 100 },
+			{ name: "huge-b.js", bytes: MAX_FILE_SIZE + 1 },
+			{ name: "huge-a.js", bytes: MAX_FILE_SIZE + 2 },
+		];
+		const violations = validateBundleSize(entries);
+		const fileViolations = violations.filter((v) => v.startsWith("File "));
+		expect(fileViolations).toHaveLength(2);
+		// Alphabetical ordering — huge-a before huge-b — keeps error text
+		// deterministic for the same bundle.
+		expect(fileViolations[0]).toMatch(/File huge-a\.js/);
+		expect(fileViolations[1]).toMatch(/File huge-b\.js/);
+	});
+
+	it("reports total, count, and per-file violations together when all three trip", () => {
+		const entries = Array.from({ length: MAX_FILE_COUNT + 5 }, (_, i) => ({
+			name: `chunk-${String(i).padStart(2, "0")}.js`,
+			bytes: MAX_FILE_SIZE + 1,
+		}));
+		const violations = validateBundleSize(entries);
+		// One total-size violation, one file-count violation, one per oversized file.
+		expect(violations[0]).toMatch(/Bundle size/);
+		expect(violations[1]).toMatch(/contains/);
+		expect(violations.length).toBe(2 + entries.length);
+	});
+
+	it("returns the same violation list when called twice with the same input", () => {
+		const entries = [
+			{ name: "z.js", bytes: MAX_FILE_SIZE + 1 },
+			{ name: "a.js", bytes: MAX_FILE_SIZE + 1 },
+		];
+		expect(validateBundleSize(entries)).toEqual(validateBundleSize(entries));
+	});
+});
+
+describe("totalBundleBytes", () => {
+	it("returns 0 for an empty list", () => {
+		expect(totalBundleBytes([])).toBe(0);
+	});
+
+	it("sums the byte sizes of all entries", () => {
+		expect(
+			totalBundleBytes([
+				{ name: "a", bytes: 10 },
+				{ name: "b", bytes: 20 },
+				{ name: "c", bytes: 30 },
+			]),
+		).toBe(60);
+	});
+});
+
+describe("collectBundleEntries", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "emdash-collect-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("returns an empty list for an empty directory", async () => {
+		expect(await collectBundleEntries(dir)).toEqual([]);
+	});
+
+	it("flattens nested directories with forward-slash relative paths", async () => {
+		await writeFile(join(dir, "manifest.json"), "{}");
+		await mkdir(join(dir, "screenshots"));
+		await writeFile(join(dir, "screenshots", "one.png"), "x");
+		await writeFile(join(dir, "screenshots", "two.png"), "yz");
+
+		const entries = await collectBundleEntries(dir);
+		const byName = Object.fromEntries(entries.map((e) => [e.name, e.bytes]));
+		expect(byName).toEqual({
+			"manifest.json": 2,
+			"screenshots/one.png": 1,
+			"screenshots/two.png": 2,
+		});
+	});
+
+	it("integrates with validateBundleSize for end-to-end cap enforcement", async () => {
+		await writeFile(join(dir, "backend.js"), "x".repeat(MAX_FILE_SIZE + 1));
+		const violations = validateBundleSize(await collectBundleEntries(dir));
+		expect(violations).toContainEqual(expect.stringMatching(/File backend\.js is/));
+	});
+});
+
+describe("formatBytes", () => {
+	it("renders bytes under 1 KB with the B suffix", () => {
+		expect(formatBytes(0)).toBe("0 B");
+		expect(formatBytes(1023)).toBe("1023 B");
+	});
+
+	it("renders KB at one decimal place from 1 KB through just under 1 MB", () => {
+		expect(formatBytes(1024)).toBe("1.0 KB");
+		expect(formatBytes(256 * 1024)).toBe("256.0 KB");
+	});
+
+	it("renders MB at two decimal places at or above 1 MB", () => {
+		expect(formatBytes(1024 * 1024)).toBe("1.00 MB");
+		expect(formatBytes(5 * 1024 * 1024)).toBe("5.00 MB");
 	});
 });

--- a/packages/registry-cli/tests/publish-tarball.test.ts
+++ b/packages/registry-cli/tests/publish-tarball.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -31,8 +31,7 @@ describe("extractManifestFromTarball (publish CLI)", () => {
 	async function buildTarball(files: Record<string, string | Uint8Array>): Promise<Uint8Array> {
 		for (const [name, body] of Object.entries(files)) {
 			const fullPath = join(stagingDir, name);
-			const dir = fullPath.slice(0, fullPath.lastIndexOf("/"));
-			if (dir !== stagingDir) await mkdir(dir, { recursive: true });
+			await mkdir(dirname(fullPath), { recursive: true });
 			await writeFile(fullPath, body);
 		}
 		const tarballPath = join(outDir, "test.tar.gz");

--- a/packages/registry-cli/tests/publish-tarball.test.ts
+++ b/packages/registry-cli/tests/publish-tarball.test.ts
@@ -1,0 +1,124 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createTarball, MAX_FILE_SIZE } from "../src/bundle/utils.js";
+import { extractManifestFromTarballForTest } from "../src/commands/publish.js";
+
+/**
+ * Round-trip the tarball-extraction step from the publish CLI: build a real
+ * gzipped tarball on disk, read its bytes, and feed them through the same
+ * function the publish flow calls. This exercises the bundle-size-cap wiring
+ * end-to-end (decompression + per-file accounting + total accounting) which
+ * the pure `validateBundleSize` unit tests cannot.
+ */
+describe("extractManifestFromTarball (publish CLI)", () => {
+	let stagingDir: string;
+	let outDir: string;
+
+	beforeEach(async () => {
+		stagingDir = await mkdtemp(join(tmpdir(), "emdash-tar-staging-"));
+		outDir = await mkdtemp(join(tmpdir(), "emdash-tar-out-"));
+	});
+
+	afterEach(async () => {
+		await rm(stagingDir, { recursive: true, force: true });
+		await rm(outDir, { recursive: true, force: true });
+	});
+
+	async function buildTarball(files: Record<string, string | Uint8Array>): Promise<Uint8Array> {
+		for (const [name, body] of Object.entries(files)) {
+			const fullPath = join(stagingDir, name);
+			const dir = fullPath.slice(0, fullPath.lastIndexOf("/"));
+			if (dir !== stagingDir) await mkdir(dir, { recursive: true });
+			await writeFile(fullPath, body);
+		}
+		const tarballPath = join(outDir, "test.tar.gz");
+		await createTarball(stagingDir, tarballPath);
+		return new Uint8Array(await readFile(tarballPath));
+	}
+
+	const minimalManifest = JSON.stringify({
+		id: "test-plugin",
+		version: "1.0.0",
+		capabilities: [],
+		allowedHosts: [],
+		storage: {},
+		hooks: [],
+		routes: [],
+		admin: {},
+	});
+
+	it("returns the manifest for a tarball within all caps", async () => {
+		const bytes = await buildTarball({
+			"manifest.json": minimalManifest,
+			"backend.js": "export default {};\n",
+		});
+		const manifest = await extractManifestFromTarballForTest(bytes);
+		expect(manifest.id).toBe("test-plugin");
+		expect(manifest.version).toBe("1.0.0");
+	});
+
+	it("rejects a tarball with a single file over the per-file cap", async () => {
+		const bytes = await buildTarball({
+			"manifest.json": minimalManifest,
+			"backend.js": "x".repeat(MAX_FILE_SIZE + 1),
+		});
+		await expect(extractManifestFromTarballForTest(bytes)).rejects.toThrow(
+			/violates bundle size caps[\s\S]*backend\.js/,
+		);
+	});
+
+	it("rejects a tarball whose total decompressed size exceeds the bundle cap", async () => {
+		// Three files at exactly MAX_FILE_SIZE — each within per-file cap, but
+		// total (3 × 128 KB = 384 KB) exceeds the 256 KB total cap.
+		const bytes = await buildTarball({
+			"manifest.json": minimalManifest,
+			"a.js": "a".repeat(MAX_FILE_SIZE),
+			"b.js": "b".repeat(MAX_FILE_SIZE),
+			"c.js": "c".repeat(MAX_FILE_SIZE),
+		});
+		await expect(extractManifestFromTarballForTest(bytes)).rejects.toThrow(
+			/violates bundle size caps[\s\S]*Bundle size/,
+		);
+	});
+
+	it("rejects a tarball with too many files even when each is tiny", async () => {
+		const files: Record<string, string> = { "manifest.json": minimalManifest };
+		for (let i = 0; i < 25; i++) files[`f-${String(i).padStart(2, "0")}.js`] = "x";
+		const bytes = await buildTarball(files);
+		await expect(extractManifestFromTarballForTest(bytes)).rejects.toThrow(
+			/violates bundle size caps[\s\S]*contains \d+ files/,
+		);
+	});
+
+	it("does not count non-file tar entries (symlinks etc.) toward the file cap", async () => {
+		// Hand-build a tarball with 25 symlink entries plus one real file.
+		// Symlinks have type "2" and size 0 in USTAR. The file cap is 20, so
+		// counting symlinks would reject this; the filter should only see one
+		// real file (manifest.json) and accept it.
+		const { packTar } = await import("modern-tar");
+		const { gzipSync } = await import("node:zlib");
+		const symlinkEntries = Array.from({ length: 25 }, (_, i) => ({
+			header: {
+				name: `link-${i}`,
+				size: 0,
+				type: "symlink" as const,
+				linkname: "manifest.json",
+			},
+			body: new Uint8Array(0),
+		}));
+		const tarBytes = await packTar([
+			{
+				header: { name: "manifest.json", size: minimalManifest.length, type: "file" as const },
+				body: new TextEncoder().encode(minimalManifest),
+			},
+			...symlinkEntries,
+		]);
+		const gzipped = gzipSync(tarBytes);
+		const manifest = await extractManifestFromTarballForTest(new Uint8Array(gzipped));
+		expect(manifest.id).toBe("test-plugin");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Implements the bundle size caps from RFC 0001 §"Bundle size limits" in the registry CLI. Replaces the existing single 5 MB total cap with three layered caps applied uniformly in both the `bundle` and `publish` flows:

- Total decompressed ≤ **256 KB**
- Per-file decompressed ≤ **128 KB**
- File count ≤ **20**

Sized against observed first-party sandboxed plugins (largest is `atproto` at ~37 KB built; most are under 20 KB) — roughly 7× headroom over real-world usage. The publish-side fetch buffer drops from 5 MB to 384 KB to fit the decompressed cap plus tar headers and worst-case gzip overhead.

The publish CLI now re-validates decompressed entries against the same caps after fetching and unpacking the tarball, so a publisher hits the cap locally before the aggregator rejects the release at ingest. The fetch error tells the user both the gzipped fetch cap *and* the decompressed cap they actually need to satisfy, so retries aim at the right number. Tar entry filtering uses `header.type === "file"` rather than a trailing-slash heuristic so symlinks/hardlinks/devices/FIFOs aren't counted toward the file cap, matching what the staging-dir walk does.

Mirrored into the legacy core CLI copy (`packages/core/src/cli/commands/bundle-utils.ts` + `bundle.ts`) until phase 1 cutover, per the in-file sync comment.

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

This implements the published `wip/plugin-rfc` branch's RFC 0001 §"Bundle size limits" subsection. The Discussion gate is the RFC itself.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Test output

```
registry-cli: 7 files, 104 tests passing (13 new unit cases for validateBundleSize / collectBundleEntries / formatBytes / totalBundleBytes; 5 integration cases that round-trip real gzipped tarballs through the publish CLI's extractor, including a regression case for the non-file filter)
core: 204 files, 3214 tests passing
```

## Notes for reviewers

The breaking-behavior side: any existing plugin between 256 KB and 5 MB that previously bundled fine will now be rejected by `bundle` and `publish`. The changeset calls this out. This is a deliberate cap tightening that's also the protocol contract — anything in that range would have been rejected by the aggregator at ingest anyway, so the CLI is just bringing the local-validation point in line with the published spec.

Adversarial review pass run before opening; the two HIGH/MEDIUM findings (misleading fetch error, non-file filter counting symlinks) are fixed in this PR. Remaining LOW findings (empty bundle, dotfiles, fix-guidance message text) are noted but intentionally deferred — they're not regressions and not blockers per the project's review-codes-out-of-tests rule.