### PR TITLE
feat(aggregator): read API — 5 XRPC endpoints + cached sync.getRecord

### DIFF
--- a/apps/aggregator/migrations/0002_indexed_at.sql
+++ b/apps/aggregator/migrations/0002_indexed_at.sql
@@ -1,0 +1,35 @@
+-- Add `indexed_at` to the four content tables that the read API exposes via
+-- the `packageView` / `releaseView` lexicon shapes.
+--
+-- Why a separate column from `verified_at`: `verified_at` tracks "when the
+-- aggregator last verified this record", and is bumped on every upsert
+-- (including no-op re-verifications). The read API needs "when the aggregator
+-- first observed this record" so the lexicon's `indexedAt` field is stable
+-- across re-ingest. They diverge whenever a record is re-fetched (e.g.
+-- backfill catching up on a record we already had via Jetstream).
+--
+-- Defaulting to `verified_at` for any rows that pre-date this migration: the
+-- closest approximation we can make for already-indexed content. Going
+-- forward, the consumer's INSERTs set `indexed_at` to `now()` on first write
+-- and COALESCE the existing value on conflict (see records-consumer.ts).
+--
+-- NOT NULL after backfill from `verified_at`. SQLite's `ALTER TABLE` doesn't
+-- support DEFAULT-with-NOT-NULL in one step, so we add the column nullable,
+-- backfill, then move the constraint via the new-table dance — except SQLite
+-- also can't add NOT NULL via ALTER, so we keep the column nullable at the
+-- schema level and have the writer (consumer) treat it as required. The
+-- read-API code defends against NULL by falling back to verified_at if
+-- indexed_at is somehow missing on a row, which won't happen for new writes
+-- but covers the historical-data corner case without a table rebuild.
+
+ALTER TABLE packages ADD COLUMN indexed_at TEXT;
+UPDATE packages SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE releases ADD COLUMN indexed_at TEXT;
+UPDATE releases SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE publishers ADD COLUMN indexed_at TEXT;
+UPDATE publishers SET indexed_at = verified_at WHERE indexed_at IS NULL;
+
+ALTER TABLE publisher_verifications ADD COLUMN indexed_at TEXT;
+UPDATE publisher_verifications SET indexed_at = verified_at WHERE indexed_at IS NULL;

--- a/apps/aggregator/src/backfill-consumer.ts
+++ b/apps/aggregator/src/backfill-consumer.ts
@@ -35,6 +35,7 @@ import { processBackfillJob, type ProcessBackfillJobDeps } from "./backfill.js";
 import { createD1DidDocCache, DidResolver } from "./did-resolver.js";
 import type { BackfillJob } from "./env.js";
 import type { MessageBatchLike } from "./records-consumer.js";
+import { boundFetch } from "./utils.js";
 
 /**
  * Process one batch of backfill jobs. Mirrors `records-consumer.processBatch`'s
@@ -67,7 +68,7 @@ export async function processBackfillBatch(
 			console.error("[aggregator] backfill job failed, retrying", {
 				did: job.did,
 				collection: job.collection,
-				error: err instanceof Error ? err.message : String(err),
+				error: formatErrorChain(err),
 			});
 			message.retry();
 		}
@@ -96,11 +97,36 @@ export function drainBackfillDeadLetterBatch(
 	}
 }
 
+/** Walk an Error's `cause` chain into a single human-readable string for
+ * log output. Library code (`@atcute/identity-resolver`,
+ * `@atcute/util-fetch`) wraps low-level failures in higher-level errors
+ * via `{ cause }`; logging only `err.message` hides the actual root
+ * cause. The chain is joined with `; cause: ` so a multi-level wrap
+ * reads top-down. Bounded at 5 levels so a circular chain can't loop
+ * forever. */
+function formatErrorChain(err: unknown): string {
+	const parts: string[] = [];
+	let current: unknown = err;
+	for (let i = 0; i < 5 && current; i++) {
+		if (current instanceof Error) {
+			parts.push(`${current.name}: ${current.message}`);
+			current = (current as { cause?: unknown }).cause;
+		} else {
+			// JSON.stringify (rather than String) so a plain object cause
+			// (some libraries throw `{ code, ... }` shapes) prints its
+			// fields instead of `[object Object]`.
+			parts.push(typeof current === "string" ? current : JSON.stringify(current));
+			break;
+		}
+	}
+	return parts.join("; cause: ");
+}
+
 function createProductionDeps(env: Env): ProcessBackfillJobDeps {
 	const composite = new CompositeDidDocumentResolver({
 		methods: {
-			plc: new PlcDidDocumentResolver(),
-			web: new AtprotoWebDidDocumentResolver(),
+			plc: new PlcDidDocumentResolver({ fetch: boundFetch }),
+			web: new AtprotoWebDidDocumentResolver({ fetch: boundFetch }),
 		},
 	});
 	return {
@@ -109,5 +135,10 @@ function createProductionDeps(env: Env): ProcessBackfillJobDeps {
 			resolver: composite,
 		}),
 		queue: env.RECORDS_QUEUE,
+		// listRecords + sendBatch use this fetch for the PDS calls. Same
+		// bound-wrapper requirement as the resolver constructors —
+		// workerd's `fetch` rejects calls made through a stored
+		// reference (`const fetchImpl = deps.fetch ?? fetch; fetchImpl(url)`).
+		fetch: boundFetch,
 	};
 }

--- a/apps/aggregator/src/index.ts
+++ b/apps/aggregator/src/index.ts
@@ -56,6 +56,7 @@ export { RecordsJetstreamDO } from "./records-do.js";
  */
 const BOOTSTRAP_PATH = "/_admin/start";
 const BACKFILL_PATH = "/_admin/backfill";
+const STATUS_PATH = "/_admin/status";
 
 /**
  * Cap on the explicit DID list a single POST may submit. Lower than the
@@ -194,6 +195,24 @@ export default {
 			// was already running, just woke up, or is mid-startup.
 			ctx.waitUntil(stub.fetch("https://do.internal/bootstrap"));
 			return new Response(null, { status: 204 });
+		}
+		if (url.pathname === STATUS_PATH) {
+			if (request.method !== "GET") {
+				return new Response("method not allowed", {
+					status: 405,
+					headers: { allow: "GET" },
+				});
+			}
+			const denied = requireAdminAuth(request, env);
+			if (denied) return denied;
+			// Proxy the DO's status JSON straight through. The DO returns
+			// `{cursor, consecutiveFailures}` — `consecutiveFailures: 0`
+			// means the latest connection attempt produced events; non-zero
+			// means Jetstream is unreachable, the wantedCollections filter
+			// is mismatched, or queue backpressure is biting.
+			const id = env.RECORDS_DO.idFromName(RECORDS_DO_NAME);
+			const stub = env.RECORDS_DO.get(id);
+			return stub.fetch("https://do.internal/status");
 		}
 		if (url.pathname === BACKFILL_PATH) {
 			if (request.method !== "POST") {

--- a/apps/aggregator/src/index.ts
+++ b/apps/aggregator/src/index.ts
@@ -22,6 +22,7 @@ import { discoverDids, enqueueBackfillJobs } from "./backfill.js";
 import type { BackfillJob, RecordsJob } from "./env.js";
 import { drainDeadLetterBatch, processBatch } from "./records-consumer.js";
 import { RECORDS_DO_NAME } from "./records-do.js";
+import { handleXrpc } from "./routes/xrpc/router.js";
 import { isPlainObject } from "./utils.js";
 
 const RECORDS_QUEUE_NAME = "emdash-aggregator-records";
@@ -232,8 +233,13 @@ export default {
 			ctx.waitUntil(runBackfill(parsed, env));
 			return new Response(null, { status: 202 });
 		}
-		return new Response("emdash-aggregator: not yet implemented", {
-			status: 503,
+		// XRPC read API: aggregator endpoints + cached sync.getRecord
+		// passthrough. Returns null if pathname doesn't start with /xrpc/, so
+		// non-matching paths fall through to the catch-all below.
+		const xrpc = await handleXrpc(env, request);
+		if (xrpc) return xrpc;
+		return new Response("emdash-aggregator: not found", {
+			status: 404,
 			headers: { "content-type": "text/plain" },
 		});
 	},

--- a/apps/aggregator/src/jetstream-ingestor.ts
+++ b/apps/aggregator/src/jetstream-ingestor.ts
@@ -73,6 +73,21 @@ export interface JetstreamIngestorOptions {
 	sleep?: (ms: number) => Promise<void>;
 	/** Random source for jitter, swap in tests for determinism. */
 	random?: () => number;
+	/**
+	 * Called when no cursor is persisted in DO storage (fresh deploy,
+	 * regional failover, dev-state wipe). Should return a Jetstream
+	 * `time_us` (microseconds since epoch) to start from, or `null` to
+	 * fall back to the subscription library's default (effectively
+	 * "now"). The DO supplies `MAX(verified_at)` across the four
+	 * content tables — events older than the latest record we've
+	 * already verified are no-ops thanks to consumer idempotency, but
+	 * events newer than that are the gap we'd otherwise miss between
+	 * our last known data and the moment Jetstream reconnects.
+	 *
+	 * Optional so tests can omit it; production wiring always supplies
+	 * it via the DO.
+	 */
+	cursorFloor?: () => Promise<number | null>;
 }
 
 const DEFAULT_BACKOFF: Required<IngestorBackoffConfig> = {
@@ -101,6 +116,8 @@ export class JetstreamIngestor {
 	 * spiral into ever-larger backoffs. */
 	private madeProgress = false;
 
+	private readonly cursorFloor: (() => Promise<number | null>) | null;
+
 	constructor(opts: JetstreamIngestorOptions) {
 		this.client = opts.client;
 		this.queue = opts.queue;
@@ -110,6 +127,7 @@ export class JetstreamIngestor {
 		this.logger = opts.logger ?? {};
 		this.sleep = opts.sleep ?? defaultSleep;
 		this.random = opts.random ?? Math.random;
+		this.cursorFloor = opts.cursorFloor ?? null;
 	}
 
 	/** The cursor most recently enqueued + persisted. `null` until the first event. */
@@ -131,6 +149,27 @@ export class JetstreamIngestor {
 	 */
 	async run(): Promise<void> {
 		this.cursor = (await this.storage.get(CURSOR_STORAGE_KEY)) ?? null;
+		if (this.cursor === null && this.cursorFloor !== null) {
+			// Storage was empty (fresh deploy / regional failover / dev wipe)
+			// but our content tables may have rows from a prior backfill.
+			// Derive a cursor from the latest verified record so we don't
+			// silently skip events between backfill-time and reconnect-time.
+			// Persist immediately so a crash before the first Jetstream event
+			// arrives doesn't re-derive on the next run (the floor function
+			// is allowed to be expensive).
+			try {
+				const floor = await this.cursorFloor();
+				if (floor !== null) {
+					this.cursor = floor;
+					await this.storage.put(CURSOR_STORAGE_KEY, floor);
+					this.logger.info?.("jetstream cursor seeded from D1 floor", { cursor: floor });
+				}
+			} catch (err) {
+				this.logger.warn?.("cursorFloor lookup failed, falling back to subscription default", {
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
 
 		while (!this.stopped) {
 			try {

--- a/apps/aggregator/src/records-consumer.ts
+++ b/apps/aggregator/src/records-consumer.ts
@@ -53,7 +53,7 @@ import {
 	type VerificationFailureReason,
 	type VerifiedPdsRecord,
 } from "./pds-verify.js";
-import { isPlainObject } from "./utils.js";
+import { isPlainObject, parseSignatureMetadataCid } from "./utils.js";
 
 /**
  * Deps the consumer needs at runtime. Constructed once per `processBatch` call
@@ -602,7 +602,7 @@ export async function ingestPackageRelease(
 			.bind(job.did, record.package, record.version)
 			.first<{ signature_metadata: string; tombstoned_at: string | null }>();
 		if (existing) {
-			const existingCid = parseCid(existing.signature_metadata);
+			const existingCid = parseSignatureMetadataCid(existing.signature_metadata);
 			const sameContent = existingCid === verified.cid;
 			if (sameContent && existing.tombstoned_at !== null) {
 				await db.batch([
@@ -1090,22 +1090,6 @@ function computeVersionSort(version: string): string | null {
 		return `${pad(major)}.${pad(minor)}.${pad(patch)}.${padded.join(".")}`;
 	}
 	return `${pad(major)}.${pad(minor)}.${pad(patch)}.${FINAL_VERSION_SENTINEL}`;
-}
-
-/**
- * Pull the verified record's CID out of the JSON-stringified
- * `signature_metadata` column. Returns null if the column is missing or
- * malformed (which shouldn't happen in writer-controlled data, but the
- * fallback keeps the comparison robust against future schema drift).
- */
-function parseCid(signatureMetadata: string): string | null {
-	try {
-		const parsed: unknown = JSON.parse(signatureMetadata);
-		if (isPlainObject(parsed) && typeof parsed.cid === "string") return parsed.cid;
-	} catch {
-		// fall through
-	}
-	return null;
 }
 
 function formatValidationIssues(issues: unknown): string {

--- a/apps/aggregator/src/records-consumer.ts
+++ b/apps/aggregator/src/records-consumer.ts
@@ -53,7 +53,7 @@ import {
 	type VerificationFailureReason,
 	type VerifiedPdsRecord,
 } from "./pds-verify.js";
-import { isPlainObject, parseSignatureMetadataCid } from "./utils.js";
+import { boundFetch, isPlainObject, parseSignatureMetadataCid } from "./utils.js";
 
 /**
  * Deps the consumer needs at runtime. Constructed once per `processBatch` call
@@ -955,8 +955,8 @@ async function writeDeadLetter(
 function createProductionDeps(env: Env): ConsumerDeps {
 	const composite = new CompositeDidDocumentResolver({
 		methods: {
-			plc: new PlcDidDocumentResolver(),
-			web: new AtprotoWebDidDocumentResolver(),
+			plc: new PlcDidDocumentResolver({ fetch: boundFetch }),
+			web: new AtprotoWebDidDocumentResolver({ fetch: boundFetch }),
 		},
 	});
 	return {
@@ -965,6 +965,11 @@ function createProductionDeps(env: Env): ConsumerDeps {
 			cache: createD1DidDocCache(env.DB),
 			resolver: composite,
 		}),
+		// PDS verify uses this fetch for the CAR fetch. workerd's `fetch`
+		// rejects calls made through a stored reference, so we hand off
+		// the bound wrapper rather than letting `pds-verify.ts` fall
+		// back to bare global `fetch`.
+		fetch: boundFetch,
 	};
 }
 

--- a/apps/aggregator/src/records-consumer.ts
+++ b/apps/aggregator/src/records-consumer.ts
@@ -392,12 +392,13 @@ export async function ingestPackageProfile(
 	}
 	const slug = record.slug ?? job.rkey;
 	const sigMeta = JSON.stringify({ cid: verified.cid });
+	const nowIso = now.toISOString();
 	await db
 		.prepare(
 			`INSERT INTO packages
 			   (did, slug, type, name, description, license, authors, security, keywords, sections,
-			    last_updated, latest_version, capabilities, record_blob, signature_metadata, verified_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			    last_updated, latest_version, capabilities, record_blob, signature_metadata, verified_at, indexed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(did, slug) DO UPDATE SET
 			   type = excluded.type,
 			   name = excluded.name,
@@ -411,6 +412,10 @@ export async function ingestPackageProfile(
 			   record_blob = excluded.record_blob,
 			   signature_metadata = excluded.signature_metadata,
 			   verified_at = excluded.verified_at`,
+			// indexed_at intentionally NOT in DO UPDATE SET — we want the
+			// first-observed timestamp preserved across re-ingest. SQLite's
+			// upsert leaves untouched columns alone, so omitting from SET
+			// keeps the original value.
 		)
 		.bind(
 			job.did,
@@ -428,7 +433,8 @@ export async function ingestPackageProfile(
 			null, // capabilities — populated by release writer
 			verified.carBytes,
 			sigMeta,
-			now.toISOString(),
+			nowIso,
+			nowIso, // indexed_at on first insert; preserved on conflict (see SQL comment)
 		)
 		.run();
 }
@@ -520,12 +526,13 @@ export async function ingestPackageRelease(
 	}
 
 	const sigMeta = JSON.stringify({ cid: verified.cid });
+	const nowIso = now.toISOString();
 	const insertStmt = db
 		.prepare(
 			`INSERT INTO releases
 			   (did, package, version, rkey, version_sort, artifacts, requires, suggests,
-			    emdash_extension, repo_url, cts, record_blob, signature_metadata, verified_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			    emdash_extension, repo_url, cts, record_blob, signature_metadata, verified_at, indexed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(did, package, version) DO NOTHING`,
 		)
 		.bind(
@@ -546,10 +553,14 @@ export async function ingestPackageRelease(
 			// has no creation-timestamp field today and the atproto MST commit
 			// rev isn't surfaced by verifyRecord. Tracked: revisit if the
 			// lexicon adds a createdAt or @atcute/repo exposes commit metadata.
-			now.toISOString(),
+			nowIso,
 			verified.carBytes,
 			sigMeta,
-			now.toISOString(),
+			nowIso,
+			// Releases use ON CONFLICT DO NOTHING (versions are immutable per
+			// FAIR PR #77), so indexed_at is only ever set on first insert —
+			// no preservation logic needed.
+			nowIso,
 		);
 
 	// Atomic with the refresh: D1 wraps a batch in a single transaction. If
@@ -745,12 +756,13 @@ export async function ingestPublisherProfile(
 		}
 	}
 	const sigMeta = JSON.stringify({ cid: verified.cid });
+	const nowIso = now.toISOString();
 	await db
 		.prepare(
 			`INSERT INTO publishers
 			   (did, display_name, description, url, contact, updated_at,
-			    record_blob, signature_metadata, verified_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			    record_blob, signature_metadata, verified_at, indexed_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(did) DO UPDATE SET
 			   display_name = excluded.display_name,
 			   description = excluded.description,
@@ -760,6 +772,8 @@ export async function ingestPublisherProfile(
 			   record_blob = excluded.record_blob,
 			   signature_metadata = excluded.signature_metadata,
 			   verified_at = excluded.verified_at`,
+			// indexed_at omitted from DO UPDATE SET — first-observed
+			// timestamp preserved across re-ingest. Same pattern as packages.
 		)
 		.bind(
 			job.did,
@@ -770,7 +784,8 @@ export async function ingestPublisherProfile(
 			record.updatedAt ?? null,
 			verified.carBytes,
 			sigMeta,
-			now.toISOString(),
+			nowIso,
+			nowIso,
 		)
 		.run();
 }
@@ -791,12 +806,13 @@ export async function ingestPublisherVerification(
 	}
 	const record = validation.value;
 	const sigMeta = JSON.stringify({ cid: verified.cid });
+	const nowIso = now.toISOString();
 	await db
 		.prepare(
 			`INSERT INTO publisher_verifications
 			   (issuer_did, rkey, subject_did, subject_handle, subject_display_name,
-			    created_at, expires_at, record_blob, signature_metadata, verified_at, tombstoned_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+			    created_at, expires_at, record_blob, signature_metadata, verified_at, indexed_at, tombstoned_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
 			 ON CONFLICT(issuer_did, rkey) DO UPDATE SET
 			   subject_did = excluded.subject_did,
 			   subject_handle = excluded.subject_handle,
@@ -807,6 +823,8 @@ export async function ingestPublisherVerification(
 			   signature_metadata = excluded.signature_metadata,
 			   verified_at = excluded.verified_at,
 			   tombstoned_at = NULL`,
+			// indexed_at omitted from DO UPDATE SET — same first-observed
+			// preservation as packages/publishers.
 		)
 		.bind(
 			job.did,
@@ -818,7 +836,8 @@ export async function ingestPublisherVerification(
 			record.expiresAt ?? null,
 			verified.carBytes,
 			sigMeta,
-			now.toISOString(),
+			nowIso,
+			nowIso,
 		)
 		.run();
 }

--- a/apps/aggregator/src/records-do.ts
+++ b/apps/aggregator/src/records-do.ts
@@ -19,6 +19,30 @@ import { DurableObject } from "cloudflare:workers";
 import { RealJetstreamClient } from "./jetstream-client.js";
 import { JetstreamIngestor, type IngestorStorage } from "./jetstream-ingestor.js";
 
+/** SQL `time_us` floor across the four content tables. Microseconds since
+ * epoch (Jetstream's cursor unit). Returns null when no rows exist
+ * (truly fresh install) so the subscription falls back to its own
+ * "now" default — there's nothing to gap-fill for. */
+async function deriveJetstreamCursorFloor(db: D1Database): Promise<number | null> {
+	const row = await db
+		.prepare(
+			`SELECT MAX(t) AS latest FROM (
+				SELECT MAX(verified_at) AS t FROM packages
+				UNION ALL
+				SELECT MAX(verified_at) AS t FROM releases
+				UNION ALL
+				SELECT MAX(verified_at) AS t FROM publishers
+				UNION ALL
+				SELECT MAX(verified_at) AS t FROM publisher_verifications
+			)`,
+		)
+		.first<{ latest: string | null }>();
+	if (!row?.latest) return null;
+	const ms = new Date(row.latest).getTime();
+	if (!Number.isFinite(ms)) return null;
+	return ms * 1000;
+}
+
 /** Singleton DO ID. There's exactly one ingestor per deployment. */
 export const RECORDS_DO_NAME = "main";
 
@@ -33,6 +57,7 @@ export class RecordsJetstreamDO extends DurableObject {
 			client: new RealJetstreamClient(env.JETSTREAM_URL),
 			queue: env.RECORDS_QUEUE,
 			storage: wrapDoStorage(state.storage),
+			cursorFloor: () => deriveJetstreamCursorFloor(env.DB),
 		});
 		// Fire-and-forget. The run loop absorbs every error path internally
 		// today (transient queue failures, connection drops, parse errors

--- a/apps/aggregator/src/routes/xrpc/cursor.ts
+++ b/apps/aggregator/src/routes/xrpc/cursor.ts
@@ -4,17 +4,30 @@
  * Cursors are opaque base64url strings to clients; internally they encode
  * a small JSON object specific to the endpoint's ORDER BY clause. We use
  * different shapes for different endpoints (list cursors carry sort
- * keys; offset cursors carry an integer) — keep each endpoint's encoder
- * paired with its decoder.
+ * keys; offset cursors carry an integer).
  *
- * `decode*` functions accept `undefined` for "no cursor" and never throw.
- * A malformed cursor (forged, base64 garbage, or carrying an unexpected
- * shape) returns `null`, which callers treat as "start from the
- * beginning". Throwing would let a client attacker DOS by sending bad
- * cursors; silently restarting is safer than 400ing.
+ * Decode discipline: an *absent* cursor (`undefined`) means "first page".
+ * A *provided* cursor that fails to decode throws `InvalidCursorError`,
+ * which handlers translate into a 400 InvalidRequest. Earlier drafts
+ * silently restarted on bad cursors to defend against DOS via forged
+ * cursors, but that policy lets a legitimate client (with a corrupted
+ * cursor from URL-encoding mishaps, mid-rollout schema changes, etc.)
+ * loop forever re-fetching page 1 thinking they're paginating. The DOS
+ * argument doesn't apply because the workload is bounded by `limit`
+ * regardless. Throw loud, fail fast.
+ *
+ * Offset cursors additionally cap `offset` to `MAX_OFFSET` so a forged
+ * cursor with a wildly large offset can't trigger an arbitrarily deep
+ * SQL scan. Real clients never paginate that deep.
  */
 
 import { isPlainObject } from "../../utils.js";
+
+/** Throw when a *provided* cursor fails to decode. Handler catches and
+ * converts to 400 InvalidRequest. */
+export class InvalidCursorError extends Error {
+	override readonly name = "InvalidCursorError";
+}
 
 interface ListCursor {
 	versionSort: string;
@@ -27,21 +40,33 @@ export function encodeListCursor(cursor: ListCursor): string {
 
 export function decodeListCursor(raw: string | undefined): ListCursor | null {
 	if (raw === undefined) return null;
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(base64UrlDecode(raw));
-		if (!isPlainObject(parsed)) return null;
-		const versionSort = parsed["versionSort"];
-		const version = parsed["version"];
-		if (typeof versionSort !== "string" || typeof version !== "string") return null;
-		return { versionSort, version };
+		parsed = JSON.parse(base64UrlDecode(raw));
 	} catch {
-		return null;
+		throw new InvalidCursorError("cursor is not a valid base64url-encoded JSON object");
 	}
+	if (!isPlainObject(parsed)) {
+		throw new InvalidCursorError("cursor must decode to a JSON object");
+	}
+	const versionSort = parsed["versionSort"];
+	const version = parsed["version"];
+	if (typeof versionSort !== "string" || typeof version !== "string") {
+		throw new InvalidCursorError("cursor must carry string `versionSort` and `version` fields");
+	}
+	return { versionSort, version };
 }
 
 interface OffsetCursor {
 	offset: number;
 }
+
+/** Cap on offset values accepted from a client cursor. Real pagination
+ * never reaches this depth — at the lexicon's `limit: 100` cap that's
+ * 100 pages of 100 results = 10k items; defaulting to `limit: 25` makes
+ * it 400 pages. Past that, a forged cursor is the more likely
+ * explanation than a legitimate client. */
+const MAX_OFFSET = 10_000;
 
 export function encodeOffsetCursor(cursor: OffsetCursor): string {
 	return base64UrlEncode(JSON.stringify(cursor));
@@ -49,15 +74,23 @@ export function encodeOffsetCursor(cursor: OffsetCursor): string {
 
 export function decodeOffsetCursor(raw: string | undefined): OffsetCursor | null {
 	if (raw === undefined) return null;
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(base64UrlDecode(raw));
-		if (!isPlainObject(parsed)) return null;
-		const offset = parsed["offset"];
-		if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) return null;
-		return { offset };
+		parsed = JSON.parse(base64UrlDecode(raw));
 	} catch {
-		return null;
+		throw new InvalidCursorError("cursor is not a valid base64url-encoded JSON object");
 	}
+	if (!isPlainObject(parsed)) {
+		throw new InvalidCursorError("cursor must decode to a JSON object");
+	}
+	const offset = parsed["offset"];
+	if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) {
+		throw new InvalidCursorError("cursor `offset` must be a non-negative integer");
+	}
+	if (offset > MAX_OFFSET) {
+		throw new InvalidCursorError(`cursor offset exceeds maximum (${MAX_OFFSET})`);
+	}
+	return { offset };
 }
 
 const BASE64URL_PLUS = /\+/g;

--- a/apps/aggregator/src/routes/xrpc/cursor.ts
+++ b/apps/aggregator/src/routes/xrpc/cursor.ts
@@ -1,0 +1,93 @@
+/**
+ * Cursor encoding for paginated XRPC responses.
+ *
+ * Cursors are opaque base64url strings to clients; internally they encode
+ * a small JSON object specific to the endpoint's ORDER BY clause. We use
+ * different shapes for different endpoints (list cursors carry sort
+ * keys; offset cursors carry an integer) — keep each endpoint's encoder
+ * paired with its decoder.
+ *
+ * `decode*` functions accept `undefined` for "no cursor" and never throw.
+ * A malformed cursor (forged, base64 garbage, or carrying an unexpected
+ * shape) returns `null`, which callers treat as "start from the
+ * beginning". Throwing would let a client attacker DOS by sending bad
+ * cursors; silently restarting is safer than 400ing.
+ */
+
+import { isPlainObject } from "../../utils.js";
+
+interface ListCursor {
+	versionSort: string;
+	version: string;
+}
+
+export function encodeListCursor(cursor: ListCursor): string {
+	return base64UrlEncode(JSON.stringify(cursor));
+}
+
+export function decodeListCursor(raw: string | undefined): ListCursor | null {
+	if (raw === undefined) return null;
+	try {
+		const parsed: unknown = JSON.parse(base64UrlDecode(raw));
+		if (!isPlainObject(parsed)) return null;
+		const versionSort = parsed["versionSort"];
+		const version = parsed["version"];
+		if (typeof versionSort !== "string" || typeof version !== "string") return null;
+		return { versionSort, version };
+	} catch {
+		return null;
+	}
+}
+
+interface OffsetCursor {
+	offset: number;
+}
+
+export function encodeOffsetCursor(cursor: OffsetCursor): string {
+	return base64UrlEncode(JSON.stringify(cursor));
+}
+
+export function decodeOffsetCursor(raw: string | undefined): OffsetCursor | null {
+	if (raw === undefined) return null;
+	try {
+		const parsed: unknown = JSON.parse(base64UrlDecode(raw));
+		if (!isPlainObject(parsed)) return null;
+		const offset = parsed["offset"];
+		if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) return null;
+		return { offset };
+	} catch {
+		return null;
+	}
+}
+
+const BASE64URL_PLUS = /\+/g;
+const BASE64URL_SLASH = /\//g;
+const BASE64URL_TRAILING_EQUALS = /=+$/;
+const BASE64URL_DASH = /-/g;
+const BASE64URL_UNDERSCORE = /_/g;
+
+function base64UrlEncode(value: string): string {
+	// btoa needs latin-1; encode UTF-8 first via TextEncoder.
+	const bytes = new TextEncoder().encode(value);
+	let str = "";
+	for (let i = 0; i < bytes.length; i++) {
+		const byte = bytes[i];
+		if (byte === undefined) continue;
+		str += String.fromCharCode(byte);
+	}
+	return btoa(str)
+		.replace(BASE64URL_PLUS, "-")
+		.replace(BASE64URL_SLASH, "_")
+		.replace(BASE64URL_TRAILING_EQUALS, "");
+}
+
+function base64UrlDecode(value: string): string {
+	const padded = value
+		.replace(BASE64URL_DASH, "+")
+		.replace(BASE64URL_UNDERSCORE, "/")
+		.padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
+	const binary = atob(padded);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return new TextDecoder().decode(bytes);
+}

--- a/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
+++ b/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
@@ -5,9 +5,16 @@
  *
  * The aggregator's writer maintains `packages.latest_version` denormalised
  * from each `releases` insert (see `refreshPackageLatestStmt` in
- * records-consumer.ts), so a single JOIN is sufficient — we don't compute
- * "latest" with an ORDER BY here. If the parent package doesn't exist, or
- * exists but has no eligible releases, returns `NotFound`.
+ * records-consumer.ts), so the fast path is a single JOIN. If that misses
+ * — typically because `latest_version` points at a release that was
+ * tombstoned after the pointer was written, and the refresh hasn't
+ * propagated yet (or failed transactionally) — we fall back to the
+ * authoritative ORDER BY query.
+ *
+ * Without the fallback, a tombstoned-but-still-pointed-at release would
+ * make this endpoint return `NotFound` even though the package
+ * demonstrably has other live releases (visible via `listReleases`). The
+ * denormalisation is an optimisation, not a correctness gate.
  */
 
 import { json, XRPCError } from "@atcute/xrpc-server";
@@ -20,12 +27,12 @@ export async function getLatestRelease(
 	params: AggregatorGetLatestRelease.$params,
 ): Promise<Response> {
 	const session = env.DB.withSession("first-primary");
-	// Single round-trip: pull the latest_version pointer from `packages` and
-	// the matching release row in one query. The tombstoned_at filter is the
-	// safety net — `latest_version` is updated by the writer to skip
-	// tombstones, but a race between tombstone-then-list could still hand
-	// back a stale pointer.
-	const row = await session
+
+	// Fast path: pull the latest_version pointer + matching release in one
+	// query. The tombstoned_at filter is the integrity gate — if the
+	// pointer is stale (release tombstoned, refresh pending), this misses
+	// and we fall through.
+	const fast = await session
 		.prepare(
 			`SELECT ${releaseColumns("r.")}
 			 FROM packages p
@@ -34,13 +41,27 @@ export async function getLatestRelease(
 		)
 		.bind(params.did, params.package)
 		.first<ReleaseRow>();
+	if (fast) return json(releaseView(fast));
 
-	if (!row) {
-		throw new XRPCError({
-			status: 404,
-			error: "NotFound",
-			message: `No eligible release for (${params.did}, ${params.package}).`,
-		});
-	}
-	return json(releaseView(row));
+	// Slow-path fallback: the authoritative ORDER BY. Costs an extra D1
+	// round-trip on the rare miss but guarantees we don't 404 on a package
+	// that has live releases. Tiebreakers (version, rkey) keep the result
+	// deterministic if version_sort ties, matching listReleases' ordering.
+	const slow = await session
+		.prepare(
+			`SELECT ${releaseColumns()}
+			 FROM releases
+			 WHERE did = ? AND package = ? AND tombstoned_at IS NULL
+			 ORDER BY version_sort DESC, version DESC, rkey DESC
+			 LIMIT 1`,
+		)
+		.bind(params.did, params.package)
+		.first<ReleaseRow>();
+	if (slow) return json(releaseView(slow));
+
+	throw new XRPCError({
+		status: 404,
+		error: "NotFound",
+		message: `No eligible release for (${params.did}, ${params.package}).`,
+	});
 }

--- a/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
+++ b/apps/aggregator/src/routes/xrpc/getLatestRelease.ts
@@ -1,0 +1,46 @@
+/**
+ * `com.emdashcms.experimental.aggregator.getLatestRelease` — single-release
+ * lookup that returns the highest-precedence non-tombstoned release for a
+ * (did, package).
+ *
+ * The aggregator's writer maintains `packages.latest_version` denormalised
+ * from each `releases` insert (see `refreshPackageLatestStmt` in
+ * records-consumer.ts), so a single JOIN is sufficient — we don't compute
+ * "latest" with an ORDER BY here. If the parent package doesn't exist, or
+ * exists but has no eligible releases, returns `NotFound`.
+ */
+
+import { json, XRPCError } from "@atcute/xrpc-server";
+import { type AggregatorGetLatestRelease } from "@emdash-cms/registry-lexicons";
+
+import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
+
+export async function getLatestRelease(
+	env: Env,
+	params: AggregatorGetLatestRelease.$params,
+): Promise<Response> {
+	const session = env.DB.withSession("first-primary");
+	// Single round-trip: pull the latest_version pointer from `packages` and
+	// the matching release row in one query. The tombstoned_at filter is the
+	// safety net — `latest_version` is updated by the writer to skip
+	// tombstones, but a race between tombstone-then-list could still hand
+	// back a stale pointer.
+	const row = await session
+		.prepare(
+			`SELECT ${releaseColumns("r.")}
+			 FROM packages p
+			 JOIN releases r ON r.did = p.did AND r.package = p.slug AND r.version = p.latest_version
+			 WHERE p.did = ? AND p.slug = ? AND r.tombstoned_at IS NULL`,
+		)
+		.bind(params.did, params.package)
+		.first<ReleaseRow>();
+
+	if (!row) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No eligible release for (${params.did}, ${params.package}).`,
+		});
+	}
+	return json(releaseView(row));
+}

--- a/apps/aggregator/src/routes/xrpc/getPackage.ts
+++ b/apps/aggregator/src/routes/xrpc/getPackage.ts
@@ -1,0 +1,38 @@
+/**
+ * `com.emdashcms.experimental.aggregator.getPackage` — single package by
+ * (did, slug). Returns the lexicon's `packageView` envelope (decoded
+ * record + cid + indexedAt + empty mirrors/labels).
+ *
+ * Throws `XRPCError("NotFound")` when no row matches. Tombstone is not a
+ * separate state on `packages` (deletes hard-delete the row), so a NotFound
+ * covers both cases — the lexicon's documented "Tombstoned" error name is
+ * reserved for if/when we move to soft-delete on packages.
+ */
+
+import { json, XRPCError } from "@atcute/xrpc-server";
+import { type AggregatorDefs, type AggregatorGetPackage } from "@emdash-cms/registry-lexicons";
+
+import { type PackageRow, packageColumns, packageView } from "./views.js";
+
+export async function getPackage(
+	env: Env,
+	params: AggregatorGetPackage.$params,
+): Promise<Response> {
+	// `first-primary` because the same row could become subject to a takedown
+	// label between two reads; once the labeller (Slice 2) writes, the next
+	// read everywhere should reflect it. Per plan §XRPC endpoints.
+	const session = env.DB.withSession("first-primary");
+	const row = await session
+		.prepare(`SELECT ${packageColumns()} FROM packages WHERE did = ? AND slug = ?`)
+		.bind(params.did, params.slug)
+		.first<PackageRow>();
+	if (!row) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under (${params.did}, ${params.slug}).`,
+		});
+	}
+	const view: AggregatorDefs.PackageView = packageView(row);
+	return json(view);
+}

--- a/apps/aggregator/src/routes/xrpc/listReleases.ts
+++ b/apps/aggregator/src/routes/xrpc/listReleases.ts
@@ -10,10 +10,10 @@
  * (did, package)".
  */
 
-import { json, XRPCError } from "@atcute/xrpc-server";
+import { InvalidRequestError, json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorDefs, type AggregatorListReleases } from "@emdash-cms/registry-lexicons";
 
-import { decodeListCursor, encodeListCursor } from "./cursor.js";
+import { decodeListCursor, encodeListCursor, InvalidCursorError } from "./cursor.js";
 import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
 
 const DEFAULT_LIMIT = 25;
@@ -46,8 +46,17 @@ export async function listReleases(
 	// Cursor encodes the LAST seen (version_sort, version) on the previous
 	// page so the next page picks up below it in DESC order. `WHERE`
 	// half-tuple inequality so SQLite's index on (did, package, version_sort
-	// DESC) stays useful.
-	const cursor = decodeListCursor(params.cursor);
+	// DESC) stays useful. A *provided* cursor that fails to decode 400s
+	// (would otherwise loop the client through page 1 forever).
+	let cursor: ReturnType<typeof decodeListCursor>;
+	try {
+		cursor = decodeListCursor(params.cursor);
+	} catch (err) {
+		if (err instanceof InvalidCursorError) {
+			throw new InvalidRequestError({ error: "InvalidRequest", message: err.message });
+		}
+		throw err;
+	}
 	const rows = await session
 		.prepare(
 			`SELECT ${releaseColumns()}, version_sort
@@ -84,6 +93,12 @@ export async function listReleases(
 		releases: page.map(releaseView),
 	};
 	if (hasMore && last) {
+		// Cursor encodes the internal `version_sort` format. If the
+		// `computeVersionSort` encoding ever changes, in-flight cursors
+		// will be cursor-incompatible across the deploy — clients will
+		// 400 (per the strict-cursor policy) and fall back to fetching
+		// page 1. Acceptable for the experimental NSID; revisit if/when
+		// we stabilise.
 		response.cursor = encodeListCursor({ versionSort: last.version_sort, version: last.version });
 	}
 	return json(response);

--- a/apps/aggregator/src/routes/xrpc/listReleases.ts
+++ b/apps/aggregator/src/routes/xrpc/listReleases.ts
@@ -1,0 +1,97 @@
+/**
+ * `com.emdashcms.experimental.aggregator.listReleases` — releases for a
+ * (did, package), descending semver. Cursor pagination over
+ * `(version_sort, version)` so tied semver-precedence cases (shouldn't
+ * happen in practice but defensive) still page deterministically.
+ *
+ * Returns `NotFound` when the parent package isn't indexed, even if a
+ * (orphaned) release row exists — the lexicon's contract is "list
+ * releases of a known package", not "list any release rows for this
+ * (did, package)".
+ */
+
+import { json, XRPCError } from "@atcute/xrpc-server";
+import { type AggregatorDefs, type AggregatorListReleases } from "@emdash-cms/registry-lexicons";
+
+import { decodeListCursor, encodeListCursor } from "./cursor.js";
+import { type ReleaseRow, releaseColumns, releaseView } from "./views.js";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function listReleases(
+	env: Env,
+	params: AggregatorListReleases.$params,
+): Promise<Response> {
+	const limit = clampLimit(params.limit);
+	const session = env.DB.withSession("first-primary");
+
+	// Confirm parent package exists. One extra D1 read per request — could be
+	// folded into a JOIN, but the explicit existence check keeps the NotFound
+	// signal cheap and unambiguous (the empty-list response shape would
+	// otherwise mean "package exists, no releases" or "package doesn't exist"
+	// indistinguishably).
+	const parentExists = await session
+		.prepare(`SELECT 1 AS hit FROM packages WHERE did = ? AND slug = ?`)
+		.bind(params.did, params.package)
+		.first<{ hit: number }>();
+	if (!parentExists) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under (${params.did}, ${params.package}).`,
+		});
+	}
+
+	// Cursor encodes the LAST seen (version_sort, version) on the previous
+	// page so the next page picks up below it in DESC order. `WHERE`
+	// half-tuple inequality so SQLite's index on (did, package, version_sort
+	// DESC) stays useful.
+	const cursor = decodeListCursor(params.cursor);
+	const rows = await session
+		.prepare(
+			`SELECT ${releaseColumns()}, version_sort
+			 FROM releases
+			 WHERE did = ? AND package = ? AND tombstoned_at IS NULL
+			 ${cursor ? "AND (version_sort < ? OR (version_sort = ? AND version < ?))" : ""}
+			 ORDER BY version_sort DESC, version DESC
+			 LIMIT ?`,
+		)
+		.bind(
+			...(cursor
+				? [
+						params.did,
+						params.package,
+						cursor.versionSort,
+						cursor.versionSort,
+						cursor.version,
+						limit + 1,
+					]
+				: [params.did, params.package, limit + 1]),
+		)
+		.all<ReleaseRow & { version_sort: string }>();
+
+	const items = rows.results ?? [];
+	// Read limit+1 to detect a next page without a trailing COUNT query.
+	const hasMore = items.length > limit;
+	const page = hasMore ? items.slice(0, limit) : items;
+	const last = page.at(-1);
+
+	const response: {
+		releases: AggregatorDefs.ReleaseView[];
+		cursor?: string;
+	} = {
+		releases: page.map(releaseView),
+	};
+	if (hasMore && last) {
+		response.cursor = encodeListCursor({ versionSort: last.version_sort, version: last.version });
+	}
+	return json(response);
+}
+
+function clampLimit(raw: number | undefined): number {
+	if (raw === undefined) return DEFAULT_LIMIT;
+	if (raw < 1) return 1;
+	if (raw > MAX_LIMIT) return MAX_LIMIT;
+	return raw;
+}

--- a/apps/aggregator/src/routes/xrpc/resolvePackage.ts
+++ b/apps/aggregator/src/routes/xrpc/resolvePackage.ts
@@ -1,0 +1,81 @@
+/**
+ * `com.emdashcms.experimental.aggregator.resolvePackage` — handle/slug →
+ * package view. Convenience wrapper that:
+ *
+ *   1. Resolves the handle to a DID via the publisher's DID document.
+ *   2. Looks up the package by (resolved DID, slug).
+ *
+ * Throws `HandleNotFound` when handle resolution fails (publisher's
+ * `_atproto` TXT record / `.well-known/atproto-did` file missing or
+ * mismatched). Throws `NotFound` when handle resolves but no package is
+ * indexed under (did, slug).
+ *
+ * Resolution path: bidirectional handle resolution per atproto spec
+ * (`@atcute/identity-resolver`'s `HandleResolver`). We deliberately don't
+ * cache the handle→DID mapping at the aggregator: handles are mutable and
+ * resolvable on every request keeps the contract honest. If/when this
+ * becomes a hot path, add a short-TTL cache here keyed by handle.
+ */
+
+import {
+	CompositeHandleResolver,
+	DohJsonHandleResolver,
+	WellKnownHandleResolver,
+} from "@atcute/identity-resolver";
+import { json, XRPCError } from "@atcute/xrpc-server";
+import { type AggregatorResolvePackage } from "@emdash-cms/registry-lexicons";
+
+import { type PackageRow, packageColumns, packageView } from "./views.js";
+
+/** Cache the resolver per worker isolate. Construction is allocation-only
+ * (no I/O), but reusing a single instance avoids per-request setup. */
+let cachedResolver: CompositeHandleResolver | null = null;
+function getHandleResolver(): CompositeHandleResolver {
+	if (!cachedResolver) {
+		cachedResolver = new CompositeHandleResolver({
+			strategy: "race",
+			methods: {
+				dns: new DohJsonHandleResolver({ dohUrl: "https://mozilla.cloudflare-dns.com/dns-query" }),
+				http: new WellKnownHandleResolver(),
+			},
+		});
+	}
+	return cachedResolver;
+}
+
+export async function resolvePackage(
+	env: Env,
+	params: AggregatorResolvePackage.$params,
+): Promise<Response> {
+	let did: string;
+	try {
+		// Lexicon validates `handle` format upstream so `params.handle` is
+		// already typed `${string}.${string}`, which structurally satisfies
+		// the resolver's `Handle` parameter — no cast needed.
+		did = await getHandleResolver().resolve(params.handle);
+	} catch (err) {
+		throw new XRPCError({
+			status: 404,
+			error: "HandleNotFound",
+			message: `Could not resolve handle '${params.handle}': ${err instanceof Error ? err.message : String(err)}`,
+		});
+	}
+
+	const session = env.DB.withSession("first-primary");
+	const row = await session
+		.prepare(`SELECT ${packageColumns()} FROM packages WHERE did = ? AND slug = ?`)
+		.bind(did, params.slug)
+		.first<PackageRow>();
+	if (!row) {
+		throw new XRPCError({
+			status: 404,
+			error: "NotFound",
+			message: `No package indexed under resolved (${did}, ${params.slug}).`,
+		});
+	}
+	const view = packageView(row);
+	// Surface the handle we resolved — the lexicon's view has an optional
+	// `handle` field for exactly this case (best-effort current handle).
+	view.handle = params.handle;
+	return json(view);
+}

--- a/apps/aggregator/src/routes/xrpc/resolvePackage.ts
+++ b/apps/aggregator/src/routes/xrpc/resolvePackage.ts
@@ -25,6 +25,7 @@ import {
 import { json, XRPCError } from "@atcute/xrpc-server";
 import { type AggregatorResolvePackage } from "@emdash-cms/registry-lexicons";
 
+import { boundFetch } from "../../utils.js";
 import { type PackageRow, packageColumns, packageView } from "./views.js";
 
 /** Cache the resolver per worker isolate. Construction is allocation-only
@@ -35,8 +36,11 @@ function getHandleResolver(): CompositeHandleResolver {
 		cachedResolver = new CompositeHandleResolver({
 			strategy: "race",
 			methods: {
-				dns: new DohJsonHandleResolver({ dohUrl: "https://mozilla.cloudflare-dns.com/dns-query" }),
-				http: new WellKnownHandleResolver(),
+				dns: new DohJsonHandleResolver({
+					dohUrl: "https://mozilla.cloudflare-dns.com/dns-query",
+					fetch: boundFetch,
+				}),
+				http: new WellKnownHandleResolver({ fetch: boundFetch }),
 			},
 		});
 	}

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -1,0 +1,103 @@
+/**
+ * XRPC dispatcher for the aggregator's read API.
+ *
+ * Aggregator endpoints (`com.emdashcms.experimental.aggregator.*`) flow
+ * through `@atcute/xrpc-server`'s typed router — handlers receive
+ * lexicon-validated `params` and return `JSONResponse<…>` typed against
+ * the lexicon's output schema. The router handles 400 (bad params),
+ * 404 (no handler), and 500 (unexpected throw) automatically; handlers
+ * throw `XRPCError` for typed application errors (`NotFound`, etc.).
+ *
+ * `com.atproto.sync.getRecord` is intercepted *before* the router because
+ * we don't have a generated lexicon binding for atproto's own NSIDs and
+ * the response is `application/vnd.ipld.car` not JSON. See
+ * `sync-get-record.ts`.
+ *
+ * Caching headers:
+ *   - All aggregator endpoints: `private, no-store` (label-state can change
+ *     at any time and Cloudflare's Cache API is colo-local — see plan
+ *     §Caching).
+ *   - `sync.getRecord`: `public, max-age=300` set on the response itself
+ *     (immutable bytes).
+ */
+
+import { XRPCRouter } from "@atcute/xrpc-server";
+import {
+	AggregatorGetLatestRelease,
+	AggregatorGetPackage,
+	AggregatorListReleases,
+	AggregatorResolvePackage,
+	AggregatorSearchPackages,
+} from "@emdash-cms/registry-lexicons";
+
+import { getLatestRelease } from "./getLatestRelease.js";
+import { getPackage } from "./getPackage.js";
+import { listReleases } from "./listReleases.js";
+import { resolvePackage } from "./resolvePackage.js";
+import { searchPackages } from "./searchPackages.js";
+import { syncGetRecord } from "./sync-get-record.js";
+
+const NO_STORE = "private, no-store";
+const SYNC_GET_RECORD_PATH = "/xrpc/com.atproto.sync.getRecord";
+
+/**
+ * Dispatch any `/xrpc/*` request. Returns null when the path isn't an
+ * XRPC route (caller falls through to other route matching).
+ */
+export async function handleXrpc(env: Env, request: Request): Promise<Response | null> {
+	const url = new URL(request.url);
+	if (!url.pathname.startsWith("/xrpc/")) return null;
+
+	if (url.pathname === SYNC_GET_RECORD_PATH) {
+		return syncGetRecord(env, request);
+	}
+
+	const router = getRouter(env);
+	const response = await router.fetch(request);
+	// Override Cache-Control unconditionally on aggregator endpoints — the
+	// router doesn't set one and the takedown story requires `no-store`
+	// regardless of which endpoint responded. Cloning so we don't mutate
+	// a frozen Response from `json()`.
+	const headers = new Headers(response.headers);
+	headers.set("cache-control", NO_STORE);
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+}
+
+/** Cache the router per worker isolate. Construction registers handler
+ * closures that capture `env`; env is stable across requests within an
+ * isolate so single-instance is fine. */
+let cachedRouter: XRPCRouter | null = null;
+let cachedEnvRef: Env | null = null;
+function getRouter(env: Env): XRPCRouter {
+	// If somehow re-invoked with a different env reference (shouldn't happen
+	// in workerd but cheap to guard), rebuild — better than serving stale
+	// closures pointing at a swapped-out env.
+	if (cachedRouter && cachedEnvRef === env) return cachedRouter;
+	cachedRouter = createRouter(env);
+	cachedEnvRef = env;
+	return cachedRouter;
+}
+
+function createRouter(env: Env): XRPCRouter {
+	const router = new XRPCRouter();
+	router.addQuery(AggregatorGetPackage.mainSchema, {
+		handler: ({ params }) => getPackage(env, params),
+	});
+	router.addQuery(AggregatorListReleases.mainSchema, {
+		handler: ({ params }) => listReleases(env, params),
+	});
+	router.addQuery(AggregatorGetLatestRelease.mainSchema, {
+		handler: ({ params }) => getLatestRelease(env, params),
+	});
+	router.addQuery(AggregatorSearchPackages.mainSchema, {
+		handler: ({ params }) => searchPackages(env, params),
+	});
+	router.addQuery(AggregatorResolvePackage.mainSchema, {
+		handler: ({ params }) => resolvePackage(env, params),
+	});
+	return router;
+}

--- a/apps/aggregator/src/routes/xrpc/router.ts
+++ b/apps/aggregator/src/routes/xrpc/router.ts
@@ -55,9 +55,12 @@ export async function handleXrpc(env: Env, request: Request): Promise<Response |
 	const router = getRouter(env);
 	const response = await router.fetch(request);
 	// Override Cache-Control unconditionally on aggregator endpoints — the
-	// router doesn't set one and the takedown story requires `no-store`
-	// regardless of which endpoint responded. Cloning so we don't mutate
-	// a frozen Response from `json()`.
+	// takedown story requires `no-store` regardless of which endpoint
+	// responded, and it's deliberately not per-handler-overridable (a
+	// future endpoint that wants public caching has to be intercepted
+	// before the router, like sync.getRecord, where the cache contract
+	// can be reasoned about end-to-end). Cloning so we don't mutate a
+	// frozen Response from `json()`.
 	const headers = new Headers(response.headers);
 	headers.set("cache-control", NO_STORE);
 	return new Response(response.body, {

--- a/apps/aggregator/src/routes/xrpc/searchPackages.ts
+++ b/apps/aggregator/src/routes/xrpc/searchPackages.ts
@@ -1,0 +1,173 @@
+/**
+ * `com.emdashcms.experimental.aggregator.searchPackages` — FTS5 search over
+ * `packages_fts` with optional capability filter.
+ *
+ * Pagination: offset-based (cursor encodes `{offset}`), since BM25 ranking
+ * isn't stable across queries — a cursor encoding `(rank, slug)` would
+ * misbehave if the corpus changed between calls. Offset is the simplest
+ * stable pagination contract for ranked search; the trade is that deep
+ * pagination scans more rows. At Slice 1 scale (hundreds of packages) it's
+ * a non-issue.
+ *
+ * Takedown filter joins `label_state` even though that table is empty in
+ * Slice 1 — keeps the contract honest for Slice 2 (when the labeller starts
+ * writing), and the optimiser short-circuits the NOT EXISTS subquery
+ * cheaply when no rows match. See plan §Search.
+ *
+ * `q` is passed directly to FTS5 MATCH. Special characters in user input
+ * are escaped via `quoteFtsQuery` so a stray `"`/`*`/`(` doesn't blow up
+ * the FTS parser. Empty query returns all packages (paginated, ordered by
+ * last_updated DESC) — the lexicon's documented behaviour.
+ */
+
+import { json } from "@atcute/xrpc-server";
+import {
+	type AggregatorDefs,
+	NSID,
+	type AggregatorSearchPackages,
+} from "@emdash-cms/registry-lexicons";
+
+import { decodeOffsetCursor, encodeOffsetCursor } from "./cursor.js";
+import { type PackageRow, packageColumns, packageView } from "./views.js";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function searchPackages(
+	env: Env,
+	params: AggregatorSearchPackages.$params,
+): Promise<Response> {
+	const limit = clampLimit(params.limit);
+	const offset = decodeOffsetCursor(params.cursor)?.offset ?? 0;
+	const session = env.DB.withSession("first-primary");
+
+	const hasQuery = typeof params.q === "string" && params.q.trim().length > 0;
+	const hasCapability = typeof params.capability === "string" && params.capability.length > 0;
+
+	let rows: PackageRow[];
+	if (hasQuery) {
+		const ftsQuery = quoteFtsQuery(params.q!);
+		const result = await session
+			.prepare(buildFtsSearchSql(hasCapability))
+			.bind(
+				...buildFtsBindings(
+					ftsQuery,
+					hasCapability ? params.capability : undefined,
+					limit + 1,
+					offset,
+				),
+			)
+			.all<PackageRow>();
+		rows = result.results ?? [];
+	} else {
+		// No query → ordered list of all packages, label-filtered. last_updated
+		// DESC keeps the "what's new" view sensible for an empty search box.
+		const result = await session
+			.prepare(buildBrowseSql(hasCapability))
+			.bind(
+				...buildBrowseBindings(hasCapability ? params.capability : undefined, limit + 1, offset),
+			)
+			.all<PackageRow>();
+		rows = result.results ?? [];
+	}
+
+	const hasMore = rows.length > limit;
+	const page = hasMore ? rows.slice(0, limit) : rows;
+
+	const response: {
+		packages: AggregatorDefs.PackageView[];
+		cursor?: string;
+	} = {
+		packages: page.map(packageView),
+	};
+	if (hasMore) response.cursor = encodeOffsetCursor({ offset: offset + limit });
+	return json(response);
+}
+
+function buildFtsSearchSql(hasCapability: boolean): string {
+	return `
+		SELECT ${packageColumns("p.")}
+		FROM packages_fts
+		JOIN packages p ON p.rowid = packages_fts.rowid
+		WHERE packages_fts MATCH ?
+		${ENFORCEMENT_FILTER_SQL}
+		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
+		ORDER BY bm25(packages_fts), p.last_updated DESC
+		LIMIT ? OFFSET ?
+	`;
+}
+
+function buildFtsBindings(
+	ftsQuery: string,
+	capability: string | undefined,
+	limit: number,
+	offset: number,
+): unknown[] {
+	const out: unknown[] = [ftsQuery];
+	if (capability !== undefined) out.push(capability);
+	out.push(limit, offset);
+	return out;
+}
+
+function buildBrowseSql(hasCapability: boolean): string {
+	return `
+		SELECT ${packageColumns("p.")}
+		FROM packages p
+		WHERE 1=1
+		${ENFORCEMENT_FILTER_SQL}
+		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
+		ORDER BY p.last_updated DESC
+		LIMIT ? OFFSET ?
+	`;
+}
+
+function buildBrowseBindings(
+	capability: string | undefined,
+	limit: number,
+	offset: number,
+): unknown[] {
+	const out: unknown[] = [];
+	if (capability !== undefined) out.push(capability);
+	out.push(limit, offset);
+	return out;
+}
+
+/** Hard-enforcement label filter. The Slice 2 labeller writes to
+ * `label_state`; until then the table is empty so this clause is a no-op
+ * (the NOT EXISTS short-circuits). The plan calls for shipping the filter
+ * now to lock the contract — adding it later would be a behaviour change
+ * for cached clients. */
+const ENFORCEMENT_FILTER_SQL = `
+	AND NOT EXISTS (
+		SELECT 1 FROM label_state ls
+		WHERE ls.uri = 'at://' || p.did || '/${NSID.packageProfile}/' || p.slug
+		  AND ls.val IN ('!takedown', 'security:yanked')
+		  AND ls.trusted = 1
+		  AND ls.neg = 0
+		  AND (ls.exp IS NULL OR ls.exp > strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+	)
+`;
+
+const CAPABILITY_FILTER_SQL = `
+	AND p.capabilities IS NOT NULL
+	AND EXISTS (SELECT 1 FROM json_each(p.capabilities) WHERE value = ?)
+`;
+
+/** Quote a user-supplied search string for FTS5 MATCH. FTS5 treats `"`,
+ * `*`, `(`, `)`, `.`, `:`, `^`, `+`, `-` as syntax. The simplest robust
+ * escape is to wrap the whole query as a single phrase string and double
+ * any embedded quotes. This loses prefix-search functionality
+ * (`"foo*"` is treated literally) but is safe and sufficient for v1; if
+ * advanced query syntax becomes a product feature we'll layer a parsed
+ * mode on top. */
+const FTS_QUOTE_RE = /"/g;
+function quoteFtsQuery(raw: string): string {
+	return `"${raw.replace(FTS_QUOTE_RE, '""')}"`;
+}
+
+function clampLimit(raw: number | undefined): number {
+	if (raw === undefined) return DEFAULT_LIMIT;
+	if (raw < 1) return 1;
+	if (raw > MAX_LIMIT) return MAX_LIMIT;
+	return raw;
+}

--- a/apps/aggregator/src/routes/xrpc/searchPackages.ts
+++ b/apps/aggregator/src/routes/xrpc/searchPackages.ts
@@ -20,14 +20,14 @@
  * last_updated DESC) — the lexicon's documented behaviour.
  */
 
-import { json } from "@atcute/xrpc-server";
+import { InvalidRequestError, json } from "@atcute/xrpc-server";
 import {
 	type AggregatorDefs,
 	NSID,
 	type AggregatorSearchPackages,
 } from "@emdash-cms/registry-lexicons";
 
-import { decodeOffsetCursor, encodeOffsetCursor } from "./cursor.js";
+import { decodeOffsetCursor, encodeOffsetCursor, InvalidCursorError } from "./cursor.js";
 import { type PackageRow, packageColumns, packageView } from "./views.js";
 
 const DEFAULT_LIMIT = 25;
@@ -38,7 +38,15 @@ export async function searchPackages(
 	params: AggregatorSearchPackages.$params,
 ): Promise<Response> {
 	const limit = clampLimit(params.limit);
-	const offset = decodeOffsetCursor(params.cursor)?.offset ?? 0;
+	let offset: number;
+	try {
+		offset = decodeOffsetCursor(params.cursor)?.offset ?? 0;
+	} catch (err) {
+		if (err instanceof InvalidCursorError) {
+			throw new InvalidRequestError({ error: "InvalidRequest", message: err.message });
+		}
+		throw err;
+	}
 	const session = env.DB.withSession("first-primary");
 
 	const hasQuery = typeof params.q === "string" && params.q.trim().length > 0;
@@ -92,7 +100,7 @@ function buildFtsSearchSql(hasCapability: boolean): string {
 		WHERE packages_fts MATCH ?
 		${ENFORCEMENT_FILTER_SQL}
 		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
-		ORDER BY bm25(packages_fts), p.last_updated DESC
+		ORDER BY bm25(packages_fts), p.last_updated DESC, p.did ASC, p.slug ASC
 		LIMIT ? OFFSET ?
 	`;
 }
@@ -110,13 +118,18 @@ function buildFtsBindings(
 }
 
 function buildBrowseSql(hasCapability: boolean): string {
+	// Stable tiebreakers (did, slug) so offset pagination doesn't shuffle
+	// rows across pages when many packages share `last_updated` (or it's
+	// NULL — `last_updated` comes from the optional record.lastUpdated
+	// field). NULLS LAST keeps NULL `last_updated` rows out of the way
+	// of the freshness sort but still reachable via pagination.
 	return `
 		SELECT ${packageColumns("p.")}
 		FROM packages p
 		WHERE 1=1
 		${ENFORCEMENT_FILTER_SQL}
 		${hasCapability ? CAPABILITY_FILTER_SQL : ""}
-		ORDER BY p.last_updated DESC
+		ORDER BY p.last_updated IS NULL, p.last_updated DESC, p.did ASC, p.slug ASC
 		LIMIT ? OFFSET ?
 	`;
 }

--- a/apps/aggregator/src/routes/xrpc/sync-get-record.ts
+++ b/apps/aggregator/src/routes/xrpc/sync-get-record.ts
@@ -52,12 +52,17 @@ export async function syncGetRecord(env: Env, request: Request): Promise<Respons
 			`record not found for (${did}, ${collection}, ${rkey})`,
 		);
 	}
-	// Normalise to a fresh Uint8Array. D1 returns BLOBs as ArrayBuffer in
-	// production but as Uint8Array via miniflare in tests; copying through
-	// `new Uint8Array(buf)` covers both and produces the byte-stream shape
-	// workerd's Response constructor wants. (Without this normalisation,
-	// passing an `ArrayBuffer` directly works in production but trips
-	// miniflare's "ReadableStream did not return bytes" check.)
+	// Normalise to a Uint8Array view. D1 returns BLOBs as ArrayBuffer in
+	// production but as Uint8Array via miniflare in tests; wrapping in
+	// `new Uint8Array(buf)` produces the byte-stream shape workerd's
+	// Response constructor wants. (Without this normalisation, passing an
+	// `ArrayBuffer` directly works in production but trips miniflare's
+	// "ReadableStream did not return bytes" check.)
+	//
+	// `new Uint8Array(arrayBuffer)` *views* the buffer rather than copying.
+	// That's safe here because workerd buffers the entire body during
+	// Response construction (the body isn't streamed asynchronously back
+	// to the client over the lifetime of the underlying buffer).
 	const body = carBytes instanceof Uint8Array ? carBytes : new Uint8Array(carBytes);
 	return new Response(request.method === "HEAD" ? null : body, {
 		status: 200,

--- a/apps/aggregator/src/routes/xrpc/sync-get-record.ts
+++ b/apps/aggregator/src/routes/xrpc/sync-get-record.ts
@@ -1,0 +1,148 @@
+/**
+ * `com.atproto.sync.getRecord` — passthrough of stored CAR bytes.
+ *
+ * Slingshot-style behaviour: the aggregator is also a cached record store
+ * for the four collections it indexes. Install-time clients fetch the
+ * signed CAR from us instead of round-tripping to per-publisher PDSes —
+ * faster install, resilient when a publisher's PDS is slow/down, lower
+ * load on publisher PDSes.
+ *
+ * Trust model holds because clients re-verify the signature against the
+ * publisher's signing key (resolved independently from the DID document).
+ * The aggregator can serve stale or withhold but cannot forge.
+ *
+ * Implemented as a manual route rather than via @atcute/xrpc-server because
+ * we don't have a generated lexicon binding for atproto's
+ * `com.atproto.sync.getRecord` (it's atproto's, not ours), and the response
+ * is `application/vnd.ipld.car` not JSON. Wiring it through the typed
+ * router would mean authoring a stub lexicon for the sole purpose of
+ * registration, which is more code than this module.
+ */
+
+import { isDid } from "@atcute/lexicons/syntax";
+import { NSID } from "@emdash-cms/registry-lexicons";
+
+const CAR_CONTENT_TYPE = "application/vnd.ipld.car";
+/** 5 minutes. The CAR bytes are content-addressed (CID-derivable) so a
+ * stale cache is detectable client-side; we trade absolute freshness for
+ * lower aggregator load on the install-time hot path. Tighter than the
+ * aggregator endpoints (`no-store`) because there's no label-dependent
+ * filtering on this passthrough. */
+const CACHE_CONTROL = "public, max-age=300";
+
+interface ParsedQuery {
+	did: string;
+	collection: string;
+	rkey: string;
+}
+
+export async function syncGetRecord(env: Env, request: Request): Promise<Response> {
+	if (request.method !== "GET" && request.method !== "HEAD") {
+		return jsonError(405, "MethodNotAllowed", "method not allowed", { allow: "GET, HEAD" });
+	}
+	const parseResult = parseQuery(request);
+	if ("error" in parseResult) return parseResult.error;
+	const { did, collection, rkey } = parseResult;
+
+	const carBytes = await fetchRecordBlob(env, did, collection, rkey);
+	if (!carBytes) {
+		return jsonError(
+			404,
+			"RecordNotFound",
+			`record not found for (${did}, ${collection}, ${rkey})`,
+		);
+	}
+	// Normalise to a fresh Uint8Array. D1 returns BLOBs as ArrayBuffer in
+	// production but as Uint8Array via miniflare in tests; copying through
+	// `new Uint8Array(buf)` covers both and produces the byte-stream shape
+	// workerd's Response constructor wants. (Without this normalisation,
+	// passing an `ArrayBuffer` directly works in production but trips
+	// miniflare's "ReadableStream did not return bytes" check.)
+	const body = carBytes instanceof Uint8Array ? carBytes : new Uint8Array(carBytes);
+	return new Response(request.method === "HEAD" ? null : body, {
+		status: 200,
+		headers: {
+			"content-type": CAR_CONTENT_TYPE,
+			"content-length": String(body.byteLength),
+			"cache-control": CACHE_CONTROL,
+		},
+	});
+}
+
+function parseQuery(request: Request): ParsedQuery | { error: Response } {
+	const url = new URL(request.url);
+	const did = url.searchParams.get("did");
+	const collection = url.searchParams.get("collection");
+	const rkey = url.searchParams.get("rkey");
+	if (!did || !collection || !rkey) {
+		return {
+			error: jsonError(400, "InvalidRequest", "missing required param: did, collection, rkey"),
+		};
+	}
+	if (!isDid(did)) {
+		return { error: jsonError(400, "InvalidRequest", `invalid did: ${did}`) };
+	}
+	return { did, collection, rkey };
+}
+
+async function fetchRecordBlob(
+	env: Env,
+	did: string,
+	collection: string,
+	rkey: string,
+): Promise<ArrayBuffer | Uint8Array | null> {
+	// Cacheable read — `first-unconstrained` lets D1 hit the nearest
+	// replica. The CAR bytes are immutable per record version (the writer
+	// rejects content changes via CID-based dedup), so even a slightly stale
+	// replica returns the same bytes a primary would.
+	const session = env.DB.withSession("first-unconstrained");
+	switch (collection) {
+		case NSID.packageProfile:
+			return selectBlob(session, `SELECT record_blob FROM packages WHERE did = ? AND slug = ?`, [
+				did,
+				rkey,
+			]);
+		case NSID.packageRelease:
+			return selectBlob(
+				session,
+				`SELECT record_blob FROM releases WHERE did = ? AND rkey = ? AND tombstoned_at IS NULL`,
+				[did, rkey],
+			);
+		case NSID.publisherProfile:
+			// publisher.profile rkey is always 'self' per the writer's enforcement.
+			if (rkey !== "self") return null;
+			return selectBlob(session, `SELECT record_blob FROM publishers WHERE did = ?`, [did]);
+		case NSID.publisherVerification:
+			return selectBlob(
+				session,
+				`SELECT record_blob FROM publisher_verifications WHERE issuer_did = ? AND rkey = ? AND tombstoned_at IS NULL`,
+				[did, rkey],
+			);
+		default:
+			return null;
+	}
+}
+
+async function selectBlob(
+	session: D1DatabaseSession,
+	sql: string,
+	bindings: unknown[],
+): Promise<ArrayBuffer | Uint8Array | null> {
+	const row = await session
+		.prepare(sql)
+		.bind(...bindings)
+		.first<{ record_blob: ArrayBuffer | Uint8Array }>();
+	return row?.record_blob ?? null;
+}
+
+function jsonError(
+	status: number,
+	error: string,
+	message: string,
+	headers: Record<string, string> = {},
+): Response {
+	return new Response(JSON.stringify({ error, message }), {
+		status,
+		headers: { "content-type": "application/json", ...headers },
+	});
+}

--- a/apps/aggregator/src/routes/xrpc/views.ts
+++ b/apps/aggregator/src/routes/xrpc/views.ts
@@ -1,0 +1,247 @@
+/**
+ * Row → lexicon-view mappers for the Read API.
+ *
+ * The `packages` and `releases` tables are normalised projections of the
+ * signed records (with the raw CAR bytes also kept verbatim in
+ * `record_blob` for the `sync.getRecord` passthrough). The Read API needs
+ * to return a JSON shape that mirrors what the publisher signed — for
+ * display on the wire, with `cid` carried alongside so clients can re-verify
+ * against `sync.getRecord` if they want byte-identical bytes.
+ *
+ * These mappers are the single source of truth for that round-trip. Adding
+ * a new column to the schema means updating both the writer (in
+ * `records-consumer.ts`) and the relevant mapper here, in lock-step.
+ *
+ * Mirrors and labels: the lexicon allows them on both views; v1 always
+ * returns empty arrays. Mirror integration ships in Slice 3; label
+ * hydration ships in Slice 2. The contract is in place so adding either
+ * later doesn't change the response shape.
+ */
+
+import { type AggregatorDefs, NSID } from "@emdash-cms/registry-lexicons";
+
+import { isPlainObject, parseSignatureMetadataCid } from "../../utils.js";
+
+/** Subset of columns from `packages` we read for `packageView`. Selecting
+ * exactly these columns keeps the SQL query auditable and cheap. */
+export interface PackageRow {
+	did: string;
+	slug: string;
+	type: string;
+	name: string | null;
+	description: string | null;
+	license: string;
+	authors: string; // JSON array
+	security: string; // JSON array
+	keywords: string | null; // JSON array
+	sections: string | null; // JSON map
+	last_updated: string | null;
+	latest_version: string | null;
+	signature_metadata: string | null;
+	verified_at: string;
+	indexed_at: string | null;
+}
+
+/** Subset of columns from `releases` we read for `releaseView`. */
+export interface ReleaseRow {
+	did: string;
+	package: string;
+	version: string;
+	rkey: string;
+	artifacts: string; // JSON
+	requires: string | null; // JSON
+	suggests: string | null; // JSON
+	emdash_extension: string; // JSON of validated releaseExtension contents
+	repo_url: string | null;
+	signature_metadata: string | null;
+	verified_at: string;
+	indexed_at: string | null;
+}
+
+/** Column list backing `PackageRow`. Single source of truth so a column
+ * added to the schema needs writer + reader updates in one grep target. */
+const PACKAGE_VIEW_COLUMN_NAMES = [
+	"did",
+	"slug",
+	"type",
+	"name",
+	"description",
+	"license",
+	"authors",
+	"security",
+	"keywords",
+	"sections",
+	"last_updated",
+	"latest_version",
+	"signature_metadata",
+	"verified_at",
+	"indexed_at",
+] as const;
+
+/** Column list backing `ReleaseRow`. */
+const RELEASE_VIEW_COLUMN_NAMES = [
+	"did",
+	"package",
+	"version",
+	"rkey",
+	"artifacts",
+	"requires",
+	"suggests",
+	"emdash_extension",
+	"repo_url",
+	"signature_metadata",
+	"verified_at",
+	"indexed_at",
+] as const;
+
+/** SELECT-clause string for `PackageRow`. Pass an alias prefix (with the
+ * trailing dot) for use in JOINs: `packageColumns("p.")` →
+ * `"p.did, p.slug, ..."`. No prefix is unambiguous when only one table is
+ * in scope. */
+export function packageColumns(prefix = ""): string {
+	return PACKAGE_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
+}
+
+/** SELECT-clause string for `ReleaseRow`, optionally prefixed for JOINs. */
+export function releaseColumns(prefix = ""): string {
+	return RELEASE_VIEW_COLUMN_NAMES.map((c) => `${prefix}${c}`).join(", ");
+}
+
+/**
+ * Map a `packages` row to the lexicon's `packageView`. The synthesized
+ * `profile` field reconstructs the package.profile record JSON from the
+ * normalised columns — same field values the publisher signed. For
+ * byte-identical bytes, clients call `sync.getRecord` and re-verify.
+ *
+ * `indexedAt` falls back to `verified_at` for any historical row that
+ * predates migration 0002 (`indexed_at` is nullable at the schema level —
+ * see migration comment).
+ */
+export function packageView(row: PackageRow): AggregatorDefs.PackageView {
+	const uri = `at://${row.did}/${NSID.packageProfile}/${row.slug}` as const;
+	const cid = parseSignatureMetadataCid(row.signature_metadata) ?? "";
+	// `mirrors` is on releaseView, not packageView — packages aren't
+	// mirrored, releases are. Don't add it here even though they share the
+	// "envelope" idiom in plan-doc shorthand.
+	const view: AggregatorDefs.PackageView = {
+		uri,
+		cid,
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- `did` is consumer-validated at write time
+		did: row.did as `did:${string}:${string}`,
+		slug: row.slug,
+		profile: synthesizePackageProfile(row, uri),
+		indexedAt: row.indexed_at ?? row.verified_at,
+		labels: [],
+	};
+	if (row.latest_version !== null) {
+		view.latestVersion = row.latest_version;
+	}
+	return view;
+}
+
+/**
+ * Map a `releases` row to the lexicon's `releaseView`. The synthesized
+ * `release` field reconstructs the package.release record JSON from the
+ * normalised columns. `mirrors: []` is intentional — the artifact mirror
+ * worker (Slice 3) is what populates real mirror URLs; until then the
+ * field is the empty contract.
+ */
+export function releaseView(row: ReleaseRow): AggregatorDefs.ReleaseView {
+	const uri = `at://${row.did}/${NSID.packageRelease}/${row.rkey}` as const;
+	const cid = parseSignatureMetadataCid(row.signature_metadata) ?? "";
+	return {
+		uri,
+		cid,
+		// eslint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- `did` is consumer-validated at write time
+		did: row.did as `did:${string}:${string}`,
+		package: row.package,
+		version: row.version,
+		release: synthesizePackageRelease(row),
+		mirrors: [],
+		indexedAt: row.indexed_at ?? row.verified_at,
+		labels: [],
+	};
+}
+
+/** Reconstruct the `com.emdashcms.experimental.package.profile` record
+ * JSON from the row's columns. Field set matches what the consumer's
+ * `ingestPackageProfile` writer accepts; optional fields are omitted
+ * (rather than emitted as null) so the JSON shape matches what a
+ * publisher would have written.
+ *
+ * Returned as `Record<string, unknown>` rather than typed to the lexicon
+ * Main schema — the columns hold writer-validated JSON but TypeScript
+ * can't narrow `JSON.parse` output to the lexicon's structural types
+ * without re-validating, and the lexicon explicitly types `packageView.profile`
+ * as `unknown` for exactly this reason: the value is a passthrough on
+ * the wire and clients re-validate against the published lexicon. */
+function synthesizePackageProfile(row: PackageRow, uri: string): Record<string, unknown> {
+	const profile: Record<string, unknown> = {
+		$type: NSID.packageProfile,
+		id: uri,
+		type: row.type,
+		license: row.license,
+		authors: parseJsonArray(row.authors),
+		security: parseJsonArray(row.security),
+	};
+	if (row.name !== null) profile["name"] = row.name;
+	if (row.description !== null) profile["description"] = row.description;
+	if (row.keywords !== null) profile["keywords"] = parseJsonArray(row.keywords);
+	if (row.sections !== null) {
+		const sections = parseJsonObject(row.sections);
+		if (sections) profile["sections"] = sections;
+	}
+	if (row.last_updated !== null) profile["lastUpdated"] = row.last_updated;
+	// `slug` in the record is optional but, when present, must equal the
+	// rkey. We always have it as the PK of the row, so always emit.
+	profile["slug"] = row.slug;
+	return profile;
+}
+
+/** Reconstruct the `com.emdashcms.experimental.package.release` record
+ * JSON from the row's columns. The `extensions` map is rebuilt from the
+ * stored `emdash_extension` payload (which the writer validates against
+ * the `releaseExtension` lexicon at ingest time). Same passthrough-shape
+ * caveat as `synthesizePackageProfile`. */
+function synthesizePackageRelease(row: ReleaseRow): Record<string, unknown> {
+	const release: Record<string, unknown> = {
+		$type: NSID.packageRelease,
+		package: row.package,
+		version: row.version,
+		artifacts: parseJsonObject(row.artifacts) ?? {},
+	};
+	if (row.requires !== null) {
+		const requires = parseJsonObject(row.requires);
+		if (requires) release["requires"] = requires;
+	}
+	if (row.suggests !== null) {
+		const suggests = parseJsonObject(row.suggests);
+		if (suggests) release["suggests"] = suggests;
+	}
+	if (row.repo_url !== null) release["repo"] = row.repo_url;
+	const ext = parseJsonObject(row.emdash_extension);
+	if (ext) {
+		release["extensions"] = {
+			[NSID.packageReleaseExtension]: { ...ext, $type: NSID.packageReleaseExtension },
+		};
+	}
+	return release;
+}
+
+function parseJsonArray(json: string): unknown[] {
+	try {
+		const parsed: unknown = JSON.parse(json);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+function parseJsonObject(json: string): Record<string, unknown> | null {
+	try {
+		const parsed: unknown = JSON.parse(json);
+		return isPlainObject(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/aggregator/src/utils.ts
+++ b/apps/aggregator/src/utils.ts
@@ -13,6 +13,14 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 /**
+ * `globalThis.fetch` pre-bound. Pass this whenever a library wants a
+ * `fetch` callable (resolver constructors, deps objects); the bare
+ * global trips workerd's "Illegal invocation" check when called via a
+ * stored reference.
+ */
+export const boundFetch: typeof fetch = globalThis.fetch.bind(globalThis);
+
+/**
  * Pull the verified record's CID out of a JSON-stringified
  * `signature_metadata` column value. Returns null on malformed input
  * (missing column, non-JSON, missing `cid` key) — callers decide what

--- a/apps/aggregator/src/utils.ts
+++ b/apps/aggregator/src/utils.ts
@@ -11,3 +11,22 @@
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+
+/**
+ * Pull the verified record's CID out of a JSON-stringified
+ * `signature_metadata` column value. Returns null on malformed input
+ * (missing column, non-JSON, missing `cid` key) — callers decide what
+ * to do; in writer-controlled data this never happens, but the
+ * fallback keeps read-side comparisons robust against future schema
+ * drift.
+ */
+export function parseSignatureMetadataCid(signatureMetadata: string | null): string | null {
+	if (signatureMetadata === null) return null;
+	try {
+		const parsed: unknown = JSON.parse(signatureMetadata);
+		if (isPlainObject(parsed) && typeof parsed["cid"] === "string") return parsed["cid"];
+	} catch {
+		// fall through
+	}
+	return null;
+}

--- a/apps/aggregator/test/jetstream-ingestor.test.ts
+++ b/apps/aggregator/test/jetstream-ingestor.test.ts
@@ -194,6 +194,104 @@ describe("JetstreamIngestor", () => {
 		await runPromise;
 	});
 
+	it("seeds cursor from cursorFloor when storage is empty", async () => {
+		// DO storage is empty (fresh deploy / regional failover) but the
+		// cursorFloor callback supplies a time_us derived from D1 — typically
+		// MAX(verified_at) across content tables. The ingestor should adopt
+		// it AND persist it immediately so a crash before the first event
+		// doesn't re-derive on next run.
+		const stream = new MockJetstream();
+		const queue = new InMemoryQueue();
+		const storage = new MapStorage();
+		const floorTimeUs = 1_700_000_000_000_000; // arbitrary stable epoch us
+		let calls = 0;
+
+		const ingestor = new JetstreamIngestor({
+			client: new MockJetstreamClient(stream),
+			queue,
+			storage,
+			wantedCollections: [PROFILE_NSID],
+			backoff: { initialDelayMs: 1, maxDelayMs: 5, multiplier: 2, jitter: 0 },
+			sleep: () => Promise.resolve(),
+			cursorFloor: () => {
+				calls += 1;
+				return Promise.resolve(floorTimeUs);
+			},
+		});
+		const runPromise = ingestor.run();
+
+		// Persistence is the contract — the run loop should write the floor
+		// to storage before opening any subscription.
+		await waitFor(() => ingestor.currentCursor === floorTimeUs, "floor adopted by ingestor");
+		expect(calls).toBe(1);
+		expect(await storage.get("jetstream:cursor")).toBe(floorTimeUs);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("ignores cursorFloor when storage already has a cursor (no override)", async () => {
+		// The persisted cursor wins — cursorFloor is for the empty-storage
+		// case only. A call to floor() on a warm DO would silently roll the
+		// cursor back to a stale value.
+		const stream = new MockJetstream();
+		const queue = new InMemoryQueue();
+		const storage = new MapStorage();
+		const persisted = 2_000_000_000_000_000;
+		await storage.put("jetstream:cursor", persisted);
+		let floorCalled = false;
+
+		const ingestor = new JetstreamIngestor({
+			client: new MockJetstreamClient(stream),
+			queue,
+			storage,
+			wantedCollections: [PROFILE_NSID],
+			backoff: { initialDelayMs: 1, maxDelayMs: 5, multiplier: 2, jitter: 0 },
+			sleep: () => Promise.resolve(),
+			cursorFloor: () => {
+				floorCalled = true;
+				return Promise.resolve(1_000_000_000_000_000);
+			},
+		});
+		const runPromise = ingestor.run();
+		// Give the run loop a tick to read storage.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		expect(floorCalled).toBe(false);
+		expect(ingestor.currentCursor).toBe(persisted);
+
+		ingestor.stop();
+		await runPromise;
+	});
+
+	it("falls back to subscription default when cursorFloor returns null", async () => {
+		// Truly fresh install — D1 has no rows so floor() returns null.
+		// Storage stays empty; the subscription's own default kicks in
+		// (effectively "now"). Ingestor's cursor stays null until the
+		// first event lands.
+		const stream = new MockJetstream();
+		const queue = new InMemoryQueue();
+		const storage = new MapStorage();
+
+		const ingestor = new JetstreamIngestor({
+			client: new MockJetstreamClient(stream),
+			queue,
+			storage,
+			wantedCollections: [PROFILE_NSID],
+			backoff: { initialDelayMs: 1, maxDelayMs: 5, multiplier: 2, jitter: 0 },
+			sleep: () => Promise.resolve(),
+			cursorFloor: () => Promise.resolve(null),
+		});
+		const runPromise = ingestor.run();
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		expect(ingestor.currentCursor).toBeNull();
+		expect(await storage.get("jetstream:cursor")).toBeUndefined();
+
+		ingestor.stop();
+		await runPromise;
+	});
+
 	it("handles delete operations (no record body, empty cid)", async () => {
 		const h = buildHarness();
 		h.stream.emit({

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Read API integration tests.
+ *
+ * Each test seeds D1 directly with the columns the handlers read, then
+ * exercises the handler via `SELF.fetch` to a `/xrpc/...` URL — same path
+ * a real client would take. Asserts on the envelope shape (uri, cid, did,
+ * indexedAt, mirrors, labels) and on error mappings (404 NotFound, 400
+ * InvalidRequest).
+ *
+ * `mirrors: []` and `labels: []` are the v1 contract; Slice 2 (labels)
+ * and Slice 3 (mirrors) populate them, but the contract is locked now so
+ * cached clients don't see a shape change later.
+ */
+
+import { NSID } from "@emdash-cms/registry-lexicons";
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+interface TestEnv {
+	DB: D1Database;
+	TEST_MIGRATIONS: Parameters<typeof applyD1Migrations>[1];
+}
+const testEnv = env as unknown as TestEnv;
+
+const DID_A = "did:plc:read000000000000000000aa";
+const DID_B = "did:plc:read000000000000000000bb";
+const NOW = new Date("2026-05-10T12:00:00.000Z");
+
+beforeAll(async () => {
+	await applyD1Migrations(testEnv.DB, testEnv.TEST_MIGRATIONS);
+});
+
+beforeEach(async () => {
+	// Tables in dependency order: releases → packages (FK), then publishers
+	// + verifications.
+	await testEnv.DB.prepare("DELETE FROM releases").run();
+	await testEnv.DB.prepare("DELETE FROM packages").run();
+	await testEnv.DB.prepare("DELETE FROM publishers").run();
+	await testEnv.DB.prepare("DELETE FROM publisher_verifications").run();
+});
+
+interface SeedPackageOpts {
+	did?: string;
+	slug?: string;
+	type?: string;
+	name?: string | null;
+	description?: string | null;
+	license?: string;
+	keywords?: string[] | null;
+	latestVersion?: string | null;
+	cid?: string;
+	indexedAt?: string;
+	verifiedAt?: string;
+	carBytes?: Uint8Array;
+}
+
+async function seedPackage(opts: SeedPackageOpts = {}): Promise<void> {
+	const did = opts.did ?? DID_A;
+	const slug = opts.slug ?? "demo";
+	const indexedAt = opts.indexedAt ?? NOW.toISOString();
+	await testEnv.DB.prepare(
+		`INSERT INTO packages
+		   (did, slug, type, name, description, license, authors, security, keywords,
+		    sections, last_updated, latest_version, capabilities, record_blob,
+		    signature_metadata, verified_at, indexed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			slug,
+			opts.type ?? "emdash-plugin",
+			opts.name ?? "Demo Plugin",
+			opts.description ?? "A demo plugin",
+			opts.license ?? "MIT",
+			JSON.stringify([{ name: "Tester" }]),
+			JSON.stringify([{ email: "x@y.test" }]),
+			opts.keywords === null ? null : JSON.stringify(opts.keywords ?? ["demo"]),
+			null,
+			NOW.toISOString(),
+			opts.latestVersion ?? null,
+			null,
+			opts.carBytes ?? new Uint8Array([0xa1, 0xa2, 0xa3]),
+			JSON.stringify({ cid: opts.cid ?? "bafyseed" }),
+			opts.verifiedAt ?? NOW.toISOString(),
+			indexedAt,
+		)
+		.run();
+}
+
+interface SeedReleaseOpts {
+	did?: string;
+	package?: string;
+	version: string;
+	versionSort?: string;
+	tombstoned?: boolean;
+	cid?: string;
+	carBytes?: Uint8Array;
+}
+
+async function seedRelease(opts: SeedReleaseOpts): Promise<void> {
+	const did = opts.did ?? DID_A;
+	const pkg = opts.package ?? "demo";
+	const rkey = `${pkg}:${opts.version}`;
+	await testEnv.DB.prepare(
+		`INSERT INTO releases
+		   (did, package, version, rkey, version_sort, artifacts, requires, suggests,
+		    emdash_extension, repo_url, cts, record_blob, signature_metadata,
+		    verified_at, indexed_at, tombstoned_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			did,
+			pkg,
+			opts.version,
+			rkey,
+			opts.versionSort ?? defaultVersionSort(opts.version),
+			JSON.stringify({ package: { url: "https://x.test/d.tgz", checksum: "bsha256-abc" } }),
+			null,
+			null,
+			JSON.stringify({ declaredAccess: {} }),
+			null,
+			NOW.toISOString(),
+			opts.carBytes ?? new Uint8Array([0xb1, 0xb2, 0xb3]),
+			JSON.stringify({ cid: opts.cid ?? `bafrel-${opts.version}` }),
+			NOW.toISOString(),
+			NOW.toISOString(),
+			opts.tombstoned ? NOW.toISOString() : null,
+		)
+		.run();
+}
+
+/** Naive 1.x.y zero-padded version_sort for the test fixtures. Real values
+ * come from the consumer's `computeVersionSort`; tests just need the
+ * relative ordering to be right. */
+function defaultVersionSort(version: string): string {
+	const [major = "0", minor = "0", patch = "0"] = version.split(".");
+	const pad = (s: string) => s.padStart(10, "0");
+	return `${pad(major)}.${pad(minor)}.${pad(patch)}.~`;
+}
+
+describe("getPackage", () => {
+	it("returns the packageView envelope for an indexed package", async () => {
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body).toMatchObject({
+			uri: `at://${DID_A}/${NSID.packageProfile}/demo`,
+			cid: "bafyseed",
+			did: DID_A,
+			slug: "demo",
+			latestVersion: "1.0.0",
+			indexedAt: NOW.toISOString(),
+			labels: [],
+		});
+		// `mirrors` is on releaseView only — assert it's NOT on packageView.
+		expect(body).not.toHaveProperty("mirrors");
+		const profile = body["profile"] as Record<string, unknown>;
+		expect(profile["$type"]).toBe(NSID.packageProfile);
+		expect(profile["id"]).toBe(`at://${DID_A}/${NSID.packageProfile}/demo`);
+		expect(profile["license"]).toBe("MIT");
+		expect(profile["slug"]).toBe("demo");
+	});
+
+	it("returns 404 NotFound when no row matches", async () => {
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=missing`,
+		);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("NotFound");
+	});
+
+	it("returns 400 InvalidRequest on missing required params", async () => {
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}`);
+		expect(res.status).toBe(400);
+	});
+
+	it("sets Cache-Control: private, no-store on success", async () => {
+		await seedPackage({ slug: "demo" });
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=demo`,
+		);
+		expect(res.headers.get("cache-control")).toBe("private, no-store");
+	});
+
+	it("omits latestVersion when no release has been written yet", async () => {
+		await seedPackage({ slug: "fresh", latestVersion: null });
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetPackage}?did=${DID_A}&slug=fresh`,
+		);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body).not.toHaveProperty("latestVersion");
+	});
+});
+
+describe("listReleases", () => {
+	it("returns releases ordered by descending semver", async () => {
+		await seedPackage({ slug: "demo", latestVersion: "2.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "1.10.0" });
+		await seedRelease({ version: "2.0.0" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { releases: Array<{ version: string }>; cursor?: string };
+		expect(body.releases.map((r) => r.version)).toEqual(["2.0.0", "1.10.0", "1.0.0"]);
+		expect(body).not.toHaveProperty("cursor");
+	});
+
+	it("filters tombstoned releases", async () => {
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "1.1.0", tombstoned: true });
+		await seedRelease({ version: "1.2.0" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo`,
+		);
+		const body = (await res.json()) as { releases: Array<{ version: string }> };
+		expect(body.releases.map((r) => r.version)).toEqual(["1.2.0", "1.0.0"]);
+	});
+
+	it("paginates via cursor", async () => {
+		await seedPackage({ slug: "demo" });
+		for (let i = 1; i <= 5; i++) await seedRelease({ version: `1.${i}.0` });
+
+		const first = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo&limit=2`,
+		);
+		const firstBody = (await first.json()) as {
+			releases: Array<{ version: string }>;
+			cursor: string;
+		};
+		expect(firstBody.releases.map((r) => r.version)).toEqual(["1.5.0", "1.4.0"]);
+		expect(firstBody.cursor).toBeTruthy();
+
+		const second = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo&limit=2&cursor=${encodeURIComponent(firstBody.cursor)}`,
+		);
+		const secondBody = (await second.json()) as {
+			releases: Array<{ version: string }>;
+			cursor?: string;
+		};
+		expect(secondBody.releases.map((r) => r.version)).toEqual(["1.3.0", "1.2.0"]);
+		expect(secondBody.cursor).toBeTruthy();
+	});
+
+	it("returns 404 when the parent package is missing", async () => {
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=missing`,
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("getLatestRelease", () => {
+	it("returns the release pointed to by packages.latest_version", async () => {
+		await seedPackage({ slug: "demo", latestVersion: "2.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0" });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["version"]).toBe("2.0.0");
+		expect(body["uri"]).toBe(`at://${DID_A}/${NSID.packageRelease}/demo:2.0.0`);
+	});
+
+	it("returns 404 when latest_version points at a tombstoned release", async () => {
+		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
+		await seedRelease({ version: "1.0.0", tombstoned: true });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 when no package row exists", async () => {
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=missing`,
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe("searchPackages", () => {
+	it("returns FTS-matched packages", async () => {
+		await seedPackage({ slug: "gallery", name: "Gallery Plugin", description: "image gallery" });
+		await seedPackage({ slug: "form", name: "Form Plugin", description: "form builder" });
+
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}?q=gallery`);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug)).toContain("gallery");
+		expect(body.packages.map((p) => p.slug)).not.toContain("form");
+	});
+
+	it("returns all packages ordered by last_updated DESC when q is empty", async () => {
+		await seedPackage({ slug: "alpha" });
+		await seedPackage({ slug: "beta" });
+		const res = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}`);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages.map((p) => p.slug).toSorted()).toEqual(["alpha", "beta"]);
+	});
+
+	it("paginates via offset cursor", async () => {
+		for (let i = 0; i < 5; i++) await seedPackage({ slug: `pkg${i}` });
+
+		const first = await SELF.fetch(`https://test/xrpc/${NSID.aggregatorSearchPackages}?limit=2`);
+		const firstBody = (await first.json()) as {
+			packages: Array<{ slug: string }>;
+			cursor: string;
+		};
+		expect(firstBody.packages).toHaveLength(2);
+		expect(firstBody.cursor).toBeTruthy();
+
+		const second = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorSearchPackages}?limit=2&cursor=${encodeURIComponent(firstBody.cursor)}`,
+		);
+		const secondBody = (await second.json()) as { packages: Array<{ slug: string }> };
+		expect(secondBody.packages).toHaveLength(2);
+		// Distinct from page 1 — seeded slugs don't overlap.
+		const overlap = firstBody.packages
+			.map((p) => p.slug)
+			.filter((s) => secondBody.packages.some((p) => p.slug === s));
+		expect(overlap).toEqual([]);
+	});
+
+	it("doesn't blow up on FTS-unsafe query chars (defensive quoting)", async () => {
+		await seedPackage({ slug: "demo", name: "Demo" });
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorSearchPackages}?q=${encodeURIComponent('demo "*"(')}`,
+		);
+		// Either matches nothing or matches normally — but doesn't 500.
+		expect(res.status).toBe(200);
+	});
+});
+
+describe("sync.getRecord", () => {
+	const PATH = "/xrpc/com.atproto.sync.getRecord";
+
+	it("returns CAR bytes for an indexed package profile", async () => {
+		await seedPackage({ slug: "demo", carBytes: new Uint8Array([0x11, 0x22, 0x33]) });
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageProfile}&rkey=demo`,
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe("application/vnd.ipld.car");
+		expect(res.headers.get("cache-control")).toBe("public, max-age=300");
+		const bytes = new Uint8Array(await res.arrayBuffer());
+		expect([...bytes]).toEqual([0x11, 0x22, 0x33]);
+	});
+
+	it("returns CAR bytes for an indexed release", async () => {
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0", carBytes: new Uint8Array([0x44, 0x55]) });
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageRelease}&rkey=demo:1.0.0`,
+		);
+		expect(res.status).toBe(200);
+		const bytes = new Uint8Array(await res.arrayBuffer());
+		expect([...bytes]).toEqual([0x44, 0x55]);
+	});
+
+	it("returns 404 for a tombstoned release", async () => {
+		await seedPackage({ slug: "demo" });
+		await seedRelease({ version: "1.0.0", tombstoned: true });
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageRelease}&rkey=demo:1.0.0`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 for an unknown rkey", async () => {
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageProfile}&rkey=does-not-exist`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 400 InvalidRequest on missing query params", async () => {
+		const res = await SELF.fetch(`https://test${PATH}?did=${DID_A}`);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 on a malformed DID", async () => {
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=not-a-did&collection=${NSID.packageProfile}&rkey=demo`,
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns HEAD with content-length but no body", async () => {
+		await seedPackage({ slug: "demo", carBytes: new Uint8Array([0x11, 0x22, 0x33]) });
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageProfile}&rkey=demo`,
+			{ method: "HEAD" },
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-length")).toBe("3");
+		const bytes = new Uint8Array(await res.arrayBuffer());
+		expect(bytes.byteLength).toBe(0);
+	});
+
+	it("rejects non-GET/HEAD methods with 405", async () => {
+		const res = await SELF.fetch(
+			`https://test${PATH}?did=${DID_A}&collection=${NSID.packageProfile}&rkey=demo`,
+			{ method: "POST" },
+		);
+		expect(res.status).toBe(405);
+		expect(res.headers.get("allow")).toBe("GET, HEAD");
+	});
+
+	it("only matches publisher.profile when rkey='self'", async () => {
+		// publisher.profile rkey is always 'self'; any other rkey returns 404
+		// even if the (did) row exists.
+		await testEnv.DB.prepare(
+			`INSERT INTO publishers
+			   (did, display_name, record_blob, verified_at, indexed_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+		)
+			.bind(DID_B, "Pub", new Uint8Array([0x99]), NOW.toISOString(), NOW.toISOString())
+			.run();
+		const wrongRkey = await SELF.fetch(
+			`https://test${PATH}?did=${DID_B}&collection=${NSID.publisherProfile}&rkey=other`,
+		);
+		expect(wrongRkey.status).toBe(404);
+		const correctRkey = await SELF.fetch(
+			`https://test${PATH}?did=${DID_B}&collection=${NSID.publisherProfile}&rkey=self`,
+		);
+		expect(correctRkey.status).toBe(200);
+	});
+});
+
+describe("XRPC dispatcher", () => {
+	it("returns 404 on non-XRPC paths", async () => {
+		const res = await SELF.fetch("https://test/some/random/path");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 on unknown XRPC NSIDs", async () => {
+		const res = await SELF.fetch("https://test/xrpc/com.example.notARealEndpoint");
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/aggregator/test/read-api.test.ts
+++ b/apps/aggregator/test/read-api.test.ts
@@ -257,6 +257,14 @@ describe("listReleases", () => {
 		);
 		expect(res.status).toBe(404);
 	});
+
+	it("400s on a provided-but-malformed cursor", async () => {
+		await seedPackage({ slug: "demo" });
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorListReleases}?did=${DID_A}&package=demo&cursor=garbage!!!`,
+		);
+		expect(res.status).toBe(400);
+	});
 });
 
 describe("getLatestRelease", () => {
@@ -274,7 +282,7 @@ describe("getLatestRelease", () => {
 		expect(body["uri"]).toBe(`at://${DID_A}/${NSID.packageRelease}/demo:2.0.0`);
 	});
 
-	it("returns 404 when latest_version points at a tombstoned release", async () => {
+	it("returns 404 when ALL releases are tombstoned (or none exist)", async () => {
 		await seedPackage({ slug: "demo", latestVersion: "1.0.0" });
 		await seedRelease({ version: "1.0.0", tombstoned: true });
 
@@ -282,6 +290,23 @@ describe("getLatestRelease", () => {
 			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
 		);
 		expect(res.status).toBe(404);
+	});
+
+	it("falls back to the next-best release when latest_version points at a tombstoned one", async () => {
+		// `latest_version` was set to 2.0.0, then 2.0.0 was tombstoned but
+		// `refreshPackageLatestStmt` hasn't run yet (or failed). The fast-path
+		// JOIN misses; the slow-path ORDER BY should still find 1.0.0 and
+		// return it instead of 404ing.
+		await seedPackage({ slug: "demo", latestVersion: "2.0.0" });
+		await seedRelease({ version: "1.0.0" });
+		await seedRelease({ version: "2.0.0", tombstoned: true });
+
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorGetLatestRelease}?did=${DID_A}&package=demo`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body["version"]).toBe("1.0.0");
 	});
 
 	it("returns 404 when no package row exists", async () => {
@@ -342,6 +367,41 @@ describe("searchPackages", () => {
 		);
 		// Either matches nothing or matches normally — but doesn't 500.
 		expect(res.status).toBe(200);
+	});
+
+	it("treats FTS operators as literal tokens (the escape actually works)", async () => {
+		await seedPackage({ slug: "alpha", name: "Alpha" });
+		await seedPackage({ slug: "beta", name: "Beta" });
+		// `alpha OR beta` would match both packages if `OR` were interpreted
+		// as the FTS5 operator. With proper escaping the whole string is one
+		// literal phrase that can't possibly appear in either record's
+		// indexed text → zero matches. A buggy escape that stripped the
+		// quotes would return *both* packages.
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorSearchPackages}?q=${encodeURIComponent("alpha OR beta")}`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { packages: Array<{ slug: string }> };
+		expect(body.packages).toEqual([]);
+	});
+
+	it("400s on a provided-but-malformed cursor (no silent restart)", async () => {
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorSearchPackages}?cursor=not-a-valid-cursor`,
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("400s on a forged cursor with an out-of-range offset", async () => {
+		// Encode {offset: 1_000_000} → over MAX_OFFSET → 400.
+		const forged = btoa(JSON.stringify({ offset: 1_000_000 }))
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+		const res = await SELF.fetch(
+			`https://test/xrpc/${NSID.aggregatorSearchPackages}?cursor=${forged}`,
+		);
+		expect(res.status).toBe(400);
 	});
 });
 

--- a/apps/aggregator/test/records-consumer.test.ts
+++ b/apps/aggregator/test/records-consumer.test.ts
@@ -144,6 +144,27 @@ describe("ingestPackageProfile", () => {
 		expect(row?.license).toBe("Apache-2.0");
 	});
 
+	it("preserves indexed_at across re-ingest, advances verified_at", async () => {
+		// Lexicon's `packageView.indexedAt` semantic is "first observed".
+		// The upsert omits `indexed_at` from `DO UPDATE SET` to keep the
+		// first-write timestamp stable. `verified_at` is bumped (it tracks
+		// "last verified" — the opposite intent).
+		const job = jobFor(DID_A, NSID.packageProfile, "demo");
+		const firstSeen = new Date("2026-01-01T00:00:00.000Z");
+		const reIngested = new Date("2026-05-10T12:00:00.000Z");
+
+		await ingestPackageProfile(testEnv.DB, job, fakeVerified(validRecord), firstSeen);
+		await ingestPackageProfile(testEnv.DB, job, fakeVerified(validRecord), reIngested);
+
+		const row = await testEnv.DB.prepare(
+			`SELECT indexed_at, verified_at FROM packages WHERE did = ?`,
+		)
+			.bind(DID_A)
+			.first<{ indexed_at: string; verified_at: string }>();
+		expect(row?.indexed_at).toBe(firstSeen.toISOString());
+		expect(row?.verified_at).toBe(reIngested.toISOString());
+	});
+
 	it("rejects when rkey ≠ record.slug", async () => {
 		const job = jobFor(DID_A, NSID.packageProfile, "different");
 		await expect(

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPackage.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/getPackage.json
@@ -33,11 +33,7 @@
 			"errors": [
 				{
 					"name": "NotFound",
-					"description": "No package indexed under the given (did, slug)."
-				},
-				{
-					"name": "Tombstoned",
-					"description": "The package was indexed but has been deleted by the publisher."
+					"description": "No package indexed under the given (did, slug). Aggregators that hard-delete on publisher deletion (rather than soft-deleting) return NotFound for both the never-indexed and the deleted cases — clients should treat them equivalently."
 				}
 			]
 		}

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/searchPackages.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/aggregator/searchPackages.json
@@ -17,6 +17,7 @@
 					"capability": {
 						"type": "string",
 						"description": "Optional filter: only return packages that declare this access category (e.g. 'email', 'network'). Compares against the latest release's declaredAccess top-level keys.",
+						"minLength": 1,
 						"maxLength": 64
 					},
 					"limit": {

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/searchPackages.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/aggregator/searchPackages.ts
@@ -9,11 +9,12 @@ const _mainSchema = /*#__PURE__*/ v.query(
 		params: /*#__PURE__*/ v.object({
 			/**
 			 * Optional filter: only return packages that declare this access category (e.g. 'email', 'network'). Compares against the latest release's declaredAccess top-level keys.
+			 * @minLength 1
 			 * @maxLength 64
 			 */
 			capability: /*#__PURE__*/ v.optional(
 				/*#__PURE__*/ v.constrain(/*#__PURE__*/ v.string(), [
-					/*#__PURE__*/ v.stringLength(0, 64),
+					/*#__PURE__*/ v.stringLength(1, 64),
 				]),
 			),
 			/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     '@atcute/identity-resolver':
-      specifier: ^1.2.2
-      version: 1.2.2
+      specifier: ^2.0.0
+      version: 2.0.0
     '@atcute/jetstream':
       specifier: ^2.0.0
       version: 2.0.0
@@ -313,7 +313,7 @@ importers:
         version: 2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3)
       '@atcute/identity-resolver':
         specifier: 'catalog:'
-        version: 1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3))
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3))(@atcute/lexicons@1.3.0)(typescript@5.9.3)
       '@atcute/jetstream':
         specifier: 'catalog:'
         version: 2.0.0(@atcute/lexicons@1.3.0)(react@19.2.4)(typescript@5.9.3)
@@ -1784,7 +1784,7 @@ importers:
         version: 4.2.1
       '@atcute/identity-resolver':
         specifier: 'catalog:'
-        version: 1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3))
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3))(@atcute/lexicons@1.3.0)(typescript@5.9.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
         version: 1.3.0
@@ -10962,13 +10962,6 @@ snapshots:
   '@atcute/identity-resolver@1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.2.10)(typescript@5.9.3))':
     dependencies:
       '@atcute/identity': 2.0.0(@atcute/lexicons@1.2.10)(typescript@5.9.3)
-      '@atcute/lexicons': 1.3.0
-      '@atcute/util-fetch': 1.0.5
-      '@badrap/valita': 0.4.6
-
-  '@atcute/identity-resolver@1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3))':
-    dependencies:
-      '@atcute/identity': 2.0.0(@atcute/lexicons@1.3.0)(typescript@5.9.3)
       '@atcute/lexicons': 1.3.0
       '@atcute/util-fetch': 1.0.5
       '@badrap/valita': 0.4.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   "@atcute/crypto": ^2.4.1
   "@atcute/firehose": ^1.0.0
   "@atcute/identity": ^2.0.0
-  "@atcute/identity-resolver": ^1.2.2
+  "@atcute/identity-resolver": ^2.0.0
   "@atcute/jetstream": ^2.0.0
   "@atcute/lex-cli": ^2.8.1
   "@atcute/lexicons": ^1.3.0


### PR DESCRIPTION
## What does this PR do?

Wires the Slice 1 read API for the EmDash plugin registry aggregator per plan §Read API checklist. Five aggregator XRPC endpoints over D1 plus a cached \`com.atproto.sync.getRecord\` passthrough.

**Aggregator endpoints** (under \`/xrpc/com.emdashcms.experimental.aggregator.*\`):

- \`getPackage\` — single packageView by (did, slug)
- \`listReleases\` — descending semver, cursor-paginated, filters tombstoned
- \`getLatestRelease\` — JOIN \`packages.latest_version\` → \`releases.version\` with a slow-path ORDER BY fallback when the pointer is stale
- \`searchPackages\` — FTS5 + BM25, takedown filter via \`label_state\` (locked-in for Slice 2's labeller), offset cursor capped at 10k
- \`resolvePackage\` — handle/slug → packageView via @atcute/identity-resolver (DoH + well-known, race)

All five use \`env.DB.withSession("first-primary")\` so a takedown written by the Slice 2 labeller is visible globally on the next read. \`Cache-Control: private, no-store\`.

**Cached \`com.atproto.sync.getRecord\`** serves stored CAR bytes verbatim from \`record_blob\` for the four indexed collections (package profile/release, publisher profile/verification). \`Content-Type: application/vnd.ipld.car\`, \`Cache-Control: public, max-age=300\`. Slingshot-style: install-time clients verify against us instead of round-tripping per-publisher PDSes.

**Schema**: adds \`indexed_at\` to the four content tables (migration 0002). The lexicon's \`indexedAt\` semantic is "first observed", which \`verified_at\` (bumped on every upsert) couldn't satisfy.

This PR was driven through an adversarial review pre-push — see commit \`70b2a971\` for the fixes (silent-miss in getLatestRelease, ordering non-determinism in search, cursor strict-mode, offset DOS cap, lexicon contract drift on \`Tombstoned\`, others).

Closes nothing — incremental Slice 1 work tracked in \`.claude/plans/plugin-registry.md\`.

## Type of change

- [x] Feature (Slice 1 of an approved Discussion-tracked initiative)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (0 aggregator/registry-lexicons diagnostics)
- [x] \`pnpm test\` passes (183 aggregator tests, 33 new for this PR)
- [x] \`pnpm format\` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings — N/A (server-side only)
- [ ] Changeset — N/A (apps/aggregator is private)
- [x] New features link to an approved Discussion (Slice 1 initiative)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Test output

- 183 tests passing across 8 files (was 150 before this PR; 33 new).
- New file: \`apps/aggregator/test/read-api.test.ts\` (29 integration tests via SELF.fetch + seeded D1).
- New tests in \`records-consumer.test.ts\`: \`indexed_at\` preservation across re-ingest.
- Lint and typecheck clean.