### PR TITLE
I18n(es-ES): Adds Spanish (Spain) 

### DIFF
--- a/packages/admin/src/locales/es-ES/messages.po
+++ b/packages/admin/src/locales/es-ES/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es-ES\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: packages/admin/src/routes/bylines.tsx:226
 msgid " - Guest"
@@ -4463,7 +4469,10 @@ msgid ""
 "Option 1\n"
 "Option 2\n"
 "Option 3"
-msgstr "Opción 1\nOpción 2\nOpción 3"
+msgstr ""
+"Opción 1\n"
+"Opción 2\n"
+"Opción 3"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:474

--- a/packages/admin/src/locales/es-ES/messages.po
+++ b/packages/admin/src/locales/es-ES/messages.po
@@ -1,0 +1,7089 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-05-10 20:39-0500\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es-ES\n"
+
+#: packages/admin/src/routes/bylines.tsx:226
+msgid " - Guest"
+msgstr " - Invitado"
+
+#: packages/admin/src/routes/bylines.tsx:226
+msgid " - Linked"
+msgstr " - Vinculado"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:76
+msgid " (default)"
+msgstr " (defecto)"
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+msgid " (opens in new window)"
+msgstr " (se abre en una nueva ventana)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:716
+#: packages/admin/src/components/MediaPickerModal.tsx:798
+msgid " (selected)"
+msgstr " (seleccionado)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", o abre el administrador en"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": usa"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:656
+msgid "(from {0})"
+msgstr "(de {0})"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(sincronizado)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(con tu puerto de desarrollo)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:147
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, una {(# item)} otras {(# items)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, una {# collection} otras {# collections}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1118
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr ""
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2080
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr ""
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2056
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr ""
+
+#. placeholder {0}: filteredItems.length
+#: packages/admin/src/components/ContentList.tsx:291
+msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr ""
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:527
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2085
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr ""
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr ""
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1739
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr ""
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2292
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr ""
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr ""
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2064
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr ""
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr ""
+
+#. placeholder {0}: filteredItems.length
+#. placeholder {1}: hasMore ? "+" : ""
+#. placeholder {2}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:295
+msgid "{0, plural, one {#{1} item} other {#{2} items}}"
+msgstr ""
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:576
+msgid "{0, plural, one {field} other {fields}}"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr ""
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1142
+msgid "{0} detected"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:104
+msgid "{0} has been deactivated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:256
+msgid "{0} has been removed"
+msgstr ""
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "{0} installs"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:85
+msgid "{0} is now active"
+msgstr ""
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1809
+msgid "{0} items → {1}"
+msgstr ""
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "{0} items will be imported"
+msgstr ""
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/PluginManager.tsx:349
+msgid "{0} permission{1}"
+msgstr ""
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:161
+msgid "{0} plugins"
+msgstr ""
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
+msgid "{0} preview"
+msgstr ""
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const plural = value ? `${value}s` : ""; handleLabelChange(plural); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:574
+msgid "{0} system + {1} custom {2}"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:316
+msgid "{0} updated"
+msgstr ""
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:243
+msgid "{0} updated to v{1}"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:716
+#: packages/admin/src/components/MediaPickerModal.tsx:798
+msgid "{0}{1}"
+msgstr ""
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:168
+msgid "{0}/160 characters"
+msgstr ""
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:255
+msgid "{base} to: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1908
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2157
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1979
+msgid "{current} of {total}"
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2267
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1715
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1724
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:76
+msgid "{pluginName} is requesting additional permissions:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:77
+msgid "{pluginName} requires the following permissions:"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:140
+#: packages/admin/src/components/MediaLibrary.tsx:176
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:145
+#: packages/admin/src/components/MediaLibrary.tsx:181
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:150
+#: packages/admin/src/components/MediaLibrary.tsx:186
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:137
+msgid "/new-page or /articles/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:129
+msgid "/old-page or /blog/[slug]"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1929
+msgid "• Files are downloaded from your WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1930
+msgid "• Uploaded to your EmDash media storage"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1931
+msgid "• URLs in your content are updated automatically"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1440
+msgid "← Back"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1361
+msgid "1. Log into your WordPress admin"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+msgid "1. Log into your WordPress admin dashboard"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "2. Go to"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1362
+msgid "2. Go to Users → Profile"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1363
+msgid "3. Scroll to \"Application Passwords\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "3. Select \"All content\""
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:150
+msgid "301 Permanent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "302 Temporary"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "307 Temporary (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "308 Permanent (Strict)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "4. Click \"Download Export File\""
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:368
+msgid "404 Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1365
+msgid "5. Copy the generated password"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1120
+msgid "5. Upload the file here"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:418
+msgid "A brief description of this content type"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Accept & Install"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:147
+msgid "Accept & Update"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:206
+msgid "Accept Invite"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1138
+msgid "Access Denied"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Access your media library"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:121
+msgid "Account already exists"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:235
+#: packages/admin/src/components/ContentList.tsx:349
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/MediaLibrary.tsx:419
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+msgid "Actions"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentEditor.tsx:1930
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TaxonomyManager.tsx:812
+#: packages/admin/src/components/TaxonomySidebar.tsx:439
+msgid "Add"
+msgstr ""
+
+#. placeholder {0}: field.item_label
+#: packages/admin/src/components/PortableTextEditor.tsx:1462
+msgid "Add {0}"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:238
+msgid "Add {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:204
+msgid "Add a new passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
+msgid "Add an allowed domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2510
+msgid "Add column after"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2503
+msgid "Add column before"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:291
+#: packages/admin/src/components/MenuEditor.tsx:406
+msgid "Add Content"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:303
+#: packages/admin/src/components/MenuEditor.tsx:310
+#: packages/admin/src/components/MenuEditor.tsx:409
+msgid "Add Custom Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Add Domain"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:582
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Add Field"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1820
+msgid "Add fields"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:604
+msgid "Add fields to define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:607
+msgid "Add First Field"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:169
+msgid "Add First Item"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1462
+msgid "Add item"
+msgstr ""
+
+#: packages/admin/src/components/RepeaterField.tsx:153
+msgid "Add Item"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2470
+msgid "Add link"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:399
+msgid "Add links to build your navigation menu"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:159
+msgid "Add New"
+msgstr ""
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:449
+msgid "Add new {0}"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Add noindex meta tag"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:225
+msgid "Add Passkey"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:197
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2533
+msgid "Add row after"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2526
+msgid "Add row before"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:476
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:237
+msgid "Add tags..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:338
+msgid "Add Widget Area"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+msgid "Adding..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1592
+msgid "Additional data to import."
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:438
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:378
+msgid "Admin navigation"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "After send:"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2858
+msgid "Align Center"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2851
+msgid "Align Left"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2865
+msgid "Align Right"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:186
+msgid "All"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:192
+msgid "All bylines"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2324
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr ""
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "All statuses"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "All types"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:497
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
+msgid "Allowed Domains"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:575
+msgid "Also delete plugin storage data"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:202
+msgid "Alt text"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:202
+msgid "Alt Text"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "Alt text set"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1234
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:91
+#: packages/admin/src/components/PluginManager.tsx:110
+#: packages/admin/src/components/TaxonomySidebar.tsx:321
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:339
+#: packages/admin/src/router.tsx:354
+#: packages/admin/src/router.tsx:368
+#: packages/admin/src/router.tsx:382
+#: packages/admin/src/router.tsx:702
+#: packages/admin/src/router.tsx:733
+#: packages/admin/src/router.tsx:749
+#: packages/admin/src/router.tsx:765
+#: packages/admin/src/router.tsx:784
+#: packages/admin/src/router.tsx:802
+#: packages/admin/src/router.tsx:820
+#: packages/admin/src/router.tsx:850
+#: packages/admin/src/router.tsx:870
+#: packages/admin/src/router.tsx:1083
+#: packages/admin/src/router.tsx:1099
+#: packages/admin/src/router.tsx:1124
+#: packages/admin/src/router.tsx:1541
+msgid "An error occurred"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:217
+msgid "An unknown error occurred"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1414
+msgid "Analyzing export file..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:735
+msgid "Analyzing WordPress site..."
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:375
+msgid "Appears on posts and pages"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1329
+msgid "Application Password"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2925
+msgid "Apply"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2410
+#: packages/admin/src/components/PortableTextEditor.tsx:2411
+msgid "Apply link"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:670
+msgid "archived"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+msgid "Archives"
+msgstr ""
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr ""
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:660
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2262
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+msgid "Audio"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:256
+msgid "Authentication failed"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:129
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2277
+msgid "Author Mapping"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:495
+msgid "auto"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Auto (slug change)"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:541
+msgid "Auto-approve authenticated users"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:406
+msgid "Auto-generated from name (you can edit)"
+msgstr ""
+
+#: packages/admin/src/router.tsx:732
+msgid "Autosave failed"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:613
+msgid "Autosave status"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:595
+msgid "Available media"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "Available Providers"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Available Widgets"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:254
+#: packages/admin/src/components/MenuEditor.tsx:275
+#: packages/admin/src/components/WordPressImport.tsx:1349
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Back"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:582
+msgid "Back to {collectionLabel} list"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:139
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:116
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:392
+msgid "Back to marketplace"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+#: packages/admin/src/components/SectionEditor.tsx:174
+msgid "Back to sections"
+msgstr ""
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:219
+msgid "Before send:"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:144
+msgid "Bing Verification"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:267
+msgid "Bio"
+msgstr ""
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
+msgid "Block actions - drag to reorder, click for menu"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2434
+#: packages/admin/src/components/PortableTextEditor.tsx:2740
+msgid "Bold"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:169
+msgid "Brief summary shown below the title in search results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:966
+#: packages/admin/src/components/WordPressImport.tsx:1433
+msgid "Browse Files"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:190
+msgid "Browse the"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:101
+#: packages/admin/src/components/PortableTextEditor.tsx:886
+#: packages/admin/src/components/PortableTextEditor.tsx:2808
+msgid "Bullet List"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:966
+#: packages/admin/src/components/Sidebar.tsx:206
+msgid "Bylines"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:139
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentEditor.tsx:675
+#: packages/admin/src/components/ContentEditor.tsx:880
+#: packages/admin/src/components/ContentEditor.tsx:932
+#: packages/admin/src/components/ContentEditor.tsx:2033
+#: packages/admin/src/components/ContentEditor.tsx:2086
+#: packages/admin/src/components/ContentList.tsx:558
+#: packages/admin/src/components/ContentList.tsx:629
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/editor/ImageNode.tsx:223
+#: packages/admin/src/components/editor/ImageNode.tsx:224
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:648
+#: packages/admin/src/components/MediaDetailPanel.tsx:234
+#: packages/admin/src/components/MediaPickerModal.tsx:663
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:581
+#: packages/admin/src/components/PortableTextEditor.tsx:2909
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:313
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:423
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:325
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:453
+#: packages/admin/src/components/settings/SecuritySettings.tsx:206
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:470
+#: packages/admin/src/components/TaxonomyManager.tsx:684
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/Widgets.tsx:386
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Cancel"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:356
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:181
+msgid "Canonical URL"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:420
+msgid "Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:62
+msgid "Capability consent"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:210
+msgid "Caption"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr ""
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1621
+msgid "Categories ({0})"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:68
+#: packages/admin/src/components/ContentEditor.tsx:1616
+#: packages/admin/src/components/ContentEditor.tsx:1789
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/SeoImageField.tsx:47
+msgid "Change"
+msgstr ""
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:237
+msgid "Change Favicon"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:193
+msgid "Change Logo"
+msgstr ""
+
+#: packages/admin/src/router.tsx:777
+msgid "Changes discarded"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:135
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:153
+msgid "Check for updates"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:937
+msgid "Check Site"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+msgid "Checking {urlInput}..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:437
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+#: packages/admin/src/components/MediaDetailPanel.tsx:133
+#: packages/admin/src/components/MediaPickerModal.tsx:423
+#: packages/admin/src/components/MediaPickerModal.tsx:429
+#: packages/admin/src/components/MediaPickerModal.tsx:433
+#: packages/admin/src/components/MenuEditor.tsx:313
+#: packages/admin/src/components/MenuEditor.tsx:319
+#: packages/admin/src/components/MenuEditor.tsx:323
+#: packages/admin/src/components/MenuEditor.tsx:481
+#: packages/admin/src/components/MenuEditor.tsx:487
+#: packages/admin/src/components/MenuEditor.tsx:491
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1246
+#: packages/admin/src/components/PortableTextEditor.tsx:1252
+#: packages/admin/src/components/PortableTextEditor.tsx:1256
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:371
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:377
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:369
+#: packages/admin/src/components/TaxonomyManager.tsx:375
+#: packages/admin/src/components/TaxonomyManager.tsx:379
+#: packages/admin/src/components/TaxonomyManager.tsx:603
+#: packages/admin/src/components/TaxonomyManager.tsx:609
+#: packages/admin/src/components/TaxonomyManager.tsx:613
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:348
+#: packages/admin/src/components/Widgets.tsx:354
+#: packages/admin/src/components/Widgets.tsx:358
+msgid "Close"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:520
+msgid "Close comments after (days)"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:2462
+#: packages/admin/src/components/Redirects.tsx:443
+msgid "Code"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:93
+#: packages/admin/src/components/PortableTextEditor.tsx:916
+#: packages/admin/src/components/PortableTextEditor.tsx:2829
+msgid "Code Block"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:407
+msgid "Collapse"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Collapse details"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "Collections"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2133
+msgid "Collections created:"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "Comma-separated keywords for search."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:487
+#: packages/admin/src/components/Sidebar.tsx:190
+msgid "Comments"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:544
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:851
+msgid "Component"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Confirm"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:627
+msgid "Connect"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1346
+msgid "Connect & Analyze"
+msgstr ""
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1296
+msgid "Connect to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1212
+msgid "Connect with WordPress"
+msgstr ""
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:164
+#: packages/admin/src/components/PortableTextEditor.tsx:1952
+#: packages/admin/src/components/SectionEditor.tsx:194
+#: packages/admin/src/components/Sidebar.tsx:412
+#: packages/admin/src/components/Widgets.tsx:819
+msgid "Content"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr ""
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2188
+msgid "Content Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1156
+msgid "Content found:"
+msgstr ""
+
+#: packages/admin/src/router.tsx:796
+msgid "Content has been scheduled for publishing"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:131
+msgid "Content has been updated to the selected revision."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr ""
+
+#: packages/admin/src/router.tsx:744
+msgid "Content is now live"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "content items"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr ""
+
+#: packages/admin/src/router.tsx:760
+msgid "Content removed from public view"
+msgstr ""
+
+#: packages/admin/src/router.tsx:814
+msgid "Content reverted to draft"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:296
+msgid "Content snapshot:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1570
+msgid "Content to Import"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:210
+msgid "Content Types"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2116
+msgid "Content was skipped because it already exists"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2335
+msgid "Continue Import"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
+msgid "Copied to clipboard"
+msgstr ""
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+msgid "Copy URL"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:382
+msgid "Could not load image from URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Couldn't detect WordPress"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:820
+msgid "Count"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2057
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:184
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:477
+#: packages/admin/src/components/Widgets.tsx:389
+#: packages/admin/src/routes/bylines.tsx:314
+msgid "Create"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Create \"{trimmedInput}\""
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:887
+msgid "Create a bullet list"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:365
+msgid "Create a new {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:897
+msgid "Create a numbered list"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:81
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2005
+#: packages/admin/src/routes/bylines.tsx:247
+msgid "Create byline"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
+msgid "Create New Token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1340
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr ""
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:237
+msgid "Create redirect for this path"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:435
+msgid "Create redirect rules to manage URL changes."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "Create Schema & Import"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:596
+#: packages/admin/src/components/TaxonomyManager.tsx:687
+msgid "Create Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+msgid "Create Token"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:345
+msgid "Create Widget Area"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:259
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:72
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Create, update, and delete content"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr ""
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:844
+msgid "Created {0} translation"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr ""
+
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:900
+msgid "Created: {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "Creating collections and fields..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2057
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:181
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+#: packages/admin/src/components/TaxonomyManager.tsx:687
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Creating..."
+msgstr ""
+
+#: packages/admin/src/components/TranslationsPanel.tsx:78
+msgid "current"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:264
+msgid "Current"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:614
+msgid "Custom Fields"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:154
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Custom Section"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:176
+#: packages/admin/src/components/Sidebar.tsx:401
+msgid "Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:232
+msgid "Date"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:279
+msgid "Date Format"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
+msgid "Default Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
+msgid "Default role:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:599
+msgid "Define a new taxonomy for classifying content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:361
+msgid "Defined in code"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:663
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:298
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+#: packages/admin/src/components/MenuEditor.tsx:455
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:552
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+#: packages/admin/src/components/Widgets.tsx:636
+#: packages/admin/src/routes/bylines.tsx:323
+#: packages/admin/src/routes/bylines.tsx:338
+msgid "Delete"
+msgstr ""
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "Delete {0}"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:740
+msgid "Delete {0} field"
+msgstr ""
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr ""
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:584
+msgid "Delete {0} widget area"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:880
+msgid "Delete {0}?"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:336
+msgid "Delete Byline?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2517
+msgid "Delete column"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:657
+msgid "Delete Field?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:191
+#: packages/admin/src/components/editor/ImageNode.tsx:192
+msgid "Delete image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:253
+msgid "Delete Media?"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:640
+msgid "Delete Permanently"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:620
+msgid "Delete Permanently?"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Delete redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:510
+msgid "Delete redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:550
+msgid "Delete Redirect?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2538
+msgid "Delete row"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2553
+msgid "Delete table"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:634
+msgid "Delete Widget Area?"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:346
+msgid "Deleted"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:664
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:553
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/TaxonomyManager.tsx:885
+#: packages/admin/src/components/Widgets.tsx:637
+#: packages/admin/src/routes/bylines.tsx:339
+msgid "Deleting..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Describe the image..."
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:205
+msgid "Describe this image for accessibility"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:262
+msgid "Describe what this section is for..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:415
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:373
+msgid "Description"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:432
+msgid "Description (optional)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Destination"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:407
+msgid "details"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:176
+msgid "Dimensions:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Disable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Disable redirect"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:304
+#: packages/admin/src/components/Redirects.tsx:392
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:478
+msgid "Disabled:"
+msgstr ""
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:660
+#: packages/admin/src/components/ContentEditor.tsx:682
+msgid "Discard changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:666
+msgid "Discard draft changes?"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
+msgid "Dismiss"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2008
+#: packages/admin/src/components/ContentEditor.tsx:2070
+#: packages/admin/src/routes/bylines.tsx:252
+msgid "Display name"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:636
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:926
+msgid "Divider"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+msgid "Documents"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
+msgid "Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
+msgid "Domain added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
+msgid "Domain removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
+msgid "Domain updated"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1964
+msgid "Done"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1951
+msgid "Down"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1962
+msgid "Downloading"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "draft"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:831
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+msgid "Draft"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:188
+msgid "Drafts"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:961
+msgid "Drag and drop or click to browse (.xml)"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drag here to add"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1638
+msgid "Drag to reorder"
+msgstr ""
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:707
+#: packages/admin/src/components/Widgets.tsx:722
+msgid "Drag to reorder {0}"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:335
+msgid "Drag to reorder block"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:624
+msgid "Drag widgets here to add them"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:402
+msgid "Drag widgets into an area to add them"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drop to add widget"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1427
+msgid "Drop your WordPress export file here"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:289
+msgid "Duplicate"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:531
+msgid "Duplicate {title}"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "e.g. import, blog"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
+msgid "e.g., CI/CD Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1960
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:450
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/PortableTextEditor.tsx:1243
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TranslationsPanel.tsx:88
+msgid "Edit"
+msgstr ""
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: selected.displayName
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:276
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/routes/bylines.tsx:247
+msgid "Edit {0}"
+msgstr ""
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+msgid "Edit {0} field"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:599
+msgid "Edit {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:523
+msgid "Edit {title}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2067
+msgid "Edit byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
+msgid "Edit Domain"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2470
+msgid "Edit link"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:478
+msgid "Edit Menu Item"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:282
+msgid "Edit menu items"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:501
+msgid "Edit redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr ""
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "Edit redirect {0}"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:59
+#: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
+msgid "Email address"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:215
+msgid "Email Middleware"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:125
+msgid "Email Pipeline"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:199
+msgid "Email provider active"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:85
+#: packages/admin/src/components/settings/EmailSettings.tsx:100
+msgid "Email Settings"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr ""
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:1965
+msgid "Embed a {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1968
+msgid "Embeds"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1047
+msgid "EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Enable comments"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:395
+msgid "Enable plugin"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Enable redirect"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:168
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "Enabled"
+msgstr ""
+
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1191
+msgid "Enter {0}..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:336
+#: packages/admin/src/components/MenuEditor.tsx:506
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1439
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1219
+msgid "Enter credentials manually"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:635
+msgid "Enter distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1213
+msgid "Enter markdown content..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1298
+msgid "Enter your WordPress credentials to import content directly."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:924
+msgid "Enter your WordPress site URL"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:101
+#: packages/admin/src/components/MenuEditor.tsx:139
+#: packages/admin/src/components/MenuEditor.tsx:179
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:689
+#: packages/admin/src/router.tsx:1722
+msgid "Error"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:174
+msgid "Error adding widget"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:235
+msgid "Error reordering widgets"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:52
+msgid "Error saving section"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Error updating widget"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1846
+msgid "Exists"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:593
+msgid "Exit distraction-free mode"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2971
+msgid "Exit Spotlight Mode"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:407
+msgid "Expand"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:401
+msgid "Expand details"
+msgstr ""
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
+msgid "Expires {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
+msgid "Expiry"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1112
+msgid "Export from WordPress manually"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1236
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:144
+msgid "Facebook"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1966
+msgid "Failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:189
+msgid "Failed security audit"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Failed to add domain"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:367
+msgid "Failed to analyze WordPress site"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2051
+msgid "Failed to create byline"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1553
+msgid "Failed to create some collections"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:456
+msgid "Failed to create term"
+msgstr ""
+
+#: packages/admin/src/router.tsx:849
+msgid "Failed to create translation"
+msgstr ""
+
+#: packages/admin/src/router.tsx:338
+#: packages/admin/src/router.tsx:367
+#: packages/admin/src/router.tsx:869
+msgid "Failed to delete"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr ""
+
+#: packages/admin/src/lib/api/bylines.ts:89
+msgid "Failed to delete byline"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr ""
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1098
+msgid "Failed to delete comment"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:217
+msgid "Failed to delete content"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:278
+msgid "Failed to delete field"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:338
+msgid "Failed to delete from provider"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:215
+msgid "Failed to delete media"
+msgstr ""
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr ""
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr ""
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr ""
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:109
+msgid "Failed to disable plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr ""
+
+#: packages/admin/src/router.tsx:783
+msgid "Failed to discard changes"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr ""
+
+#: packages/admin/src/router.tsx:381
+msgid "Failed to duplicate"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:90
+msgid "Failed to enable plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:295
+msgid "Failed to execute import"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:81
+msgid "Failed to fetch entry terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/client.ts:189
+msgid "Failed to fetch manifest"
+msgstr ""
+
+#: packages/admin/src/lib/api/plugins.ts:55
+#: packages/admin/src/lib/api/plugins.ts:59
+msgid "Failed to fetch plugin"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:462
+#: packages/admin/src/lib/api/content.ts:467
+msgid "Failed to fetch revision"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:65
+msgid "Failed to fetch terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:642
+#: packages/admin/src/router.tsx:1029
+msgid "Failed to fetch user"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
+msgid "Failed to generate preview"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:386
+msgid "Failed to import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:319
+#: packages/admin/src/lib/api/import.ts:256
+msgid "Failed to import media"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+msgid "Failed to install plugin"
+msgstr ""
+
+#: packages/admin/src/router.tsx:244
+msgid "Failed to load admin"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Failed to load allowed domains"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:170
+msgid "Failed to load bylines: {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:89
+msgid "Failed to load email settings"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:365
+msgid "Failed to load image"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:144
+msgid "Failed to load passkeys"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:111
+msgid "Failed to load plugin"
+msgstr ""
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Failed to load plugins: {0}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:180
+msgid "Failed to load revisions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr ""
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1123
+msgid "Failed to perform bulk action"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:260
+msgid "Failed to permanently delete content"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:276
+msgid "Failed to prepare import"
+msgstr ""
+
+#: packages/admin/src/router.tsx:748
+msgid "Failed to publish"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
+msgid "Failed to remove domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr ""
+
+#: packages/admin/src/lib/api/schema.ts:293
+msgid "Failed to reorder fields"
+msgstr ""
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr ""
+
+#: packages/admin/src/router.tsx:353
+msgid "Failed to restore"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:249
+msgid "Failed to restore content"
+msgstr ""
+
+#: packages/admin/src/lib/api/content.ts:484
+#: packages/admin/src/lib/api/content.ts:489
+msgid "Failed to restore revision"
+msgstr ""
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:332
+msgid "Failed to rewrite URLs"
+msgstr ""
+
+#: packages/admin/src/router.tsx:701
+#: packages/admin/src/router.tsx:1540
+msgid "Failed to save"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:58
+#: packages/admin/src/components/settings/SeoSettings.tsx:53
+#: packages/admin/src/components/settings/SocialSettings.tsx:53
+msgid "Failed to save settings"
+msgstr ""
+
+#: packages/admin/src/router.tsx:801
+msgid "Failed to schedule"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr ""
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:61
+msgid "Failed to send test email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:100
+msgid "Failed to set entry terms"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+msgid "Failed to uninstall plugin"
+msgstr ""
+
+#: packages/admin/src/router.tsx:764
+msgid "Failed to unpublish"
+msgstr ""
+
+#: packages/admin/src/router.tsx:819
+msgid "Failed to unschedule"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:320
+msgid "Failed to update {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2101
+msgid "Failed to update byline"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+msgid "Failed to update domain"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+msgid "Failed to update plugin"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1082
+msgid "Failed to update status"
+msgstr ""
+
+#: packages/admin/src/lib/api/media.ts:132
+msgid "Failed to upload file"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:250
+msgid "Failed to verify authentication"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:221
+#: packages/admin/src/components/settings/GeneralSettings.tsx:226
+msgid "Favicon"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1022
+msgid "Feature"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:736
+msgid "Fetching content from the EmDash Exporter API."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:572
+msgid "Fields"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Fields created:"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr ""
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:1994
+msgid "File {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:416
+msgid "Filename"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:196
+msgid "Filename cannot be changed after upload"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2172
+msgid "files imported"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:393
+msgid "Filter by status"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:399
+msgid "Filter by type"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:188
+msgid "Filter byline type"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1237
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1046
+msgid "For the best import experience, install the"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:101
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:624
+msgid "Genres"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:138
+msgid "GitHub"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2224
+#: packages/admin/src/router.tsx:1742
+msgid "Go to Dashboard"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:138
+msgid "Google Verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Grid view"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "Group (optional)"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:290
+msgid "Guest byline"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:193
+msgid "Guest only"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:61
+#: packages/admin/src/components/PortableTextEditor.tsx:856
+#: packages/admin/src/components/PortableTextEditor.tsx:2781
+msgid "Heading 1"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:69
+#: packages/admin/src/components/PortableTextEditor.tsx:866
+#: packages/admin/src/components/PortableTextEditor.tsx:2788
+msgid "Heading 2"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:77
+#: packages/admin/src/components/PortableTextEditor.tsx:876
+#: packages/admin/src/components/PortableTextEditor.tsx:2795
+msgid "Heading 3"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:271
+msgid "hero, banner, cta"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:191
+msgid "Hide from search engines"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:647
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:216
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "Hits"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "Home"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:335
+msgid "Hooks"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1359
+msgid "How to create an Application Password"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:337
+msgid "https://example.com or /about"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:449
+msgid "https://example.com/image.jpg"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:143
+msgid "Icon blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/PortableTextEditor.tsx:1934
+msgid "Image"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:179
+#: packages/admin/src/components/editor/ImageNode.tsx:180
+msgid "Image settings"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:450
+msgid "Image URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2176
+msgid "image URLs updated in"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+msgid "Images"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:228
+#: packages/admin/src/components/WordPressImport.tsx:664
+msgid "Import"
+msgstr ""
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1794
+msgid "Import {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1205
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2222
+msgid "Import Another File"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1016
+msgid "Import Capabilities"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2110
+msgid "Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2111
+msgid "Import Completed with Errors"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Import failed"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:617
+msgid "Import from WordPress"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1943
+msgid "Import Media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "Import Media Files"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:619
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1650
+msgid "Import site configuration from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Import via EmDash Exporter"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2150
+msgid "Imported by Collection"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:820
+msgid "Importing content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1975
+msgid "Importing Media"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1816
+msgid "Incompatible"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2768
+msgid "Inline Code"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:461
+#: packages/admin/src/components/MediaPickerModal.tsx:666
+#: packages/admin/src/components/PortableTextEditor.tsx:1243
+msgid "Insert"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:907
+msgid "Insert a blockquote"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:917
+msgid "Insert a code block"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:927
+msgid "Insert a horizontal rule"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1949
+msgid "Insert a reusable section"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:937
+msgid "Insert a table"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1935
+msgid "Insert an image"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:443
+msgid "Insert from URL"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2938
+msgid "Insert Horizontal Rule"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2933
+msgid "Insert Image"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2880
+msgid "Insert Link"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2838
+msgid "Insert Table"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:150
+msgid "Instagram"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:193
+msgid "Install"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:181
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:187
+msgid "Install blocked"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:174
+msgid "Installed"
+msgstr ""
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:447
+msgid "Installed from marketplace (v{0})"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:466
+msgid "Installed:"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:145
+msgid "Installing..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:119
+msgid "Invalid invite link"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1508
+msgid "Invalid JSON"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:207
+msgid "Invite Error"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:117
+msgid "Invite expired"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2441
+#: packages/admin/src/components/PortableTextEditor.tsx:2747
+msgid "Italic"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1624
+#: packages/admin/src/components/RepeaterField.tsx:234
+msgid "Item {0}"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Item added"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:133
+msgid "Item deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:158
+msgid "Item updated"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:294
+#: packages/admin/src/components/SectionEditor.tsx:268
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:329
+#: packages/admin/src/components/MenuEditor.tsx:498
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:621
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Label"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:394
+msgid "Label (Plural)"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:386
+msgid "Label (Singular)"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:857
+msgid "Large section heading"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:472
+msgid "Last enabled:"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "Last seen"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr ""
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Leave unassigned"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:82
+#: packages/admin/src/components/MediaLibrary.tsx:202
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Library"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr ""
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:194
+msgid "Linked only"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:273
+msgid "Linked user"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:156
+msgid "LinkedIn"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:241
+msgid "List view"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:714
+msgid "Live View"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:239
+msgid "Load more"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:330
+#: packages/admin/src/components/ContentList.tsx:387
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr ""
+
+#: packages/admin/src/router.tsx:1711
+msgid "Loading configuration..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2268
+msgid "Loading editor..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:255
+msgid "Loading menu..."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:127
+msgid "Loading plugins..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:430
+msgid "Loading redirects..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:81
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+msgid "Loading settings..."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:825
+msgid "Loading terms..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:310
+msgid "Loading widgets..."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:245
+#: packages/admin/src/components/ContentList.tsx:330
+#: packages/admin/src/components/ContentList.tsx:359
+#: packages/admin/src/components/ContentList.tsx:387
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/PortableTextEditor.tsx:1751
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:176
+#: packages/admin/src/components/settings/SecuritySettings.tsx:113
+#: packages/admin/src/components/TaxonomyManager.tsx:777
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:239
+msgid "Loading..."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:225
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:177
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+msgid "Logo"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1668
+msgid "Logo & favicon"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:639
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Main Sidebar"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Make network requests"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests to any host (unrestricted)"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:426
+msgid "Manage"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:796
+msgid "Manage {0} for {1}"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:326
+msgid "Manage content widgets in your widget areas"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:166
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:333
+msgid "Manage URL redirects and view 404 errors."
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Manual"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2260
+msgid "Map Authors"
+msgstr ""
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2308
+msgid "Map WordPress user {0} to EmDash user"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:192
+msgid "marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:158
+#: packages/admin/src/components/PluginManager.tsx:305
+#: packages/admin/src/components/Sidebar.tsx:219
+msgid "Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:626
+msgid "Max Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1938
+#: packages/admin/src/components/Sidebar.tsx:185
+#: packages/admin/src/components/WordPressImport.tsx:678
+#: packages/admin/src/components/WordPressImport.tsx:1173
+msgid "Media"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:130
+msgid "Media Details"
+msgstr ""
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2206
+msgid "Media Errors ({0})"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2168
+msgid "Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2109
+msgid "Media Import Complete"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2120
+msgid "Media import was skipped"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:226
+msgid "Media Library"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:867
+msgid "Medium section heading"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:834
+msgid "Menu"
+msgstr ""
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:90
+msgid "Menu \"{0}\" ({1}) created."
+msgstr ""
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Menu item has been added."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:134
+msgid "Menu item has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:159
+msgid "Menu item has been updated."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:263
+msgid "Menu not found"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:174
+msgid "Menu order has been updated."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:195
+msgid "Menus"
+msgstr ""
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1604
+msgid "Menus ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Meta Description"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:147
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:141
+msgid "Meta tag content for Google Search Console verification"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1681
+msgid "Meta titles, descriptions, and social images"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:619
+msgid "Min Items"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:506
+msgid "Moderation"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:552
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:543
+msgid "Move {title} to trash"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:443
+msgid "Move down"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:917
+#: packages/admin/src/components/ContentEditor.tsx:939
+#: packages/admin/src/components/ContentList.tsx:565
+msgid "Move to Trash"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:923
+#: packages/admin/src/components/ContentList.tsx:550
+msgid "Move to Trash?"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "Move up"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:387
+#: packages/admin/src/components/TaxonomyManager.tsx:630
+#: packages/admin/src/components/TaxonomyManager.tsx:819
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:365
+msgid "Name"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:556
+msgid "Name and label are required"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:562
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr ""
+
+#: packages/admin/src/router.tsx:844
+msgid "new"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:206
+msgid "New"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:103
+msgid "NEW"
+msgstr ""
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:427
+msgid "New {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:599
+msgid "New {collectionLabel}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1818
+msgid "New collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:336
+msgid "New Redirect"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:809
+msgid "New Taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:343
+#: packages/admin/src/components/MenuEditor.tsx:346
+#: packages/admin/src/components/MenuEditor.tsx:514
+#: packages/admin/src/components/MenuEditor.tsx:517
+msgid "New window"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "News"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:318
+msgid "Next page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Next screenshot"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+msgid "No"
+msgstr ""
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:397
+msgid "No {0} available."
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:252
+msgid "No {0} yet."
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:828
+msgid "No {0} yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:208
+msgid "No 404 errors recorded yet."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:612
+#: packages/admin/src/components/MediaLibrary.tsx:669
+msgid "No alt text"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
+msgid "No API tokens yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:231
+msgid "No bylines found"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1992
+msgid "No bylines selected."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:80
+msgid "No content"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:603
+msgid "No custom fields yet"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:265
+msgid "No detailed description available."
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
+msgid "No domains configured. Users must be invited individually."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:178
+msgid "No email provider configured"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "No EmDash users found"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:327
+msgid "No fields to compare"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:189
+msgid "No headings in document"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:159
+msgid "No invite token provided"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1547
+#: packages/admin/src/components/RepeaterField.tsx:160
+msgid "No items yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:630
+msgid "No limit"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:284
+msgid "No linked user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+#: packages/admin/src/components/MediaPickerModal.tsx:579
+msgid "No media available from this provider"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:363
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "No media found"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "No media yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:398
+msgid "No menu items yet"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "No passkeys registered yet."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:186
+msgid "No plugins configured"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:434
+msgid "No redirects yet"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1112
+msgid "No results"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:266
+msgid "No results for \"{searchQuery}\""
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:183
+msgid "No revisions yet"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "No widget areas yet. Create one to get started."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:416
+#: packages/admin/src/components/TaxonomyManager.tsx:422
+msgid "None (top level)"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:276
+msgid "Number of posts to show per page on list views"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:109
+#: packages/admin/src/components/PortableTextEditor.tsx:896
+#: packages/admin/src/components/PortableTextEditor.tsx:2815
+msgid "Numbered List"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Open WordPress Profile"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:213
+msgid "Optional caption for display"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:435
+msgid "Optional description"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:473
+msgid "or choose from library"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1429
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Or upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:949
+msgid "or upload directly"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:173
+msgid "Order saved"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr ""
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:181
+msgid "Outline"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:155
+msgid "Overrides the page title in search engine results"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:954
+msgid "Ownership"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Package"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1737
+msgid "Page Not Found"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:323
+#: packages/admin/src/components/WordPressImport.tsx:1167
+msgid "Pages"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:53
+msgid "Paragraph"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:412
+msgid "Parent"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:483
+#: packages/admin/src/components/Redirects.tsx:489
+msgid "Part of a redirect loop"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr ""
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr ""
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:215
+msgid "Path"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr ""
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:437
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr ""
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:433
+msgid "Pattern must include a {0} placeholder"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:689
+msgid "pending"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+msgid "Pending"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:829
+msgid "Pending changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:623
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:612
+msgid "Permanently delete {title}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:274
+msgid "Permissions"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:133
+msgid "Please ask your administrator to send a new invite."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:342
+msgid "Please enter a valid URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1024
+msgid "Plugin"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:103
+msgid "Plugin disabled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:84
+msgid "Plugin enabled"
+msgstr ""
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr ""
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:113
+msgid "Plugin not found"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1048
+msgid "plugin on your WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Plugin Permissions"
+msgstr ""
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:255
+msgid "Plugin uninstalled"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:242
+msgid "Plugin updated"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:126
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/Sidebar.tsx:212
+#: packages/admin/src/components/Sidebar.tsx:450
+msgid "Plugins"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:182
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1161
+msgid "Posts"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:270
+msgid "Posts Per Page"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2020
+msgid "Preparing to download files from WordPress..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:649
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:415
+msgid "Preview"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:649
+msgid "Preview draft"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:306
+msgid "Previous page"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:446
+msgid "Previous screenshot"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:202
+msgid "Provider:"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:704
+#: packages/admin/src/components/ContentEditor.tsx:810
+msgid "Publish"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:694
+msgid "Publish changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:664
+msgid "published"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:825
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/Dashboard.tsx:187
+#: packages/admin/src/router.tsx:744
+msgid "Published"
+msgstr ""
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:327
+msgid "Published {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2000
+msgid "Quick create byline"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:167
+#: packages/admin/src/components/editor/ImageNode.tsx:168
+msgid "Quick edit alt text"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:85
+#: packages/admin/src/components/PortableTextEditor.tsx:906
+#: packages/admin/src/components/PortableTextEditor.tsx:2822
+msgid "Quote"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Read user accounts"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:230
+msgid "Read your content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:267
+msgid "Reading"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1822
+msgid "Ready"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:144
+msgid "Recipient email"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:416
+msgid "Redirect loop detected"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:332
+#: packages/admin/src/components/Redirects.tsx:351
+#: packages/admin/src/components/Sidebar.tsx:196
+msgid "Redirects"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2958
+msgid "Redo"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:220
+msgid "Register Passkey"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/ContentEditor.tsx:1969
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/PortableTextEditor.tsx:2921
+#: packages/admin/src/components/settings/GeneralSettings.tsx:202
+#: packages/admin/src/components/settings/GeneralSettings.tsx:246
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
+msgid "Remove"
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:222
+msgid "Remove {0}"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1797
+msgid "Remove {label}"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
+msgid "Remove Domain"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
+msgid "Remove Domain?"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1624
+#: packages/admin/src/components/SeoImageField.tsx:55
+msgid "Remove image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1663
+#: packages/admin/src/components/RepeaterField.tsx:270
+msgid "Remove item {0}"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2422
+#: packages/admin/src/components/PortableTextEditor.tsx:2423
+msgid "Remove link"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:610
+msgid "Remove sub-field"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
+msgid "Removing..."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:721
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1835
+msgid "Required fields:"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr ""
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:325
+msgid "Requires EmDash {0}"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restore"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:600
+msgid "Restore {title}"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:136
+msgid "Restore failed"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:214
+msgid "Restore Revision?"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Restore this version"
+msgstr ""
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:217
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:221
+msgid "Restoring..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:1725
+msgid "Retry"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr ""
+
+#: packages/admin/src/router.tsx:778
+msgid "Reverted to published version"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:650
+msgid "Review"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:72
+msgid "Review New Permissions"
+msgstr ""
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Revision restored"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:161
+msgid "Revisions"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
+msgid "Revoke token"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoke?"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Revoking..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr ""
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:312
+msgid "Risk score: {0}/100"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1974
+msgid "Role label"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:343
+#: packages/admin/src/components/MenuEditor.tsx:345
+#: packages/admin/src/components/MenuEditor.tsx:514
+#: packages/admin/src/components/MenuEditor.tsx:516
+msgid "Same window"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2107
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/editor/ImageNode.tsx:235
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:525
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:314
+msgid "Save"
+msgstr ""
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageNode.tsx:236
+msgid "Save alt text"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:162
+msgid "Save SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+msgid "Save Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+msgid "Save Social Links"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:624
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:619
+#: packages/admin/src/components/ContentEditor.tsx:2107
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/FieldEditor.tsx:659
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:525
+#: packages/admin/src/components/Redirects.tsx:180
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:296
+#: packages/admin/src/components/settings/SeoSettings.tsx:99
+#: packages/admin/src/components/settings/SeoSettings.tsx:162
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+#: packages/admin/src/components/TaxonomyManager.tsx:474
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:314
+msgid "Saving..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:869
+msgid "Schedule"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:855
+msgid "Schedule for"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:892
+msgid "Schedule for later"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:668
+msgid "scheduled"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:832
+#: packages/admin/src/router.tsx:795
+msgid "Scheduled"
+msgstr ""
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:842
+msgid "Scheduled for: {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Schema Changes"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Schema preparation failed"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
+msgid "Scopes"
+msgstr ""
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
+msgid "Scopes: {0}"
+msgstr ""
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr ""
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:454
+msgid "Screenshot {0} of {1}"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:247
+msgid "Screenshot blurred due to image audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:432
+msgid "Screenshot viewer"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:234
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+msgid "Search"
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:170
+msgid "Search {0}"
+msgstr ""
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:169
+msgid "Search {0}..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:181
+msgid "Search bylines"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:128
+msgid "Search Engine Optimization"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:519
+msgid "Search media"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+msgid "Search plugins"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+msgid "Search plugins..."
+msgstr ""
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:383
+msgid "Search source or destination..."
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr ""
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:336
+#: packages/admin/src/components/MediaPickerModal.tsx:518
+msgid "Search..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:723
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1948
+msgid "Section"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:82
+msgid "Section \"{slug}\" could not be found."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:233
+msgid "Section Details"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:78
+msgid "Section Not Found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:44
+msgid "Section saved"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "Section title"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:198
+msgid "Sections"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:308
+msgid "Security Audit"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:126
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:127
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+msgid "Security Settings"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:100
+#: packages/admin/src/components/ContentEditor.tsx:1651
+#: packages/admin/src/components/ContentEditor.tsx:1809
+#: packages/admin/src/components/ContentEditor.tsx:1825
+msgid "Select {label}"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:871
+msgid "Select a component..."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:839
+msgid "Select a menu..."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1917
+msgid "Select byline"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1914
+msgid "Select byline..."
+msgstr ""
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:258
+#: packages/admin/src/components/settings/GeneralSettings.tsx:314
+msgid "Select Favicon"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1813
+msgid "Select file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:125
+msgid "Select File"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1639
+msgid "Select image"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:125
+#: packages/admin/src/components/PortableTextEditor.tsx:2310
+#: packages/admin/src/components/PortableTextEditor.tsx:2983
+msgid "Select Image"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:214
+#: packages/admin/src/components/settings/GeneralSettings.tsx:307
+msgid "Select Logo"
+msgstr ""
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:91
+msgid "Select media"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr ""
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1571
+msgid "Select which content types to import."
+msgstr ""
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:1758
+#: packages/admin/src/components/RepeaterField.tsx:361
+msgid "Select..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:653
+msgid "Selected:"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
+msgid "Self-Signup Domains"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:139
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Send Test"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:136
+msgid "Send Test Email"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1008
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:78
+#: packages/admin/src/components/settings/SeoSettings.tsx:103
+msgid "SEO Settings"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1679
+msgid "SEO settings (Yoast)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:48
+msgid "SEO settings saved"
+msgstr ""
+
+#: packages/admin/src/components/SeoPanel.tsx:154
+msgid "SEO Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:531
+msgid "Set to 0 to never close comments automatically."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentTypeEditor.tsx:383
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:384
+#: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:229
+#: packages/admin/src/components/WordPressImport.tsx:1647
+msgid "Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:53
+msgid "Settings saved successfully"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr ""
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr ""
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+msgid "Site Settings"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1659
+msgid "Site title & tagline"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:418
+msgid "Size"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:170
+msgid "Size:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1940
+msgid "Skip Media Import"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1965
+msgid "Skipped"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:813
+#: packages/admin/src/components/ContentEditor.tsx:2016
+#: packages/admin/src/components/ContentEditor.tsx:2078
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:404
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:244
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+#: packages/admin/src/routes/bylines.tsx:257
+msgid "Slug"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:877
+msgid "Small section heading"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:78
+#: packages/admin/src/components/settings/SocialSettings.tsx:103
+msgid "Social Links"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:48
+msgid "Social links saved"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:126
+msgid "Social Profiles"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1696
+msgid "Some content types cannot be imported"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:122
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:215
+#: packages/admin/src/components/PluginManager.tsx:444
+#: packages/admin/src/components/Redirects.tsx:440
+#: packages/admin/src/components/SectionEditor.tsx:279
+msgid "Source"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2971
+msgid "Spotlight Mode"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1758
+msgid "Start Import"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:819
+#: packages/admin/src/components/ContentList.tsx:218
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:445
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:146
+msgid "Status code"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2455
+#: packages/admin/src/components/PortableTextEditor.tsx:2761
+msgid "Strikethrough"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1591
+msgid "Structure"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:768
+msgid "System"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:590
+msgid "System Fields"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:936
+msgid "Table"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr ""
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1633
+msgid "Tags ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:340
+#: packages/admin/src/components/MenuEditor.tsx:511
+msgid "Target"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:495
+msgid "Taxonomies"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:896
+msgid "Taxonomy created"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:783
+msgid "Taxonomy not found:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TaxonomyManager.tsx:812
+msgid "Term"
+msgstr ""
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:757
+msgid "Term \"{0}\" created in {1}."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:739
+msgid "Term deleted"
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "test@example.com"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2731
+msgid "Text formatting"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1698
+msgid "The existing collection has fields with incompatible types."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr ""
+
+#: packages/admin/src/router.tsx:1739
+msgid "The page you're looking for doesn't exist."
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr ""
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:292
+msgid "Theme ID: {0}"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Theme Section"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr ""
+
+#: packages/admin/src/components/Sidebar.tsx:223
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:372
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:361
+msgid "This field does not accept {sniffedMime} files."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1655
+#: packages/admin/src/components/ContentEditor.tsx:1828
+msgid "This field is required"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "This is a custom section."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "This is a WordPress site."
+msgstr ""
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:821
+msgid "This may take a while for large exports."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:277
+msgid "This plugin requires no special permissions."
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:551
+msgid "This redirect rule will be permanently removed."
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:337
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:283
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This section was imported from another system."
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:635
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:926
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr ""
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr ""
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:570
+msgid "This will remove the plugin and its bundle from your site."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:669
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:285
+msgid "Timezone"
+msgstr ""
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:288
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:212
+#: packages/admin/src/components/ContentList.tsx:343
+#: packages/admin/src/components/SectionEditor.tsx:236
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:811
+msgid "Title"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr ""
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:132
+msgid "Title Separator"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2547
+msgid "Toggle header row"
+msgstr ""
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr ""
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
+msgid "Token Name"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "Tools → Export"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translate"
+msgstr ""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr ""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translating..."
+msgstr ""
+
+#: packages/admin/src/components/MenuEditor.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:756
+#: packages/admin/src/router.tsx:843
+msgid "Translation created"
+msgstr ""
+
+#: packages/admin/src/components/TranslationsPanel.tsx:56
+msgid "Translations"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:192
+msgid "Trash"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:366
+msgid "Trash is empty"
+msgstr ""
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+#: packages/admin/src/components/MediaPickerModal.tsx:576
+msgid "Try a different search term"
+msgstr ""
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr ""
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr ""
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1421
+msgid "Try Again"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1125
+#: packages/admin/src/components/WordPressImport.tsx:1247
+msgid "Try Another URL"
+msgstr ""
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr ""
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:279
+msgid "Turn into"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:132
+msgid "Twitter"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:417
+msgid "Type"
+msgstr ""
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1854
+msgid "Type mismatch ({0})"
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:2121
+#: packages/admin/src/components/ContentEditor.tsx:2136
+msgid "Unassigned"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2448
+#: packages/admin/src/components/PortableTextEditor.tsx:2754
+msgid "Underline"
+msgstr ""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2951
+msgid "Undo"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:181
+#: packages/admin/src/components/PluginManager.tsx:494
+#: packages/admin/src/components/PluginManager.tsx:584
+msgid "Uninstall"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:568
+msgid "Uninstall {pluginName}?"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:563
+msgid "Uninstall confirmation"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:584
+msgid "Uninstalling..."
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:722
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr ""
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr ""
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:698
+msgid "Unpublish"
+msgstr ""
+
+#: packages/admin/src/router.tsx:760
+msgid "Unpublished"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:844
+msgid "Unschedule"
+msgstr ""
+
+#: packages/admin/src/router.tsx:813
+msgid "Unscheduled"
+msgstr ""
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1731
+msgid "Untitled file"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:466
+#: packages/admin/src/components/Widgets.tsx:729
+msgid "Untitled Widget"
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1948
+msgid "Up"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Update"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Update Field"
+msgstr ""
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
+msgid "Update settings for {0}"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr ""
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:364
+msgid "Update the {0} details"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:364
+msgid "Update to v{0}"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr ""
+
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:901
+msgid "Updated: {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:844
+msgid "Updating content URLs..."
+msgstr ""
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:364
+msgid "Updating..."
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:540
+msgid "Upload"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:127
+msgid "Upload a file to get started"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Upload an export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:128
+msgid "Upload an image to get started"
+msgstr ""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr ""
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Upload and manage media"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1123
+#: packages/admin/src/components/WordPressImport.tsx:1244
+msgid "Upload Export File"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:560
+msgid "Upload failed: {uploadError}"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:552
+msgid "Upload file"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:129
+msgid "Upload File"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:323
+msgid "Upload files"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:357
+msgid "Upload Files"
+msgstr ""
+
+#: packages/admin/src/components/MediaPickerModal.tsx:129
+msgid "Upload Image"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:354
+msgid "Upload images, videos, and documents to get started."
+msgstr ""
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:368
+msgid "Upload media to get started"
+msgstr ""
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:314
+msgid "Upload to {0}"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:960
+msgid "Upload WordPress export file"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:184
+msgid "Uploaded:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1963
+msgid "Uploading"
+msgstr ""
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:289
+msgid "Uploading {0}/{1}..."
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:290
+#: packages/admin/src/components/MediaPickerModal.tsx:540
+msgid "Uploading..."
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:331
+#: packages/admin/src/components/MenuEditor.tsx:501
+#: packages/admin/src/components/PortableTextEditor.tsx:2887
+msgid "URL"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:425
+msgid "URL Pattern"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr ""
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:642
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr ""
+
+#: packages/admin/src/components/ContentEditor.tsx:1290
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr ""
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Used by screen readers and when image fails to load"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:410
+msgid "Used in URLs and API endpoints"
+msgstr ""
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr ""
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:211
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
+msgid "Users from"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr ""
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:308
+msgid "v{0} available"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:194
+msgid "Verifying your invite..."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:321
+msgid "Version"
+msgstr ""
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+msgid "Video"
+msgstr ""
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr ""
+
+#: packages/admin/src/components/PluginManager.tsx:376
+msgid "View in Marketplace"
+msgstr ""
+
+#: packages/admin/src/components/MediaLibrary.tsx:227
+msgid "View mode"
+msgstr ""
+
+#: packages/admin/src/components/ContentList.tsx:516
+msgid "View published {title}"
+msgstr ""
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr ""
+
+#: packages/admin/src/components/Redirects.tsx:422
+msgid "Visitors hitting these paths will see an error."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr ""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr ""
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:926
+msgid "We'll check what import options are available for your site."
+msgstr ""
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr ""
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:226
+msgid "Website"
+msgstr ""
+
+#: packages/admin/src/routes/bylines.tsx:262
+msgid "Website URL"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1927
+msgid "What happens when you import:"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1710
+msgid "What will happen when you import"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr ""
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr ""
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Which content types can use this taxonomy"
+msgstr ""
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:722
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "widget"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:170
+msgid "Widget added"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Widget area created"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:565
+msgid "Widget area deleted"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:685
+msgid "Widget deleted"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:814
+msgid "Widget title"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Widget updated"
+msgstr ""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:329
+#: packages/admin/src/components/Sidebar.tsx:197
+#: packages/admin/src/components/Widgets.tsx:325
+msgid "Widgets"
+msgstr ""
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1850
+msgid "Will create"
+msgstr ""
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr ""
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:184
+msgid "Without an email provider, invite links must be shared manually."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1315
+msgid "WordPress Username"
+msgstr ""
+
+#: packages/admin/src/components/Widgets.tsx:824
+msgid "Write widget content..."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1023
+msgid "WXR File"
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+msgid "Yes"
+msgstr ""
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr ""
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr ""
+
+#: packages/admin/src/router.tsx:1139
+msgid "You need Editor permissions to moderate comments."
+msgstr ""
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr ""
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You'll be joining as <0>{0}</0>"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr ""
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:50
+msgid "You've been invited!"
+msgstr ""
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr ""
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Your Facebook page or profile username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:141
+msgid "Your GitHub username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:153
+msgid "Your Instagram username"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:159
+msgid "Your LinkedIn profile username"
+msgstr ""
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr ""
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr ""
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:135
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr ""
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1898
+msgid "Your WordPress export contains {0} media files."
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:165
+msgid "Your YouTube channel ID or handle"
+msgstr ""
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:162
+msgid "YouTube"
+msgstr ""

--- a/packages/admin/src/locales/es-ES/messages.po
+++ b/packages/admin/src/locales/es-ES/messages.po
@@ -18,7 +18,7 @@ msgstr " - Vinculado"
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:76
 msgid " (default)"
-msgstr " (defecto)"
+msgstr " (predeterminado)"
 
 #: packages/admin/src/components/MenuEditor.tsx:427
 msgid " (opens in new window)"
@@ -58,434 +58,434 @@ msgstr "(con tu puerto de desarrollo)."
 #: packages/admin/src/components/ContentTypeList.tsx:69
 #: packages/admin/src/components/RepeaterField.tsx:147
 msgid "{0, plural, one {(# item)} other {(# items)}}"
-msgstr "{0, plural, una {(# item)} otras {(# items)}}"
+msgstr "{0, plural, one {(# elemento)} other {(# elementos)}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr "{0, plural, una {# collection} otras {# collections}}"
+msgstr "{0, plural, one {# colección} other {# colecciones}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1118
 msgid "{0, plural, one {# comment updated} other {# comments updated}}"
-msgstr ""
+msgstr "{0, plural, one {# comentario actualizado} other {# comentarios actualizados}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:344
 msgid "{0, plural, one {# comment} other {# comments}}"
-msgstr ""
+msgstr "{0, plural, one {# comentario} other {# comentarios}}"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2080
 msgid "{0, plural, one {# content error} other {# content errors}}"
-msgstr ""
+msgstr "{0, plural, one {# error de contenido} other {# errores de contenido}}"
 
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2056
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr ""
+msgstr "{0, plural, one {# elemento de contenido importado} other {# elementos de contenido importados}}"
 
 #. placeholder {0}: filteredItems.length
 #: packages/admin/src/components/ContentList.tsx:291
 msgid "{0, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{0, plural, one {# elemento que coincide con \"{searchQuery}\"} other {# elementos que coinciden con \"{searchQuery}\"}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
 #: packages/admin/src/components/MediaPickerModal.tsx:527
 #: packages/admin/src/components/MenuList.tsx:217
 msgid "{0, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{0, plural, one {# elemento} other {# elementos}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2085
 msgid "{0, plural, one {# media error} other {# media errors}}"
-msgstr ""
+msgstr "{0, plural, one {# error de medios} other {# errores de medios}}"
 
 #. placeholder {0}: mediaResult.imported.length
 #: packages/admin/src/components/WordPressImport.tsx:2072
 msgid "{0, plural, one {# media file imported} other {# media files imported}}"
-msgstr ""
+msgstr "{0, plural, one {# archivo multimedia importado} other {# archivos multimedia importados}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
 msgid "{0, plural, one {# media file} other {# media files}}"
-msgstr ""
+msgstr "{0, plural, one {# archivo multimedia} other {# archivos multimedia}}"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1739
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
-msgstr ""
+msgstr "{0, plural, one {se importará # menú} other {se importarán # menús}}"
 
 #. placeholder {0}: plugin.capabilities.length
 #: packages/admin/src/components/MarketplaceBrowse.tsx:288
 msgid "{0, plural, one {# permission} other {# permissions}}"
-msgstr ""
+msgstr "{0, plural, one {# permiso} other {# permisos}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2292
 msgid "{0, plural, one {# post} other {# posts}}"
-msgstr ""
+msgstr "{0, plural, one {# entrada} other {# entradas}}"
 
 #. placeholder {0}: loopRedirectIds.size
 #: packages/admin/src/components/Redirects.tsx:418
 msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
-msgstr ""
+msgstr "{0, plural, one {# redirección es parte de un bucle.} other {# redirecciones son parte de un bucle.}}"
 
 #. placeholder {0}: selected.size
 #: packages/admin/src/components/comments/CommentInbox.tsx:228
 msgid "{0, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{0, plural, one {# seleccionado} other {# seleccionados}}"
 
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2064
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr ""
+msgstr "{0, plural, one {# omitido (ya existe)} other {# omitidos (ya existen)}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:128
 msgid "{0, plural, one {# user} other {# users}}"
-msgstr ""
+msgstr "{0, plural, one {# usuario} other {# usuarios}}"
 
 #. placeholder {0}: filteredItems.length
 #. placeholder {1}: hasMore ? "+" : ""
 #. placeholder {2}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:295
 msgid "{0, plural, one {#{1} item} other {#{2} items}}"
-msgstr ""
+msgstr "{0, plural, one {#{1} elemento} other {#{2} elementos}}"
 
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:576
 msgid "{0, plural, one {field} other {fields}}"
-msgstr ""
+msgstr "{0, plural, one {campo} other {campos}}"
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
 #: packages/admin/src/components/MenuList.tsx:215
 msgid "{0} • {1}"
-msgstr ""
+msgstr "{0} • {1}"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1142
 msgid "{0} detected"
-msgstr ""
+msgstr "{0} detectado"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:104
 msgid "{0} has been deactivated"
-msgstr ""
+msgstr "{0} ha sido desactivado"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:256
 msgid "{0} has been removed"
-msgstr ""
+msgstr "{0} ha sido eliminado"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:203
 msgid "{0} installs"
-msgstr ""
+msgstr "{0} instalados"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:85
 msgid "{0} is now active"
-msgstr ""
+msgstr "{0} ahora está activo"
 
 #. placeholder {0}: postType.count
 #. placeholder {1}: postType.suggestedCollection
 #: packages/admin/src/components/WordPressImport.tsx:1809
 msgid "{0} items → {1}"
-msgstr ""
+msgstr "{0} elementos → {1}"
 
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1732
 msgid "{0} items will be imported"
-msgstr ""
+msgstr "Se importarán {0} elementos"
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
 #: packages/admin/src/components/PluginManager.tsx:349
 msgid "{0} permission{1}"
-msgstr ""
+msgstr "{0} Permiso{1}"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:161
 msgid "{0} plugins"
-msgstr ""
+msgstr "{0} plugins"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
 msgid "{0} preview"
-msgstr ""
+msgstr "{0} vista previa"
 
 #. placeholder {0}: SYSTEM_FIELDS.length
 #. placeholder {1}: fields.length
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const plural = value ? `${value}s` : ""; handleLabelChange(plural); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:574
 msgid "{0} system + {1} custom {2}"
-msgstr ""
+msgstr "{0} de sistema + {1} personalizado {2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:316
 msgid "{0} updated"
-msgstr ""
+msgstr "{0} actualizado"
 
 #. placeholder {0}: plugin.name
 #. placeholder {1}: updateInfo?.latest
 #: packages/admin/src/components/PluginManager.tsx:243
 msgid "{0} updated to v{1}"
-msgstr ""
+msgstr "{0} actualizado a v{1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
 #: packages/admin/src/components/MediaPickerModal.tsx:716
 #: packages/admin/src/components/MediaPickerModal.tsx:798
 msgid "{0}{1}"
-msgstr ""
+msgstr "{0}{1}"
 
 #. placeholder {0}: draft.description.length
 #: packages/admin/src/components/SeoPanel.tsx:168
 msgid "{0}/160 characters"
-msgstr ""
+msgstr "{0}/160 caracteres"
 
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:255
 msgid "{base} to: {0}"
-msgstr ""
+msgstr "{base} a: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:337
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr ""
+msgstr "{changedCount, plural, one {# cambio de la próxima revisión} other {# cambios de la próxima revisión}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1908
 msgid "{count, plural, one {# file} other {# files}}"
-msgstr ""
+msgstr "{count, plural, one {# archivo} other {# archivos}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2157
 msgid "{count, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{count, plural, one {# elemento} other {# elementos}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1979
 msgid "{current} of {total}"
-msgstr ""
+msgstr "{current} de {total}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
-msgstr ""
+msgstr "{label} — sin traducción"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — view translation"
-msgstr ""
+msgstr "{label} — ver traducción"
 
 #: packages/admin/src/components/WordPressImport.tsx:2279
 msgid "{matchedCount} of {totalCount} assigned"
-msgstr ""
+msgstr "{matchedCount} de {totalCount} asignado"
 
 #: packages/admin/src/components/WordPressImport.tsx:2267
 msgid "{matchedCount} of {totalCount} authors matched by email"
-msgstr ""
+msgstr "{matchedCount} de {totalCount} autores coincidentes por correo electrónico"
 
 #: packages/admin/src/components/WordPressImport.tsx:1715
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr ""
+msgstr "{needsNewCollections, plural, one {se creará # nueva colección} other {se crearán # nuevas colecciones}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1724
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr ""
+msgstr "{needsNewFields, plural, one {Se agregarán campos a # colección existente} other {Se agregarán campos a # colecciones existentes}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:76
 msgid "{pluginName} is requesting additional permissions:"
-msgstr ""
+msgstr "{pluginName} solicita permisos adicionales:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:77
 msgid "{pluginName} requires the following permissions:"
-msgstr ""
+msgstr "{pluginName} requiere los siguientes permisos:"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:149
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr ""
+msgstr "{total, plural, one {# total} other {# total}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:140
 #: packages/admin/src/components/MediaLibrary.tsx:176
 msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
-msgstr ""
+msgstr "{total, plural, one {Archivo subido} other {# archivos subidos}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:145
 #: packages/admin/src/components/MediaLibrary.tsx:181
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr ""
+msgstr "{total, plural, one {Error en la carga} other {Error en todas las # cargas}}"
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
-msgstr ""
+msgstr "{totalDrafts, plural, one {# borrador} other {# borradores}}"
 
 #: packages/admin/src/components/Dashboard.tsx:118
 msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
-msgstr ""
+msgstr "{totalScheduled, plural, one {# programado} other {# programados}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:349
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Ocultar # sin cambios} other {Ocultar # sin cambios}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:350
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {Mostrar # sin cambios} other {Mostrar # sin cambios}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:150
 #: packages/admin/src/components/MediaLibrary.tsx:186
 msgid "{uploaded} uploaded, {failed} failed"
-msgstr ""
+msgstr "{uploaded} subido, {failed} falló"
 
 #: packages/admin/src/components/Redirects.tsx:137
 msgid "/new-page or /articles/[slug]"
-msgstr ""
+msgstr "/pagina-nueva o /articulos/[slug]"
 
 #: packages/admin/src/components/Redirects.tsx:129
 msgid "/old-page or /blog/[slug]"
-msgstr ""
+msgstr "/pagina-vieja o /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:1929
 msgid "• Files are downloaded from your WordPress site"
-msgstr ""
+msgstr "• Los archivos se descargan desde tu sitio de WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1930
 msgid "• Uploaded to your EmDash media storage"
-msgstr ""
+msgstr "• Subido a su almacenamiento multimedia EmDash"
 
 #: packages/admin/src/components/WordPressImport.tsx:1931
 msgid "• URLs in your content are updated automatically"
-msgstr ""
+msgstr "• Las URL de tu contenido se actualizan automáticamente"
 
 #: packages/admin/src/components/SetupWizard.tsx:225
 #: packages/admin/src/components/SetupWizard.tsx:277
 #: packages/admin/src/components/SetupWizard.tsx:332
 #: packages/admin/src/components/WordPressImport.tsx:1440
 msgid "← Back"
-msgstr ""
+msgstr "← Volver"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
 msgid "1 year"
-msgstr ""
+msgstr "1 año"
 
 #: packages/admin/src/components/WordPressImport.tsx:1361
 msgid "1. Log into your WordPress admin"
-msgstr ""
+msgstr "1. Inicia sesión en tu administrador de WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1114
 msgid "1. Log into your WordPress admin dashboard"
-msgstr ""
+msgstr "1. Inicia sesión en tu panel de administración de WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "2. Go to"
-msgstr ""
+msgstr "2. Ir a"
 
 #: packages/admin/src/components/WordPressImport.tsx:1362
 msgid "2. Go to Users → Profile"
-msgstr ""
+msgstr "2. Ve a Usuarios → Perfil"
 
 #: packages/admin/src/components/WordPressImport.tsx:1363
 msgid "3. Scroll to \"Application Passwords\""
-msgstr ""
+msgstr "3. Desplácese hasta \"Contraseñas de aplicaciones\"."
 
 #: packages/admin/src/components/WordPressImport.tsx:1118
 msgid "3. Select \"All content\""
-msgstr ""
+msgstr "3. Selecciona \"Todo el contenido\""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
 msgid "30 days"
-msgstr ""
+msgstr "30 dias"
 
 #: packages/admin/src/components/Redirects.tsx:150
 msgid "301 Permanent"
-msgstr ""
+msgstr "301 Permanente"
 
 #: packages/admin/src/components/Redirects.tsx:151
 msgid "302 Temporary"
-msgstr ""
+msgstr "302 Temporal"
 
 #: packages/admin/src/components/Redirects.tsx:152
 msgid "307 Temporary (Strict)"
-msgstr ""
+msgstr "307 Temporal (Estricto)"
 
 #: packages/admin/src/components/Redirects.tsx:153
 msgid "308 Permanent (Strict)"
-msgstr ""
+msgstr "308 Permanente (Estricto)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "4. Click \"Download Export File\""
-msgstr ""
+msgstr "4. Haz clic en \"Descargar archivo de exportación\"."
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr ""
+msgstr "4. Introduce \"EmDash\" y haz clic en \"Agregar nuevo\"."
 
 #: packages/admin/src/components/Redirects.tsx:368
 msgid "404 Errors"
-msgstr ""
+msgstr "Errores 404"
 
 #: packages/admin/src/components/WordPressImport.tsx:1365
 msgid "5. Copy the generated password"
-msgstr ""
+msgstr "5. Copie la contraseña generada"
 
 #: packages/admin/src/components/WordPressImport.tsx:1120
 msgid "5. Upload the file here"
-msgstr ""
+msgstr "5. Sube el archivo aquí"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
 msgid "7 days"
-msgstr ""
+msgstr "7 dias"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
 msgid "90 days"
-msgstr ""
+msgstr "90 dias"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:418
 msgid "A brief description of this content type"
-msgstr ""
+msgstr "Una breve descripción de este tipo de contenido"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr ""
+msgstr "Un banner principal a ancho completo con título, texto y botón de llamada a la acción"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "A short description of your site"
-msgstr ""
+msgstr "Una breve descripción de tu sitio."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:148
 msgid "Accept & Install"
-msgstr ""
+msgstr "Aceptar e instalar"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:147
 msgid "Accept & Update"
-msgstr ""
+msgstr "Aceptar y actualizar"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:206
 msgid "Accept Invite"
-msgstr ""
+msgstr "Aceptar invitación"
 
 #: packages/admin/src/router.tsx:1138
 msgid "Access Denied"
-msgstr ""
+msgstr "Acceso denegado"
 
 #: packages/admin/src/lib/api/marketplace.ts:224
 #: packages/admin/src/lib/api/marketplace.ts:232
 msgid "Access your media library"
-msgstr ""
+msgstr "Accede a tu biblioteca multimedia"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
-msgstr ""
+msgstr "Cuenta"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:121
 msgid "Account already exists"
-msgstr ""
+msgstr "La cuenta ya existe"
 
 #: packages/admin/src/components/SignupPage.tsx:261
 msgid "Account exists"
-msgstr ""
+msgstr "La cuenta existe"
 
 #: packages/admin/src/components/users/UserDetail.tsx:216
 msgid "Account Info"
-msgstr ""
+msgstr "Información de cuenta"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:299
 #: packages/admin/src/components/ContentList.tsx:235
@@ -494,12 +494,12 @@ msgstr ""
 #: packages/admin/src/components/MediaLibrary.tsx:419
 #: packages/admin/src/components/TaxonomyManager.tsx:821
 msgid "Actions"
-msgstr ""
+msgstr "Acciones"
 
 #: packages/admin/src/components/users/UserDetail.tsx:206
 #: packages/admin/src/components/users/UserList.tsx:217
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:171
 #: packages/admin/src/components/ContentEditor.tsx:1930
@@ -508,270 +508,270 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:812
 #: packages/admin/src/components/TaxonomySidebar.tsx:439
 msgid "Add"
-msgstr ""
+msgstr "Agregar"
 
 #. placeholder {0}: field.item_label
 #: packages/admin/src/components/PortableTextEditor.tsx:1462
 msgid "Add {0}"
-msgstr ""
+msgstr "Añadir {0}"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:238
 msgid "Add {label}"
-msgstr ""
+msgstr "Añadir {label}"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:204
 msgid "Add a new passkey"
-msgstr ""
+msgstr "Agregar una nueva Passkey"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
 msgid "Add an allowed domain"
-msgstr ""
+msgstr "Agregar un dominio permitido"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr ""
+msgstr "Agregue al menos un subcampo para definir la estructura del repetidor."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2510
 msgid "Add column after"
-msgstr ""
+msgstr "Añadir columna después"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2503
 msgid "Add column before"
-msgstr ""
+msgstr "Añadir columna antes"
 
 #: packages/admin/src/components/MenuEditor.tsx:291
 #: packages/admin/src/components/MenuEditor.tsx:406
 msgid "Add Content"
-msgstr ""
+msgstr "Agregar contenido"
 
 #: packages/admin/src/components/MenuEditor.tsx:303
 #: packages/admin/src/components/MenuEditor.tsx:310
 #: packages/admin/src/components/MenuEditor.tsx:409
 msgid "Add Custom Link"
-msgstr ""
+msgstr "Agregar enlace personalizado"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
 msgid "Add Domain"
-msgstr ""
+msgstr "Agregar dominio"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:582
 #: packages/admin/src/components/FieldEditor.tsx:342
 #: packages/admin/src/components/FieldEditor.tsx:659
 msgid "Add Field"
-msgstr ""
+msgstr "Agregar campo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1820
 msgid "Add fields"
-msgstr ""
+msgstr "Agregar campos"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:604
 msgid "Add fields to define the structure of your content"
-msgstr ""
+msgstr "Añade campos para definir la estructura de tu contenido"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:607
 msgid "Add First Field"
-msgstr ""
+msgstr "Añadir primer campo"
 
 #: packages/admin/src/components/RepeaterField.tsx:169
 msgid "Add First Item"
-msgstr ""
+msgstr "Agregar primer elemento"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1462
 msgid "Add item"
-msgstr ""
+msgstr "Añadir elemento"
 
 #: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add Item"
-msgstr ""
+msgstr "Agregar elemento"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2470
 msgid "Add link"
-msgstr ""
+msgstr "Añadir enlace"
 
 #: packages/admin/src/components/MenuEditor.tsx:399
 msgid "Add links to build your navigation menu"
-msgstr ""
+msgstr "Agregue enlaces para crear su menú de navegación"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:162
 msgid "Add MIME type or extension"
-msgstr ""
+msgstr "Añadir tipo MIME o extensión"
 
 #: packages/admin/src/components/ContentList.tsx:159
 msgid "Add New"
-msgstr ""
+msgstr "Agregar nuevo"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:449
 msgid "Add new {0}"
-msgstr ""
+msgstr "Añadir nuevo {0}"
 
 #: packages/admin/src/components/SeoPanel.tsx:192
 msgid "Add noindex meta tag"
-msgstr ""
+msgstr "Agregar metaetiqueta noindex"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:225
 msgid "Add Passkey"
-msgstr ""
+msgstr "Agregar Passkey"
 
 #: packages/admin/src/components/PluginManager.tsx:197
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr ""
+msgstr "Agregue plugins a su astro.config.mjs para ampliar la funcionalidad de EmDash."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2533
 msgid "Add row after"
-msgstr ""
+msgstr "Añadir fila después"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2526
 msgid "Add row before"
-msgstr ""
+msgstr "Añadir fila antes"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:476
 msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
-msgstr ""
+msgstr "Añade campos de metadatos SEO (título, descripción, imagen) e inclúyelo en el sitemap"
 
 #: packages/admin/src/components/FieldEditor.tsx:538
 msgid "Add Sub-Field"
-msgstr ""
+msgstr "Agregar subcampo"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:237
 msgid "Add tags..."
-msgstr ""
+msgstr "Añadir etiquetas..."
 
 #: packages/admin/src/components/Widgets.tsx:338
 msgid "Add Widget Area"
-msgstr ""
+msgstr "Añadir área de widgets"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr ""
+msgstr "Añade tus perfiles de redes sociales. Estos están disponibles para el tema de tu sitio y se pueden mostrar en encabezados, pies de página o biografías de los autores."
 
 #: packages/admin/src/components/MenuEditor.tsx:354
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
 msgid "Adding..."
-msgstr ""
+msgstr "Añadiendo..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1592
 msgid "Additional data to import."
-msgstr ""
+msgstr "Datos adicionales para importar."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
 #: packages/admin/src/components/Sidebar.tsx:438
 #: packages/admin/src/components/users/roleDefinitions.ts:42
 msgid "Admin"
-msgstr ""
+msgstr "Admin"
 
 #: packages/admin/src/components/Sidebar.tsx:378
 msgid "Admin navigation"
-msgstr ""
+msgstr "Navegación de administrador"
 
 #: packages/admin/src/components/WelcomeModal.tsx:25
 msgid "Administrator"
-msgstr ""
+msgstr "Administrador"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:224
 msgid "After send:"
-msgstr ""
+msgstr "Después del envío:"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2858
 msgid "Align Center"
-msgstr ""
+msgstr "Alinear al centro"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2851
 msgid "Align Left"
-msgstr ""
+msgstr "Alinear a la izquierda"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2865
 msgid "Align Right"
-msgstr ""
+msgstr "Alinear a la derecha"
 
 #: packages/admin/src/components/ContentList.tsx:186
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 #: packages/admin/src/routes/bylines.tsx:192
 msgid "All bylines"
-msgstr ""
+msgstr "Todas las firmas"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
-msgstr ""
+msgstr "Todas las capacidades"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:133
 msgid "All collections"
-msgstr ""
+msgstr "Todas las colecciones"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
-msgstr ""
+msgstr "Todos los comentarios requieren aprobación"
 
 #: packages/admin/src/components/WordPressImport.tsx:2324
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr ""
+msgstr "Todo el contenido importado será desasignado. Puedes reasignar autores más tarde desde el editor de contenido."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
-msgstr ""
+msgstr "Todos los locales"
 
 #: packages/admin/src/components/users/UserList.tsx:42
 #: packages/admin/src/components/users/UserList.tsx:46
 msgid "All roles"
-msgstr ""
+msgstr "Todos los roles"
 
 #: packages/admin/src/components/Sections.tsx:240
 msgid "All Sources"
-msgstr ""
+msgstr "Todas las fuentes"
 
 #: packages/admin/src/components/Redirects.tsx:392
 msgid "All statuses"
-msgstr ""
+msgstr "Todos los estados"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "All types"
-msgstr ""
+msgstr "Todos los tipos"
 
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
-msgstr ""
+msgstr "Permitir que los usuarios de dominios específicos se registren"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:497
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr ""
+msgstr "Permite a los visitantes dejar comentarios en el contenido de esta colección"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
 msgid "Allowed Domains"
-msgstr ""
+msgstr "Dominios permitidos"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
-msgstr ""
+msgstr "Tipos permitidos"
 
 #: packages/admin/src/components/SignupPage.tsx:437
 msgid "Already have an account?"
-msgstr ""
+msgstr "¿Ya tienes una cuenta?"
 
 #: packages/admin/src/components/PluginManager.tsx:575
 msgid "Also delete plugin storage data"
-msgstr ""
+msgstr "Eliminar también los datos de almacenamiento del plugin"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:202
 msgid "Alt text"
-msgstr ""
+msgstr "Texto alternativo"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
 #: packages/admin/src/components/MediaDetailPanel.tsx:202
 msgid "Alt Text"
-msgstr ""
+msgstr "Texto alternativo"
 
 #: packages/admin/src/components/MediaLibrary.tsx:612
 #: packages/admin/src/components/MediaLibrary.tsx:669
 msgid "Alt text set"
-msgstr ""
+msgstr "Texto alternativo establecido"
 
 #: packages/admin/src/components/WordPressImport.tsx:1234
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
-msgstr ""
+msgstr "Alternativamente, puede exportar desde WordPress (Herramientas → Exportar) y cargar el archivo."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
 #: packages/admin/src/components/PluginManager.tsx:91
@@ -796,202 +796,202 @@ msgstr ""
 #: packages/admin/src/router.tsx:1124
 #: packages/admin/src/router.tsx:1541
 msgid "An error occurred"
-msgstr ""
+msgstr "Se produjo un error"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:217
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "Se ha producido un error desconocido"
 
 #: packages/admin/src/components/WordPressImport.tsx:1414
 msgid "Analyzing export file..."
-msgstr ""
+msgstr "Analizando el archivo de exportación..."
 
 #: packages/admin/src/components/WordPressImport.tsx:735
 msgid "Analyzing WordPress site..."
-msgstr ""
+msgstr "Analizando el sitio de WordPress..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr ""
+msgstr "Se permite cualquier tipo de medio (sujeto a los límites globales)."
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
 msgid "API Tokens"
-msgstr ""
+msgstr "Tokens de API"
 
 #: packages/admin/src/components/Widgets.tsx:375
 msgid "Appears on posts and pages"
-msgstr ""
+msgstr "Aparece en entradas y páginas"
 
 #: packages/admin/src/components/WordPressImport.tsx:1329
 msgid "Application Password"
-msgstr ""
+msgstr "Contraseña de la aplicación"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2925
 msgid "Apply"
-msgstr ""
+msgstr "Aplicar"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2410
 #: packages/admin/src/components/PortableTextEditor.tsx:2411
 msgid "Apply link"
-msgstr ""
+msgstr "Aplicar enlace"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:237
 #: packages/admin/src/components/comments/CommentInbox.tsx:489
 msgid "Approve"
-msgstr ""
+msgstr "Aprobar"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:195
 msgid "approved"
-msgstr ""
+msgstr "aprobado"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:202
 msgid "Approved"
-msgstr ""
+msgstr "Aprobado"
 
 #: packages/admin/src/components/FieldEditor.tsx:223
 msgid "Arbitrary JSON data"
-msgstr ""
+msgstr "Datos JSON arbitrarios"
 
 #: packages/admin/src/components/ContentList.tsx:670
 msgid "archived"
-msgstr ""
+msgstr "archivado"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 msgid "Archives"
-msgstr ""
+msgstr "Archivos"
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr ""
+msgstr "¿Está seguro de que desea eliminar \"{0}\"? Esto también eliminará todo el contenido de esta colección."
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:660
 msgid "Are you sure you want to delete the \"{0}\" field?"
-msgstr ""
+msgstr "¿Seguro que quieres eliminar el campo «{0}»?"
 
 #: packages/admin/src/components/MenuList.tsx:254
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-msgstr ""
+msgstr "¿Está seguro de que desea eliminar este menú? Esto también eliminará todos los elementos del menú. Esta acción no se puede deshacer."
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
-msgstr ""
+msgstr "Como administrador, puedes invitar a otros usuarios desde la sección Usuarios."
 
 #: packages/admin/src/components/WordPressImport.tsx:2262
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr ""
+msgstr "Asigne autores de WordPress a usuarios de EmDash. Las entradas se atribuirán al usuario seleccionado."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:279
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
 msgid "Authentication error: {0}"
-msgstr ""
+msgstr "Error de autenticación: {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:195
 msgid "Authentication error: {error}"
-msgstr ""
+msgstr "Error de autenticación: {error}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:256
 msgid "Authentication failed"
-msgstr ""
+msgstr "Error de autenticación"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:129
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr ""
+msgstr "La autenticación es administrada por un proveedor externo ({0}). La configuración de la Passkey no está disponible cuando se utiliza la autenticación externa."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:263
 msgid "Authentication was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "La autenticación fue cancelada o se agotó el tiempo de espera. Por favor inténtalo de nuevo."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:77
 #: packages/admin/src/components/comments/CommentInbox.tsx:287
 #: packages/admin/src/components/users/roleDefinitions.ts:30
 #: packages/admin/src/components/WelcomeModal.tsx:27
 msgid "Author"
-msgstr ""
+msgstr "Autor"
 
 #: packages/admin/src/components/WordPressImport.tsx:2277
 msgid "Author Mapping"
-msgstr ""
+msgstr "Mapeo de autores"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:197
 msgid "Authorization denied"
-msgstr ""
+msgstr "Autorización denegada"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:105
 msgid "Authorization failed"
-msgstr ""
+msgstr "Error de autorización"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
-msgstr ""
+msgstr "Autorizar"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:176
 msgid "Authorize Device"
-msgstr ""
+msgstr "Autorizar dispositivo"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autorizando..."
 
 #: packages/admin/src/components/Redirects.tsx:495
 msgid "auto"
-msgstr ""
+msgstr "auto"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Auto (slug change)"
-msgstr ""
+msgstr "Auto (cambio de slug)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:541
 msgid "Auto-approve authenticated users"
-msgstr ""
+msgstr "Aprobar automáticamente a los usuarios autenticados"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:406
 msgid "Auto-generated from name (you can edit)"
-msgstr ""
+msgstr "Generado automáticamente a partir del nombre (puedes editarlo)"
 
 #: packages/admin/src/router.tsx:732
 msgid "Autosave failed"
-msgstr ""
+msgstr "Error al autoguardar"
 
 #: packages/admin/src/components/ContentEditor.tsx:613
 msgid "Autosave status"
-msgstr ""
+msgstr "Estado del autoguardado"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:595
 msgid "Available media"
-msgstr ""
+msgstr "Medios disponibles"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:233
 msgid "Available Providers"
-msgstr ""
+msgstr "Proveedores disponibles"
 
 #: packages/admin/src/components/Widgets.tsx:401
 msgid "Available Widgets"
-msgstr ""
+msgstr "Widgets disponibles"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:254
 #: packages/admin/src/components/MenuEditor.tsx:275
 #: packages/admin/src/components/WordPressImport.tsx:1349
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Back"
-msgstr ""
+msgstr "Atrás"
 
 #: packages/admin/src/components/ContentEditor.tsx:582
 msgid "Back to {collectionLabel} list"
-msgstr ""
+msgstr "Volver a la lista {collectionLabel}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:336
 msgid "Back to Content Types"
-msgstr ""
+msgstr "Volver a los tipos de contenido"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:139
 #: packages/admin/src/components/LoginPage.tsx:117
@@ -999,100 +999,100 @@ msgstr ""
 #: packages/admin/src/components/LoginPage.tsx:311
 #: packages/admin/src/components/SignupPage.tsx:281
 msgid "Back to login"
-msgstr ""
+msgstr "Volver a iniciar sesión"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:116
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:392
 msgid "Back to marketplace"
-msgstr ""
+msgstr "Volver al mercado"
 
 #: packages/admin/src/components/SectionEditor.tsx:73
 #: packages/admin/src/components/SectionEditor.tsx:174
 msgid "Back to sections"
-msgstr ""
+msgstr "Volver a secciones"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
-msgstr ""
+msgstr "Volver a la configuración"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
 msgid "Back to Themes"
-msgstr ""
+msgstr "Volver a Temas"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:219
 msgid "Before send:"
-msgstr ""
+msgstr "Antes de enviar:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:144
 msgid "Bing Verification"
-msgstr ""
+msgstr "Verificación de Bing"
 
 #: packages/admin/src/routes/bylines.tsx:267
 msgid "Bio"
-msgstr ""
+msgstr "Biografía"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
 msgid "Block actions - drag to reorder, click for menu"
-msgstr ""
+msgstr "Acciones de bloque: arrastra para reordenar, haz clic para abrir el menú"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2434
 #: packages/admin/src/components/PortableTextEditor.tsx:2740
 msgid "Bold"
-msgstr ""
+msgstr "Negrita"
 
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
 msgid "Boolean"
-msgstr ""
+msgstr "Booleano"
 
 #: packages/admin/src/components/SeoPanel.tsx:169
 msgid "Brief summary shown below the title in search results"
-msgstr ""
+msgstr "Breve resumen que se muestra debajo del título en los resultados de búsqueda."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:88
 msgid "Browse and install plugins to extend your site."
-msgstr ""
+msgstr "Explora e instale plugins para ampliar tu sitio."
 
 #: packages/admin/src/components/WordPressImport.tsx:966
 #: packages/admin/src/components/WordPressImport.tsx:1433
 msgid "Browse Files"
-msgstr ""
+msgstr "Explorar archivos"
 
 #: packages/admin/src/components/PluginManager.tsx:190
 msgid "Browse the"
-msgstr ""
+msgstr "Navega por el"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
-msgstr ""
+msgstr "Explora temas y obtenga una vista previa de ellos con su propio contenido."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:886
 #: packages/admin/src/components/PortableTextEditor.tsx:2808
 msgid "Bullet List"
-msgstr ""
+msgstr "Lista de viñetas"
 
 #: packages/admin/src/components/ContentEditor.tsx:966
 #: packages/admin/src/components/Sidebar.tsx:206
 msgid "Bylines"
-msgstr ""
+msgstr "Firmas"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
-msgstr ""
+msgstr "Puede crear contenido"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:37
 msgid "Can manage all content"
-msgstr ""
+msgstr "Puede gestionar todo el contenido"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:31
 msgid "Can publish own content"
-msgstr ""
+msgstr "Puede publicar contenido propio"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:19
 msgid "Can view content"
-msgstr ""
+msgstr "Puede ver contenido"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:139
 #: packages/admin/src/components/ConfirmDialog.tsx:57
@@ -1131,54 +1131,54 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:386
 #: packages/admin/src/components/WordPressImport.tsx:1753
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:405
 msgid "Cancel (Esc)"
-msgstr ""
+msgstr "Cancelar (Esc)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
-msgstr ""
+msgstr "Cancelar cambio de nombre"
 
 #: packages/admin/src/components/Sections.tsx:407
 msgid "Cannot delete theme sections"
-msgstr ""
+msgstr "No se pueden eliminar secciones de temas"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:356
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr ""
+msgstr "No se puede determinar el tipo MIME a partir de la URL. Usa una URL que termine en una extensión de imagen reconocida (p. ej. .jpg, .png, .webp)."
 
 #: packages/admin/src/components/SeoPanel.tsx:181
 msgid "Canonical URL"
-msgstr ""
+msgstr "URL canónica"
 
 #: packages/admin/src/components/PluginManager.tsx:420
 msgid "Capabilities"
-msgstr ""
+msgstr "Capacidades"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:62
 msgid "Capability consent"
-msgstr ""
+msgstr "Consentimiento de capacidad"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
 #: packages/admin/src/components/MediaDetailPanel.tsx:210
 msgid "Caption"
-msgstr ""
+msgstr "Leyenda"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:68
 msgid "Captions / Subtitles"
-msgstr ""
+msgstr "Subtítulos"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
-msgstr ""
+msgstr "Categorías"
 
 #. placeholder {0}: analysis.categories
 #: packages/admin/src/components/WordPressImport.tsx:1621
 msgid "Categories ({0})"
-msgstr ""
+msgstr "Categorías ({0})"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:68
 #: packages/admin/src/components/ContentEditor.tsx:1616
@@ -1186,72 +1186,72 @@ msgstr ""
 #: packages/admin/src/components/FieldEditor.tsx:402
 #: packages/admin/src/components/SeoImageField.tsx:47
 msgid "Change"
-msgstr ""
+msgstr "Cambiar"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr ""
+msgstr "¿Cambiar <0>{0}</0> de <1>{1}</1> a <2>{2}</2>? Perderá el acceso a funciones de nivel superior."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:237
 msgid "Change Favicon"
-msgstr ""
+msgstr "Cambiar favicon"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:193
 msgid "Change Logo"
-msgstr ""
+msgstr "Cambiar logotipo"
 
 #: packages/admin/src/router.tsx:777
 msgid "Changes discarded"
-msgstr ""
+msgstr "Cambios descartados"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:135
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr ""
+msgstr "Carácter entre el título de la página y el nombre del sitio (por ejemplo, \"Mi entrada | Mi sitio\")"
 
 #: packages/admin/src/components/PluginManager.tsx:153
 msgid "Check for updates"
-msgstr ""
+msgstr "Buscar actualizaciones"
 
 #: packages/admin/src/components/WordPressImport.tsx:937
 msgid "Check Site"
-msgstr ""
+msgstr "Verificar sitio"
 
 #: packages/admin/src/components/LoginPage.tsx:101
 #: packages/admin/src/components/SignupPage.tsx:130
 #: packages/admin/src/components/SignupPage.tsx:400
 msgid "Check your email"
-msgstr ""
+msgstr "Revisa tu correo electrónico"
 
 #: packages/admin/src/components/WordPressImport.tsx:701
 msgid "Checking {urlInput}..."
-msgstr ""
+msgstr "Comprobando {urlInput}..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
-msgstr ""
+msgstr "Comprobando autenticación..."
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr ""
+msgstr "Elige cómo iniciar sesión"
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
-msgstr ""
+msgstr "Elige su idioma de administrador preferido"
 
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
-msgstr ""
+msgstr "Limpiar filtros"
 
 #: packages/admin/src/components/SignupPage.tsx:138
 msgid "Click the link in the email to continue setting up your account."
-msgstr ""
+msgstr "Haz clic en el enlace del correo electrónico para continuar configurando tu cuenta."
 
 #: packages/admin/src/components/LoginPage.tsx:112
 msgid "Click the link in the email to sign in."
-msgstr ""
+msgstr "Haz clic en el enlace del correo electrónico para iniciar sesión."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:59
 #: packages/admin/src/components/ContentPickerModal.tsx:120
@@ -1309,116 +1309,116 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:354
 #: packages/admin/src/components/Widgets.tsx:358
 msgid "Close"
-msgstr ""
+msgstr "Cerrar"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:520
 msgid "Close comments after (days)"
-msgstr ""
+msgstr "Cerrar los comentarios después de (días)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
-msgstr ""
+msgstr "Cerrar panel"
 
 #: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/PortableTextEditor.tsx:2462
 #: packages/admin/src/components/Redirects.tsx:443
 msgid "Code"
-msgstr ""
+msgstr "Código"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:916
 #: packages/admin/src/components/PortableTextEditor.tsx:2829
 msgid "Code Block"
-msgstr ""
+msgstr "Bloque de código"
 
 #: packages/admin/src/components/PluginManager.tsx:407
 msgid "Collapse"
-msgstr ""
+msgstr "Colapsar"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 msgid "Collapse details"
-msgstr ""
+msgstr "Contraer detalles"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:158
 msgid "colleague@example.com"
-msgstr ""
+msgstr "colega@ejemplo.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr ""
+msgstr "Colección"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr ""
+msgstr "Colección:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:654
 msgid "Collections"
-msgstr ""
+msgstr "Colecciones"
 
 #: packages/admin/src/components/WordPressImport.tsx:2133
 msgid "Collections created:"
-msgstr ""
+msgstr "Colecciones creadas:"
 
 #: packages/admin/src/components/SectionEditor.tsx:273
 msgid "Comma-separated keywords for search."
-msgstr ""
+msgstr "Palabras clave de búsqueda separadas por comas."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:95
 #: packages/admin/src/components/comments/CommentInbox.tsx:290
 msgid "Comment"
-msgstr ""
+msgstr "Comentario"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:58
 msgid "Comment Detail"
-msgstr ""
+msgstr "Detalle del comentario"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:146
 #: packages/admin/src/components/ContentTypeEditor.tsx:487
 #: packages/admin/src/components/Sidebar.tsx:190
 msgid "Comments"
-msgstr ""
+msgstr "Comentarios"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:544
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr ""
+msgstr "Los comentarios de los usuarios del CMS con sesión iniciada se aprueban automáticamente"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Complete signup"
-msgstr ""
+msgstr "Registro completo"
 
 #: packages/admin/src/components/Widgets.tsx:851
 msgid "Component"
-msgstr ""
+msgstr "Componente"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Configure Field"
-msgstr ""
+msgstr "Configurar campo"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmar"
 
 #: packages/admin/src/components/WordPressImport.tsx:627
 msgid "Connect"
-msgstr ""
+msgstr "Conectar"
 
 #: packages/admin/src/components/WordPressImport.tsx:1346
 msgid "Connect & Analyze"
-msgstr ""
+msgstr "Conectar y analizar"
 
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1296
 msgid "Connect to {0}"
-msgstr ""
+msgstr "Conéctate a {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1212
 msgid "Connect with WordPress"
-msgstr ""
+msgstr "Conéctate con WordPress"
 
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr ""
+msgstr "Conectado {0}"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1429,143 +1429,143 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:412
 #: packages/admin/src/components/Widgets.tsx:819
 msgid "Content"
-msgstr ""
+msgstr "Contenido"
 
 #: packages/admin/src/components/Widgets.tsx:96
 msgid "Content Block"
-msgstr ""
+msgstr "Bloque de contenido"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2188
 msgid "Content Errors ({0})"
-msgstr ""
+msgstr "Errores de contenido ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1156
 msgid "Content found:"
-msgstr ""
+msgstr "Contenido encontrado:"
 
 #: packages/admin/src/router.tsx:796
 msgid "Content has been scheduled for publishing"
-msgstr ""
+msgstr "El contenido ha sido programado para publicación"
 
 #: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
-msgstr ""
+msgstr "El contenido se ha actualizado a la revisión seleccionada."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr ""
+msgstr "ID de contenido:"
 
 #: packages/admin/src/router.tsx:744
 msgid "Content is now live"
-msgstr ""
+msgstr "El contenido ya está publicado"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "content items"
-msgstr ""
+msgstr "elementos de contenido"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
 msgid "Content Read"
-msgstr ""
+msgstr "Lectura de contenido"
 
 #: packages/admin/src/router.tsx:760
 msgid "Content removed from public view"
-msgstr ""
+msgstr "Contenido retirado de la vista pública"
 
 #: packages/admin/src/router.tsx:814
 msgid "Content reverted to draft"
-msgstr ""
+msgstr "Contenido revertido a borrador"
 
 #: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
-msgstr ""
+msgstr "Instantánea del contenido:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1570
 msgid "Content to Import"
-msgstr ""
+msgstr "Contenido para importar"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
 #: packages/admin/src/components/ContentTypeList.tsx:40
 #: packages/admin/src/components/Sidebar.tsx:210
 msgid "Content Types"
-msgstr ""
+msgstr "Tipos de contenido"
 
 #: packages/admin/src/components/WordPressImport.tsx:2116
 msgid "Content was skipped because it already exists"
-msgstr ""
+msgstr "El contenido se omitió porque ya existe."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
 msgid "Content Write"
-msgstr ""
+msgstr "Escritura de contenido"
 
 #: packages/admin/src/components/SignupPage.tsx:91
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Continue →"
-msgstr ""
+msgstr "Continuar →"
 
 #: packages/admin/src/components/WordPressImport.tsx:2335
 msgid "Continue Import"
-msgstr ""
+msgstr "Continuar importando"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
 msgid "Contributor"
-msgstr ""
+msgstr "Contribuyente"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
 #: packages/admin/src/components/users/InviteUserModal.tsx:134
 msgid "Copied to clipboard"
-msgstr ""
+msgstr "Copiado al portapapeles"
 
 #. placeholder {0}: section.slug
 #: packages/admin/src/components/Sections.tsx:399
 msgid "Copy {0} to clipboard"
-msgstr ""
+msgstr "Copiar {0} al portapapeles"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:124
 msgid "Copy invite link"
-msgstr ""
+msgstr "Copiar enlace de invitación"
 
 #: packages/admin/src/components/Sections.tsx:398
 msgid "Copy slug"
-msgstr ""
+msgstr "Copiar slug"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
 msgid "Copy this token now — it won't be shown again."
-msgstr ""
+msgstr "Copie este token ahora; no se volverá a mostrar."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
 msgid "Copy token"
-msgstr ""
+msgstr "Copiar token"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:322
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:323
 msgid "Copy URL"
-msgstr ""
+msgstr "Copiar URL"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:138
 msgid "Could not copy automatically. Please select the URL above and copy manually."
-msgstr ""
+msgstr "No se pudo copiar automáticamente. Selecciona la URL de arriba y cópiela manualmente."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:382
 msgid "Could not load image from URL"
-msgstr ""
+msgstr "No se pudo cargar la imagen desde la URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1103
 msgid "Couldn't detect WordPress"
-msgstr ""
+msgstr "No se pudo detectar WordPress"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
-msgstr ""
+msgstr "No se ha podido asignar «{draft}» a un tipo MIME. Escribe el MIME directamente."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:820
 msgid "Count"
-msgstr ""
+msgstr "Contar"
 
 #: packages/admin/src/components/ContentEditor.tsx:2057
 #: packages/admin/src/components/MenuList.tsx:175
@@ -1575,176 +1575,176 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:389
 #: packages/admin/src/routes/bylines.tsx:314
 msgid "Create"
-msgstr ""
+msgstr "Crear"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:263
 msgid "Create \"{trimmedInput}\""
-msgstr ""
+msgstr "Crear «{trimmedInput}»"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:887
 msgid "Create a bullet list"
-msgstr ""
+msgstr "Crear una lista con viñetas"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:365
 msgid "Create a new {0}"
-msgstr ""
+msgstr "Crear un nuevo {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:897
 msgid "Create a numbered list"
-msgstr ""
+msgstr "Crear una lista numerada"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:81
 #: packages/admin/src/components/SignupPage.tsx:220
 msgid "Create Account"
-msgstr ""
+msgstr "Crear una cuenta"
 
 #: packages/admin/src/components/SignupPage.tsx:399
 msgid "Create an account"
-msgstr ""
+msgstr "Crea una cuenta"
 
 #: packages/admin/src/components/ContentEditor.tsx:2005
 #: packages/admin/src/routes/bylines.tsx:247
 msgid "Create byline"
-msgstr ""
+msgstr "Crear firma"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 msgid "Create Content Type"
-msgstr ""
+msgstr "Crear tipo de contenido"
 
 #: packages/admin/src/components/MenuList.tsx:126
 #: packages/admin/src/components/MenuList.tsx:189
 msgid "Create Menu"
-msgstr ""
+msgstr "Crear menú"
 
 #: packages/admin/src/components/MenuList.tsx:133
 msgid "Create New Menu"
-msgstr ""
+msgstr "Crear nuevo menú"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
 msgid "Create New Token"
-msgstr ""
+msgstr "Crear nuevo token"
 
 #: packages/admin/src/components/WordPressImport.tsx:1340
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr ""
+msgstr "Cree uno en WordPress: Usuarios → Perfil → Contraseñas de aplicación"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
-msgstr ""
+msgstr "Crear Passkey"
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
 msgid "Create personal access tokens for programmatic API access"
-msgstr ""
+msgstr "Cree tokens de acceso personal para acceso API programático"
 
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:238
 msgid "Create redirect for {0}"
-msgstr ""
+msgstr "Crear redirección para {0}"
 
 #: packages/admin/src/components/Redirects.tsx:237
 msgid "Create redirect for this path"
-msgstr ""
+msgstr "Crear redirección para esta ruta"
 
 #: packages/admin/src/components/Redirects.tsx:435
 msgid "Create redirect rules to manage URL changes."
-msgstr ""
+msgstr "Cree reglas de redirección para gestionar los cambios de URL."
 
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "Create Schema & Import"
-msgstr ""
+msgstr "Crear esquema e importar"
 
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
 msgid "Create Section"
-msgstr ""
+msgstr "Crear sección"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:109
 msgid "Create sections in the Sections library to use them here"
-msgstr ""
+msgstr "Crea secciones en la biblioteca de Secciones para usarlas aquí"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:687
 msgid "Create Taxonomy"
-msgstr ""
+msgstr "Crear taxonomía"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
 msgid "Create Token"
-msgstr ""
+msgstr "Crear token"
 
 #: packages/admin/src/components/Widgets.tsx:345
 msgid "Create Widget Area"
-msgstr ""
+msgstr "Crear área de widgets"
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
-msgstr ""
+msgstr "Crea tu cuenta"
 
 #: packages/admin/src/components/MenuList.tsx:187
 msgid "Create your first navigation menu to get started"
-msgstr ""
+msgstr "Crea tu primer menú de navegación para comenzar"
 
 #: packages/admin/src/components/ContentList.tsx:259
 #: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
-msgstr ""
+msgstr "Crea el primero"
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr ""
+msgstr "Cree su primera sección de contenido reutilizable para comenzar."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:72
 #: packages/admin/src/components/SignupPage.tsx:211
 msgid "Create your passkey"
-msgstr ""
+msgstr "Crea tu Passkey"
 
 #: packages/admin/src/lib/api/marketplace.ts:223
 #: packages/admin/src/lib/api/marketplace.ts:231
 msgid "Create, update, and delete content"
-msgstr ""
+msgstr "Crear, actualizar y eliminar contenido"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "Crear, actualizar y eliminar menús de navegación"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "Crear, actualizar y eliminar términos de taxonomía"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
-msgstr ""
+msgstr "Crear, actualizar, eliminar contenido"
 
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
-msgstr ""
+msgstr "Creado"
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
 #: packages/admin/src/components/users/UserDetail.tsx:260
 msgid "Created {0}"
-msgstr ""
+msgstr "Creado {0}"
 
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:844
 msgid "Created {0} translation"
-msgstr ""
+msgstr "Traducción {0} creada"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
-msgstr ""
+msgstr "Creado en"
 
 #. placeholder {0}: new Date(item.createdAt).toLocaleString()
 #: packages/admin/src/components/ContentEditor.tsx:900
 msgid "Created: {0}"
-msgstr ""
+msgstr "Creado: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:812
 msgid "Creating collections and fields..."
-msgstr ""
+msgstr "Creando colecciones y campos..."
 
 #: packages/admin/src/components/ContentEditor.tsx:2057
 #: packages/admin/src/components/MenuList.tsx:175
@@ -1754,39 +1754,39 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:687
 #: packages/admin/src/components/TaxonomySidebar.tsx:263
 msgid "Creating..."
-msgstr ""
+msgstr "Creando..."
 
 #: packages/admin/src/components/TranslationsPanel.tsx:78
 msgid "current"
-msgstr ""
+msgstr "actual"
 
 #: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
-msgstr ""
+msgstr "Actual"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
-msgstr ""
+msgstr "Personalizado"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:614
 msgid "Custom Fields"
-msgstr ""
+msgstr "Campos personalizados"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:154
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr ""
+msgstr "Contenido personalizado de robots.txt. Déjelo vacío para usar el valor predeterminado."
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Custom Section"
-msgstr ""
+msgstr "Sección personalizada"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
-msgstr ""
+msgstr "oscuro"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Dark"
-msgstr ""
+msgstr "Oscuro"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:131
 #: packages/admin/src/components/ContentTypeList.tsx:246
@@ -1794,50 +1794,50 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:176
 #: packages/admin/src/components/Sidebar.tsx:401
 msgid "Dashboard"
-msgstr ""
+msgstr "Escritorio"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:296
 #: packages/admin/src/components/ContentList.tsx:232
 msgid "Date"
-msgstr ""
+msgstr "Fecha"
 
 #: packages/admin/src/components/FieldEditor.tsx:180
 #: packages/admin/src/components/FieldEditor.tsx:584
 msgid "Date & Time"
-msgstr ""
+msgstr "Fecha y hora"
 
 #: packages/admin/src/components/FieldEditor.tsx:181
 msgid "Date and time picker"
-msgstr ""
+msgstr "Selector de fecha y hora"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:279
 msgid "Date Format"
-msgstr ""
+msgstr "Formato de fecha"
 
 #: packages/admin/src/components/FieldEditor.tsx:163
 msgid "Decimal number"
-msgstr ""
+msgstr "numero decimal"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
 msgid "Default Role"
-msgstr ""
+msgstr "Rol predeterminado"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
 msgid "Default role:"
-msgstr ""
+msgstr "Rol predeterminado:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:599
 msgid "Define a new taxonomy for classifying content"
-msgstr ""
+msgstr "Definir una nueva taxonomía para clasificar contenidos"
 
 #: packages/admin/src/components/ContentTypeList.tsx:41
 msgid "Define the structure of your content"
-msgstr ""
+msgstr "Define la estructura de tu contenido"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:361
 msgid "Defined in code"
-msgstr ""
+msgstr "Definido en código"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:267
 #: packages/admin/src/components/comments/CommentInbox.tsx:407
@@ -1857,12 +1857,12 @@ msgstr ""
 #: packages/admin/src/routes/bylines.tsx:323
 #: packages/admin/src/routes/bylines.tsx:338
 msgid "Delete"
-msgstr ""
+msgstr "Borrar"
 
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:254
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr ""
+msgstr "¿Eliminar \"{0}\"? Esto no se puede deshacer."
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -1873,110 +1873,110 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:97
 #: packages/admin/src/components/Widgets.tsx:737
 msgid "Delete {0}"
-msgstr ""
+msgstr "Eliminar {0}"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:740
 msgid "Delete {0} field"
-msgstr ""
+msgstr "Eliminar campo {0}"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:237
 msgid "Delete {0} menu"
-msgstr ""
+msgstr "Eliminar menú {0}"
 
 #. placeholder {0}: area.label
 #: packages/admin/src/components/Widgets.tsx:584
 msgid "Delete {0} widget area"
-msgstr ""
+msgstr "Eliminar área de widgets {0}"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:880
 msgid "Delete {0}?"
-msgstr ""
+msgstr "¿Eliminar {0}?"
 
 #: packages/admin/src/routes/bylines.tsx:336
 msgid "Delete Byline?"
-msgstr ""
+msgstr "¿Eliminar firma?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2517
 msgid "Delete column"
-msgstr ""
+msgstr "Eliminar columna"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:405
 msgid "Delete Comment?"
-msgstr ""
+msgstr "¿Eliminar comentario?"
 
 #: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
-msgstr ""
+msgstr "¿Eliminar tipo de contenido?"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
-msgstr ""
+msgstr "Eliminar incrustación"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:657
 msgid "Delete Field?"
-msgstr ""
+msgstr "¿Eliminar campo?"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:191
 #: packages/admin/src/components/editor/ImageNode.tsx:192
 msgid "Delete image"
-msgstr ""
+msgstr "Eliminar imagen"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:253
 msgid "Delete Media?"
-msgstr ""
+msgstr "¿Eliminar medios?"
 
 #: packages/admin/src/components/MenuList.tsx:253
 msgid "Delete Menu"
-msgstr ""
+msgstr "Eliminar menú"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:525
 msgid "Delete permanently"
-msgstr ""
+msgstr "Eliminar permanentemente"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:640
 msgid "Delete Permanently"
-msgstr ""
+msgstr "Eliminar permanentemente"
 
 #: packages/admin/src/components/ContentList.tsx:620
 msgid "Delete Permanently?"
-msgstr ""
+msgstr "¿Eliminar permanentemente?"
 
 #: packages/admin/src/components/Redirects.tsx:509
 msgid "Delete redirect"
-msgstr ""
+msgstr "Eliminar redirección"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:510
 msgid "Delete redirect {0}"
-msgstr ""
+msgstr "Eliminar redirección {0}"
 
 #: packages/admin/src/components/Redirects.tsx:550
 msgid "Delete Redirect?"
-msgstr ""
+msgstr "¿Eliminar redirección?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2538
 msgid "Delete row"
-msgstr ""
+msgstr "Eliminar fila"
 
 #: packages/admin/src/components/Sections.tsx:296
 msgid "Delete Section?"
-msgstr ""
+msgstr "¿Eliminar sección?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2553
 msgid "Delete table"
-msgstr ""
+msgstr "Eliminar tabla"
 
 #: packages/admin/src/components/Widgets.tsx:634
 msgid "Delete Widget Area?"
-msgstr ""
+msgstr "¿Eliminar área de widgets?"
 
 #: packages/admin/src/components/ContentList.tsx:346
 msgid "Deleted"
-msgstr ""
+msgstr "Eliminado"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
 #: packages/admin/src/components/ContentTypeEditor.tsx:664
@@ -1990,293 +1990,293 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:637
 #: packages/admin/src/routes/bylines.tsx:339
 msgid "Deleting..."
-msgstr ""
+msgstr "Eliminando..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
 msgid "Demo"
-msgstr ""
+msgstr "Demo"
 
 #: packages/admin/src/routes/users.tsx:303
 msgid "Demote User"
-msgstr ""
+msgstr "Bajar de nivel al usuario"
 
 #: packages/admin/src/routes/users.tsx:294
 msgid "Demote User?"
-msgstr ""
+msgstr "¿Bajar de nivel al usuario?"
 
 #: packages/admin/src/routes/users.tsx:304
 msgid "Demoting..."
-msgstr ""
+msgstr "Bajando de nivel..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
-msgstr ""
+msgstr "Denegar"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Describe the image..."
-msgstr ""
+msgstr "Describe la imagen..."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
 #: packages/admin/src/components/MediaDetailPanel.tsx:205
 msgid "Describe this image for accessibility"
-msgstr ""
+msgstr "Describe esta imagen para accesibilidad."
 
 #: packages/admin/src/components/SectionEditor.tsx:262
 msgid "Describe what this section is for..."
-msgstr ""
+msgstr "Describe para qué sirve esta sección..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:415
 #: packages/admin/src/components/SectionEditor.tsx:259
 #: packages/admin/src/components/Sections.tsx:200
 #: packages/admin/src/components/Widgets.tsx:373
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:432
 msgid "Description (optional)"
-msgstr ""
+msgstr "Descripción (opcional)"
 
 #: packages/admin/src/components/Redirects.tsx:442
 msgid "Destination"
-msgstr ""
+msgstr "Destino"
 
 #: packages/admin/src/components/Redirects.tsx:136
 msgid "Destination path"
-msgstr ""
+msgstr "Ruta de destino"
 
 #: packages/admin/src/components/PluginManager.tsx:407
 msgid "details"
-msgstr ""
+msgstr "detalles"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:186
 msgid "Device authorized"
-msgstr ""
+msgstr "Dispositivo autorizado"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:229
 msgid "Device code"
-msgstr ""
+msgstr "Código del dispositivo"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr ""
+msgstr "Vinculado al dispositivo"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr ""
+msgstr "Passkey vinculada al dispositivo"
 
 #: packages/admin/src/components/SignupPage.tsx:143
 msgid "Didn't receive the email?"
-msgstr ""
+msgstr "¿No recibiste el correo electrónico?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:176
 msgid "Dimensions:"
-msgstr ""
+msgstr "Dimensiones:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
-msgstr ""
+msgstr "Desactivar"
 
 #: packages/admin/src/components/PluginManager.tsx:395
 msgid "Disable plugin"
-msgstr ""
+msgstr "Deshabilitar plugin"
 
 #: packages/admin/src/components/Redirects.tsx:478
 msgid "Disable redirect"
-msgstr ""
+msgstr "Deshabilitar redirección"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr ""
+msgstr "Desactivar usuario"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr ""
+msgstr "¿Desactivar usuario?"
 
 #: packages/admin/src/components/PluginManager.tsx:304
 #: packages/admin/src/components/Redirects.tsx:392
 #: packages/admin/src/components/users/UserDetail.tsx:201
 #: packages/admin/src/components/users/UserList.tsx:212
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivado"
 
 #: packages/admin/src/components/PluginManager.tsx:478
 msgid "Disabled:"
-msgstr ""
+msgstr "Desactivado:"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr ""
+msgstr "Desactivar a <0>{0}</0> impedirá que inicia sesión hasta que se reactive. Tu contenido se conservará."
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
-msgstr ""
+msgstr "Desactivando..."
 
 #: packages/admin/src/components/ContentEditor.tsx:660
 #: packages/admin/src/components/ContentEditor.tsx:682
 msgid "Discard changes"
-msgstr ""
+msgstr "Descartar cambios"
 
 #: packages/admin/src/components/ContentEditor.tsx:666
 msgid "Discard draft changes?"
-msgstr ""
+msgstr "¿Descartar cambios en el borrador?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
 msgid "Dismiss"
-msgstr ""
+msgstr "Descartar"
 
 #: packages/admin/src/components/Widgets.tsx:103
 msgid "Display a navigation menu"
-msgstr ""
+msgstr "Mostrar un menú de navegación"
 
 #: packages/admin/src/components/ContentEditor.tsx:2008
 #: packages/admin/src/components/ContentEditor.tsx:2070
 #: packages/admin/src/routes/bylines.tsx:252
 msgid "Display name"
-msgstr ""
+msgstr "Nombre para mostrar"
 
 #: packages/admin/src/components/MenuList.tsx:167
 msgid "Display name for admin interface"
-msgstr ""
+msgstr "Nombre para mostrar para la interfaz de administración"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
 msgid "Display Size"
-msgstr ""
+msgstr "Tamaño de visualización"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
 msgid "Displayed below the image as a visible caption."
-msgstr ""
+msgstr "Se muestra debajo de la imagen como leyenda visible."
 
 #: packages/admin/src/components/ContentEditor.tsx:636
 msgid "Distraction-free mode (⌘⇧\\)"
-msgstr ""
+msgstr "Modo sin distracciones (⌘⇧\\)"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:926
 msgid "Divider"
-msgstr ""
+msgstr "Divisor"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 msgid "Documents"
-msgstr ""
+msgstr "Documentos"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
 msgid "Domain"
-msgstr ""
+msgstr "Dominio"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
 msgid "Domain added successfully"
-msgstr ""
+msgstr "Dominio agregado exitosamente"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
 msgid "Domain removed"
-msgstr ""
+msgstr "Dominio eliminado"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
 msgid "Domain updated"
-msgstr ""
+msgstr "Dominio actualizado"
 
 #: packages/admin/src/components/LoginPage.tsx:332
 msgid "Don't have an account? <0>Sign up</0>"
-msgstr ""
+msgstr "¿No tienes una cuenta? <0>Registrarse</0>"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:144
 #: packages/admin/src/components/WordPressImport.tsx:1964
 msgid "Done"
-msgstr ""
+msgstr "Hecho"
 
 #: packages/admin/src/components/ContentEditor.tsx:1951
 msgid "Down"
-msgstr ""
+msgstr "Abajo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1962
 msgid "Downloading"
-msgstr ""
+msgstr "Descargando"
 
 #: packages/admin/src/components/ContentList.tsx:666
 msgid "draft"
-msgstr ""
+msgstr "borrador"
 
 #: packages/admin/src/components/ContentEditor.tsx:831
 #: packages/admin/src/components/ContentPickerModal.tsx:212
 msgid "Draft"
-msgstr ""
+msgstr "Borrador"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:119
 msgid "draft, published, or archived"
-msgstr ""
+msgstr "borrador, publicado o archivado"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:71
 #: packages/admin/src/components/Dashboard.tsx:188
 msgid "Drafts"
-msgstr ""
+msgstr "Borradores"
 
 #: packages/admin/src/components/WordPressImport.tsx:961
 msgid "Drag and drop or click to browse (.xml)"
-msgstr ""
+msgstr "Arrastre y suelte o haz clic para explorar (.xml)"
 
 #: packages/admin/src/components/Widgets.tsx:620
 msgid "Drag here to add"
-msgstr ""
+msgstr "Arrastra aquí para añadir"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1638
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Arrastra para reordenar"
 
 #. placeholder {0}: field.label
 #. placeholder {0}: widget.title ?? t`widget`
 #: packages/admin/src/components/ContentTypeEditor.tsx:707
 #: packages/admin/src/components/Widgets.tsx:722
 msgid "Drag to reorder {0}"
-msgstr ""
+msgstr "Arrastra para reordenar {0}"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:335
 msgid "Drag to reorder block"
-msgstr ""
+msgstr "Arrastra para reordenar el bloque"
 
 #: packages/admin/src/components/Widgets.tsx:624
 msgid "Drag widgets here to add them"
-msgstr ""
+msgstr "Arrastra widgets aquí para añadirlos"
 
 #: packages/admin/src/components/Widgets.tsx:402
 msgid "Drag widgets into an area to add them"
-msgstr ""
+msgstr "Arrastra widgets a un área para añadirlos"
 
 #: packages/admin/src/components/Widgets.tsx:620
 msgid "Drop to add widget"
-msgstr ""
+msgstr "Suelta para añadir el widget"
 
 #: packages/admin/src/components/WordPressImport.tsx:1427
 msgid "Drop your WordPress export file here"
-msgstr ""
+msgstr "Suelta tu archivo de exportación de WordPress aquí"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:289
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplicar"
 
 #: packages/admin/src/components/ContentList.tsx:531
 msgid "Duplicate {title}"
-msgstr ""
+msgstr "Duplicar {title}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr ""
+msgstr "p. ej. application/zip o .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "e.g. import, blog"
-msgstr ""
+msgstr "p. ej. import, blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
 msgid "e.g., CI/CD Pipeline"
-msgstr ""
+msgstr "por ejemplo, canalización de CI/CD"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr ""
+msgstr "por ejemplo, MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentEditor.tsx:1960
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2288,7 +2288,7 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:360
 #: packages/admin/src/components/TranslationsPanel.tsx:88
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -2298,211 +2298,211 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:89
 #: packages/admin/src/routes/bylines.tsx:247
 msgid "Edit {0}"
-msgstr ""
+msgstr "Editar {0}"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:732
 msgid "Edit {0} field"
-msgstr ""
+msgstr "Editar campo {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:599
 msgid "Edit {collectionLabel}"
-msgstr ""
+msgstr "Editar {collectionLabel}"
 
 #: packages/admin/src/components/ContentList.tsx:523
 msgid "Edit {title}"
-msgstr ""
+msgstr "Editar {title}"
 
 #: packages/admin/src/components/ContentEditor.tsx:2067
 msgid "Edit byline"
-msgstr ""
+msgstr "Editar firma"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
 msgid "Edit Domain"
-msgstr ""
+msgstr "Editar dominio"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
-msgstr ""
+msgstr "Editar campo"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2470
 msgid "Edit link"
-msgstr ""
+msgstr "Editar enlace"
 
 #: packages/admin/src/components/MenuEditor.tsx:478
 msgid "Edit Menu Item"
-msgstr ""
+msgstr "Editar elemento del menú"
 
 #: packages/admin/src/components/MenuEditor.tsx:282
 msgid "Edit menu items"
-msgstr ""
+msgstr "Editar elementos del menú"
 
 #: packages/admin/src/components/Redirects.tsx:501
 msgid "Edit redirect"
-msgstr ""
+msgstr "Editar redirección"
 
 #: packages/admin/src/components/Redirects.tsx:102
 msgid "Edit Redirect"
-msgstr ""
+msgstr "Editar redirección"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:502
 msgid "Edit redirect {0}"
-msgstr ""
+msgstr "Editar redirección {0}"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:368
 msgid "Edit URL"
-msgstr ""
+msgstr "Editar URL"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
-msgstr ""
+msgstr "Editor"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:59
 #: packages/admin/src/components/Settings.tsx:115
 #: packages/admin/src/components/SignupPage.tsx:197
 #: packages/admin/src/components/users/UserDetail.tsx:154
 msgid "Email"
-msgstr ""
+msgstr "Correo electrónico"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:332
 msgid "Email (optional)"
-msgstr ""
+msgstr "Correo electrónico (opcional)"
 
 #: packages/admin/src/components/LoginPage.tsx:126
 #: packages/admin/src/components/SignupPage.tsx:66
 #: packages/admin/src/components/users/InviteUserModal.tsx:154
 msgid "Email address"
-msgstr ""
+msgstr "Dirección de correo electrónico"
 
 #: packages/admin/src/components/SetupWizard.tsx:179
 #: packages/admin/src/components/SignupPage.tsx:49
 msgid "Email is required"
-msgstr ""
+msgstr "Se requiere correo electrónico"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:215
 msgid "Email Middleware"
-msgstr ""
+msgstr "Middleware de correo electrónico"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:125
 msgid "Email Pipeline"
-msgstr ""
+msgstr "Canalización de correo electrónico"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:199
 msgid "Email provider active"
-msgstr ""
+msgstr "Proveedor de correo electrónico activo"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:85
 #: packages/admin/src/components/settings/EmailSettings.tsx:100
 msgid "Email Settings"
-msgstr ""
+msgstr "Configuración de correo electrónico"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
-msgstr ""
+msgstr "Correo electrónico verificado"
 
 #: packages/admin/src/components/SignupPage.tsx:189
 msgid "Email verified!"
-msgstr ""
+msgstr "Correo electrónico verificado!"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:1965
 msgid "Embed a {0}"
-msgstr ""
+msgstr "Incrustar un {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1968
 msgid "Embeds"
-msgstr ""
+msgstr "Incrustaciones"
 
 #: packages/admin/src/components/WordPressImport.tsx:1047
 msgid "EmDash Exporter"
-msgstr ""
+msgstr "Exportador EmDash"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "EmDash Exporter plugin detected! You can import directly."
-msgstr ""
+msgstr "¡Se detectó el plugin EmDash Exporter! Puedes importar directamente."
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
-msgstr ""
+msgstr "Habilitar"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:495
 msgid "Enable comments"
-msgstr ""
+msgstr "Activar comentarios"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
-msgstr ""
+msgstr "Habilitar la búsqueda de texto completo en esta colección"
 
 #: packages/admin/src/components/PluginManager.tsx:395
 msgid "Enable plugin"
-msgstr ""
+msgstr "Habilitar plugin"
 
 #: packages/admin/src/components/Redirects.tsx:478
 msgid "Enable redirect"
-msgstr ""
+msgstr "Habilitar redirección"
 
 #: packages/admin/src/components/Redirects.tsx:168
 #: packages/admin/src/components/Redirects.tsx:392
 msgid "Enabled"
-msgstr ""
+msgstr "Activado"
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1191
 msgid "Enter {0}..."
-msgstr ""
+msgstr "Introduce {0}..."
 
 #: packages/admin/src/components/MenuEditor.tsx:336
 #: packages/admin/src/components/MenuEditor.tsx:506
 msgid "Enter a URL (https://…) or a relative path (/…)"
-msgstr ""
+msgstr "Introduce una URL (https://…) o una ruta relativa (/…)"
 
 #: packages/admin/src/components/ContentEditor.tsx:1439
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr ""
+msgstr "Introduce una URL válida (p. ej. https://example.com)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1219
 msgid "Enter credentials manually"
-msgstr ""
+msgstr "Introduce las credenciales manualmente"
 
 #: packages/admin/src/components/ContentEditor.tsx:635
 msgid "Enter distraction-free mode"
-msgstr ""
+msgstr "Introduce al modo sin distracciones"
 
 #: packages/admin/src/components/users/UserDetail.tsx:158
 msgid "Enter email"
-msgstr ""
+msgstr "Introduce el correo electrónico"
 
 #: packages/admin/src/components/ContentEditor.tsx:1213
 msgid "Enter markdown content..."
-msgstr ""
+msgstr "Introduce contenido Markdown..."
 
 #: packages/admin/src/components/users/UserDetail.tsx:151
 msgid "Enter name"
-msgstr ""
+msgstr "Introduce el nombre"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:177
 msgid "Enter the code from your terminal"
-msgstr ""
+msgstr "Introduce el código desde tu terminal"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:123
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:132
 msgid "Enter URL..."
-msgstr ""
+msgstr "Introduce una URL..."
 
 #: packages/admin/src/components/LoginPage.tsx:325
 msgid "Enter your handle to sign in."
-msgstr ""
+msgstr "Introduce tu identificador para iniciar sesión."
 
 #: packages/admin/src/components/WordPressImport.tsx:1298
 msgid "Enter your WordPress credentials to import content directly."
-msgstr ""
+msgstr "Introduce sus credenciales de WordPress para importar contenido directamente."
 
 #: packages/admin/src/components/WordPressImport.tsx:924
 msgid "Enter your WordPress site URL"
-msgstr ""
+msgstr "Introduce la URL de tu sitio de WordPress"
 
 #: packages/admin/src/components/MenuEditor.tsx:101
 #: packages/admin/src/components/MenuEditor.tsx:139
@@ -2511,1008 +2511,1008 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:689
 #: packages/admin/src/router.tsx:1722
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #: packages/admin/src/components/Widgets.tsx:174
 msgid "Error adding widget"
-msgstr ""
+msgstr "Error al añadir el widget"
 
 #: packages/admin/src/components/Widgets.tsx:235
 msgid "Error reordering widgets"
-msgstr ""
+msgstr "Error al reordenar los widgets"
 
 #: packages/admin/src/components/SectionEditor.tsx:52
 msgid "Error saving section"
-msgstr ""
+msgstr "Error al guardar la sección"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Error updating widget"
-msgstr ""
+msgstr "Error al actualizar el widget"
 
 #: packages/admin/src/components/WordPressImport.tsx:1846
 msgid "Exists"
-msgstr ""
+msgstr "existe"
 
 #: packages/admin/src/components/ContentEditor.tsx:593
 msgid "Exit distraction-free mode"
-msgstr ""
+msgstr "Salir del modo sin distracciones"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2971
 msgid "Exit Spotlight Mode"
-msgstr ""
+msgstr "Salir del modo enfoque"
 
 #: packages/admin/src/components/PluginManager.tsx:407
 msgid "Expand"
-msgstr ""
+msgstr "Expandir"
 
 #: packages/admin/src/components/PluginManager.tsx:401
 msgid "Expand details"
-msgstr ""
+msgstr "Ampliar detalles"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
 msgid "Expires {0}"
-msgstr ""
+msgstr "Vence {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
 msgid "Expiry"
-msgstr ""
+msgstr "Expiración"
 
 #: packages/admin/src/components/WordPressImport.tsx:1112
 msgid "Export from WordPress manually"
-msgstr ""
+msgstr "Exportar desde WordPress manualmente"
 
 #: packages/admin/src/components/WordPressImport.tsx:1236
 msgid "Export your content from WordPress to import everything including drafts."
-msgstr ""
+msgstr "Exporta tu contenido desde WordPress para importarlo todo, incluidos los borradores."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:144
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:343
 msgid "Fail"
-msgstr ""
+msgstr "Fallar"
 
 #: packages/admin/src/components/WordPressImport.tsx:1966
 msgid "Failed"
-msgstr ""
+msgstr "Fallido"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:189
 msgid "Failed security audit"
-msgstr ""
+msgstr "Auditoría de seguridad fallida"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
 msgid "Failed to add domain"
-msgstr ""
+msgstr "No se pudo agregar el dominio"
 
 #: packages/admin/src/components/WordPressImport.tsx:367
 msgid "Failed to analyze WordPress site"
-msgstr ""
+msgstr "Error al analizar el sitio de WordPress"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:54
 msgid "Failed to communicate with plugin"
-msgstr ""
+msgstr "Error al comunicar con el plugin"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr ""
+msgstr "Error al crear el administrador"
 
 #: packages/admin/src/components/ContentEditor.tsx:2051
 msgid "Failed to create byline"
-msgstr ""
+msgstr "No se pudo crear la firma"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
-msgstr ""
+msgstr "No se pudieron crear algunas colecciones."
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:456
 msgid "Failed to create term"
-msgstr ""
+msgstr "Error al crear el término"
 
 #: packages/admin/src/router.tsx:849
 msgid "Failed to create translation"
-msgstr ""
+msgstr "Error al crear la traducción"
 
 #: packages/admin/src/router.tsx:338
 #: packages/admin/src/router.tsx:367
 #: packages/admin/src/router.tsx:869
 msgid "Failed to delete"
-msgstr ""
+msgstr "Error al eliminar"
 
 #: packages/admin/src/lib/api/users.ts:345
 msgid "Failed to delete allowed domain"
-msgstr ""
+msgstr "Error al eliminar el dominio permitido"
 
 #: packages/admin/src/lib/api/bylines.ts:89
 msgid "Failed to delete byline"
-msgstr ""
+msgstr "Error al eliminar la firma"
 
 #: packages/admin/src/lib/api/schema.ts:222
 msgid "Failed to delete collection"
-msgstr ""
+msgstr "Error al eliminar la colección"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1098
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "Error al eliminar el comentario"
 
 #: packages/admin/src/lib/api/content.ts:217
 msgid "Failed to delete content"
-msgstr ""
+msgstr "Error al eliminar el contenido"
 
 #: packages/admin/src/lib/api/schema.ts:278
 msgid "Failed to delete field"
-msgstr ""
+msgstr "Error al eliminar el campo"
 
 #: packages/admin/src/lib/api/media.ts:338
 msgid "Failed to delete from provider"
-msgstr ""
+msgstr "Error al eliminar del proveedor"
 
 #: packages/admin/src/lib/api/media.ts:215
 msgid "Failed to delete media"
-msgstr ""
+msgstr "Error al eliminar el medio"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
-msgstr ""
+msgstr "Error al eliminar el menú"
 
 #: packages/admin/src/lib/api/menus.ts:217
 msgid "Failed to delete menu item"
-msgstr ""
+msgstr "Error al eliminar el elemento del menú"
 
 #: packages/admin/src/lib/api/users.ts:256
 msgid "Failed to delete passkey"
-msgstr ""
+msgstr "Error al eliminar la passkey"
 
 #: packages/admin/src/lib/api/redirects.ts:111
 msgid "Failed to delete redirect"
-msgstr ""
+msgstr "Error al eliminar la redirección"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr ""
+msgstr "Error al eliminar la sección"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr ""
+msgstr "Error al eliminar el término"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
-msgstr ""
+msgstr "Error al eliminar el widget"
 
 #: packages/admin/src/lib/api/widgets.ts:108
 msgid "Failed to delete widget area"
-msgstr ""
+msgstr "Error al eliminar el área de widgets"
 
 #: packages/admin/src/components/PluginManager.tsx:109
 msgid "Failed to disable plugin"
-msgstr ""
+msgstr "No se pudo deshabilitar el plugin"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
-msgstr ""
+msgstr "Error al desactivar el usuario"
 
 #: packages/admin/src/router.tsx:783
 msgid "Failed to discard changes"
-msgstr ""
+msgstr "Error al descartar los cambios"
 
 #: packages/admin/src/components/WelcomeModal.tsx:70
 msgid "Failed to dismiss welcome"
-msgstr ""
+msgstr "Error al cerrar la bienvenida"
 
 #: packages/admin/src/router.tsx:381
 msgid "Failed to duplicate"
-msgstr ""
+msgstr "Error al duplicar"
 
 #: packages/admin/src/components/PluginManager.tsx:90
 msgid "Failed to enable plugin"
-msgstr ""
+msgstr "No se pudo habilitar el plugin"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr ""
+msgstr "Error al activar el usuario"
 
 #: packages/admin/src/components/WordPressImport.tsx:295
 msgid "Failed to execute import"
-msgstr ""
+msgstr "Error al ejecutar la importación"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
 msgid "Failed to fetch collection"
-msgstr ""
+msgstr "Error al obtener la colección"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:81
 msgid "Failed to fetch entry terms"
-msgstr ""
+msgstr "Error al obtener los términos de la entrada"
 
 #: packages/admin/src/lib/api/client.ts:189
 msgid "Failed to fetch manifest"
-msgstr ""
+msgstr "Error al obtener el manifiesto"
 
 #: packages/admin/src/lib/api/plugins.ts:55
 #: packages/admin/src/lib/api/plugins.ts:59
 msgid "Failed to fetch plugin"
-msgstr ""
+msgstr "Error al obtener el plugin"
 
 #: packages/admin/src/lib/api/content.ts:462
 #: packages/admin/src/lib/api/content.ts:467
 msgid "Failed to fetch revision"
-msgstr ""
+msgstr "Error al obtener la revisión"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr ""
+msgstr "Error al obtener el estado de configuración"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:65
 msgid "Failed to fetch terms"
-msgstr ""
+msgstr "Error al obtener los términos"
 
 #: packages/admin/src/lib/api/users.ts:88
 #: packages/admin/src/lib/api/users.ts:93
 #: packages/admin/src/router.tsx:642
 #: packages/admin/src/router.tsx:1029
 msgid "Failed to fetch user"
-msgstr ""
+msgstr "Error al obtener el usuario"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
 msgid "Failed to generate preview"
-msgstr ""
+msgstr "No se pudo generar la vista previa"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr ""
+msgstr "No se pudo generar la URL de vista previa"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr ""
+msgstr "Error al obtener las opciones de autenticación"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr ""
+msgstr "Error al obtener las opciones de registro"
 
 #: packages/admin/src/components/WordPressImport.tsx:386
 msgid "Failed to import from WordPress"
-msgstr ""
+msgstr "Error al importar desde WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:319
 #: packages/admin/src/lib/api/import.ts:256
 msgid "Failed to import media"
-msgstr ""
+msgstr "Error al importar los medios"
 
 #: packages/admin/src/lib/api/marketplace.ts:160
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "Error al instalar el plugin"
 
 #: packages/admin/src/router.tsx:244
 msgid "Failed to load admin"
-msgstr ""
+msgstr "Error al cargar el administrador"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
 msgid "Failed to load allowed domains"
-msgstr ""
+msgstr "No se pudieron cargar los dominios permitidos"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:170
 msgid "Failed to load bylines: {0}"
-msgstr ""
+msgstr "Error al cargar las firmas: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:89
 msgid "Failed to load email settings"
-msgstr ""
+msgstr "No se pudo cargar la configuración de correo electrónico"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:365
 msgid "Failed to load image"
-msgstr ""
+msgstr "Error al cargar la imagen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:144
 msgid "Failed to load passkeys"
-msgstr ""
+msgstr "No se pudieron cargar las passkeys"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:111
 msgid "Failed to load plugin"
-msgstr ""
+msgstr "No se pudo cargar el plugin"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:136
 msgid "Failed to load plugins: {0}"
-msgstr ""
+msgstr "No se pudieron cargar los plugins: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
-msgstr ""
+msgstr "No se pudieron cargar las revisiones"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr ""
+msgstr "No se pudo cargar la configuración"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
-msgstr ""
+msgstr "No se pudo cargar el tema"
 
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr ""
+msgstr "Error al cargar los usuarios: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
-msgstr ""
+msgstr "Error al cargar el widget"
 
 #: packages/admin/src/router.tsx:1123
 msgid "Failed to perform bulk action"
-msgstr ""
+msgstr "Error al realizar la acción masiva"
 
 #: packages/admin/src/lib/api/content.ts:260
 msgid "Failed to permanently delete content"
-msgstr ""
+msgstr "Error al eliminar permanentemente el contenido"
 
 #: packages/admin/src/components/WordPressImport.tsx:276
 msgid "Failed to prepare import"
-msgstr ""
+msgstr "Error al preparar la importación"
 
 #: packages/admin/src/router.tsx:748
 msgid "Failed to publish"
-msgstr ""
+msgstr "Error al publicar"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
 msgid "Failed to remove domain"
-msgstr ""
+msgstr "No se pudo eliminar el dominio"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:99
 #: packages/admin/src/components/settings/SecuritySettings.tsx:82
 msgid "Failed to remove passkey"
-msgstr ""
+msgstr "No se pudo eliminar la Passkey"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:66
 msgid "Failed to rename passkey"
-msgstr ""
+msgstr "No se pudo cambiar el nombre de la Passkey"
 
 #: packages/admin/src/lib/api/schema.ts:293
 msgid "Failed to reorder fields"
-msgstr ""
+msgstr "Error al reordenar los campos"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr ""
+msgstr "Error al reordenar los widgets"
 
 #: packages/admin/src/router.tsx:353
 msgid "Failed to restore"
-msgstr ""
+msgstr "Error al restaurar"
 
 #: packages/admin/src/lib/api/content.ts:249
 msgid "Failed to restore content"
-msgstr ""
+msgstr "Error al restaurar el contenido"
 
 #: packages/admin/src/lib/api/content.ts:484
 #: packages/admin/src/lib/api/content.ts:489
 msgid "Failed to restore revision"
-msgstr ""
+msgstr "Error al restaurar la revisión"
 
 #: packages/admin/src/lib/api/api-tokens.ts:98
 msgid "Failed to revoke API token"
-msgstr ""
+msgstr "Error al revocar el token de API"
 
 #: packages/admin/src/components/WordPressImport.tsx:332
 msgid "Failed to rewrite URLs"
-msgstr ""
+msgstr "Error al reescribir las URL"
 
 #: packages/admin/src/router.tsx:701
 #: packages/admin/src/router.tsx:1540
 msgid "Failed to save"
-msgstr ""
+msgstr "Error al guardar"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:58
 #: packages/admin/src/components/settings/SeoSettings.tsx:53
 #: packages/admin/src/components/settings/SocialSettings.tsx:53
 msgid "Failed to save settings"
-msgstr ""
+msgstr "No se pudo guardar la configuración"
 
 #: packages/admin/src/router.tsx:801
 msgid "Failed to schedule"
-msgstr ""
+msgstr "Error al programar"
 
 #: packages/admin/src/components/LoginPage.tsx:70
 #: packages/admin/src/components/LoginPage.tsx:75
 msgid "Failed to send magic link"
-msgstr ""
+msgstr "No se pudo enviar el enlace mágico"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
-msgstr ""
+msgstr "Error al enviar el enlace de recuperación"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:61
 msgid "Failed to send test email"
-msgstr ""
+msgstr "No se pudo enviar el correo electrónico de prueba"
 
 #: packages/admin/src/components/SignupPage.tsx:349
 msgid "Failed to send verification email"
-msgstr ""
+msgstr "Error al enviar el correo de verificación"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:100
 msgid "Failed to set entry terms"
-msgstr ""
+msgstr "Error al establecer los términos de la entrada"
 
 #: packages/admin/src/lib/api/marketplace.ts:192
 msgid "Failed to uninstall plugin"
-msgstr ""
+msgstr "Error al desinstalar el plugin"
 
 #: packages/admin/src/router.tsx:764
 msgid "Failed to unpublish"
-msgstr ""
+msgstr "Error al despublicar"
 
 #: packages/admin/src/router.tsx:819
 msgid "Failed to unschedule"
-msgstr ""
+msgstr "Error al desprogramar"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:320
 msgid "Failed to update {0}"
-msgstr ""
+msgstr "Error al actualizar {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:2101
 msgid "Failed to update byline"
-msgstr ""
+msgstr "No se pudo actualizar la firma"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
 msgid "Failed to update domain"
-msgstr ""
+msgstr "No se pudo actualizar el dominio"
 
 #: packages/admin/src/lib/api/marketplace.ts:176
 msgid "Failed to update plugin"
-msgstr ""
+msgstr "Error al actualizar el plugin"
 
 #: packages/admin/src/router.tsx:1082
 msgid "Failed to update status"
-msgstr ""
+msgstr "Error al actualizar el estado"
 
 #: packages/admin/src/lib/api/media.ts:132
 msgid "Failed to upload file"
-msgstr ""
+msgstr "Error al subir el archivo"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:250
 msgid "Failed to verify authentication"
-msgstr ""
+msgstr "Error al verificar la autenticación"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr ""
+msgstr "Error al verificar el registro"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:221
 #: packages/admin/src/components/settings/GeneralSettings.tsx:226
 msgid "Favicon"
-msgstr ""
+msgstr "favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1022
 msgid "Feature"
-msgstr ""
+msgstr "Característica"
 
 #: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
-msgstr ""
+msgstr "Características"
 
 #: packages/admin/src/components/WordPressImport.tsx:736
 msgid "Fetching content from the EmDash Exporter API."
-msgstr ""
+msgstr "Obteniendo contenido de la API EmDash Exporter."
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr ""
+msgstr "Etiqueta de campo"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr ""
+msgstr "Etiqueta de campo"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
-msgstr ""
+msgstr "Los slugs de campo no se pueden cambiar después de la creación"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:572
 msgid "Fields"
-msgstr ""
+msgstr "Campos"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Fields created:"
-msgstr ""
+msgstr "Campos creados:"
 
 #: packages/admin/src/components/FieldEditor.tsx:210
 msgid "File"
-msgstr ""
+msgstr "Archivo"
 
 #. placeholder {0}: progress.current
 #: packages/admin/src/components/WordPressImport.tsx:1994
 msgid "File {0}"
-msgstr ""
+msgstr "Archivo {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "File from media library"
-msgstr ""
+msgstr "Archivo de la biblioteca multimedia"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:416
 msgid "Filename"
-msgstr ""
+msgstr "Nombre del archivo"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:196
 msgid "Filename cannot be changed after upload"
-msgstr ""
+msgstr "El nombre del archivo no se puede cambiar después de cargarlo"
 
 #: packages/admin/src/components/WordPressImport.tsx:2172
 msgid "files imported"
-msgstr ""
+msgstr "archivos importados"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
-msgstr ""
+msgstr "Filtrar por capacidad"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:177
 msgid "Filter by collection"
-msgstr ""
+msgstr "Filtrar por colección"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr ""
+msgstr "Filtrar por rol"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
-msgstr ""
+msgstr "Filtrar por origen"
 
 #: packages/admin/src/components/Redirects.tsx:393
 msgid "Filter by status"
-msgstr ""
+msgstr "Filtrar por estado"
 
 #: packages/admin/src/components/Redirects.tsx:399
 msgid "Filter by type"
-msgstr ""
+msgstr "Filtrar por tipo"
 
 #: packages/admin/src/routes/bylines.tsx:188
 msgid "Filter byline type"
-msgstr ""
+msgstr "Filtrar por tipo de firma"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr ""
+msgstr "Solo quienes comentan por primera vez"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
-msgstr ""
+msgstr "Fuentes"
 
 #: packages/admin/src/components/WordPressImport.tsx:1237
 msgid "For a complete import including drafts and all content, export from WordPress."
-msgstr ""
+msgstr "Para una importación completa, incluidos borradores y todo el contenido, exporte desde WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1046
 msgid "For the best import experience, install the"
-msgstr ""
+msgstr "Para obtener la mejor experiencia de importación, instale el"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
-msgstr ""
+msgstr "Acceso completo"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
 msgid "Full admin access"
-msgstr ""
+msgstr "Acceso completo de administrador"
 
 #: packages/admin/src/components/Settings.tsx:69
 msgid "General"
-msgstr ""
+msgstr "General"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:101
 #: packages/admin/src/components/settings/GeneralSettings.tsx:129
 msgid "General Settings"
-msgstr ""
+msgstr "Configuraciones generales"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:624
 msgid "Genres"
-msgstr ""
+msgstr "Géneros"
 
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
-msgstr ""
+msgstr "Empezar"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:138
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr ""
+msgstr "Asigne un nombre a esta Passkey para poder identificarla más adelante."
 
 #: packages/admin/src/components/WordPressImport.tsx:2224
 #: packages/admin/src/router.tsx:1742
 msgid "Go to Dashboard"
-msgstr ""
+msgstr "Ir al panel"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:138
 msgid "Google Verification"
-msgstr ""
+msgstr "Verificación de Google"
 
 #: packages/admin/src/components/MediaLibrary.tsx:232
 msgid "Grid view"
-msgstr ""
+msgstr "Vista de cuadrícula"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "Group (optional)"
-msgstr ""
+msgstr "Grupo (opcional)"
 
 #: packages/admin/src/routes/bylines.tsx:290
 msgid "Guest byline"
-msgstr ""
+msgstr "Firma invitada"
 
 #: packages/admin/src/routes/bylines.tsx:193
 msgid "Guest only"
-msgstr ""
+msgstr "Solo invitado"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:856
 #: packages/admin/src/components/PortableTextEditor.tsx:2781
 msgid "Heading 1"
-msgstr ""
+msgstr "Título 1"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:69
 #: packages/admin/src/components/PortableTextEditor.tsx:866
 #: packages/admin/src/components/PortableTextEditor.tsx:2788
 msgid "Heading 2"
-msgstr ""
+msgstr "Título 2"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:77
 #: packages/admin/src/components/PortableTextEditor.tsx:876
 #: packages/admin/src/components/PortableTextEditor.tsx:2795
 msgid "Heading 3"
-msgstr ""
+msgstr "Título 3"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
 msgid "Height"
-msgstr ""
+msgstr "Altura"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
-msgstr ""
+msgstr "Banner principal"
 
 #: packages/admin/src/components/SectionEditor.tsx:271
 msgid "hero, banner, cta"
-msgstr ""
+msgstr "hero, banner, cta"
 
 #: packages/admin/src/components/SeoPanel.tsx:191
 msgid "Hide from search engines"
-msgstr ""
+msgstr "Ocultarse de los motores de búsqueda"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Hide token"
-msgstr ""
+msgstr "Ocultar token"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:647
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr ""
+msgstr "Jerárquico (como categorías, con relaciones padre/hijo)"
 
 #: packages/admin/src/components/Redirects.tsx:216
 #: packages/admin/src/components/Redirects.tsx:444
 msgid "Hits"
-msgstr ""
+msgstr "Visitas"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "Home"
-msgstr ""
+msgstr "Hogar"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
 msgid "Homepage"
-msgstr ""
+msgstr "Página principal"
 
 #: packages/admin/src/components/PluginManager.tsx:335
 msgid "Hooks"
-msgstr ""
+msgstr "Hooks"
 
 #: packages/admin/src/components/WordPressImport.tsx:1359
 msgid "How to create an Application Password"
-msgstr ""
+msgstr "Cómo crear una contraseña de aplicación"
 
 #: packages/admin/src/components/MenuEditor.tsx:337
 msgid "https://example.com or /about"
-msgstr ""
+msgstr "https://ejemplo.com o /acerca de"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:449
 msgid "https://example.com/image.jpg"
-msgstr ""
+msgstr "https://example.com/imagen.jpg"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:241
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:143
 msgid "Icon blurred due to image audit"
-msgstr ""
+msgstr "Icono borroso debido a auditoría de imagen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: packages/admin/src/components/LoginPage.tsx:103
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
-msgstr ""
+msgstr "Si existe una cuenta para <0>{email}</0>, te hemos enviado un enlace de inicio de sesión."
 
 #: packages/admin/src/components/FieldEditor.tsx:204
 #: packages/admin/src/components/PortableTextEditor.tsx:1934
 msgid "Image"
-msgstr ""
+msgstr "Imagen"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "Image from media library"
-msgstr ""
+msgstr "Imagen de la biblioteca multimedia"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:179
 #: packages/admin/src/components/editor/ImageNode.tsx:180
 msgid "Image settings"
-msgstr ""
+msgstr "Ajustes de imagen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
 msgid "Image Settings"
-msgstr ""
+msgstr "Configuración de imagen"
 
 #: packages/admin/src/components/SeoImageField.tsx:75
 msgid "Image shown when this page is shared on social media"
-msgstr ""
+msgstr "Imagen que se muestra cuando esta página se comparte en las redes sociales."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:450
 msgid "Image URL"
-msgstr ""
+msgstr "URL de la imagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2176
 msgid "image URLs updated in"
-msgstr ""
+msgstr "URL de imágenes actualizadas en"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 msgid "Images"
-msgstr ""
+msgstr "Imágenes"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:228
 #: packages/admin/src/components/WordPressImport.tsx:664
 msgid "Import"
-msgstr ""
+msgstr "Importar"
 
 #. placeholder {0}: postType.name
 #: packages/admin/src/components/WordPressImport.tsx:1794
 msgid "Import {0}"
-msgstr ""
+msgstr "Importar {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1205
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr ""
+msgstr "Importe todo el contenido directamente, incluidos borradores, tipos de entrada personalizados, campos ACF y datos de SEO. No es necesario descargar archivos."
 
 #: packages/admin/src/components/WordPressImport.tsx:2222
 msgid "Import Another File"
-msgstr ""
+msgstr "Importar otro archivo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1016
 msgid "Import Capabilities"
-msgstr ""
+msgstr "Capacidades de importación"
 
 #: packages/admin/src/components/WordPressImport.tsx:2110
 msgid "Import Complete"
-msgstr ""
+msgstr "Importación completa"
 
 #: packages/admin/src/components/WordPressImport.tsx:2111
 msgid "Import Completed with Errors"
-msgstr ""
+msgstr "Importación completada con errores"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Import failed"
-msgstr ""
+msgstr "Importación fallida"
 
 #: packages/admin/src/components/WordPressImport.tsx:617
 msgid "Import from WordPress"
-msgstr ""
+msgstr "Importar desde WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1943
 msgid "Import Media"
-msgstr ""
+msgstr "Importar medios"
 
 #: packages/admin/src/components/WordPressImport.tsx:1896
 msgid "Import Media Files"
-msgstr ""
+msgstr "Importar archivos multimedia"
 
 #: packages/admin/src/components/WordPressImport.tsx:619
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr ""
+msgstr "Importe entradas, páginas y tipos de entrada personalizados desde WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1650
 msgid "Import site configuration from WordPress."
-msgstr ""
+msgstr "Importar la configuración del sitio desde WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1203
 msgid "Import via EmDash Exporter"
-msgstr ""
+msgstr "Importar a través del exportador EmDash"
 
 #: packages/admin/src/components/Sections.tsx:47
 msgid "Imported"
-msgstr ""
+msgstr "Importado"
 
 #: packages/admin/src/components/WordPressImport.tsx:2150
 msgid "Imported by Collection"
-msgstr ""
+msgstr "Importado por colección"
 
 #: packages/admin/src/components/WordPressImport.tsx:820
 msgid "Importing content..."
-msgstr ""
+msgstr "Importando contenido..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1975
 msgid "Importing Media"
-msgstr ""
+msgstr "Importación de medios"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
-msgstr ""
+msgstr "Incluir contenido de muestra (recomendado para sitios nuevos)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1816
 msgid "Incompatible"
-msgstr ""
+msgstr "Incompatible"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2768
 msgid "Inline Code"
-msgstr ""
+msgstr "Código en línea"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:461
 #: packages/admin/src/components/MediaPickerModal.tsx:666
 #: packages/admin/src/components/PortableTextEditor.tsx:1243
 msgid "Insert"
-msgstr ""
+msgstr "Insertar"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:907
 msgid "Insert a blockquote"
-msgstr ""
+msgstr "Insertar una cita en bloque"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:917
 msgid "Insert a code block"
-msgstr ""
+msgstr "Insertar un bloque de código"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:927
 msgid "Insert a horizontal rule"
-msgstr ""
+msgstr "Insertar una regla horizontal"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1949
 msgid "Insert a reusable section"
-msgstr ""
+msgstr "Insertar una sección reutilizable"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:937
 msgid "Insert a table"
-msgstr ""
+msgstr "Insertar una tabla"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1935
 msgid "Insert an image"
-msgstr ""
+msgstr "Insertar una imagen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:443
 msgid "Insert from URL"
-msgstr ""
+msgstr "Insertar desde URL"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2938
 msgid "Insert Horizontal Rule"
-msgstr ""
+msgstr "Insertar línea horizontal"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2933
 msgid "Insert Image"
-msgstr ""
+msgstr "Insertar imagen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2880
 msgid "Insert Link"
-msgstr ""
+msgstr "Insertar enlace"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:57
 msgid "Insert Section"
-msgstr ""
+msgstr "Insertar sección"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2838
 msgid "Insert Table"
-msgstr ""
+msgstr "Insertar tabla"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:150
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:193
 msgid "Install"
-msgstr ""
+msgstr "Instalar"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:181
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr ""
+msgstr "Instale y activa un plugin de proveedor de correo electrónico para habilitar funciones de correo electrónico como invitaciones, enlaces mágicos y recuperación de contraseña."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:187
 msgid "Install blocked"
-msgstr ""
+msgstr "Instalar bloqueado"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:261
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:174
 msgid "Installed"
-msgstr ""
+msgstr "Instalado"
 
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:447
 msgid "Installed from marketplace (v{0})"
-msgstr ""
+msgstr "Instalado desde Marketplace (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:466
 msgid "Installed:"
-msgstr ""
+msgstr "Instalado:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:145
 msgid "Installing..."
-msgstr ""
+msgstr "Instalando..."
 
 #: packages/admin/src/components/FieldEditor.tsx:168
 #: packages/admin/src/components/FieldEditor.tsx:582
 msgid "Integer"
-msgstr ""
+msgstr "Entero"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:119
 msgid "Invalid invite link"
-msgstr ""
+msgstr "Enlace de invitación no válido"
 
 #: packages/admin/src/components/ContentEditor.tsx:1508
 msgid "Invalid JSON"
-msgstr ""
+msgstr "JSON no válido"
 
 #: packages/admin/src/components/SignupPage.tsx:259
 msgid "Invalid link"
-msgstr ""
+msgstr "Enlace no válido"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:207
 msgid "Invite Error"
-msgstr ""
+msgstr "Error de invitación"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:117
 msgid "Invite expired"
-msgstr ""
+msgstr "La invitación ha caducado"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
-msgstr ""
+msgstr "Enlace de invitación creado"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
 msgid "Invite User"
-msgstr ""
+msgstr "Invitar usuario"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr ""
+msgstr "Invita al primer miembro de tu equipo"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2441
 #: packages/admin/src/components/PortableTextEditor.tsx:2747
 msgid "Italic"
-msgstr ""
+msgstr "Cursiva"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:1624
 #: packages/admin/src/components/RepeaterField.tsx:234
 msgid "Item {0}"
-msgstr ""
+msgstr "Artículo {0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:121
 msgid "Item added"
-msgstr ""
+msgstr "Artículo agregado"
 
 #: packages/admin/src/components/MenuEditor.tsx:133
 msgid "Item deleted"
-msgstr ""
+msgstr "Artículo eliminado"
 
 #: packages/admin/src/components/MenuEditor.tsx:158
 msgid "Item updated"
-msgstr ""
+msgstr "Artículo actualizado"
 
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:205
 msgid "Jane Doe"
-msgstr ""
+msgstr "Jane Doe"
 
 #: packages/admin/src/components/FieldEditor.tsx:222
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:294
 #: packages/admin/src/components/SectionEditor.tsx:268
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
 msgid "Keywords"
-msgstr ""
+msgstr "Palabras clave"
 
 #: packages/admin/src/components/FieldEditor.tsx:411
 #: packages/admin/src/components/FieldEditor.tsx:553
@@ -3522,191 +3522,191 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:621
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Label"
-msgstr ""
+msgstr "Etiqueta"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:394
 msgid "Label (Plural)"
-msgstr ""
+msgstr "Etiqueta (plural)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:386
 msgid "Label (Singular)"
-msgstr ""
+msgstr "Etiqueta (singular)"
 
 #: packages/admin/src/components/LoginPage.tsx:345
 #: packages/admin/src/components/Settings.tsx:129
 #: packages/admin/src/components/Settings.tsx:134
 msgid "Language"
-msgstr ""
+msgstr "Idioma"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:857
 msgid "Large section heading"
-msgstr ""
+msgstr "Encabezado de sección grande"
 
 #: packages/admin/src/components/PluginManager.tsx:472
 msgid "Last enabled:"
-msgstr ""
+msgstr "Última habilitación:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
-msgstr ""
+msgstr "Último inicio de sesión"
 
 #: packages/admin/src/components/users/UserList.tsx:107
 msgid "Last Login"
-msgstr ""
+msgstr "Último inicio de sesión"
 
 #: packages/admin/src/components/Redirects.tsx:217
 msgid "Last seen"
-msgstr ""
+msgstr "visto por última vez"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
-msgstr ""
+msgstr "Última actualización"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:161
 msgid "Last used"
-msgstr ""
+msgstr "último usado"
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
 #: packages/admin/src/components/users/UserDetail.tsx:262
 msgid "Last used {0}"
-msgstr ""
+msgstr "Usado por última vez {0}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:341
 msgid "Leave blank to use a discoverable passkey."
-msgstr ""
+msgstr "Déjelo en blanco para utilizar una clave reconocible."
 
 #: packages/admin/src/components/WordPressImport.tsx:2303
 msgid "Leave unassigned"
-msgstr ""
+msgstr "Dejar sin asignar"
 
 #: packages/admin/src/components/MediaLibrary.tsx:82
 #: packages/admin/src/components/MediaLibrary.tsx:202
 #: packages/admin/src/components/MediaLibrary.tsx:314
 msgid "Library"
-msgstr ""
+msgstr "Biblioteca"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
 msgid "License"
-msgstr ""
+msgstr "Licencia"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
-msgstr ""
+msgstr "Claro"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "Light"
-msgstr ""
+msgstr "Claro"
 
 #: packages/admin/src/components/SignupPage.tsx:257
 msgid "Link expired"
-msgstr ""
+msgstr "Enlace caducado"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "Link to another content item"
-msgstr ""
+msgstr "Enlace a otro elemento de contenido"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr ""
+msgstr "Cuentas vinculadas ({0})"
 
 #: packages/admin/src/routes/bylines.tsx:194
 msgid "Linked only"
-msgstr ""
+msgstr "Solo vinculado"
 
 #: packages/admin/src/routes/bylines.tsx:273
 msgid "Linked user"
-msgstr ""
+msgstr "Usuario vinculado"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:156
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
 msgid "Links"
-msgstr ""
+msgstr "Campo de golf"
 
 #: packages/admin/src/components/MediaLibrary.tsx:241
 msgid "List view"
-msgstr ""
+msgstr "Vista de lista"
 
 #: packages/admin/src/components/ContentEditor.tsx:714
 msgid "Live View"
-msgstr ""
+msgstr "Vista en vivo"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:236
 #: packages/admin/src/components/MarketplaceBrowse.tsx:198
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
 #: packages/admin/src/routes/bylines.tsx:239
 msgid "Load more"
-msgstr ""
+msgstr "Cargar más"
 
 #: packages/admin/src/components/ContentList.tsx:330
 #: packages/admin/src/components/ContentList.tsx:387
 #: packages/admin/src/components/users/UserList.tsx:169
 msgid "Load More"
-msgstr ""
+msgstr "Cargar más"
 
 #: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
-msgstr ""
+msgstr "Cargando colecciones..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:307
 msgid "Loading comments..."
-msgstr ""
+msgstr "Cargando comentarios..."
 
 #: packages/admin/src/router.tsx:1711
 msgid "Loading configuration..."
-msgstr ""
+msgstr "Cargando configuración..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:164
 msgid "Loading content..."
-msgstr ""
+msgstr "Cargando contenido..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2268
 msgid "Loading editor..."
-msgstr ""
+msgstr "Cargando el editor..."
 
 #: packages/admin/src/components/MenuEditor.tsx:255
 msgid "Loading menu..."
-msgstr ""
+msgstr "Cargando menú..."
 
 #: packages/admin/src/components/MenuList.tsx:94
 msgid "Loading menus..."
-msgstr ""
+msgstr "Cargando menús..."
 
 #: packages/admin/src/components/PluginManager.tsx:127
 msgid "Loading plugins..."
-msgstr ""
+msgstr "Cargando plugins..."
 
 #: packages/admin/src/components/Redirects.tsx:430
 msgid "Loading redirects..."
-msgstr ""
+msgstr "Cargando redirecciones..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:94
 #: packages/admin/src/components/Sections.tsx:252
 msgid "Loading sections..."
-msgstr ""
+msgstr "Cargando secciones..."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:104
 #: packages/admin/src/components/settings/SeoSettings.tsx:81
 #: packages/admin/src/components/settings/SocialSettings.tsx:81
 msgid "Loading settings..."
-msgstr ""
+msgstr "Cargando configuración..."
 
 #: packages/admin/src/components/SetupWizard.tsx:528
 msgid "Loading setup..."
-msgstr ""
+msgstr "Cargando configuración..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:825
 msgid "Loading terms..."
-msgstr ""
+msgstr "Cargando términos..."
 
 #: packages/admin/src/components/Widgets.tsx:310
 msgid "Loading widgets..."
-msgstr ""
+msgstr "Cargando widgets..."
 
 #: packages/admin/src/components/ContentList.tsx:245
 #: packages/admin/src/components/ContentList.tsx:330
@@ -3725,324 +3725,324 @@ msgstr ""
 #: packages/admin/src/components/WelcomeModal.tsx:143
 #: packages/admin/src/routes/bylines.tsx:239
 msgid "Loading..."
-msgstr ""
+msgstr "Cargando..."
 
 #: packages/admin/src/components/ContentList.tsx:225
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
 msgid "Locale"
-msgstr ""
+msgstr "Lugar"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Lock aspect ratio"
-msgstr ""
+msgstr "Bloquear relación de aspecto"
 
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
-msgstr ""
+msgstr "Cerrar sesión"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:177
 #: packages/admin/src/components/settings/GeneralSettings.tsx:182
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1668
 msgid "Logo & favicon"
-msgstr ""
+msgstr "Logotipo y favicon"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
 msgid "Long Text"
-msgstr ""
+msgstr "Texto largo"
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr ""
+msgstr "Sólo letras minúsculas, números y guiones"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:639
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
-msgstr ""
+msgstr "Letras minúsculas, números y guiones bajos únicamente, comenzando con una letra"
 
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Main Sidebar"
-msgstr ""
+msgstr "Barra lateral principal"
 
 #: packages/admin/src/lib/api/marketplace.ts:227
 #: packages/admin/src/lib/api/marketplace.ts:235
 msgid "Make network requests"
-msgstr ""
+msgstr "Realizar peticiones de red"
 
 #: packages/admin/src/lib/api/marketplace.ts:228
 #: packages/admin/src/lib/api/marketplace.ts:236
 msgid "Make network requests to any host (unrestricted)"
-msgstr ""
+msgstr "Realizar peticiones de red a cualquier host (sin restricciones)"
 
 #: packages/admin/src/components/Sidebar.tsx:426
 msgid "Manage"
-msgstr ""
+msgstr "Gestionar"
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:796
 msgid "Manage {0} for {1}"
-msgstr ""
+msgstr "Gestionar {0} para {1}"
 
 #: packages/admin/src/components/Widgets.tsx:326
 msgid "Manage content widgets in your widget areas"
-msgstr ""
+msgstr "Gestiona los widgets de contenido en tus áreas de widgets"
 
 #: packages/admin/src/components/PluginManager.tsx:166
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr ""
+msgstr "Gestionar plugins instalados. Habilite o deshabilite plugins para controlar su funcionalidad."
 
 #: packages/admin/src/components/MenuList.tsx:104
 msgid "Manage navigation menus for your site"
-msgstr ""
+msgstr "Gestionar menús de navegación para tu sitio"
 
 #: packages/admin/src/components/Redirects.tsx:333
 msgid "Manage URL redirects and view 404 errors."
-msgstr ""
+msgstr "Gestiona redirecciones de URL y vea errores 404."
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
-msgstr ""
+msgstr "Gestiona tus passkeys y autenticación"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 #: packages/admin/src/components/WordPressImport.tsx:2260
 msgid "Map Authors"
-msgstr ""
+msgstr "Autores del mapa"
 
 #. placeholder {0}: mapping.wpLogin
 #: packages/admin/src/components/WordPressImport.tsx:2308
 msgid "Map WordPress user {0} to EmDash user"
-msgstr ""
+msgstr "Asignar el usuario de WordPress {0} a un usuario de EmDash"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:501
 msgid "Mark as spam"
-msgstr ""
+msgstr "Marcar como spam"
 
 #: packages/admin/src/components/PluginManager.tsx:192
 msgid "marketplace"
-msgstr ""
+msgstr "mercado"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:87
 #: packages/admin/src/components/PluginManager.tsx:158
 #: packages/admin/src/components/PluginManager.tsx:305
 #: packages/admin/src/components/Sidebar.tsx:219
 msgid "Marketplace"
-msgstr ""
+msgstr "Mercado"
 
 #: packages/admin/src/components/FieldEditor.tsx:626
 msgid "Max Items"
-msgstr ""
+msgstr "Artículos máximos"
 
 #: packages/admin/src/components/FieldEditor.tsx:470
 msgid "Max Length"
-msgstr ""
+msgstr "Longitud máxima"
 
 #: packages/admin/src/components/FieldEditor.tsx:500
 msgid "Max Value"
-msgstr ""
+msgstr "Valor máximo"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1938
 #: packages/admin/src/components/Sidebar.tsx:185
 #: packages/admin/src/components/WordPressImport.tsx:678
 #: packages/admin/src/components/WordPressImport.tsx:1173
 msgid "Media"
-msgstr ""
+msgstr "Media"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:130
 msgid "Media Details"
-msgstr ""
+msgstr "Detalles de los medios"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2206
 msgid "Media Errors ({0})"
-msgstr ""
+msgstr "Errores de medios ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:2168
 msgid "Media Import"
-msgstr ""
+msgstr "Importación de medios"
 
 #: packages/admin/src/components/WordPressImport.tsx:2109
 msgid "Media Import Complete"
-msgstr ""
+msgstr "Importación de medios completada"
 
 #: packages/admin/src/components/WordPressImport.tsx:2120
 msgid "Media import was skipped"
-msgstr ""
+msgstr "Se omitió la importación de medios"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
 #: packages/admin/src/components/MediaLibrary.tsx:226
 msgid "Media Library"
-msgstr ""
+msgstr "Biblioteca multimedia"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
 msgid "Media Read"
-msgstr ""
+msgstr "Lectura de medios"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
 msgid "Media Write"
-msgstr ""
+msgstr "Escritura de medios"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:867
 msgid "Medium section heading"
-msgstr ""
+msgstr "Encabezado de sección media"
 
 #: packages/admin/src/components/Widgets.tsx:102
 #: packages/admin/src/components/Widgets.tsx:834
 msgid "Menu"
-msgstr ""
+msgstr "Menú"
 
 #. placeholder {0}: translated.label
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:90
 msgid "Menu \"{0}\" ({1}) created."
-msgstr ""
+msgstr "Menú «{0}» ({1}) creado."
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu \"{0}\" has been created."
-msgstr ""
+msgstr "Se ha creado el menú \"{0}\"."
 
 #: packages/admin/src/components/MenuList.tsx:54
 msgid "Menu created"
-msgstr ""
+msgstr "Menú creado"
 
 #: packages/admin/src/components/MenuList.tsx:74
 msgid "Menu deleted"
-msgstr ""
+msgstr "Menú eliminado"
 
 #: packages/admin/src/components/MenuEditor.tsx:121
 msgid "Menu item has been added."
-msgstr ""
+msgstr "Se ha agregado un elemento de menú."
 
 #: packages/admin/src/components/MenuEditor.tsx:134
 msgid "Menu item has been deleted."
-msgstr ""
+msgstr "Se ha eliminado el elemento del menú."
 
 #: packages/admin/src/components/MenuEditor.tsx:159
 msgid "Menu item has been updated."
-msgstr ""
+msgstr "El elemento del menú ha sido actualizado."
 
 #: packages/admin/src/components/MenuEditor.tsx:263
 msgid "Menu not found"
-msgstr ""
+msgstr "Menú no encontrado"
 
 #: packages/admin/src/components/MenuEditor.tsx:174
 msgid "Menu order has been updated."
-msgstr ""
+msgstr "Se ha actualizado el orden del menú."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
 #: packages/admin/src/components/MenuList.tsx:103
 #: packages/admin/src/components/Sidebar.tsx:195
 msgid "Menus"
-msgstr ""
+msgstr "Menús"
 
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1604
 msgid "Menus ({0})"
-msgstr ""
+msgstr "Menús ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Menus Manage"
-msgstr ""
+msgstr "Gestionar menús"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Meta Description"
-msgstr ""
+msgstr "Meta descripción"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:147
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr ""
+msgstr "Contenido de metaetiqueta para la verificación de Herramientas para webmasters de Bing"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:141
 msgid "Meta tag content for Google Search Console verification"
-msgstr ""
+msgstr "Contenido de metaetiqueta para la verificación de Google Search Console"
 
 #: packages/admin/src/components/WordPressImport.tsx:1681
 msgid "Meta titles, descriptions, and social images"
-msgstr ""
+msgstr "Metatítulos, descripciones e imágenes sociales."
 
 #: packages/admin/src/components/FieldEditor.tsx:619
 msgid "Min Items"
-msgstr ""
+msgstr "Artículos mínimos"
 
 #: packages/admin/src/components/FieldEditor.tsx:463
 msgid "Min Length"
-msgstr ""
+msgstr "Longitud mínima"
 
 #: packages/admin/src/components/FieldEditor.tsx:493
 msgid "Min Value"
-msgstr ""
+msgstr "Valor mínimo"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:506
 msgid "Moderation"
-msgstr ""
+msgstr "Moderación"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr ""
+msgstr "Señales de moderación"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:211
 msgid "Modified"
-msgstr ""
+msgstr "Modificado"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Modify collection schemas"
-msgstr ""
+msgstr "Modificar esquemas de colección"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
-msgstr ""
+msgstr "Más populares"
 
 #: packages/admin/src/components/ContentList.tsx:552
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr ""
+msgstr "¿Mover \"{title}\" a la papelera? Puedes restaurarlo más tarde."
 
 #: packages/admin/src/components/ContentList.tsx:543
 msgid "Move {title} to trash"
-msgstr ""
+msgstr "Mover {title} a la papelera"
 
 #: packages/admin/src/components/MenuEditor.tsx:443
 msgid "Move down"
-msgstr ""
+msgstr "Bajar"
 
 #: packages/admin/src/components/ContentEditor.tsx:917
 #: packages/admin/src/components/ContentEditor.tsx:939
 #: packages/admin/src/components/ContentList.tsx:565
 msgid "Move to Trash"
-msgstr ""
+msgstr "Mover a la papelera"
 
 #: packages/admin/src/components/ContentEditor.tsx:923
 #: packages/admin/src/components/ContentList.tsx:550
 msgid "Move to Trash?"
-msgstr ""
+msgstr "¿Mover a la Papelera?"
 
 #: packages/admin/src/components/MenuEditor.tsx:434
 msgid "Move up"
-msgstr ""
+msgstr "Subir"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
-msgstr ""
+msgstr "Selección múltiple"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 msgid "Multi-line plain text"
-msgstr ""
+msgstr "Texto sin formato de varias líneas"
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Multiple choices from options"
-msgstr ""
+msgstr "Múltiples opciones de opciones"
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
-msgstr ""
+msgstr "Mi blog impresionante"
 
 #: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MarketplaceBrowse.tsx:45
@@ -4054,396 +4054,396 @@ msgstr ""
 #: packages/admin/src/components/users/UserDetail.tsx:148
 #: packages/admin/src/components/Widgets.tsx:365
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:556
 msgid "Name and label are required"
-msgstr ""
+msgstr "El nombre y la etiqueta son obligatorios."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:562
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
-msgstr ""
+msgstr "El nombre debe comenzar con una letra y contener solo letras minúsculas, números y guiones bajos."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
-msgstr ""
+msgstr "Navegación"
 
 #: packages/admin/src/components/users/UserDetail.tsx:231
 #: packages/admin/src/components/users/UserList.tsx:185
 msgid "Never"
-msgstr ""
+msgstr "Nunca"
 
 #: packages/admin/src/router.tsx:844
 msgid "new"
-msgstr ""
+msgstr "nuevo"
 
 #: packages/admin/src/routes/bylines.tsx:206
 msgid "New"
-msgstr ""
+msgstr "Nuevo"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:103
 msgid "NEW"
-msgstr ""
+msgstr "NUEVO"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:427
 msgid "New {0}"
-msgstr ""
+msgstr "Nuevo {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:599
 msgid "New {collectionLabel}"
-msgstr ""
+msgstr "Nuevo {collectionLabel}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1818
 msgid "New collection"
-msgstr ""
+msgstr "Nueva colección"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:355
 #: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
-msgstr ""
+msgstr "Nuevo tipo de contenido"
 
 #: packages/admin/src/components/Redirects.tsx:102
 #: packages/admin/src/components/Redirects.tsx:336
 msgid "New Redirect"
-msgstr ""
+msgstr "Nueva redirección"
 
 #: packages/admin/src/components/Sections.tsx:143
 msgid "New Section"
-msgstr ""
+msgstr "Nueva sección"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
-msgstr ""
+msgstr "nueva pestaña"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:809
 msgid "New Taxonomy"
-msgstr ""
+msgstr "Nueva taxonomía"
 
 #: packages/admin/src/components/MenuEditor.tsx:343
 #: packages/admin/src/components/MenuEditor.tsx:346
 #: packages/admin/src/components/MenuEditor.tsx:514
 #: packages/admin/src/components/MenuEditor.tsx:517
 msgid "New window"
-msgstr ""
+msgstr "Nueva ventana"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
 msgid "Newest"
-msgstr ""
+msgstr "Más recientes"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:390
 msgid "News"
-msgstr ""
+msgstr "Noticias"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
 msgid "Next"
-msgstr ""
+msgstr "Siguiente"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:371
 #: packages/admin/src/components/ContentList.tsx:318
 msgid "Next page"
-msgstr ""
+msgstr "Página siguiente"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:464
 msgid "Next screenshot"
-msgstr ""
+msgstr "Siguiente captura de pantalla"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:397
 msgid "No {0} available."
-msgstr ""
+msgstr "No hay {0} disponible."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:252
 msgid "No {0} yet."
-msgstr ""
+msgstr "Aún no hay {0}."
 
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:828
 msgid "No {0} yet. Create one to get started."
-msgstr ""
+msgstr "Aún no hay {0}. Crea uno para comenzar."
 
 #: packages/admin/src/components/Redirects.tsx:208
 msgid "No 404 errors recorded yet."
-msgstr ""
+msgstr "Aún no se han registrado errores 404."
 
 #: packages/admin/src/components/MediaLibrary.tsx:612
 #: packages/admin/src/components/MediaLibrary.tsx:669
 msgid "No alt text"
-msgstr ""
+msgstr "Sin texto alternativo"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
 msgid "No API tokens yet. Create one to get started."
-msgstr ""
+msgstr "Aún no hay tokens API. Crea uno para comenzar."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No approved comments yet."
-msgstr ""
+msgstr "Aún no hay comentarios aprobados."
 
 #: packages/admin/src/routes/bylines.tsx:231
 msgid "No bylines found"
-msgstr ""
+msgstr "No se han encontrado firmas"
 
 #: packages/admin/src/components/ContentEditor.tsx:1992
 msgid "No bylines selected."
-msgstr ""
+msgstr "No se han seleccionado firmas."
 
 #: packages/admin/src/components/Dashboard.tsx:172
 msgid "No collections configured"
-msgstr ""
+msgstr "No hay colecciones configuradas"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:546
 msgid "No comments awaiting moderation."
-msgstr ""
+msgstr "No hay comentarios en espera de moderación."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:542
 msgid "No comments match your search."
-msgstr ""
+msgstr "Ningún comentario coincide con tu búsqueda."
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:80
 msgid "No content"
-msgstr ""
+msgstr "Sin contenido"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:171
 msgid "No content found"
-msgstr ""
+msgstr "No se encontró contenido"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 msgid "No content in this collection"
-msgstr ""
+msgstr "No hay contenido en esta colección."
 
 #: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
-msgstr ""
+msgstr "Aún no hay tipos de contenido."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:603
 msgid "No custom fields yet"
-msgstr ""
+msgstr "Aún no hay campos personalizados"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:265
 msgid "No detailed description available."
-msgstr ""
+msgstr "No hay descripción detallada disponible."
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
 msgid "No domains configured. Users must be invited individually."
-msgstr ""
+msgstr "No hay dominios configurados. Los usuarios deben ser invitados individualmente."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:178
 msgid "No email provider configured"
-msgstr ""
+msgstr "No hay ningún proveedor de correo electrónico configurado"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr ""
+msgstr "No hay ningún proveedor de correo electrónico configurado. Comparte este enlace manualmente."
 
 #: packages/admin/src/components/WordPressImport.tsx:2322
 msgid "No EmDash users found"
-msgstr ""
+msgstr "No se encontraron usuarios de EmDash"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
 msgid "No expiry"
-msgstr ""
+msgstr "Sin caducidad"
 
 #: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
-msgstr ""
+msgstr "No hay campos para comparar"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:189
 msgid "No headings in document"
-msgstr ""
+msgstr "No hay encabezados en el documento"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:159
 msgid "No invite token provided"
-msgstr ""
+msgstr "No se ha proporcionado ningún token de invitación"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1547
 #: packages/admin/src/components/RepeaterField.tsx:160
 msgid "No items yet"
-msgstr ""
+msgstr "Aún no hay artículos"
 
 #: packages/admin/src/components/FieldEditor.tsx:630
 msgid "No limit"
-msgstr ""
+msgstr "Sin límite"
 
 #: packages/admin/src/routes/bylines.tsx:284
 msgid "No linked user"
-msgstr ""
+msgstr "Sin usuario vinculado"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
-msgstr ""
+msgstr "No se encontró ninguna Passkey coincidente para esta cuenta."
 
 #: packages/admin/src/components/FieldEditor.tsx:474
 #: packages/admin/src/components/FieldEditor.tsx:504
 msgid "No maximum"
-msgstr ""
+msgstr "Sin máximo"
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
 #: packages/admin/src/components/MediaPickerModal.tsx:579
 msgid "No media available from this provider"
-msgstr ""
+msgstr "No hay medios disponibles de este proveedor"
 
 #: packages/admin/src/components/MediaLibrary.tsx:363
 #: packages/admin/src/components/MediaPickerModal.tsx:573
 msgid "No media found"
-msgstr ""
+msgstr "No se encontraron medios"
 
 #: packages/admin/src/components/MediaLibrary.tsx:352
 msgid "No media yet"
-msgstr ""
+msgstr "Aún no hay medios"
 
 #: packages/admin/src/components/MenuEditor.tsx:398
 msgid "No menu items yet"
-msgstr ""
+msgstr "Aún no hay elementos de menú"
 
 #: packages/admin/src/components/MenuList.tsx:186
 msgid "No menus yet"
-msgstr ""
+msgstr "Aún no hay menús"
 
 #: packages/admin/src/components/FieldEditor.tsx:467
 #: packages/admin/src/components/FieldEditor.tsx:497
 msgid "No minimum"
-msgstr ""
+msgstr "Sin mínimo"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr ""
+msgstr "Sin moderación (aprobar todo automáticamente)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
-msgstr ""
+msgstr "No hay claves registradas"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:195
 msgid "No passkeys registered yet."
-msgstr ""
+msgstr "Aún no se han registrado passkeys."
 
 #: packages/admin/src/components/PluginManager.tsx:186
 msgid "No plugins configured"
-msgstr ""
+msgstr "No hay plugins configurados"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:173
 msgid "No plugins found"
-msgstr ""
+msgstr "No se encontraron plugins"
 
 #: packages/admin/src/components/Sections.tsx:343
 msgid "No preview"
-msgstr ""
+msgstr "Sin vista previa"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
-msgstr ""
+msgstr "Ninguna actividad reciente"
 
 #: packages/admin/src/components/Redirects.tsx:434
 msgid "No redirects yet"
-msgstr ""
+msgstr "Aún no hay redirecciones"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1112
 msgid "No results"
-msgstr ""
+msgstr "Sin resultados"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:176
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr ""
+msgstr "No hay resultados para \"{debouncedQuery}\". Prueba con un término de búsqueda diferente."
 
 #: packages/admin/src/components/ContentList.tsx:266
 msgid "No results for \"{searchQuery}\""
-msgstr ""
+msgstr "No hay resultados para \"{searchQuery}\""
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:452
 msgid "No results found"
-msgstr ""
+msgstr "No se encontraron resultados"
 
 #: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
-msgstr ""
+msgstr "Aún no hay revisiones"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:107
 msgid "No sections available"
-msgstr ""
+msgstr "No hay secciones disponibles"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:101
 #: packages/admin/src/components/Sections.tsx:259
 msgid "No sections found"
-msgstr ""
+msgstr "No se encontraron secciones"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "No sections yet"
-msgstr ""
+msgstr "Aún no hay secciones"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:548
 msgid "No spam comments."
-msgstr ""
+msgstr "Sin comentarios spam."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
 msgid "No themes found"
-msgstr ""
+msgstr "No se encontraron temas"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
-msgstr ""
+msgstr "No se han encontrado usuarios que coincidan con tus filtros."
 
 #: packages/admin/src/components/users/UserList.tsx:134
 msgid "No users yet."
-msgstr ""
+msgstr "Aún no hay usuarios."
 
 #: packages/admin/src/components/Widgets.tsx:434
 msgid "No widget areas yet. Create one to get started."
-msgstr ""
+msgstr "Aún no hay áreas de widgets. Crea una para empezar."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:416
 #: packages/admin/src/components/TaxonomyManager.tsx:422
 msgid "None (top level)"
-msgstr ""
+msgstr "Ninguno (nivel superior)"
 
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
 msgid "Number"
-msgstr ""
+msgstr "Número"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:276
 msgid "Number of posts to show per page on list views"
-msgstr ""
+msgstr "Número de entradas a mostrar por página en las vistas de lista"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:896
 #: packages/admin/src/components/PortableTextEditor.tsx:2815
 msgid "Numbered List"
-msgstr ""
+msgstr "Lista numerada"
 
 #: packages/admin/src/components/SeoImageField.tsx:41
 msgid "OG Image"
-msgstr ""
+msgstr "Imagen original"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:314
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr ""
+msgstr "en un nombre de host personalizado no se trata como seguro, ni siquiera en bucle invertido."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr ""
+msgstr "Sólo autoriza códigos que reconozcas."
 
 #: packages/admin/src/components/SignupPage.tsx:96
 msgid "Only email addresses from allowed domains can sign up."
-msgstr ""
+msgstr "Sólo se pueden registrar direcciones de correo electrónico de dominios permitidos."
 
 #: packages/admin/src/components/MenuList.tsx:159
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr ""
+msgstr "Sólo letras minúsculas, números y guiones"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
-msgstr ""
+msgstr "Solo se aceptarán para este campo los tipos MIME indicados."
 
 #: packages/admin/src/components/SignupPage.tsx:402
 msgid "Oops!"
-msgstr ""
+msgstr "¡Ups!"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
@@ -4452,287 +4452,287 @@ msgstr ""
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:333
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:334
 msgid "Open in new tab"
-msgstr ""
+msgstr "Abrir en nueva pestaña"
 
 #: packages/admin/src/components/WordPressImport.tsx:1373
 msgid "Open WordPress Profile"
-msgstr ""
+msgstr "Abrir perfil de WordPress"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid ""
 "Option 1\n"
 "Option 2\n"
 "Option 3"
-msgstr ""
+msgstr "Opción 1\nOpción 2\nOpción 3"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
 msgid "Optional caption displayed below the image"
-msgstr ""
+msgstr "Título opcional que se muestra debajo de la imagen."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:213
 msgid "Optional caption for display"
-msgstr ""
+msgstr "Título opcional para mostrar"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:435
 msgid "Optional description"
-msgstr ""
+msgstr "Descripción opcional"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
 msgid "Optional tooltip on hover"
-msgstr ""
+msgstr "Información sobre herramientas opcional al pasar el mouse"
 
 #: packages/admin/src/components/FieldEditor.tsx:512
 msgid "Options (one per line)"
-msgstr ""
+msgstr "Opciones (una por línea)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:473
 msgid "or choose from library"
-msgstr ""
+msgstr "o elegir de la biblioteca"
 
 #: packages/admin/src/components/WordPressImport.tsx:1429
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr ""
+msgstr "O haz clic para navegar. Acepta archivos .xml exportados desde WordPress."
 
 #: packages/admin/src/components/LoginPage.tsx:261
 #: packages/admin/src/components/SetupWizard.tsx:310
 msgid "Or continue with"
-msgstr ""
+msgstr "O continuar con"
 
 #: packages/admin/src/components/WordPressImport.tsx:1230
 msgid "Or upload an export file"
-msgstr ""
+msgstr "O cargar un archivo de exportación"
 
 #: packages/admin/src/components/WordPressImport.tsx:949
 msgid "or upload directly"
-msgstr ""
+msgstr "o subir directamente"
 
 #: packages/admin/src/components/MenuEditor.tsx:173
 msgid "Order saved"
-msgstr ""
+msgstr "Orden guardada"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
 msgid "Original:"
-msgstr ""
+msgstr "Original:"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:181
 msgid "Outline"
-msgstr ""
+msgstr "Esquema"
 
 #: packages/admin/src/components/SeoPanel.tsx:155
 msgid "Overrides the page title in search engine results"
-msgstr ""
+msgstr "Anula el título de la página en los resultados del motor de búsqueda."
 
 #: packages/admin/src/components/ContentEditor.tsx:954
 msgid "Ownership"
-msgstr ""
+msgstr "Propiedad"
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "Package"
-msgstr ""
+msgstr "Paquete"
 
 #: packages/admin/src/router.tsx:1737
 msgid "Page Not Found"
-msgstr ""
+msgstr "Página no encontrada"
 
 #: packages/admin/src/components/PluginManager.tsx:323
 #: packages/admin/src/components/WordPressImport.tsx:1167
 msgid "Pages"
-msgstr ""
+msgstr "paginas"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
-msgstr ""
+msgstr "Párrafo"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:412
 msgid "Parent"
-msgstr ""
+msgstr "Padre"
 
 #: packages/admin/src/components/Redirects.tsx:483
 #: packages/admin/src/components/Redirects.tsx:489
 msgid "Part of a redirect loop"
-msgstr ""
+msgstr "Parte de un bucle de redirección"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:322
 msgid "Pass"
-msgstr ""
+msgstr "Aprobar"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:98
 msgid "Passkey added successfully"
-msgstr ""
+msgstr "Passkey agregada exitosamente"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr ""
+msgstr "Nombre de la Passkey"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr ""
+msgstr "Nombre de la Passkey (opcional)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
-msgstr ""
+msgstr "¡La Passkey se registró correctamente!"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:76
 msgid "Passkey removed"
-msgstr ""
+msgstr "Passkey eliminada"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:60
 msgid "Passkey renamed"
-msgstr ""
+msgstr "Passkey renombrada"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:177
 #: packages/admin/src/components/users/UserList.tsx:110
 msgid "Passkeys"
-msgstr ""
+msgstr "Passkeys"
 
 #. placeholder {0}: user.credentials.length
 #: packages/admin/src/components/users/UserDetail.tsx:245
 msgid "Passkeys ({0})"
-msgstr ""
+msgstr "Passkeys ({0})"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:181
 msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
-msgstr ""
+msgstr "Las passkeys son una forma segura y sin contraseña de iniciar sesión en tu cuenta. Puedes registrar varias passkeys para diferentes dispositivos."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:74
 #: packages/admin/src/components/SignupPage.tsx:213
 msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
-msgstr ""
+msgstr "Las passkeys son una forma segura y sin contraseña de iniciar sesión utilizando los datos biométricos, el PIN o la clave de seguridad de tu dispositivo."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:303
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
 msgid "Passkeys Not Available Here"
-msgstr ""
+msgstr "Passkeys no disponibles aquí"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
 msgid "Passkeys require a"
-msgstr ""
+msgstr "Las passkeys requieren una"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-msgstr ""
+msgstr "Las passkeys requieren HTTPS o http://localhost (con tu puerto); este nombre de host no es un contexto de navegador seguro."
 
 #: packages/admin/src/components/Redirects.tsx:215
 msgid "Path"
-msgstr ""
+msgstr "Camino"
 
 #: packages/admin/src/components/FieldEditor.tsx:479
 msgid "Pattern (Regex)"
-msgstr ""
+msgstr "Patrón (Regex)"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:437
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr ""
+msgstr "Patrón para generar URL, p. ej. /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:433
 msgid "Pattern must include a {0} placeholder"
-msgstr ""
+msgstr "El patrón debe incluir un marcador {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:62
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:689
 msgid "pending"
-msgstr ""
+msgstr "pendiente"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:197
 msgid "Pending"
-msgstr ""
+msgstr "Pendiente"
 
 #: packages/admin/src/components/ContentEditor.tsx:829
 msgid "Pending changes"
-msgstr ""
+msgstr "Cambios pendientes"
 
 #: packages/admin/src/components/ContentList.tsx:623
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr ""
+msgstr "¿Eliminar permanentemente \"{title}\"? Esto no se puede deshacer."
 
 #: packages/admin/src/components/ContentList.tsx:612
 msgid "Permanently delete {title}"
-msgstr ""
+msgstr "Eliminar permanentemente {title}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:274
 msgid "Permissions"
-msgstr ""
+msgstr "Permisos"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
-msgstr ""
+msgstr "Elige cualquier método para crear tu cuenta de administrador."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:313
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr ""
+msgstr "Plano"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:133
 msgid "Please ask your administrator to send a new invite."
-msgstr ""
+msgstr "Pide a tu administrador que te envíe una nueva invitación."
 
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "Please enter a valid email"
-msgstr ""
+msgstr "Por favor introduce un correo electrónico válido"
 
 #: packages/admin/src/components/SignupPage.tsx:54
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Por favor, introduce una dirección de correo electrónico válida"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:342
 msgid "Please enter a valid URL"
-msgstr ""
+msgstr "Por favor ingresa una URL válida"
 
 #: packages/admin/src/components/WordPressImport.tsx:1024
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 #: packages/admin/src/components/PluginManager.tsx:103
 msgid "Plugin disabled"
-msgstr ""
+msgstr "Plugin deshabilitado"
 
 #: packages/admin/src/components/PluginManager.tsx:84
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin habilitado"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:89
 msgid "Plugin Error"
-msgstr ""
+msgstr "Error de plugin"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:37
 msgid "Plugin error ({0})"
-msgstr ""
+msgstr "Error de plugin ({0})"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:113
 msgid "Plugin not found"
-msgstr ""
+msgstr "Plugin no encontrado"
 
 #: packages/admin/src/components/WordPressImport.tsx:1048
 msgid "plugin on your WordPress site."
-msgstr ""
+msgstr "plugin en tu sitio de WordPress."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:72
 msgid "Plugin Permissions"
-msgstr ""
+msgstr "Permisos de plugins"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr ""
+msgstr "El plugin respondió con {0}: {text}"
 
 #: packages/admin/src/components/PluginManager.tsx:255
 msgid "Plugin uninstalled"
-msgstr ""
+msgstr "Plugin desinstalado"
 
 #: packages/admin/src/components/PluginManager.tsx:242
 msgid "Plugin updated"
-msgstr ""
+msgstr "Plugin actualizado"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:126
@@ -4741,206 +4741,206 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:212
 #: packages/admin/src/components/Sidebar.tsx:450
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 #: packages/admin/src/components/SeoPanel.tsx:182
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
-msgstr ""
+msgstr "Dirige los motores de búsqueda a la versión original de esta página, si está duplicada desde otra URL."
 
 #: packages/admin/src/components/WordPressImport.tsx:1161
 msgid "Posts"
-msgstr ""
+msgstr "Entradas"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:270
 msgid "Posts Per Page"
-msgstr ""
+msgstr "Entradas por página"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
-msgstr ""
+msgstr "Preparando inscripción..."
 
 #: packages/admin/src/components/WordPressImport.tsx:2020
 msgid "Preparing to download files from WordPress..."
-msgstr ""
+msgstr "Preparándose para descargar archivos de WordPress..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:166
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Preparing..."
-msgstr ""
+msgstr "Preparante..."
 
 #: packages/admin/src/components/ContentEditor.tsx:649
 #: packages/admin/src/components/ContentTypeEditor.tsx:81
 #: packages/admin/src/components/MediaLibrary.tsx:415
 msgid "Preview"
-msgstr ""
+msgstr "Avance"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:82
 msgid "Preview content before publishing"
-msgstr ""
+msgstr "Vista previa del contenido antes de publicar"
 
 #: packages/admin/src/components/ContentEditor.tsx:649
 msgid "Preview draft"
-msgstr ""
+msgstr "Vista previa del borrador"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:352
 #: packages/admin/src/components/ContentList.tsx:306
 msgid "Previous page"
-msgstr ""
+msgstr "Pagina anterior"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:446
 msgid "Previous screenshot"
-msgstr ""
+msgstr "Captura de pantalla anterior"
 
 #: packages/admin/src/components/MenuList.tsx:166
 msgid "Primary Navigation"
-msgstr ""
+msgstr "Navegación primaria"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:202
 msgid "Provider:"
-msgstr ""
+msgstr "Proveedor:"
 
 #: packages/admin/src/components/ContentEditor.tsx:704
 #: packages/admin/src/components/ContentEditor.tsx:810
 msgid "Publish"
-msgstr ""
+msgstr "Publicar"
 
 #: packages/admin/src/components/ContentEditor.tsx:694
 msgid "Publish changes"
-msgstr ""
+msgstr "Publicar cambios"
 
 #: packages/admin/src/components/ContentList.tsx:664
 msgid "published"
-msgstr ""
+msgstr "publicado"
 
 #: packages/admin/src/components/ContentEditor.tsx:825
 #: packages/admin/src/components/ContentPickerModal.tsx:209
 #: packages/admin/src/components/Dashboard.tsx:187
 #: packages/admin/src/router.tsx:744
 msgid "Published"
-msgstr ""
+msgstr "Publicado"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:327
 msgid "Published {0}"
-msgstr ""
+msgstr "Publicado {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
-msgstr ""
+msgstr "Publicado en"
 
 #: packages/admin/src/components/ContentEditor.tsx:2000
 msgid "Quick create byline"
-msgstr ""
+msgstr "Creación rápida de firma"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:167
 #: packages/admin/src/components/editor/ImageNode.tsx:168
 msgid "Quick edit alt text"
-msgstr ""
+msgstr "Edición rápida del texto alternativo"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:85
 #: packages/admin/src/components/PortableTextEditor.tsx:906
 #: packages/admin/src/components/PortableTextEditor.tsx:2822
 msgid "Quote"
-msgstr ""
+msgstr "Cita"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
 msgid "Read collection schemas"
-msgstr ""
+msgstr "Leer esquemas de colección"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
 msgid "Read content entries"
-msgstr ""
+msgstr "Leer entradas de contenido"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
 msgid "Read media files"
-msgstr ""
+msgstr "Leer archivos multimedia"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
 msgid "Read site settings"
-msgstr ""
+msgstr "Leer los ajustes del sitio"
 
 #: packages/admin/src/lib/api/marketplace.ts:226
 #: packages/admin/src/lib/api/marketplace.ts:234
 msgid "Read user accounts"
-msgstr ""
+msgstr "Leer las cuentas de usuario"
 
 #: packages/admin/src/lib/api/marketplace.ts:222
 #: packages/admin/src/lib/api/marketplace.ts:230
 msgid "Read your content"
-msgstr ""
+msgstr "Leer tu contenido"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:267
 msgid "Reading"
-msgstr ""
+msgstr "Lectura"
 
 #: packages/admin/src/components/WordPressImport.tsx:1822
 msgid "Ready"
-msgstr ""
+msgstr "Listo"
 
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
-msgstr ""
+msgstr "Actividad reciente"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
 msgid "Recently Updated"
-msgstr ""
+msgstr "Actualizados recientemente"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:144
 msgid "Recipient email"
-msgstr ""
+msgstr "Correo electrónico del destinatario"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/users/UserDetail.tsx:336
 msgid "Recovery link sent to {0}"
-msgstr ""
+msgstr "Enlace de recuperación enviado a {0}"
 
 #: packages/admin/src/components/Redirects.tsx:416
 msgid "Redirect loop detected"
-msgstr ""
+msgstr "Bucle de redirección detectado"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr ""
+msgstr "Redirigiendo para iniciar sesión..."
 
 #: packages/admin/src/components/Redirects.tsx:332
 #: packages/admin/src/components/Redirects.tsx:351
 #: packages/admin/src/components/Sidebar.tsx:196
 msgid "Redirects"
-msgstr ""
+msgstr "Redirecciones"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2958
 msgid "Redo"
-msgstr ""
+msgstr "Rehacer"
 
 #: packages/admin/src/components/FieldEditor.tsx:216
 msgid "Reference"
-msgstr ""
+msgstr "Referencia"
 
 #: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
-msgstr ""
+msgstr "Registro"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
 #: packages/admin/src/components/settings/SecuritySettings.tsx:220
 msgid "Register Passkey"
-msgstr ""
+msgstr "Registrar Passkey"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:83
 msgid "Registered user"
-msgstr ""
+msgstr "Usuario registrado"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr ""
+msgstr "Error en el registro"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "El registro fue cancelado o agotado. Por favor inténtalo de nuevo."
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/ContentEditor.tsx:1969
@@ -4951,260 +4951,260 @@ msgstr ""
 #: packages/admin/src/components/settings/PasskeyItem.tsx:187
 #: packages/admin/src/components/settings/PasskeyItem.tsx:209
 msgid "Remove"
-msgstr ""
+msgstr "Eliminar"
 
 #. placeholder {0}: passkey.name
 #. placeholder {0}: term.label
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:222
 msgid "Remove {0}"
-msgstr ""
+msgstr "Eliminar {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:145
 msgid "Remove {entry}"
-msgstr ""
+msgstr "Quitar {entry}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1797
 msgid "Remove {label}"
-msgstr ""
+msgstr "Quitar {label}"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
 msgid "Remove Domain"
-msgstr ""
+msgstr "Eliminar dominio"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
 msgid "Remove Domain?"
-msgstr ""
+msgstr "¿Quitar dominio?"
 
 #: packages/admin/src/components/ContentEditor.tsx:1624
 #: packages/admin/src/components/SeoImageField.tsx:55
 msgid "Remove image"
-msgstr ""
+msgstr "Quitar imagen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
 msgid "Remove Image"
-msgstr ""
+msgstr "Quitar imagen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
 msgid "Remove Image?"
-msgstr ""
+msgstr "¿Quitar imagen?"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:1663
 #: packages/admin/src/components/RepeaterField.tsx:270
 msgid "Remove item {0}"
-msgstr ""
+msgstr "Eliminar elemento {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2422
 #: packages/admin/src/components/PortableTextEditor.tsx:2423
 msgid "Remove link"
-msgstr ""
+msgstr "Quitar enlace"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 msgid "Remove passkey"
-msgstr ""
+msgstr "Quitar Passkey"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
 msgid "Remove passkey?"
-msgstr ""
+msgstr "¿Quitar la Passkey?"
 
 #: packages/admin/src/components/FieldEditor.tsx:610
 msgid "Remove sub-field"
-msgstr ""
+msgstr "Eliminar subcampo"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
 msgid "Remove this image from the document?"
-msgstr ""
+msgstr "¿Eliminar esta imagen del documento?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
 #: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
-msgstr ""
+msgstr "Eliminando..."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:176
 msgid "Rename"
-msgstr ""
+msgstr "Rebautizar"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
-msgstr ""
+msgstr "Cambiar nombre {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename passkey"
-msgstr ""
+msgstr "Cambiar nombre de Passkey"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
-msgstr ""
+msgstr "Reloj de repetición"
 
 #: packages/admin/src/components/FieldEditor.tsx:241
 msgid "Repeating group of fields"
-msgstr ""
+msgstr "Grupo repetido de campos."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
 msgid "Replace Image"
-msgstr ""
+msgstr "Reemplazar imagen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr ""
+msgstr "Responder a:"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
-msgstr ""
+msgstr "Repositorio"
 
 #: packages/admin/src/components/SignupPage.tsx:273
 msgid "Request a new link"
-msgstr ""
+msgstr "Solicitar un nuevo enlace"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:721
 #: packages/admin/src/components/FieldEditor.tsx:437
 #: packages/admin/src/components/FieldEditor.tsx:592
 msgid "Required"
-msgstr ""
+msgstr "Requerido"
 
 #: packages/admin/src/components/WordPressImport.tsx:1835
 msgid "Required fields:"
-msgstr ""
+msgstr "Campos obligatorios:"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
 msgid "Required for accessibility. Describes the image for screen readers."
-msgstr ""
+msgstr "Requerido para accesibilidad. Describe la imagen para lectores de pantalla."
 
 #. placeholder {0}: latest.minEmDashVersion
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:325
 msgid "Requires EmDash {0}"
-msgstr ""
+msgstr "Requiere EmDash {0}"
 
 #: packages/admin/src/components/SignupPage.tsx:154
 msgid "Resend email"
-msgstr ""
+msgstr "Reenviar correo electrónico"
 
 #: packages/admin/src/components/SignupPage.tsx:153
 msgid "Resend in {resendCooldown}s"
-msgstr ""
+msgstr "Reenviar en {resendCooldown}s"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
 msgid "Reset to original"
-msgstr ""
+msgstr "Restablecer al original"
 
 #: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
-msgstr ""
+msgstr "Restaurar"
 
 #: packages/admin/src/components/ContentList.tsx:600
 msgid "Restore {title}"
-msgstr ""
+msgstr "Restaurar {title}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
-msgstr ""
+msgstr "Restauración fallida"
 
 #: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
-msgstr ""
+msgstr "¿Restaurar revisión?"
 
 #: packages/admin/src/components/RevisionHistory.tsx:281
 #: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
-msgstr ""
+msgstr "Restaurar esta versión"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr ""
+msgstr "¿Restaurar esta versión desde {0}? Esto actualizará el contenido actual con los datos de esta revisión."
 
 #: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
-msgstr ""
+msgstr "Restaurando..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:141
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
 #: packages/admin/src/router.tsx:1725
 msgid "Retry"
-msgstr ""
+msgstr "Rever"
 
 #: packages/admin/src/components/Sections.tsx:136
 msgid "Reusable content blocks you can insert into any content"
-msgstr ""
+msgstr "Bloques de contenido reutilizables que puedes insertar en cualquier contenido"
 
 #: packages/admin/src/router.tsx:778
 msgid "Reverted to published version"
-msgstr ""
+msgstr "Revertido a la versión publicada"
 
 #: packages/admin/src/components/WordPressImport.tsx:650
 msgid "Review"
-msgstr ""
+msgstr "Revisar"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:72
 msgid "Review New Permissions"
-msgstr ""
+msgstr "Revisar nuevos permisos"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
-msgstr ""
+msgstr "Revisión restaurada"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:76
 #: packages/admin/src/components/RevisionHistory.tsx:161
 msgid "Revisions"
-msgstr ""
+msgstr "Revisiones"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
 msgid "Revoke token"
-msgstr ""
+msgstr "Revocar token"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
 msgid "Revoke?"
-msgstr ""
+msgstr "¿Revocar?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
 msgid "Revoking..."
-msgstr ""
+msgstr "Revocando..."
 
 #: packages/admin/src/components/FieldEditor.tsx:198
 msgid "Rich Text"
-msgstr ""
+msgstr "Texto enriquecido"
 
 #: packages/admin/src/components/Widgets.tsx:97
 msgid "Rich text content"
-msgstr ""
+msgstr "Contenido de texto enriquecido"
 
 #: packages/admin/src/components/FieldEditor.tsx:199
 msgid "Rich text editor"
-msgstr ""
+msgstr "editor de texto enriquecido"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:312
 msgid "Risk score: {0}/100"
-msgstr ""
+msgstr "Puntuación de riesgo: {0}/100"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:166
 #: packages/admin/src/components/users/UserDetail.tsx:169
 #: packages/admin/src/components/users/UserDetail.tsx:181
 #: packages/admin/src/components/users/UserList.tsx:101
 msgid "Role"
-msgstr ""
+msgstr "Role"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
-msgstr ""
+msgstr "Rol {role}"
 
 #: packages/admin/src/components/ContentEditor.tsx:1974
 msgid "Role label"
-msgstr ""
+msgstr "Etiqueta de rol"
 
 #: packages/admin/src/components/MenuEditor.tsx:343
 #: packages/admin/src/components/MenuEditor.tsx:345
 #: packages/admin/src/components/MenuEditor.tsx:514
 #: packages/admin/src/components/MenuEditor.tsx:516
 msgid "Same window"
-msgstr ""
+msgstr "Misma ventana"
 
 #: packages/admin/src/components/ContentEditor.tsx:2107
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
@@ -5218,48 +5218,48 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:894
 #: packages/admin/src/routes/bylines.tsx:314
 msgid "Save"
-msgstr ""
+msgstr "Guardar"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:416
 msgid "Save (Enter)"
-msgstr ""
+msgstr "Guardar (Intro)"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:236
 msgid "Save alt text"
-msgstr ""
+msgstr "Guardar texto alternativo"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
-msgstr ""
+msgstr "Guardar cambios"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:72
 msgid "Save content as draft before publishing"
-msgstr ""
+msgstr "Guarde el contenido como borrador antes de publicarlo"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:137
 msgid "Save name"
-msgstr ""
+msgstr "Guardar nombre"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:99
 #: packages/admin/src/components/settings/SeoSettings.tsx:162
 msgid "Save SEO Settings"
-msgstr ""
+msgstr "Guardar configuración de SEO"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:125
 #: packages/admin/src/components/settings/GeneralSettings.tsx:296
 msgid "Save Settings"
-msgstr ""
+msgstr "Guardar configuración"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:99
 #: packages/admin/src/components/settings/SocialSettings.tsx:173
 msgid "Save Social Links"
-msgstr ""
+msgstr "Guardar enlaces sociales"
 
 #: packages/admin/src/components/ContentEditor.tsx:624
 #: packages/admin/src/components/SaveButton.tsx:42
 msgid "Saved"
-msgstr ""
+msgstr "Guardado"
 
 #: packages/admin/src/components/ContentEditor.tsx:619
 #: packages/admin/src/components/ContentEditor.tsx:2107
@@ -5280,58 +5280,58 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:894
 #: packages/admin/src/routes/bylines.tsx:314
 msgid "Saving..."
-msgstr ""
+msgstr "Salvando..."
 
 #: packages/admin/src/components/ContentEditor.tsx:869
 msgid "Schedule"
-msgstr ""
+msgstr "Cronograma"
 
 #: packages/admin/src/components/ContentEditor.tsx:855
 msgid "Schedule for"
-msgstr ""
+msgstr "Horario para"
 
 #: packages/admin/src/components/ContentEditor.tsx:892
 msgid "Schedule for later"
-msgstr ""
+msgstr "Agenda para más tarde"
 
 #: packages/admin/src/components/ContentList.tsx:668
 msgid "scheduled"
-msgstr ""
+msgstr "programado"
 
 #: packages/admin/src/components/ContentEditor.tsx:832
 #: packages/admin/src/router.tsx:795
 msgid "Scheduled"
-msgstr ""
+msgstr "Programado"
 
 #. placeholder {0}: formatScheduledDate(item.scheduledAt)
 #: packages/admin/src/components/ContentEditor.tsx:842
 msgid "Scheduled for: {0}"
-msgstr ""
+msgstr "Programado para: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2128
 msgid "Schema Changes"
-msgstr ""
+msgstr "Cambios de esquema"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Schema preparation failed"
-msgstr ""
+msgstr "Error en la preparación del esquema"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
 msgid "Schema Read"
-msgstr ""
+msgstr "Lectura de esquema"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
 msgid "Schema Write"
-msgstr ""
+msgstr "Escritura de esquema"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
 msgid "Scopes"
-msgstr ""
+msgstr "Alcances"
 
 #. placeholder {0}: token.scopes.join(", ")
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
 msgid "Scopes: {0}"
-msgstr ""
+msgstr "Alcances: {0}"
 
 #. placeholder {0}: i + 1
 #. placeholder {0}: index + 1
@@ -5339,329 +5339,329 @@ msgstr ""
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
 msgid "Screenshot {0}"
-msgstr ""
+msgstr "Captura de pantalla {0}"
 
 #. placeholder {0}: index + 1
 #. placeholder {1}: screenshots.length
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:454
 msgid "Screenshot {0} of {1}"
-msgstr ""
+msgstr "Captura de pantalla {0} de {1}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:247
 msgid "Screenshot blurred due to image audit"
-msgstr ""
+msgstr "Captura de pantalla borrosa debido a una auditoría de imagen"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:432
 msgid "Screenshot viewer"
-msgstr ""
+msgstr "Visor de capturas de pantalla"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:234
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
 msgid "Screenshots"
-msgstr ""
+msgstr "Capturas de pantalla"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 msgid "Search"
-msgstr ""
+msgstr "Buscar"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:170
 msgid "Search {0}"
-msgstr ""
+msgstr "Buscar {0}"
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:169
 msgid "Search {0}..."
-msgstr ""
+msgstr "Buscar {0}..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
-msgstr ""
+msgstr "Buscar por nombre o correo..."
 
 #: packages/admin/src/routes/bylines.tsx:181
 msgid "Search bylines"
-msgstr ""
+msgstr "Buscar firmas"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:163
 msgid "Search comments"
-msgstr ""
+msgstr "Buscar comentarios"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:162
 msgid "Search comments..."
-msgstr ""
+msgstr "Buscar comentarios..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:141
 msgid "Search content..."
-msgstr ""
+msgstr "Buscar contenido..."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:128
 msgid "Search Engine Optimization"
-msgstr ""
+msgstr "Optimización de motores de búsqueda"
 
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
-msgstr ""
+msgstr "Optimización y verificación de motores de búsqueda."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:519
 msgid "Search media"
-msgstr ""
+msgstr "Buscar medios"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
-msgstr ""
+msgstr "Buscar páginas y contenido..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:101
 msgid "Search plugins"
-msgstr ""
+msgstr "Buscar plugins"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:97
 msgid "Search plugins..."
-msgstr ""
+msgstr "Buscar plugins..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:81
 #: packages/admin/src/components/Sections.tsx:226
 msgid "Search sections..."
-msgstr ""
+msgstr "Buscar secciones..."
 
 #: packages/admin/src/components/Redirects.tsx:383
 msgid "Search source or destination..."
-msgstr ""
+msgstr "Buscar origen o destino..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr ""
+msgstr "Buscar temas"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
-msgstr ""
+msgstr "Buscar temas..."
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
-msgstr ""
+msgstr "Buscar usuarios"
 
 #: packages/admin/src/components/MediaLibrary.tsx:336
 #: packages/admin/src/components/MediaPickerModal.tsx:518
 msgid "Search..."
-msgstr ""
+msgstr "Buscar..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:723
 #: packages/admin/src/components/FieldEditor.tsx:452
 msgid "Searchable"
-msgstr ""
+msgstr "Buscable"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1948
 msgid "Section"
-msgstr ""
+msgstr "Sección"
 
 #: packages/admin/src/components/SectionEditor.tsx:82
 msgid "Section \"{slug}\" could not be found."
-msgstr ""
+msgstr "No se pudo encontrar la sección \"{slug}\"."
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
-msgstr ""
+msgstr "Sección creada"
 
 #: packages/admin/src/components/Sections.tsx:107
 msgid "Section deleted"
-msgstr ""
+msgstr "Sección eliminada"
 
 #: packages/admin/src/components/SectionEditor.tsx:233
 msgid "Section Details"
-msgstr ""
+msgstr "Detalles de la sección"
 
 #: packages/admin/src/components/SectionEditor.tsx:78
 msgid "Section Not Found"
-msgstr ""
+msgstr "Sección no encontrada"
 
 #: packages/admin/src/components/SectionEditor.tsx:44
 msgid "Section saved"
-msgstr ""
+msgstr "Sección guardada"
 
 #: packages/admin/src/components/SectionEditor.tsx:239
 msgid "Section title"
-msgstr ""
+msgstr "Título de la sección"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
 #: packages/admin/src/components/Sections.tsx:134
 #: packages/admin/src/components/Sidebar.tsx:198
 msgid "Sections"
-msgstr ""
+msgstr "Secciones"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
 msgid "secure context"
-msgstr ""
+msgstr "contexto seguro"
 
 #: packages/admin/src/components/SetupWizard.tsx:561
 msgid "Secure your account"
-msgstr ""
+msgstr "Asegura tu cuenta"
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
-msgstr ""
+msgstr "Seguridad"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:308
 msgid "Security Audit"
-msgstr ""
+msgstr "Auditoría de seguridad"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:340
 msgid "Security audit failed"
-msgstr ""
+msgstr "La auditoría de seguridad falló"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:330
 msgid "Security audit flagged concerns"
-msgstr ""
+msgstr "La auditoría de seguridad señaló preocupaciones"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:126
 msgid "Security audit flagged potential concerns with this plugin."
-msgstr ""
+msgstr "La auditoría de seguridad detectó posibles problemas con este plugin."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:127
 msgid "Security audit flagged this plugin as potentially unsafe."
-msgstr ""
+msgstr "La auditoría de seguridad marcó este plugin como potencialmente inseguro."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:319
 msgid "Security audit passed"
-msgstr ""
+msgstr "Auditoría de seguridad superada"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:272
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
 msgid "Security error. Make sure you're on a secure connection."
-msgstr ""
+msgstr "Error de seguridad. Asegúrate de estar en una conexión segura."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
 #: packages/admin/src/components/settings/SecuritySettings.tsx:104
 msgid "Security Settings"
-msgstr ""
+msgstr "Configuración de seguridad"
 
 #: packages/admin/src/components/FieldEditor.tsx:186
 #: packages/admin/src/components/FieldEditor.tsx:585
 msgid "Select"
-msgstr ""
+msgstr "Seleccionar"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:100
 #: packages/admin/src/components/ContentEditor.tsx:1651
 #: packages/admin/src/components/ContentEditor.tsx:1809
 #: packages/admin/src/components/ContentEditor.tsx:1825
 msgid "Select {label}"
-msgstr ""
+msgstr "Selecciona {label}"
 
 #: packages/admin/src/components/Widgets.tsx:871
 msgid "Select a component..."
-msgstr ""
+msgstr "Selecciona un componente..."
 
 #: packages/admin/src/components/Widgets.tsx:839
 msgid "Select a menu..."
-msgstr ""
+msgstr "Selecciona un menú..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:283
 msgid "Select all"
-msgstr ""
+msgstr "Seleccionar todo"
 
 #: packages/admin/src/components/ContentEditor.tsx:1917
 msgid "Select byline"
-msgstr ""
+msgstr "Seleccionar firma"
 
 #: packages/admin/src/components/ContentEditor.tsx:1914
 msgid "Select byline..."
-msgstr ""
+msgstr "Selecciona firma..."
 
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:456
 msgid "Select comment by {0}"
-msgstr ""
+msgstr "Seleccionar comentario de {0}"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
-msgstr ""
+msgstr "Seleccionar contenido"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:258
 #: packages/admin/src/components/settings/GeneralSettings.tsx:314
 msgid "Select Favicon"
-msgstr ""
+msgstr "Seleccionar favicon"
 
 #: packages/admin/src/components/ContentEditor.tsx:1813
 msgid "Select file"
-msgstr ""
+msgstr "Seleccionar archivo"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:125
 msgid "Select File"
-msgstr ""
+msgstr "Seleccionar archivo"
 
 #: packages/admin/src/components/ContentEditor.tsx:1639
 msgid "Select image"
-msgstr ""
+msgstr "Seleccionar imagen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:125
 #: packages/admin/src/components/PortableTextEditor.tsx:2310
 #: packages/admin/src/components/PortableTextEditor.tsx:2983
 msgid "Select Image"
-msgstr ""
+msgstr "Seleccionar imagen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:214
 #: packages/admin/src/components/settings/GeneralSettings.tsx:307
 msgid "Select Logo"
-msgstr ""
+msgstr "Seleccionar logotipo"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:91
 msgid "Select media"
-msgstr ""
+msgstr "Seleccionar medio"
 
 #: packages/admin/src/components/SeoImageField.tsx:70
 msgid "Select OG image"
-msgstr ""
+msgstr "Seleccionar imagen original"
 
 #: packages/admin/src/components/SeoImageField.tsx:82
 msgid "Select OG Image"
-msgstr ""
+msgstr "Seleccionar imagen original"
 
 #: packages/admin/src/components/WordPressImport.tsx:1571
 msgid "Select which content types to import."
-msgstr ""
+msgstr "Selecciona qué tipos de contenido importar."
 
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:108
 #: packages/admin/src/components/PortableTextEditor.tsx:1758
 #: packages/admin/src/components/RepeaterField.tsx:361
 msgid "Select..."
-msgstr ""
+msgstr "Seleccionar..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:653
 msgid "Selected:"
-msgstr ""
+msgstr "Seleccionado:"
 
 #: packages/admin/src/components/Settings.tsx:98
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
 msgid "Self-Signup Domains"
-msgstr ""
+msgstr "Dominios de registro automático"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:139
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr ""
+msgstr "Envíe un correo electrónico de prueba a través del proceso completo para verificar su configuración de correo electrónico."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr ""
+msgstr "Envíe un correo electrónico de invitación a un nuevo miembro del equipo."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 msgid "Send Invite"
-msgstr ""
+msgstr "Enviar invitación"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 msgid "Send magic link"
-msgstr ""
+msgstr "Enviar enlace mágico"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
-msgstr ""
+msgstr "Enviar enlace de recuperación"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
 msgid "Send Test"
-msgstr ""
+msgstr "Enviar prueba"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:136
 msgid "Send Test Email"
-msgstr ""
+msgstr "Enviar correo electrónico de prueba"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
@@ -5670,47 +5670,47 @@ msgstr ""
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Sending..."
-msgstr ""
+msgstr "Envío..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1008
 #: packages/admin/src/components/ContentTypeEditor.tsx:474
 #: packages/admin/src/components/Settings.tsx:81
 msgid "SEO"
-msgstr ""
+msgstr "SEO"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:78
 #: packages/admin/src/components/settings/SeoSettings.tsx:103
 msgid "SEO Settings"
-msgstr ""
+msgstr "Configuración de SEO"
 
 #: packages/admin/src/components/WordPressImport.tsx:1679
 msgid "SEO settings (Yoast)"
-msgstr ""
+msgstr "Configuración de SEO (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:48
 msgid "SEO settings saved"
-msgstr ""
+msgstr "Configuración SEO guardada"
 
 #: packages/admin/src/components/SeoPanel.tsx:154
 msgid "SEO Title"
-msgstr ""
+msgstr "Título SEO"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
 msgid "Set a custom display size for this image instance."
-msgstr ""
+msgstr "Establezca un tamaño de visualización personalizado para esta instancia de imagen."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:531
 msgid "Set to 0 to never close comments automatically."
-msgstr ""
+msgstr "Establece 0 para no cerrar nunca los comentarios automáticamente."
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
-msgstr ""
+msgstr "Configura tu sitio"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 msgid "Setting up..."
-msgstr ""
+msgstr "Configurando..."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/ContentTypeEditor.tsx:383
@@ -5720,140 +5720,140 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:229
 #: packages/admin/src/components/WordPressImport.tsx:1647
 msgid "Settings"
-msgstr ""
+msgstr "Ajustes"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
 msgid "Settings Manage"
-msgstr ""
+msgstr "Gestionar ajustes"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
 msgid "Settings Read"
-msgstr ""
+msgstr "Leer ajustes"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:53
 msgid "Settings saved successfully"
-msgstr ""
+msgstr "Configuración guardada exitosamente"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr ""
+msgstr "Error en la configuración"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr ""
+msgstr "Comparte este enlace con el usuario invitado."
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
 msgid "Short Text"
-msgstr ""
+msgstr "Texto corto"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Show token"
-msgstr ""
+msgstr "Mostrar token"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
 msgid "Shown when hovering over the image."
-msgstr ""
+msgstr "Se muestra al pasar el cursor sobre la imagen."
 
 #: packages/admin/src/components/SignupPage.tsx:439
 msgid "Sign in"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #: packages/admin/src/components/SetupWizard.tsx:355
 msgid "Sign In"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:129
 #: packages/admin/src/components/SignupPage.tsx:269
 msgid "Sign in instead"
-msgstr ""
+msgstr "Inicia sesión en su lugar"
 
 #: packages/admin/src/components/LoginPage.tsx:232
 msgid "Sign in to your site"
-msgstr ""
+msgstr "Inicia sesión en tu sitio"
 
 #. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
 #. placeholder {0}: provider.label
 #: packages/admin/src/components/LoginPage.tsx:231
 #: packages/admin/src/components/SetupWizard.tsx:264
 msgid "Sign in with {0}"
-msgstr ""
+msgstr "Iniciar sesión con {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:229
 msgid "Sign in with email"
-msgstr ""
+msgstr "Iniciar sesión con correo electrónico"
 
 #: packages/admin/src/components/LoginPage.tsx:290
 msgid "Sign in with email link"
-msgstr ""
+msgstr "Iniciar sesión con enlace de correo electrónico"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:136
 #: packages/admin/src/components/LoginPage.tsx:252
 msgid "Sign in with Passkey"
-msgstr ""
+msgstr "Iniciar sesión con Passkey"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr ""
+msgstr "Iniciado sesión como {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
-msgstr ""
+msgstr "Elección única entre opciones"
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 msgid "Single line text input"
-msgstr ""
+msgstr "Entrada de texto de una sola línea"
 
 #: packages/admin/src/components/SetupWizard.tsx:353
 msgid "Site"
-msgstr ""
+msgstr "Sitio"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:153
 msgid "Site Identity"
-msgstr ""
+msgstr "Identidad del sitio"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr ""
+msgstr "Identidad del sitio, logotipo, favicon y preferencias de lectura"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 msgid "Site Settings"
-msgstr ""
+msgstr "Configuración del sitio"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:156
 #: packages/admin/src/components/SetupWizard.tsx:116
 msgid "Site Title"
-msgstr ""
+msgstr "Título del sitio"
 
 #: packages/admin/src/components/WordPressImport.tsx:1659
 msgid "Site title & tagline"
-msgstr ""
+msgstr "Título y eslogan del sitio"
 
 #: packages/admin/src/components/SetupWizard.tsx:100
 msgid "Site title is required"
-msgstr ""
+msgstr "El título del sitio es obligatorio."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:168
 msgid "Site URL"
-msgstr ""
+msgstr "URL del sitio"
 
 #: packages/admin/src/components/MediaLibrary.tsx:418
 msgid "Size"
-msgstr ""
+msgstr "Tamaño"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:170
 msgid "Size:"
-msgstr ""
+msgstr "Tamaño:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1940
 msgid "Skip Media Import"
-msgstr ""
+msgstr "Saltar importación de medios"
 
 #: packages/admin/src/components/WordPressImport.tsx:1965
 msgid "Skipped"
-msgstr ""
+msgstr "Saltado"
 
 #: packages/admin/src/components/ContentEditor.tsx:813
 #: packages/admin/src/components/ContentEditor.tsx:2016
@@ -5868,50 +5868,50 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:396
 #: packages/admin/src/routes/bylines.tsx:257
 msgid "Slug"
-msgstr ""
+msgstr "Slug"
 
 #: packages/admin/src/components/Sections.tsx:124
 msgid "Slug copied to clipboard"
-msgstr ""
+msgstr "Slug copiado al portapapeles"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:877
 msgid "Small section heading"
-msgstr ""
+msgstr "Encabezado de sección pequeña"
 
 #: packages/admin/src/components/Settings.tsx:75
 #: packages/admin/src/components/settings/SocialSettings.tsx:78
 #: packages/admin/src/components/settings/SocialSettings.tsx:103
 msgid "Social Links"
-msgstr ""
+msgstr "Enlaces sociales"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:48
 msgid "Social links saved"
-msgstr ""
+msgstr "Enlaces sociales guardados"
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
-msgstr ""
+msgstr "Enlaces de perfil de redes sociales"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:126
 msgid "Social Profiles"
-msgstr ""
+msgstr "Perfiles sociales"
 
 #: packages/admin/src/components/WordPressImport.tsx:1696
 msgid "Some content types cannot be imported"
-msgstr ""
+msgstr "Algunos tipos de contenido no se pueden importar"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:122
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Something went wrong"
-msgstr ""
+msgstr "algo salió mal"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:123
 msgid "Sort plugins"
-msgstr ""
+msgstr "Ordenar plugins"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
 msgid "Sort themes"
-msgstr ""
+msgstr "Ordenar temas"
 
 #: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
@@ -5921,33 +5921,33 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:440
 #: packages/admin/src/components/SectionEditor.tsx:279
 msgid "Source"
-msgstr ""
+msgstr "Fuente"
 
 #: packages/admin/src/components/Redirects.tsx:128
 msgid "Source path"
-msgstr ""
+msgstr "Ruta de origen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr ""
+msgstr "correo basura"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:207
 #: packages/admin/src/components/comments/CommentInbox.tsx:247
 msgid "Spam"
-msgstr ""
+msgstr "Correo basura"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2971
 msgid "Spotlight Mode"
-msgstr ""
+msgstr "Modo enfoque"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr ""
+msgstr "Hojas de cálculo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
-msgstr ""
+msgstr "Iniciar importación"
 
 #: packages/admin/src/components/ContentEditor.tsx:819
 #: packages/admin/src/components/ContentList.tsx:218
@@ -5955,297 +5955,297 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:445
 #: packages/admin/src/components/users/UserList.tsx:104
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #: packages/admin/src/components/Redirects.tsx:146
 msgid "Status code"
-msgstr ""
+msgstr "Código de estado"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2455
 #: packages/admin/src/components/PortableTextEditor.tsx:2761
 msgid "Strikethrough"
-msgstr ""
+msgstr "Tachado"
 
 #: packages/admin/src/components/WordPressImport.tsx:1591
 msgid "Structure"
-msgstr ""
+msgstr "Estructura"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
-msgstr ""
+msgstr "Subcampos"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
 msgid "Subscriber"
-msgstr ""
+msgstr "Abonado"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
-msgstr ""
+msgstr "Sincronizado"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr ""
+msgstr "Passkey sincronizada"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:768
 msgid "System"
-msgstr ""
+msgstr "Sistema"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
-msgstr ""
+msgstr "Sistema ({resolvedLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:590
 msgid "System Fields"
-msgstr ""
+msgstr "Campos del sistema"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:936
 msgid "Table"
-msgstr ""
+msgstr "Tabla"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:162
 #: packages/admin/src/components/SetupWizard.tsx:127
 msgid "Tagline"
-msgstr ""
+msgstr "Lema"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
-msgstr ""
+msgstr "Etiquetas"
 
 #. placeholder {0}: analysis.tags
 #: packages/admin/src/components/WordPressImport.tsx:1633
 msgid "Tags ({0})"
-msgstr ""
+msgstr "Etiquetas ({0})"
 
 #: packages/admin/src/components/MenuEditor.tsx:340
 #: packages/admin/src/components/MenuEditor.tsx:511
 msgid "Target"
-msgstr ""
+msgstr "Objetivo"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:172
 msgid "Target locale"
-msgstr ""
+msgstr "Idioma de destino"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:495
 msgid "Taxonomies"
-msgstr ""
+msgstr "Taxonomías"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "Gestionar taxonomías"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:896
 msgid "Taxonomy created"
-msgstr ""
+msgstr "Taxonomía creada"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:783
 msgid "Taxonomy not found:"
-msgstr ""
+msgstr "Taxonomía no encontrada:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:159
 msgid "Taxonomy: {taxonomyName}"
-msgstr ""
+msgstr "Taxonomía: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr ""
+msgstr "Plantilla:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:360
 #: packages/admin/src/components/TaxonomyManager.tsx:812
 msgid "Term"
-msgstr ""
+msgstr "Término"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:757
 msgid "Term \"{0}\" created in {1}."
-msgstr ""
+msgstr "Término «{0}» creado en {1}."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:739
 msgid "Term deleted"
-msgstr ""
+msgstr "Término eliminado"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "test@example.com"
-msgstr ""
+msgstr "prueba@ejemplo.com"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2731
 msgid "Text formatting"
-msgstr ""
+msgstr "Formato de texto"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
-msgstr ""
+msgstr "No se concederá acceso al dispositivo."
 
 #: packages/admin/src/components/WordPressImport.tsx:1698
 msgid "The existing collection has fields with incompatible types."
-msgstr ""
+msgstr "La colección existente tiene campos con tipos incompatibles."
 
 #: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr ""
+msgstr "Las siguientes tablas contienen contenido pero no están registradas como colecciones. Regístrelos para gestionar este contenido en el administrador."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
-msgstr ""
+msgstr "El usuario invitado tendrá este rol una vez que complete el registro."
 
 #: packages/admin/src/components/LoginPage.tsx:113
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "The link will expire in 15 minutes."
-msgstr ""
+msgstr "El enlace caducará en 15 minutos."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:177
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr ""
+msgstr "El mercado está vacío. Vuelve más tarde para ver nuevos plugins."
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "The menu has been deleted."
-msgstr ""
+msgstr "El menú ha sido eliminado."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:159
 msgid "The name of your site, used in the header and metadata"
-msgstr ""
+msgstr "El nombre de tu sitio, utilizado en el encabezado y los metadatos."
 
 #: packages/admin/src/router.tsx:1739
 msgid "The page you're looking for doesn't exist."
-msgstr ""
+msgstr "La página que estás buscando no existe."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:172
 msgid "The public URL of your site (used for canonical links and sitemaps)"
-msgstr ""
+msgstr "La URL pública de tu sitio (utilizada para enlaces canónicos y mapas de sitio)"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
-msgstr ""
+msgstr "El mercado temático está vacío. Vuelve a consultar más tarde."
 
 #: packages/admin/src/components/Sections.tsx:45
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:292
 msgid "Theme ID: {0}"
-msgstr ""
+msgstr "ID del tema: {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Theme not found"
-msgstr ""
+msgstr "Tema no encontrado"
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Theme Section"
-msgstr ""
+msgstr "Sección temática"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr ""
+msgstr "Las secciones proporcionadas por el tema no se pueden eliminar. Edite la sección para crear una copia personalizada y luego elimínela."
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
-msgstr ""
+msgstr "Tema: {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:223
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Themes"
-msgstr ""
+msgstr "Temas"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:372
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr ""
+msgstr "Esta colección está definida en código. Algunos ajustes no pueden cambiarse aquí. Edita tu archivo live.config.ts para modificar el esquema."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:361
 msgid "This field does not accept {sniffedMime} files."
-msgstr ""
+msgstr "Este campo no acepta archivos {sniffedMime}."
 
 #: packages/admin/src/components/ContentEditor.tsx:1655
 #: packages/admin/src/components/ContentEditor.tsx:1828
 msgid "This field is required"
-msgstr ""
+msgstr "Este campo es obligatorio"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "This is a custom section."
-msgstr ""
+msgstr "Esta es una sección personalizada."
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "This is a WordPress site."
-msgstr ""
+msgstr "Este es un sitio de WordPress."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
-msgstr ""
+msgstr "Este enlace caduca en 7 días y solo se puede utilizar una vez."
 
 #: packages/admin/src/components/WordPressImport.tsx:821
 msgid "This may take a while for large exports."
-msgstr ""
+msgstr "Esto puede llevar algún tiempo en el caso de las grandes exportaciones."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
 msgid "This passkey is already registered on this device."
-msgstr ""
+msgstr "Esta Passkey ya está registrada en este dispositivo."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:277
 msgid "This plugin requires no special permissions."
-msgstr ""
+msgstr "Este plugin no requiere permisos especiales."
 
 #: packages/admin/src/components/Redirects.tsx:551
 msgid "This redirect rule will be permanently removed."
-msgstr ""
+msgstr "Esta regla de redirección se eliminará permanentemente."
 
 #: packages/admin/src/routes/bylines.tsx:337
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr ""
+msgstr "Esto elimina el perfil de la firma. Se quitarán los enlaces de firma del contenido y se borrarán los punteros principales."
 
 #: packages/admin/src/components/SectionEditor.tsx:283
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr ""
+msgstr "Esta sección está proporcionada por el tema. La edición creará una copia personalizada que anulará la versión del tema."
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "This section was imported from another system."
-msgstr ""
+msgstr "Esta sección fue importada de otro sistema."
 
 #: packages/admin/src/components/Widgets.tsx:635
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
-msgstr ""
+msgstr "Esto eliminará el área de widgets y todos sus widgets. Esta acción no se puede deshacer."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
-msgstr ""
+msgstr "Esto otorgará acceso CLI con sus permisos."
 
 #: packages/admin/src/components/ContentEditor.tsx:926
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr ""
+msgstr "Esto moverá el artículo a la papelera. Puedes restaurarlo más tarde desde la papelera."
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:882
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr ""
+msgstr "Esto eliminará permanentemente \"{0}\" y ​​lo eliminará de todo el contenido."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr ""
+msgstr "Esto eliminará permanentemente \"{0}\". Esta acción no se puede deshacer."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr ""
+msgstr "Esto eliminará permanentemente este comentario. Esta acción no se puede deshacer."
 
 #: packages/admin/src/components/PluginManager.tsx:570
 msgid "This will remove the plugin and its bundle from your site."
-msgstr ""
+msgstr "Esto eliminará el plugin y su paquete de tu sitio."
 
 #: packages/admin/src/components/ContentEditor.tsx:669
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr ""
+msgstr "Esto volverá a la versión publicada. Los borradores de cambios se perderán."
 
 #: packages/admin/src/components/SetupWizard.tsx:131
 msgid "Thoughts, tutorials, and more"
-msgstr ""
+msgstr "Pensamientos, tutoriales y más"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:285
 msgid "Timezone"
-msgstr ""
+msgstr "Zona horaria"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:288
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr ""
+msgstr "Zona horaria para mostrar fechas (por ejemplo, América/Nueva_York)"
 
 #: packages/admin/src/components/ContentList.tsx:212
 #: packages/admin/src/components/ContentList.tsx:343
@@ -6253,89 +6253,89 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:170
 #: packages/admin/src/components/Widgets.tsx:811
 msgid "Title"
-msgstr ""
+msgstr "Título"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
 msgid "Title (Tooltip)"
-msgstr ""
+msgstr "Título (información sobre herramientas)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:132
 msgid "Title Separator"
-msgstr ""
+msgstr "Separador de título"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
-msgstr ""
+msgstr "cerrar"
 
 #: packages/admin/src/components/PluginManager.tsx:194
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr ""
+msgstr "para instalar plugins o agregarlos a su astro.config.mjs."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
-msgstr ""
+msgstr "para seleccionar"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2547
 msgid "Toggle header row"
-msgstr ""
+msgstr "Alternar fila de encabezado"
 
 #: packages/admin/src/components/ThemeToggle.tsx:30
 #: packages/admin/src/components/ThemeToggle.tsx:41
 msgid "Toggle theme (current: {label})"
-msgstr ""
+msgstr "Alternar tema (actual: {label})"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
 msgid "Token created: {0}"
-msgstr ""
+msgstr "Token creado: {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
 msgid "Token Name"
-msgstr ""
+msgstr "Nombre del token"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "Tools → Export"
-msgstr ""
+msgstr "Herramientas → Exportar"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:77
 msgid "Track content history"
-msgstr ""
+msgstr "Seguimiento del historial de contenido"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:83
 #: packages/admin/src/components/TaxonomyManager.tsx:194
 #: packages/admin/src/components/TranslationsPanel.tsx:99
 msgid "Translate"
-msgstr ""
+msgstr "Traducir"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:156
 msgid "Translate \"{0}\""
-msgstr ""
+msgstr "Traducir «{0}»"
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:80
 msgid "Translate {0}"
-msgstr ""
+msgstr "Traducir {0}"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:194
 #: packages/admin/src/components/TranslationsPanel.tsx:99
 msgid "Translating..."
-msgstr ""
+msgstr "Traduciendo..."
 
 #: packages/admin/src/components/MenuEditor.tsx:89
 #: packages/admin/src/components/TaxonomyManager.tsx:756
 #: packages/admin/src/router.tsx:843
 msgid "Translation created"
-msgstr ""
+msgstr "Traducción creada"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:56
 msgid "Translations"
-msgstr ""
+msgstr "Traducciones"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:198
 msgid "trash"
-msgstr ""
+msgstr "basura"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:170
 #: packages/admin/src/components/comments/CommentInbox.tsx:216
@@ -6343,324 +6343,324 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:513
 #: packages/admin/src/components/ContentList.tsx:192
 msgid "Trash"
-msgstr ""
+msgstr "Basura"
 
 #: packages/admin/src/components/ContentList.tsx:366
 msgid "Trash is empty"
-msgstr ""
+msgstr "la papelera esta vacia"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:549
 msgid "Trash is empty."
-msgstr ""
+msgstr "La papelera está vacía."
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 msgid "True/false toggle"
-msgstr ""
+msgstr "Alternar verdadero/falso"
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
 #: packages/admin/src/components/MediaPickerModal.tsx:576
 msgid "Try a different search term"
-msgstr ""
+msgstr "Prueba con un término de búsqueda diferente"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:172
 #: packages/admin/src/components/SectionPickerModal.tsx:102
 msgid "Try adjusting your search"
-msgstr ""
+msgstr "Intenta ajustar tu búsqueda"
 
 #: packages/admin/src/components/Sections.tsx:260
 msgid "Try adjusting your search or filters."
-msgstr ""
+msgstr "Intente ajustar su búsqueda o filtros."
 
 #: packages/admin/src/routes/users.tsx:210
 msgid "Try again"
-msgstr ""
+msgstr "Inténtalo de nuevo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1421
 msgid "Try Again"
-msgstr ""
+msgstr "Intentar otra vez"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:207
 msgid "Try another code"
-msgstr ""
+msgstr "Prueba con otro código"
 
 #: packages/admin/src/components/WordPressImport.tsx:1125
 #: packages/admin/src/components/WordPressImport.tsx:1247
 msgid "Try Another URL"
-msgstr ""
+msgstr "Prueba con otra URL"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
 msgid "Try with my data"
-msgstr ""
+msgstr "prueba con mis datos"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:279
 msgid "Turn into"
-msgstr ""
+msgstr "Convertir en"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:132
 msgid "Twitter"
-msgstr ""
+msgstr "Gorjeo"
 
 #: packages/admin/src/components/FieldEditor.tsx:571
 #: packages/admin/src/components/MediaLibrary.tsx:417
 msgid "Type"
-msgstr ""
+msgstr "Tipo"
 
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:1854
 msgid "Type mismatch ({0})"
-msgstr ""
+msgstr "El tipo no coincide ({0})"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
 msgid "Unable to reach marketplace"
-msgstr ""
+msgstr "No se puede llegar al mercado"
 
 #: packages/admin/src/components/ContentEditor.tsx:2121
 #: packages/admin/src/components/ContentEditor.tsx:2136
 msgid "Unassigned"
-msgstr ""
+msgstr "No asignado"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2448
 #: packages/admin/src/components/PortableTextEditor.tsx:2754
 msgid "Underline"
-msgstr ""
+msgstr "Subrayado"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2951
 msgid "Undo"
-msgstr ""
+msgstr "Deshacer"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:181
 #: packages/admin/src/components/PluginManager.tsx:494
 #: packages/admin/src/components/PluginManager.tsx:584
 msgid "Uninstall"
-msgstr ""
+msgstr "Desinstalar"
 
 #: packages/admin/src/components/PluginManager.tsx:568
 msgid "Uninstall {pluginName}?"
-msgstr ""
+msgstr "¿Desinstalar {pluginName}?"
 
 #: packages/admin/src/components/PluginManager.tsx:563
 msgid "Uninstall confirmation"
-msgstr ""
+msgstr "Confirmación de desinstalación"
 
 #: packages/admin/src/components/PluginManager.tsx:584
 msgid "Uninstalling..."
-msgstr ""
+msgstr "Desinstalando..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:722
 #: packages/admin/src/components/FieldEditor.tsx:442
 msgid "Unique"
-msgstr ""
+msgstr "Único"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
-msgstr ""
+msgstr "Identificador único (ULID)"
 
 #: packages/admin/src/components/users/useRolesConfig.ts:7
 msgid "Unknown"
-msgstr ""
+msgstr "Desconocido"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:62
 msgid "Unknown role"
-msgstr ""
+msgstr "Rol desconocido"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Unlock aspect ratio"
-msgstr ""
+msgstr "Desbloquear relación de aspecto"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
 msgid "Unnamed passkey"
-msgstr ""
+msgstr "Passkey sin nombre"
 
 #: packages/admin/src/components/ContentEditor.tsx:698
 msgid "Unpublish"
-msgstr ""
+msgstr "Despublicar"
 
 #: packages/admin/src/router.tsx:760
 msgid "Unpublished"
-msgstr ""
+msgstr "Despublicado"
 
 #: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
-msgstr ""
+msgstr "Se encontraron tablas de contenido no registrado"
 
 #: packages/admin/src/components/ContentEditor.tsx:844
 msgid "Unschedule"
-msgstr ""
+msgstr "Desprogramar"
 
 #: packages/admin/src/router.tsx:813
 msgid "Unscheduled"
-msgstr ""
+msgstr "Desprogramado"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr ""
+msgstr "Tipo de elemento de widget no admitido: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:249
 msgid "Untitled"
-msgstr ""
+msgstr "Intitulado"
 
 #: packages/admin/src/components/ContentEditor.tsx:1731
 msgid "Untitled file"
-msgstr ""
+msgstr "Archivo sin título"
 
 #: packages/admin/src/components/Widgets.tsx:466
 #: packages/admin/src/components/Widgets.tsx:729
 msgid "Untitled Widget"
-msgstr ""
+msgstr "Widget sin título"
 
 #: packages/admin/src/components/ContentEditor.tsx:1948
 msgid "Up"
-msgstr ""
+msgstr "Arriba"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:476
 msgid "Update"
-msgstr ""
+msgstr "Actualizar"
 
 #: packages/admin/src/components/FieldEditor.tsx:659
 msgid "Update Field"
-msgstr ""
+msgstr "Actualizar campo"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
 msgid "Update settings for {0}"
-msgstr ""
+msgstr "Actualizar configuración para {0}"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Update site settings"
-msgstr ""
+msgstr "Actualizar los ajustes del sitio"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:364
 msgid "Update the {0} details"
-msgstr ""
+msgstr "Actualizar los detalles de {0}"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Update this redirect rule."
-msgstr ""
+msgstr "Actualice esta regla de redirección."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:364
 msgid "Update to v{0}"
-msgstr ""
+msgstr "Actualizar a v{0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
-msgstr ""
+msgstr "Actualizado en"
 
 #. placeholder {0}: new Date(item.updatedAt).toLocaleString()
 #: packages/admin/src/components/ContentEditor.tsx:901
 msgid "Updated: {0}"
-msgstr ""
+msgstr "Actualizado: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:844
 msgid "Updating content URLs..."
-msgstr ""
+msgstr "Actualizando URL de contenido..."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:144
 #: packages/admin/src/components/PluginManager.tsx:364
 msgid "Updating..."
-msgstr ""
+msgstr "Actualizando..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:540
 msgid "Upload"
-msgstr ""
+msgstr "Subir"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:127
 msgid "Upload a file to get started"
-msgstr ""
+msgstr "Sube un archivo para empezar"
 
 #: packages/admin/src/components/WordPressImport.tsx:1230
 msgid "Upload an export file"
-msgstr ""
+msgstr "Cargar un archivo de exportación"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:128
 msgid "Upload an image to get started"
-msgstr ""
+msgstr "Sube una imagen para comenzar"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Upload and delete media"
-msgstr ""
+msgstr "Cargar y eliminar medios"
 
 #: packages/admin/src/lib/api/marketplace.ts:225
 #: packages/admin/src/lib/api/marketplace.ts:233
 msgid "Upload and manage media"
-msgstr ""
+msgstr "Sube y gestiona medios"
 
 #: packages/admin/src/components/WordPressImport.tsx:1123
 #: packages/admin/src/components/WordPressImport.tsx:1244
 msgid "Upload Export File"
-msgstr ""
+msgstr "Cargar archivo de exportación"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:560
 msgid "Upload failed: {uploadError}"
-msgstr ""
+msgstr "Error al subir: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:552
 msgid "Upload file"
-msgstr ""
+msgstr "Subir archivo"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:129
 msgid "Upload File"
-msgstr ""
+msgstr "Subir archivo"
 
 #: packages/admin/src/components/MediaLibrary.tsx:323
 msgid "Upload files"
-msgstr ""
+msgstr "Subir archivos"
 
 #: packages/admin/src/components/MediaLibrary.tsx:357
 msgid "Upload Files"
-msgstr ""
+msgstr "Subir archivos"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:129
 msgid "Upload Image"
-msgstr ""
+msgstr "Subir imagen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:354
 msgid "Upload images, videos, and documents to get started."
-msgstr ""
+msgstr "Cargue imágenes, videos y documentos para comenzar."
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
-msgstr ""
+msgstr "Subir medios"
 
 #: packages/admin/src/components/MediaLibrary.tsx:368
 msgid "Upload media to get started"
-msgstr ""
+msgstr "Cargue medios para comenzar"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:314
 msgid "Upload to {0}"
-msgstr ""
+msgstr "Subir a {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:960
 msgid "Upload WordPress export file"
-msgstr ""
+msgstr "Subir archivo de exportación de WordPress"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:184
 msgid "Uploaded:"
-msgstr ""
+msgstr "Subido:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1963
 msgid "Uploading"
-msgstr ""
+msgstr "Subiendo"
 
 #. placeholder {0}: uploadState.progress.current
 #. placeholder {1}: uploadState.progress.total
 #: packages/admin/src/components/MediaLibrary.tsx:289
 msgid "Uploading {0}/{1}..."
-msgstr ""
+msgstr "Subiendo {0}/{1}..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:290
 #: packages/admin/src/components/MediaPickerModal.tsx:540
 msgid "Uploading..."
-msgstr ""
+msgstr "Subiendo..."
 
 #: packages/admin/src/components/FieldEditor.tsx:234
 #: packages/admin/src/components/FieldEditor.tsx:586
@@ -6668,422 +6668,422 @@ msgstr ""
 #: packages/admin/src/components/MenuEditor.tsx:501
 #: packages/admin/src/components/PortableTextEditor.tsx:2887
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:425
 msgid "URL Pattern"
-msgstr ""
+msgstr "Patrón de URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:113
 #: packages/admin/src/components/FieldEditor.tsx:229
 msgid "URL-friendly identifier"
-msgstr ""
+msgstr "Identificador compatible con URL"
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr ""
+msgstr "Identificador compatible con URL (por ejemplo, \"principal\", \"pie de página\")"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr ""
+msgstr "Utiliza [param] o [...rest] en rutas para hacer coincidir patrones."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:366
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr ""
+msgstr "Utiliza la autenticación biométrica, la clave de seguridad o el PIN de tu dispositivo para iniciar sesión."
 
 #: packages/admin/src/components/LoginPage.tsx:326
 msgid "Use your registered passkey to sign in securely."
-msgstr ""
+msgstr "Utiliza su Passkey registrada para iniciar sesión de forma segura."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:642
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
-msgstr ""
+msgstr "Utilizado como identificador. Sólo letras minúsculas, números y guiones bajos."
 
 #: packages/admin/src/components/ContentEditor.tsx:1290
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
-msgstr ""
+msgstr "Se utiliza como elemento visual principal de esta entrada en las páginas de listado y en la parte superior de la entrada."
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:206
 msgid "Used by screen readers and when image fails to load"
-msgstr ""
+msgstr "Utilizado por lectores de pantalla y cuando la imagen no se carga"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:410
 msgid "Used in URLs and API endpoints"
-msgstr ""
+msgstr "Se usa en las URL y en los endpoints de la API"
 
 #: packages/admin/src/components/SectionEditor.tsx:254
 #: packages/admin/src/components/Sections.tsx:196
 msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
-msgstr ""
+msgstr "Se utiliza para identificar esta sección. Sólo letras minúsculas, números y guiones."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
 #: packages/admin/src/components/Header.tsx:75
 #: packages/admin/src/components/users/UserList.tsx:98
 msgid "User"
-msgstr ""
+msgstr "Usuario"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr ""
+msgstr "El acceso de los usuarios lo gestiona un proveedor externo ({0}). La configuración del dominio de registro automático no está disponible cuando se utiliza la autenticación externa."
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr ""
+msgstr "Detalles del usuario"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr ""
+msgstr "Usuario no encontrado"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
 #: packages/admin/src/components/Sidebar.tsx:211
 #: packages/admin/src/components/users/UserList.tsx:54
 msgid "Users"
-msgstr ""
+msgstr "Usuarios"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
 msgid "Users from"
-msgstr ""
+msgstr "Usuarios de"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr ""
+msgstr "Los usuarios con direcciones de correo electrónico de estos dominios pueden registrarse sin invitación. Se les asignará el rol especificado automáticamente."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:308
 msgid "v{0} available"
-msgstr ""
+msgstr "v{0} disponible"
 
 #: packages/admin/src/components/FieldEditor.tsx:460
 #: packages/admin/src/components/FieldEditor.tsx:490
 msgid "Validation"
-msgstr ""
+msgstr "Validación"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:194
 msgid "Verifying your invite..."
-msgstr ""
+msgstr "Verificando tu invitación..."
 
 #: packages/admin/src/components/SignupPage.tsx:386
 msgid "Verifying your link..."
-msgstr ""
+msgstr "Verificando tu enlace..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:213
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
 msgid "Verifying..."
-msgstr ""
+msgstr "Verificando..."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:321
 msgid "Version"
-msgstr ""
+msgstr "Versión"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:67
 msgid "Video"
-msgstr ""
+msgstr "Vídeo"
 
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
-msgstr ""
+msgstr "Ver el estado del proveedor de correo electrónico y enviar correos electrónicos de prueba"
 
 #: packages/admin/src/components/PluginManager.tsx:376
 msgid "View in Marketplace"
-msgstr ""
+msgstr "Ver en el mercado"
 
 #: packages/admin/src/components/MediaLibrary.tsx:227
 msgid "View mode"
-msgstr ""
+msgstr "Modo de visualización"
 
 #: packages/admin/src/components/ContentList.tsx:516
 msgid "View published {title}"
-msgstr ""
+msgstr "Ver publicado {title}"
 
 #: packages/admin/src/components/Header.tsx:51
 msgid "View Site"
-msgstr ""
+msgstr "Ver sitio"
 
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Visitors hitting these paths will see an error."
-msgstr ""
+msgstr "Los visitantes que lleguen a estos caminos verán un error."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
 msgid "Waiting for passkey..."
-msgstr ""
+msgstr "Esperando la Passkey..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:333
 msgid "Warn"
-msgstr ""
+msgstr "Advertir"
 
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1105
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr ""
+msgstr "No pudimos conectarnos a un sitio de WordPress en {0}. Esto podría significar que el sitio no es WordPress, que la API REST está deshabilitada o que no se puede acceder al sitio."
 
 #: packages/admin/src/components/WordPressImport.tsx:926
 msgid "We'll check what import options are available for your site."
-msgstr ""
+msgstr "Comprobaremos qué opciones de importación están disponibles para tu sitio."
 
 #: packages/admin/src/components/LoginPage.tsx:323
 msgid "We'll send you a link to sign in without a password."
-msgstr ""
+msgstr "Le enviaremos un enlace para iniciar sesión sin contraseña."
 
 #: packages/admin/src/components/SignupPage.tsx:132
 msgid "We've sent a verification link to"
-msgstr ""
+msgstr "Hemos enviado un enlace de verificación a"
 
 #: packages/admin/src/components/FieldEditor.tsx:235
 msgid "Web address"
-msgstr ""
+msgstr "Dirección web"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:159
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
 msgid "WebAuthn is not supported in this browser"
-msgstr ""
+msgstr "WebAuthn no es compatible con este navegador"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:226
 msgid "Website"
-msgstr ""
+msgstr "Sitio web"
 
 #: packages/admin/src/routes/bylines.tsx:262
 msgid "Website URL"
-msgstr ""
+msgstr "URL del sitio web"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
-msgstr ""
+msgstr "¡Bienvenido a EmDash, {firstName}!"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash!"
-msgstr ""
+msgstr "¡Bienvenido a EmDash!"
 
 #: packages/admin/src/components/WordPressImport.tsx:1927
 msgid "What happens when you import:"
-msgstr ""
+msgstr "¿Qué sucede cuando importas?"
 
 #: packages/admin/src/components/WordPressImport.tsx:1710
 msgid "What will happen when you import"
-msgstr ""
+msgstr "¿Qué pasará cuando importes?"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
-msgstr ""
+msgstr "Cuando se creó la entrada"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:131
 msgid "When the entry was last modified"
-msgstr ""
+msgstr "Cuándo se modificó la entrada por última vez"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:137
 msgid "When the entry was published"
-msgstr ""
+msgstr "Cuando se publicó la entrada."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:656
 msgid "Which content types can use this taxonomy"
-msgstr ""
+msgstr "¿Qué tipos de contenido pueden utilizar esta taxonomía?"
 
 #: packages/admin/src/components/FieldEditor.tsx:169
 msgid "Whole number"
-msgstr ""
+msgstr "numero entero"
 
 #: packages/admin/src/components/Widgets.tsx:722
 #: packages/admin/src/components/Widgets.tsx:737
 msgid "widget"
-msgstr ""
+msgstr "widget"
 
 #: packages/admin/src/components/Widgets.tsx:170
 msgid "Widget added"
-msgstr ""
+msgstr "Widget añadido"
 
 #: packages/admin/src/components/Widgets.tsx:158
 msgid "Widget area created"
-msgstr ""
+msgstr "Área de widgets creada"
 
 #: packages/admin/src/components/Widgets.tsx:565
 msgid "Widget area deleted"
-msgstr ""
+msgstr "Área de widgets eliminada"
 
 #: packages/admin/src/components/Widgets.tsx:685
 msgid "Widget deleted"
-msgstr ""
+msgstr "Widget eliminado"
 
 #: packages/admin/src/components/Widgets.tsx:814
 msgid "Widget title"
-msgstr ""
+msgstr "Título del widget"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Widget updated"
-msgstr ""
+msgstr "Widget actualizado"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
 #: packages/admin/src/components/PluginManager.tsx:329
 #: packages/admin/src/components/Sidebar.tsx:197
 #: packages/admin/src/components/Widgets.tsx:325
 msgid "Widgets"
-msgstr ""
+msgstr "Widgets"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
 msgid "Width"
-msgstr ""
+msgstr "Ancho"
 
 #: packages/admin/src/components/WordPressImport.tsx:1850
 msgid "Will create"
-msgstr ""
+msgstr "creará"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr ""
+msgstr "ya no podrá registrarse sin una invitación. Los usuarios existentes no se ven afectados."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:184
 msgid "Without an email provider, invite links must be shared manually."
-msgstr ""
+msgstr "Sin un proveedor de correo electrónico, los enlaces de invitación deben compartirse manualmente."
 
 #: packages/admin/src/components/WordPressImport.tsx:1315
 msgid "WordPress Username"
-msgstr ""
+msgstr "Nombre de usuario de WordPress"
 
 #: packages/admin/src/components/Widgets.tsx:824
 msgid "Write widget content..."
-msgstr ""
+msgstr "Escribe el contenido del widget..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1023
 msgid "WXR File"
-msgstr ""
+msgstr "Archivo WXR"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
-msgstr ""
+msgstr "Puedes cerrar esta página y volver a tu terminal."
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
-msgstr ""
+msgstr "Puedes crear y editar tu propio contenido."
 
 #: packages/admin/src/components/WelcomeModal.tsx:42
 msgid "You can manage content, media, menus, and taxonomies."
-msgstr ""
+msgstr "Puede gestionar contenido, medios, menús y taxonomías."
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
-msgstr ""
+msgstr "Puede ver y contribuir al sitio."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr ""
+msgstr "No puedes cambiar tu propio rol."
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
-msgstr ""
+msgstr "Tiene acceso completo para gestionar este sitio, incluidos los usuarios, la configuración y todo el contenido."
 
 #: packages/admin/src/router.tsx:1139
 msgid "You need Editor permissions to moderate comments."
-msgstr ""
+msgstr "Necesitas permisos de editor para moderar los comentarios."
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Ya no podrás utilizar \"{0}\" para iniciar sesión. Esta acción no se puede deshacer."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:207
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Ya no podrás utilizar esta Passkey para iniciar sesión. Esta acción no se puede deshacer."
 
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:52
 msgid "You'll be joining as <0>{0}</0>"
-msgstr ""
+msgstr "Te unirás como <0>{0}</0>"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr ""
+msgstr "Se le pedirá que utiliza la autenticación biométrica, la clave de seguridad o el PIN de tu dispositivo."
 
 #: packages/admin/src/components/WordPressImport.tsx:1208
 msgid "You'll be redirected to WordPress to authorize the connection."
-msgstr ""
+msgstr "Serás redirigido a WordPress para autorizar la conexión."
 
 #: packages/admin/src/components/SignupPage.tsx:191
 msgid "You'll be signing up as"
-msgstr ""
+msgstr "Te registrarás como"
 
 #: packages/admin/src/components/SetupWizard.tsx:564
 msgid "You're signed in via Cloudflare Access"
-msgstr ""
+msgstr "Has iniciado sesión a través de Cloudflare Access"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:50
 msgid "You've been invited!"
-msgstr ""
+msgstr "¡Te han invitado!"
 
 #: packages/admin/src/components/SignupPage.tsx:70
 msgid "you@company.com"
-msgstr ""
+msgstr "tu@empresa.com"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:336
 #: packages/admin/src/components/SetupWizard.tsx:201
 msgid "you@example.com"
-msgstr ""
+msgstr "tu@ejemplo.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
-msgstr ""
+msgstr "Tu cuenta ha sido creada exitosamente."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:318
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
 msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
-msgstr ""
+msgstr "Tu navegador no admite passkeys. Utiliza un navegador moderno como Chrome, Safari, Firefox o Edge."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:269
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
 msgid "Your device doesn't support the required security features."
-msgstr ""
+msgstr "Tu dispositivo no admite las funciones de seguridad requeridas."
 
 #: packages/admin/src/components/SetupWizard.tsx:197
 msgid "Your Email"
-msgstr ""
+msgstr "Tu correo electrónico"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:147
 msgid "Your Facebook page or profile username"
-msgstr ""
+msgstr "Su página de Facebook o nombre de usuario de perfil"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:141
 msgid "Your GitHub username"
-msgstr ""
+msgstr "Tu nombre de usuario de GitHub"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:153
 msgid "Your Instagram username"
-msgstr ""
+msgstr "Tu nombre de usuario de Instagram"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:159
 msgid "Your LinkedIn profile username"
-msgstr ""
+msgstr "El nombre de usuario de tu perfil de LinkedIn"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
-msgstr ""
+msgstr "Tu nombre"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/SignupPage.tsx:201
 msgid "Your name (optional)"
-msgstr ""
+msgstr "Tu nombre (opcional)"
 
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
-msgstr ""
+msgstr "Tu papel"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:135
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr ""
+msgstr "Tu identificador de Twitter/X (por ejemplo, @nombredeusuario)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1898
 msgid "Your WordPress export contains {0} media files."
-msgstr ""
+msgstr "Tu exportación de WordPress contiene {0} archivos multimedia."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:165
 msgid "Your YouTube channel ID or handle"
-msgstr ""
+msgstr "El identificador o identificador de tu canal de YouTube"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:162
 msgid "YouTube"
-msgstr ""
+msgstr "YouTube"

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -45,6 +45,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "pl", label: "Polski", enabled: true }, // Polish
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
+	{ code: "es-ES", label: "Español (España)", enabled: false }, // Spanish (Spain) - BCP 47
 	// Pseudo-locale for i18n testing - never enabled in the admin UI by default.
 	// Set EMDASH_PSEUDO_LOCALE=1 in .env to expose it in the locale switcher (dev only).
 	{ code: "pseudo", label: "Pseudo", enabled: false },

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -45,7 +45,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "pl", label: "Polski", enabled: true }, // Polish
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
-	{ code: "es-ES", label: "Español (España)", enabled: false }, // Spanish (Spain) - BCP 47
+	{ code: "es-ES", label: "Español (España)", enabled: true }, // Spanish (Spain) - BCP 47
 	// Pseudo-locale for i18n testing - never enabled in the admin UI by default.
 	// Set EMDASH_PSEUDO_LOCALE=1 in .env to expose it in the locale switcher (dev only).
 	{ code: "pseudo", label: "Pseudo", enabled: false },


### PR DESCRIPTION
## What does this PR do?

Adds Spanish (Spain) — `es-ES` — as a new translation locale for the EmDash admin UI.

- Registers `es-ES` in `packages/admin/src/locales/locales.ts` (label: `Español (España)`, `enabled: true`).
- Generates `packages/admin/src/locales/es-ES/messages.po` via `pnpm run locale:extract`.
- Translates all 1560 catalog entries into peninsular Spanish. Note that `es-419` (Latin American Spanish) already exists in the repo, but vocabulary, register, and grammar differ enough to justify a separate catalog (e.g. `ordenador` vs `computadora`, `móvil` vs `celular`, `vídeo` vs `video`, tuteo with peninsular imperatives, `vosotros` where applicable).

Conventions applied across the catalog:

- Tuteo throughout (`tú`, `tu`, `te`) — no `usted`, no `vos`.
- Infinitive forms for action buttons (`Guardar`, `Cancelar`, `Eliminar`, `Publicar`).
- Direct/imperative for inline helpers (`Pulsa aquí`, `Introduce tu correo`).
- Standard peninsular tech vocabulary: `correo electrónico`, `contraseña`, `hacer clic`, `siguiente`, `por defecto`, `actualizar`, `iniciar sesión`, `cerrar sesión`.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A, translation-only.
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — This **is** a translation PR, so `messages.po` changes are intentional.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A for translation-only changes.
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A, not a feature.

## AI-generated code disclosure

- [ ] This PR includes AI-generated code