### PR TITLE
Fix forms embed definition envelope handling

### DIFF
--- a/.changeset/forms-embed-definition-envelope.md
+++ b/.changeset/forms-embed-definition-envelope.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-forms": patch
+---
+
+Fix embedded forms so public rendering accepts the API response envelope returned by the form definition route.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"typecheck:templates": "pnpm run --workspace-concurrency=1 --filter {./templates/*} typecheck",
 		"check": "pnpm run typecheck && pnpm run --filter {./packages/*} check",
 		"test": "pnpm run --filter {./packages/*} test",
-		"test:unit": "pnpm run --filter emdash --filter @emdash-cms/auth --filter @emdash-cms/blocks --filter @emdash-cms/gutenberg-to-portable-text --filter @emdash-cms/marketplace --filter @emdash-cms/plugin-types --filter @emdash-cms/registry-cli --filter @emdash-cms/registry-client --filter @emdash-cms/registry-lexicons test",
+		"test:unit": "pnpm run --filter emdash --filter @emdash-cms/auth --filter @emdash-cms/blocks --filter @emdash-cms/gutenberg-to-portable-text --filter @emdash-cms/marketplace --filter @emdash-cms/plugin-forms --filter @emdash-cms/plugin-types --filter @emdash-cms/registry-cli --filter @emdash-cms/registry-client --filter @emdash-cms/registry-lexicons test",
 		"test:browser": "pnpm run --filter @emdash-cms/admin test",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",

--- a/packages/plugins/forms/package.json
+++ b/packages/plugins/forms/package.json
@@ -31,10 +31,14 @@
 		"@phosphor-icons/react": "^2.1.10",
 		"@cloudflare/kumo": "^1.0.0"
 	},
+	"devDependencies": {
+		"vitest": "catalog:"
+	},
 	"dependencies": {
 		"ulidx": "^2.4.1"
 	},
 	"scripts": {
+		"test": "vitest run",
 		"typecheck": "tsgo --noEmit"
 	},
 	"repository": {

--- a/packages/plugins/forms/src/astro/FormEmbed.astro
+++ b/packages/plugins/forms/src/astro/FormEmbed.astro
@@ -6,52 +6,11 @@
  * Without JavaScript, all pages are visible as one long form.
  * The client-side script enhances with multi-page navigation, AJAX, etc.
  */
+import { parsePublicFormDefinitionResponse } from "../public-definition.js";
+import type { FormField, FormPage } from "../types.js";
 
 interface Props {
 	node: { formId: string };
-}
-
-interface FormField {
-	id: string;
-	type: string;
-	label: string;
-	name: string;
-	placeholder?: string;
-	helpText?: string;
-	required: boolean;
-	validation?: {
-		minLength?: number;
-		maxLength?: number;
-		min?: number;
-		max?: number;
-		pattern?: string;
-		patternMessage?: string;
-		accept?: string;
-		maxFileSize?: number;
-	};
-	options?: Array<{ label: string; value: string }>;
-	defaultValue?: string;
-	width: "full" | "half";
-	condition?: { field: string; op: string; value?: string };
-}
-
-interface FormPage {
-	title?: string;
-	fields: FormField[];
-}
-
-interface FormDefinition {
-	name: string;
-	slug: string;
-	pages: FormPage[];
-	settings: {
-		spamProtection: string;
-		submitLabel: string;
-		nextLabel?: string;
-		prevLabel?: string;
-	};
-	status: string;
-	_turnstileSiteKey?: string | null;
 }
 
 const { node } = Astro.props;
@@ -67,10 +26,8 @@ const response = await fetch(
 	}
 );
 
-if (!response.ok) return;
-
-const form = (await response.json()) as FormDefinition;
-if (!form || form.status !== "active") return;
+const form = await parsePublicFormDefinitionResponse(response);
+if (!form) return;
 
 const submitUrl = `/_emdash/api/plugins/emdash-forms/submit`;
 const isMultiPage = form.pages.length > 1;

--- a/packages/plugins/forms/src/public-definition.ts
+++ b/packages/plugins/forms/src/public-definition.ts
@@ -1,0 +1,30 @@
+import { parseApiResponse } from "emdash/plugin-utils";
+
+import type { FormDefinition } from "./types.js";
+
+export interface PublicFormDefinition {
+	name: string;
+	slug: string;
+	pages: FormDefinition["pages"];
+	settings: Pick<
+		FormDefinition["settings"],
+		"spamProtection" | "submitLabel" | "nextLabel" | "prevLabel"
+	>;
+	status: FormDefinition["status"];
+	_turnstileSiteKey?: string | null;
+}
+
+export async function parsePublicFormDefinitionResponse(
+	response: Response,
+): Promise<PublicFormDefinition | null> {
+	if (!response.ok) {
+		return null;
+	}
+
+	const form = await parseApiResponse<PublicFormDefinition | undefined>(response);
+	if (!form || form.status !== "active") {
+		return null;
+	}
+
+	return form;
+}

--- a/packages/plugins/forms/tests/public-definition.test.ts
+++ b/packages/plugins/forms/tests/public-definition.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { PublicFormDefinition } from "../src/public-definition.js";
+import { parsePublicFormDefinitionResponse } from "../src/public-definition.js";
+
+const activeForm: PublicFormDefinition = {
+	name: "Contact",
+	slug: "contact",
+	pages: [
+		{
+			fields: [
+				{
+					id: "email",
+					type: "email",
+					label: "Email",
+					name: "email",
+					required: true,
+					width: "full",
+				},
+			],
+		},
+	],
+	settings: {
+		spamProtection: "none",
+		submitLabel: "Send",
+	},
+	status: "active",
+	_turnstileSiteKey: null,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("parsePublicFormDefinitionResponse", () => {
+	it("unwraps public plugin route responses from the standard API envelope", async () => {
+		await expect(
+			parsePublicFormDefinitionResponse(jsonResponse({ data: activeForm })),
+		).resolves.toEqual(activeForm);
+	});
+
+	it("returns null for missing form data", async () => {
+		await expect(
+			parsePublicFormDefinitionResponse(jsonResponse({ data: undefined })),
+		).resolves.toBeNull();
+	});
+
+	it("returns null for inactive forms and failed responses", async () => {
+		await expect(
+			parsePublicFormDefinitionResponse(
+				jsonResponse({ data: { ...activeForm, status: "paused" } }),
+			),
+		).resolves.toBeNull();
+
+		await expect(
+			parsePublicFormDefinitionResponse(jsonResponse({ error: { message: "Not found" } }, 404)),
+		).resolves.toBeNull();
+	});
+});

--- a/packages/plugins/forms/vitest.config.ts
+++ b/packages/plugins/forms/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["tests/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1737,6 +1737,10 @@ importers:
       ulidx:
         specifier: ^2.4.1
         version: 2.4.1
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@vitest/browser-playwright@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/marketplace-test:
     dependencies:


### PR DESCRIPTION
## What does this PR do?

Fixes embedded forms rendered by `@emdash-cms/plugin-forms` so the Astro block component reads the standard plugin API success envelope.

The public form definition route is exposed through the core plugin API route, which returns successful responses as `{ data: ... }`. `FormEmbed.astro` previously treated the whole JSON body as the form definition, so `form.status` was undefined and the form silently did not render.

This PR moves public definition response handling into a small forms-owned parser that reuses `emdash/plugin-utils`' existing `parseApiResponse()` envelope unwrapping, then uses that parser from the Astro embed component.

No related issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Validated locally on Windows:

- `pnpm build` passes
- `pnpm typecheck` passes
- `pnpm lint` passes with 0 errors
- `pnpm --filter @emdash-cms/plugin-forms test` passes
- `pnpm --filter @emdash-cms/plugin-forms typecheck` passes
- Targeted Prettier write/check for changed files passes
- `git diff --check` passes

Notes:

- `CI=true pnpm test:unit` currently fails locally on Windows before the forms test run because `@emdash-cms/marketplace`'s `publish-e2e.test.ts` invokes the built CLI and hits Node's ESM loader error for a `d:` absolute Windows path. This appears unrelated to this forms change.
- Full `pnpm format:check` reports repo-wide formatting issues on Windows, while targeted Prettier checks for this PR's changed files pass.
