### PR TITLE
fix(templates): guard Astro.cache.set with cache.enabled check

### DIFF
--- a/templates/blog-cloudflare/src/pages/category/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/category/[slug].astro
@@ -21,7 +21,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags on every post in this category, rather
 // than calling getEntryTerms() per post (which would be one round-trip

--- a/templates/blog-cloudflare/src/pages/index.astro
+++ b/templates/blog-cloudflare/src/pages/index.astro
@@ -23,7 +23,7 @@ const [{ entries: posts, cacheHint }, settings] = await Promise.all([
 ]);
 const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Trim the lookahead post used to detect overflow
 const visiblePosts = posts.slice(0, POSTS_PER_PAGE);

--- a/templates/blog-cloudflare/src/pages/pages/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/pages/[slug].astro
@@ -15,7 +15,7 @@ if (!page) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base

--- a/templates/blog-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/posts/[slug].astro
@@ -32,7 +32,7 @@ if (!post) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Get featured image URL for OG fallback
 // The image may have src (external) or meta.storageKey (local)

--- a/templates/blog-cloudflare/src/pages/posts/index.astro
+++ b/templates/blog-cloudflare/src/pages/posts/index.astro
@@ -9,7 +9,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags across all posts, instead of one
 // getEntryTerms() call per post (which would be N round-trips).

--- a/templates/blog-cloudflare/src/pages/tag/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/tag/[slug].astro
@@ -21,7 +21,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags on every post tagged with this term,
 // rather than calling getEntryTerms() per post.

--- a/templates/blog/src/pages/category/[slug].astro
+++ b/templates/blog/src/pages/category/[slug].astro
@@ -21,7 +21,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags on every post in this category, rather
 // than calling getEntryTerms() per post (which would be one round-trip

--- a/templates/blog/src/pages/index.astro
+++ b/templates/blog/src/pages/index.astro
@@ -23,7 +23,7 @@ const [{ entries: posts, cacheHint }, settings] = await Promise.all([
 ]);
 const { siteTitle, siteTagline } = resolveBlogSiteIdentity(settings);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Trim the lookahead post used to detect overflow
 const visiblePosts = posts.slice(0, POSTS_PER_PAGE);

--- a/templates/blog/src/pages/pages/[slug].astro
+++ b/templates/blog/src/pages/pages/[slug].astro
@@ -15,7 +15,7 @@ if (!page) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base

--- a/templates/blog/src/pages/posts/[slug].astro
+++ b/templates/blog/src/pages/posts/[slug].astro
@@ -32,7 +32,7 @@ if (!post) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Get featured image URL for OG fallback
 // The image may have src (external) or meta.storageKey (local)

--- a/templates/blog/src/pages/posts/index.astro
+++ b/templates/blog/src/pages/posts/index.astro
@@ -9,7 +9,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags across all posts, instead of one
 // getEntryTerms() call per post (which would be N round-trips).

--- a/templates/blog/src/pages/tag/[slug].astro
+++ b/templates/blog/src/pages/tag/[slug].astro
@@ -21,7 +21,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags on every post tagged with this term,
 // rather than calling getEntryTerms() per post.

--- a/templates/marketing-cloudflare/src/pages/index.astro
+++ b/templates/marketing-cloudflare/src/pages/index.astro
@@ -5,7 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "home");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 const pageTitle = page?.data.title;
 const pageContent = page?.data.content;

--- a/templates/marketing-cloudflare/src/pages/pricing.astro
+++ b/templates/marketing-cloudflare/src/pages/pricing.astro
@@ -5,7 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "pricing");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 const pageContent = page?.data.content;
 ---

--- a/templates/marketing/src/pages/index.astro
+++ b/templates/marketing/src/pages/index.astro
@@ -5,7 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "home");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 const pageTitle = page?.data.title;
 const pageContent = page?.data.content;

--- a/templates/marketing/src/pages/pricing.astro
+++ b/templates/marketing/src/pages/pricing.astro
@@ -5,7 +5,7 @@ import MarketingBlocks from "../components/MarketingBlocks.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "pricing");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 const pageContent = page?.data.content;
 ---

--- a/templates/portfolio-cloudflare/src/pages/about.astro
+++ b/templates/portfolio-cloudflare/src/pages/about.astro
@@ -5,7 +5,7 @@ import Base from "../layouts/Base.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "about");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base title="About" description="Learn more about who we are and what we do.">

--- a/templates/portfolio-cloudflare/src/pages/index.astro
+++ b/templates/portfolio-cloudflare/src/pages/index.astro
@@ -14,7 +14,7 @@ const [settings, { entries: featuredProjects, cacheHint }] = await Promise.all([
 	}),
 ]);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base>

--- a/templates/portfolio-cloudflare/src/pages/work/[slug].astro
+++ b/templates/portfolio-cloudflare/src/pages/work/[slug].astro
@@ -16,7 +16,7 @@ if (!project) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Related projects: order by date in the DB and request a small lookahead
 // so we can drop the current entry without re-querying. Avoids loading

--- a/templates/portfolio-cloudflare/src/pages/work/index.astro
+++ b/templates/portfolio-cloudflare/src/pages/work/index.astro
@@ -23,7 +23,7 @@ const [{ entries: sortedProjects, cacheHint }, tags] = await Promise.all([
 	getTaxonomyTerms("tag"),
 ]);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched JOIN for the tag pills shown on each card, instead of
 // one getEntryTerms() round-trip per card.

--- a/templates/portfolio/src/pages/about.astro
+++ b/templates/portfolio/src/pages/about.astro
@@ -5,7 +5,7 @@ import Base from "../layouts/Base.astro";
 
 const { entry: page, cacheHint } = await getEmDashEntry("pages", "about");
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base title="About" description="Learn more about who we are and what we do.">

--- a/templates/portfolio/src/pages/index.astro
+++ b/templates/portfolio/src/pages/index.astro
@@ -14,7 +14,7 @@ const [settings, { entries: featuredProjects, cacheHint }] = await Promise.all([
 	}),
 ]);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base>

--- a/templates/portfolio/src/pages/work/[slug].astro
+++ b/templates/portfolio/src/pages/work/[slug].astro
@@ -16,7 +16,7 @@ if (!project) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Related projects: order by date in the DB and request a small lookahead
 // so we can drop the current entry without re-querying. Avoids loading

--- a/templates/portfolio/src/pages/work/index.astro
+++ b/templates/portfolio/src/pages/work/index.astro
@@ -23,7 +23,7 @@ const [{ entries: sortedProjects, cacheHint }, tags] = await Promise.all([
 	getTaxonomyTerms("tag"),
 ]);
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched JOIN for the tag pills shown on each card, instead of
 // one getEntryTerms() round-trip per card.

--- a/templates/starter-cloudflare/src/pages/[slug].astro
+++ b/templates/starter-cloudflare/src/pages/[slug].astro
@@ -16,7 +16,7 @@ if (!page) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 const { siteTitle } = resolveStarterSiteIdentity(await getSiteSettings());
 
 const seo = getSeoMeta(page, {

--- a/templates/starter-cloudflare/src/pages/index.astro
+++ b/templates/starter-cloudflare/src/pages/index.astro
@@ -8,7 +8,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 const { siteTitle, siteTagline } = resolveStarterSiteIdentity(await getSiteSettings());
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base title={siteTitle} description={siteTagline}>

--- a/templates/starter-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/starter-cloudflare/src/pages/posts/[slug].astro
@@ -16,7 +16,7 @@ if (!post) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 const { siteTitle } = resolveStarterSiteIdentity(await getSiteSettings());
 
 // SEO meta from content fields

--- a/templates/starter-cloudflare/src/pages/posts/index.astro
+++ b/templates/starter-cloudflare/src/pages/posts/index.astro
@@ -6,7 +6,7 @@ import Base from "../../layouts/Base.astro";
 const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags across every post, instead of calling
 // getEntryTerms() per post (which would be N round-trips).

--- a/templates/starter/src/pages/[slug].astro
+++ b/templates/starter/src/pages/[slug].astro
@@ -16,7 +16,7 @@ if (!page) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 const { siteTitle } = resolveStarterSiteIdentity(await getSiteSettings());
 
 const seo = getSeoMeta(page, {

--- a/templates/starter/src/pages/index.astro
+++ b/templates/starter/src/pages/index.astro
@@ -8,7 +8,7 @@ const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
 const { siteTitle, siteTagline } = resolveStarterSiteIdentity(await getSiteSettings());
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 ---
 
 <Base title={siteTitle} description={siteTagline}>

--- a/templates/starter/src/pages/posts/[slug].astro
+++ b/templates/starter/src/pages/posts/[slug].astro
@@ -16,7 +16,7 @@ if (!post) {
 	return Astro.redirect("/404");
 }
 
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 const { siteTitle } = resolveStarterSiteIdentity(await getSiteSettings());
 
 // SEO meta from content fields

--- a/templates/starter/src/pages/posts/index.astro
+++ b/templates/starter/src/pages/posts/index.astro
@@ -6,7 +6,7 @@ import Base from "../../layouts/Base.astro";
 const { entries: posts, cacheHint } = await getEmDashCollection("posts", {
 	orderBy: { published_at: "desc" },
 });
-Astro.cache.set(cacheHint);
+if (Astro.cache?.enabled) Astro.cache.set(cacheHint);
 
 // Single batched query for tags across every post, instead of calling
 // getEntryTerms() per post (which would be N round-trips).


### PR DESCRIPTION
## What does this PR do?

Wraps every unguarded `Astro.cache.set(cacheHint)` call in the base templates (`blog`, `starter`, `portfolio`, `marketing`) with `if (Astro.cache?.enabled)`, then runs `sync-cloudflare-templates.sh` to propagate the change to the four cloudflare variants. The `CacheLike` contract says `enabled` is `false` when no cache provider is configured or in dev mode — calling `cache.set` in those cases is wasteful (and noisy on adapters that throw).

`marketing/src/pages/contact.astro` is intentionally left alone: it already wraps `cache.set` in a `try/catch` for the POST-response case, which the `enabled` check doesn't cover.

Fixes #945

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A, template-only edit
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — N/A, templates are in changeset `ignore` list
- [ ] New features link to an approved Discussion: N/A

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Claude Code)

## Screenshots / test output

Verification:

- Before: 16 unguarded `Astro.cache.set(cacheHint);` calls across base templates.
- After: 32 calls of the form `if (Astro.cache?.enabled) Astro.cache.set(cacheHint);` (16 base × 2 with the synced cloudflare variants). The only remaining unguarded calls are the two `contact.astro` files, which keep their `try/catch`.