### PR TITLE
fix(forms): render public form embeds via SSR plugin routes

### DIFF
--- a/.changeset/public-form-ssr-routes.md
+++ b/.changeset/public-form-ssr-routes.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/plugin-forms": patch
+---
+
+Fixes public form embeds during SSR by allowing frontend plugin components to call public plugin routes without self-fetching.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -369,9 +369,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					try {
 						const runtime = await getRuntime(config, initSubTimings);
 						setupVerified = true;
+						const handlePublicPluginApiRoute = createPublicPluginApiRouteHandler(runtime);
 						// eslint-disable-next-line typescript/no-unsafe-type-assertion -- partial object; getPageRuntime() only checks for the page-contribution methods
 						locals.emdash = {
-							handlePluginApiRoute: createPublicPluginApiRouteHandler(runtime),
+							handlePublicPluginApiRoute,
 							collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
 							collectPageFragments: runtime.collectPageFragments.bind(runtime),
 							getPublicMediaUrl: createPublicMediaUrlResolver(runtime.storage),
@@ -498,6 +499,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 					// Plugin routes
 					handlePluginApiRoute: runtime.handlePluginApiRoute.bind(runtime),
+					handlePublicPluginApiRoute: createPublicPluginApiRouteHandler(runtime),
 					getPluginRouteMeta: runtime.getPluginRouteMeta.bind(runtime),
 
 					// Media provider methods

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -51,6 +51,7 @@ import {
 	runWithContext,
 } from "../request-context.js";
 import type { EmDashConfig } from "./integration/runtime.js";
+import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js";
 import type { EmDashHandlers } from "./types.js";
 
 // Cached runtime instance (persists across requests within worker)
@@ -370,6 +371,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 						setupVerified = true;
 						// eslint-disable-next-line typescript/no-unsafe-type-assertion -- partial object; getPageRuntime() only checks for the page-contribution methods
 						locals.emdash = {
+							handlePluginApiRoute: createPublicPluginApiRouteHandler(runtime),
 							collectPageMetadata: runtime.collectPageMetadata.bind(runtime),
 							collectPageFragments: runtime.collectPageFragments.bind(runtime),
 							getPublicMediaUrl: createPublicMediaUrlResolver(runtime.storage),

--- a/packages/core/src/astro/public-plugin-api-routes.ts
+++ b/packages/core/src/astro/public-plugin-api-routes.ts
@@ -1,0 +1,41 @@
+import type { HandlerResponse } from "./types.js";
+
+export type PublicPluginApiRouteHandler = (
+	pluginId: string,
+	method: string,
+	path: string,
+	request: Request,
+) => Promise<HandlerResponse>;
+
+interface PublicPluginApiRouteRuntime {
+	getPluginRouteMeta(pluginId: string, path: string): { public: boolean } | null;
+	handlePluginApiRoute(
+		pluginId: string,
+		method: string,
+		path: string,
+		request: Request,
+	): Promise<HandlerResponse>;
+}
+
+function pluginRouteNotFound(): HandlerResponse {
+	return {
+		success: false,
+		error: {
+			code: "NOT_FOUND",
+			message: "Plugin route not found",
+		},
+	};
+}
+
+export function createPublicPluginApiRouteHandler(
+	runtime: PublicPluginApiRouteRuntime,
+): PublicPluginApiRouteHandler {
+	return async (pluginId, method, path, request) => {
+		const meta = runtime.getPluginRouteMeta(pluginId, path);
+		if (meta?.public !== true) {
+			return pluginRouteNotFound();
+		}
+
+		return runtime.handlePluginApiRoute(pluginId, method, path, request);
+	};
+}

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -385,6 +385,14 @@ export interface EmDashHandlers {
 		request: Request,
 	) => Promise<HandlerResponse>;
 
+	// Public-only plugin API route handler for SSR page components.
+	handlePublicPluginApiRoute: (
+		pluginId: string,
+		method: string,
+		path: string,
+		request: Request,
+	) => Promise<HandlerResponse>;
+
 	// Plugin route metadata (for auth decisions before dispatch)
 	getPluginRouteMeta: (pluginId: string, path: string) => { public: boolean } | null;
 

--- a/packages/core/src/plugin-utils.ts
+++ b/packages/core/src/plugin-utils.ts
@@ -8,6 +8,16 @@
  * Import as: `import { apiFetch, parseApiResponse, isRecord } from "emdash/plugin-utils";`
  */
 
+import type { EmDashHandlers } from "./astro/types.js";
+
+export type PublicPluginApiRouteHandler = EmDashHandlers["handlePublicPluginApiRoute"];
+
+export interface PublicPluginRuntimeLocals {
+	emdash?: {
+		handlePublicPluginApiRoute?: PublicPluginApiRouteHandler;
+	};
+}
+
 /**
  * Fetch wrapper that adds the `X-EmDash-Request` CSRF protection header.
  *
@@ -18,6 +28,19 @@ export function apiFetch(input: string | URL | Request, init?: RequestInit): Pro
 	const headers = new Headers(init?.headers);
 	headers.set("X-EmDash-Request", "1");
 	return fetch(input, { ...init, headers });
+}
+
+/**
+ * Get the public-only plugin route dispatcher exposed to SSR page components.
+ *
+ * This intentionally reads `handlePublicPluginApiRoute`, not the raw
+ * `handlePluginApiRoute` used by core's authenticated plugin API route.
+ */
+export function getPublicPluginApiRouteHandler(
+	locals: PublicPluginRuntimeLocals | null | undefined,
+): PublicPluginApiRouteHandler | undefined {
+	const handler = locals?.emdash?.handlePublicPluginApiRoute;
+	return typeof handler === "function" ? handler : undefined;
 }
 
 /**

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -11,28 +11,78 @@ const { DB_CONFIG_MARKER } = vi.hoisted(() => ({
 	DB_CONFIG_MARKER: { binding: "DB", session: "auto" },
 }));
 
-const { MOCK_RUNTIME } = vi.hoisted(() => ({
-	MOCK_RUNTIME: new Proxy(
-		{
-			storage: null,
+const {
+	MOCK_RUNTIME,
+	PUBLIC_PLUGIN_RESULT,
+	mockGetPluginRouteMeta,
+	mockHandlePluginApiRoute,
+	mockGetPublicUrl,
+} = vi.hoisted(() => {
+	const publicPluginResult = { success: true, data: { ok: true } };
+	const ok = async () => ({ success: true });
+	const getPublicUrl = vi.fn((key: string) => `https://media.example.com/${key}`);
+	const getPluginRouteMeta = vi.fn((pluginId: string, path: string) => {
+		if (pluginId !== "emdash-forms") return null;
+		if (path === "/definition") return { public: true };
+		if (path === "/private") return { public: false };
+		return null;
+	});
+	const handlePluginApiRoute = vi.fn(async () => publicPluginResult);
+
+	return {
+		MOCK_RUNTIME: {
+			storage: { getPublicUrl },
 			db: {},
 			hooks: {},
 			email: null,
 			configuredPlugins: [],
+			handleContentList: ok,
+			handleContentGet: ok,
+			handleContentCreate: ok,
+			handleContentUpdate: ok,
+			handleContentDelete: ok,
+			handleContentListTrashed: ok,
+			handleContentRestore: ok,
+			handleContentPermanentDelete: ok,
+			handleContentCountTrashed: ok,
+			handleContentGetIncludingTrashed: ok,
+			handleContentDuplicate: ok,
+			handleContentPublish: ok,
+			handleContentUnpublish: ok,
+			handleContentSchedule: ok,
+			handleContentUnschedule: ok,
+			handleContentCountScheduled: ok,
+			handleContentDiscardDraft: ok,
+			handleContentCompare: ok,
+			handleContentTranslations: ok,
+			handleMediaList: ok,
+			handleMediaGet: ok,
+			handleMediaCreate: ok,
+			handleMediaUpdate: ok,
+			handleMediaDelete: ok,
+			handleRevisionList: ok,
+			handleRevisionGet: ok,
+			handleRevisionRestore: ok,
+			getPluginRouteMeta,
+			handlePluginApiRoute,
+			getMediaProvider: () => undefined,
+			getMediaProviderList: () => [],
+			collectPageMetadata: async () => [],
+			collectPageFragments: async () => [],
+			ensureSearchHealthy: async () => undefined,
+			getManifest: async () => ({}),
+			getSandboxRunner: () => null,
+			isSandboxBypassed: () => false,
+			syncMarketplacePlugins: async () => undefined,
+			syncRegistryPlugins: async () => undefined,
+			setPluginStatus: async () => undefined,
 		},
-		{
-			get(target, prop) {
-				if (prop === "then") return undefined;
-				if (prop in target) return target[prop as keyof typeof target];
-				if (prop === "getPluginRouteMeta") return () => ({ public: true });
-				if (prop === "handlePluginApiRoute") return async () => ({ success: true, data: {} });
-				if (prop === "collectPageMetadata") return async () => [];
-				if (prop === "collectPageFragments") return async () => [];
-				return async () => ({ success: true });
-			},
-		},
-	),
-}));
+		PUBLIC_PLUGIN_RESULT: publicPluginResult,
+		mockGetPluginRouteMeta: getPluginRouteMeta,
+		mockHandlePluginApiRoute: handlePluginApiRoute,
+		mockGetPublicUrl: getPublicUrl,
+	};
+});
 
 vi.mock(
 	"virtual:emdash/config",
@@ -60,6 +110,7 @@ vi.mock(
 	"virtual:emdash/sandbox-runner",
 	() => ({
 		createSandboxRunner: null,
+		sandboxBypassed: false,
 		sandboxEnabled: false,
 	}),
 	{ virtual: true },
@@ -91,21 +142,51 @@ import { createRequestScopedDb } from "virtual:emdash/dialect";
 import onRequest from "../../../src/astro/middleware.js";
 import { getRequestContext } from "../../../src/request-context.js";
 
+function createAnonymousPublicPageContext(locals: Record<string, unknown> = {}) {
+	const cookies = {
+		get: vi.fn((name: string) => {
+			if (name === "astro-session") return undefined;
+			return undefined;
+		}),
+		set: vi.fn(),
+	};
+	const sessionGet = vi.fn(async () => null);
+	const astroSession = { get: sessionGet };
+
+	return {
+		context: {
+			request: new Request("https://example.com/contact"),
+			url: new URL("https://example.com/contact"),
+			cookies,
+			locals,
+			redirect: vi.fn(),
+			isPrerendered: false,
+			session: astroSession,
+		} as Record<string, unknown>,
+		cookies,
+		sessionGet,
+	};
+}
+
 describe("astro middleware prerendered routes", () => {
 	beforeEach(() => {
 		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+		mockGetPluginRouteMeta.mockClear();
+		mockHandlePluginApiRoute.mockClear();
+		mockGetPublicUrl.mockClear();
 	});
 
 	it("does not access context.session on prerendered public runtime routes", async () => {
 		const cookies = {
 			get: vi.fn(() => undefined),
 		};
+		const locals: Record<string, unknown> = {};
 
 		const context: Record<string, unknown> = {
 			request: new Request("https://example.com/robots.txt"),
 			url: new URL("https://example.com/robots.txt"),
 			cookies,
-			locals: {},
+			locals,
 			redirect: vi.fn(),
 			isPrerendered: true,
 		};
@@ -122,6 +203,9 @@ describe("astro middleware prerendered routes", () => {
 		);
 
 		expect(response.status).toBe(200);
+		const emdash = locals.emdash as Record<string, unknown>;
+		expect(typeof emdash.handlePluginApiRoute).toBe("function");
+		expect(typeof emdash.handlePublicPluginApiRoute).toBe("function");
 	});
 
 	it("does not access context.session when prerendering public pages", async () => {
@@ -160,6 +244,9 @@ describe("astro middleware prerendered routes", () => {
 describe("astro middleware anonymous session reads", () => {
 	beforeEach(() => {
 		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+		mockGetPluginRouteMeta.mockClear();
+		mockHandlePluginApiRoute.mockClear();
+		mockGetPublicUrl.mockClear();
 	});
 
 	it("does not read the Astro session when no astro-session cookie is present", async () => {
@@ -197,26 +284,8 @@ describe("astro middleware anonymous session reads", () => {
 	});
 
 	it("exposes only restricted public runtime helpers to anonymous public pages", async () => {
-		const cookies = {
-			get: vi.fn((name: string) => {
-				if (name === "astro-session") return undefined;
-				return undefined;
-			}),
-			set: vi.fn(),
-		};
-		const sessionGet = vi.fn(async () => null);
-		const astroSession = { get: sessionGet };
 		const locals: Record<string, unknown> = {};
-
-		const context: Record<string, unknown> = {
-			request: new Request("https://example.com/contact"),
-			url: new URL("https://example.com/contact"),
-			cookies,
-			locals,
-			redirect: vi.fn(),
-			isPrerendered: false,
-			session: astroSession,
-		};
+		const { context, sessionGet } = createAnonymousPublicPageContext(locals);
 
 		const response = await onRequest(
 			context as Parameters<typeof onRequest>[0],
@@ -226,13 +295,82 @@ describe("astro middleware anonymous session reads", () => {
 		expect(response.status).toBe(200);
 		expect(sessionGet).not.toHaveBeenCalled();
 		const emdash = locals.emdash as Record<string, unknown>;
-		expect(typeof emdash.handlePluginApiRoute).toBe("function");
+		expect(typeof emdash.handlePublicPluginApiRoute).toBe("function");
 		expect(typeof emdash.collectPageMetadata).toBe("function");
 		expect(typeof emdash.collectPageFragments).toBe("function");
+		expect(typeof emdash.getPublicMediaUrl).toBe("function");
+		expect((emdash.getPublicMediaUrl as (key: string) => string)("01ABC.jpg")).toBe(
+			"https://media.example.com/01ABC.jpg",
+		);
+		expect(mockGetPublicUrl).toHaveBeenCalledWith("01ABC.jpg");
+		expect("handlePluginApiRoute" in emdash).toBe(false);
 		expect("getPluginRouteMeta" in emdash).toBe(false);
 		expect("handleContentList" in emdash).toBe(false);
 		expect("db" in emdash).toBe(false);
 		expect("config" in emdash).toBe(false);
+	});
+
+	it("dispatches public plugin API routes through the anonymous public-page helper", async () => {
+		const locals: Record<string, unknown> = {};
+		const { context } = createAnonymousPublicPageContext(locals);
+
+		await onRequest(context as Parameters<typeof onRequest>[0], async () => new Response("ok"));
+
+		const emdash = locals.emdash as Record<string, unknown>;
+		const request = new Request("https://example.com/_emdash/api/plugins/emdash-forms/definition", {
+			method: "POST",
+			body: "{}",
+		});
+
+		await expect(
+			(
+				emdash.handlePublicPluginApiRoute as (
+					pluginId: string,
+					method: string,
+					path: string,
+					request: Request,
+				) => Promise<unknown>
+			)("emdash-forms", "POST", "/definition", request),
+		).resolves.toBe(PUBLIC_PLUGIN_RESULT);
+
+		expect(mockGetPluginRouteMeta).toHaveBeenCalledWith("emdash-forms", "/definition");
+		expect(mockHandlePluginApiRoute).toHaveBeenCalledWith(
+			"emdash-forms",
+			"POST",
+			"/definition",
+			request,
+		);
+	});
+
+	it("does not dispatch private plugin API routes through the anonymous public-page helper", async () => {
+		const locals: Record<string, unknown> = {};
+		const { context } = createAnonymousPublicPageContext(locals);
+
+		await onRequest(context as Parameters<typeof onRequest>[0], async () => new Response("ok"));
+
+		const emdash = locals.emdash as Record<string, unknown>;
+
+		await expect(
+			(
+				emdash.handlePublicPluginApiRoute as (
+					pluginId: string,
+					method: string,
+					path: string,
+					request: Request,
+				) => Promise<unknown>
+			)(
+				"emdash-forms",
+				"POST",
+				"/private",
+				new Request("https://example.com/_emdash/api/plugins/emdash-forms/private"),
+			),
+		).resolves.toEqual({
+			success: false,
+			error: { code: "NOT_FOUND", message: "Plugin route not found" },
+		});
+
+		expect(mockGetPluginRouteMeta).toHaveBeenCalledWith("emdash-forms", "/private");
+		expect(mockHandlePluginApiRoute).not.toHaveBeenCalled();
 	});
 
 	it("reads the Astro session when an astro-session cookie is present", async () => {
@@ -271,6 +409,9 @@ describe("astro middleware anonymous session reads", () => {
 describe("astro middleware request-scoped db", () => {
 	beforeEach(() => {
 		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+		mockGetPluginRouteMeta.mockClear();
+		mockHandlePluginApiRoute.mockClear();
+		mockGetPublicUrl.mockClear();
 	});
 
 	it("asks the adapter for a scoped db on anonymous public pages and exposes it via ALS", async () => {

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -11,6 +11,29 @@ const { DB_CONFIG_MARKER } = vi.hoisted(() => ({
 	DB_CONFIG_MARKER: { binding: "DB", session: "auto" },
 }));
 
+const { MOCK_RUNTIME } = vi.hoisted(() => ({
+	MOCK_RUNTIME: new Proxy(
+		{
+			storage: null,
+			db: {},
+			hooks: {},
+			email: null,
+			configuredPlugins: [],
+		},
+		{
+			get(target, prop) {
+				if (prop === "then") return undefined;
+				if (prop in target) return target[prop as keyof typeof target];
+				if (prop === "getPluginRouteMeta") return () => ({ public: true });
+				if (prop === "handlePluginApiRoute") return async () => ({ success: true, data: {} });
+				if (prop === "collectPageMetadata") return async () => [];
+				if (prop === "collectPageFragments") return async () => [];
+				return async () => ({ success: true });
+			},
+		},
+	),
+}));
+
 vi.mock(
 	"virtual:emdash/config",
 	() => ({
@@ -44,6 +67,12 @@ vi.mock(
 vi.mock("virtual:emdash/sandboxed-plugins", () => ({ sandboxedPlugins: [] }), { virtual: true });
 vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: true });
 vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
+
+vi.mock("../../../src/emdash-runtime.js", () => ({
+	EmDashRuntime: {
+		create: async () => MOCK_RUNTIME,
+	},
+}));
 
 vi.mock("../../../src/loader.js", () => ({
 	getDb: vi.fn(async () => ({
@@ -165,6 +194,45 @@ describe("astro middleware anonymous session reads", () => {
 
 		expect(response.status).toBe(200);
 		expect(sessionGet).not.toHaveBeenCalled();
+	});
+
+	it("exposes only restricted public runtime helpers to anonymous public pages", async () => {
+		const cookies = {
+			get: vi.fn((name: string) => {
+				if (name === "astro-session") return undefined;
+				return undefined;
+			}),
+			set: vi.fn(),
+		};
+		const sessionGet = vi.fn(async () => null);
+		const astroSession = { get: sessionGet };
+		const locals: Record<string, unknown> = {};
+
+		const context: Record<string, unknown> = {
+			request: new Request("https://example.com/contact"),
+			url: new URL("https://example.com/contact"),
+			cookies,
+			locals,
+			redirect: vi.fn(),
+			isPrerendered: false,
+			session: astroSession,
+		};
+
+		const response = await onRequest(
+			context as Parameters<typeof onRequest>[0],
+			async () => new Response("ok"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(sessionGet).not.toHaveBeenCalled();
+		const emdash = locals.emdash as Record<string, unknown>;
+		expect(typeof emdash.handlePluginApiRoute).toBe("function");
+		expect(typeof emdash.collectPageMetadata).toBe("function");
+		expect(typeof emdash.collectPageFragments).toBe("function");
+		expect("getPluginRouteMeta" in emdash).toBe(false);
+		expect("handleContentList" in emdash).toBe(false);
+		expect("db" in emdash).toBe(false);
+		expect("config" in emdash).toBe(false);
 	});
 
 	it("reads the Astro session when an astro-session cookie is present", async () => {

--- a/packages/core/tests/unit/astro/public-plugin-api-routes.test.ts
+++ b/packages/core/tests/unit/astro/public-plugin-api-routes.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPublicPluginApiRouteHandler } from "../../../src/astro/public-plugin-api-routes.js";
+
+function createRuntime(meta: { public: boolean } | null) {
+	const result = { success: true, data: { ok: true } };
+	const handlePluginApiRoute = vi.fn(async () => result);
+	const getPluginRouteMeta = vi.fn(() => meta);
+
+	return {
+		runtime: {
+			getPluginRouteMeta,
+			handlePluginApiRoute,
+		},
+		getPluginRouteMeta,
+		handlePluginApiRoute,
+		result,
+	};
+}
+
+describe("createPublicPluginApiRouteHandler", () => {
+	it("delegates to the runtime when the plugin route is public", async () => {
+		const { runtime, getPluginRouteMeta, handlePluginApiRoute, result } = createRuntime({
+			public: true,
+		});
+		const request = new Request("https://example.com/_emdash/api/plugins/demo/definition", {
+			method: "POST",
+			body: "{}",
+		});
+
+		const handler = createPublicPluginApiRouteHandler(runtime);
+		const actual = await handler("demo", "POST", "/definition", request);
+
+		expect(getPluginRouteMeta).toHaveBeenCalledWith("demo", "/definition");
+		expect(handlePluginApiRoute).toHaveBeenCalledWith("demo", "POST", "/definition", request);
+		expect(actual).toBe(result);
+	});
+
+	it("returns not found without invoking private plugin routes", async () => {
+		const { runtime, handlePluginApiRoute } = createRuntime({ public: false });
+		const handler = createPublicPluginApiRouteHandler(runtime);
+
+		const result = await handler(
+			"demo",
+			"POST",
+			"/admin",
+			new Request("https://example.com/_emdash/api/plugins/demo/admin"),
+		);
+
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			success: false,
+			error: {
+				code: "NOT_FOUND",
+				message: "Plugin route not found",
+			},
+		});
+	});
+
+	it("returns not found without invoking missing plugin routes", async () => {
+		const { runtime, handlePluginApiRoute } = createRuntime(null);
+		const handler = createPublicPluginApiRouteHandler(runtime);
+
+		const result = await handler(
+			"demo",
+			"POST",
+			"/missing",
+			new Request("https://example.com/_emdash/api/plugins/demo/missing"),
+		);
+
+		expect(handlePluginApiRoute).not.toHaveBeenCalled();
+		expect(result.error?.code).toBe("NOT_FOUND");
+	});
+});

--- a/packages/core/tests/utils/mcp-runtime.ts
+++ b/packages/core/tests/utils/mcp-runtime.ts
@@ -212,6 +212,9 @@ export function handlersFromRuntime(runtime: EmDashRuntime): EmDashHandlers {
 		handlePluginApiRoute: () => {
 			throw new Error("handlePluginApiRoute not implemented in test runtime");
 		},
+		handlePublicPluginApiRoute: () => {
+			throw new Error("handlePublicPluginApiRoute not implemented in test runtime");
+		},
 		getPluginRouteMeta: () => null,
 		getMediaProvider: runtime.getMediaProvider.bind(runtime),
 		getMediaProviderList: runtime.getMediaProviderList.bind(runtime),

--- a/packages/plugins/forms/src/astro/FormEmbed.astro
+++ b/packages/plugins/forms/src/astro/FormEmbed.astro
@@ -6,10 +6,9 @@
  * Without JavaScript, all pages are visible as one long form.
  * The client-side script enhances with multi-page navigation, AJAX, etc.
  */
-import {
-	loadPublicFormDefinition,
-	type PublicPluginApiRouteHandler,
-} from "../public-definition.js";
+import { getPublicPluginApiRouteHandler } from "emdash/plugin-utils";
+
+import { loadPublicFormDefinition } from "../public-definition.js";
 import type { FormField, FormPage } from "../types.js";
 
 interface Props {
@@ -19,14 +18,12 @@ interface Props {
 const { node } = Astro.props;
 const formId = node.formId;
 
-const handlePluginApiRoute = (Astro.locals.emdash as
-	| { handlePluginApiRoute?: PublicPluginApiRouteHandler }
-	| undefined)?.handlePluginApiRoute;
+const handlePublicPluginApiRoute = getPublicPluginApiRouteHandler(Astro.locals);
 
 const form = await loadPublicFormDefinition({
 	formId,
 	baseUrl: Astro.url,
-	handlePluginApiRoute,
+	handlePublicPluginApiRoute,
 });
 if (!form) return;
 

--- a/packages/plugins/forms/src/astro/FormEmbed.astro
+++ b/packages/plugins/forms/src/astro/FormEmbed.astro
@@ -6,7 +6,10 @@
  * Without JavaScript, all pages are visible as one long form.
  * The client-side script enhances with multi-page navigation, AJAX, etc.
  */
-import { parsePublicFormDefinitionResponse } from "../public-definition.js";
+import {
+	loadPublicFormDefinition,
+	type PublicPluginApiRouteHandler,
+} from "../public-definition.js";
 import type { FormField, FormPage } from "../types.js";
 
 interface Props {
@@ -16,17 +19,15 @@ interface Props {
 const { node } = Astro.props;
 const formId = node.formId;
 
-// Fetch form definition server-side
-const response = await fetch(
-	new URL("/_emdash/api/plugins/emdash-forms/definition", Astro.url),
-	{
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ id: formId }),
-	}
-);
+const handlePluginApiRoute = (Astro.locals.emdash as
+	| { handlePluginApiRoute?: PublicPluginApiRouteHandler }
+	| undefined)?.handlePluginApiRoute;
 
-const form = await parsePublicFormDefinitionResponse(response);
+const form = await loadPublicFormDefinition({
+	formId,
+	baseUrl: Astro.url,
+	handlePluginApiRoute,
+});
 if (!form) return;
 
 const submitUrl = `/_emdash/api/plugins/emdash-forms/submit`;

--- a/packages/plugins/forms/src/public-definition.ts
+++ b/packages/plugins/forms/src/public-definition.ts
@@ -1,4 +1,4 @@
-import { parseApiResponse } from "emdash/plugin-utils";
+import { parseApiResponse, type PublicPluginApiRouteHandler } from "emdash/plugin-utils";
 
 import type { FormDefinition } from "./types.js";
 
@@ -14,45 +14,130 @@ export interface PublicFormDefinition {
 	_turnstileSiteKey?: string | null;
 }
 
-export type PublicPluginApiRouteHandler = (
-	pluginId: string,
-	method: string,
-	path: string,
-	request: Request,
-) => Promise<unknown>;
-
 interface LoadPublicFormDefinitionOptions {
 	formId: string;
 	baseUrl: URL;
-	handlePluginApiRoute?: PublicPluginApiRouteHandler;
+	handlePublicPluginApiRoute?: PublicPluginApiRouteHandler;
 	fetch?: (input: Request) => Promise<Response>;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function parsePublicFormDefinitionPayload(payload: unknown): PublicFormDefinition | null {
+function isOptionalString(value: unknown): boolean {
+	return value === undefined || typeof value === "string";
+}
+
+function isOptionalStringOrNull(value: unknown): boolean {
+	return value === undefined || value === null || typeof value === "string";
+}
+
+const VALID_FIELD_TYPES = new Set([
+	"text",
+	"email",
+	"textarea",
+	"number",
+	"tel",
+	"url",
+	"date",
+	"select",
+	"radio",
+	"checkbox",
+	"checkbox-group",
+	"file",
+	"hidden",
+]);
+
+const VALID_SPAM_PROTECTION = new Set(["none", "honeypot", "turnstile"]);
+
+function hasValidOptions(value: unknown): boolean {
+	return (
+		value === undefined ||
+		(Array.isArray(value) &&
+			value.every(
+				(option) =>
+					isObject(option) &&
+					typeof option.label === "string" &&
+					typeof option.value === "string",
+			))
+	);
+}
+
+function isPublicFormField(value: unknown): boolean {
+	if (!isObject(value)) {
+		return false;
+	}
+
+	return (
+		typeof value.id === "string" &&
+		typeof value.type === "string" &&
+		VALID_FIELD_TYPES.has(value.type) &&
+		typeof value.label === "string" &&
+		typeof value.name === "string" &&
+		typeof value.required === "boolean" &&
+		(value.width === "full" || value.width === "half") &&
+		isOptionalString(value.placeholder) &&
+		isOptionalString(value.helpText) &&
+		isOptionalString(value.defaultValue) &&
+		hasValidOptions(value.options) &&
+		(value.validation === undefined || isObject(value.validation)) &&
+		(value.condition === undefined || isObject(value.condition))
+	);
+}
+
+function isPublicFormPage(value: unknown): boolean {
+	return (
+		isObject(value) &&
+		isOptionalString(value.title) &&
+		Array.isArray(value.fields) &&
+		value.fields.every(isPublicFormField)
+	);
+}
+
+function isPublicFormSettings(value: unknown): boolean {
+	if (!isObject(value)) {
+		return false;
+	}
+
+	return (
+		typeof value.spamProtection === "string" &&
+		VALID_SPAM_PROTECTION.has(value.spamProtection) &&
+		typeof value.submitLabel === "string" &&
+		isOptionalString(value.nextLabel) &&
+		isOptionalString(value.prevLabel)
+	);
+}
+
+function parsePublicFormDefinitionData(payload: unknown): PublicFormDefinition | null {
 	if (!isObject(payload)) {
 		return null;
-	}
-
-	if ("success" in payload) {
-		if (payload.success !== true) {
-			return null;
-		}
-		return parsePublicFormDefinitionPayload(payload.data);
-	}
-
-	if ("data" in payload) {
-		return parsePublicFormDefinitionPayload(payload.data);
 	}
 
 	if (payload.status !== "active") {
 		return null;
 	}
 
+	if (
+		typeof payload.name !== "string" ||
+		typeof payload.slug !== "string" ||
+		!Array.isArray(payload.pages) ||
+		!payload.pages.every(isPublicFormPage) ||
+		!isPublicFormSettings(payload.settings) ||
+		!isOptionalStringOrNull(payload._turnstileSiteKey)
+	) {
+		return null;
+	}
+
 	return payload as unknown as PublicFormDefinition;
+}
+
+export function parsePublicFormDefinitionPayload(payload: unknown): PublicFormDefinition | null {
+	if (!isObject(payload) || payload.success !== true) {
+		return null;
+	}
+
+	return parsePublicFormDefinitionData(payload.data);
 }
 
 export async function parsePublicFormDefinitionResponse(
@@ -62,8 +147,8 @@ export async function parsePublicFormDefinitionResponse(
 		return null;
 	}
 
-	const form = await parseApiResponse<PublicFormDefinition | undefined>(response);
-	return parsePublicFormDefinitionPayload(form);
+	const form = await parseApiResponse<unknown>(response);
+	return parsePublicFormDefinitionData(form);
 }
 
 function createPublicFormDefinitionRequest(formId: string, baseUrl: URL): Request {
@@ -77,21 +162,22 @@ function createPublicFormDefinitionRequest(formId: string, baseUrl: URL): Reques
 export async function loadPublicFormDefinition({
 	formId,
 	baseUrl,
-	handlePluginApiRoute,
+	handlePublicPluginApiRoute,
 	fetch: fetchImpl = fetch,
 }: LoadPublicFormDefinitionOptions): Promise<PublicFormDefinition | null> {
-	if (handlePluginApiRoute) {
+	if (handlePublicPluginApiRoute) {
 		try {
 			return parsePublicFormDefinitionPayload(
-				await handlePluginApiRoute(
+				await handlePublicPluginApiRoute(
 					"emdash-forms",
 					"POST",
 					"/definition",
 					createPublicFormDefinitionRequest(formId, baseUrl),
 				),
 			);
-		} catch {
-			// Fall back to HTTP fetch for older runtimes or unexpected dispatcher failures.
+		} catch (error) {
+			console.warn("[emdash-forms] public definition dispatcher failed:", error);
+			return null;
 		}
 	}
 

--- a/packages/plugins/forms/src/public-definition.ts
+++ b/packages/plugins/forms/src/public-definition.ts
@@ -14,6 +14,47 @@ export interface PublicFormDefinition {
 	_turnstileSiteKey?: string | null;
 }
 
+export type PublicPluginApiRouteHandler = (
+	pluginId: string,
+	method: string,
+	path: string,
+	request: Request,
+) => Promise<unknown>;
+
+interface LoadPublicFormDefinitionOptions {
+	formId: string;
+	baseUrl: URL;
+	handlePluginApiRoute?: PublicPluginApiRouteHandler;
+	fetch?: (input: Request) => Promise<Response>;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function parsePublicFormDefinitionPayload(payload: unknown): PublicFormDefinition | null {
+	if (!isObject(payload)) {
+		return null;
+	}
+
+	if ("success" in payload) {
+		if (payload.success !== true) {
+			return null;
+		}
+		return parsePublicFormDefinitionPayload(payload.data);
+	}
+
+	if ("data" in payload) {
+		return parsePublicFormDefinitionPayload(payload.data);
+	}
+
+	if (payload.status !== "active") {
+		return null;
+	}
+
+	return payload as unknown as PublicFormDefinition;
+}
+
 export async function parsePublicFormDefinitionResponse(
 	response: Response,
 ): Promise<PublicFormDefinition | null> {
@@ -22,9 +63,39 @@ export async function parsePublicFormDefinitionResponse(
 	}
 
 	const form = await parseApiResponse<PublicFormDefinition | undefined>(response);
-	if (!form || form.status !== "active") {
-		return null;
+	return parsePublicFormDefinitionPayload(form);
+}
+
+function createPublicFormDefinitionRequest(formId: string, baseUrl: URL): Request {
+	return new Request(new URL("/_emdash/api/plugins/emdash-forms/definition", baseUrl), {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ id: formId }),
+	});
+}
+
+export async function loadPublicFormDefinition({
+	formId,
+	baseUrl,
+	handlePluginApiRoute,
+	fetch: fetchImpl = fetch,
+}: LoadPublicFormDefinitionOptions): Promise<PublicFormDefinition | null> {
+	if (handlePluginApiRoute) {
+		try {
+			return parsePublicFormDefinitionPayload(
+				await handlePluginApiRoute(
+					"emdash-forms",
+					"POST",
+					"/definition",
+					createPublicFormDefinitionRequest(formId, baseUrl),
+				),
+			);
+		} catch {
+			// Fall back to HTTP fetch for older runtimes or unexpected dispatcher failures.
+		}
 	}
 
-	return form;
+	return parsePublicFormDefinitionResponse(
+		await fetchImpl(createPublicFormDefinitionRequest(formId, baseUrl)),
+	);
 }

--- a/packages/plugins/forms/src/public-definition.ts
+++ b/packages/plugins/forms/src/public-definition.ts
@@ -57,9 +57,7 @@ function hasValidOptions(value: unknown): boolean {
 		(Array.isArray(value) &&
 			value.every(
 				(option) =>
-					isObject(option) &&
-					typeof option.label === "string" &&
-					typeof option.value === "string",
+					isObject(option) && typeof option.label === "string" && typeof option.value === "string",
 			))
 	);
 }

--- a/packages/plugins/forms/tests/public-definition.test.ts
+++ b/packages/plugins/forms/tests/public-definition.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { PublicFormDefinition } from "../src/public-definition.js";
-import { parsePublicFormDefinitionResponse } from "../src/public-definition.js";
+import {
+	loadPublicFormDefinition,
+	parsePublicFormDefinitionPayload,
+	parsePublicFormDefinitionResponse,
+} from "../src/public-definition.js";
 
 const activeForm: PublicFormDefinition = {
 	name: "Contact",
@@ -58,5 +62,107 @@ describe("parsePublicFormDefinitionResponse", () => {
 		await expect(
 			parsePublicFormDefinitionResponse(jsonResponse({ error: { message: "Not found" } }, 404)),
 		).resolves.toBeNull();
+	});
+});
+
+describe("parsePublicFormDefinitionPayload", () => {
+	it("unwraps successful handler results with an active form", () => {
+		expect(parsePublicFormDefinitionPayload({ success: true, data: activeForm })).toEqual(
+			activeForm,
+		);
+	});
+
+	it("returns null for missing or inactive handler result data", () => {
+		expect(parsePublicFormDefinitionPayload({ success: true, data: undefined })).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { ...activeForm, status: "paused" },
+			}),
+		).toBeNull();
+	});
+
+	it("returns null for failed handler results", () => {
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: false,
+				error: { code: "NOT_FOUND", message: "Form not found" },
+			}),
+		).toBeNull();
+	});
+});
+
+describe("loadPublicFormDefinition", () => {
+	it("loads active forms through the internal public plugin route handler", async () => {
+		const handlePluginApiRoute = vi.fn(async () => ({ success: true, data: activeForm }));
+		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
+
+		await expect(
+			loadPublicFormDefinition({
+				formId: "contact",
+				baseUrl: new URL("https://example.com/contact"),
+				handlePluginApiRoute,
+				fetch,
+			}),
+		).resolves.toEqual(activeForm);
+
+		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+			"emdash-forms",
+			"POST",
+			"/definition",
+			expect.any(Request),
+		);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("treats internal missing or inactive results as definitive", async () => {
+		const handlePluginApiRoute = vi.fn(async () => ({
+			success: false,
+			error: { code: "NOT_FOUND", message: "Form not found" },
+		}));
+		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
+
+		await expect(
+			loadPublicFormDefinition({
+				formId: "missing",
+				baseUrl: new URL("https://example.com/contact"),
+				handlePluginApiRoute,
+				fetch,
+			}),
+		).resolves.toBeNull();
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("falls back to fetching the public definition route when no handler is available", async () => {
+		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
+
+		await expect(
+			loadPublicFormDefinition({
+				formId: "contact",
+				baseUrl: new URL("https://example.com/contact"),
+				fetch,
+			}),
+		).resolves.toEqual(activeForm);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to fetching when the internal handler throws", async () => {
+		const handlePluginApiRoute = vi.fn(async () => {
+			throw new Error("dispatcher unavailable");
+		});
+		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
+
+		await expect(
+			loadPublicFormDefinition({
+				formId: "contact",
+				baseUrl: new URL("https://example.com/contact"),
+				handlePluginApiRoute,
+				fetch,
+			}),
+		).resolves.toEqual(activeForm);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/plugins/forms/tests/public-definition.test.ts
+++ b/packages/plugins/forms/tests/public-definition.test.ts
@@ -63,6 +63,17 @@ describe("parsePublicFormDefinitionResponse", () => {
 			parsePublicFormDefinitionResponse(jsonResponse({ error: { message: "Not found" } }, 404)),
 		).resolves.toBeNull();
 	});
+
+	it("does not recursively unwrap nested response envelopes", async () => {
+		await expect(
+			parsePublicFormDefinitionResponse(jsonResponse({ data: { data: activeForm } })),
+		).resolves.toBeNull();
+		await expect(
+			parsePublicFormDefinitionResponse(
+				jsonResponse({ data: { success: true, data: activeForm } }),
+			),
+		).resolves.toBeNull();
+	});
 });
 
 describe("parsePublicFormDefinitionPayload", () => {
@@ -90,23 +101,77 @@ describe("parsePublicFormDefinitionPayload", () => {
 			}),
 		).toBeNull();
 	});
+
+	it("does not recursively unwrap nested handler result data", () => {
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { data: activeForm },
+			}),
+		).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { success: true, data: activeForm },
+			}),
+		).toBeNull();
+	});
+
+	it("returns null for malformed active form data", () => {
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { status: "active" },
+			}),
+		).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { ...activeForm, pages: undefined },
+			}),
+		).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: { ...activeForm, settings: undefined },
+			}),
+		).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: {
+					...activeForm,
+					pages: [{ fields: [{ ...activeForm.pages[0]!.fields[0]!, type: "unknown" }] }],
+				},
+			}),
+		).toBeNull();
+		expect(
+			parsePublicFormDefinitionPayload({
+				success: true,
+				data: {
+					...activeForm,
+					pages: [{ fields: [{ ...activeForm.pages[0]!.fields[0]!, options: {} }] }],
+				},
+			}),
+		).toBeNull();
+	});
 });
 
 describe("loadPublicFormDefinition", () => {
 	it("loads active forms through the internal public plugin route handler", async () => {
-		const handlePluginApiRoute = vi.fn(async () => ({ success: true, data: activeForm }));
+		const handlePublicPluginApiRoute = vi.fn(async () => ({ success: true, data: activeForm }));
 		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
 
 		await expect(
 			loadPublicFormDefinition({
 				formId: "contact",
 				baseUrl: new URL("https://example.com/contact"),
-				handlePluginApiRoute,
+				handlePublicPluginApiRoute,
 				fetch,
 			}),
 		).resolves.toEqual(activeForm);
 
-		expect(handlePluginApiRoute).toHaveBeenCalledWith(
+		expect(handlePublicPluginApiRoute).toHaveBeenCalledWith(
 			"emdash-forms",
 			"POST",
 			"/definition",
@@ -116,7 +181,7 @@ describe("loadPublicFormDefinition", () => {
 	});
 
 	it("treats internal missing or inactive results as definitive", async () => {
-		const handlePluginApiRoute = vi.fn(async () => ({
+		const handlePublicPluginApiRoute = vi.fn(async () => ({
 			success: false,
 			error: { code: "NOT_FOUND", message: "Form not found" },
 		}));
@@ -126,7 +191,26 @@ describe("loadPublicFormDefinition", () => {
 			loadPublicFormDefinition({
 				formId: "missing",
 				baseUrl: new URL("https://example.com/contact"),
-				handlePluginApiRoute,
+				handlePublicPluginApiRoute,
+				fetch,
+			}),
+		).resolves.toBeNull();
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("treats malformed internal results as definitive", async () => {
+		const handlePublicPluginApiRoute = vi.fn(async () => ({
+			success: true,
+			data: { status: "active" },
+		}));
+		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
+
+		await expect(
+			loadPublicFormDefinition({
+				formId: "contact",
+				baseUrl: new URL("https://example.com/contact"),
+				handlePublicPluginApiRoute,
 				fetch,
 			}),
 		).resolves.toBeNull();
@@ -148,21 +232,30 @@ describe("loadPublicFormDefinition", () => {
 		expect(fetch).toHaveBeenCalledTimes(1);
 	});
 
-	it("falls back to fetching when the internal handler throws", async () => {
-		const handlePluginApiRoute = vi.fn(async () => {
+	it("does not fall back to fetching when the internal handler throws", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const handlePublicPluginApiRoute = vi.fn(async () => {
 			throw new Error("dispatcher unavailable");
 		});
 		const fetch = vi.fn(async () => jsonResponse({ data: activeForm }));
 
-		await expect(
-			loadPublicFormDefinition({
-				formId: "contact",
-				baseUrl: new URL("https://example.com/contact"),
-				handlePluginApiRoute,
-				fetch,
-			}),
-		).resolves.toEqual(activeForm);
+		try {
+			await expect(
+				loadPublicFormDefinition({
+					formId: "contact",
+					baseUrl: new URL("https://example.com/contact"),
+					handlePublicPluginApiRoute,
+					fetch,
+				}),
+			).resolves.toBeNull();
 
-		expect(fetch).toHaveBeenCalledTimes(1);
+			expect(fetch).not.toHaveBeenCalled();
+			expect(warn).toHaveBeenCalledWith(
+				"[emdash-forms] public definition dispatcher failed:",
+				expect.any(Error),
+			);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Fixes public form embeds during SSR by giving anonymous public pages a restricted way to call public plugin routes. Form embeds now resolve their public definition through the core dispatcher when available, which avoids server-side self-fetching in Worker SSR while preserving the old fetch path for older runtimes or dispatcher failures.

The core helper gates every internal dispatch on `getPluginRouteMeta(...).public === true`, so private plugin routes still require the normal API route auth, scope, and CSRF path. The forms plugin only calls the fixed `emdash-forms` `/definition` route and continues to parse the existing `{ data: ... }` API envelope.

Closes: none

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs; a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

No screenshots; this is an SSR/plugin route bug fix.

Verification run:

- `pnpm --filter emdash test -- public-plugin-api-routes middleware-prerender` passed
- `pnpm --filter @emdash-cms/plugin-forms test -- public-definition` passed
- `pnpm --filter @emdash-cms/plugin-forms typecheck` passed
- `pnpm --filter emdash build` passed
- `pnpm typecheck` passed
- `pnpm lint` exited with 0 errors; it reports existing warnings outside this change
- `pnpm exec prettier --check` on the touched files passed

Notes:

- I did not run full `pnpm format` because `pnpm format:check` reports broad existing formatting drift in this Windows checkout; I kept formatting validation scoped to touched files to avoid unrelated churn.
- `pnpm --filter emdash test` currently has unrelated Windows-environment failures in `tests/unit/astro/vite-config.test.ts` (`File URL path must be absolute`) and `tests/unit/cli/bundle-utils.test.ts` (system `tar` listing CRLF). The targeted core tests for this change pass.