### PR TITLE
fix(core): guard cache.enabled with optional chaining in content API routes

### DIFF
--- a/.changeset/beige-pets-bow.md
+++ b/.changeset/beige-pets-bow.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes TypeError crash on all content mutation API routes when Astro's cache API is not available. The `cache` context parameter is undefined when the cache feature is not enabled, causing `cache.enabled` to throw. All 11 call sites now use optional chaining (`cache?.enabled`).

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -125,7 +125,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };
@@ -171,7 +171,7 @@ export const DELETE: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/discard-draft.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/discard-draft.ts
@@ -50,7 +50,7 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/duplicate.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/duplicate.ts
@@ -55,7 +55,7 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection] });
 
 	return unwrapResult(result, 201);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/permanent.ts
@@ -27,7 +27,7 @@ export const DELETE: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, id] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, id] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/publish.ts
@@ -80,7 +80,7 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/restore.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/restore.ts
@@ -50,7 +50,7 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/schedule.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/schedule.ts
@@ -63,7 +63,7 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId ?? id] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId ?? id] });
 
 	return unwrapResult(result);
 };
@@ -95,7 +95,7 @@ export const DELETE: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId ?? id] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId ?? id] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/[id]/unpublish.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id]/unpublish.ts
@@ -50,7 +50,7 @@ export const POST: APIRoute = async ({ params, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection, resolvedId] });
 
 	return unwrapResult(result);
 };

--- a/packages/core/src/astro/routes/api/content/[collection]/index.ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/index.ts
@@ -91,7 +91,7 @@ export const POST: APIRoute = async ({ params, request, locals, cache }) => {
 
 	if (!result.success) return unwrapResult(result);
 
-	if (cache.enabled) await cache.invalidate({ tags: [collection] });
+	if (cache?.enabled) await cache.invalidate({ tags: [collection] });
 
 	return unwrapResult(result, 201);
 };


### PR DESCRIPTION
## What does this PR do?

All 11 content mutation API routes access `cache.enabled` to conditionally invalidate Astro's route cache after writes. When the Astro cache feature is not enabled, `cache` is `undefined` on the API context, causing a `TypeError: Cannot read properties of undefined (reading 'enabled')`.

The DB write succeeds before the crash, but the error response causes the admin UI to show a failure. Users retry, hit slug conflicts (409), and end up confused about whether their content was saved.

This was reported by a user on D1/Cloudflare (`danielstanica.com`) after upgrading. The template-side fix landed in #984; this is the matching fix for core API routes.

The upstream Astro fix (withastro/astro#16675) makes `cache` always present with `enabled: false` when not configured, but that hasn't been released yet. The optional chaining guard is forwards-compatible and will become a no-op once the Astro fix ships.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.6 via OpenCode

## Screenshots / test output

Error from user logs:
```
TypeError: Cannot read properties of undefined (reading 'enabled')
    at Module.DELETE (chunks/permanent_B29RrOAy.mjs:17:13)
```

Affected routes (all 11 content mutation endpoints):
- `POST /content/{collection}` (create)
- `PUT /content/{collection}/{id}` (update)
- `DELETE /content/{collection}/{id}` (soft delete)
- `POST /content/{collection}/{id}/publish`
- `POST /content/{collection}/{id}/unpublish`
- `POST /content/{collection}/{id}/restore`
- `DELETE /content/{collection}/{id}/permanent`
- `POST /content/{collection}/{id}/discard-draft`
- `POST /content/{collection}/{id}/duplicate`
- `POST /content/{collection}/{id}/schedule`
- `DELETE /content/{collection}/{id}/schedule`