### PR TITLE
fix(admin): use infinite scroll for media library to support large libraries

### DIFF
--- a/.changeset/fix-media-library-infinite-scroll.md
+++ b/.changeset/fix-media-library-infinite-scroll.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fix media library admin page to support libraries larger than 50 items by wiring up cursor-based infinite scroll (mirrors the content list fix from #135)

--- a/.changeset/fix-media-library-infinite-scroll.md
+++ b/.changeset/fix-media-library-infinite-scroll.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Fix media library admin page to support libraries larger than 50 items by wiring up cursor-based infinite scroll (mirrors the content list fix from #135)
+Fix media library admin page and the media picker modal (used by the rich text editor and image fields when embedding media into content) to support libraries larger than 50 items by wiring up cursor-based infinite scroll (mirrors the content list fix from #135)

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -24,6 +24,10 @@ export interface MediaLibraryProps {
 	onSelect?: (item: MediaItem) => void;
 	onDelete?: (id: string) => void;
 	onItemUpdated?: () => void;
+	/** True when more local-library items can be fetched via cursor pagination */
+	hasMore?: boolean;
+	/** Triggered to fetch the next page of local-library items */
+	onLoadMore?: () => void;
 }
 
 /**
@@ -35,6 +39,8 @@ export function MediaLibrary({
 	onUpload,
 	onDelete,
 	onItemUpdated,
+	hasMore,
+	onLoadMore,
 }: MediaLibraryProps) {
 	const { t } = useLingui();
 	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
@@ -456,6 +462,15 @@ export function MediaLibrary({
 									))}
 						</tbody>
 					</table>
+				</div>
+			)}
+
+			{/* Load more (local library only — providers handle pagination internally) */}
+			{activeProvider === "local" && hasMore && onLoadMore && (
+				<div className="flex justify-center">
+					<Button variant="outline" onClick={onLoadMore} disabled={isLoading}>
+						{isLoading ? t`Loading...` : t`Load More`}
+					</Button>
 				</div>
 			)}
 

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -348,7 +348,13 @@ export function MediaLibrary({
 			)}
 
 			{/* Content */}
-			{currentLoading ? (
+			{/*
+			 * Gate the full-area loader on items being empty so that "Load More"
+			 * (which sets isLoading=true while fetching the next page) does not
+			 * blank out the already-rendered grid. Mirrors the ContentList
+			 * pattern from #135.
+			 */}
+			{currentLoading && currentItems.length === 0 && currentProviderItems.length === 0 ? (
 				<div className="flex items-center justify-center py-12">
 					<Loader />
 				</div>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -11,7 +11,7 @@ import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Upload, Image, Check, Globe, MagnifyingGlass, Paperclip } from "@phosphor-icons/react";
 import { X } from "@phosphor-icons/react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
 import {
@@ -179,14 +179,24 @@ export function MediaPickerModal({
 		return providers?.find((p) => p.id === activeProvider);
 	}, [activeProvider, providers]);
 
-	// Fetch local media list
-	const { data: localData, isLoading: localLoading } = useQuery({
+	// Fetch local media list (cursor-paginated so libraries beyond the
+	// first page remain selectable from the picker, not just the first 50).
+	const {
+		data: localData,
+		isLoading: localLoading,
+		fetchNextPage: fetchNextLocalPage,
+		hasNextPage: hasNextLocalPage,
+		isFetchingNextPage: isFetchingNextLocalPage,
+	} = useInfiniteQuery({
 		queryKey: ["media", filters?.join(",") ?? ""],
-		queryFn: () =>
+		queryFn: ({ pageParam }) =>
 			fetchMediaList({
 				mimeType: filters,
-				limit: 50,
+				cursor: pageParam as string | undefined,
+				limit: 100,
 			}),
+		initialPageParam: undefined as string | undefined,
+		getNextPageParam: (lastPage) => lastPage.nextCursor,
 		enabled: open && activeProvider === "local",
 	});
 
@@ -202,7 +212,8 @@ export function MediaPickerModal({
 		enabled: open && activeProvider !== "local",
 	});
 
-	const isLoading = activeProvider === "local" ? localLoading : providerLoading;
+	const isLoading =
+		activeProvider === "local" ? localLoading || isFetchingNextLocalPage : providerLoading;
 
 	const [uploadError, setUploadError] = React.useState<string | null>(null);
 
@@ -245,11 +256,21 @@ export function MediaPickerModal({
 		onSuccess: (_updated, { id, width, height }) => {
 			queryClient.setQueryData(
 				["media", filters?.join(",") ?? ""],
-				(old: { items: MediaItem[]; nextCursor?: string } | undefined) => {
+				(
+					old:
+						| {
+								pages: { items: MediaItem[]; nextCursor?: string }[];
+								pageParams: unknown[];
+						  }
+						| undefined,
+				) => {
 					if (!old) return old;
 					return {
 						...old,
-						items: old.items.map((item) => (item.id === id ? { ...item, width, height } : item)),
+						pages: old.pages.map((page) => ({
+							...page,
+							items: page.items.map((item) => (item.id === id ? { ...item, width, height } : item)),
+						})),
 					};
 				},
 			);
@@ -279,11 +300,11 @@ export function MediaPickerModal({
 	// Get items for current view
 	const items = React.useMemo(() => {
 		if (activeProvider === "local") {
-			const localItems = localData?.items || [];
+			const localItems = localData?.pages.flatMap((page) => page.items) || [];
 			return localItems.filter((item) => matchesAnyFilter(item.mimeType, filters));
 		}
 		return providerData?.items || [];
-	}, [activeProvider, localData?.items, providerData?.items, filters]);
+	}, [activeProvider, localData, providerData?.items, filters]);
 
 	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = e.target.files;
@@ -642,6 +663,20 @@ export function MediaPickerModal({
 										/>
 									))}
 						</ul>
+					)}
+
+					{/* Load more (local library only — providers handle pagination internally) */}
+					{activeProvider === "local" && hasNextLocalPage && (
+						<div className="flex justify-center py-3">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => void fetchNextLocalPage()}
+								disabled={isFetchingNextLocalPage}
+							>
+								{isFetchingNextLocalPage ? t`Loading...` : t`Load More`}
+							</Button>
+						</div>
 					)}
 				</div>
 

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -584,7 +584,13 @@ export function MediaPickerModal({
 
 				{/* Media Grid */}
 				<div className="flex-1 overflow-y-auto min-h-0">
-					{isLoading ? (
+					{/*
+					 * Gate the centered loader on items being empty so that "Load More"
+					 * (which sets isLoading=true while fetching the next cursor page)
+					 * does not blank out already-rendered items / lose the user's
+					 * selection. Mirrors the ContentList pattern from #135.
+					 */}
+					{isLoading && items.length === 0 ? (
 						<div className="flex items-center justify-center h-full">
 							<Loader />
 						</div>

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -968,10 +968,17 @@ const mediaRoute = createRoute({
 function MediaPage() {
 	const queryClient = useQueryClient();
 
-	const { data, isLoading, error } = useQuery({
-		queryKey: ["media"],
-		queryFn: () => fetchMediaList(),
-	});
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } =
+		useInfiniteQuery({
+			queryKey: ["media"],
+			queryFn: ({ pageParam }) =>
+				fetchMediaList({
+					cursor: pageParam as string | undefined,
+					limit: 100,
+				}),
+			initialPageParam: undefined as string | undefined,
+			getNextPageParam: (lastPage) => lastPage.nextCursor,
+		});
 
 	const uploadMutation = useMutation({
 		mutationFn: (file: File) => uploadMedia(file),
@@ -987,14 +994,20 @@ function MediaPage() {
 		},
 	});
 
+	const items = React.useMemo(() => {
+		return data?.pages.flatMap((page) => page.items) || [];
+	}, [data]);
+
 	if (error) {
 		return <ErrorScreen error={error.message} />;
 	}
 
 	return (
 		<MediaLibrary
-			items={data?.items || []}
-			isLoading={isLoading}
+			items={items}
+			isLoading={isLoading || isFetchingNextPage}
+			hasMore={!!hasNextPage}
+			onLoadMore={() => void fetchNextPage()}
 			onUpload={(file) => uploadMutation.mutate(file)}
 			onDelete={(id) => deleteMutation.mutate(id)}
 		/>

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -203,5 +203,19 @@ describe("MediaLibrary", () => {
 			await screen.getByRole("button", { name: "Load More" }).click();
 			expect(onLoadMore).toHaveBeenCalled();
 		});
+
+		it("keeps already-loaded items visible while fetching the next page (isLoading=true with items)", async () => {
+			// Reproduces the Copilot review concern: when isLoading flips true
+			// during a Load-More fetch, the grid must not be blanked out into a
+			// centered spinner — already-rendered items should remain visible.
+			const items = [makeMediaItem({ id: "1", filename: "first-page.jpg" })];
+			const screen = await renderLibrary({
+				items,
+				isLoading: true,
+				hasMore: true,
+				onLoadMore: vi.fn(),
+			});
+			await expect.element(screen.getByAltText("first-page.jpg")).toBeInTheDocument();
+		});
 	});
 });

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -182,4 +182,26 @@ describe("MediaLibrary", () => {
 			await expect.element(screen.getByText("Media Library")).toBeInTheDocument();
 		});
 	});
+
+	describe("load more pagination", () => {
+		it("renders Load More button when hasMore is true", async () => {
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({ items, hasMore: true, onLoadMore: vi.fn() });
+			await expect.element(screen.getByRole("button", { name: "Load More" })).toBeInTheDocument();
+		});
+
+		it("does not render Load More button when hasMore is false", async () => {
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({ items, hasMore: false, onLoadMore: vi.fn() });
+			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
+		});
+
+		it("invokes onLoadMore when Load More button is clicked", async () => {
+			const onLoadMore = vi.fn();
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({ items, hasMore: true, onLoadMore });
+			await screen.getByRole("button", { name: "Load More" }).click();
+			expect(onLoadMore).toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -336,4 +336,89 @@ describe("MediaPickerModal", () => {
 			await expect.element(screen.getByLabelText("Upload file")).toBeInTheDocument();
 		});
 	});
+
+	describe("load more pagination", () => {
+		it("renders Load More button when first page returns nextCursor", async () => {
+			const api = await import("../../src/lib/api");
+			(api.fetchMediaList as any).mockResolvedValueOnce({
+				items: [
+					{
+						id: "p1",
+						filename: "page1.jpg",
+						mimeType: "image/jpeg",
+						url: "/media/page1.jpg",
+						size: 1024,
+						width: 800,
+						height: 600,
+						createdAt: "2024-01-01",
+					},
+				],
+				nextCursor: "cursor-2",
+			});
+
+			const screen = await renderModal();
+			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
+			await expect.element(screen.getByRole("button", { name: "Load More" })).toBeInTheDocument();
+		});
+
+		it("does not render Load More button when no nextCursor", async () => {
+			const screen = await renderModal();
+			// Default mock returns 2 items with no nextCursor → button should be absent
+			await expect.element(screen.getByRole("option", { name: "photo.jpg" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
+		});
+
+		it("Load More click fetches the next page with the previous cursor", async () => {
+			const api = await import("../../src/lib/api");
+			const mock = api.fetchMediaList as any;
+			mock.mockReset();
+			mock
+				.mockResolvedValueOnce({
+					items: [
+						{
+							id: "p1",
+							filename: "page1.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/page1.jpg",
+							size: 1024,
+							width: 800,
+							height: 600,
+							createdAt: "2024-01-01",
+						},
+					],
+					nextCursor: "cursor-2",
+				})
+				.mockResolvedValueOnce({
+					items: [
+						{
+							id: "p2",
+							filename: "page2.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/page2.jpg",
+							size: 1024,
+							width: 800,
+							height: 600,
+							createdAt: "2024-01-02",
+						},
+					],
+				});
+
+			const screen = await renderModal();
+			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
+
+			// Direct DOM click to bypass the dialog's inert overlay
+			const loadMoreBtn = [...document.querySelectorAll("button")].find(
+				(b) => b.textContent?.trim() === "Load More",
+			)!;
+			loadMoreBtn.click();
+
+			await expect.element(screen.getByRole("option", { name: "page2.jpg" })).toBeInTheDocument();
+
+			// Second call should have been made with the previous response's cursor.
+			expect(mock).toHaveBeenCalledTimes(2);
+			expect(mock.mock.calls[1][0]).toEqual(
+				expect.objectContaining({ cursor: "cursor-2", limit: 100 }),
+			);
+		});
+	});
 });

--- a/packages/admin/tests/components/MediaPickerModal.test.tsx
+++ b/packages/admin/tests/components/MediaPickerModal.test.tsx
@@ -368,6 +368,50 @@ describe("MediaPickerModal", () => {
 			expect(screen.getByRole("button", { name: "Load More" }).query()).toBeNull();
 		});
 
+		it("keeps already-loaded items visible while fetching the next page", async () => {
+			// Reproduces the Copilot review concern: when the next-page fetch is
+			// in flight, the picker grid must not blank out into a centered
+			// loader — the user's prior selection / scroll context would be lost.
+			const api = await import("../../src/lib/api");
+			const mock = api.fetchMediaList as any;
+			mock.mockReset();
+			let resolveSecond: (value: unknown) => void = () => {};
+			const secondPagePromise = new Promise((resolve) => {
+				resolveSecond = resolve;
+			});
+			mock
+				.mockResolvedValueOnce({
+					items: [
+						{
+							id: "p1",
+							filename: "page1.jpg",
+							mimeType: "image/jpeg",
+							url: "/media/page1.jpg",
+							size: 1024,
+							width: 800,
+							height: 600,
+							createdAt: "2024-01-01",
+						},
+					],
+					nextCursor: "cursor-2",
+				})
+				.mockReturnValueOnce(secondPagePromise);
+
+			const screen = await renderModal();
+			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
+
+			const loadMoreBtn = [...document.querySelectorAll("button")].find(
+				(b) => b.textContent?.trim() === "Load More",
+			)!;
+			loadMoreBtn.click();
+
+			// While the second page is still pending, the first-page item must
+			// stay in the DOM (not be replaced by a centered loader).
+			await expect.element(screen.getByRole("option", { name: "page1.jpg" })).toBeInTheDocument();
+
+			resolveSecond({ items: [] });
+		});
+
 		it("Load More click fetches the next page with the previous cursor", async () => {
 			const api = await import("../../src/lib/api");
 			const mock = api.fetchMediaList as any;


### PR DESCRIPTION
## What does this PR do?

Wire the **media library admin page** *and* the **media picker modal** (used by the rich text editor and image fields when embedding media into content) to cursor-based infinite scroll, so libraries with more than 50 items are fully browsable / selectable. Mirrors the content-list fix from #135.

Closes (no existing issue — filed alongside this PR; happy to open one if preferred)

### Root cause

The backend `MediaRepository.findMany` (in `packages/core/src/database/repositories/media.ts`) already supports cursor pagination with `nextCursor`, defaulting to `limit: 50` (max 100). Two admin call-sites never used the cursor:

1. `MediaPage` in `packages/admin/src/router.tsx` — `fetchMediaList()` called with no arguments. Only the first 50 items ever loaded; library was unbrowsable past the first page.
2. `MediaPickerModal` in `packages/admin/src/components/MediaPickerModal.tsx` — `useQuery` with hardcoded `limit: 50`. The same ceiling applied when picking media to embed into content from the rich text editor or image fields.

`MediaLibrary` had no `hasMore` / `onLoadMore` props either, so there was no Load More UI to wire to.

Real-world hit: a library with ~820 ready media items only ever showed 50, both in the admin media page and in any media picker (so embedding media beyond the most recent 50 in posts was impossible).

### Fix

- **`router.tsx` `MediaPage`**: switch from `useQuery` to `useInfiniteQuery` with `limit: 100`, flatten `data.pages.flatMap(p => p.items)`, pass `hasMore` / `onLoadMore` through to `MediaLibrary`.
- **`MediaLibrary.tsx`**: add `hasMore?: boolean` and `onLoadMore?: () => void` props; render a "Load More" button under the grid/list (local provider only — external providers continue to manage their own pagination internally).
- **`MediaPickerModal.tsx`**: switch the local-library query to `useInfiniteQuery` with `limit: 100`; update the dimensions mutation's `setQueryData` to walk every infinite page rather than the legacy `{ items, nextCursor }` shape; render a Load More button under the picker grid (local provider only).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (modified files: 0 new errors; pre-existing errors in `BlockKitFieldWidget.tsx` / `PortableTextEditor.tsx` are unrelated)
- [x] `pnpm lint` passes (oxlint: 0 warnings, 0 errors on changed files)
- [x] `pnpm test` passes for `tests/components/MediaLibrary.test.tsx` (12/12 — 3 new cases for Load More) and `tests/components/MediaPickerModal.test.tsx` (17/17 — 3 new cases for Load More)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings (`Load More`, `Loading...`) are wrapped with `t``
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Notes

- The fix scope is intentionally narrow and parallels #135. External media providers (CF Images etc.) already handle their own pagination via `fetchProviderMedia`, so the new "Load More" button is gated on `activeProvider === "local"` in both call-sites.
- No locale/`messages.po` updates included (per CONTRIBUTING — extracted on merge).
