### PR TITLE
fix(core): support Postgres plugin storage filters

### DIFF
--- a/.changeset/mean-fans-mix.md
+++ b/.changeset/mean-fans-mix.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes filtered plugin storage queries on Postgres.

--- a/packages/core/src/database/repositories/plugin-storage.ts
+++ b/packages/core/src/database/repositories/plugin-storage.ts
@@ -7,7 +7,7 @@
  * @see PLUGIN-SYSTEM.md § Plugin Storage > Full API Reference
  */
 
-import type { Kysely } from "kysely";
+import type { Kysely, SqlBool } from "kysely";
 import { sql } from "kysely";
 
 import {
@@ -223,7 +223,7 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 					whereSqlParts.push(sql.raw(sqlParts[i]));
 				}
 			}
-			query = query.where(({ eb }) => eb(sql.join(whereSqlParts, sql.raw("")), "=", sql.raw("1")));
+			query = query.where(sql<SqlBool>`${sql.join(whereSqlParts, sql.raw(""))}`);
 		}
 
 		// Handle cursor-based pagination — throws on invalid cursor.
@@ -301,9 +301,7 @@ export class PluginStorageRepository<T = unknown> implements StorageCollection<T
 						whereSqlParts.push(sql.raw(sqlParts[i]));
 					}
 				}
-				query = query.where(({ eb }) =>
-					eb(sql.join(whereSqlParts, sql.raw("")), "=", sql.raw("1")),
-				);
+				query = query.where(sql<SqlBool>`${sql.join(whereSqlParts, sql.raw(""))}`);
 			}
 		}
 

--- a/packages/core/tests/integration/plugins/storage.test.ts
+++ b/packages/core/tests/integration/plugins/storage.test.ts
@@ -8,7 +8,15 @@ import {
 	deletePluginCollection,
 } from "../../../src/database/repositories/plugin-storage.js";
 import type { Database } from "../../../src/database/types.js";
-import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	setupTestDatabase,
+	teardownForDialect,
+	teardownTestDatabase,
+	type DialectName,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
 
 interface AnalyticsEvent {
 	eventType: string;
@@ -289,5 +297,33 @@ describe("Plugin Storage Integration", () => {
 			const count = await repo.count();
 			expect(count).toBe(5);
 		});
+	});
+});
+
+describeEachDialect("Plugin Storage filtered queries", (dialect: DialectName) => {
+	let ctx: DialectTestContext;
+	let repo: PluginStorageRepository<{ name: string; status: string }>;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		repo = new PluginStorageRepository(ctx.db, "filtered-plugin", "items", ["name", "status"]);
+		await repo.putMany([
+			{ id: "one", data: { name: "alpha", status: "active" } },
+			{ id: "two", data: { name: "beta", status: "inactive" } },
+			{ id: "three", data: { name: "alpha", status: "active" } },
+		]);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("should query and count with indexed filters", async () => {
+		const result = await repo.query({ where: { name: "alpha" } });
+		const count = await repo.count({ status: "active" });
+
+		expect(result.items).toHaveLength(2);
+		expect(result.items.every((item) => item.data.name === "alpha")).toBe(true);
+		expect(count).toBe(2);
 	});
 });

--- a/packages/core/tests/unit/plugins/plugin-storage.test.ts
+++ b/packages/core/tests/unit/plugins/plugin-storage.test.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { Kysely, PostgresDialect } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { PluginStorageRepository } from "../../../src/database/repositories/plugin-storage.js";
@@ -6,6 +6,31 @@ import type { Database } from "../../../src/database/types.js";
 import { IdentifierError } from "../../../src/database/validate.js";
 import { StorageQueryError } from "../../../src/plugins/storage-query.js";
 import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+type PostgresDialectPool = ConstructorParameters<typeof PostgresDialect>[0]["pool"];
+
+function createRecordingPostgresDatabase(sqlLog: string[]): Kysely<Database> {
+	const client = {
+		async query(query: string | { text?: string }) {
+			const text = typeof query === "string" ? query : (query.text ?? "");
+			sqlLog.push(text);
+			return text.includes("COUNT(*)")
+				? { rows: [{ count: 0 }], rowCount: 1 }
+				: { rows: [], rowCount: 0 };
+		},
+		release() {},
+	};
+	const pool = {
+		async connect() {
+			return client;
+		},
+		async end() {},
+	};
+
+	return new Kysely<Database>({
+		dialect: new PostgresDialect({ pool: pool as PostgresDialectPool }),
+	});
+}
 
 interface TestDocument {
 	title: string;
@@ -439,5 +464,41 @@ describe("PluginStorageRepository", () => {
 			const result = await otherRepo.get("doc1");
 			expect(result).toBeNull();
 		});
+	});
+});
+
+describe("Postgres filtered plugin storage SQL", () => {
+	it("should not compare query() predicates to an integer sentinel", async () => {
+		const sqlLog: string[] = [];
+		const db = createRecordingPostgresDatabase(sqlLog);
+		const repo = new PluginStorageRepository<{ name: string }>(db, "test-plugin", "items", [
+			"name",
+		]);
+
+		try {
+			await repo.query({ where: { name: "foo" } });
+		} finally {
+			await db.destroy();
+		}
+
+		expect(sqlLog[0]).toContain("data->>'name'");
+		expect(sqlLog[0]).not.toContain("= 1");
+	});
+
+	it("should not compare count() predicates to an integer sentinel", async () => {
+		const sqlLog: string[] = [];
+		const db = createRecordingPostgresDatabase(sqlLog);
+		const repo = new PluginStorageRepository<{ name: string }>(db, "test-plugin", "items", [
+			"name",
+		]);
+
+		try {
+			await repo.count({ name: "foo" });
+		} finally {
+			await db.destroy();
+		}
+
+		expect(sqlLog[0]).toContain("data->>'name'");
+		expect(sqlLog[0]).not.toContain("= 1");
 	});
 });


### PR DESCRIPTION
﻿## What does this PR do?

Fixes filtered plugin storage `query()`/count SQL on Postgres by passing the generated boolean predicate directly to Kysely instead of comparing it to integer `1`.

Closes #920

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs - a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A - bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: GPT-5 Codex in Codex desktop

## Screenshots / test output

- `pnpm build` - passes
- `pnpm typecheck` - passes
- `pnpm lint` - exits 0; reports existing warnings outside this diff
- `pnpm --filter emdash test -- tests/unit/plugins/plugin-storage.test.ts tests/integration/plugins/storage.test.ts` - passes, 42 tests
- `pnpm test` - attempted; local Windows run fails in unrelated tests (`packages/marketplace` publish e2e Windows ESM absolute path, plus `packages/core` Windows path/CRLF-sensitive tests outside this diff)
