### PR TITLE
ci: diagnose CI-only slash-menu test flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,18 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: pnpm run --filter @emdash-cms/admin test
+      # Upload vitest browser-mode failure screenshots so we can diagnose
+      # CI-only flakes (e.g. the recurring slash-menu race). Only runs on
+      # failure, only uploads the screenshot directories.
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: browser-test-screenshots
+          path: |
+            packages/admin/tests/**/__screenshots__/**
+          if-no-files-found: ignore
+          retention-days: 1
 
   test-e2e-rollup:
     name: E2E Tests

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -189,6 +189,59 @@ function isItemSelected(el: HTMLElement): boolean {
 	return el.className.split(WHITESPACE_SPLIT_REGEX).includes("bg-kumo-tint");
 }
 
+/**
+ * DIAGNOSTIC (temporary, see #1004 follow-up): dump everything useful about
+ * the slash menu state to console.log. Called from a catch block when
+ * vi.waitFor times out, so the failing CI log contains the actual menu
+ * contents and DOM state at the moment of failure. Remove once the
+ * underlying race is understood and fixed.
+ */
+function dumpMenuState(label: string): void {
+	const menu = getSlashMenu();
+	const lines: string[] = [
+		`[slash-menu diag] === ${label} ===`,
+		`[slash-menu diag] menu present: ${menu !== null}`,
+		`[slash-menu diag] activeElement: ${document.activeElement?.tagName} (class=${document.activeElement?.className?.slice(0, 80)})`,
+		`[slash-menu diag] body > div count: ${document.querySelectorAll("body > div").length}`,
+	];
+	if (menu) {
+		const items = getSlashMenuItems(menu);
+		lines.push(`[slash-menu diag] items rendered: ${items.length}`);
+		lines.push(`[slash-menu diag] menu textContent length: ${menu.textContent?.length ?? 0}`);
+		lines.push(`[slash-menu diag] menu first 200 chars: ${menu.textContent?.slice(0, 200)}`);
+		items.forEach((el, i) => {
+			const dataIndex = el.getAttribute("data-index");
+			const selected = isItemSelected(el);
+			const classes = el.className;
+			lines.push(
+				`[slash-menu diag]   item ${i} (data-index=${dataIndex}) selected=${selected} classes=${classes.slice(0, 200)}`,
+			);
+		});
+		// menu.outerHTML truncated to 2000 chars
+		lines.push(`[slash-menu diag] menu outerHTML: ${menu.outerHTML.slice(0, 2000)}`);
+	}
+	for (const line of lines) {
+		console.log(line);
+	}
+}
+
+/**
+ * DIAGNOSTIC wrapper around vi.waitFor that dumps menu state on timeout.
+ * Same semantics as vi.waitFor; only adds logging on failure.
+ */
+async function diagWaitFor<T>(
+	label: string,
+	predicate: () => T | Promise<T>,
+	options?: { timeout?: number; interval?: number },
+): Promise<T> {
+	try {
+		return await vi.waitFor(predicate, options);
+	} catch (err) {
+		dumpMenuState(label);
+		throw err;
+	}
+}
+
 // =============================================================================
 // Slash Command Menu
 // =============================================================================
@@ -287,7 +340,8 @@ describe("Slash Command Menu", () => {
 
 		await waitForSlashMenu();
 
-		await vi.waitFor(
+		await diagWaitFor(
+			"highlights the first item by default",
 			() => {
 				const menu = getSlashMenu()!;
 				const items = getSlashMenuItems(menu);
@@ -305,7 +359,7 @@ describe("Slash Command Menu", () => {
 
 		await userEvent.keyboard("{ArrowDown}");
 
-		await vi.waitFor(() => {
+		await diagWaitFor("moves selection down with ArrowDown", () => {
 			const menu = getSlashMenu()!;
 			const items = getSlashMenuItems(menu);
 			expect(isItemSelected(items[1]!)).toBe(true);
@@ -321,13 +375,13 @@ describe("Slash Command Menu", () => {
 
 		// Move down, then back up
 		await userEvent.keyboard("{ArrowDown}");
-		await vi.waitFor(() => {
+		await diagWaitFor("ArrowUp from second item: first ArrowDown", () => {
 			const items = getSlashMenuItems(getSlashMenu()!);
 			expect(isItemSelected(items[1]!)).toBe(true);
 		});
 
 		await userEvent.keyboard("{ArrowUp}");
-		await vi.waitFor(() => {
+		await diagWaitFor("ArrowUp from second item: back to first", () => {
 			const items = getSlashMenuItems(getSlashMenu()!);
 			expect(isItemSelected(items[0]!)).toBe(true);
 		});
@@ -341,7 +395,7 @@ describe("Slash Command Menu", () => {
 
 		await userEvent.keyboard("{ArrowUp}");
 
-		await vi.waitFor(() => {
+		await diagWaitFor("wraps selection around (ArrowUp from first)", () => {
 			const menu = getSlashMenu()!;
 			const items = getSlashMenuItems(menu);
 			const lastItem = items.at(-1)!;
@@ -360,7 +414,7 @@ describe("Slash Command Menu", () => {
 
 		await waitForSlashMenuClosed();
 
-		await vi.waitFor(() => {
+		await diagWaitFor("Enter converts to heading: h1 should exist", () => {
 			expect(pm.querySelector("h1")).toBeTruthy();
 		});
 	});

--- a/packages/admin/tests/editor/slash-menu.test.tsx
+++ b/packages/admin/tests/editor/slash-menu.test.tsx
@@ -220,9 +220,7 @@ function dumpMenuState(label: string): void {
 		// menu.outerHTML truncated to 2000 chars
 		lines.push(`[slash-menu diag] menu outerHTML: ${menu.outerHTML.slice(0, 2000)}`);
 	}
-	for (const line of lines) {
-		console.log(line);
-	}
+	console.log(lines.join("\n"));
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Temporary diagnostic change to surface what's actually happening when the 5 slash-menu tests fail on Linux CI. The same tests have been failing on `main` after #1004 merged (twice on May 12) and on PRs #988 / #1000, but I cannot reproduce the failures locally on macOS even at 40x CPU throttle via CDP `Emulation.setCPUThrottlingRate`. The current CI log only tells us "expected false to be true" with no view into the actual DOM state, so we cannot tell whether the menu rendered at all, rendered with the wrong selection, or rendered with different classes.

Two narrow changes:

1. **Upload `__screenshots__` as a CI artifact on Browser Tests failure** (1-day retention, only on failure). Vitest browser mode writes screenshots into `packages/admin/tests/**/__screenshots__/**` when an assertion in `vi.waitFor` exhausts retries -- those are currently lost when the job ends.

2. **Wrap the 5 historically-failing `vi.waitFor` blocks in a `diagWaitFor` helper** that, on timeout, dumps a structured snapshot of the slash menu's DOM state to `console.log` before re-throwing the original error. The dump includes:
   - menu presence
   - `document.activeElement` tag + class prefix
   - `body > div` count (to spot extra portals)
   - rendered items count
   - per-item: `data-index`, `selected` boolean, full class list
   - first 200 chars of `menu.textContent`
   - first 2000 chars of `menu.outerHTML`

   On success, `diagWaitFor` is a straight passthrough to `vi.waitFor` -- passing runs are unchanged. The wrappers are only on the 5 known-flaky tests; the other 18 slash-menu tests are untouched.

## How to read this when CI fails

When Browser Tests fail on a PR that includes this change, the job log will contain a block like:

```
stdout | tests/editor/slash-menu.test.tsx > Slash Command Menu > highlights the first item by default
[slash-menu diag] === highlights the first item by default ===
[slash-menu diag] menu present: true
[slash-menu diag] items rendered: 11
[slash-menu diag]   item 0 (data-index=0) selected=false classes=flex items-center gap-3 ... hover:bg-kumo-tint/50
[slash-menu diag]   item 1 (data-index=1) selected=true classes=... bg-kumo-tint text-kumo-default
...
```

That tells us definitively which item is/isn't selected at the moment of failure, what classes are applied, and whether the menu rendered at all -- enough to identify the actual race.

## Reproduction attempts that did NOT work

For the record:

- macOS local: tests run in 1.88s, all pass
- 6x CDP CPU throttle: 4.34s, all pass
- 10x throttle (matches CI's failing 10.4s runtime): 9.36s, all pass
- 20x throttle: 19.16s, all pass
- 40x throttle: 38.95s, all pass
- 10x throttle + full 875-test suite in parallel: all pass

The failure is genuinely CI/Linux-Chromium specific (not pure CPU timing), which is why we need on-CI diagnostics.

## Revert plan

Both changes are reverted once we have a failing CI run with diag output, identify the root cause, and ship the real fix. The branch name (`ci/diagnose-slash-menu-flake`) and commit message make the revert easy to find.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics on changed files)
- [x] `pnpm test` passes (slash-menu suite: 23/23 with no diag output on success)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (no admin UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (no published-package behavior change -- CI + test-only)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7 (opencode)

## Screenshots / test output

Forced-failure local run confirms the dump format:

\`\`\`
[slash-menu diag] === highlights the first item by default ===
[slash-menu diag] menu present: true
[slash-menu diag] activeElement: DIV (class=tiptap ProseMirror prose ...)
[slash-menu diag] body > div count: 2
[slash-menu diag] items rendered: 11
[slash-menu diag] menu textContent length: 312
[slash-menu diag] menu first 200 chars: Heading 1Large section headingHeading 2Medium section heading...
[slash-menu diag]   item 0 (data-index=0) selected=true classes=... bg-kumo-tint text-kumo-default
[slash-menu diag]   item 1 (data-index=1) selected=false classes=... hover:bg-kumo-tint/50
... (all 11 items)
[slash-menu diag] menu outerHTML: <div style="..."><button type="button" data-index="0" ...
\`\`\`