### PR TITLE
fix(deps): catalog-pin zod so trusted plugins typecheck

### DIFF
--- a/.changeset/sharp-knives-invite.md
+++ b/.changeset/sharp-knives-invite.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/auth": patch
+---
+
+Fixes a Zod type-incompatibility between trusted plugins and core. Without a workspace-level pin, emdash's `zod: ^4.3.5` could resolve to a different patch than Astro's bundled Zod, and Zod 4 embeds the version in the type — so schemas imported via `astro/zod` in trusted plugins (e.g. `@emdash-cms/plugin-forms`) were not assignable to `definePlugin`'s `PluginRoute<TInput>['input']`. Pins Zod in the pnpm catalog so the entire workspace dedupes on one instance.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,7 +42,7 @@
     "@oslojs/encoding": "catalog:",
     "@oslojs/webauthn": "catalog:",
     "ulidx": "^2.4.1",
-    "zod": "^4.3.5"
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "astro": ">=6.0.0-beta.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -207,7 +207,7 @@
     "sax": "^1.4.1",
     "ulidx": "^2.4.1",
     "upng-js": "^2.1.0",
-    "zod": "^4.3.5"
+    "zod": "catalog:"
   },
   "optionalDependencies": {
     "@libsql/kysely-libsql": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ catalogs:
     wrangler:
       specifier: ^4.83.0
       version: 4.90.0
+    zod:
+      specifier: ^4.3.6
+      version: 4.4.1
 
 importers:
 
@@ -1080,8 +1083,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       zod:
-        specifier: ^4.3.5
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -1330,7 +1333,7 @@ importers:
         version: 0.27.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       '@oslojs/crypto':
         specifier: 'catalog:'
         version: 1.0.1
@@ -1440,8 +1443,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       zod:
-        specifier: ^4.3.5
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 4.4.1
     devDependencies:
       '@apidevtools/swagger-parser':
         specifier: ^12.1.0
@@ -1487,7 +1490,7 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@vitest/browser-playwright@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       zod-openapi:
         specifier: ^5.4.6
-        version: 5.4.6(zod@4.3.6)
+        version: 5.4.6(zod@4.4.1)
     optionalDependencies:
       '@libsql/kysely-libsql':
         specifier: ^0.4.0
@@ -10391,9 +10394,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
@@ -12625,7 +12625,7 @@ snapshots:
     dependencies:
       moo: 0.5.3
 
-  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.4)
       ajv: 8.17.1
@@ -12642,8 +12642,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.1(zod@4.4.1)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -15093,7 +15093,7 @@ snapshots:
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.1
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -15187,7 +15187,7 @@ snapshots:
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.1
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -15281,7 +15281,7 @@ snapshots:
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.1
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -15468,7 +15468,7 @@ snapshots:
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.3.6
+      zod: 4.4.1
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -16885,7 +16885,7 @@ snapshots:
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
       typescript: 6.0.0-beta
-      zod: 4.3.6
+      zod: 4.4.1
 
   kysely-d1@0.4.0(kysely@0.27.6):
     dependencies:
@@ -20003,21 +20003,15 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
-  zod-openapi@5.4.6(zod@4.3.6):
+  zod-openapi@5.4.6(zod@4.4.1):
     dependencies:
-      zod: 4.3.6
-
-  zod-to-json-schema@3.25.1(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
+      zod: 4.4.1
 
   zod-to-json-schema@3.25.1(zod@4.4.1):
     dependencies:
       zod: 4.4.1
 
   zod@3.25.76: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,3 +91,9 @@ catalog:
   vite: ^8.0.11
   vitest: ^4.1.5
   wrangler: ^4.83.0
+  # Catalog-pin Zod so the whole workspace dedupes on a single instance.
+  # Zod 4 embeds the version in the type, so even ^4.3.6 vs ^4.4.1 produce
+  # structurally incompatible ZodType<T> across packages that mix astro/zod
+  # and emdash's zod (e.g. trusted plugins like @emdash-cms/plugin-forms
+  # importing 'z' from astro/zod and passing schemas to definePlugin).
+  zod: ^4.3.6


### PR DESCRIPTION
## What does this PR do?

Catalog-pins `zod` in `pnpm-workspace.yaml` so the whole workspace dedupes on a single Zod instance. Without the pin, emdash's `zod: ^4.3.5` was free to resolve to a different patch than Astro's bundled Zod, and Zod 4 encodes its semver in the type system -- two Zod 4 patches in one tree produce structurally incompatible `ZodType<T>`.

The user-visible symptom was an 8-error typecheck failure in `packages/plugins/forms` that's been silently broken on `main` for a while (only PR CI runs `pnpm typecheck` over the whole workspace, and no recent PR touched this package). I noticed it because the typecheck step started failing on an unrelated PR.

### What was actually wrong

`@emdash-cms/plugin-forms` imports `z` from `astro/zod` (Astro's bundled Zod) and passes the resulting schemas to `definePlugin()` from `emdash` as route input. The `definePlugin` native overload expects `PluginRoute<TInput>['input']: z.ZodType<TInput>` using `emdash`'s Zod. When the two Zods diverge by even a patch (e.g. 4.3.6 vs 4.4.1), the `_zod.version.minor` field on `$ZodTypeInternals` is a different literal type (`3` vs `4`) and the schemas aren't assignable.

The native `definePlugin` overload silently failed, TS fell through to the `StandardPluginDefinition` overload, and reported a misleading `'id' does not exist in type 'StandardPluginDefinition'` -- masking 8 cascading errors (7 implicit-any on handler params, 1 nominal overload mismatch).

### What this PR changes

- Adds `zod: ^4.3.6` to the pnpm catalog in `pnpm-workspace.yaml`, with a comment explaining the gotcha.
- Switches `packages/core` and `packages/auth` from `"zod": "^4.3.5"` to `"zod": "catalog:"`.
- pnpm now resolves to a single workspace-wide Zod (4.4.1 in the new lockfile, as `^4.3.6` allows).
- No code changes in `packages/core` or `packages/plugins/forms`.
- `packages/marketplace` is still on Zod 3 and is unaffected.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (n/a, dependency pin)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (n/a)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7