### PR TITLE
ci: always report code scanning results for CodeQL and zizmor

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
       security-events: write
       contents: read
       actions: read
+      pull-requests: read # dorny/paths-filter calls the PRs API on pull_request events
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,131 @@
+name: CodeQL
+
+# Advanced setup so we can control when analysis runs. The "Require code
+# scanning results" ruleset rule waits for a SARIF upload; if a PR doesn't
+# touch code (locale-only, workflow-only) and the workflow never runs, the
+# check sits pending forever. We always run a job per language and either do
+# the real analysis (when relevant paths changed) or upload an empty SARIF so
+# the check reports cleanly.
+#
+# Parity with the previous default setup:
+#   - languages: actions, javascript-typescript
+#     (javascript and typescript are subsumed by javascript-typescript)
+#   - query suite: default
+#   - threat model: remote
+#   - schedule: weekly
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run, matches previous default setup cadence.
+    - cron: "0 6 * * 1"
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            paths-filter: |
+              code:
+                - '.github/workflows/**'
+                - '.github/actions/**'
+          - language: javascript-typescript
+            paths-filter: |
+              code:
+                - '**/*.ts'
+                - '**/*.tsx'
+                - '**/*.js'
+                - '**/*.jsx'
+                - '**/*.mjs'
+                - '**/*.cjs'
+                - '**/package.json'
+                - '**/pnpm-lock.yaml'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # On push and schedule, always analyze. On pull_request, only analyze
+      # when paths relevant to this language changed.
+      - name: Detect relevant changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: ${{ matrix.paths-filter }}
+
+      - name: Decide whether to analyze
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGED: ${{ steps.changes.outputs.code }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$CHANGED" = "true" ]; then
+            echo "analyze=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "analyze=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Initialize CodeQL
+        if: steps.decide.outputs.analyze == 'true'
+        uses: github/codeql-action/init@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        if: steps.decide.outputs.analyze == 'true'
+        uses: github/codeql-action/analyze@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+      # When skipped, upload an empty SARIF so the "Require code scanning
+      # results" rule on the branch ruleset sees a result and passes the PR.
+      - name: Write empty SARIF
+        if: steps.decide.outputs.analyze != 'true'
+        env:
+          LANGUAGE: ${{ matrix.language }}
+        run: |
+          cat > empty.sarif <<EOF
+          {
+            "version": "2.1.0",
+            "\$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "CodeQL",
+                    "semanticVersion": "0.0.0",
+                    "rules": []
+                  }
+                },
+                "results": [],
+                "automationDetails": {
+                  "id": "/language:${LANGUAGE}/"
+                }
+              }
+            ]
+          }
+          EOF
+
+      - name: Upload empty SARIF
+        if: steps.decide.outputs.analyze != 'true'
+        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        with:
+          sarif_file: empty.sarif
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,13 +84,13 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.decide.outputs.analyze == 'true'
-        uses: github/codeql-action/init@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
         if: steps.decide.outputs.analyze == 'true'
-        uses: github/codeql-action/analyze@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: "/language:${{ matrix.language }}"
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload empty SARIF
         if: steps.decide.outputs.analyze != 'true'
-        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: empty.sarif
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload empty SARIF
         if: steps.decide.outputs.analyze != 'true'
-        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: zizmor.sarif
           category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,6 +21,7 @@ jobs:
       security-events: write # upload SARIF to code scanning
       contents: read
       actions: read
+      pull-requests: read # dorny/paths-filter calls the PRs API on pull_request events
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,12 +1,15 @@
 name: zizmor
 
+# Always runs on PRs so the "Require code scanning results" ruleset rule
+# always has a SARIF to inspect. Real analysis only runs when workflow files
+# changed; otherwise we upload an empty SARIF so locale-only / code-only PRs
+# aren't blocked waiting for a check that never reports.
+
 on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - ".github/zizmor.yml"
+    branches: [main]
 
 permissions: {}
 
@@ -24,5 +27,62 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect workflow changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/zizmor.yml'
+
+      - name: Decide whether to analyze
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGED: ${{ steps.changes.outputs.workflows }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$CHANGED" = "true" ]; then
+            echo "analyze=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "analyze=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run zizmor
+        if: steps.decide.outputs.analyze == 'true'
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+
+      # When skipped, upload an empty SARIF so the ruleset rule passes.
+      - name: Write empty SARIF
+        if: steps.decide.outputs.analyze != 'true'
+        run: |
+          cat > zizmor.sarif <<'EOF'
+          {
+            "version": "2.1.0",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "zizmor",
+                    "semanticVersion": "0.0.0",
+                    "rules": []
+                  }
+                },
+                "results": [],
+                "automationDetails": {
+                  "id": "zizmor/"
+                }
+              }
+            ]
+          }
+          EOF
+
+      - name: Upload empty SARIF
+        if: steps.decide.outputs.analyze != 'true'
+        uses: github/codeql-action/upload-sarif@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
## What does this PR do?

Fixes PRs being blocked indefinitely by the \"Require code scanning results\" ruleset rule when the analysis workflow's paths filter excludes everything. A locale-only PR or a non-workflow PR currently has no way to satisfy the rule because the workflow never runs and never uploads a SARIF.

This switches CodeQL from default setup to advanced setup (workflow file in-repo) and rewrites both CodeQL and zizmor with an always-run + empty-SARIF pattern:

- Every PR triggers the job.
- A paths-filter step decides whether to run the real analysis.
- If the analysis is skipped, the job writes a minimal valid empty SARIF and uploads it to code scanning so the ruleset rule reports a clean result.
- Real findings at the configured severity threshold (currently \`high_or_higher\` / \`errors\` for CodeQL) still block the PR.

### CodeQL parity with previous default setup

- Languages: \`actions\`, \`javascript-typescript\` (covers \`javascript\` and \`typescript\`).
- Query suite: default.
- Threat model: \`remote\` (the CodeQL default).
- Schedule: weekly, Mondays 06:00 UTC.

### Zizmor

Same trigger model. Analysis runs only when \`.github/workflows/**\`, \`.github/actions/**\`, or \`.github/zizmor.yml\` change; otherwise an empty SARIF is uploaded under the \`zizmor\` category.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Follow-up steps after merge

1. **Disable CodeQL default setup**: Settings → Code security → Code scanning → switch CodeQL from \"Default\" to \"Advanced\". GitHub auto-disables default setup once the advanced workflow uploads results for the same languages, but doing it explicitly avoids the brief overlap.
2. **Add zizmor to the ruleset**: Settings → Rules → \`main\` → \"Require code scanning results\" → add \`zizmor\` with thresholds matching CodeQL.
3. Verify with a locale-only PR that both checks report green without manual override.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] \`pnpm typecheck\` passes (N/A - workflow YAML only)
- [x] \`pnpm lint\` passes (N/A - workflow YAML only)
- [x] \`pnpm test\` passes (N/A - workflow YAML only)
- [x] \`pnpm format\` has been run
- [ ] I have added/updated tests for my changes (N/A)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A)
- [ ] I have added a changeset (N/A - no published package affected)
- [ ] New features link to an approved Discussion (N/A - not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7