### PR TITLE
chore: add plugins-site worker for plugins.emdashcms.com

### DIFF
--- a/infra/plugins-site/package.json
+++ b/infra/plugins-site/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@emdash-cms/plugins-site",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy"
+	},
+	"devDependencies": {
+		"wrangler": "catalog:"
+	}
+}

--- a/infra/plugins-site/public/.well-known/atproto-did
+++ b/infra/plugins-site/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:xyraubanwc5fwemkduw3upi6

--- a/infra/plugins-site/public/index.html
+++ b/infra/plugins-site/public/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>EmDash Plugin Registry</title>
+		<style>
+			body {
+				font-family:
+					ui-sans-serif,
+					system-ui,
+					-apple-system,
+					sans-serif;
+				max-width: 36rem;
+				margin: 4rem auto;
+				padding: 0 1rem;
+				line-height: 1.5;
+				color: #1a1a1a;
+			}
+			a {
+				color: #0066cc;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>EmDash Plugin Registry</h1>
+		<p>Coming soon. In the meantime, see <a href="https://emdashcms.com">emdashcms.com</a>.</p>
+	</body>
+</html>

--- a/infra/plugins-site/wrangler.jsonc
+++ b/infra/plugins-site/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "emdash-plugins-site",
+	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
+	"compatibility_date": "2026-04-01",
+	"assets": {
+		"directory": "./public",
+		"not_found_handling": "404-page",
+	},
+	"routes": [
+		{
+			"pattern": "plugins.emdashcms.com",
+			"custom_domain": true,
+		},
+	],
+	"observability": {
+		"enabled": true,
+	},
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,6 +838,12 @@ importers:
         specifier: 'catalog:'
         version: 4.90.0(@cloudflare/workers-types@4.20260305.1)
 
+  infra/plugins-site:
+    devDependencies:
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.90.0(@cloudflare/workers-types@4.20260305.1)
+
   packages/admin:
     dependencies:
       '@atcute/identity-resolver':
@@ -2372,7 +2378,7 @@ packages:
       wrangler: ^4.61.1
 
   '@astrojs/cloudflare@https://pkg.pr.new/@astrojs/cloudflare@94d342d':
-    resolution: {tarball: https://pkg.pr.new/@astrojs/cloudflare@94d342d}
+    resolution: {integrity: sha512-Bt+G512Dr1SqYdsza6HOLP2azfHg0m5UE0s6SBGX77g+ThFV95Nai5boyM8HO3jVpqwVPPh+5ycMptjrtzv7Yg==, tarball: https://pkg.pr.new/@astrojs/cloudflare@94d342d}
     version: 13.1.10
     peerDependencies:
       astro: ^6.0.0
@@ -2474,7 +2480,7 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/telemetry@https://pkg.pr.new/withastro/astro/@astrojs/telemetry@94d342d':
-    resolution: {tarball: https://pkg.pr.new/withastro/astro/@astrojs/telemetry@94d342d}
+    resolution: {integrity: sha512-xfarx9l9HW3YpytsM2OpnD3aADtxueYWk6xg81PmVRLxfszskZzoaPVvZwfmqnpIxjBP1tOF1RLVaS10TwnNLQ==, tarball: https://pkg.pr.new/withastro/astro/@astrojs/telemetry@94d342d}
     version: 3.3.0
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
@@ -6435,7 +6441,7 @@ packages:
     hasBin: true
 
   astro@https://pkg.pr.new/astro@94d342d:
-    resolution: {tarball: https://pkg.pr.new/astro@94d342d}
+    resolution: {integrity: sha512-1XlhRGRCQP4L5KPZUgSRCKOD28aKiGYQ8TBAxBIJvFV/HUuct3eHvc7sY/krhhCAju81JMlvbWU+1XVzltgZTQ==, tarball: https://pkg.pr.new/astro@94d342d}
     version: 6.1.7
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
@@ -14778,7 +14784,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@vitest/browser-playwright@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@vitest/browser-playwright@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.5':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - infra/cache-demo
   - infra/perf-monitor
   - infra/discord-bot
+  - infra/plugins-site
 
 catalog:
   "@arethetypeswrong/cli": ^0.18.2


### PR DESCRIPTION
## What does this PR do?

Adds an assets-only Worker (`infra/plugins-site`) bound to `plugins.emdashcms.com`. It serves:

- A placeholder `index.html` ("EmDash Plugin Registry -- Coming soon")
- `/.well-known/atproto-did` returning `did:plc:xyraubanwc5fwemkduw3upi6`

Context: the ATProto handle for the plugin registry account was migrated from `emdashplugins.npmx.social` to `plugins.emdashcms.com`. The DNS TXT record at `_atproto.plugins.emdashcms.com` and the PLC directory entry are already updated. This Worker provides the well-known HTTPS endpoint that Bluesky's identity resolver also checks.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (n/a -- no TypeScript)
- [x] `pnpm lint` passes (n/a -- static assets only)
- [x] `pnpm test` passes (n/a -- no tests for static assets)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include \`messages.po\` changes except in translation PRs -- a workflow extracts catalogs on merge to \`main\`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7 (opencode)

## Screenshots / test output

Worker already deployed and verified:

\`\`\`
$ curl -s https://plugins.emdashcms.com/.well-known/atproto-did
did:plc:xyraubanwc5fwemkduw3upi6

$ curl -s https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=plugins.emdashcms.com
{"did":"did:plc:xyraubanwc5fwemkduw3upi6"}
\`\`\`