### PR TITLE
feat(core): support field-level and range filters in where clause

### DIFF
--- a/.changeset/where-field-range-filters.md
+++ b/.changeset/where-field-range-filters.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds field-level and range filtering to `getEmDashCollection`'s `where` option. Previously, only taxonomy-based keys were processed via JOIN; non-taxonomy field names were silently discarded. Now the `where` clause supports exact match (`string`), multi-value match (`string[]`), and range comparisons (`{ gt?, gte?, lt?, lte? }`) on any content table column, all executed at the SQL layer with parameterized queries.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,8 @@ export type {
 	ResolvePathResult,
 	TranslationSummary,
 	TranslationsResult,
+	WhereRange,
+	WhereValue,
 } from "./query.js";
 
 // Request context (ALS-based ambient state for query functions)

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -408,6 +408,61 @@ function buildCursorCondition(
 	return sql`(${sql.ref(primary.field)} > ${orderValue} OR (${sql.ref(primary.field)} = ${orderValue} AND ${sql.ref(idField)} > ${cursorId}))`;
 }
 
+/** Type guard: is the where value a range object (not a string or array)? */
+function isWhereRange(value: WhereValue): value is WhereRange {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Build AND conditions for non-taxonomy field filters.
+ * Returns an array of sql fragments; empty if no field filters apply.
+ * Field names are validated against FIELD_NAME_PATTERN to prevent injection.
+ */
+function buildFieldConditions(
+	fields: Record<string, WhereValue>,
+	tablePrefix?: string,
+): ReturnType<typeof sql>[] {
+	const conditions: ReturnType<typeof sql>[] = [];
+
+	for (const [key, value] of Object.entries(fields)) {
+		if (!FIELD_NAME_PATTERN.test(key)) continue;
+		const ref = tablePrefix ? sql.ref(`${tablePrefix}.${key}`) : sql.ref(key);
+
+		if (isWhereRange(value)) {
+			if (value.gt !== undefined) conditions.push(sql`${ref} > ${value.gt}`);
+			if (value.gte !== undefined) conditions.push(sql`${ref} >= ${value.gte}`);
+			if (value.lt !== undefined) conditions.push(sql`${ref} < ${value.lt}`);
+			if (value.lte !== undefined) conditions.push(sql`${ref} <= ${value.lte}`);
+		} else if (Array.isArray(value)) {
+			if (value.length > 0) {
+				conditions.push(sql`${ref} IN (${sql.join(value.map((v) => sql`${v}`))})`);
+			}
+		} else {
+			conditions.push(sql`${ref} = ${value}`);
+		}
+	}
+
+	return conditions;
+}
+
+/**
+ * Range filter for comparison operators on field values.
+ * Values are compared as strings in the database. This works correctly for
+ * ISO 8601 dates (e.g. "2024-01-01T00:00:00Z") because lexicographic ordering
+ * matches chronological ordering. Ensure date values use a consistent format.
+ */
+export interface WhereRange {
+	gt?: string;
+	gte?: string;
+	lt?: string;
+	lte?: string;
+}
+
+/**
+ * A where clause value: exact match, multi-value match, or range comparison.
+ */
+export type WhereValue = string | string[] | WhereRange;
+
 /**
  * Filter for loadCollection - type is required
  */
@@ -423,7 +478,7 @@ export interface CollectionFilter {
 	/**
 	 * Filter by field values or taxonomy terms
 	 */
-	where?: Record<string, string | string[]>;
+	where?: Record<string, WhereValue>;
 	/**
 	 * Order results by field(s)
 	 * @default { created_at: "desc" }
@@ -538,7 +593,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				const status = filter?.status || "published";
 				const limit = filter?.limit;
 				const cursor = filter?.cursor;
-				const where = filter?.where;
+				const where = filter?.where as Record<string, WhereValue> | undefined;
 				const orderBy = filter?.orderBy;
 				const locale = filter?.locale;
 
@@ -551,79 +606,78 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					? buildCursorCondition(cursor, orderBy, tableName)
 					: null;
 
-				// Check if we need taxonomy filtering
+				// Separate taxonomy filters from field filters
 				let result: { rows: Record<string, unknown>[] };
+				let taxonomyFilter: { name: string; slugs: string[] } | null = null;
+				const fieldFilters: Record<string, WhereValue> = {};
 
 				if (where && Object.keys(where).length > 0) {
-					// Get taxonomy names to detect taxonomy filters
 					const taxNames = await getTaxonomyNames(db);
-					const taxonomyFilters: Record<string, string | string[]> = {};
 
 					for (const [key, value] of Object.entries(where)) {
-						if (taxNames.has(key)) {
-							taxonomyFilters[key] = value;
+						if (taxNames.has(key) && !isWhereRange(value)) {
+							// Only one taxonomy JOIN is supported per query;
+							// additional taxonomy keys are ignored.
+							if (!taxonomyFilter) {
+								const slugs = Array.isArray(value) ? value : [value];
+								taxonomyFilter = { name: key, slugs };
+							}
+						} else {
+							fieldFilters[key] = value;
 						}
 					}
+				}
 
-					// If we have taxonomy filters, use JOIN
-					if (Object.keys(taxonomyFilters).length > 0) {
-						// Build query with taxonomy JOIN
-						// For now, support single taxonomy filter (can extend later for multiple)
-						const [taxName, termSlugs] = Object.entries(taxonomyFilters)[0];
-						const slugs = Array.isArray(termSlugs) ? termSlugs : [termSlugs];
-						const orderByClause = buildOrderByClause(orderBy, tableName);
+				if (taxonomyFilter) {
+					const orderByClause = buildOrderByClause(orderBy, tableName);
+					const statusCondition = buildStatusCondition(db, status, tableName);
+					const localeCondition = locale
+						? sql`AND ${sql.ref(tableName)}.locale = ${locale}`
+						: sql``;
+					const cursorCond = cursorConditionPrefixed
+						? sql`AND ${cursorConditionPrefixed}`
+						: sql``;
+					const fieldConds = buildFieldConditions(fieldFilters, tableName);
+					const fieldCondsSQL =
+						fieldConds.length > 0
+							? sql`${sql.join(fieldConds, sql` AND `)}`
+							: null;
 
-						const statusCondition = buildStatusCondition(db, status, tableName);
-						const localeCondition = locale
-							? sql`AND ${sql.ref(tableName)}.locale = ${locale}`
-							: sql``;
-						const cursorCond = cursorConditionPrefixed
-							? sql`AND ${cursorConditionPrefixed}`
-							: sql``;
-						result = await sql<Record<string, unknown>>`
-							SELECT DISTINCT ${sql.ref(tableName)}.* FROM ${sql.ref(tableName)}
-							INNER JOIN content_taxonomies ct
-								ON ct.collection = ${type}
-								AND ct.entry_id = ${sql.ref(tableName)}.id
-							INNER JOIN taxonomies t
-								ON t.id = ct.taxonomy_id
-							WHERE ${sql.ref(tableName)}.deleted_at IS NULL
-								AND ${statusCondition}
-								${localeCondition}
-								${cursorCond}
-								AND t.name = ${taxName}
-								AND t.slug IN (${sql.join(slugs.map((s) => sql`${s}`))})
-							${orderByClause}
-							${fetchLimit ? sql`LIMIT ${fetchLimit}` : sql``}
-						`.execute(db);
-					} else {
-						// No taxonomy filters, use simple query
-						const orderByClause = buildOrderByClause(orderBy);
-						const statusCondition = buildStatusCondition(db, status);
-						const localeFilter = locale ? sql`AND locale = ${locale}` : sql``;
-						const cursorCond = cursorCondition ? sql`AND ${cursorCondition}` : sql``;
-						result = await sql<Record<string, unknown>>`
-							SELECT * FROM ${sql.ref(tableName)}
-							WHERE deleted_at IS NULL
+					result = await sql<Record<string, unknown>>`
+						SELECT DISTINCT ${sql.ref(tableName)}.* FROM ${sql.ref(tableName)}
+						INNER JOIN content_taxonomies ct
+							ON ct.collection = ${type}
+							AND ct.entry_id = ${sql.ref(tableName)}.id
+						INNER JOIN taxonomies t
+							ON t.id = ct.taxonomy_id
+						WHERE ${sql.ref(tableName)}.deleted_at IS NULL
 							AND ${statusCondition}
-							${localeFilter}
+							${localeCondition}
 							${cursorCond}
-							${orderByClause}
-							${fetchLimit ? sql`LIMIT ${fetchLimit}` : sql``}
-						`.execute(db);
-					}
+							AND t.name = ${taxonomyFilter.name}
+							AND t.slug IN (${sql.join(taxonomyFilter.slugs.map((s) => sql`${s}`))})
+							${fieldCondsSQL ? sql`AND ${fieldCondsSQL}` : sql``}
+						${orderByClause}
+						${fetchLimit ? sql`LIMIT ${fetchLimit}` : sql``}
+					`.execute(db);
 				} else {
-					// No where clause, use simple query
 					const orderByClause = buildOrderByClause(orderBy);
 					const statusCondition = buildStatusCondition(db, status);
 					const localeFilter = locale ? sql`AND locale = ${locale}` : sql``;
 					const cursorCond = cursorCondition ? sql`AND ${cursorCondition}` : sql``;
+					const fieldConds = buildFieldConditions(fieldFilters);
+					const fieldCondsSQL =
+						fieldConds.length > 0
+							? sql`${sql.join(fieldConds, sql` AND `)}`
+							: null;
+
 					result = await sql<Record<string, unknown>>`
 						SELECT * FROM ${sql.ref(tableName)}
 						WHERE deleted_at IS NULL
 						AND ${statusCondition}
 						${localeFilter}
 						${cursorCond}
+						${fieldCondsSQL ? sql`AND ${fieldCondsSQL}` : sql``}
 						${orderByClause}
 						${fetchLimit ? sql`LIMIT ${fetchLimit}` : sql``}
 					`.execute(db);

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -634,14 +634,10 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					const localeCondition = locale
 						? sql`AND ${sql.ref(tableName)}.locale = ${locale}`
 						: sql``;
-					const cursorCond = cursorConditionPrefixed
-						? sql`AND ${cursorConditionPrefixed}`
-						: sql``;
+					const cursorCond = cursorConditionPrefixed ? sql`AND ${cursorConditionPrefixed}` : sql``;
 					const fieldConds = buildFieldConditions(fieldFilters, tableName);
 					const fieldCondsSQL =
-						fieldConds.length > 0
-							? sql`${sql.join(fieldConds, sql` AND `)}`
-							: null;
+						fieldConds.length > 0 ? sql`${sql.join(fieldConds, sql` AND `)}` : null;
 
 					result = await sql<Record<string, unknown>>`
 						SELECT DISTINCT ${sql.ref(tableName)}.* FROM ${sql.ref(tableName)}
@@ -667,9 +663,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					const cursorCond = cursorCondition ? sql`AND ${cursorCondition}` : sql``;
 					const fieldConds = buildFieldConditions(fieldFilters);
 					const fieldCondsSQL =
-						fieldConds.length > 0
-							? sql`${sql.join(fieldConds, sql` AND `)}`
-							: null;
+						fieldConds.length > 0 ? sql`${sql.join(fieldConds, sql` AND `)}` : null;
 
 					result = await sql<Record<string, unknown>>`
 						SELECT * FROM ${sql.ref(tableName)}

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -20,7 +20,7 @@ import { decodeCursor, encodeCursor } from "./database/repositories/types.js";
 import { validateIdentifier } from "./database/validate.js";
 import type { Database } from "./index.js";
 import { getRequestContext } from "./request-context.js";
-import { isMissingTableError } from "./utils/db-errors.js";
+import { isMissingColumnError, isMissingTableError } from "./utils/db-errors.js";
 
 const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -425,7 +425,11 @@ function buildFieldConditions(
 	const conditions: ReturnType<typeof sql>[] = [];
 
 	for (const [key, value] of Object.entries(fields)) {
-		if (!FIELD_NAME_PATTERN.test(key)) continue;
+		if (!FIELD_NAME_PATTERN.test(key)) {
+			console.warn(`[emdash] where filter: invalid field name "${key}" ignored`);
+			continue;
+		}
+		if (value == null) continue;
 		const ref = tablePrefix ? sql.ref(`${tablePrefix}.${key}`) : sql.ref(key);
 
 		if (isWhereRange(value)) {
@@ -476,7 +480,14 @@ export interface CollectionFilter {
 	 */
 	cursor?: string;
 	/**
-	 * Filter by field values or taxonomy terms
+	 * Filter by field values, taxonomy terms, or ranges.
+	 *
+	 * Taxonomy names are detected automatically and filtered via JOIN.
+	 * Other keys are treated as column filters on the content table.
+	 *
+	 * @example { category: 'news' } - taxonomy term
+	 * @example { series: 'main' } - exact match on a content field
+	 * @example { published_at: { gte: '2024-01-01', lt: '2025-01-01' } } - date range
 	 */
 	where?: Record<string, WhereValue>;
 	/**
@@ -593,7 +604,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				const status = filter?.status || "published";
 				const limit = filter?.limit;
 				const cursor = filter?.cursor;
-				const where = filter?.where as Record<string, WhereValue> | undefined;
+				const where = filter?.where;
 				const orderBy = filter?.orderBy;
 				const locale = filter?.locale;
 
@@ -615,13 +626,22 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					const taxNames = await getTaxonomyNames(db);
 
 					for (const [key, value] of Object.entries(where)) {
-						if (taxNames.has(key) && !isWhereRange(value)) {
-							// Only one taxonomy JOIN is supported per query;
-							// additional taxonomy keys are ignored.
-							if (!taxonomyFilter) {
-								const slugs = Array.isArray(value) ? value : [value];
-								taxonomyFilter = { name: key, slugs };
+						if (value == null) continue;
+						if (taxNames.has(key)) {
+							if (isWhereRange(value)) {
+								console.warn(
+									`[emdash] where filter: range operators are not supported on taxonomy "${key}", ignored`,
+								);
+								continue;
 							}
+							if (taxonomyFilter) {
+								console.warn(
+									`[emdash] where filter: only one taxonomy is supported per query, "${key}" ignored`,
+								);
+								continue;
+							}
+							const slugs = Array.isArray(value) ? value : [value];
+							taxonomyFilter = { name: key, slugs };
 						} else {
 							fieldFilters[key] = value;
 						}
@@ -741,13 +761,17 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					},
 				};
 			} catch (error) {
-				// Handle missing table gracefully - return empty collection.
-				// This happens before migrations have run.
-				if (isMissingTableError(error)) {
+				// Handle missing table/column gracefully - return empty collection.
+				// Missing table happens before migrations have run.
+				// Missing column happens when a where filter references a non-existent field.
+				const message = error instanceof Error ? error.message : String(error);
+				if (isMissingTableError(error) || isMissingColumnError(error)) {
+					if (isMissingColumnError(error)) {
+						console.warn(`[emdash] where filter: ${message}`);
+					}
 					return { entries: [] };
 				}
 
-				const message = error instanceof Error ? error.message : String(error);
 				return {
 					error: new Error(`Failed to load collection: ${message}`),
 				};

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -26,7 +26,7 @@
 
 import { encodeCursor } from "./database/repositories/types.js";
 import { getFallbackChain, getI18nConfig, isI18nEnabled } from "./i18n/config.js";
-import { CURSOR_RAW_VALUES } from "./loader.js";
+import { CURSOR_RAW_VALUES, type WhereRange, type WhereValue } from "./loader.js";
 import { requestCached } from "./request-cache.js";
 import { getRequestContext } from "./request-context.js";
 import { isMissingTableError } from "./utils/db-errors.js";
@@ -82,6 +82,8 @@ export type SortDirection = "asc" | "desc";
  */
 export type OrderBySpec = Record<string, SortDirection>;
 
+export type { WhereRange, WhereValue };
+
 export interface CollectionFilter {
 	status?: "draft" | "published" | "archived";
 	limit?: number;
@@ -99,11 +101,17 @@ export interface CollectionFilter {
 	 */
 	cursor?: string;
 	/**
-	 * Filter by field values or taxonomy terms
+	 * Filter by field values, taxonomy terms, or ranges.
+	 *
+	 * Taxonomy names are detected automatically and filtered via JOIN.
+	 * Other keys are treated as column filters on the content table.
+	 *
 	 * @example { category: 'news' } - Filter by taxonomy term
 	 * @example { category: ['news', 'featured'] } - Filter by multiple terms (OR)
+	 * @example { series: 'main' } - Exact match on a content field
+	 * @example { published_at: { gte: '2024-01-01', lt: '2025-01-01' } } - Date range
 	 */
-	where?: Record<string, string | string[]>;
+	where?: Record<string, WhereValue>;
 	/**
 	 * Order results by field(s)
 	 * @default { created_at: "desc" }
@@ -458,7 +466,13 @@ function collectionCacheKey(type: string, filter?: CollectionFilter): string {
 function stableStringify(value: Record<string, unknown>): string {
 	const keys = Object.keys(value).toSorted();
 	const ordered: Record<string, unknown> = {};
-	for (const k of keys) ordered[k] = value[k];
+	for (const k of keys) {
+		const v = value[k];
+		ordered[k] =
+			v !== null && typeof v === "object" && !Array.isArray(v)
+				? stableStringify(v as Record<string, unknown>)
+				: v;
+	}
 	return JSON.stringify(ordered);
 }
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -481,7 +481,6 @@ function stableOrder(value: Record<string, unknown>): Record<string, unknown> {
 	return ordered;
 }
 
-
 async function getEmDashCollectionUncached<T extends string, D = InferCollectionData<T>>(
 	type: T,
 	filter?: CollectionFilter,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -464,16 +464,20 @@ function collectionCacheKey(type: string, filter?: CollectionFilter): string {
 }
 
 function stableStringify(value: Record<string, unknown>): string {
+	return JSON.stringify(stableOrder(value));
+}
+
+function stableOrder(value: Record<string, unknown>): Record<string, unknown> {
 	const keys = Object.keys(value).toSorted();
 	const ordered: Record<string, unknown> = {};
 	for (const k of keys) {
 		const v = value[k];
 		ordered[k] =
 			v !== null && typeof v === "object" && !Array.isArray(v)
-				? stableStringify(v as Record<string, unknown>)
+				? stableOrder(v as Record<string, unknown>)
 				: v;
 	}
-	return JSON.stringify(ordered);
+	return ordered;
 }
 
 async function getEmDashCollectionUncached<T extends string, D = InferCollectionData<T>>(

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -472,13 +472,15 @@ function stableOrder(value: Record<string, unknown>): Record<string, unknown> {
 	const ordered: Record<string, unknown> = {};
 	for (const k of keys) {
 		const v = value[k];
-		ordered[k] =
-			v !== null && typeof v === "object" && !Array.isArray(v)
-				? stableOrder(v as Record<string, unknown>)
-				: v;
+		if (isRecord(v)) {
+			ordered[k] = stableOrder(v);
+		} else {
+			ordered[k] = v;
+		}
 	}
 	return ordered;
 }
+
 
 async function getEmDashCollectionUncached<T extends string, D = InferCollectionData<T>>(
 	type: T,

--- a/packages/core/src/utils/db-errors.ts
+++ b/packages/core/src/utils/db-errors.ts
@@ -36,7 +36,12 @@ export function isMissingColumnError(error: unknown): boolean {
 
 	// PostgreSQL SQLSTATE 42703: 'column "foo" does not exist'
 	// Exclude "relation" to avoid false positives on table names containing "column"
-	if (message.includes("does not exist") && message.includes("column") && !message.includes("relation")) return true;
+	if (
+		message.includes("does not exist") &&
+		message.includes("column") &&
+		!message.includes("relation")
+	)
+		return true;
 
 	return false;
 }

--- a/packages/core/src/utils/db-errors.ts
+++ b/packages/core/src/utils/db-errors.ts
@@ -35,7 +35,8 @@ export function isMissingColumnError(error: unknown): boolean {
 	if (message.includes("no such column")) return true;
 
 	// PostgreSQL SQLSTATE 42703: 'column "foo" does not exist'
-	if (message.includes("does not exist") && message.includes("column")) return true;
+	// Exclude "relation" to avoid false positives on table names containing "column"
+	if (message.includes("does not exist") && message.includes("column") && !message.includes("relation")) return true;
 
 	return false;
 }

--- a/packages/core/src/utils/db-errors.ts
+++ b/packages/core/src/utils/db-errors.ts
@@ -23,6 +23,24 @@ function messageOf(error: unknown): string {
 }
 
 /**
+ * Returns true when `error` is a "column does not exist" error.
+ * Used to handle where filters that reference non-existent field names
+ * gracefully (return empty results) instead of propagating a SQL error.
+ */
+export function isMissingColumnError(error: unknown): boolean {
+	const message = messageOf(error);
+	if (!message) return false;
+
+	// SQLite / D1: "no such column: foo"
+	if (message.includes("no such column")) return true;
+
+	// PostgreSQL SQLSTATE 42703: 'column "foo" does not exist'
+	if (message.includes("does not exist") && message.includes("column")) return true;
+
+	return false;
+}
+
+/**
  * Returns true when `error` is a "table does not exist" error across the
  * dialects EmDash supports (D1/SQLite and PostgreSQL). Used by runtime
  * probes to treat pre-migration databases as empty without logging a scary

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -1,0 +1,301 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { handleContentCreate } from "../../src/api/index.js";
+import type { Database } from "../../src/database/types.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+describe("Loader field filters", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		// Add a 'series' field to the post collection for field filtering tests
+		const registry = new SchemaRegistry(db);
+		await registry.createField("post", {
+			slug: "series",
+			label: "Series",
+			type: "string",
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	async function createPost(title: string, opts: { series?: string; publishedAt?: string } = {}) {
+		const result = await handleContentCreate(db, "post", {
+			data: { title, series: opts.series ?? null },
+			status: "published",
+			publishedAt: opts.publishedAt,
+		});
+		if (!result.success) throw new Error("Failed to create post");
+		return result.data!.item;
+	}
+
+	it("should filter by exact field match", async () => {
+		await createPost("Post A", { series: "alpha" });
+		await createPost("Post B", { series: "beta" });
+		await createPost("Post C", { series: "alpha" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({ filter: { type: "post", where: { series: "alpha" } } }),
+		);
+
+		expect(result.entries).toHaveLength(2);
+		const titles = result.entries.map((e) => e.data.title);
+		expect(titles).toContain("Post A");
+		expect(titles).toContain("Post C");
+	});
+
+	it("should filter by multi-value field match (IN)", async () => {
+		await createPost("Post A", { series: "alpha" });
+		await createPost("Post B", { series: "beta" });
+		await createPost("Post C", { series: "gamma" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { series: ["alpha", "gamma"] } },
+			}),
+		);
+
+		expect(result.entries).toHaveLength(2);
+		const titles = result.entries.map((e) => e.data.title);
+		expect(titles).toContain("Post A");
+		expect(titles).toContain("Post C");
+	});
+
+	it("should filter by date range (gte + lt)", async () => {
+		await createPost("Old Post", { publishedAt: "2023-06-15T00:00:00Z" });
+		await createPost("Mid Post", { publishedAt: "2024-03-01T00:00:00Z" });
+		await createPost("New Post", { publishedAt: "2025-01-10T00:00:00Z" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { published_at: { gte: "2024-01-01T00:00:00Z", lt: "2025-01-01T00:00:00Z" } },
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("Mid Post");
+	});
+
+	it("should combine field filter with cursor pagination", async () => {
+		for (let i = 1; i <= 5; i++) {
+			await createPost(`Alpha ${i}`, { series: "alpha" });
+		}
+		await createPost("Beta 1", { series: "beta" });
+
+		const loader = emdashLoader();
+		const page1 = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { series: "alpha" }, limit: 3 },
+			}),
+		);
+
+		expect(page1.entries).toHaveLength(3);
+		expect(page1.nextCursor).toBeTruthy();
+
+		const page2 = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { series: "alpha" }, limit: 3, cursor: page1.nextCursor },
+			}),
+		);
+
+		expect(page2.entries).toHaveLength(2);
+		expect(page2.nextCursor).toBeUndefined();
+	});
+
+	it("should return all entries when where has only invalid field names", async () => {
+		await createPost("Post A", { series: "alpha" });
+		await createPost("Post B", { series: "beta" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { "invalid-field!": "value" } },
+			}),
+		);
+
+		// Invalid field names are skipped, so no filter is applied
+		expect(result.entries).toHaveLength(2);
+	});
+
+	it("should handle empty WhereRange object (no conditions added)", async () => {
+		await createPost("Post A");
+		await createPost("Post B");
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { published_at: {} } },
+			}),
+		);
+
+		expect(result.entries).toHaveLength(2);
+	});
+
+	it("should filter by gt (strict greater than)", async () => {
+		await createPost("Early", { publishedAt: "2024-01-01T00:00:00Z" });
+		await createPost("Exact", { publishedAt: "2024-06-01T00:00:00Z" });
+		await createPost("Late", { publishedAt: "2024-12-01T00:00:00Z" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { published_at: { gt: "2024-06-01T00:00:00Z" } },
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("Late");
+	});
+
+	it("should combine exact match and range filter on different fields", async () => {
+		await createPost("A-Old", { series: "alpha", publishedAt: "2023-06-01T00:00:00Z" });
+		await createPost("A-New", { series: "alpha", publishedAt: "2024-06-01T00:00:00Z" });
+		await createPost("B-New", { series: "beta", publishedAt: "2024-06-01T00:00:00Z" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: {
+						series: "alpha",
+						published_at: { gte: "2024-01-01T00:00:00Z" },
+					},
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("A-New");
+	});
+
+	it("should filter by lte (less than or equal)", async () => {
+		await createPost("Early", { publishedAt: "2024-01-01T00:00:00Z" });
+		await createPost("Exact", { publishedAt: "2024-06-01T00:00:00Z" });
+		await createPost("Late", { publishedAt: "2024-12-01T00:00:00Z" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { published_at: { lte: "2024-06-01T00:00:00Z" } },
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(2);
+		const titles = result.entries.map((e) => e.data.title);
+		expect(titles).toContain("Early");
+		expect(titles).toContain("Exact");
+	});
+
+	it("should combine taxonomy filter with field filter", async () => {
+		// Create a taxonomy term and assign it to posts
+		await db
+			.insertInto("taxonomies" as never)
+			.values({
+				id: "tax_cat_news",
+				name: "category",
+				slug: "news",
+				label: "News",
+			} as never)
+			.execute();
+
+		const postA = await createPost("A-News-Alpha", { series: "alpha" });
+		const postB = await createPost("B-News-Beta", { series: "beta" });
+		await createPost("C-Other-Alpha", { series: "alpha" });
+
+		// Assign taxonomy to posts A and B
+		await db
+			.insertInto("content_taxonomies" as never)
+			.values([
+				{ collection: "post", entry_id: postA.id, taxonomy_id: "tax_cat_news" },
+				{ collection: "post", entry_id: postB.id, taxonomy_id: "tax_cat_news" },
+			] as never)
+			.execute();
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { category: "news", series: "alpha" },
+				},
+			}),
+		);
+
+		// Only post A matches both category=news AND series=alpha
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("A-News-Alpha");
+	});
+
+	it("should preserve backward compatibility with taxonomy-only filter", async () => {
+		await db
+			.insertInto("taxonomies" as never)
+			.values({
+				id: "tax_cat_tech",
+				name: "category",
+				slug: "tech",
+				label: "Tech",
+			} as never)
+			.execute();
+
+		const postA = await createPost("Tech Post");
+		await createPost("Other Post");
+
+		await db
+			.insertInto("content_taxonomies" as never)
+			.values({
+				collection: "post",
+				entry_id: postA.id,
+				taxonomy_id: "tax_cat_tech",
+			} as never)
+			.execute();
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", where: { category: "tech" } },
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("Tech Post");
+	});
+
+	it("should handle range with only one bound (lt without gte)", async () => {
+		await createPost("Early", { publishedAt: "2023-01-01T00:00:00Z" });
+		await createPost("Mid", { publishedAt: "2024-06-01T00:00:00Z" });
+		await createPost("Late", { publishedAt: "2025-12-01T00:00:00Z" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { published_at: { lt: "2024-01-01T00:00:00Z" } },
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].data.title).toBe("Early");
+	});
+});

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -365,9 +365,7 @@ describe("Loader field filters", () => {
 		);
 
 		expect(result.entries).toHaveLength(0);
-		expect(warnSpy).toHaveBeenCalledWith(
-			expect.stringContaining("no such column"),
-		);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("no such column"));
 		warnSpy.mockRestore();
 	});
 });

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { handleContentCreate } from "../../src/api/index.js";
 import type { Database } from "../../src/database/types.js";
-import { SchemaRegistry } from "../../src/schema/registry.js";
 import { emdashLoader } from "../../src/loader.js";
 import { runWithContext } from "../../src/request-context.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
 
 describe("Loader field filters", () => {

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -1,5 +1,5 @@
 import type { Kysely } from "kysely";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { handleContentCreate } from "../../src/api/index.js";
 import type { Database } from "../../src/database/types.js";
@@ -278,6 +278,57 @@ describe("Loader field filters", () => {
 
 		expect(result.entries).toHaveLength(1);
 		expect(result.entries[0].data.title).toBe("Tech Post");
+	});
+
+	it("should skip null/undefined values in where filter", async () => {
+		await createPost("Post A", { series: "alpha" });
+		await createPost("Post B", { series: "beta" });
+
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { series: null as unknown as string },
+				},
+			}),
+		);
+
+		// null values are skipped, so no filter is applied
+		expect(result.entries).toHaveLength(2);
+	});
+
+	it("should warn and skip range operators on taxonomy keys", async () => {
+		await db
+			.insertInto("taxonomies" as never)
+			.values({
+				id: "tax_cat_range",
+				name: "category",
+				slug: "test",
+				label: "Test",
+			} as never)
+			.execute();
+
+		await createPost("Post A");
+		await createPost("Post B");
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { category: { gte: "a" } as unknown as string },
+				},
+			}),
+		);
+
+		// Range on taxonomy is ignored, returns all entries
+		expect(result.entries).toHaveLength(2);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("range operators are not supported on taxonomy"),
+		);
+		warnSpy.mockRestore();
 	});
 
 	it("should handle range with only one bound (lt without gte)", async () => {

--- a/packages/core/tests/unit/loader-field-filters.test.ts
+++ b/packages/core/tests/unit/loader-field-filters.test.ts
@@ -349,4 +349,25 @@ describe("Loader field filters", () => {
 		expect(result.entries).toHaveLength(1);
 		expect(result.entries[0].data.title).toBe("Early");
 	});
+
+	it("should return empty results for non-existent column in where filter", async () => {
+		await createPost("Post A", { series: "alpha" });
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const loader = emdashLoader();
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					where: { nonexistent_column: "value" },
+				},
+			}),
+		);
+
+		expect(result.entries).toHaveLength(0);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("no such column"),
+		);
+		warnSpy.mockRestore();
+	});
 });


### PR DESCRIPTION
## What does this PR do?

The loader's `where` option previously only processed taxonomy-based keys (via JOIN). Non-taxonomy field names were silently discarded, forcing sites with large content libraries to load entire collections into memory and filter in JavaScript.

This adds two capabilities to `getEmDashCollection`'s `where` clause:

- **Exact/multi-value match on content table columns** — `{ series: "main" }` or `{ series: ["main", "side"] }`
- **Range comparisons** — `{ published_at: { gte: "2024-01-01T00:00:00Z", lt: "2025-01-01T00:00:00Z" } }`

Both execute at the SQL layer with parameterized queries and validated identifiers. Taxonomy filtering remains unchanged (backward compatible).

**Motivation:** A fiction serialization site with ~4000 chapters spanning 10+ years. The timeline page needs to filter by year (`published_at` range) and by series (field exact match). Without SQL-level field filtering, the only options are wasteful full-table JS filtering or dropping to raw `getDb()` and losing preview, visual editing, byline hydration, and request caching.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A — no UI changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1065

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.6 (Claude Code)

## Screenshots / test output

```
 Test Files  209 passed (209)
      Tests  3305 passed (3305)
```

### Usage examples

```typescript
// Exact match on a content field
const { entries } = await getEmDashCollection("posts", {
  where: { series: "main" },
});

// Date range filtering
const { entries } = await getEmDashCollection("posts", {
  where: { published_at: { gte: "2024-01-01T00:00:00Z", lt: "2025-01-01T00:00:00Z" } },
  orderBy: { published_at: "asc" },
});

// Combined: taxonomy + field + range
const { entries } = await getEmDashCollection("posts", {
  where: { category: "fiction", series: "main", published_at: { gte: "2024-01-01" } },
});
```