### PR TITLE
fix(templates): drop trustPolicy: no-downgrade

### DIFF
--- a/scripts/sync-templates-repo.mjs
+++ b/scripts/sync-templates-repo.mjs
@@ -144,15 +144,13 @@ function pnpmWorkspaceYaml(template) {
 allowBuilds:
 ${allowBuilds}
 
-# Supply-chain hardening. chokidar@4.0.3 is the lone trust exclusion --
-# Astro pins that provenance-dropped release; self-expires on its next bump.
+# Supply-chain hardening: cooldown on brand-new releases (EmDash exempt)
+# and no non-registry transitive sources. (No trustPolicy: no-downgrade --
+# it trips on upstream provenance regressions we don't control.)
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - emdash
   - "@emdash-cms/*"
-trustPolicy: no-downgrade
-trustPolicyExclude:
-  - "chokidar@4.0.3"
 blockExoticSubdeps: true
 `;
 }


### PR DESCRIPTION
## What does this PR do?

Removes `trustPolicy: no-downgrade` (and its now-unneeded `trustPolicyExclude`) from the generated `pnpm-workspace.yaml`.

`no-downgrade` fires on a provenance/trust-level regression *anywhere in the transitive dependency graph* — packages the template author doesn't control. We've already hit `chokidar@4.0.3` (#1066) and now `@portabletext/toolkit`, and there will be more. Each one blocks every scaffolded `pnpm install` and would need its own version-pinned exclusion shipped via a merge + templates-sync cycle. That's untenable, so the policy is dropped rather than maintained as a growing per-dependency allowlist.

Kept (no whack-a-mole failure mode):
- `allowBuilds` — only the native builds each runtime needs
- `minimumReleaseAge: 1440` (EmDash packages exempt)
- `blockExoticSubdeps: true`

Supersedes the chokidar exclusion added in #1066.

No related issue.

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — not run locally (no TS changed; CI covers it)
- [ ] `pnpm lint` passes — not run locally; CI covers it
- [ ] `pnpm test` passes — targeted: `node --check` + generator eval asserting no `trustPolicy` key emitted
- [x] `pnpm format` has been run — N/A: only the `.mjs` generator string changed, matches surrounding style
- [ ] I have added/updated tests — N/A (sync tooling)
- [ ] User-visible strings wrapped for translation — N/A
- [x] I have added a changeset (if this PR changes a published package) — N/A: sync tooling only
- [ ] New features link to an approved Discussion — N/A (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Claude Code)

## Screenshots / test output

Generated `pnpm-workspace.yaml` (starter-cloudflare) top-level keys: `allowBuilds`, `minimumReleaseAge`, `minimumReleaseAgeExclude`, `blockExoticSubdeps` — no `trustPolicy`. `node --check` passes.

## Notes

- Reaches users once a templates sync propagates to `emdash-cms/templates`.