### PR TITLE
fix(client): map { terms } envelope to ListResult.items in client.terms()

### DIFF
--- a/.changeset/fix-client-terms-items-key.md
+++ b/.changeset/fix-client-terms-items-key.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `EmDashClient.terms()` returning `{ terms }` instead of `{ items }`, which caused `page.items` to be `undefined` for any caller that iterated the result. The API handler returns `{ terms: TermWithCount[] }` but the client was typed and advertised as `ListResult<Term>` — the key name mismatch is now mapped correctly.

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -737,10 +737,11 @@ export class EmDashClient {
 		if (options?.cursor) params.set("cursor", options.cursor);
 
 		const qs = params.toString();
-		return this.request<ListResult<Term>>(
+		const data = await this.request<{ terms: Term[] }>(
 			"GET",
 			`/taxonomies/${encodeURIComponent(taxonomy)}/terms${qs ? `?${qs}` : ""}`,
 		);
+		return { items: data.terms };
 	}
 
 	/** Create a taxonomy term */

--- a/packages/core/tests/integration/cli/cli.test.ts
+++ b/packages/core/tests/integration/cli/cli.test.ts
@@ -327,14 +327,14 @@ describe("CLI Integration", () => {
 		});
 
 		it("taxonomy terms returns terms for a taxonomy", async () => {
-			const result = await cliJson<{ terms: { slug: string }[] }>(
+			const result = await cliJson<{ items: { slug: string }[] }>(
 				"taxonomy",
 				"terms",
 				"categories",
 			);
-			expect(result.terms).toBeDefined();
-			expect(Array.isArray(result.terms)).toBe(true);
-			const slugs = result.terms.map((t) => t.slug);
+			expect(result.items).toBeDefined();
+			expect(Array.isArray(result.items)).toBe(true);
+			const slugs = result.items.map((t) => t.slug);
 			expect(slugs).toContain("news");
 		});
 	});

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -677,6 +677,36 @@ describe("EmDashClient", () => {
 		});
 	});
 
+	describe("terms()", () => {
+		it("returns ListResult with items mapped from { terms } envelope", async () => {
+			const backend = createMockBackend([
+				{
+					method: "GET",
+					path: "/taxonomies/categories/terms",
+					handler: () =>
+						jsonResponse({
+							terms: [
+								{ id: "t1", slug: "uncategorized", label: "Uncategorized", count: 3 },
+								{ id: "t2", slug: "news", label: "News", count: 1 },
+							],
+						}),
+				},
+			]);
+
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			const result = await client.terms("categories");
+			expect(result.items).toHaveLength(2);
+			expect(result.items[0]!.slug).toBe("uncategorized");
+			expect(result.items[1]!.slug).toBe("news");
+			expect(result.nextCursor).toBeUndefined();
+		});
+	});
+
 	describe("menus()", () => {
 		it("returns menu array from bare-array envelope", async () => {
 			const backend = createMockBackend([


### PR DESCRIPTION
## What does this PR do?

`EmDashClient.terms()` was declared as returning `Promise<ListResult<Term>>` (i.e. `{ items: Term[], nextCursor?: string }`), but the handler at `packages/core/src/api/handlers/taxonomies.ts:395` returns `{ terms: TermWithCount[] }`. The client's `request<T>()` helper unwraps `json.data` and type-casts it, so callers received `{ terms: [...] }` at runtime while TypeScript said `{ items: [...] }`. Accessing `result.items` would yield `undefined`, causing a `TypeError` on iteration.

The only internal caller (`cli/commands/taxonomy.ts`) passed the whole result to `output()` without accessing `.items`, so the mismatch was never caught.

Fix: unwrap the actual `{ terms }` key inside `terms()` and return `{ items: data.terms }`.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 4.6

## Screenshots / test output

```
✓ tests/unit/client/client.test.ts (17 tests) 33ms

Test Files  1 passed (1)
     Tests  17 passed (17)
```