### PR TITLE
fix(plugin-cli): normalise multi-word flags to kebab-case

### DIFF
--- a/.changeset/plugin-cli-kebab-flags.md
+++ b/.changeset/plugin-cli-kebab-flags.md
@@ -1,0 +1,10 @@
+---
+"@emdash-cms/plugin-cli": patch
+---
+
+Renames the multi-word flags on `build`, `dev`, and `bundle` from camelCase to kebab-case for consistency with `publish` and standard Unix CLI convention.
+
+- `--outDir` -> `--out-dir`
+- `--validateOnly` -> `--validate-only`
+
+The short alias `-o` for `--out-dir` is unchanged.

--- a/packages/plugin-cli/src/build/command.ts
+++ b/packages/plugin-cli/src/build/command.ts
@@ -30,7 +30,7 @@ export const buildCommand = defineCommand({
 			description: "Plugin directory (default: current directory)",
 			default: process.cwd(),
 		},
-		outDir: {
+		"out-dir": {
 			type: "string",
 			alias: "o",
 			description: "Output directory (default: ./dist)",
@@ -49,7 +49,7 @@ export const buildCommand = defineCommand({
 		try {
 			result = await buildPlugin({
 				dir: args.dir,
-				outDir: args.outDir,
+				outDir: args["out-dir"],
 				logger,
 			});
 		} catch (error) {

--- a/packages/plugin-cli/src/bundle/command.ts
+++ b/packages/plugin-cli/src/bundle/command.ts
@@ -26,13 +26,13 @@ export const bundleCommand = defineCommand({
 			description: "Plugin directory (default: current directory)",
 			default: process.cwd(),
 		},
-		outDir: {
+		"out-dir": {
 			type: "string",
 			alias: "o",
 			description: "Output directory for the tarball (default: ./dist)",
 			default: "dist",
 		},
-		validateOnly: {
+		"validate-only": {
 			type: "boolean",
 			description: "Run validation only, skip tarball creation",
 			default: false,
@@ -50,8 +50,8 @@ export const bundleCommand = defineCommand({
 		try {
 			result = await bundlePlugin({
 				dir: args.dir,
-				outDir: args.outDir,
-				validateOnly: args.validateOnly,
+				outDir: args["out-dir"],
+				validateOnly: args["validate-only"],
 				logger,
 			});
 		} catch (error) {
@@ -67,7 +67,7 @@ export const bundleCommand = defineCommand({
 		// hosts the artifact (GitHub release asset, R2, S3, their own server)
 		// and the registry indexes the URL. Spell out the next step so users
 		// don't have to dig for it.
-		if (!args.validateOnly && result.tarballPath) {
+		if (!args["validate-only"] && result.tarballPath) {
 			console.log();
 			consola.info("Next steps:");
 			console.log(`  1. Upload ${pc.cyan(result.tarballPath)} to a public URL.`);

--- a/packages/plugin-cli/src/dev/command.ts
+++ b/packages/plugin-cli/src/dev/command.ts
@@ -58,7 +58,7 @@ export const devCommand = defineCommand({
 			description: "Plugin directory (default: current directory)",
 			default: process.cwd(),
 		},
-		outDir: {
+		"out-dir": {
 			type: "string",
 			alias: "o",
 			description: "Output directory (default: ./dist)",
@@ -93,7 +93,7 @@ export const devCommand = defineCommand({
 			try {
 				await buildPlugin({
 					dir: args.dir,
-					outDir: args.outDir,
+					outDir: args["out-dir"],
 					logger,
 				});
 			} catch (error) {
@@ -146,10 +146,10 @@ export const devCommand = defineCommand({
 		await runBuild("initial build");
 
 		// Resolve outDir relative to the plugin dir so the ignore
-		// pattern matches whatever the user passed for `--outDir`.
+		// pattern matches whatever the user passed for `--out-dir`.
 		// chokidar wants forward-slash globs even on Windows, so
 		// normalise the platform separator (path.sep) to "/".
-		const resolvedOutDir = resolve(args.dir, args.outDir);
+		const resolvedOutDir = resolve(args.dir, args["out-dir"]);
 		const cwdAbs = resolve(args.dir);
 		const outDirRel = relative(cwdAbs, resolvedOutDir);
 		// `outDirGlob` is the ignore pattern only when outDir is

--- a/packages/plugin-cli/tests/bundle.test.ts
+++ b/packages/plugin-cli/tests/bundle.test.ts
@@ -15,7 +15,7 @@ const BAD_FIXTURE = fileURLToPath(new URL("./fixtures/bad-plugin", import.meta.u
  * directory, assert the resulting tarball + manifest match expectations.
  *
  * Each test runs the bundler at a different `outDir` under a fresh tempdir so
- * concurrent runs don't collide, and so `--outDir` resolution works as
+ * concurrent runs don't collide, and so `--out-dir` resolution works as
  * advertised (it can be either absolute or relative to `dir`).
  */
 describe("bundlePlugin", () => {


### PR DESCRIPTION
## What does this PR do?

Normalises multi-word CLI flags on `@emdash-cms/plugin-cli` to kebab-case for consistency with the `publish` subcommand and standard Unix CLI convention.

Today the CLI has both styles side-by-side:

- `publish`: `--author-name`, `--author-url`, `--security-email`, `--no-manifest` (kebab)
- `build` / `dev` / `bundle`: `--outDir`, `--validateOnly` (camel)

After this change, the three outliers use kebab too:

- `--outDir` -> `--out-dir`
- `--validateOnly` -> `--validate-only`

The short alias `-o` for `--out-dir` is unchanged. The programmatic API options on `bundlePlugin()` / `buildPlugin()` stay camelCase — they're JS function options, not CLI flags.

Surfaced during review of #1059 (plugin authoring docs). The docs branch documents the kebab form, so this PR needs to land before — or together with — the docs PR.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

```
=== build ===
  --dir="..."             Plugin directory (default: current directory)
  -o, --out-dir="dist"    Output directory (default: ./dist)
=== dev ===
  --dir="..."             Plugin directory (default: current directory)
  -o, --out-dir="dist"    Output directory (default: ./dist)
=== bundle ===
  --dir="..."             Plugin directory (default: current directory)
  -o, --out-dir="dist"    Output directory for the tarball (default: ./dist)
  --validate-only         Run validation only, skip tarball creation
```

Tests: 256/256 passing in `packages/plugin-cli`. Typecheck clean.
