### PR TITLE
fix(plugin-cli): rename --aggregator flag to --registry-url

### DIFF
--- a/.changeset/plugin-cli-registry-url-flag.md
+++ b/.changeset/plugin-cli-registry-url-flag.md
@@ -1,0 +1,17 @@
+---
+"@emdash-cms/plugin-cli": patch
+---
+
+Renames the `--aggregator` flag on `search` and `info` to `--registry-url` for consistency with the `EMDASH_REGISTRY_URL` env var and the rest of the user-facing surface. Internally the override still selects the aggregator service to query — the rename only affects what users type.
+
+Old:
+
+```sh
+emdash-plugin search "image" --aggregator https://registry.example.com
+```
+
+New:
+
+```sh
+emdash-plugin search "image" --registry-url https://registry.example.com
+```

--- a/packages/plugin-cli/README.md
+++ b/packages/plugin-cli/README.md
@@ -34,7 +34,7 @@ emdash-plugin search <query>                 Free-text search
 emdash-plugin info <handle-or-did> <slug>    Show package details
 ```
 
-All commands accept `--json`. Discovery commands accept `--aggregator <url>` (or `EMDASH_REGISTRY_URL`).
+The non-interactive output commands (`whoami`, `validate`, `search`, `info`, `login`, `publish`) accept `--json` for machine-readable output. Discovery commands (`search`, `info`) accept `--registry-url <url>` (or `EMDASH_REGISTRY_URL`).
 
 ## Authoring
 

--- a/packages/plugin-cli/src/commands/info.ts
+++ b/packages/plugin-cli/src/commands/info.ts
@@ -35,9 +35,9 @@ export const infoCommand = defineCommand({
 			description: "Package slug",
 			required: true,
 		},
-		aggregator: {
+		"registry-url": {
 			type: "string",
-			description: "Override aggregator URL",
+			description: "Override registry URL",
 		},
 		json: {
 			type: "boolean",
@@ -45,7 +45,7 @@ export const infoCommand = defineCommand({
 		},
 	},
 	async run({ args }) {
-		const aggregatorUrl = resolveAggregatorUrl(args.aggregator);
+		const aggregatorUrl = resolveAggregatorUrl(args["registry-url"]);
 		const client = new DiscoveryClient({ aggregatorUrl });
 
 		let result;

--- a/packages/plugin-cli/src/commands/search.ts
+++ b/packages/plugin-cli/src/commands/search.ts
@@ -36,9 +36,9 @@ export const searchCommand = defineCommand({
 			description:
 				"Continuation cursor from a previous search result (printed at the end when more results exist)",
 		},
-		aggregator: {
+		"registry-url": {
 			type: "string",
-			description: "Override aggregator URL (defaults to EMDASH_REGISTRY_URL or experimental host)",
+			description: "Override registry URL (defaults to EMDASH_REGISTRY_URL or experimental host)",
 		},
 		json: {
 			type: "boolean",
@@ -46,7 +46,7 @@ export const searchCommand = defineCommand({
 		},
 	},
 	async run({ args }) {
-		const aggregatorUrl = resolveAggregatorUrl(args.aggregator);
+		const aggregatorUrl = resolveAggregatorUrl(args["registry-url"]);
 		const limit = clamp(parseInt(args.limit, 10) || 25, 1, 100);
 
 		const client = new DiscoveryClient({ aggregatorUrl });

--- a/packages/plugin-cli/src/config.ts
+++ b/packages/plugin-cli/src/config.ts
@@ -2,7 +2,7 @@
  * Shared config for the registry CLI.
  *
  * The aggregator URL defaults to the experimental host but can be overridden
- * per-invocation via `--aggregator <url>` or by the `EMDASH_REGISTRY_URL`
+ * per-invocation via `--registry-url <url>` or by the `EMDASH_REGISTRY_URL`
  * env var. We resolve in that order, falling back to the default.
  *
  * EXPERIMENTAL: the default host is provisional. It will be retired and


### PR DESCRIPTION
## What does this PR do?

The discovery commands (`search`, `info`) on `@emdash-cms/plugin-cli` accept a `--aggregator <url>` flag to override the registry endpoint. The env var, the default URL host (`registry.emdashcms.com`), and the user-facing concept all speak of the **registry**. Three surface words for adjacent concepts hurts the read-out-loud test:

```sh
emdash-plugin search "image" --aggregator https://registry.example.com
EMDASH_REGISTRY_URL=https://registry.example.com emdash-plugin search "image"
```

Rename the flag to `--registry-url` to converge on one user-facing term.

```sh
emdash-plugin search "image" --registry-url https://registry.example.com
```

Internally the helper still queries an aggregator service. The registry is the broader system (atproto records on PDSes plus aggregator indexers); an aggregator is one indexer of it. The rename only changes what users type, not what the code does — `resolveAggregatorUrl()` and `DEFAULT_AGGREGATOR_URL` stay as-is.

Surfaced during review of #1059.

Also fixes the README's `--json` description while we're at it (it mirrored the out-of-date "all commands accept --json" claim being corrected in the docs PR).

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

```
USAGE emdash-plugin search [OPTIONS] <QUERY>
    --capability    Filter to packages declaring this access category (e.g. 'email', 'network')
    --limit="25"    Max results per page (1-100, default 25)
        --cursor    Continuation cursor from a previous search result
  --registry-url    Override registry URL (defaults to EMDASH_REGISTRY_URL or experimental host)
          --json    Output as JSON

USAGE emdash-plugin info [OPTIONS] <PUBLISHER> <SLUG>
  --registry-url    Override registry URL
          --json    Output as JSON
```

Tests: 256/256 passing in `packages/plugin-cli`. Typecheck clean.
