### PR TITLE
ci(release): grant contents:read to sync-templates caller job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
     if: >-
       needs.release.outputs.published == 'true' ||
       inputs.publish-only
+    permissions:
+      contents: read
     uses: ./.github/workflows/sync-templates.yml
     # Pass only the secrets sync-templates actually uses, not the full set
     # available to this release workflow.


### PR DESCRIPTION
## What does this PR do?

Fixes the release workflow, which has been failing with a startup error since the merge of #1059:

> The nested job 'sync' is requesting 'contents: read', but is only allowed 'contents: none'.

`release.yml` sets `permissions: {}` at the workflow level (default-deny). The `sync-templates` reusable workflow's job declares `permissions: contents: read`, but a reusable-workflow job cannot exceed the calling job's permissions. Without an explicit grant on the caller, the nested job is denied and the entire workflow fails to start (no jobs run at all).

Grants `contents: read` on the `sync-templates` caller job in `release.yml` so the nested job is allowed to request it.

Example failed run: https://github.com/emdash-cms/emdash/actions/runs/26053444840

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (n/a, workflow-only change)
- [x] `pnpm lint` passes (n/a, workflow-only change)
- [x] `pnpm test` passes (n/a, workflow-only change)
- [x] `pnpm format` has been run (n/a, YAML)
- [ ] I have added/updated tests for my changes (if applicable) -- n/a
- [ ] User-visible strings in the admin UI are wrapped for translation -- n/a
- [ ] I have added a changeset -- n/a, CI-only
- [ ] New features link to an approved Discussion -- n/a, bugfix

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.7

## Screenshots / test output

n/a -- single workflow YAML change, will be verified by the next push to `main`.
