### PR TITLE
Fix local media ID normalization

### DIFF
--- a/.changeset/fix-local-media-id-normalization.md
+++ b/.changeset/fix-local-media-id-normalization.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Resolve bare local media IDs in media fields before falling back to external URLs.

--- a/packages/core/src/media/normalize.ts
+++ b/packages/core/src/media/normalize.ts
@@ -20,6 +20,7 @@ const URL_PATTERN = /^https?:\/\//;
  * - `null`/`undefined` → `null`
  * - Bare URL string → `{ provider: "external", id: "", src: url }`
  * - Bare internal media URL → resolved via local provider's `get()`
+ * - Bare local media ID → resolved via local provider's `get()`
  * - Object with `provider` + `id` → enriched with missing fields from provider
  */
 export async function normalizeMediaValue(
@@ -79,7 +80,7 @@ export async function normalizeMediaValue(
 	return mergeProviderData(result, providerItem);
 }
 
-function normalizeStringUrl(
+async function normalizeStringUrl(
 	url: string,
 	getProvider: (id: string) => MediaProvider | undefined,
 ): Promise<MediaValue | null> {
@@ -97,12 +98,15 @@ function normalizeStringUrl(
 		});
 	}
 
-	// Unrecognized string — treat as external
-	return Promise.resolve({
+	const localMedia = await resolveLocalId(url, getProvider);
+	if (localMedia) return localMedia;
+
+	// Unrecognized string — preserve legacy behavior and treat as external
+	return {
 		provider: "external",
 		id: "",
 		src: url,
-	});
+	};
 }
 
 async function resolveInternalUrl(
@@ -126,6 +130,35 @@ async function resolveInternalUrl(
 	if (!item) {
 		return { provider: "external", id: "", src: url };
 	}
+
+	return {
+		provider: "local",
+		id: item.id,
+		filename: item.filename,
+		mimeType: item.mimeType,
+		width: item.width,
+		height: item.height,
+		alt: item.alt,
+		meta: item.meta,
+	};
+}
+
+async function resolveLocalId(
+	id: string,
+	getProvider: (id: string) => MediaProvider | undefined,
+): Promise<MediaValue | null> {
+	const localProvider = getProvider("local");
+
+	if (!localProvider?.get) return null;
+
+	let item: MediaProviderItem | null;
+	try {
+		item = await localProvider.get(id);
+	} catch {
+		return null;
+	}
+
+	if (!item) return null;
 
 	return {
 		provider: "local",

--- a/packages/core/tests/unit/media/normalize.test.ts
+++ b/packages/core/tests/unit/media/normalize.test.ts
@@ -58,10 +58,7 @@ describe("normalizeMediaValue", () => {
 		};
 		const local = mockProvider(providerItem);
 
-		const result = await normalizeMediaValue(
-			"01KRZKN0BK219P9HBMPYYGYRHY",
-			getProvider({ local }),
-		);
+		const result = await normalizeMediaValue("01KRZKN0BK219P9HBMPYYGYRHY", getProvider({ local }));
 
 		expect(local.get).toHaveBeenCalledWith("01KRZKN0BK219P9HBMPYYGYRHY");
 		expect(result).toEqual({

--- a/packages/core/tests/unit/media/normalize.test.ts
+++ b/packages/core/tests/unit/media/normalize.test.ts
@@ -46,6 +46,36 @@ describe("normalizeMediaValue", () => {
 		});
 	});
 
+	it("converts bare local media ID to full local MediaValue when provider resolves it", async () => {
+		const providerItem: MediaProviderItem = {
+			id: "01KRZKN0BK219P9HBMPYYGYRHY",
+			filename: "photo.png",
+			mimeType: "image/png",
+			width: 1024,
+			height: 768,
+			alt: "A photo",
+			meta: { storageKey: "uploads/photo.png" },
+		};
+		const local = mockProvider(providerItem);
+
+		const result = await normalizeMediaValue(
+			"01KRZKN0BK219P9HBMPYYGYRHY",
+			getProvider({ local }),
+		);
+
+		expect(local.get).toHaveBeenCalledWith("01KRZKN0BK219P9HBMPYYGYRHY");
+		expect(result).toEqual({
+			provider: "local",
+			id: "01KRZKN0BK219P9HBMPYYGYRHY",
+			filename: "photo.png",
+			mimeType: "image/png",
+			width: 1024,
+			height: 768,
+			alt: "A photo",
+			meta: { storageKey: "uploads/photo.png" },
+		});
+	});
+
 	it("converts bare internal media URL to full local MediaValue via provider", async () => {
 		const providerItem: MediaProviderItem = {
 			id: "01ABC",


### PR DESCRIPTION
## What does this PR do?

Fixes media normalization so bare local media IDs are resolved through the local media provider before falling back to external URL behavior.

This matters for API/MCP-style writes that create media first, then use the returned media ID directly in an image field:

```json
{
  "featured_image": "01KRZKN0BK219P9HBMPYYGYRHY"
}
```

Previously, EmDash stored that as an external image value:

```json
{
  "provider": "external",
  "id": "",
  "src": "01KRZKN0BK219P9HBMPYYGYRHY"
}
```

That produced broken rendered image URLs. With this change, EmDash checks whether the bare string resolves as local media and stores it as a local media value. Unknown strings still keep the previous external fallback behavior.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex / GPT-5

## Screenshots / test output

Targeted test passed:

```txt
vitest run tests/unit/media/normalize.test.ts

✓ tests/unit/media/normalize.test.ts (23 tests) 5ms

Test Files  1 passed (1)
Tests       23 passed (23)
```

Note: the pnpm wrapper currently exits before running tests with:

```txt
ERR_PNPM_VERIFY_DEPS_BEFORE_RUN The value of the workspacePackagePatterns setting has changed
Run "pnpm install"
```

So I validated the touched test file directly with Vitest.