### PR TITLE
fix: enable experimental registry admin UI

### DIFF
--- a/.changeset/ready-worlds-rush.md
+++ b/.changeset/ready-worlds-rush.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes experimental registry navigation and allows the configured registry aggregator through the admin CSP.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -59,6 +59,9 @@ export interface SidebarNavProps {
 		version?: string;
 		commit?: string;
 		marketplace?: string;
+		registry?: {
+			aggregatorUrl: string;
+		};
 		admin?: {
 			logo?: string;
 			siteName?: string;
@@ -212,16 +215,29 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 		{ to: "/plugins-manager", label: t`Plugins`, icon: PuzzlePiece, minRole: ROLE_ADMIN },
 	];
 
+	if (manifest.registry) {
+		adminItems.push({
+			to: "/plugins/marketplace",
+			label: t`Registry`,
+			icon: Storefront,
+			minRole: ROLE_ADMIN,
+		});
+	} else if (manifest.marketplace) {
+		adminItems.push({
+			to: "/plugins/marketplace",
+			label: t`Marketplace`,
+			icon: Storefront,
+			minRole: ROLE_ADMIN,
+		});
+	}
+
 	if (manifest.marketplace) {
-		adminItems.push(
-			{
-				to: "/plugins/marketplace",
-				label: t`Marketplace`,
-				icon: Storefront,
-				minRole: ROLE_ADMIN,
-			},
-			{ to: "/themes/marketplace", label: t`Themes`, icon: Palette, minRole: ROLE_ADMIN },
-		);
+		adminItems.push({
+			to: "/themes/marketplace",
+			label: t`Themes`,
+			icon: Palette,
+			minRole: ROLE_ADMIN,
+		});
 	}
 
 	adminItems.push(

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -302,7 +302,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 		const response = await next();
 		if (!import.meta.env.DEV) {
-			response.headers.set("Content-Security-Policy", buildEmDashCsp());
+			response.headers.set(
+				"Content-Security-Policy",
+				buildEmDashCsp(context.locals.emdash?.config.experimental?.registry),
+			);
 		}
 		return response;
 	}
@@ -311,7 +314,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 	// Set strict CSP on all /_emdash responses (prod only)
 	if (!import.meta.env.DEV) {
-		response.headers.set("Content-Security-Policy", buildEmDashCsp());
+		response.headers.set(
+			"Content-Security-Policy",
+			buildEmDashCsp(context.locals.emdash?.config.experimental?.registry),
+		);
 	}
 
 	return response;

--- a/packages/core/src/astro/middleware/csp.ts
+++ b/packages/core/src/astro/middleware/csp.ts
@@ -8,14 +8,36 @@
  * img-src allows any HTTPS origin because the admin renders user content that
  * may reference external images (migrations, external hosting, embeds).
  * Plugin security does not rely on img-src -- plugins run in V8 isolates with
- * no DOM access, and connect-src 'self' blocks fetch-based exfiltration.
+ * no DOM access. connect-src stays at 'self' unless the experimental registry
+ * is configured, in which case the configured aggregator origin is allowed.
  */
-export function buildEmDashCsp(): string {
+import type { RegistryConfigInput } from "../../registry/types.js";
+
+function getRegistryAggregatorOrigin(
+	registry: RegistryConfigInput | undefined,
+): string | undefined {
+	const aggregatorUrl = typeof registry === "string" ? registry : registry?.aggregatorUrl;
+	if (!aggregatorUrl) return undefined;
+
+	try {
+		const url = new URL(aggregatorUrl);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+		return url.origin;
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildEmDashCsp(registry?: RegistryConfigInput): string {
+	const connectSrc = ["connect-src 'self'"];
+	const registryAggregatorOrigin = getRegistryAggregatorOrigin(registry);
+	if (registryAggregatorOrigin) connectSrc.push(registryAggregatorOrigin);
+
 	return [
 		"default-src 'self'",
 		"script-src 'self' 'unsafe-inline'",
 		"style-src 'self' 'unsafe-inline'",
-		"connect-src 'self'",
+		connectSrc.join(" "),
 		"form-action 'self'",
 		"frame-ancestors 'none'",
 		"img-src 'self' https: data: blob:",

--- a/packages/core/tests/unit/middleware/csp.test.ts
+++ b/packages/core/tests/unit/middleware/csp.test.ts
@@ -23,6 +23,18 @@ describe("buildEmDashCsp", () => {
 		expect(connectSrc).toBe("connect-src 'self'");
 	});
 
+	it("allows the configured registry aggregator origin in connect-src", () => {
+		const csp = buildEmDashCsp({ aggregatorUrl: "https://registry.emdashcms.com/xrpc" });
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self' https://registry.emdashcms.com");
+	});
+
+	it("allows shorthand registry URLs in connect-src", () => {
+		const csp = buildEmDashCsp("https://registry.emdashcms.com");
+		const connectSrc = csp.split("; ").find((d) => d.startsWith("connect-src"));
+		expect(connectSrc).toBe("connect-src 'self' https://registry.emdashcms.com");
+	});
+
 	it("blocks framing with frame-ancestors none", () => {
 		const csp = buildEmDashCsp();
 		expect(csp).toContain("frame-ancestors 'none'");


### PR DESCRIPTION
## What does this PR do?

Fixes the experimental registry admin path so sites with `experimental.registry` configured can discover and install registry plugins in production.

- Shows a `Registry` sidebar item when the manifest includes registry config.
- Keeps marketplace themes visible only when the marketplace is configured.
- Allows the configured registry aggregator origin through the production admin CSP `connect-src` directive.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode + GPT-5.5

## Screenshots / test output

- `pnpm typecheck`
- `pnpm --filter emdash test -- packages/core/tests/unit/middleware/csp.test.ts`
- `pnpm --silent lint:quick` still reports 6 existing diagnostics unrelated to this change.
