### PR TITLE
ci(release): reconcile lockfile before gated changeset commands

### DIFF
--- a/.github/scripts/release.mjs
+++ b/.github/scripts/release.mjs
@@ -5,17 +5,20 @@ const mode = process.argv[2];
 const run = (args) => execFileSync("pnpm", args, { stdio: "inherit" });
 
 // changesets/action runs `git checkout changeset-release/main` + `git reset
-// --hard` immediately before this, which can leave the lockfile's overrides
-// hash out of sync with pnpm-workspace.yaml. The next gated pnpm call
+// --hard` immediately before this, which can leave the deps state out of
+// sync with pnpm-workspace.yaml. The next gated pnpm call
 // (verifyDepsBeforeRun: error) would then abort the release. `pnpm install`
 // is not gated, so reconcile here, after the action's git work and before
 // any `pnpm changeset` call. Do not hoist this into an earlier workflow
 // step: the action's git reset runs after workflow steps and undoes it.
-run(["install", "--no-frozen-lockfile"]);
+// prefer-frozen avoids re-resolving deps when the lockfile is already
+// satisfiable (so published packages, which rebuild via prepublishOnly,
+// match what was tested) but falls back to a full install when it isn't.
+run(["install", "--prefer-frozen-lockfile"]);
 
 if (mode === "version") {
 	run(["changeset", "version"]);
-	run(["install", "--no-frozen-lockfile"]);
+	run(["install", "--prefer-frozen-lockfile"]);
 } else if (mode === "publish") {
 	run(["changeset", "publish"]);
 } else {

--- a/.github/scripts/release.mjs
+++ b/.github/scripts/release.mjs
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+
+const mode = process.argv[2];
+
+const run = (args) => execFileSync("pnpm", args, { stdio: "inherit" });
+
+// changesets/action runs `git checkout changeset-release/main` + `git reset
+// --hard` immediately before this, which can leave the lockfile's overrides
+// hash out of sync with pnpm-workspace.yaml. The next gated pnpm call
+// (verifyDepsBeforeRun: error) would then abort the release. `pnpm install`
+// is not gated, so reconcile here, after the action's git work and before
+// any `pnpm changeset` call. Do not hoist this into an earlier workflow
+// step: the action's git reset runs after workflow steps and undoes it.
+run(["install", "--no-frozen-lockfile"]);
+
+if (mode === "version") {
+	run(["changeset", "version"]);
+	run(["install", "--no-frozen-lockfile"]);
+} else if (mode === "publish") {
+	run(["changeset", "publish"]);
+} else {
+	throw new Error(`Unknown release mode: ${JSON.stringify(mode)} (expected "version" or "publish")`);
+}

--- a/.github/scripts/release.mjs
+++ b/.github/scripts/release.mjs
@@ -11,14 +11,14 @@ const run = (args) => execFileSync("pnpm", args, { stdio: "inherit" });
 // is not gated, so reconcile here, after the action's git work and before
 // any `pnpm changeset` call. Do not hoist this into an earlier workflow
 // step: the action's git reset runs after workflow steps and undoes it.
-// prefer-frozen avoids re-resolving deps when the lockfile is already
-// satisfiable (so published packages, which rebuild via prepublishOnly,
-// match what was tested) but falls back to a full install when it isn't.
-run(["install", "--prefer-frozen-lockfile"]);
+// Must be --no-frozen-lockfile, not --prefer-frozen-lockfile: prefer-frozen
+// can take the lockfile fast path and skip rewriting the stale deps-state
+// hash, which is the exact condition that trips the gate.
+run(["install", "--no-frozen-lockfile"]);
 
 if (mode === "version") {
 	run(["changeset", "version"]);
-	run(["install", "--prefer-frozen-lockfile"]);
+	run(["install", "--no-frozen-lockfile"]);
 } else if (mode === "publish") {
 	run(["changeset", "publish"]);
 } else {

--- a/.github/scripts/release.mjs
+++ b/.github/scripts/release.mjs
@@ -19,5 +19,7 @@ if (mode === "version") {
 } else if (mode === "publish") {
 	run(["changeset", "publish"]);
 } else {
-	throw new Error(`Unknown release mode: ${JSON.stringify(mode)} (expected "version" or "publish")`);
+	throw new Error(
+		`Unknown release mode: ${JSON.stringify(mode)} (expected "version" or "publish")`,
+	);
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,19 +66,13 @@ jobs:
       - name: Block 1.x releases (we are in 0.x)
         run: node .github/scripts/check-no-major.mjs
 
-      # Not redundant with the frozen install: frozen install does not
-      # refresh the lockfile's overrides hash, so a drifted lockfile trips
-      # verifyDepsBeforeRun on the gated changeset commands below.
-      - name: Reconcile lockfile
-        run: pnpm install --no-frozen-lockfile
-
       - name: Create Release Pull Request or Publish
         if: ${{ !inputs.publish-only }}
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
-          version: pnpm run changeset:version
-          publish: pnpm changeset publish
+          version: node .github/scripts/release.mjs version
+          publish: node .github/scripts/release.mjs publish
           commit: "ci: release"
           title: "ci: release"
         env:
@@ -86,7 +80,7 @@ jobs:
 
       - name: Publish (manual)
         if: ${{ inputs.publish-only }}
-        run: pnpm changeset publish
+        run: node .github/scripts/release.mjs publish
 
   sync-templates:
     name: Sync Templates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Block 1.x releases (we are in 0.x)
         run: node .github/scripts/check-no-major.mjs
 
+      # Not redundant with the frozen install: frozen install does not
+      # refresh the lockfile's overrides hash, so a drifted lockfile trips
+      # verifyDepsBeforeRun on the gated changeset commands below.
+      - name: Reconcile lockfile
+        run: pnpm install --no-frozen-lockfile
+
       - name: Create Release Pull Request or Publish
         if: ${{ !inputs.publish-only }}
         id: changesets

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
 		"screenshots": "node scripts/screenshot-all-templates.mjs",
 		"query-counts": "node scripts/query-counts.mjs",
 		"locale:extract": "pnpm --filter @emdash-cms/admin locale:extract",
-		"locale:compile": "pnpm --filter @emdash-cms/admin locale:compile",
-		"changeset:version": "pnpm changeset version && pnpm install --no-frozen-lockfile"
+		"locale:compile": "pnpm --filter @emdash-cms/admin locale:compile"
 	},
 	"keywords": [],
 	"author": "Matt Kane",


### PR DESCRIPTION
## What does this PR do?

Fixes the Release workflow silently failing to publish.

`pnpm-workspace.yaml` sets `verifyDepsBeforeRun: error`, which gates every `pnpm run` / `pnpm <bin>` call. `changesets/action` runs `git checkout changeset-release/main` + `git reset --hard <main>` and *then* invokes its version/publish command. After that git reset, the lockfile state can be inconsistent enough that the gated `pnpm changeset version` / `pnpm changeset publish` call aborts with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN: Setting overrides of lockfile ... is outdated` — before anything is versioned or published.

This is what broke the last release: the post-merge runs for #1100/#1101/#1102 all failed at the changesets step, the release PR merged without those changesets folded in, `0.13.0` was bumped on `main` but never published, and the bot opened a fresh `0.13.1` release PR (#1103) instead.

A reconcile **cannot** be a prior workflow step: the action's `git reset --hard` runs after all workflow steps and discards a working-tree lockfile fix. It has to happen after the action's git work and immediately before the gated `pnpm` call.

This PR routes the action's `version`/`publish` (and the manual-publish step) through `node .github/scripts/release.mjs` — a single non-gated entrypoint that runs `pnpm install --no-frozen-lockfile` (not gated by `verifyDepsBeforeRun`) and then `pnpm changeset version|publish` (gated, now passing). The now-unreferenced `changeset:version` package script is removed so there's a single release path. `verifyDepsBeforeRun: error` is unchanged for local dev and normal CI.

Workflow/tooling only; no application code touched.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (N/A — CI/tooling only, no TS changed)
- [x] `pnpm lint` passes (N/A — CI/tooling only)
- [x] `pnpm test` passes (N/A — CI/tooling only)
- [x] `pnpm format` has been run (release.mjs uses tab indentation per repo style)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A)
- [x] I have added a changeset (N/A — CI-only change, no published package affected; root package.json is private)
- [ ] New features link to an approved Discussion (N/A — not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

Failing release run that motivated this — the `Create Release Pull Request or Publish` step:

```
[command]/usr/bin/git checkout changeset-release/main
[command]/usr/bin/git reset --hard d16a3d527f...
[command]/.../pnpm run changeset:version
 ERR_PNPM_VERIFY_DEPS_BEFORE_RUN  Setting overrides of lockfile in /home/runner/work/emdash/emdash is outdated
##[error]The process '.../pnpm' failed with exit code 1
```
