### PR TITLE
chore(release): drop pending changesets to publish 0.13.0

### DIFF
--- a/.changeset/fix-local-media-id-normalization.md
+++ b/.changeset/fix-local-media-id-normalization.md
@@ -1,5 +1,0 @@
----
-"emdash": patch
----
-
-Resolve bare local media IDs in media fields before falling back to external URLs.

--- a/.changeset/ready-worlds-rush.md
+++ b/.changeset/ready-worlds-rush.md
@@ -1,6 +1,0 @@
----
-"@emdash-cms/admin": patch
-"emdash": patch
----
-
-Fixes experimental registry navigation and allows the configured registry aggregator through the admin CSP.


### PR DESCRIPTION
## What does this PR do?

**Release recovery — this PR triggers the `0.13.0` npm publish.** Merging it ships `0.13.0`.

`main` is already at `0.13.0` (the #1096 release-PR merge bumped versions and wrote the full `## 0.13.0` changelogs), but `0.13.0` was never published: the `verifyDepsBeforeRun` release bug (fixed in #1104) made every post-merge release run die before publishing, so changesets/action opened a fresh `0.13.1` PR (#1103) instead. Two changesets — `fix-local-media-id-normalization.md` (#1100) and `ready-worlds-rush.md` (#1101) — were left on `main`, which keeps changesets/action on the *version* path forever.

This PR removes only those two changeset files. Nothing else changes: `package.json` stays at `0.13.0`, the `## 0.13.0` changelog sections stay intact. With zero changesets on `main`, the next Release run takes the **publish** path: `pnpm changeset publish` ships `0.13.0` to npm, pushes the `pkg@0.13.0` tags, and changesets/action creates the GitHub Releases from the full `## 0.13.0` notes (including the breaking sandboxed-plugin change from #1057).

The two removed changesets are restored verbatim in the immediate follow-up PR, which will release `0.13.1` (the #1100/#1101 fixes) on top of the now-published `0.13.0`.

This is the only mechanism by which `0.13.0` gets a proper, fully-noted release; it cannot be recovered after the fact.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (N/A — removes 2 changeset files, no code)
- [x] `pnpm lint` passes (N/A — no code)
- [x] `pnpm test` passes (N/A — no code)
- [x] `pnpm format` has been run (N/A — no code)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A)
- [x] I have added a changeset (N/A — this PR intentionally *removes* changesets to trigger the already-versioned `0.13.0` publish; restored in the `0.13.1` follow-up)
- [ ] New features link to an approved Discussion (N/A — not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

After merge, the Release run should log `node .github/scripts/release.mjs publish` → `pnpm changeset publish` publishing `0.13.0`, with `published: true` and GitHub Releases created for each package at `0.13.0`. `npm view emdash version` should go `0.12.0 → 0.13.0`.
