### PR TITLE
Docs: unblock local docs build without AI Search

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,28 @@ Documentation site for EmDash, built with [Starlight](https://starlight.astro.bu
 pnpm dev
 ```
 
+If you're running in a remote or API-token-only environment that cannot access the
+Cloudflare AI Search instance, keep using `pnpm dev` for local content work and
+use the local-only Wrangler config for built-worker preview checks instead:
+
+```bash
+pnpm build
+pnpm exec wrangler dev --config wrangler.local.jsonc
+```
+
+The `/mcp` endpoint still works, but it returns a helpful message until a
+Cloudflare AI Search binding is configured.
+
 ## Build
 
 ```bash
 pnpm build
+```
+
+For remote docs preview/deploy checks that require production bindings, run the
+main config as usual:
+
+```bash
+pnpm exec wrangler dev
+pnpm exec wrangler deploy
 ```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
 		starlight({
 			title: "EmDash",
 			tagline: "The Astro-native CMS",
+			disable404Route: true,
 			components: {
 				SkipLink: "./src/components/SkipLink.astro",
 			},
@@ -237,5 +238,5 @@ export default defineConfig({
 		}),
 	],
 
-	adapter: cloudflare(),
+	adapter: cloudflare({ remoteBindings: false, prerenderEnvironment: "node" }),
 });

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,0 +1,18 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+
+export const prerender = true;
+
+const frontmatter = {
+	title: "404",
+	template: "splash",
+	editUrl: false,
+	pagefind: false,
+	hero: {
+		tagline: Astro.locals.t("404.text"),
+		actions: [],
+	},
+};
+---
+
+<StarlightPage frontmatter={frontmatter} />

--- a/docs/src/worker.ts
+++ b/docs/src/worker.ts
@@ -31,58 +31,50 @@ function buildMcpServer(env: Env): McpServer {
 	});
 	const aiSearch = (env as { AI_SEARCH?: Env["AI_SEARCH"] }).AI_SEARCH;
 	if (!aiSearch) {
-		server.registerTool(
-			"search_docs",
-			searchDocsTool,
-			async () => ({
-				content: [
-					{
-						type: "text",
-						text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
-					},
-				],
-			}),
-		);
+		server.registerTool("search_docs", searchDocsTool, async () => ({
+			content: [
+				{
+					type: "text",
+					text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
+				},
+			],
+		}));
 
 		return server;
 	}
 
-	server.registerTool(
-		"search_docs",
-		searchDocsTool,
-		async ({ query, max_results }) => {
-			const limit = max_results ?? 8;
+	server.registerTool("search_docs", searchDocsTool, async ({ query, max_results }) => {
+		const limit = max_results ?? 8;
 
-			const results = await aiSearch.search({
-				messages: [{ role: "user", content: query }],
-				ai_search_options: {
-					retrieval: { max_num_results: limit },
-				},
-			});
+		const results = await aiSearch.search({
+			messages: [{ role: "user", content: query }],
+			ai_search_options: {
+				retrieval: { max_num_results: limit },
+			},
+		});
 
-			if (!results.chunks.length) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: "No matching docs found.",
-						},
-					],
-				};
-			}
-
+		if (!results.chunks.length) {
 			return {
-				content: results.chunks.map((chunk) => {
-					const source = chunk.item.key;
-					const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
-					return {
-						type: "text" as const,
-						text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
-					};
-				}),
+				content: [
+					{
+						type: "text",
+						text: "No matching docs found.",
+					},
+				],
 			};
-		},
-	);
+		}
+
+		return {
+			content: results.chunks.map((chunk) => {
+				const source = chunk.item.key;
+				const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
+				return {
+					type: "text" as const,
+					text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
+				};
+			}),
+		};
+	});
 
 	return server;
 }

--- a/docs/src/worker.ts
+++ b/docs/src/worker.ts
@@ -29,52 +29,60 @@ function buildMcpServer(env: Env): McpServer {
 		name: "emdash-docs",
 		version: "1.0.0",
 	});
-	const aiSearch = env.AI_SEARCH;
+	const aiSearch = (env as { AI_SEARCH?: Env["AI_SEARCH"] }).AI_SEARCH;
 	if (!aiSearch) {
-		server.registerTool("search_docs", searchDocsTool, async () => ({
-			content: [
-				{
-					type: "text",
-					text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
-				},
-			],
-		}));
+		server.registerTool(
+			"search_docs",
+			searchDocsTool,
+			async () => ({
+				content: [
+					{
+						type: "text",
+						text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
+					},
+				],
+			}),
+		);
 
 		return server;
 	}
 
-	server.registerTool("search_docs", searchDocsTool, async ({ query, max_results }) => {
-		const limit = max_results ?? 8;
+	server.registerTool(
+		"search_docs",
+		searchDocsTool,
+		async ({ query, max_results }) => {
+			const limit = max_results ?? 8;
 
-		const results = await aiSearch.search({
-			messages: [{ role: "user", content: query }],
-			ai_search_options: {
-				retrieval: { max_num_results: limit },
-			},
-		});
+			const results = await aiSearch.search({
+				messages: [{ role: "user", content: query }],
+				ai_search_options: {
+					retrieval: { max_num_results: limit },
+				},
+			});
 
-		if (!results.chunks.length) {
-			return {
-				content: [
-					{
-						type: "text",
-						text: "No matching docs found.",
-					},
-				],
-			};
-		}
-
-		return {
-			content: results.chunks.map((chunk) => {
-				const source = chunk.item.key;
-				const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
+			if (!results.chunks.length) {
 				return {
-					type: "text" as const,
-					text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
+					content: [
+						{
+							type: "text",
+							text: "No matching docs found.",
+						},
+					],
 				};
-			}),
-		};
-	});
+			}
+
+			return {
+				content: results.chunks.map((chunk) => {
+					const source = chunk.item.key;
+					const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
+					return {
+						type: "text" as const,
+						text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
+					};
+				}),
+			};
+		},
+	);
 
 	return server;
 }

--- a/docs/src/worker.ts
+++ b/docs/src/worker.ts
@@ -13,6 +13,37 @@ function buildMcpServer(env: Env): McpServer {
 		name: "emdash-docs",
 		version: "1.0.0",
 	});
+	const aiSearch = env.AI_SEARCH;
+	if (!aiSearch) {
+		server.registerTool(
+			"search_docs",
+			{
+				title: "Search EmDash documentation",
+				description:
+					"Search the EmDash CMS documentation. This endpoint is not configured in this environment.",
+				inputSchema: {
+					query: z.string().min(1).max(1000).describe("Query to run against docs indexing."),
+					max_results: z
+						.number()
+						.int()
+						.min(1)
+						.max(20)
+						.optional()
+						.describe("Maximum number of chunks to return. Defaults to 8."),
+				},
+			},
+			async () => ({
+				content: [
+					{
+						type: "text",
+						text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
+					},
+				],
+			}),
+		);
+
+		return server;
+	}
 
 	server.registerTool(
 		"search_docs",
@@ -38,7 +69,7 @@ function buildMcpServer(env: Env): McpServer {
 		async ({ query, max_results }) => {
 			const limit = max_results ?? 8;
 
-			const results = await env.AI_SEARCH.search({
+			const results = await aiSearch.search({
 				messages: [{ role: "user", content: query }],
 				ai_search_options: {
 					retrieval: { max_num_results: limit },

--- a/docs/src/worker.ts
+++ b/docs/src/worker.ts
@@ -31,58 +31,50 @@ function buildMcpServer(env: Env): McpServer {
 	});
 	const aiSearch = env.AI_SEARCH;
 	if (!aiSearch) {
-		server.registerTool(
-			"search_docs",
-			searchDocsTool,
-			async () => ({
-				content: [
-					{
-						type: "text",
-						text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
-					},
-				],
-			}),
-		);
+		server.registerTool("search_docs", searchDocsTool, async () => ({
+			content: [
+				{
+					type: "text",
+					text: "Docs search is unavailable in this environment. Configure Cloudflare AI Search in the Workers binding to enable this tool.",
+				},
+			],
+		}));
 
 		return server;
 	}
 
-	server.registerTool(
-		"search_docs",
-		searchDocsTool,
-		async ({ query, max_results }) => {
-			const limit = max_results ?? 8;
+	server.registerTool("search_docs", searchDocsTool, async ({ query, max_results }) => {
+		const limit = max_results ?? 8;
 
-			const results = await aiSearch.search({
-				messages: [{ role: "user", content: query }],
-				ai_search_options: {
-					retrieval: { max_num_results: limit },
-				},
-			});
+		const results = await aiSearch.search({
+			messages: [{ role: "user", content: query }],
+			ai_search_options: {
+				retrieval: { max_num_results: limit },
+			},
+		});
 
-			if (!results.chunks.length) {
-				return {
-					content: [
-						{
-							type: "text",
-							text: "No matching docs found.",
-						},
-					],
-				};
-			}
-
+		if (!results.chunks.length) {
 			return {
-				content: results.chunks.map((chunk) => {
-					const source = chunk.item.key;
-					const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
-					return {
-						type: "text" as const,
-						text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
-					};
-				}),
+				content: [
+					{
+						type: "text",
+						text: "No matching docs found.",
+					},
+				],
 			};
-		},
-	);
+		}
+
+		return {
+			content: results.chunks.map((chunk) => {
+				const source = chunk.item.key;
+				const score = typeof chunk.score === "number" ? chunk.score.toFixed(3) : "n/a";
+				return {
+					type: "text" as const,
+					text: `<result source="${source}" score="${score}">\n${chunk.text}\n</result>`,
+				};
+			}),
+		};
+	});
 
 	return server;
 }

--- a/docs/src/worker.ts
+++ b/docs/src/worker.ts
@@ -8,6 +8,22 @@ import { z } from "zod";
  * underlying transport asserts that the server is not already connected, so we
  * cannot reuse a single server instance across requests.
  */
+const searchDocsTool = {
+	title: "Search EmDash documentation",
+	description:
+		"Search the EmDash CMS documentation. Returns relevant chunks with source URLs and similarity scores.",
+	inputSchema: {
+		query: z.string().min(1).max(1000).describe("Natural-language query against the EmDash docs."),
+		max_results: z
+			.number()
+			.int()
+			.min(1)
+			.max(20)
+			.optional()
+			.describe("Maximum number of chunks to return. Defaults to 8."),
+	},
+};
+
 function buildMcpServer(env: Env): McpServer {
 	const server = new McpServer({
 		name: "emdash-docs",
@@ -17,21 +33,7 @@ function buildMcpServer(env: Env): McpServer {
 	if (!aiSearch) {
 		server.registerTool(
 			"search_docs",
-			{
-				title: "Search EmDash documentation",
-				description:
-					"Search the EmDash CMS documentation. This endpoint is not configured in this environment.",
-				inputSchema: {
-					query: z.string().min(1).max(1000).describe("Query to run against docs indexing."),
-					max_results: z
-						.number()
-						.int()
-						.min(1)
-						.max(20)
-						.optional()
-						.describe("Maximum number of chunks to return. Defaults to 8."),
-				},
-			},
+			searchDocsTool,
 			async () => ({
 				content: [
 					{
@@ -47,25 +49,7 @@ function buildMcpServer(env: Env): McpServer {
 
 	server.registerTool(
 		"search_docs",
-		{
-			title: "Search EmDash documentation",
-			description:
-				"Search the EmDash CMS documentation. Returns relevant chunks with source URLs and similarity scores.",
-			inputSchema: {
-				query: z
-					.string()
-					.min(1)
-					.max(1000)
-					.describe("Natural-language query against the EmDash docs."),
-				max_results: z
-					.number()
-					.int()
-					.min(1)
-					.max(20)
-					.optional()
-					.describe("Maximum number of chunks to return. Defaults to 8."),
-			},
-		},
+		searchDocsTool,
 		async ({ query, max_results }) => {
 			const limit = max_results ?? 8;
 

--- a/docs/wrangler.local.jsonc
+++ b/docs/wrangler.local.jsonc
@@ -1,0 +1,14 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"compatibility_date": "2026-03-01",
+	"compatibility_flags": ["global_fetch_strictly_public", "nodejs_compat"],
+	"name": "docs",
+	"main": "./src/worker.ts",
+	"assets": {
+		"directory": "./dist",
+		"binding": "ASSETS",
+	},
+	"observability": {
+		"enabled": true,
+	},
+}

--- a/docs/wrangler.local.jsonc
+++ b/docs/wrangler.local.jsonc
@@ -1,4 +1,5 @@
 {
+	// Keep shared fields in sync with wrangler.jsonc.
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"compatibility_date": "2026-03-01",
 	"compatibility_flags": ["global_fetch_strictly_public", "nodejs_compat"],


### PR DESCRIPTION
## What does this PR do?

Fixes the docs app so local/built Worker preview and docs builds do not require a live Cloudflare AI Search binding.

Closes #

- Adds a local-only Wrangler config for docs Worker preview.
- Adds an MCP fallback response when `AI_SEARCH` is not configured.
- Uses a custom Starlight 404 page and disables the injected route that was producing build-time lookup noise.
- Switches the Cloudflare adapter config to avoid remote binding dependency during docs builds.
- Clarifies the docs README for the built-worker preview flow.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4 / OpenCode

## Screenshots / test output

- `pnpm --dir docs build`
- `prettier --check` on changed docs files