### PR TITLE
chore(release): restore changesets for 0.13.1

### DIFF
--- a/.changeset/fix-local-media-id-normalization.md
+++ b/.changeset/fix-local-media-id-normalization.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Resolve bare local media IDs in media fields before falling back to external URLs.

--- a/.changeset/ready-worlds-rush.md
+++ b/.changeset/ready-worlds-rush.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": patch
+"emdash": patch
+---
+
+Fixes experimental registry navigation and allows the configured registry aggregator through the admin CSP.


### PR DESCRIPTION
## What does this PR do?

**Release recovery — the `0.13.1` follow-up to #1105.** Restores the two changesets that #1105 removed.

#1105 removed `fix-local-media-id-normalization.md` (#1100) and `ready-worlds-rush.md` (#1101) *only* to flip changesets/action onto the publish path so the already-versioned `0.13.0` would ship. `0.13.0` is now published (npm `latest`, tags, GitHub releases with the full notes). These two changesets are restored here, byte-identical to their pre-#1105 state, so the work they describe gets a documented release.

Merging this puts the two changesets back on `main` → the next Release run takes the **version** path → bumps `0.13.0 → 0.13.1` → refreshes the changeset-release PR (#1103). Merging **that** PR publishes `0.13.1`.

So this PR does **not** itself publish anything — it re-arms the normal release flow. Two merges to land `0.13.1`: this PR, then the refreshed #1103.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (N/A — restores 2 changeset files, no code)
- [x] `pnpm lint` passes (N/A — no code)
- [x] `pnpm test` passes (N/A — no code)
- [x] `pnpm format` has been run (N/A — no code)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A)
- [x] I have added a changeset (this PR *is* the changesets — restored from #1105)
- [ ] New features link to an approved Discussion (N/A — not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

After merge, the Release run logs `node .github/scripts/release.mjs version` (version path, no publish), and the changeset-release PR (#1103) updates to bump `0.13.0 → 0.13.1`. `npm view emdash version` stays `0.13.0` until #1103 is merged.
