### PR TITLE
chore(release): fix changeset attribution for 0.13.1

### DIFF
--- a/.changeset/fix-local-media-id-normalization.md
+++ b/.changeset/fix-local-media-id-normalization.md
@@ -2,4 +2,8 @@
 "emdash": patch
 ---
 
+pr: 1100
+commit: f753dba340dca791d4cf34a78c29ed6a0d552cd4
+author: jcheese1
+
 Resolve bare local media IDs in media fields before falling back to external URLs.

--- a/.changeset/ready-worlds-rush.md
+++ b/.changeset/ready-worlds-rush.md
@@ -3,4 +3,8 @@
 "emdash": patch
 ---
 
+pr: 1101
+commit: e539731451994206bf60824a31815a8a925c7252
+author: ascorbic
+
 Fixes experimental registry navigation and allows the configured registry aggregator through the admin CSP.


### PR DESCRIPTION
## What does this PR do?

Fixes mis-attribution in the pending `0.13.1` release.

#1110 reintroduced `fix-local-media-id-normalization.md` and `ready-worlds-rush.md` (removed in #1105 to publish `0.13.0`). Because `@changesets/changelog-github` derives credit from the PR that introduced a changeset, the regenerated release PR (#1103) now credits **both** to #1110/@ascorbic — dropping @jcheese1's credit for #1100.

`@changesets/changelog-github@0.5.2` reads optional `pr:` / `commit:` / `author:` lines from the changeset body and uses them instead of the API lookup. This PR adds those overrides so the regenerated changelog reads:

- `[#1100] [f753dba] Thanks @jcheese1! — Resolve bare local media IDs…`
- `[#1101] [e539731] Thanks @ascorbic! — Fixes experimental registry navigation…`

The fix has to live in the changeset files on `main`, not in #1103: `changesets/action` force-pushes `changeset-release/main` on every version run, so a hand-edit to the release PR is overwritten on the next push.

Verified by simulating the changelog-github parser against both files (correct PR/commit/author, clean summary, no leftover lines).

After this merges, the version run regenerates #1103 with correct attribution; merging #1103 then publishes `0.13.1`.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (N/A — changeset metadata only, no code)
- [x] `pnpm lint` passes (N/A — no code)
- [x] `pnpm test` passes (N/A — no code)
- [x] `pnpm format` has been run (N/A — no code)
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (N/A)
- [x] I have added a changeset (N/A — edits existing pending changesets' metadata; no published-package behavior change)
- [ ] New features link to an approved Discussion (N/A — not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

```
.changeset/fix-local-media-id-normalization.md => pr=1100 commit=f753dba users=["jcheese1"] line="Resolve bare local media IDs…" rest=[]
.changeset/ready-worlds-rush.md                => pr=1101 commit=e539731 users=["ascorbic"] line="Fixes experimental registry…"   rest=[]
```
