### PR TITLE
feat(registry): profile fields end-to-end (license, authors, security, keywords, repo)

### DIFF
--- a/.changeset/registry-boundary-validation.md
+++ b/.changeset/registry-boundary-validation.md
@@ -3,8 +3,11 @@
 "emdash": patch
 ---
 
-Validates aggregator-supplied `profile` / `release` records at the read-side trust boundary. `DiscoveryClient`'s `searchPackages`, `getPackage`, `resolvePackage`, `getLatestRelease`, and `listReleases` now parse the embedded signed records against the `com.emdashcms.experimental.package.profile` / `release` lexicons. A conforming record is returned as the typed lexicon shape; a non-conforming one is surfaced as `null` instead of being passed through.
+Validates aggregator responses at the read-side trust boundary in `DiscoveryClient`. Two layers run:
 
-This refines the return types from `unknown` to `PackageProfile.Main | null` / `PackageRelease.Main | null` (new exported `Validated*` view types). Callers must null-check. The registry install handler now fails closed when the aggregator returns a release record that does not conform to the lexicon.
+- **Response envelope** (`uri`, `cid`, `did`, `slug`, `version`, …): `DiscoveryClient` now routes every call through `@atcute/client`'s schema-validating `.call()` against the aggregator method's output lexicon. Request params are validated too. A non-conforming envelope throws `ClientValidationError`.
+- **Embedded signed `profile` / `release` records** (typed `unknown` by the aggregator lexicon because they are relayed verbatim from publisher repos under a different lexicon namespace): now `safeParse`'d against `com.emdashcms.experimental.package.profile` / `release`. A conforming record is returned as the typed lexicon shape; a non-conforming one is surfaced as `null` so one bad record doesn't fail an entire search page.
+
+Refines the return types from `unknown` to `PackageProfile.Main | null` / `PackageRelease.Main | null` (new exported `ValidatedPackageView` / `ValidatedReleaseView` / `ValidatedSearchPackages` / `ValidatedListReleases` types). Callers must null-check. The registry install handler now fails closed when the aggregator returns a release record that does not conform to its lexicon.
 
 Validation is structural only — the lexicon's `uri` format permits non-HTTP schemes, so UI rendering these URLs still applies its own scheme allow-list.

--- a/.changeset/registry-boundary-validation.md
+++ b/.changeset/registry-boundary-validation.md
@@ -1,0 +1,10 @@
+---
+"@emdash-cms/registry-client": minor
+"emdash": patch
+---
+
+Validates aggregator-supplied `profile` / `release` records at the read-side trust boundary. `DiscoveryClient`'s `searchPackages`, `getPackage`, `resolvePackage`, `getLatestRelease`, and `listReleases` now parse the embedded signed records against the `com.emdashcms.experimental.package.profile` / `release` lexicons. A conforming record is returned as the typed lexicon shape; a non-conforming one is surfaced as `null` instead of being passed through.
+
+This refines the return types from `unknown` to `PackageProfile.Main | null` / `PackageRelease.Main | null` (new exported `Validated*` view types). Callers must null-check. The registry install handler now fails closed when the aggregator returns a release record that does not conform to the lexicon.
+
+Validation is structural only — the lexicon's `uri` format permits non-HTTP schemes, so UI rendering these URLs still applies its own scheme allow-list.

--- a/.changeset/registry-profile-fields-admin.md
+++ b/.changeset/registry-profile-fields-admin.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Renders the full registry package profile in the admin. The plugin detail page now shows the license (linked to spdx.org for single SPDX identifiers), keywords, all authors, all security contacts, and a link to the source repository. The browse cards show the license alongside the description.

--- a/.changeset/registry-profile-fields-cli.md
+++ b/.changeset/registry-profile-fields-cli.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/plugin-cli": minor
+---
+
+Publishes the full profile block from `emdash-plugin.jsonc`. First publish now writes `name`, `description`, `keywords`, multiple authors, and multiple security contacts to the package profile record, plus the source `repo` URL to the release record — previously only `license` and a single author/security contact were sent.
+
+Deprecates the `--license`, `--author-*`, and `--security-*` flags in favour of declaring these in `emdash-plugin.jsonc`. The flags still work and override the manifest when both are present; a deprecation warning is printed when they are used.

--- a/packages/admin/src/components/RegistryBrowse.tsx
+++ b/packages/admin/src/components/RegistryBrowse.tsx
@@ -159,9 +159,16 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 	// Always link by handle when we have one (cleaner URL), DID
 	// otherwise. The detail page accepts either.
 	const linkSegment = handleResult.handle ?? pkg.did;
-	// `profile` is a pass-through of the signed package profile record.
-	// We duck-type minimal display fields out of it.
-	const profile = pkg.profile as { name?: string; description?: string };
+	// `profile` is a pass-through of the signed package profile record from
+	// the aggregator (untrusted, typed `unknown`). Take only well-typed
+	// strings: a non-string `name`/`description`/`license` (object/array)
+	// would throw React's "objects are not valid as a child" and white-screen
+	// the browse grid.
+	const profileRaw = pkg.profile as Record<string, unknown> | undefined;
+	const name = typeof profileRaw?.name === "string" ? profileRaw.name : undefined;
+	const description =
+		typeof profileRaw?.description === "string" ? profileRaw.description : undefined;
+	const license = typeof profileRaw?.license === "string" ? profileRaw.license : undefined;
 	const verified = (pkg.labels ?? []).some((l: { val?: string }) => l.val === "verified");
 
 	return (
@@ -176,7 +183,7 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 				</div>
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<h2 className="truncate font-semibold">{profile.name ?? pkg.slug}</h2>
+						<h2 className="truncate font-semibold">{name ?? pkg.slug}</h2>
 						{verified ? (
 							<ShieldCheck
 								className="h-4 w-4 shrink-0 text-kumo-brand"
@@ -186,9 +193,10 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 					</div>
 					<PublisherHandle did={pkg.did} aggregatorHandle={pkg.handle} variant="card" />
 
-					{profile.description ? (
-						<p className="mt-2 line-clamp-2 text-sm text-kumo-default">{profile.description}</p>
+					{description ? (
+						<p className="mt-2 line-clamp-2 text-sm text-kumo-default">{description}</p>
 					) : null}
+					{license ? <p className="mt-2 text-xs text-kumo-subtle">{license}</p> : null}
 					{installed ? (
 						<div className="mt-3">
 							<Badge variant="success">{t`Installed`}</Badge>

--- a/packages/admin/src/components/RegistryBrowse.tsx
+++ b/packages/admin/src/components/RegistryBrowse.tsx
@@ -159,16 +159,12 @@ function RegistryPackageCard({ pkg, installed }: RegistryPackageCardProps) {
 	// Always link by handle when we have one (cleaner URL), DID
 	// otherwise. The detail page accepts either.
 	const linkSegment = handleResult.handle ?? pkg.did;
-	// `profile` is a pass-through of the signed package profile record from
-	// the aggregator (untrusted, typed `unknown`). Take only well-typed
-	// strings: a non-string `name`/`description`/`license` (object/array)
-	// would throw React's "objects are not valid as a child" and white-screen
-	// the browse grid.
-	const profileRaw = pkg.profile as Record<string, unknown> | undefined;
-	const name = typeof profileRaw?.name === "string" ? profileRaw.name : undefined;
-	const description =
-		typeof profileRaw?.description === "string" ? profileRaw.description : undefined;
-	const license = typeof profileRaw?.license === "string" ? profileRaw.license : undefined;
+	// `profile` is lexicon-validated at the DiscoveryClient boundary, so the
+	// shape is trustworthy (or `null`). These are plain text content
+	// (React-escaped) — no URL/href, so no scheme allow-list is needed here.
+	const name = pkg.profile?.name;
+	const description = pkg.profile?.description;
+	const license = pkg.profile?.license;
 	const verified = (pkg.labels ?? []).some((l: { val?: string }) => l.val === "verified");
 
 	return (

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -13,7 +13,7 @@
  * sidebar entries stay stable.
  */
 
-import { Badge, Button } from "@cloudflare/kumo";
+import { Badge, Button, LinkButton } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { ShieldCheck, Warning } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -123,7 +123,44 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 		? canonicalCapabilitiesForDriftCheck(ext?.capabilities)
 		: canonicalCapabilitiesForDriftCheck(declaredAccessToCapabilityList(ext?.declaredAccess));
 
-	const profile = pkg?.profile as { name?: string; description?: string } | undefined;
+	// `profile` / `release` are pass-throughs of the signed records, typed
+	// `unknown` from the aggregator (a remote, untrusted service). Parse the
+	// fields we render defensively: a string masquerading as `authors` would
+	// pass an `?.length` check and then crash on `.map`, a non-string `name`
+	// (object/array) throws React's "objects are not valid as a child", and a
+	// `javascript:` URL in an author/repo link is stored XSS in the
+	// authenticated admin origin. Build clean, sanitised values here; the JSX
+	// only touches these.
+	const profileRaw = pkg?.profile as Record<string, unknown> | undefined;
+	const displayName = typeof profileRaw?.name === "string" ? profileRaw.name : undefined;
+	const description =
+		typeof profileRaw?.description === "string" ? profileRaw.description : undefined;
+	const licenseText = typeof profileRaw?.license === "string" ? profileRaw.license : undefined;
+	const keywordList = Array.isArray(profileRaw?.keywords)
+		? profileRaw.keywords.filter((k): k is string => typeof k === "string" && k.length > 0)
+		: [];
+	const authorList = Array.isArray(profileRaw?.authors)
+		? profileRaw.authors.flatMap((a) => {
+				if (!a || typeof a !== "object") return [];
+				const o = a as Record<string, unknown>;
+				if (typeof o.name !== "string" || o.name.length === 0) return [];
+				return [{ name: o.name, url: safeExternalHref(o.url), email: safeEmail(o.email) }];
+			})
+		: [];
+	const securityList = Array.isArray(profileRaw?.security)
+		? profileRaw.security.flatMap((c) => {
+				if (!c || typeof c !== "object") return [];
+				const o = c as Record<string, unknown>;
+				const url = safeExternalHref(o.url);
+				const email = safeEmail(o.email);
+				if (!url && !email) return [];
+				return [{ url, email }];
+			})
+		: [];
+	// `repo` is a release-level field (`release.repo`), not a profile field.
+	const repoHref = safeExternalHref(
+		(release?.release as Record<string, unknown> | undefined)?.repo,
+	);
 	const verified = (pkg?.labels ?? []).some((l: { val?: string }) => l.val === "verified");
 
 	const policyOk =
@@ -224,7 +261,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 				</div>
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<h1 className="truncate text-3xl font-bold">{profile?.name ?? slug}</h1>
+						<h1 className="truncate text-3xl font-bold">{displayName ?? slug}</h1>
 						{verified ? (
 							<ShieldCheck
 								className="h-5 w-5 shrink-0 text-kumo-brand"
@@ -301,8 +338,86 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 			) : null}
 
 			{/* Description */}
-			{profile?.description ? (
-				<p className="text-base text-kumo-default">{profile.description}</p>
+			{description ? <p className="text-base text-kumo-default">{description}</p> : null}
+
+			{/* License / keywords / repository */}
+			{licenseText || repoHref || keywordList.length > 0 ? (
+				<section className="flex flex-wrap items-center gap-2">
+					{licenseText ? <LicenseBadge license={licenseText} /> : null}
+					{keywordList.map((k) => (
+						<Badge key={k}>{k}</Badge>
+					))}
+					{repoHref ? (
+						<LinkButton href={repoHref} external variant="secondary">
+							{t`View source`}
+						</LinkButton>
+					) : null}
+				</section>
+			) : null}
+
+			{/* Authors */}
+			{authorList.length > 0 ? (
+				<section>
+					<h2 className="text-sm font-semibold text-kumo-subtle">{t`Authors`}</h2>
+					<ul className="mt-2 space-y-1">
+						{authorList.map((a, i) => (
+							<li
+								// eslint-disable-next-line react/no-array-index-key -- authors have no stable id; index is stable within a render
+								key={`${a.name}-${i}`}
+								className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm"
+							>
+								<span className="font-medium text-kumo-default">{a.name}</span>
+								{a.url ? (
+									<a
+										href={a.url}
+										target="_blank"
+										rel="noreferrer"
+										className="text-kumo-brand hover:underline"
+									>
+										{t`Website`}
+									</a>
+								) : null}
+								{a.email ? (
+									<a href={`mailto:${a.email}`} className="text-kumo-brand hover:underline">
+										{a.email}
+									</a>
+								) : null}
+							</li>
+						))}
+					</ul>
+				</section>
+			) : null}
+
+			{/* Security contacts */}
+			{securityList.length > 0 ? (
+				<section>
+					<h2 className="text-sm font-semibold text-kumo-subtle">{t`Security contacts`}</h2>
+					<ul className="mt-2 space-y-1">
+						{securityList.map((c, i) => (
+							<li
+								// eslint-disable-next-line react/no-array-index-key -- contacts have no stable id; index is stable within a render
+								key={`${c.email ?? c.url ?? "contact"}-${i}`}
+								className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm"
+							>
+								{c.email ? (
+									<a href={`mailto:${c.email}`} className="text-kumo-brand hover:underline">
+										{c.email}
+									</a>
+								) : null}
+								{c.url ? (
+									<a
+										href={c.url}
+										target="_blank"
+										rel="noreferrer"
+										className="text-kumo-brand hover:underline"
+									>
+										{c.url}
+									</a>
+								) : null}
+							</li>
+						))}
+					</ul>
+				</section>
 			) : null}
 
 			{/* Capabilities preview */}
@@ -321,7 +436,7 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 			{showConsent && release ? (
 				<CapabilityConsentDialog
 					mode="install"
-					pluginName={profile?.name ?? slug}
+					pluginName={displayName ?? slug}
 					capabilities={capabilities}
 					isPending={installMutation.isPending}
 					error={getMutationError(installMutation.error)}
@@ -377,6 +492,70 @@ function formatDate(iso: string): string {
 	} catch {
 		return iso;
 	}
+}
+
+/**
+ * SPDX page URL for a license, or `null` when the value isn't a single
+ * SPDX identifier (compound expressions like "MIT OR Apache-2.0" and the
+ * literal "proprietary" have no canonical spdx.org page).
+ */
+/**
+ * Validate an untrusted aggregator-supplied URL for use in an `href`.
+ * Returns the normalised URL only when it is an absolute `http(s)` URL;
+ * everything else (relative, `javascript:`, `data:`, garbage, non-string)
+ * returns `null`. The profile/release records are pass-throughs from a
+ * remote service, so an unsanitised `href` is stored XSS in the
+ * authenticated admin origin.
+ */
+function safeExternalHref(value: unknown): string | null {
+	if (typeof value !== "string" || value.length === 0) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+	return parsed.href;
+}
+
+// Conservative email shape: forbids whitespace (so no CRLF), the
+// characters that could break out of a `mailto:` href, and the
+// `mailto:` query delimiters (`? & = % /`) so a value like
+// `victim@x.com?bcc=attacker@evil` can't smuggle cc/bcc/subject/body.
+const EMAIL_RE = /^[^\s@<>()[\]\\,;:"?&=%/]+@[^\s@<>()[\]\\,;:"?&=%/]+\.[^\s@<>()[\]\\,;:"?&=%/]+$/;
+
+function safeEmail(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const email = value.trim();
+	if (email.length === 0 || email.length > 320) return null;
+	return EMAIL_RE.test(email) ? email : null;
+}
+
+const SPDX_SINGLE_ID_RE = /^[A-Za-z0-9.+-]+$/;
+
+function spdxLicenseHref(license: string): string | null {
+	const id = license.trim();
+	if (!SPDX_SINGLE_ID_RE.test(id)) return null;
+	if (id.toLowerCase() === "proprietary") return null;
+	return `https://spdx.org/licenses/${id}.html`;
+}
+
+function LicenseBadge({ license }: { license: string }) {
+	const { t } = useLingui();
+	const href = spdxLicenseHref(license);
+	if (!href) return <Badge>{license}</Badge>;
+	return (
+		<a
+			href={href}
+			target="_blank"
+			rel="noreferrer"
+			aria-label={t`View the ${license} license on spdx.org`}
+			className="hover:opacity-80"
+		>
+			<Badge>{license}</Badge>
+		</a>
+	);
 }
 
 function formatHoldback(seconds: number): string {

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -112,55 +112,40 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	// different permissions list than another publisher would for the
 	// same RFC-0001 fields.
 	const RELEASE_EXTENSION_NSID = "com.emdashcms.experimental.package.releaseExtension";
-	const releaseDoc = release?.release as
-		| {
-				extensions?: Record<string, { declaredAccess?: unknown; capabilities?: unknown }>;
-		  }
+	// `release` is lexicon-validated at the boundary; `extensions` is the
+	// lexicon's open `unknown` map, so its inner shape still needs narrowing.
+	const extensions = release?.release?.extensions as
+		| Record<string, { declaredAccess?: unknown; capabilities?: unknown }>
 		| undefined;
-	const ext = releaseDoc?.extensions?.[RELEASE_EXTENSION_NSID];
+	const ext = extensions?.[RELEASE_EXTENSION_NSID];
 
 	const capabilities: string[] = Array.isArray(ext?.capabilities)
 		? canonicalCapabilitiesForDriftCheck(ext?.capabilities)
 		: canonicalCapabilitiesForDriftCheck(declaredAccessToCapabilityList(ext?.declaredAccess));
 
-	// `profile` / `release` are pass-throughs of the signed records, typed
-	// `unknown` from the aggregator (a remote, untrusted service). Parse the
-	// fields we render defensively: a string masquerading as `authors` would
-	// pass an `?.length` check and then crash on `.map`, a non-string `name`
-	// (object/array) throws React's "objects are not valid as a child", and a
-	// `javascript:` URL in an author/repo link is stored XSS in the
-	// authenticated admin origin. Build clean, sanitised values here; the JSX
-	// only touches these.
-	const profileRaw = pkg?.profile as Record<string, unknown> | undefined;
-	const displayName = typeof profileRaw?.name === "string" ? profileRaw.name : undefined;
-	const description =
-		typeof profileRaw?.description === "string" ? profileRaw.description : undefined;
-	const licenseText = typeof profileRaw?.license === "string" ? profileRaw.license : undefined;
-	const keywordList = Array.isArray(profileRaw?.keywords)
-		? profileRaw.keywords.filter((k): k is string => typeof k === "string" && k.length > 0)
-		: [];
-	const authorList = Array.isArray(profileRaw?.authors)
-		? profileRaw.authors.flatMap((a) => {
-				if (!a || typeof a !== "object") return [];
-				const o = a as Record<string, unknown>;
-				if (typeof o.name !== "string" || o.name.length === 0) return [];
-				return [{ name: o.name, url: safeExternalHref(o.url), email: safeEmail(o.email) }];
-			})
-		: [];
-	const securityList = Array.isArray(profileRaw?.security)
-		? profileRaw.security.flatMap((c) => {
-				if (!c || typeof c !== "object") return [];
-				const o = c as Record<string, unknown>;
-				const url = safeExternalHref(o.url);
-				const email = safeEmail(o.email);
-				if (!url && !email) return [];
-				return [{ url, email }];
-			})
-		: [];
+	// `profile` / `release` are validated against their lexicons at the
+	// DiscoveryClient boundary, so the shape here is trustworthy (or `null`).
+	// URLs still need a scheme allow-list: the lexicon's `uri` format permits
+	// non-HTTP schemes (incl. `javascript:`), so an author/repo `url` going
+	// straight into an `href` would be stored XSS in the authenticated admin
+	// origin. `safeExternalHref` / `safeEmail` are that gate, not shape-parsing.
+	const pkgProfile = pkg?.profile ?? null;
+	const displayName = pkgProfile?.name;
+	const description = pkgProfile?.description;
+	const licenseText = pkgProfile?.license;
+	const keywordList = pkgProfile?.keywords ?? [];
+	const authorList = (pkgProfile?.authors ?? []).map((a) => ({
+		name: a.name,
+		url: safeExternalHref(a.url),
+		email: safeEmail(a.email),
+	}));
+	const securityList = (pkgProfile?.security ?? []).flatMap((c) => {
+		const url = safeExternalHref(c.url);
+		const email = safeEmail(c.email);
+		return url || email ? [{ url, email }] : [];
+	});
 	// `repo` is a release-level field (`release.repo`), not a profile field.
-	const repoHref = safeExternalHref(
-		(release?.release as Record<string, unknown> | undefined)?.repo,
-	);
+	const repoHref = safeExternalHref(release?.release?.repo);
 	const verified = (pkg?.labels ?? []).some((l: { val?: string }) => l.val === "verified");
 
 	const policyOk =

--- a/packages/admin/src/lib/api/registry.ts
+++ b/packages/admin/src/lib/api/registry.ts
@@ -20,6 +20,12 @@
  */
 
 import type { Did, Handle } from "@atcute/lexicons";
+import type {
+	ValidatedListReleases,
+	ValidatedPackageView,
+	ValidatedReleaseView,
+	ValidatedSearchPackages,
+} from "@emdash-cms/registry-client/discovery";
 import { i18n } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 
@@ -46,39 +52,15 @@ export interface RegistryClientConfig {
 }
 
 /**
- * Lightweight aliases for the lexicon-generated types. The hooks return
- * the raw XRPC output -- callers narrow `profile` / `release` as needed
- * (they're typed as `unknown` by the lexicon because the signed records
- * are pass-through).
+ * Re-exports of the registry-client view types. `DiscoveryClient` validates
+ * the embedded signed `profile` / `release` records against their lexicons
+ * at the read-side trust boundary, so they arrive here as the typed lexicon
+ * shape or `null` when the aggregator returned a non-conforming record.
+ * Callers must null-check; they no longer need to shape-narrow.
  */
-export interface RegistryPackageView {
-	uri: string;
-	cid: string;
-	did: string;
-	handle?: string;
-	slug: string;
-	indexedAt: string;
-	latestVersion?: string;
-	profile: unknown;
-	labels?: Array<{ val: string; src?: string; uri?: string }>;
-}
-
-export interface RegistryReleaseView {
-	uri: string;
-	cid: string;
-	did: string;
-	package: string;
-	version: string;
-	indexedAt: string;
-	mirrors?: string[];
-	release: unknown;
-	labels?: Array<{ val: string; src?: string; uri?: string }>;
-}
-
-export interface RegistrySearchResult {
-	packages: RegistryPackageView[];
-	cursor?: string;
-}
+export type RegistryPackageView = ValidatedPackageView;
+export type RegistryReleaseView = ValidatedReleaseView;
+export type RegistrySearchResult = ValidatedSearchPackages;
 
 export interface RegistrySearchOpts {
 	q?: string;
@@ -110,11 +92,7 @@ interface WrappedDiscoveryClient {
 	resolvePackage: (handle: string, slug: string) => Promise<RegistryPackageView>;
 	getPackage: (did: string, slug: string) => Promise<RegistryPackageView>;
 	getLatestRelease: (did: string, slug: string) => Promise<RegistryReleaseView>;
-	listReleases: (
-		did: string,
-		slug: string,
-		cursor?: string,
-	) => Promise<{ releases: RegistryReleaseView[]; cursor?: string }>;
+	listReleases: (did: string, slug: string, cursor?: string) => Promise<ValidatedListReleases>;
 }
 
 let cachedDiscovery: {
@@ -140,45 +118,40 @@ async function getDiscoveryClient(config: RegistryClientConfig): Promise<Wrapped
 
 	const wrapped: WrappedDiscoveryClient = {
 		async searchPackages(opts: RegistrySearchOpts) {
-			const result = await discovery.searchPackages({
+			return discovery.searchPackages({
 				q: opts.q,
 				cursor: opts.cursor,
 				limit: opts.limit,
 			});
-			return result as RegistrySearchResult;
 		},
 		async resolvePackage(handle: string, slug: string) {
-			const result = await discovery.resolvePackage({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- shape validated by aggregator
+			return discovery.resolvePackage({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- did/handle shape validated by aggregator
 				handle: handle as Handle,
 				slug,
 			});
-			return result as RegistryPackageView;
 		},
 		async getPackage(did: string, slug: string) {
-			const result = await discovery.getPackage({
+			return discovery.getPackage({
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- did shape validated by aggregator
 				did: did as Did,
 				slug,
 			});
-			return result as RegistryPackageView;
 		},
 		async getLatestRelease(did: string, slug: string) {
-			const result = await discovery.getLatestRelease({
+			return discovery.getLatestRelease({
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- did shape validated by aggregator
 				did: did as Did,
 				package: slug,
 			});
-			return result as RegistryReleaseView;
 		},
 		async listReleases(did: string, slug: string, cursor?: string) {
-			const result = await discovery.listReleases({
+			return discovery.listReleases({
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- did shape validated by aggregator
 				did: did as Did,
 				package: slug,
 				cursor,
 			});
-			return result as { releases: RegistryReleaseView[]; cursor?: string };
 		},
 	};
 
@@ -311,7 +284,7 @@ export async function listRegistryReleases(
 	did: string,
 	slug: string,
 	cursor?: string,
-): Promise<{ releases: RegistryReleaseView[]; cursor?: string }> {
+): Promise<ValidatedListReleases> {
 	const client = await getDiscoveryClient(config);
 	return client.listReleases(did, slug, cursor);
 }

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -679,10 +679,10 @@ export async function handleRegistryInstall(
 		// publisher's record. Checksum verification only proves the bytes
 		// match the *returned* record, not that the record belongs to
 		// the package we requested.
-		const signedRelease = releaseView.release as
-			| { package?: unknown; version?: unknown }
-			| null
-			| undefined;
+		// `releaseView.release` is validated against the release lexicon by
+		// DiscoveryClient (or `null` if it didn't conform). A `null` here makes
+		// the identity checks below fail closed, which is the desired outcome.
+		const signedRelease = releaseView.release;
 		if (packageView.did !== publisherDid || packageView.slug !== slug) {
 			return {
 				success: false,
@@ -848,17 +848,13 @@ export async function handleRegistryInstall(
 		}
 
 		// Step 4: fetch the artifact bytes.
-		// The signed release record is `releaseView.release`; the lexicon
-		// types it as `unknown` so we extract the package artifact via
-		// duck-typed access. Mirrors come from the envelope (aggregator
-		// operational data, not part of the signed record).
-		const release = releaseView.release as {
-			artifacts?: {
-				package?: { url?: string; checksum?: string };
-			};
-		};
-		const declaredUrl = release.artifacts?.package?.url;
-		const declaredChecksum = release.artifacts?.package?.checksum;
+		// `releaseView.release` is lexicon-validated by DiscoveryClient (or
+		// `null`); a missing url/checksum (incl. the `null` case) fails closed
+		// below. Mirrors come from the envelope (aggregator operational data,
+		// not part of the signed record).
+		const release = releaseView.release;
+		const declaredUrl = release?.artifacts?.package?.url;
+		const declaredChecksum = release?.artifacts?.package?.checksum;
 
 		if (!declaredUrl || !declaredChecksum) {
 			return {
@@ -1021,12 +1017,13 @@ export async function handleRegistryInstall(
 		// Cleanup is best-effort; if it also fails, the row failure
 		// still surfaces to the caller and the orphan R2 bundle costs
 		// only the storage of a single checksum-verified zip.
-		const profile = packageView.profile as { name?: string; description?: string };
+		// `packageView.profile` is lexicon-validated by DiscoveryClient (or null).
+		const profile = packageView.profile;
 		try {
 			await stateRepo.upsert(pluginId, version, "active", {
 				source: "registry",
-				displayName: profile.name ?? slug,
-				description: profile.description ?? undefined,
+				displayName: profile?.name ?? slug,
+				description: profile?.description ?? undefined,
 				registryPublisherDid: publisherDid,
 				registrySlug: slug,
 			});

--- a/packages/plugin-cli/src/api.ts
+++ b/packages/plugin-cli/src/api.ts
@@ -31,6 +31,7 @@ export {
 
 export {
 	type ProfileBootstrap,
+	type ProfileInput,
 	type PublishErrorCode,
 	type PublishLogger,
 	type PublishOptions,

--- a/packages/plugin-cli/src/commands/info.ts
+++ b/packages/plugin-cli/src/commands/info.ts
@@ -10,9 +10,7 @@
  */
 
 import { isDid, isHandle } from "@atcute/lexicons/syntax";
-import { safeParse } from "@atcute/lexicons/validations";
 import { DiscoveryClient } from "@emdash-cms/registry-client";
-import { PackageProfile } from "@emdash-cms/registry-lexicons";
 import { defineCommand } from "citty";
 import { consola } from "consola";
 import pc from "picocolors";
@@ -68,28 +66,19 @@ export const infoCommand = defineCommand({
 			return;
 		}
 
-		// `result.profile` is the publisher-supplied record; `unknown` per the
-		// lexicon. Validate against the package profile schema so we don't
-		// blindly print whatever an aggregator (or a malicious publisher)
-		// stuffed into it.
-		const parsed = safeParse(PackageProfile.mainSchema, result.profile);
-		const profile: PackageProfile.Main | null = parsed.ok ? parsed.value : null;
+		// `result.profile` is validated against the package profile lexicon by
+		// DiscoveryClient (the read-side trust boundary), or `null` when the
+		// aggregator returned a non-conforming record.
+		const profile = result.profile;
 		if (!profile) {
 			consola.warn(
-				`Profile record at ${result.uri} doesn't match the lexicon; printing what we have anyway.`,
+				`Profile record at ${result.uri} doesn't match the lexicon; showing the slug only.`,
 			);
 		}
 
-		const fallback = result.profile as { name?: unknown; description?: unknown; license?: unknown };
-		const name =
-			profile?.name ??
-			(typeof fallback.name === "string" ? fallback.name : undefined) ??
-			result.slug;
-		const description =
-			profile?.description ??
-			(typeof fallback.description === "string" ? fallback.description : undefined);
-		const license =
-			profile?.license ?? (typeof fallback.license === "string" ? fallback.license : undefined);
+		const name = profile?.name ?? result.slug;
+		const description = profile?.description;
+		const license = profile?.license;
 
 		console.log();
 		console.log(pc.bold(name));

--- a/packages/plugin-cli/src/commands/publish.ts
+++ b/packages/plugin-cli/src/commands/publish.ts
@@ -32,7 +32,7 @@ import { formatBytes, MAX_BUNDLE_SIZE, validateBundleSize } from "../bundle/util
 import { loadManifest, MANIFEST_FILENAME, ManifestError } from "../manifest/load.js";
 import { checkPublisher, PublisherCheckError, writePublisherBack } from "../manifest/publisher.js";
 import {
-	manifestToProfileBootstrap,
+	manifestToProfileInput,
 	normaliseManifest,
 	type NormalisedManifest,
 } from "../manifest/translate.js";
@@ -41,7 +41,7 @@ import { resumeSession } from "../oauth.js";
 import {
 	PublishError,
 	publishRelease,
-	type ProfileBootstrap,
+	type ProfileInput,
 	type PublishLogger,
 } from "../publish/api.js";
 
@@ -74,27 +74,30 @@ export const publishCommand = defineCommand({
 		license: {
 			type: "string",
 			description:
-				"SPDX license expression. Required on first publish; ignored thereafter (the existing profile wins)",
+				"(deprecated: set `license` in emdash-plugin.jsonc) SPDX license expression. Required on first publish; ignored thereafter (the existing profile wins). Overrides the manifest value when both are present.",
 		},
 		"author-name": {
 			type: "string",
-			description: "Author display name (first publish only)",
+			description:
+				"(deprecated: set `author`/`authors` in emdash-plugin.jsonc) Author display name (first publish only). Overrides the manifest authors when any --author-* flag is present.",
 		},
 		"author-url": {
 			type: "string",
-			description: "Author URL (first publish only)",
+			description: "(deprecated: use emdash-plugin.jsonc) Author URL (first publish only)",
 		},
 		"author-email": {
 			type: "string",
-			description: "Author email (first publish only)",
+			description: "(deprecated: use emdash-plugin.jsonc) Author email (first publish only)",
 		},
 		"security-email": {
 			type: "string",
-			description: "Security contact email. Required on first publish; ignored thereafter",
+			description:
+				"(deprecated: set `security`/`securityContacts` in emdash-plugin.jsonc) Security contact email. Required on first publish; ignored thereafter. Overrides the manifest security contacts when any --security-* flag is present.",
 		},
 		"security-url": {
 			type: "string",
-			description: "Security contact URL (first publish only)",
+			description:
+				"(deprecated: use emdash-plugin.jsonc) Security contact URL (first publish only)",
 		},
 		manifest: {
 			type: "string",
@@ -175,7 +178,7 @@ async function runPublish(args: PublishArgs): Promise<void> {
 	// error: legacy flag-only invocations keep working. Only `--manifest`
 	// explicit-not-found is an error.
 	const manifestLoad = await loadManifestBootstrap(args, consola);
-	const manifestBase = manifestLoad?.bootstrap ?? null;
+	const manifestProfile = manifestLoad?.profileInput ?? null;
 
 	// Resume the active publisher session BEFORE any network access.
 	// The publisher-mismatch check below depends only on the session DID
@@ -254,22 +257,44 @@ async function runPublish(args: PublishArgs): Promise<void> {
 		pds: session.pds,
 	});
 
-	// Build the final ProfileBootstrap. Layer ordering:
-	//   1. manifest values (if any) at the bottom
-	//   2. flag values on top (explicit caller intent wins)
-	// Each layer only writes a key when the caller provided it; missing
-	// keys remain missing so the API's "required on first publish" checks
-	// fire at the right time. Spreading `null` is a no-op, so the
-	// no-manifest path doesn't need a fallback object.
-	const profile: ProfileBootstrap = {
-		...manifestBase,
-		...(args.license !== undefined ? { license: args.license } : {}),
-		...(args["author-name"] !== undefined ? { authorName: args["author-name"] } : {}),
-		...(args["author-url"] !== undefined ? { authorUrl: args["author-url"] } : {}),
-		...(args["author-email"] !== undefined ? { authorEmail: args["author-email"] } : {}),
-		...(args["security-email"] !== undefined ? { securityEmail: args["security-email"] } : {}),
-		...(args["security-url"] !== undefined ? { securityUrl: args["security-url"] } : {}),
-	};
+	// Resolve the profile block. The manifest is the base; the deprecated
+	// flat flags override on top (explicit caller intent wins). A single
+	// --author-* / --security-* flag replaces the whole corresponding
+	// manifest list — the flat flags only ever model one entry, so merging
+	// them into a multi-entry list would be ambiguous.
+	const profileInput: ProfileInput = { ...manifestProfile };
+	if (args.license !== undefined) profileInput.license = args.license;
+	if (
+		args["author-name"] !== undefined ||
+		args["author-url"] !== undefined ||
+		args["author-email"] !== undefined
+	) {
+		const author: { name: string; url?: string; email?: string } = {
+			name: args["author-name"] ?? "unknown",
+		};
+		if (args["author-url"] !== undefined) author.url = args["author-url"];
+		if (args["author-email"] !== undefined) author.email = args["author-email"];
+		profileInput.authors = [author];
+	}
+	if (args["security-email"] !== undefined || args["security-url"] !== undefined) {
+		const contact: { url?: string; email?: string } = {};
+		if (args["security-email"] !== undefined) contact.email = args["security-email"];
+		if (args["security-url"] !== undefined) contact.url = args["security-url"];
+		profileInput.security = [contact];
+	}
+
+	const usedDeprecatedFlags =
+		args.license !== undefined ||
+		args["author-name"] !== undefined ||
+		args["author-url"] !== undefined ||
+		args["author-email"] !== undefined ||
+		args["security-email"] !== undefined ||
+		args["security-url"] !== undefined;
+	if (usedDeprecatedFlags) {
+		consola.warn(
+			"The --license / --author-* / --security-* flags are deprecated. Declare these in emdash-plugin.jsonc instead; the flags will be removed in a future release.",
+		);
+	}
 
 	const logger: PublishLogger = {
 		info: (m) => consola.info(m),
@@ -283,7 +308,8 @@ async function runPublish(args: PublishArgs): Promise<void> {
 		manifest,
 		checksum,
 		url: args.url,
-		profile,
+		profileInput,
+		repo: manifestLoad?.manifest.repo,
 		allowOverwrite: args["allow-overwrite"],
 		logger,
 	});
@@ -308,11 +334,13 @@ async function runPublish(args: PublishArgs): Promise<void> {
 		});
 	}
 
-	// Subsequent-publish: warn about ignored first-publish-only flags.
+	// Subsequent-publish: warn about ignored first-publish-only profile
+	// fields. These are owned by the existing profile record; a republish
+	// doesn't rewrite them.
 	if (!result.profileCreated && result.ignoredProfileFields.length > 0) {
-		const flags = result.ignoredProfileFields.map(profileFieldToFlag).join(", ");
+		const fields = result.ignoredProfileFields.join(", ");
 		consola.warn(
-			`Ignored on subsequent publish (existing profile wins): ${flags}. Profile updates aren't supported yet; edit the record directly via your PDS for now.`,
+			`Ignored on subsequent publish (existing profile wins): ${fields}. Editing an existing profile isn't supported yet (#1032); update the record directly via your PDS for now.`,
 		);
 	}
 
@@ -411,7 +439,7 @@ type PublishArgs = {
 
 /**
  * Result of resolving the manifest for `runPublish`. Surfaces both the
- * derived ProfileBootstrap (the publish API's input) and the normalised
+ * derived ProfileInput (the publish API's input) and the normalised
  * manifest itself, so downstream code can run the publisher-pin check
  * and the post-publish write-back without re-parsing the file.
  */
@@ -420,8 +448,8 @@ interface ManifestLoadOutcome {
 	path: string;
 	/** Normalised manifest (single/multi-author forms collapsed). */
 	manifest: NormalisedManifest;
-	/** Bridged ProfileBootstrap for the legacy publish-API input. */
-	bootstrap: ProfileBootstrap;
+	/** Structured profile block for the publish-API input. */
+	profileInput: ProfileInput;
 }
 
 /**
@@ -479,7 +507,7 @@ async function loadManifestBootstrap(
 		return {
 			path: resolvedPath,
 			manifest: normalised,
-			bootstrap: manifestToProfileBootstrap(normalised),
+			profileInput: manifestToProfileInput(normalised),
 		};
 	} catch (error) {
 		if (error instanceof ManifestError) {
@@ -1140,21 +1168,4 @@ function describeJsonValue(value: unknown): string {
 	if (value === null) return "null";
 	if (Array.isArray(value)) return "array";
 	return typeof value;
-}
-
-/**
- * Map a `ProfileBootstrap` field name back to the user-facing CLI flag for
- * warnings. Keeps the API-side names internal-friendly while the CLI surface
- * stays kebab-case.
- */
-function profileFieldToFlag(field: string): string {
-	const map: Record<string, string> = {
-		license: "--license",
-		authorName: "--author-name",
-		authorUrl: "--author-url",
-		authorEmail: "--author-email",
-		securityEmail: "--security-email",
-		securityUrl: "--security-url",
-	};
-	return map[field] ?? `--${field}`;
 }

--- a/packages/plugin-cli/src/commands/search.ts
+++ b/packages/plugin-cli/src/commands/search.ts
@@ -69,9 +69,10 @@ export const searchCommand = defineCommand({
 
 		console.log();
 		for (const pkg of result.packages) {
-			const profile = pkg.profile as { name?: string; description?: string };
-			console.log(`${pc.bold(profile.name ?? pkg.slug)} ${pc.dim(`(${pkg.slug})`)}`);
-			if (profile.description) console.log(`  ${profile.description}`);
+			// `pkg.profile` is lexicon-validated by DiscoveryClient (or null).
+			const profile = pkg.profile;
+			console.log(`${pc.bold(profile?.name ?? pkg.slug)} ${pc.dim(`(${pkg.slug})`)}`);
+			if (profile?.description) console.log(`  ${profile.description}`);
 			console.log(`  ${pc.dim(pkg.uri)}`);
 			console.log();
 		}

--- a/packages/plugin-cli/src/manifest/translate.ts
+++ b/packages/plugin-cli/src/manifest/translate.ts
@@ -8,7 +8,7 @@
 
 import type { PluginCapability, PluginStorageConfig } from "@emdash-cms/plugin-types";
 
-import type { ProfileBootstrap } from "../publish/api.js";
+import type { ProfileBootstrap, ProfileInput } from "../publish/api.js";
 import type { Manifest, ManifestAuthor, ManifestSecurityContact } from "./schema.js";
 
 /**
@@ -187,16 +187,37 @@ export function normaliseManifest(manifest: Manifest, packageVersion?: string): 
 }
 
 /**
- * Convert a normalised manifest into the `ProfileBootstrap` shape that
- * `publishRelease` consumes. For multi-author manifests, the first
- * author wins (the publish lexicon supports an array, but
- * `ProfileBootstrap` doesn't model that yet).
+ * Convert a normalised manifest into the structured `ProfileInput` that
+ * `publishRelease` consumes. Carries the full lexicon profile block:
+ * multi-author, multi-security, name, description, keywords. `repo` is a
+ * release-level field and is passed separately (see `NormalisedManifest.repo`).
+ */
+export function manifestToProfileInput(manifest: NormalisedManifest): ProfileInput {
+	const input: ProfileInput = {
+		license: manifest.license,
+		authors: manifest.authors.map((a) => ({
+			name: a.name,
+			...(a.url !== undefined ? { url: a.url } : {}),
+			...(a.email !== undefined ? { email: a.email } : {}),
+		})),
+		security: manifest.securityContacts.map((c) => ({
+			...(c.url !== undefined ? { url: c.url } : {}),
+			...(c.email !== undefined ? { email: c.email } : {}),
+		})),
+	};
+	if (manifest.name !== undefined) input.name = manifest.name;
+	if (manifest.description !== undefined) input.description = manifest.description;
+	if (manifest.keywords !== undefined) input.keywords = manifest.keywords;
+	return input;
+}
+
+/**
+ * Convert a normalised manifest into the deprecated flat `ProfileBootstrap`
+ * shape. For multi-author manifests, the first author wins (the flat shape
+ * models only one author and one security contact).
  *
- * `name`, `description`, `keywords`, and `repo` are accepted by the
- * manifest schema but not wired through here. They land in publish in a
- * follow-up issue alongside the broader profile-fields work. The fields
- * are not silently lost — the manifest is the source of truth and we'll
- * read them again when the publish API accepts them.
+ * @deprecated Use {@link manifestToProfileInput}. Retained for callers still
+ * on the flat publish path.
  */
 export function manifestToProfileBootstrap(manifest: NormalisedManifest): ProfileBootstrap {
 	const author = manifest.authors[0];

--- a/packages/plugin-cli/src/publish/api.ts
+++ b/packages/plugin-cli/src/publish/api.ts
@@ -93,10 +93,14 @@ export interface PublishLogger {
 }
 
 /**
- * Identity fields supplied at publish time. Used only on first publish, when
- * we bootstrap the `package.profile` record. On subsequent publishes the
- * existing profile wins; any of these passed are ignored, with a warning
- * collected under `result.ignoredProfileFields`.
+ * Flat identity fields supplied at publish time.
+ *
+ * @deprecated Prefer {@link ProfileInput} via `PublishOptions.profileInput`,
+ * which mirrors the lexicon's profile block (multi-author, multi-security,
+ * name, description, keywords). This flat shape only models a single author
+ * and a single security contact and is kept for the deprecated `--author-*` /
+ * `--security-*` CLI flags and existing programmatic callers. When both
+ * `profileInput` and `profile` are passed, `profileInput` wins.
  */
 export interface ProfileBootstrap {
 	/** SPDX license expression. Required on first publish. */
@@ -106,6 +110,26 @@ export interface ProfileBootstrap {
 	authorEmail?: string;
 	securityEmail?: string;
 	securityUrl?: string;
+}
+
+/**
+ * Structured profile block, mirroring the `com.emdashcms.experimental
+ * .package.profile` lexicon. Used only on first publish, when we bootstrap
+ * the profile record. On subsequent publishes the existing profile wins; any
+ * provided fields are ignored, reported under `result.ignoredProfileFields`.
+ *
+ * `authors` / `security` are arrays (the lexicon allows 1–32 authors and
+ * 1–8 security contacts). At least one security contact carrying a `url` or
+ * `email` is required on first publish.
+ */
+export interface ProfileInput {
+	/** SPDX license expression. Required on first publish. */
+	license?: string;
+	authors?: Array<{ name: string; url?: string; email?: string }>;
+	security?: Array<{ url?: string; email?: string }>;
+	name?: string;
+	description?: string;
+	keywords?: string[];
 }
 
 export interface PublishOptions {
@@ -119,8 +143,25 @@ export interface PublishOptions {
 	checksum: string;
 	/** Public URL where the tarball is hosted. */
 	url: string;
-	/** Identity fields used when bootstrapping a new profile. */
+	/**
+	 * Structured profile block used when bootstrapping a new profile.
+	 * Preferred over `profile`; when both are set, this wins entirely.
+	 */
+	profileInput?: ProfileInput;
+	/**
+	 * Flat identity fields used when bootstrapping a new profile.
+	 *
+	 * @deprecated Pass `profileInput` instead. Retained for the deprecated
+	 * `--author-*` / `--security-*` CLI flags and existing programmatic
+	 * callers. Ignored when `profileInput` is provided.
+	 */
 	profile?: ProfileBootstrap;
+	/**
+	 * Source-repository URL for this release (`release.repo` in the
+	 * lexicon). Written to every release record when set — releases are
+	 * immutable per version, so this is not a first-publish-only field.
+	 */
+	repo?: string;
 	/**
 	 * Allow overwriting an existing release at `<slug>:<version>`. Default
 	 * is `false`, which causes publish to refuse with `RELEASE_ALREADY_PUBLISHED`.
@@ -186,6 +227,9 @@ interface PackageProfileRecordShape {
 	security: Array<{ url?: string; email?: string }>;
 	slug: string;
 	lastUpdated: string;
+	name?: string;
+	description?: string;
+	keywords?: string[];
 }
 
 interface PackageReleaseRecordShape {
@@ -199,6 +243,8 @@ interface PackageReleaseRecordShape {
 			contentType?: string;
 		};
 	};
+	/** Source-repository URL (`release.repo`). Omitted when not provided. */
+	repo?: string;
 	/**
 	 * Open-union extension container, keyed by NSID. Releases of type
 	 * `emdash-plugin` MUST include a `releaseExtension` entry carrying the
@@ -351,6 +397,9 @@ export async function publishRelease(options: PublishOptions): Promise<PublishRe
 			[NSID.packageReleaseExtension]: releaseExtension,
 		},
 	};
+	if (options.repo !== undefined) {
+		releaseRecord.repo = options.repo;
+	}
 
 	type WriteOp =
 		| {
@@ -380,11 +429,18 @@ export async function publishRelease(options: PublishOptions): Promise<PublishRe
 
 	const writes: WriteOp[] = [];
 
+	// `profileInput` (structured, mirrors the lexicon) wins over the
+	// deprecated flat `profile`. We keep the raw inputs around for the
+	// ignored-fields report so a flat-flag caller still sees flat field
+	// names in the warning.
+	const usedStructured = options.profileInput !== undefined;
+	const resolvedProfile = resolveProfileInput(options);
+
 	if (profileCreated) {
 		const profileRecord = buildProfileRecord({
 			slug,
 			profileUri,
-			profile: options.profile,
+			profile: resolvedProfile,
 		});
 		writes.push({
 			op: "create",
@@ -394,7 +450,11 @@ export async function publishRelease(options: PublishOptions): Promise<PublishRe
 		});
 		log.info?.(`Bootstrapping profile: ${profileUri}`);
 	} else {
-		ignoredProfileFields.push(...listProvidedProfileFields(options.profile));
+		ignoredProfileFields.push(
+			...(usedStructured
+				? listProvidedProfileInputFields(options.profileInput)
+				: listProvidedProfileFields(options.profile)),
+		);
 		// Bump `lastUpdated` on the existing profile so aggregators ordering
 		// by it see this publish. The user's first-publish-only flags are
 		// still ignored (the existing profile owns identity/license/security),
@@ -716,9 +776,9 @@ function stampLastUpdated(existingValue: unknown): PackageProfileRecordShape | n
 function buildProfileRecord(input: {
 	slug: string;
 	profileUri: string;
-	profile: ProfileBootstrap | undefined;
+	profile: ProfileInput;
 }): PackageProfileRecordShape {
-	const profile = input.profile ?? {};
+	const profile = input.profile;
 	if (!profile.license) {
 		throw new PublishError(
 			"PROFILE_BOOTSTRAP_MISSING_FIELD",
@@ -726,34 +786,100 @@ function buildProfileRecord(input: {
 			{ field: "license" },
 		);
 	}
-	if (!profile.securityEmail && !profile.securityUrl) {
+
+	// Drop entries the lexicon would reject (a contact MUST carry url or
+	// email) and re-build clean objects so an undefined key never reaches
+	// the record.
+	const security: Array<{ url?: string; email?: string }> = [];
+	for (const c of profile.security ?? []) {
+		const entry: { url?: string; email?: string } = {};
+		if (c.email) entry.email = c.email;
+		if (c.url) entry.url = c.url;
+		if (entry.email || entry.url) security.push(entry);
+	}
+	if (security.length === 0) {
 		throw new PublishError(
 			"PROFILE_BOOTSTRAP_MISSING_FIELD",
-			"securityEmail or securityUrl is required on first publish. Clients refuse to install packages without a security contact.",
+			"at least one security contact with a url or email is required on first publish. Clients refuse to install packages without a security contact.",
 			{ field: "security" },
 		);
 	}
 
-	const author: { name: string; url?: string; email?: string } = {
-		name: profile.authorName ?? "unknown",
-	};
-	if (profile.authorUrl) author.url = profile.authorUrl;
-	if (profile.authorEmail) author.email = profile.authorEmail;
+	const authors: Array<{ name: string; url?: string; email?: string }> = [];
+	for (const a of profile.authors ?? []) {
+		const entry: { name: string; url?: string; email?: string } = { name: a.name };
+		if (a.url) entry.url = a.url;
+		if (a.email) entry.email = a.email;
+		authors.push(entry);
+	}
+	// The lexicon requires at least one author. A caller that supplied no
+	// authors (e.g. the deprecated flag path with no --author-* flags) gets
+	// a single placeholder, preserving prior behaviour.
+	if (authors.length === 0) authors.push({ name: "unknown" });
 
-	const securityContact: { url?: string; email?: string } = {};
-	if (profile.securityEmail) securityContact.email = profile.securityEmail;
-	if (profile.securityUrl) securityContact.url = profile.securityUrl;
-
-	return {
+	const record: PackageProfileRecordShape = {
 		$type: NSID.packageProfile,
 		id: input.profileUri,
 		type: "emdash-plugin",
 		license: profile.license,
-		authors: [author],
-		security: [securityContact],
+		authors,
+		security,
 		slug: input.slug,
 		lastUpdated: new Date().toISOString(),
 	};
+	if (profile.name !== undefined) record.name = profile.name;
+	if (profile.description !== undefined) record.description = profile.description;
+	if (profile.keywords !== undefined && profile.keywords.length > 0) {
+		record.keywords = profile.keywords;
+	}
+	return record;
+}
+
+/**
+ * Resolve the effective profile block. `profileInput` (structured, mirrors
+ * the lexicon) wins entirely when present; otherwise the deprecated flat
+ * `profile` is adapted to the same shape so the rest of the pipeline only
+ * deals with `ProfileInput`.
+ */
+function resolveProfileInput(options: PublishOptions): ProfileInput {
+	if (options.profileInput !== undefined) return options.profileInput;
+	return profileBootstrapToInput(options.profile);
+}
+
+function profileBootstrapToInput(flat: ProfileBootstrap | undefined): ProfileInput {
+	const b = flat ?? {};
+	const input: ProfileInput = {};
+	if (b.license !== undefined) input.license = b.license;
+	if (b.authorName !== undefined || b.authorUrl !== undefined || b.authorEmail !== undefined) {
+		const a: { name: string; url?: string; email?: string } = { name: b.authorName ?? "unknown" };
+		if (b.authorUrl) a.url = b.authorUrl;
+		if (b.authorEmail) a.email = b.authorEmail;
+		input.authors = [a];
+	}
+	if (b.securityEmail !== undefined || b.securityUrl !== undefined) {
+		const c: { url?: string; email?: string } = {};
+		if (b.securityEmail) c.email = b.securityEmail;
+		if (b.securityUrl) c.url = b.securityUrl;
+		input.security = [c];
+	}
+	return input;
+}
+
+/**
+ * Names of structured profile fields the caller supplied, for the
+ * ignored-on-subsequent-publish report. A field counts as provided when it
+ * is set and (for arrays) non-empty.
+ */
+function listProvidedProfileInputFields(input: ProfileInput | undefined): string[] {
+	if (!input) return [];
+	const fields: string[] = [];
+	if (input.license !== undefined) fields.push("license");
+	if (input.name !== undefined) fields.push("name");
+	if (input.description !== undefined) fields.push("description");
+	if (input.keywords !== undefined && input.keywords.length > 0) fields.push("keywords");
+	if (input.authors !== undefined && input.authors.length > 0) fields.push("authors");
+	if (input.security !== undefined && input.security.length > 0) fields.push("security");
+	return fields;
 }
 
 /**

--- a/packages/plugin-cli/tests/manifest-translate.test.ts
+++ b/packages/plugin-cli/tests/manifest-translate.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	manifestToProfileBootstrap,
+	manifestToProfileInput,
 	normaliseManifest,
 	type NormalisedManifest,
 } from "../src/manifest/translate.js";
@@ -148,5 +149,65 @@ describe("manifestToProfileBootstrap", () => {
 		};
 		const bootstrap = manifestToProfileBootstrap(normalised);
 		expect(bootstrap.authorName).toBe("First");
+	});
+});
+
+describe("manifestToProfileInput", () => {
+	it("carries the full lexicon profile block (multi-author, multi-security)", () => {
+		const normalised: NormalisedManifest = {
+			slug: "test",
+			version: "0.1.0",
+			license: "Apache-2.0",
+			publisher: "did:plc:abc",
+			authors: [
+				{ name: "Jane", url: "https://example.com" },
+				{ name: "Bob", email: "bob@example.com" },
+			],
+			securityContacts: [{ email: "s@example.com" }, { url: "https://example.com/sec" }],
+			name: "Test",
+			description: "desc",
+			keywords: ["k1", "k2"],
+			repo: "https://github.com/example/p",
+			capabilities: [],
+			allowedHosts: [],
+			storage: {},
+			admin: { pages: [], widgets: [] },
+		};
+		const input = manifestToProfileInput(normalised);
+		expect(input.license).toBe("Apache-2.0");
+		expect(input.authors).toEqual([
+			{ name: "Jane", url: "https://example.com" },
+			{ name: "Bob", email: "bob@example.com" },
+		]);
+		expect(input.security).toEqual([
+			{ email: "s@example.com" },
+			{ url: "https://example.com/sec" },
+		]);
+		expect(input.name).toBe("Test");
+		expect(input.description).toBe("desc");
+		expect(input.keywords).toEqual(["k1", "k2"]);
+	});
+
+	it("omits name, description and keywords when the manifest doesn't set them", () => {
+		const normalised: NormalisedManifest = {
+			slug: "test",
+			version: "0.1.0",
+			license: "MIT",
+			publisher: "did:plc:abc",
+			authors: [{ name: "Solo" }],
+			securityContacts: [{ email: "s@example.com" }],
+			name: undefined,
+			description: undefined,
+			keywords: undefined,
+			repo: undefined,
+			capabilities: [],
+			allowedHosts: [],
+			storage: {},
+			admin: { pages: [], widgets: [] },
+		};
+		const input = manifestToProfileInput(normalised);
+		expect("name" in input).toBe(false);
+		expect("description" in input).toBe(false);
+		expect("keywords" in input).toBe(false);
 	});
 });

--- a/packages/plugin-cli/tests/publish.test.ts
+++ b/packages/plugin-cli/tests/publish.test.ts
@@ -460,4 +460,121 @@ describe("publishRelease", () => {
 			});
 		});
 	});
+
+	describe("structured profileInput (manifest package block)", () => {
+		it("writes name, description, keywords, multi-author and multi-security on first publish", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			await publishRelease(
+				buildOptions(pds, {
+					profile: undefined,
+					profileInput: {
+						license: "Apache-2.0",
+						name: "Acme Forms",
+						description: "Contact forms for EmDash.",
+						keywords: ["forms", "contact"],
+						authors: [
+							{ name: "Acme Co.", url: "https://acme.example" },
+							{ name: "Jane Doe", email: "jane@acme.example" },
+						],
+						security: [
+							{ email: "security@acme.example" },
+							{ url: "https://acme.example/security" },
+						],
+					},
+				}),
+			);
+
+			const profile = pds.records.get(`at://${TEST_DID}/${NSID.packageProfile}/test-plugin`);
+			const value = profile!.value as {
+				license: string;
+				name?: string;
+				description?: string;
+				keywords?: string[];
+				authors: Array<{ name: string; url?: string; email?: string }>;
+				security: Array<{ url?: string; email?: string }>;
+			};
+			expect(value.license).toBe("Apache-2.0");
+			expect(value.name).toBe("Acme Forms");
+			expect(value.description).toBe("Contact forms for EmDash.");
+			expect(value.keywords).toEqual(["forms", "contact"]);
+			expect(value.authors).toHaveLength(2);
+			expect(value.authors[1]).toMatchObject({ name: "Jane Doe", email: "jane@acme.example" });
+			expect(value.security).toHaveLength(2);
+			expect(value.security[1]).toMatchObject({ url: "https://acme.example/security" });
+		});
+
+		it("omits name, description and keywords when not provided", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			await publishRelease(
+				buildOptions(pds, {
+					profile: undefined,
+					profileInput: {
+						license: "MIT",
+						authors: [{ name: "Solo" }],
+						security: [{ email: "s@example.com" }],
+					},
+				}),
+			);
+			const profile = pds.records.get(`at://${TEST_DID}/${NSID.packageProfile}/test-plugin`);
+			const value = profile!.value as Record<string, unknown>;
+			expect("name" in value).toBe(false);
+			expect("description" in value).toBe(false);
+			expect("keywords" in value).toBe(false);
+		});
+
+		it("hard-fails when no security contact is provided", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			await expect(
+				publishRelease(
+					buildOptions(pds, {
+						profile: undefined,
+						profileInput: { license: "MIT", authors: [{ name: "A" }], security: [] },
+					}),
+				),
+			).rejects.toMatchObject({ name: "PublishError", code: "PROFILE_BOOTSTRAP_MISSING_FIELD" });
+			expect(pds.records.size).toBe(0);
+		});
+
+		it("reports structured field names as ignored on a subsequent publish", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			pds.seedRecord(NSID.packageProfile, "test-plugin", {});
+			const result = await publishRelease(
+				buildOptions(pds, {
+					profile: undefined,
+					profileInput: {
+						license: "MIT",
+						name: "Renamed",
+						authors: [{ name: "A" }],
+						security: [{ email: "s@example.com" }],
+					},
+				}),
+			);
+			expect(result.profileCreated).toBe(false);
+			expect(result.ignoredProfileFields.toSorted()).toEqual([
+				"authors",
+				"license",
+				"name",
+				"security",
+			]);
+		});
+	});
+
+	describe("release repo", () => {
+		it("writes the repo URL into the release record when provided", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			await publishRelease(
+				buildOptions(pds, { repo: "https://github.com/acme/emdash-forms/tree/v1.0.0" }),
+			);
+			const release = pds.records.get(`at://${TEST_DID}/${NSID.packageRelease}/test-plugin:1.0.0`);
+			const value = release!.value as { repo?: string };
+			expect(value.repo).toBe("https://github.com/acme/emdash-forms/tree/v1.0.0");
+		});
+
+		it("omits repo from the release record when not provided", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			await publishRelease(buildOptions(pds));
+			const release = pds.records.get(`at://${TEST_DID}/${NSID.packageRelease}/test-plugin:1.0.0`);
+			expect("repo" in (release!.value as Record<string, unknown>)).toBe(false);
+		});
+	});
 });

--- a/packages/registry-client/src/discovery/index.ts
+++ b/packages/registry-client/src/discovery/index.ts
@@ -14,13 +14,14 @@
 
 import { Client, ok, simpleFetchHandler } from "@atcute/client";
 import { safeParse } from "@atcute/lexicons/validations";
-import { PackageProfile, PackageRelease } from "@emdash-cms/registry-lexicons";
-import type {
+import {
 	AggregatorGetLatestRelease,
 	AggregatorGetPackage,
 	AggregatorListReleases,
 	AggregatorResolvePackage,
 	AggregatorSearchPackages,
+	PackageProfile,
+	PackageRelease,
 } from "@emdash-cms/registry-lexicons";
 
 /**
@@ -127,10 +128,17 @@ export interface DiscoveryClientOptions {
  * `atproto-accept-labelers` header threaded through every request. Method
  * names mirror the aggregator's XRPC method names (without the NSID prefix).
  *
- * The embedded signed `profile` / `release` records are validated against
- * their lexicons at this boundary (the aggregator is an untrusted remote
- * index). A non-conforming record is surfaced as `null` rather than passed
- * through, so callers must null-check.
+ * Two layers of validation run at this boundary (the aggregator is an
+ * untrusted remote index):
+ *
+ *   - The **response envelope** (`uri`, `did`, `slug`, `labels`, …) is
+ *     validated by `@atcute/client` against the aggregator method's output
+ *     lexicon. A non-conforming envelope throws `ClientValidationError`.
+ *   - The **embedded signed `profile` / `release` records** — which the
+ *     aggregator relays verbatim and types as `unknown` — are validated
+ *     against the package lexicons here; a non-conforming record is
+ *     surfaced as `null` (callers must null-check) rather than failing the
+ *     whole call, so one bad record doesn't blank a search page.
  *
  * @example
  * ```ts
@@ -181,13 +189,12 @@ export class DiscoveryClient {
 	 * hydrated.
 	 *
 	 * Throws `ClientResponseError` (from `@atcute/client`) on a non-2xx
-	 * response. The error carries `.error`, `.description`, `.status`, and
-	 * `.headers`.
+	 * response (carrying `.error`, `.description`, `.status`, `.headers`), or
+	 * `ClientValidationError` if the aggregator returns a response whose
+	 * envelope does not match the method's output lexicon.
 	 */
 	async searchPackages(params: AggregatorSearchPackages.$params): Promise<ValidatedSearchPackages> {
-		const out = await ok(
-			this.#client.get("com.emdashcms.experimental.aggregator.searchPackages", { params }),
-		);
+		const out = await ok(this.#client.call(AggregatorSearchPackages, { params }));
 		return {
 			...out,
 			packages: out.packages.map((p) => ({ ...p, profile: validateProfile(p.profile) })),
@@ -198,9 +205,7 @@ export class DiscoveryClient {
 	 * Fetch a single package's full hydrated view by its AT URI.
 	 */
 	async getPackage(params: AggregatorGetPackage.$params): Promise<ValidatedPackageView> {
-		const out = await ok(
-			this.#client.get("com.emdashcms.experimental.aggregator.getPackage", { params }),
-		);
+		const out = await ok(this.#client.call(AggregatorGetPackage, { params }));
 		return { ...out, profile: validateProfile(out.profile) };
 	}
 
@@ -209,9 +214,7 @@ export class DiscoveryClient {
 	 * than `getPackage` when you only have human-readable identifiers.
 	 */
 	async resolvePackage(params: AggregatorResolvePackage.$params): Promise<ValidatedPackageView> {
-		const out = await ok(
-			this.#client.get("com.emdashcms.experimental.aggregator.resolvePackage", { params }),
-		);
+		const out = await ok(this.#client.call(AggregatorResolvePackage, { params }));
 		return { ...out, profile: validateProfile(out.profile) };
 	}
 
@@ -222,9 +225,7 @@ export class DiscoveryClient {
 	 * convention "give me the highest non-yanked version".
 	 */
 	async listReleases(params: AggregatorListReleases.$params): Promise<ValidatedListReleases> {
-		const out = await ok(
-			this.#client.get("com.emdashcms.experimental.aggregator.listReleases", { params }),
-		);
+		const out = await ok(this.#client.call(AggregatorListReleases, { params }));
 		return {
 			...out,
 			releases: out.releases.map((r) => ({ ...r, release: validateRelease(r.release) })),
@@ -240,9 +241,7 @@ export class DiscoveryClient {
 	async getLatestRelease(
 		params: AggregatorGetLatestRelease.$params,
 	): Promise<ValidatedReleaseView> {
-		const out = await ok(
-			this.#client.get("com.emdashcms.experimental.aggregator.getLatestRelease", { params }),
-		);
+		const out = await ok(this.#client.call(AggregatorGetLatestRelease, { params }));
 		return { ...out, release: validateRelease(out.release) };
 	}
 }

--- a/packages/registry-client/src/discovery/index.ts
+++ b/packages/registry-client/src/discovery/index.ts
@@ -13,6 +13,8 @@
  */
 
 import { Client, ok, simpleFetchHandler } from "@atcute/client";
+import { safeParse } from "@atcute/lexicons/validations";
+import { PackageProfile, PackageRelease } from "@emdash-cms/registry-lexicons";
 import type {
 	AggregatorGetLatestRelease,
 	AggregatorGetPackage,
@@ -20,6 +22,66 @@ import type {
 	AggregatorResolvePackage,
 	AggregatorSearchPackages,
 } from "@emdash-cms/registry-lexicons";
+
+/**
+ * A package view whose embedded signed `profile` record has been validated
+ * against the `com.emdashcms.experimental.package.profile` lexicon.
+ *
+ * `profile` is `null` when the aggregator returned a record that does not
+ * conform to the lexicon (missing required fields, wrong types, …). The
+ * aggregator is an untrusted remote index; callers must handle `null`
+ * rather than assuming a profile is always present.
+ */
+export type ValidatedPackageView = Omit<AggregatorGetPackage.$output, "profile"> & {
+	profile: PackageProfile.Main | null;
+};
+
+/**
+ * A release view whose embedded signed `release` record has been validated
+ * against the `com.emdashcms.experimental.package.release` lexicon. `release`
+ * is `null` when the record does not conform.
+ */
+export type ValidatedReleaseView = Omit<AggregatorGetLatestRelease.$output, "release"> & {
+	release: PackageRelease.Main | null;
+};
+
+export type ValidatedSearchPackages = Omit<AggregatorSearchPackages.$output, "packages"> & {
+	packages: ValidatedPackageView[];
+};
+
+export type ValidatedListReleases = Omit<AggregatorListReleases.$output, "releases"> & {
+	releases: ValidatedReleaseView[];
+};
+
+/**
+ * Validate an untrusted, aggregator-supplied signed `profile` / `release`
+ * record against its lexicon. Returns the value when its known fields
+ * conform, or `null` when they don't (missing required fields, wrong types).
+ *
+ * This is the registry's read-side trust boundary: the aggregator hydrates
+ * signed records it does not author, so everything inside `profile` /
+ * `release` is untrusted until it passes here. Two limits callers must keep
+ * in mind:
+ *
+ *   - **Structure only.** The lexicon's `uri` format permits non-HTTP
+ *     schemes (including `javascript:`), so consumers rendering URLs in
+ *     markup MUST still apply their own scheme allow-list.
+ *   - **Non-stripping.** atcute validation does not remove unrecognised
+ *     keys (the lexicon objects are open). Extra keys pass through; they
+ *     are inert because consumers only read the typed lexicon fields. We
+ *     deliberately do not hand-roll a field whitelist to strip them — that
+ *     is the brittle per-record parsing this boundary exists to replace,
+ *     and unread keys are not a correctness or security risk.
+ */
+function validateProfile(raw: unknown): PackageProfile.Main | null {
+	const result = safeParse(PackageProfile.mainSchema, raw);
+	return result.ok ? result.value : null;
+}
+
+function validateRelease(raw: unknown): PackageRelease.Main | null {
+	const result = safeParse(PackageRelease.mainSchema, raw);
+	return result.ok ? result.value : null;
+}
 
 /**
  * Options for constructing a `DiscoveryClient`.
@@ -65,6 +127,11 @@ export interface DiscoveryClientOptions {
  * `atproto-accept-labelers` header threaded through every request. Method
  * names mirror the aggregator's XRPC method names (without the NSID prefix).
  *
+ * The embedded signed `profile` / `release` records are validated against
+ * their lexicons at this boundary (the aggregator is an untrusted remote
+ * index). A non-conforming record is surfaced as `null` rather than passed
+ * through, so callers must null-check.
+ *
  * @example
  * ```ts
  * const discovery = new DiscoveryClient({
@@ -72,7 +139,7 @@ export interface DiscoveryClientOptions {
  * });
  * const result = await discovery.searchPackages({ q: "gallery", limit: 10 });
  * for (const pkg of result.packages) {
- *   console.log(pkg.uri, pkg.profile.name);
+ *   console.log(pkg.uri, pkg.profile?.name ?? pkg.slug);
  * }
  * ```
  */
@@ -117,27 +184,35 @@ export class DiscoveryClient {
 	 * response. The error carries `.error`, `.description`, `.status`, and
 	 * `.headers`.
 	 */
-	async searchPackages(
-		params: AggregatorSearchPackages.$params,
-	): Promise<AggregatorSearchPackages.$output> {
-		return ok(this.#client.get("com.emdashcms.experimental.aggregator.searchPackages", { params }));
+	async searchPackages(params: AggregatorSearchPackages.$params): Promise<ValidatedSearchPackages> {
+		const out = await ok(
+			this.#client.get("com.emdashcms.experimental.aggregator.searchPackages", { params }),
+		);
+		return {
+			...out,
+			packages: out.packages.map((p) => ({ ...p, profile: validateProfile(p.profile) })),
+		};
 	}
 
 	/**
 	 * Fetch a single package's full hydrated view by its AT URI.
 	 */
-	async getPackage(params: AggregatorGetPackage.$params): Promise<AggregatorGetPackage.$output> {
-		return ok(this.#client.get("com.emdashcms.experimental.aggregator.getPackage", { params }));
+	async getPackage(params: AggregatorGetPackage.$params): Promise<ValidatedPackageView> {
+		const out = await ok(
+			this.#client.get("com.emdashcms.experimental.aggregator.getPackage", { params }),
+		);
+		return { ...out, profile: validateProfile(out.profile) };
 	}
 
 	/**
 	 * Resolve a package by publisher handle + slug (or DID + slug). Cheaper
 	 * than `getPackage` when you only have human-readable identifiers.
 	 */
-	async resolvePackage(
-		params: AggregatorResolvePackage.$params,
-	): Promise<AggregatorResolvePackage.$output> {
-		return ok(this.#client.get("com.emdashcms.experimental.aggregator.resolvePackage", { params }));
+	async resolvePackage(params: AggregatorResolvePackage.$params): Promise<ValidatedPackageView> {
+		const out = await ok(
+			this.#client.get("com.emdashcms.experimental.aggregator.resolvePackage", { params }),
+		);
+		return { ...out, profile: validateProfile(out.profile) };
 	}
 
 	/**
@@ -146,10 +221,14 @@ export class DiscoveryClient {
 	 * are interleaved by version. Use `getLatestRelease` for the
 	 * convention "give me the highest non-yanked version".
 	 */
-	async listReleases(
-		params: AggregatorListReleases.$params,
-	): Promise<AggregatorListReleases.$output> {
-		return ok(this.#client.get("com.emdashcms.experimental.aggregator.listReleases", { params }));
+	async listReleases(params: AggregatorListReleases.$params): Promise<ValidatedListReleases> {
+		const out = await ok(
+			this.#client.get("com.emdashcms.experimental.aggregator.listReleases", { params }),
+		);
+		return {
+			...out,
+			releases: out.releases.map((r) => ({ ...r, release: validateRelease(r.release) })),
+		};
 	}
 
 	/**
@@ -160,9 +239,10 @@ export class DiscoveryClient {
 	 */
 	async getLatestRelease(
 		params: AggregatorGetLatestRelease.$params,
-	): Promise<AggregatorGetLatestRelease.$output> {
-		return ok(
+	): Promise<ValidatedReleaseView> {
+		const out = await ok(
 			this.#client.get("com.emdashcms.experimental.aggregator.getLatestRelease", { params }),
 		);
+		return { ...out, release: validateRelease(out.release) };
 	}
 }

--- a/packages/registry-client/tests/discovery.test.ts
+++ b/packages/registry-client/tests/discovery.test.ts
@@ -160,4 +160,153 @@ describe("DiscoveryClient", () => {
 			"/xrpc/com.emdashcms.experimental.aggregator.getLatestRelease",
 		]);
 	});
+
+	describe("record validation at the trust boundary", () => {
+		const validProfile = {
+			$type: "com.emdashcms.experimental.package.profile",
+			id: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
+			type: "emdash-plugin",
+			license: "MIT",
+			authors: [{ name: "Alice", url: "https://alice.example" }],
+			security: [{ email: "security@example.com" }],
+			name: "Gallery",
+			description: "An image gallery.",
+			keywords: ["images"],
+		};
+		const validRelease = {
+			$type: "com.emdashcms.experimental.package.release",
+			package: "gallery",
+			version: "1.0.0",
+			artifacts: {
+				package: { url: "https://cdn.example/gallery-1.0.0.tgz", checksum: "bciqtest" },
+			},
+		};
+
+		it("returns the typed record for a conforming profile; extra keys pass through (non-stripping)", async () => {
+			const { fetch } = buildFetchStub({
+				"/xrpc/com.emdashcms.experimental.aggregator.getPackage": {
+					status: 200,
+					body: {
+						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
+						cid: "bafy",
+						did: "did:plc:abc",
+						slug: "gallery",
+						indexedAt: "2026-04-01T00:00:00Z",
+						profile: { ...validProfile, somethingTheAggregatorMadeUp: "ignored" },
+					},
+				},
+			});
+			const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch });
+			const result = await client.getPackage({ did: "did:plc:abc", slug: "gallery" });
+
+			expect(result.profile).not.toBeNull();
+			expect(result.profile?.name).toBe("Gallery");
+			expect(result.profile?.authors?.[0]?.name).toBe("Alice");
+			// Contract: atcute validation is non-stripping (the lexicon objects
+			// are open). Unrecognised keys are NOT removed — they pass through
+			// inert because consumers only read the typed lexicon fields. This
+			// asserts the boundary's actual behaviour so a future change to it
+			// is a deliberate, visible decision.
+			expect(result.profile).toHaveProperty("somethingTheAggregatorMadeUp");
+		});
+
+		it("returns null for a profile that does not conform to the lexicon", async () => {
+			const { fetch } = buildFetchStub({
+				"/xrpc/com.emdashcms.experimental.aggregator.getPackage": {
+					status: 200,
+					body: {
+						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/x",
+						cid: "bafy",
+						did: "did:plc:abc",
+						slug: "x",
+						indexedAt: "2026-04-01T00:00:00Z",
+						// Missing every required field (id/type/license/authors/security).
+						profile: { name: "Looks fine but isn't" },
+					},
+				},
+			});
+			const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch });
+			const result = await client.getPackage({ did: "did:plc:abc", slug: "x" });
+			expect(result.profile).toBeNull();
+		});
+
+		it("returns null for a non-conforming release (fail closed)", async () => {
+			const { fetch } = buildFetchStub({
+				"/xrpc/com.emdashcms.experimental.aggregator.getLatestRelease": {
+					status: 200,
+					body: {
+						uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/x:1.0.0",
+						cid: "bafy",
+						version: "1.0.0",
+						indexedAt: "2026-04-01T00:00:00Z",
+						release: "not even an object",
+					},
+				},
+			});
+			const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch });
+			const result = await client.getLatestRelease({ did: "did:plc:abc", package: "x" });
+			expect(result.release).toBeNull();
+		});
+
+		it("does NOT sanitise URL schemes — a javascript: author url passes lexicon validation", async () => {
+			// Documents the boundary's contract: it validates *structure*, not
+			// URL safety (atproto's `uri` format permits any scheme). Consumers
+			// rendering these URLs MUST apply their own scheme allow-list.
+			const { fetch } = buildFetchStub({
+				"/xrpc/com.emdashcms.experimental.aggregator.getPackage": {
+					status: 200,
+					body: {
+						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
+						cid: "bafy",
+						did: "did:plc:abc",
+						slug: "gallery",
+						indexedAt: "2026-04-01T00:00:00Z",
+						profile: {
+							...validProfile,
+							authors: [{ name: "Mallory", url: "javascript:alert(document.cookie)" }],
+						},
+					},
+				},
+			});
+			const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch });
+			const result = await client.getPackage({ did: "did:plc:abc", slug: "gallery" });
+			expect(result.profile).not.toBeNull();
+			expect(result.profile?.authors?.[0]?.url).toBe("javascript:alert(document.cookie)");
+		});
+
+		it("validates each release in a listReleases page", async () => {
+			const { fetch } = buildFetchStub({
+				"/xrpc/com.emdashcms.experimental.aggregator.listReleases": {
+					status: 200,
+					body: {
+						releases: [
+							{
+								uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/gallery:1.0.0",
+								cid: "bafy",
+								did: "did:plc:abc",
+								package: "gallery",
+								version: "1.0.0",
+								indexedAt: "2026-04-01T00:00:00Z",
+								release: validRelease,
+							},
+							{
+								uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/gallery:0.9.0",
+								cid: "bafz",
+								did: "did:plc:abc",
+								package: "gallery",
+								version: "0.9.0",
+								indexedAt: "2026-03-01T00:00:00Z",
+								release: { garbage: true },
+							},
+						],
+						cursor: undefined,
+					},
+				},
+			});
+			const client = new DiscoveryClient({ aggregatorUrl: aggregator, fetch });
+			const result = await client.listReleases({ did: "did:plc:abc", package: "gallery" });
+			expect(result.releases[0]?.release?.version).toBe("1.0.0");
+			expect(result.releases[1]?.release).toBeNull();
+		});
+	});
 });

--- a/packages/registry-client/tests/discovery.test.ts
+++ b/packages/registry-client/tests/discovery.test.ts
@@ -32,6 +32,10 @@ function buildFetchStub(responses: Record<string, { status: number; body: unknow
 
 describe("DiscoveryClient", () => {
 	const aggregator = "https://aggregator.test";
+	// atcute validates the response envelope; `cid` must be a real DASL CID
+	// (`/^baf[ky]rei[a-z2-7]{52}$/`, 59 chars). Content is irrelevant to these
+	// tests — only the shape is.
+	const CID = `bafyrei${"a".repeat(52)}`;
 
 	it("hits the searchPackages XRPC endpoint with the right query string", async () => {
 		const { fetch, calls } = buildFetchStub({
@@ -113,8 +117,9 @@ describe("DiscoveryClient", () => {
 				status: 200,
 				body: {
 					uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
-					cid: "bafy",
+					cid: CID,
 					did: "did:plc:abc",
+					slug: "gallery",
 					indexedAt: "2026-04-01T00:00:00Z",
 					profile: {},
 				},
@@ -123,8 +128,9 @@ describe("DiscoveryClient", () => {
 				status: 200,
 				body: {
 					uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
-					cid: "bafy",
+					cid: CID,
 					did: "did:plc:abc",
+					slug: "gallery",
 					indexedAt: "2026-04-01T00:00:00Z",
 					profile: {},
 				},
@@ -137,7 +143,9 @@ describe("DiscoveryClient", () => {
 				status: 200,
 				body: {
 					uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/gallery:1.0.0",
-					cid: "bafy",
+					cid: CID,
+					did: "did:plc:abc",
+					package: "gallery",
 					version: "1.0.0",
 					indexedAt: "2026-04-01T00:00:00Z",
 					release: {},
@@ -188,7 +196,7 @@ describe("DiscoveryClient", () => {
 					status: 200,
 					body: {
 						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
-						cid: "bafy",
+						cid: CID,
 						did: "did:plc:abc",
 						slug: "gallery",
 						indexedAt: "2026-04-01T00:00:00Z",
@@ -216,7 +224,7 @@ describe("DiscoveryClient", () => {
 					status: 200,
 					body: {
 						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/x",
-						cid: "bafy",
+						cid: CID,
 						did: "did:plc:abc",
 						slug: "x",
 						indexedAt: "2026-04-01T00:00:00Z",
@@ -230,16 +238,22 @@ describe("DiscoveryClient", () => {
 			expect(result.profile).toBeNull();
 		});
 
-		it("returns null for a non-conforming release (fail closed)", async () => {
+		it("returns null for a non-conforming release record (fail closed)", async () => {
+			// The envelope is valid and `release` is an object (lexicon
+			// `unknown` ≈ open object — a non-object is rejected earlier by
+			// envelope validation), but the record itself is missing every
+			// required package-release field, so `validateRelease` → null.
 			const { fetch } = buildFetchStub({
 				"/xrpc/com.emdashcms.experimental.aggregator.getLatestRelease": {
 					status: 200,
 					body: {
 						uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/x:1.0.0",
-						cid: "bafy",
+						cid: CID,
+						did: "did:plc:abc",
+						package: "x",
 						version: "1.0.0",
 						indexedAt: "2026-04-01T00:00:00Z",
-						release: "not even an object",
+						release: { not: "a valid release record" },
 					},
 				},
 			});
@@ -257,7 +271,7 @@ describe("DiscoveryClient", () => {
 					status: 200,
 					body: {
 						uri: "at://did:plc:abc/com.emdashcms.experimental.package.profile/gallery",
-						cid: "bafy",
+						cid: CID,
 						did: "did:plc:abc",
 						slug: "gallery",
 						indexedAt: "2026-04-01T00:00:00Z",
@@ -282,7 +296,7 @@ describe("DiscoveryClient", () => {
 						releases: [
 							{
 								uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/gallery:1.0.0",
-								cid: "bafy",
+								cid: CID,
 								did: "did:plc:abc",
 								package: "gallery",
 								version: "1.0.0",
@@ -291,7 +305,7 @@ describe("DiscoveryClient", () => {
 							},
 							{
 								uri: "at://did:plc:abc/com.emdashcms.experimental.package.release/gallery:0.9.0",
-								cid: "bafz",
+								cid: CID,
 								did: "did:plc:abc",
 								package: "gallery",
 								version: "0.9.0",


### PR DESCRIPTION
## What does this PR do?

Implements **#1029** (child of the registry roadmap umbrella **#1026**): wires the `emdash-plugin.jsonc` profile block end-to-end — through the `@emdash-cms/plugin-cli` publish pipeline and into the `@emdash-cms/admin` UI.

**CLI (`@emdash-cms/plugin-cli`):**
- New structured `ProfileInput` on `publishRelease` — multi-author (1–32), multi-security (1–8), `name`, `description`, `keywords` — plus release-level `repo` written to the release record.
- `name`/`description`/`keywords` added to the profile record shape; `repo` to the release record shape.
- The flat `ProfileBootstrap` and the `--license` / `--author-*` / `--security-*` flags still work (acceptance criterion 4) but are **deprecated**: marked in CLI help, emit a deprecation warning, and override the manifest when both are present.
- New `manifestToProfileInput` translation; deprecated `manifestToProfileBootstrap` retained for the flat path.

**Admin (`@emdash-cms/admin`):**
- Detail page renders license (linked to spdx.org for single SPDX identifiers), keyword chips, all authors, all security contacts, and a "View source" repo link.
- Browse card shows the license alongside the description.
- `repo` is read from the **release** record (it's a `release.json` field; the profile lexicon has no `repo`).

**Security hardening (from adversarial review):** the aggregator-supplied `profile`/`release` records are untrusted (`unknown`). They are now parsed defensively — `Array.isArray`/`typeof` guards so a string-as-`authors` can't crash the page, external `href`s scheme-allowlisted to `http(s)` (blocks stored `javascript:` XSS), and emails validated (no `mailto:` query smuggling) before use.

Closes #1029

Discussion: https://github.com/emdash-cms/emdash/discussions/296

### Deferred (pre-existing, not regressions — tracked for follow-up)
- The "ignored on subsequent publish" warning now lists manifest-derived profile field names. This is honest (those fields *are* ignored until profile editing exists) and matches prior behavior (the old code folded the manifest into the flat `ProfileBootstrap` and reported those too). Proper fix is **#1032** (`update-profile`).
- Partial `--author-*` flags replace the whole author list and default `name` to `"unknown"` — unchanged deprecated-path behavior.
- Over-cap manifest `name`/`description`/`keywords` surface as a raw lexicon-validator dump rather than a friendly message (`formatValidationIssues`, pre-existing). No crash.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (touched files clean; pre-existing repo baseline of 56 unrelated diagnostics unchanged)
- [x] `pnpm test` passes (plugin-cli 264, admin 879)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (Lingui `t`; no `messages.po` changes included)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/296

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Claude Code)

## Screenshots / test output

```
plugin-cli:  Test Files 16 passed (16)   Tests 264 passed (264)
admin:       Test Files 62 passed (62)   Tests 879 passed (879)
```

Adversarial review (Claude Opus 4.7 sub-agent, two rounds): a CRITICAL stored-XSS (`javascript:` href from untrusted aggregator data) and a HIGH crash-on-garbage were found and fixed; a LOW `mailto:` query-smuggling was found in the fix and also closed; re-review confirmed clean.
