### PR TITLE
chore: bump pnpm to 11.1.3 and clean up template/demo pnpm config

### DIFF
--- a/.changeset/fifty-numbers-matter.md
+++ b/.changeset/fifty-numbers-matter.md
@@ -1,0 +1,5 @@
+---
+"create-emdash": patch
+---
+
+Pins `packageManager` for pnpm-scaffolded sites so a recent enough pnpm is used (settings-only `pnpm-workspace.yaml` requires pnpm 10.5+). For npm, yarn, or bun selections the field is stripped so corepack doesn't force pnpm on a non-pnpm user.

--- a/.opencode/agents/auto-implementer.md
+++ b/.opencode/agents/auto-implementer.md
@@ -126,7 +126,7 @@ Two reminders that apply specifically to CI work:
    - build the whole monorepo first, before running any tests. When iterating on a fix you can re-build just the affected package, but the first build should be full to catch any unexpected cross-package issues.
      - `pnpm build` for a full build.
      - `pnpm --filter <package> build` for an iterative fix.
-   - `pnpm --silent lint:quick` after each round of edits (sub-second).
+   - `pnpm lint:quick` after each round of edits (sub-second).
    - `pnpm typecheck` (or `pnpm typecheck:demos` if you touched a demo).
    - The package-level test suite for whatever you changed (`pnpm --filter <package> test`).
    - `pnpm format` once at the end (oxfmt, tabs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,11 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR. Key rules:
 
 ### Before Starting
 
-1. Run `pnpm --silent lint:json | jq '.diagnostics | length'` and fix any issues. Non-negotiable.
+1. Run `pnpm lint:json | jq '.diagnostics | length'` and fix any issues. Non-negotiable.
 
 ### During Work
 
-- Run `pnpm --silent lint:quick` after every edit -- takes less than a second. Returns JSON with stderr redirected to /dev/null, so it won't break parsers. Fix any issues immediately.
+- Run `pnpm lint:quick` after every edit -- takes less than a second. The `$ command` echo goes to stderr in pnpm 11, so JSON pipes cleanly without needing `--silent`. Fix any issues immediately.
 - Run `pnpm typecheck` (packages) or `pnpm typecheck:demos` (Astro demos) after each round of edits.
 - Format regularly. pnpm format in the root uses oxfmt with tabs for indentation and is very fast. Don't let formatting pile up.
 - Commit regularly, and always format and quick lint beforehand.
@@ -90,7 +90,7 @@ See [CONTRIBUTING.md § Changesets](CONTRIBUTING.md#changesets) for full guidanc
 ### PR Flow
 
 1. All tests pass: `pnpm test`
-2. Full lint suite clean: `pnpm --silent lint:json | jq '.diagnostics | length'`. Returns JSON with stderr piped to /dev/null, so it won't break parsers. Fix any issues.
+2. Full lint suite clean: `pnpm lint:json | jq '.diagnostics | length'`. The `$ command` echo goes to stderr in pnpm 11, so the JSON pipes cleanly. Fix any issues.
 3. Format with `pnpm format` (oxfmt with tabs for indentation, configured in `.prettierrc`).
 4. Add a changeset if the change affects a published package: `pnpm changeset`.
 5. Open the PR (via `gh pr create` or the GitHub UI). Fill out every section of the PR template -- copy `.github/PULL_REQUEST_TEMPLATE.md` into the body if using the API/CLI. Check the AI disclosure box if any code was AI-generated and name the model/tool you used.

--- a/fixtures/perf-site/package.json
+++ b/fixtures/perf-site/package.json
@@ -29,12 +29,5 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"better-sqlite3",
-			"esbuild",
-			"workerd"
-		]
 	}
 }

--- a/infra/blog-demo/package.json
+++ b/infra/blog-demo/package.json
@@ -28,11 +28,5 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "catalog:"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"esbuild",
-			"workerd"
-		]
 	}
 }

--- a/infra/cache-demo/package.json
+++ b/infra/cache-demo/package.json
@@ -28,11 +28,5 @@
 		"@astrojs/check": "catalog:",
 		"@cloudflare/workers-types": "catalog:",
 		"wrangler": "^4.83.0"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"esbuild",
-			"workerd"
-		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"prettier-plugin-astro": "^0.14.1",
 		"typescript": "6.0.0-beta"
 	},
-	"packageManager": "pnpm@10.28.0",
+	"packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
 	"engines": {
 		"node": ">=22"
 	}

--- a/packages/create-emdash/src/index.ts
+++ b/packages/create-emdash/src/index.ts
@@ -357,6 +357,13 @@ async function main() {
 			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
 			pkg.name = projectName;
 
+			// Templates ship with `packageManager: "pnpm@X"` baked in by the
+			// sync script. Drop it when the user picked a different PM so
+			// corepack doesn't force pnpm on yarn/npm/bun users.
+			if (pm !== "pnpm") {
+				delete pkg.packageManager;
+			}
+
 			// Add emdash config if template has seed data
 			const seedPath = resolve(projectDir, "seed", "seed.json");
 			if (existsSync(seedPath)) {

--- a/scripts/sync-templates-repo.mjs
+++ b/scripts/sync-templates-repo.mjs
@@ -83,6 +83,14 @@ function parseCatalog() {
 	return catalog;
 }
 
+function getRootPackageManager() {
+	const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+	if (!pkg.packageManager) {
+		throw new Error("Root package.json is missing a packageManager field");
+	}
+	return pkg.packageManager;
+}
+
 function collectWorkspaceVersions() {
 	const versions = {};
 	const dirs = [join(ROOT, "packages"), join(ROOT, "packages/plugins")];
@@ -116,8 +124,9 @@ function resolveDeps(deps, catalog, workspace) {
 	return resolved;
 }
 
-function transformPackageJson(srcPath, catalog, workspace) {
+function transformPackageJson(srcPath, catalog, workspace, packageManager) {
 	const pkg = JSON.parse(readFileSync(srcPath, "utf8"));
+	pkg.packageManager = packageManager;
 	pkg.dependencies = resolveDeps(pkg.dependencies, catalog, workspace);
 	pkg.devDependencies = resolveDeps(pkg.devDependencies, catalog, workspace);
 	if (pkg.peerDependencies) {
@@ -247,6 +256,7 @@ if (localIdx !== -1 && !localPath) {
 
 const catalog = parseCatalog();
 const workspace = collectWorkspaceVersions();
+const packageManager = getRootPackageManager();
 
 console.log("Workspace packages:");
 for (const [name, version] of Object.entries(workspace)) {
@@ -291,7 +301,7 @@ try {
 		if (existsSync(srcPkg)) {
 			writeFileSync(
 				join(destDir, "package.json"),
-				transformPackageJson(srcPkg, catalog, workspace),
+				transformPackageJson(srcPkg, catalog, workspace, packageManager),
 			);
 			console.log("  Transformed package.json");
 		}

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -23,11 +23,5 @@
     "@astrojs/check": "catalog:"
   },
   "peerDependencies": {},
-  "optionalDependencies": {},
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild"
-    ]
-  }
+  "optionalDependencies": {}
 }


### PR DESCRIPTION
## What does this PR do?

A few related pieces of pnpm hygiene:

- Bumps the monorepo `packageManager` to `pnpm@11.1.3` (via `corepack use pnpm@latest`).
- Makes the templates-sync script bake the root's `packageManager` into each synced template's `package.json`, so scaffolded sites auto-track the monorepo pin and avoid the original "missing `packages` field" error on older pnpm (settings-only `pnpm-workspace.yaml` requires pnpm 10.5+).
- Updates `create-emdash` to **strip** `packageManager` from the scaffolded `package.json` when the user picks npm/yarn/bun, so corepack doesn't force pnpm on a non-pnpm user.
- Removes dead `pnpm.onlyBuiltDependencies` blocks from `fixtures/perf-site`, `infra/blog-demo`, `infra/cache-demo`, and `templates/blank`. pnpm 11 no longer reads `package.json#pnpm`, and the root `pnpm-workspace.yaml` already lists these binaries under `allowBuilds`. Removes the warnings on every install.
- Drops the `--silent` flag from documented `pnpm lint:*` commands in `AGENTS.md` and `.opencode/agents/auto-implementer.md`. pnpm 11 prints the `$ command` echo to **stderr** rather than stdout, so JSON pipes cleanly without `--silent` — and dropping it preserves useful feedback for the user.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Claude Code)

## Screenshots / test output

After the changes, `CI=true pnpm install` runs clean with no `pnpm.onlyBuiltDependencies` warnings, and `pnpm lint:json 2>/dev/null | jq '.diagnostics | length'` returns the same 56 pre-existing warnings as on `main` — none introduced by this PR.