### PR TITLE
feat(plugin-cli): app-password publish auth for CI

### DIFF
--- a/.changeset/cli-app-password.md
+++ b/.changeset/cli-app-password.md
@@ -1,0 +1,9 @@
+---
+"@emdash-cms/plugin-cli": minor
+---
+
+Adds non-interactive `emdash-plugin publish` authentication for CI via atproto app passwords.
+
+Set `EMDASH_PUBLISHER_APP_PASSWORD` in the environment and pass `--publisher <handle-or-did>` (or set `EMDASH_PUBLISHER_DID` / `EMDASH_PUBLISHER_HANDLE`) to publish without the browser-based OAuth dance. The interactive OAuth path is unchanged when no app password is set.
+
+Guardrails refuse a full-account credential (only `com.atproto.appPass` and `com.atproto.appPassPrivileged` scopes are accepted), reject malformed `xxxx-xxxx-xxxx-xxxx` strings before any network call, and cross-check the logged-in DID against the resolved publisher identifier. Failures surface stable error codes through `--json` mode for CI consumers: `APP_PASSWORD_FORMAT`, `MISSING_APP_PASSWORD`, `MISSING_PUBLISHER` (exit 2, config errors); `INVALID_PUBLISHER`, `APP_PASSWORD_LOGIN_FAILED`, `FULL_ACCOUNT_CREDENTIAL`, `PUBLISHER_DID_MISMATCH` (exit 1, runtime errors).

--- a/packages/plugin-cli/src/app-password.ts
+++ b/packages/plugin-cli/src/app-password.ts
@@ -1,0 +1,402 @@
+/**
+ * App-password authentication for the registry CLI's `publish` command.
+ *
+ * The interactive OAuth path (see `./oauth.ts`) doesn't survive a stateless
+ * CI runner — refresh tokens rotate single-use, so a runner that publishes
+ * once and discards its filesystem leaves the persisted session dead unless
+ * the rotated session is written back somewhere durable. Writing back means
+ * mutating a GitHub secret (needs a PAT) or threading the token through
+ * actions cache (silent miss on a flake). App passwords sidestep all of
+ * that: long-lived, re-create a session per run, no write-back.
+ *
+ * The cost of an app password is that it's coarse — whole-repo write rather
+ * than the `repo:<nsid>` granularity OAuth grants. We mitigate that with the
+ * guardrails below: only `appPass` / `appPassPrivileged`-scoped tokens are
+ * accepted; the full-account `com.atproto.access` scope is rejected so a
+ * pasted account password fails loudly instead of publishing.
+ *
+ * Defines the `PublishAuth` two-phase interface that both this provider and
+ * the OAuth provider in `publish.ts` implement. `identify()` may hit the
+ * network for the app-password path (we don't know the DID until login
+ * succeeds); `handler()` then returns the already-logged-in
+ * `CredentialManager` without a second round trip.
+ */
+
+import type { FetchHandlerObject } from "@atcute/client";
+import { CredentialManager } from "@atcute/client";
+import type { ActorResolver } from "@atcute/identity-resolver";
+import type { Did } from "@atcute/lexicons";
+
+import { createActorResolver, parseActorIdentifier } from "./oauth.js";
+
+/**
+ * Two-phase auth abstraction consumed by `runPublish`. The split exists so
+ * the OAuth fast-fail (publisher-pin check before tarball fetch) is preserved
+ * for OAuth, while the app-password path can defer its network work until
+ * `identify()` is called — itself still BEFORE the tarball fetch, so bad
+ * credentials fail before downloading.
+ *
+ * Implementations:
+ *   - OAuth: `identify()` reads the local credential store (offline);
+ *     `handler()` resumes the stored session (network, post-tarball-fetch).
+ *   - App-password: `identify()` resolves the identifier, logs in, runs
+ *     guardrails (network, pre-tarball-fetch); `handler()` returns the
+ *     cached, already-authenticated manager (no network).
+ */
+export interface PublishAuth {
+	/**
+	 * Resolve `{ did, handle, pds }` for the active publisher. For OAuth this
+	 * is offline; for app-password it performs the actorResolver lookup and
+	 * the `createSession` call. `handle` may be null for OAuth sessions that
+	 * never recorded one; the app-password provider always sets it (the PDS
+	 * returns a handle in the createSession response).
+	 */
+	identify(): Promise<PublisherIdentity>;
+	/**
+	 * Return a fetch handler authenticated as the publisher. Must be called
+	 * AFTER `identify()` — the order matches the OAuth path, where the
+	 * handler is only built once the session DID is known.
+	 */
+	handler(): Promise<FetchHandlerObject>;
+}
+
+export interface PublisherIdentity {
+	did: Did;
+	handle: string | null;
+	pds: string;
+}
+
+/**
+ * Stable error code surfaced through `CliError` so `--json` mode can emit
+ * `{ error: { code, message } }` for CI consumers. Each one corresponds to
+ * an exact failure mode in the app-password path; matching against the code
+ * is the supported contract.
+ */
+export type AppPasswordErrorCode =
+	| "MISSING_APP_PASSWORD"
+	| "MISSING_PUBLISHER"
+	| "APP_PASSWORD_FORMAT"
+	| "FULL_ACCOUNT_CREDENTIAL"
+	| "PUBLISHER_DID_MISMATCH"
+	| "APP_PASSWORD_LOGIN_FAILED"
+	| "INVALID_PUBLISHER";
+
+export class AppPasswordError extends Error {
+	override readonly name = "AppPasswordError";
+	readonly exitCode: number;
+	constructor(
+		readonly code: AppPasswordErrorCode,
+		message: string,
+	) {
+		super(message);
+		this.exitCode = USER_CONFIG_CODES.has(code) ? 2 : 1;
+	}
+}
+
+/**
+ * Exit code 2 is reserved for user-side configuration mistakes (bad flag, bad
+ * env var, malformed password) — the same shape as citty's own arg-validation
+ * failures. Anything that could result from a transient network condition
+ * (`INVALID_PUBLISHER`, `APP_PASSWORD_LOGIN_FAILED`) stays at exit 1 so CI
+ * scripts that branch on exit code don't misclassify a PLC/DNS blip as a
+ * config error.
+ */
+const USER_CONFIG_CODES = new Set<AppPasswordErrorCode>([
+	"MISSING_APP_PASSWORD",
+	"MISSING_PUBLISHER",
+	"APP_PASSWORD_FORMAT",
+]);
+
+export interface CreateAppPasswordAuthOptions {
+	/** Raw publisher identifier (handle or DID) from --publisher / env. */
+	identifier: string;
+	/** App-password string from `EMDASH_PUBLISHER_APP_PASSWORD`. */
+	password: string;
+	/**
+	 * Override the actor resolver. Production code omits this and gets the
+	 * shared `LocalActorResolver` from `oauth.ts`. Tests pass a stub so handle
+	 * / DID resolution doesn't hit PLC or the DNS handle resolver.
+	 */
+	actorResolver?: ActorResolver;
+	/**
+	 * Override the fetch implementation handed to `CredentialManager`. Tests
+	 * use this to route `createSession` (and subsequent authenticated requests
+	 * once the manager is acting as the PublishingClient handler) at the mock
+	 * PDS. Production uses the global `fetch`.
+	 */
+	fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Build a `PublishAuth` provider that logs in with an atproto app password.
+ *
+ * `identify()` is where every guardrail lives:
+ *
+ *   1. The identifier is validated as a handle or DID (no email-shaped
+ *      identifiers — see {@link parseActorIdentifier}).
+ *   2. The password is checked against the atproto app-password format
+ *      `xxxx-xxxx-xxxx-xxxx` so a pasted account password fails before any
+ *      network call.
+ *   3. The identifier is resolved to `{ did, pds }`.
+ *   4. `createSession` runs against the resolved PDS.
+ *   5. The returned access JWT's `scope` is checked — `com.atproto.access`
+ *      (full account) is rejected; both app-password scopes accepted.
+ *   6. The logged-in DID is cross-checked against the resolved identifier
+ *      DID. A mismatch refuses to publish (we'd be writing to the wrong
+ *      repo).
+ *
+ * After `identify()` succeeds, `handler()` returns the same authenticated
+ * `CredentialManager` — no second login, no token persistence (CI sessions
+ * are explicitly transient).
+ */
+export function createAppPasswordAuth(options: CreateAppPasswordAuthOptions): PublishAuth {
+	const actor = parseActorIdentifier(options.identifier);
+	if (!isWellFormedAppPassword(options.password)) {
+		throw new AppPasswordError(
+			"APP_PASSWORD_FORMAT",
+			"EMDASH_PUBLISHER_APP_PASSWORD does not look like an atproto app password " +
+				"(expected `xxxx-xxxx-xxxx-xxxx`, lowercase alphanumeric). " +
+				"Create one at https://bsky.app/settings/app-passwords or your PDS equivalent, " +
+				"not the account password.",
+		);
+	}
+
+	// Cache the in-flight promise rather than just the resolved value: two
+	// concurrent `identify()` calls (or an `identify()` racing a `handler()`)
+	// share one `createSession` round trip. On failure the promise field is
+	// cleared so a subsequent call retries instead of returning a stuck
+	// rejection.
+	let pending: Promise<{ identity: PublisherIdentity; manager: CredentialManager }> | null = null;
+
+	const ensureLoggedIn = async () => {
+		if (pending) return pending;
+		pending = (async () => {
+			const resolver = options.actorResolver ?? createActorResolver();
+			let resolved;
+			try {
+				resolved = await resolver.resolve(actor);
+			} catch (error) {
+				throw new AppPasswordError(
+					"INVALID_PUBLISHER",
+					`Could not resolve publisher ${actor}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+			const manager = new CredentialManager({
+				service: resolved.pds,
+				...(options.fetch ? { fetch: options.fetch } : {}),
+			});
+			let session;
+			try {
+				// Send the parsed identifier (trimmed by `parseActorIdentifier`),
+				// not the raw `options.identifier`. A stray space in
+				// `EMDASH_PUBLISHER_HANDLE` shouldn't reach the PDS as a leading
+				// whitespace character — `createSession` would 400 with an opaque
+				// error and the publisher would have no idea why.
+				session = await manager.login({
+					identifier: actor,
+					password: options.password,
+				});
+			} catch (error) {
+				throw new AppPasswordError(
+					"APP_PASSWORD_LOGIN_FAILED",
+					`Login to ${resolved.pds} as ${actor} failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+			assertNonFullAccountScope(session.accessJwt);
+			if (session.did !== resolved.did) {
+				throw new AppPasswordError(
+					"PUBLISHER_DID_MISMATCH",
+					`Publisher ${actor} resolved to ${resolved.did}, but the credentials ` +
+						`authenticated as ${session.did}. Refusing to publish to the wrong repo. ` +
+						"Check the --publisher / EMDASH_PUBLISHER_* values match the account that owns " +
+						"the app password.",
+				);
+			}
+			return {
+				identity: { did: session.did, handle: session.handle, pds: resolved.pds },
+				manager,
+			};
+		})();
+		try {
+			return await pending;
+		} catch (error) {
+			pending = null;
+			throw error;
+		}
+	};
+
+	return {
+		async identify(): Promise<PublisherIdentity> {
+			const { identity } = await ensureLoggedIn();
+			return identity;
+		},
+		async handler(): Promise<FetchHandlerObject> {
+			const { manager } = await ensureLoggedIn();
+			return manager;
+		},
+	};
+}
+
+export interface SelectPublishAuthArgs {
+	/** Value of the `--publisher` CLI flag, if any. */
+	publisher?: string;
+}
+
+export interface SelectPublishAuthOptions {
+	/** Environment to read. Defaults to `process.env`. Tests pass a literal map. */
+	env?: NodeJS.ProcessEnv;
+	/**
+	 * Factory for the OAuth `PublishAuth`. Defaults to whatever the caller has
+	 * wired into publish.ts. Decoupled so this module can stay free of the
+	 * OAuth-specific filesystem dependencies — they live in the existing
+	 * credentials store, not here.
+	 */
+	oauthFactory: () => PublishAuth;
+	/** Override the actor resolver for app-password tests. */
+	actorResolver?: ActorResolver;
+	/** Override the fetch implementation for app-password tests. */
+	fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Pick the right `PublishAuth` based on environment + flag state. Selection
+ * rule: presence of `EMDASH_PUBLISHER_APP_PASSWORD` selects the app-password
+ * path. Absent → OAuth (default, interactive `emdash-plugin login`).
+ *
+ * Identifier precedence when on the app-password path:
+ *   1. `--publisher` flag
+ *   2. `EMDASH_PUBLISHER_DID` env
+ *   3. `EMDASH_PUBLISHER_HANDLE` env
+ *
+ * Misconfiguration is loud, not silent: identifier without password and
+ * password without identifier both fail with a distinct, stable error code
+ * rather than falling back to the wrong path (CI debugging from an
+ * accidental OAuth attempt is significantly worse than a clear error).
+ */
+export function selectPublishAuth(
+	args: SelectPublishAuthArgs,
+	options: SelectPublishAuthOptions,
+): PublishAuth {
+	const env = options.env ?? process.env;
+	// `??` doesn't fall through "" (`undefined`/`null` only) — but an explicit
+	// `--publisher=""` should defer to env, and `EMDASH_PUBLISHER_DID=""` should
+	// defer to the handle var. `firstNonBlank` treats whitespace-only strings as
+	// absent so a stray `EMDASH_PUBLISHER_HANDLE= ` in a CI YAML doesn't latch.
+	const password = firstNonBlank(env.EMDASH_PUBLISHER_APP_PASSWORD);
+	const identifier = firstNonBlank(
+		args.publisher,
+		env.EMDASH_PUBLISHER_DID,
+		env.EMDASH_PUBLISHER_HANDLE,
+	);
+
+	if (password) {
+		if (!identifier) {
+			throw new AppPasswordError(
+				"MISSING_PUBLISHER",
+				"EMDASH_PUBLISHER_APP_PASSWORD is set but no publisher identifier was provided. " +
+					"Pass --publisher <handle-or-did>, or set EMDASH_PUBLISHER_DID / EMDASH_PUBLISHER_HANDLE.",
+			);
+		}
+		return createAppPasswordAuth({
+			identifier,
+			password,
+			...(options.actorResolver ? { actorResolver: options.actorResolver } : {}),
+			...(options.fetch ? { fetch: options.fetch } : {}),
+		});
+	}
+	if (identifier) {
+		throw new AppPasswordError(
+			"MISSING_APP_PASSWORD",
+			`Publisher identifier ${identifier} was provided but EMDASH_PUBLISHER_APP_PASSWORD is empty. ` +
+				"Set the app-password env var, or drop the identifier to fall back to interactive OAuth " +
+				"(`emdash-plugin login`).",
+		);
+	}
+	return options.oauthFactory();
+}
+
+/**
+ * Return the first argument that's a non-blank string, or `undefined` if none
+ * are. Used by selection so explicit empty / whitespace-only env vars don't
+ * shadow the next fallback in the chain.
+ */
+function firstNonBlank(...candidates: Array<string | undefined>): string | undefined {
+	for (const candidate of candidates) {
+		if (typeof candidate !== "string") continue;
+		const trimmed = candidate.trim();
+		if (trimmed.length > 0) return trimmed;
+	}
+	return undefined;
+}
+
+/**
+ * Atproto app passwords are issued in the shape `xxxx-xxxx-xxxx-xxxx`, four
+ * groups of four lowercase alphanumeric characters joined by hyphens.
+ * Catching the common "publisher pasted the account password" mistake here
+ * means we never send the account password to `createSession`.
+ */
+const APP_PASSWORD_RE = /^[a-z0-9]{4}(-[a-z0-9]{4}){3}$/;
+
+export function isWellFormedAppPassword(password: string): boolean {
+	return APP_PASSWORD_RE.test(password);
+}
+
+/**
+ * Decode the access JWT payload and refuse the full-account scope.
+ *
+ * Three scopes can come back from `createSession`:
+ *   - `com.atproto.access`            — full account credentials. Refused.
+ *   - `com.atproto.appPass`           — app password, non-privileged. Accepted.
+ *   - `com.atproto.appPassPrivileged` — app password with extra privileges
+ *                                       (e.g. direct messages). Still not the
+ *                                       account password; accepted.
+ *
+ * Decoding is signature-unverified by design — the PDS already enforces the
+ * scope binding server-side, and we'd need its public key to verify locally.
+ * Re-reading the scope client-side is purely a footgun-catcher: if a
+ * publisher pastes the account password, the PDS returns
+ * `com.atproto.access`, and we surface that as a hard error before the
+ * publish goes through.
+ */
+function assertNonFullAccountScope(accessJwt: string): void {
+	const payload = decodeJwtPayload(accessJwt);
+	const scope =
+		payload && typeof payload === "object" ? (payload as { scope?: unknown }).scope : undefined;
+	if (scope === "com.atproto.access") {
+		throw new AppPasswordError(
+			"FULL_ACCOUNT_CREDENTIAL",
+			"EMDASH_PUBLISHER_APP_PASSWORD authenticated with the full-account scope " +
+				"(`com.atproto.access`). Refusing to publish with account credentials — " +
+				"create a dedicated app password at https://bsky.app/settings/app-passwords " +
+				"or your PDS equivalent and use that instead.",
+		);
+	}
+}
+
+/**
+ * Best-effort base64url JSON decode of a JWT payload. The signature is not
+ * checked — the PDS enforces scope server-side, and this is advisory only
+ * (see {@link assertNonFullAccountScope}).
+ *
+ * Returns `null` on any malformed input. Callers treat `null` as "couldn't
+ * tell the scope" rather than throwing — an unrecognised JWT shouldn't
+ * pretend to be a full-account credential.
+ */
+function decodeJwtPayload(jwt: string): unknown {
+	const parts = jwt.split(".");
+	if (parts.length < 2) return null;
+	const payload = parts[1];
+	if (!payload) return null;
+	const padded = payload.replaceAll("-", "+").replaceAll("_", "/");
+	const padding = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+	try {
+		const json = Buffer.from(padded + padding, "base64").toString("utf8");
+		return JSON.parse(json);
+	} catch {
+		return null;
+	}
+}

--- a/packages/plugin-cli/src/commands/publish.ts
+++ b/packages/plugin-cli/src/commands/publish.ts
@@ -28,6 +28,12 @@ import { defineCommand } from "citty";
 import consola from "consola";
 import pc from "picocolors";
 
+import {
+	AppPasswordError,
+	type PublishAuth,
+	type PublisherIdentity,
+	selectPublishAuth,
+} from "../app-password.js";
 import { formatBytes, MAX_BUNDLE_SIZE, validateBundleSize } from "../bundle/utils.js";
 import { loadManifest, MANIFEST_FILENAME, ManifestError } from "../manifest/load.js";
 import { checkPublisher, PublisherCheckError, writePublisherBack } from "../manifest/publisher.js";
@@ -120,6 +126,11 @@ export const publishCommand = defineCommand({
 			description:
 				"Emit a single-line JSON object on stdout instead of human output. Success: {profile, release, cid, checksum, url, profileCreated, releaseOverwritten}. Failure: {error: {code, message}}. Human-readable progress goes to stderr in either mode.",
 		},
+		publisher: {
+			type: "string",
+			description:
+				"Publisher handle or DID for CI app-password auth. Falls back to EMDASH_PUBLISHER_DID / EMDASH_PUBLISHER_HANDLE. Requires EMDASH_PUBLISHER_APP_PASSWORD in the environment. Omit for interactive OAuth (emdash-plugin login).",
+		},
 	},
 	async run({ args }) {
 		// In --json mode, stdout MUST contain only the final JSON object so
@@ -137,7 +148,7 @@ export const publishCommand = defineCommand({
 		try {
 			await runPublish(args);
 		} catch (error) {
-			exitCode = error instanceof CliError ? error.exitCode : 1;
+			exitCode = exitCodeFor(error);
 			handlePublishError(error, args.json);
 		} finally {
 			restoreReporters?.();
@@ -146,11 +157,42 @@ export const publishCommand = defineCommand({
 	},
 });
 
+function exitCodeFor(error: unknown): number {
+	if (error instanceof CliError) return error.exitCode;
+	if (error instanceof AppPasswordError) return error.exitCode;
+	return 1;
+}
+
+/**
+ * Test-only options for `runPublish`. Production callers (the citty command)
+ * pass `args` only; tests substitute an explicit auth provider so the publish
+ * flow doesn't depend on the filesystem credential store, OAuth state, or a
+ * real PDS for resolution.
+ */
+export interface RunPublishOverrides {
+	/**
+	 * Auth provider to use instead of the env/flag-driven selection. When set,
+	 * `selectPublishAuth` is skipped entirely — tests pass a pre-built provider
+	 * wired to a mock PDS or a stub.
+	 */
+	auth?: PublishAuth;
+}
+
 /**
  * Inner publish flow. Throws on every failure path; the outer `run` catches
  * and renders consistently (human + JSON modes).
+ *
+ * Auth indirection: `runPublish` delegates identity + authenticated handler
+ * to a {@link PublishAuth} provider. OAuth and app-password share the same
+ * outer flow — the provider decides whether `identify()` is offline (OAuth)
+ * or a network login (app-password); either way it returns before the
+ * tarball fetch so the publisher-pin check still fails fast on wrong-account
+ * publishes.
  */
-async function runPublish(args: PublishArgs): Promise<void> {
+export async function runPublish(
+	args: PublishArgs,
+	overrides: RunPublishOverrides = {},
+): Promise<void> {
 	// Validate URL before any network access. Empty or non-https URLs are
 	// rejected so we never publish a record pointing at file:// or a private
 	// IP that consumers won't be able to fetch from.
@@ -180,21 +222,20 @@ async function runPublish(args: PublishArgs): Promise<void> {
 	const manifestLoad = await loadManifestBootstrap(args, consola);
 	const manifestProfile = manifestLoad?.profileInput ?? null;
 
-	// Resume the active publisher session BEFORE any network access.
-	// The publisher-mismatch check below depends only on the session DID
+	// Resolve the active publisher identity BEFORE any tarball access.
+	// The publisher-mismatch check below depends only on the identity DID
 	// and the manifest's pinned publisher; running both up front means
 	// a wrong-account publish fails in milliseconds rather than after a
-	// full tarball fetch + decompress + manifest extract.
-	const credentials = new FileCredentialStore();
-	const session = await credentials.current();
-	if (!session) {
-		throw new CliError(
-			"Not logged in. Run: emdash-plugin login <handle-or-did>",
-			1,
-			"NOT_LOGGED_IN",
-		);
-	}
-	consola.info(`Publishing as ${pc.bold(session.handle ?? session.did)} (${pc.dim(session.did)})`);
+	// full tarball fetch + decompress + manifest extract. For app-password
+	// auth this is also where the network `createSession` runs — bad
+	// credentials fail before the download.
+	const auth =
+		overrides.auth ??
+		selectPublishAuth({ publisher: args.publisher }, { oauthFactory: createOAuthPublishAuth });
+	const identity = await auth.identify();
+	consola.info(
+		`Publishing as ${pc.bold(identity.handle ?? identity.did)} (${pc.dim(identity.did)})`,
+	);
 
 	// Verify the manifest's pinned publisher matches the active session
 	// before fetching the tarball. The check is offline (DID compare is
@@ -204,11 +245,11 @@ async function runPublish(args: PublishArgs): Promise<void> {
 		try {
 			const check = await checkPublisher({
 				manifestPublisher: manifestLoad.manifest.publisher,
-				sessionDid: session.did,
+				sessionDid: identity.did,
 			});
 			if (check.kind === "mismatch") {
 				throw new CliError(
-					`Manifest pins publisher to ${pc.bold(check.pinnedDisplay)} (${check.pinnedDid}), but the active session is ${session.did}. ` +
+					`Manifest pins publisher to ${pc.bold(check.pinnedDisplay)} (${check.pinnedDid}), but the active session is ${identity.did}. ` +
 						`Either switch sessions (\`emdash-plugin switch ${check.pinnedDid}\`), or edit the manifest if you are transferring the plugin to a new publisher.`,
 					1,
 					"MANIFEST_PUBLISHER_MISMATCH",
@@ -250,11 +291,11 @@ async function runPublish(args: PublishArgs): Promise<void> {
 		consola.success(`Local file at ${pc.dim(localPath)} matches the URL`);
 	}
 
-	const oauthSession = await resumeSession(session.did);
+	const handler = await auth.handler();
 	const publisher = PublishingClient.fromHandler({
-		handler: oauthSession,
-		did: session.did,
-		pds: session.pds,
+		handler,
+		did: identity.did,
+		pds: identity.pds,
 	});
 
 	// Resolve the profile block. The manifest is the base; the deprecated
@@ -304,7 +345,7 @@ async function runPublish(args: PublishArgs): Promise<void> {
 
 	const result = await publishRelease({
 		publisher,
-		did: session.did,
+		did: identity.did,
 		manifest,
 		checksum,
 		url: args.url,
@@ -324,11 +365,11 @@ async function runPublish(args: PublishArgs): Promise<void> {
 	if (manifestLoad && manifestLoad.manifest.publisher === undefined) {
 		await writePublisherBack({
 			manifestPath: manifestLoad.path,
-			sessionDid: session.did,
-			// session.handle is nullable; normalise to undefined for the
+			sessionDid: identity.did,
+			// identity.handle is nullable; normalise to undefined for the
 			// optional argument so the absence-vs-empty distinction stays
 			// clean at the writePublisherBack boundary.
-			sessionHandle: session.handle ?? undefined,
+			sessionHandle: identity.handle ?? undefined,
 			onInfo: (m) => consola.info(m),
 			onWarn: (m) => consola.warn(m),
 		});
@@ -367,7 +408,44 @@ async function runPublish(args: PublishArgs): Promise<void> {
 	consola.info(
 		`The aggregator will pick this up from the firehose. To verify discovery once it's indexed:`,
 	);
-	console.log(`  ${pc.cyan(`emdash-plugin info ${session.handle ?? session.did} ${result.slug}`)}`);
+	console.log(
+		`  ${pc.cyan(`emdash-plugin info ${identity.handle ?? identity.did} ${result.slug}`)}`,
+	);
+}
+
+/**
+ * OAuth `PublishAuth` provider. Wraps the existing `FileCredentialStore` +
+ * `resumeSession` pair behind the seam, preserving byte-for-byte the
+ * offline-`identify()` + network-`handler()` ordering the rest of the
+ * publish flow assumes.
+ *
+ * Defined here rather than in `oauth.ts` so it can throw the publish
+ * command's `CliError` for the "not logged in" path without re-introducing a
+ * circular import.
+ */
+function createOAuthPublishAuth(): PublishAuth {
+	let identity: PublisherIdentity | null = null;
+	return {
+		async identify(): Promise<PublisherIdentity> {
+			const credentials = new FileCredentialStore();
+			const session = await credentials.current();
+			if (!session) {
+				throw new CliError(
+					"Not logged in. Run: emdash-plugin login <handle-or-did>",
+					1,
+					"NOT_LOGGED_IN",
+				);
+			}
+			identity = { did: session.did, handle: session.handle, pds: session.pds };
+			return identity;
+		},
+		async handler() {
+			if (!identity) {
+				throw new Error("oauth handler() called before identify()");
+			}
+			return resumeSession(identity.did);
+		},
+	};
 }
 
 /**
@@ -389,7 +467,7 @@ function handlePublishError(error: unknown, jsonMode: boolean): void {
 				"To overwrite anyway, pass --allow-overwrite (use only when you're sure no consumers have installed this version yet).",
 			);
 		}
-	} else if (error instanceof CliError) {
+	} else if (error instanceof CliError || error instanceof AppPasswordError) {
 		code = error.code;
 		message = error.message;
 		consola.error(error.message);
@@ -435,6 +513,7 @@ type PublishArgs = {
 	"no-manifest"?: boolean;
 	"allow-overwrite"?: boolean;
 	json?: boolean;
+	publisher?: string;
 };
 
 /**

--- a/packages/plugin-cli/src/oauth.ts
+++ b/packages/plugin-cli/src/oauth.ts
@@ -543,8 +543,14 @@ export function tryOpenBrowser(url: string): void {
  * Validate and narrow a user-supplied identifier (handle or DID) to the
  * `ActorIdentifier` type the OAuth library expects. Throws a CLI-shaped error
  * message if neither shape matches.
+ *
+ * Exported so the app-password auth path can share the same shape check.
+ * Rejecting non-handle/DID inputs there matters for CI: the atproto
+ * createSession endpoint accepts emails too, but we don't want to publish
+ * with email-shaped identifiers — they make the authenticated DID dependent
+ * on a remote lookup we can't sanity-check locally.
  */
-function parseActorIdentifier(input: string): ActorIdentifier {
+export function parseActorIdentifier(input: string): ActorIdentifier {
 	const trimmed = input.trim();
 	if (isDid(trimmed) || isHandle(trimmed)) {
 		return trimmed;

--- a/packages/plugin-cli/tests/app-password.test.ts
+++ b/packages/plugin-cli/tests/app-password.test.ts
@@ -1,0 +1,514 @@
+/**
+ * App-password publishing tests (RFC: see `.claude/REGISTRY_APP_PASSWORD_PLAN.md`).
+ *
+ * Three layers of coverage:
+ *
+ *   1. Provider behaviour — `createAppPasswordAuth` against the mock PDS:
+ *      end-to-end happy paths for handle + DID identifiers, plus every
+ *      guardrail (format, full-account scope, DID cross-check).
+ *   2. Selection — `selectPublishAuth` precedence rules between
+ *      `--publisher`, `EMDASH_PUBLISHER_DID`, `EMDASH_PUBLISHER_HANDLE`, and
+ *      `EMDASH_PUBLISHER_APP_PASSWORD`. Pure logic, env passed explicitly.
+ *   3. Integration regression — `runPublish` under app-password auth still
+ *      enforces the manifest `publisher` pin against the logged-in DID.
+ *
+ * The resolver is injected (not stubbed via module mocking) so identifier →
+ * `{ did, pds }` never hits the network. The CredentialManager's `fetch` is
+ * pointed at the mock PDS so `createSession` round-trips end-to-end without a
+ * real atproto server.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ActorResolver, ResolvedActor } from "@atcute/identity-resolver";
+import { PublishingClient } from "@emdash-cms/registry-client";
+import { NSID } from "@emdash-cms/registry-lexicons";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	AppPasswordError,
+	createAppPasswordAuth,
+	type PublishAuth,
+	selectPublishAuth,
+} from "../src/app-password.js";
+import { runPublish } from "../src/commands/publish.js";
+import { publishRelease, type ProfileBootstrap } from "../src/publish/api.js";
+import { MockPds } from "./mock-pds.js";
+
+const TEST_DID = "did:plc:appPasswordTest" as const;
+const TEST_HANDLE = "publisher.test";
+const TEST_PDS = "http://mock.test";
+const VALID_APP_PASSWORD = "aaaa-bbbb-cccc-dddd";
+
+const validProfile: ProfileBootstrap = {
+	license: "MIT",
+	authorName: "Alice",
+	securityEmail: "security@example.com",
+};
+
+/**
+ * Wire a CredentialManager-shaped fetch at a MockPds. The CredentialManager
+ * issues full-URL requests (`http://mock.test/xrpc/...`); the mock keys on
+ * pathname, so we strip the host.
+ */
+function pdsFetch(pds: MockPds): typeof globalThis.fetch {
+	return async (input, init) => {
+		const target =
+			typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		const url = new URL(target);
+		return pds.handle(url.pathname + url.search, init ?? {});
+	};
+}
+
+function fakeResolver(resolved: ResolvedActor): ActorResolver {
+	return { resolve: async () => resolved };
+}
+
+function defaultResolved(overrides: Partial<ResolvedActor> = {}): ResolvedActor {
+	return {
+		did: TEST_DID,
+		handle: TEST_HANDLE,
+		pds: TEST_PDS,
+		...overrides,
+	};
+}
+
+describe("createAppPasswordAuth", () => {
+	describe("happy path", () => {
+		it("identifies with a handle, publishes through the authenticated handler", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+
+			const identity = await auth.identify();
+			expect(identity.did).toBe(TEST_DID);
+			expect(identity.handle).toBe("mock.test");
+			expect(identity.pds).toBe(TEST_PDS);
+
+			const handler = await auth.handler();
+			const publisher = PublishingClient.fromHandler({
+				handler,
+				did: identity.did,
+				pds: identity.pds,
+			});
+			const result = await publishRelease({
+				publisher,
+				did: identity.did,
+				manifest: {
+					id: "test-plugin",
+					version: "1.0.0",
+					capabilities: [],
+					allowedHosts: [],
+					storage: {},
+					hooks: [],
+					routes: [],
+					admin: {},
+				},
+				checksum: "bciqtestchecksum",
+				url: "https://example.com/test-plugin-1.0.0.tar.gz",
+				profile: validProfile,
+			});
+
+			expect(result.profileCreated).toBe(true);
+			expect(result.releaseUri).toBe(`at://${TEST_DID}/${NSID.packageRelease}/test-plugin:1.0.0`);
+			expect(pds.callsTo("com.atproto.server.createSession")).toHaveLength(1);
+		});
+
+		it("identifies with a DID, publishes through the authenticated handler", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: TEST_DID,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			const identity = await auth.identify();
+			expect(identity.did).toBe(TEST_DID);
+
+			const handler = await auth.handler();
+			const publisher = PublishingClient.fromHandler({
+				handler,
+				did: identity.did,
+				pds: identity.pds,
+			});
+			const result = await publishRelease({
+				publisher,
+				did: identity.did,
+				manifest: {
+					id: "test-plugin",
+					version: "1.0.0",
+					capabilities: [],
+					allowedHosts: [],
+					storage: {},
+					hooks: [],
+					routes: [],
+					admin: {},
+				},
+				checksum: "bciqtestchecksum",
+				url: "https://example.com/test-plugin-1.0.0.tar.gz",
+				profile: validProfile,
+			});
+			expect(result.profileCreated).toBe(true);
+		});
+	});
+
+	describe("guardrails", () => {
+		it("rejects a malformed app-password without ever attempting login", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			expect(() =>
+				createAppPasswordAuth({
+					identifier: TEST_HANDLE,
+					password: "not-an-app-password",
+					actorResolver: fakeResolver(defaultResolved()),
+					fetch: pdsFetch(pds),
+				}),
+			).toThrowError(
+				expect.objectContaining({
+					name: "AppPasswordError",
+					code: "APP_PASSWORD_FORMAT",
+				}),
+			);
+			expect(pds.calls).toHaveLength(0);
+		});
+
+		it("rejects email-shaped identifiers up front (no createSession call)", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			expect(() =>
+				createAppPasswordAuth({
+					identifier: "alice@example.com",
+					password: VALID_APP_PASSWORD,
+					actorResolver: fakeResolver(defaultResolved()),
+					fetch: pdsFetch(pds),
+				}),
+			).toThrowError(/not a valid handle or DID/);
+			expect(pds.calls).toHaveLength(0);
+		});
+
+		it("refuses a full-account `com.atproto.access` scope (FULL_ACCOUNT_CREDENTIAL)", async () => {
+			const pds = new MockPds({
+				did: TEST_DID,
+				createSessionScope: "com.atproto.access",
+			});
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			await expect(auth.identify()).rejects.toMatchObject({
+				name: "AppPasswordError",
+				code: "FULL_ACCOUNT_CREDENTIAL",
+			});
+			// applyWrites must not have been reachable; createSession ran but
+			// nothing past it.
+			expect(pds.callsTo("com.atproto.repo.applyWrites")).toHaveLength(0);
+		});
+
+		it("accepts the privileged app-password scope", async () => {
+			const pds = new MockPds({
+				did: TEST_DID,
+				createSessionScope: "com.atproto.appPassPrivileged",
+			});
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			const identity = await auth.identify();
+			expect(identity.did).toBe(TEST_DID);
+		});
+
+		it("refuses when the login DID disagrees with the resolved identifier DID", async () => {
+			const pds = new MockPds({
+				did: TEST_DID,
+				// Resolver claims the identifier points at TEST_DID, but the PDS
+				// authenticates as a different repo. A real attacker scenario
+				// is identifier spoofing (DNS-rebinding the handle->DID step)
+				// or a publisher who pointed two handles at the same app
+				// password.
+				createSessionDid: "did:plc:otherAccount",
+			});
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			await expect(auth.identify()).rejects.toMatchObject({
+				name: "AppPasswordError",
+				code: "PUBLISHER_DID_MISMATCH",
+			});
+		});
+
+		it("caches the manager so identify() + handler() never re-login", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			await auth.identify();
+			await auth.identify();
+			await auth.handler();
+			expect(pds.callsTo("com.atproto.server.createSession")).toHaveLength(1);
+		});
+
+		it("shares the in-flight login between concurrent callers", async () => {
+			// Cache the in-flight promise rather than the resolved value: two
+			// callers entering identify() before the first createSession
+			// settles must share one round trip, not race into two.
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			await Promise.all([auth.identify(), auth.identify(), auth.handler()]);
+			expect(pds.callsTo("com.atproto.server.createSession")).toHaveLength(1);
+		});
+
+		it("handler() works without an explicit prior identify() call", async () => {
+			// handler() and identify() are independent entry points into the
+			// same login flow. Production runPublish calls identify() first,
+			// but the provider contract should not require that ordering.
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: TEST_HANDLE,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			const handler = await auth.handler();
+			expect(handler).toBeDefined();
+			expect(pds.callsTo("com.atproto.server.createSession")).toHaveLength(1);
+		});
+
+		it("trims whitespace before sending the identifier to createSession", async () => {
+			// A stray space in EMDASH_PUBLISHER_HANDLE (CI YAML quoting
+			// mistake) shouldn't reach the PDS as a leading whitespace
+			// character.
+			const pds = new MockPds({ did: TEST_DID });
+			const auth = createAppPasswordAuth({
+				identifier: `  ${TEST_HANDLE}  `,
+				password: VALID_APP_PASSWORD,
+				actorResolver: fakeResolver(defaultResolved()),
+				fetch: pdsFetch(pds),
+			});
+			await auth.identify();
+			const call = pds.callsTo("com.atproto.server.createSession")[0];
+			expect(call?.body).toMatchObject({ identifier: TEST_HANDLE });
+		});
+
+		it("classifies transient runtime errors at exit 1, user-config errors at exit 2", () => {
+			// CI scripts that branch on exit code would misclassify a DNS blip
+			// or PDS outage if INVALID_PUBLISHER / APP_PASSWORD_LOGIN_FAILED
+			// got the user-config exit code.
+			expect(new AppPasswordError("APP_PASSWORD_LOGIN_FAILED", "x").exitCode).toBe(1);
+			expect(new AppPasswordError("INVALID_PUBLISHER", "x").exitCode).toBe(1);
+			expect(new AppPasswordError("FULL_ACCOUNT_CREDENTIAL", "x").exitCode).toBe(1);
+			expect(new AppPasswordError("PUBLISHER_DID_MISMATCH", "x").exitCode).toBe(1);
+			expect(new AppPasswordError("APP_PASSWORD_FORMAT", "x").exitCode).toBe(2);
+			expect(new AppPasswordError("MISSING_APP_PASSWORD", "x").exitCode).toBe(2);
+			expect(new AppPasswordError("MISSING_PUBLISHER", "x").exitCode).toBe(2);
+		});
+	});
+});
+
+describe("selectPublishAuth", () => {
+	const oauthSentinel: PublishAuth = {
+		async identify() {
+			throw new Error("oauth sentinel identify() should not be called");
+		},
+		async handler() {
+			throw new Error("oauth sentinel handler() should not be called");
+		},
+	};
+	const oauthFactory = () => oauthSentinel;
+
+	it("returns the OAuth provider when no env and no flag are present", () => {
+		const auth = selectPublishAuth({}, { env: {}, oauthFactory });
+		expect(auth).toBe(oauthSentinel);
+	});
+
+	it("--publisher takes precedence over EMDASH_PUBLISHER_HANDLE", async () => {
+		const pds = new MockPds({ did: TEST_DID });
+		let resolvedIdentifier: string | undefined;
+		const resolver: ActorResolver = {
+			resolve: async (actor) => {
+				resolvedIdentifier = actor;
+				return defaultResolved();
+			},
+		};
+		const auth = selectPublishAuth(
+			{ publisher: TEST_HANDLE },
+			{
+				env: {
+					EMDASH_PUBLISHER_APP_PASSWORD: VALID_APP_PASSWORD,
+					EMDASH_PUBLISHER_HANDLE: "ignored.example",
+				},
+				oauthFactory,
+				actorResolver: resolver,
+				fetch: pdsFetch(pds),
+			},
+		);
+		await auth.identify();
+		expect(resolvedIdentifier).toBe(TEST_HANDLE);
+	});
+
+	it("EMDASH_PUBLISHER_DID takes precedence over EMDASH_PUBLISHER_HANDLE", async () => {
+		const pds = new MockPds({ did: TEST_DID });
+		let resolvedIdentifier: string | undefined;
+		const resolver: ActorResolver = {
+			resolve: async (actor) => {
+				resolvedIdentifier = actor;
+				return defaultResolved();
+			},
+		};
+		const auth = selectPublishAuth(
+			{},
+			{
+				env: {
+					EMDASH_PUBLISHER_APP_PASSWORD: VALID_APP_PASSWORD,
+					EMDASH_PUBLISHER_DID: TEST_DID,
+					EMDASH_PUBLISHER_HANDLE: "ignored.example",
+				},
+				oauthFactory,
+				actorResolver: resolver,
+				fetch: pdsFetch(pds),
+			},
+		);
+		await auth.identify();
+		expect(resolvedIdentifier).toBe(TEST_DID);
+	});
+
+	it("identifier without app password fails with MISSING_APP_PASSWORD (no fallback to OAuth)", () => {
+		expect(() =>
+			selectPublishAuth({ publisher: TEST_HANDLE }, { env: {}, oauthFactory }),
+		).toThrowError(
+			expect.objectContaining({
+				name: "AppPasswordError",
+				code: "MISSING_APP_PASSWORD",
+			}),
+		);
+	});
+
+	it('treats `--publisher=""` as absent and falls through to env identifiers', async () => {
+		// `??` would otherwise short-circuit on the empty string and prevent
+		// the env fallback. A user explicitly passing an empty `--publisher=`
+		// expects the env identifier to take over, not to fail with a confusing
+		// MISSING_PUBLISHER about an empty value.
+		const pds = new MockPds({ did: TEST_DID });
+		let resolvedIdentifier: string | undefined;
+		const resolver: ActorResolver = {
+			resolve: async (actor) => {
+				resolvedIdentifier = actor;
+				return defaultResolved();
+			},
+		};
+		const auth = selectPublishAuth(
+			{ publisher: "" },
+			{
+				env: {
+					EMDASH_PUBLISHER_APP_PASSWORD: VALID_APP_PASSWORD,
+					EMDASH_PUBLISHER_DID: TEST_DID,
+				},
+				oauthFactory,
+				actorResolver: resolver,
+				fetch: pdsFetch(pds),
+			},
+		);
+		await auth.identify();
+		expect(resolvedIdentifier).toBe(TEST_DID);
+	});
+
+	it("treats whitespace-only env values as absent", () => {
+		// A stray space in a CI YAML (`EMDASH_PUBLISHER_HANDLE: " "`) shouldn't
+		// latch as an identifier and trigger MISSING_APP_PASSWORD when no
+		// password is set — that misclassifies the failure.
+		const auth = selectPublishAuth({}, { env: { EMDASH_PUBLISHER_HANDLE: "   " }, oauthFactory });
+		expect(auth).toBe(oauthSentinel);
+	});
+
+	it("app password without identifier fails with MISSING_PUBLISHER", () => {
+		expect(() =>
+			selectPublishAuth(
+				{},
+				{ env: { EMDASH_PUBLISHER_APP_PASSWORD: VALID_APP_PASSWORD }, oauthFactory },
+			),
+		).toThrowError(
+			expect.objectContaining({
+				name: "AppPasswordError",
+				code: "MISSING_PUBLISHER",
+			}),
+		);
+	});
+});
+
+describe("runPublish under app-password auth", () => {
+	let workspace: string;
+
+	beforeEach(async () => {
+		workspace = await mkdtemp(join(tmpdir(), "emdash-app-pw-"));
+	});
+
+	afterEach(async () => {
+		await rm(workspace, { recursive: true, force: true });
+	});
+
+	async function writeManifest(publisherPin: string): Promise<string> {
+		const path = join(workspace, "emdash-plugin.jsonc");
+		await mkdir(workspace, { recursive: true });
+		await writeFile(
+			path,
+			JSON.stringify({
+				slug: "test-plugin",
+				version: "1.0.0",
+				license: "MIT",
+				publisher: publisherPin,
+				author: { name: "Alice" },
+				security: { email: "security@example.com" },
+				capabilities: ["content:read"],
+				allowedHosts: [],
+			}),
+		);
+		return path;
+	}
+
+	it("manifest `publisher` pin still fires when identify() resolves to a different DID", async () => {
+		const manifestPath = await writeManifest("did:plc:pinnedDifferentAccount");
+		const pds = new MockPds({ did: TEST_DID });
+		const auth = createAppPasswordAuth({
+			identifier: TEST_HANDLE,
+			password: VALID_APP_PASSWORD,
+			actorResolver: fakeResolver(defaultResolved()),
+			fetch: pdsFetch(pds),
+		});
+
+		await expect(
+			runPublish(
+				{
+					url: "https://example.com/test-plugin-1.0.0.tar.gz",
+					manifest: manifestPath,
+				},
+				{ auth },
+			),
+		).rejects.toMatchObject({
+			name: "CliError",
+			code: "MANIFEST_PUBLISHER_MISMATCH",
+		});
+
+		// Pin check fires AFTER identify() (login ran) but BEFORE any tarball
+		// fetch (no records ever written).
+		expect(pds.callsTo("com.atproto.server.createSession")).toHaveLength(1);
+		expect(pds.callsTo("com.atproto.repo.applyWrites")).toHaveLength(0);
+	});
+});

--- a/packages/plugin-cli/tests/mock-pds.ts
+++ b/packages/plugin-cli/tests/mock-pds.ts
@@ -58,6 +58,28 @@ export interface MockPdsOptions {
 	 * that need a different one can override.
 	 */
 	did?: `did:${string}:${string}`;
+	/**
+	 * Scope embedded in the `accessJwt` payload returned by
+	 * `com.atproto.server.createSession`. Defaults to `com.atproto.appPass`, the
+	 * shape a real PDS returns for an app-password session. Tests that exercise
+	 * the publish-CLI guardrails override this — e.g. with `com.atproto.access`
+	 * to assert a full-account credential is rejected.
+	 */
+	createSessionScope?:
+		| "com.atproto.access"
+		| "com.atproto.appPass"
+		| "com.atproto.appPassPrivileged";
+	/**
+	 * DID returned by `createSession`. Defaults to {@link MockPdsOptions.did}.
+	 * Override to drive the PUBLISHER_DID_MISMATCH guard: the resolved
+	 * identifier and the logged-in account belong to different repos.
+	 */
+	createSessionDid?: `did:${string}:${string}`;
+	/**
+	 * Handle returned by `createSession`. Defaults to `mock.test`. Surfaces in
+	 * the AtpSessionData a real PDS would issue.
+	 */
+	createSessionHandle?: string;
 }
 
 const RKEY_RE = /^[a-zA-Z0-9._~:-]+$/;
@@ -70,9 +92,18 @@ export class MockPds implements FetchHandlerObject {
 	readonly did: `did:${string}:${string}`;
 	readonly records = new Map<string, StoredRecord>();
 	readonly calls: MockPdsCall[] = [];
+	readonly #createSessionScope:
+		| "com.atproto.access"
+		| "com.atproto.appPass"
+		| "com.atproto.appPassPrivileged";
+	readonly #createSessionDid: `did:${string}:${string}`;
+	readonly #createSessionHandle: string;
 
 	constructor(options: MockPdsOptions = {}) {
 		this.did = options.did ?? "did:plc:test123";
+		this.#createSessionScope = options.createSessionScope ?? "com.atproto.appPass";
+		this.#createSessionDid = options.createSessionDid ?? this.did;
+		this.#createSessionHandle = options.createSessionHandle ?? "mock.test";
 	}
 
 	async handle(pathname: string, init: RequestInit): Promise<Response> {
@@ -91,6 +122,8 @@ export class MockPds implements FetchHandlerObject {
 				return this.#listRecords(url);
 			case "/xrpc/com.atproto.repo.applyWrites":
 				return this.#applyWrites(body);
+			case "/xrpc/com.atproto.server.createSession":
+				return this.#createSession(body);
 			default:
 				return jsonResponse(404, {
 					error: "MethodNotFound",
@@ -291,6 +324,47 @@ export class MockPds implements FetchHandlerObject {
 		return jsonResponse(200, { results });
 	}
 
+	#createSession(body: unknown): Response {
+		if (!body || typeof body !== "object") {
+			return jsonResponse(400, { error: "InvalidRequest", message: "missing body" });
+		}
+		const input = body as { identifier?: unknown; password?: unknown };
+		if (typeof input.identifier !== "string" || input.identifier.length === 0) {
+			return jsonResponse(400, {
+				error: "InvalidRequest",
+				message: "identifier must be a non-empty string",
+			});
+		}
+		if (typeof input.password !== "string" || input.password.length === 0) {
+			return jsonResponse(401, {
+				error: "AuthenticationRequired",
+				message: "password must be a non-empty string",
+			});
+		}
+		const now = Math.floor(Date.now() / 1000);
+		const accessJwt = encodeUnsignedJwt({
+			scope: this.#createSessionScope,
+			sub: this.#createSessionDid,
+			iat: now,
+			exp: now + 60 * 60 * 2,
+		});
+		const refreshJwt = encodeUnsignedJwt({
+			scope: "com.atproto.refresh",
+			sub: this.#createSessionDid,
+			jti: `mock-${now}`,
+			aud: this.#createSessionDid,
+			iat: now,
+			exp: now + 60 * 60 * 24 * 90,
+		});
+		return jsonResponse(200, {
+			did: this.#createSessionDid,
+			handle: this.#createSessionHandle,
+			accessJwt,
+			refreshJwt,
+			active: true,
+		});
+	}
+
 	/**
 	 * Cross-check that every write targets this mock's repo and that the rkey
 	 * matches atproto's record-key alphabet. Real PDSes enforce both; without
@@ -338,6 +412,26 @@ function cidOf(value: unknown): string {
 		.update(JSON.stringify(value ?? null))
 		.digest("hex");
 	return `bafyreig${hash.slice(0, 52)}`;
+}
+
+/**
+ * Encode an unsigned JWT (`header.payload.<empty>`) with base64url segments.
+ * The mock PDS does not sign tokens; the publish CLI's scope guardrail decodes
+ * the payload but does not verify the signature (the real PDS enforces auth
+ * for real). Matching that shape here is all we need.
+ */
+function encodeUnsignedJwt(payload: Record<string, unknown>): string {
+	const header = base64UrlEncode(JSON.stringify({ alg: "none", typ: "JWT" }));
+	const body = base64UrlEncode(JSON.stringify(payload));
+	return `${header}.${body}.`;
+}
+
+function base64UrlEncode(input: string): string {
+	return Buffer.from(input, "utf8")
+		.toString("base64")
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/, "");
 }
 
 async function readJsonBody(body: BodyInit | null | undefined): Promise<unknown> {


### PR DESCRIPTION
## What does this PR do?

Adds non-interactive `emdash-plugin publish` authentication for CI via atproto app passwords. Set `EMDASH_PUBLISHER_APP_PASSWORD` in the environment and pass `--publisher <handle-or-did>` (or `EMDASH_PUBLISHER_DID` / `EMDASH_PUBLISHER_HANDLE`) to publish without the browser OAuth dance. Interactive OAuth is unchanged when no app password is set.

### Why app passwords instead of OAuth-in-CI

Atproto OAuth refresh tokens rotate single-use. A stateless runner publishes once, then the persisted session is dead unless the rotated token is written back somewhere durable — which needs a PAT to mutate the secret, or cache plumbing that breaks silently. App passwords are long-lived, re-create a session per run, and `createSession` is the niche they exist for. The publishing layer is already auth-agnostic, so this is contained.

### Design

A small two-phase `PublishAuth` seam (`identify()` + `handler()`) shared by OAuth and app-password. For OAuth `identify()` is offline and `handler()` resumes the stored session — preserved byte-for-byte. For app-password `identify()` runs `createSession` against the resolved PDS (still before the tarball fetch, so bad credentials fail before the download).

Guardrails refuse the full-account `com.atproto.access` scope (only `appPass` / `appPassPrivileged` are accepted), reject malformed `xxxx-xxxx-xxxx-xxxx` strings before any network call, and cross-check the logged-in DID against the resolved publisher identifier. Stable error codes surface through `--json` for CI consumers.

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new diagnostics in touched files)
- [x] `pnpm test` passes (284 tests in `@emdash-cms/plugin-cli`, was 278)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) — n/a, CLI only
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/plugin-cli` minor)
- [x] New features link to an approved Discussion — _maintainer to fill in URL_

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Test plan

- [x] `pnpm --filter @emdash-cms/plugin-cli test` — 284 tests pass (17 files)
- [x] `pnpm --filter @emdash-cms/plugin-cli typecheck` — clean
- [x] `pnpm lint:json` — no new diagnostics in `packages/plugin-cli/src/app-password.ts`, `commands/publish.ts`, `oauth.ts`, or `tests/mock-pds.ts`
- [x] Manual: OAuth path produces identical CLI output to `main` (no app-password env set → `selectPublishAuth` returns the OAuth provider, same `Publishing as ...` log, same pin-check ordering)
- [x] Adversarial review pass (separate agent) — six findings, all addressed: `INVALID_PUBLISHER` exit code 1 (was 2), concurrent `identify()` race now shares the in-flight promise, `??` chain no longer misclassifies empty strings, identifier whitespace trimmed before reaching `createSession`, changeset documents all stable codes