### PR TITLE
chore: clean up oxlint warnings across packages

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -50,7 +50,13 @@
 	},
 	"overrides": [
 		{
-			"files": ["**/*.test.ts", "**/*.test.tsx", "**/tests/**/*.ts", "**/tests/**/*.tsx"],
+			"files": [
+				"**/*.test.ts",
+				"**/*.test.tsx",
+				"**/tests/**/*.ts",
+				"**/tests/**/*.tsx",
+				"packages/atproto-test-utils/**/*.ts"
+			],
 			"rules": {
 				"typescript/no-unsafe-type-assertion": "off",
 				"typescript/no-unnecessary-type-assertion": "off",

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -65,8 +65,10 @@ test.describe("Bylines", () => {
 			return body.data.id as string;
 		};
 
-		const _firstBylineId = await createByline(primaryName, `primary-writer-${unique}`);
-		const _secondBylineId = await createByline(secondaryName, `secondary-writer-${unique}`);
+		// Create two bylines for the test post. IDs aren't needed downstream;
+		// the test selects them by name via the bylines combobox.
+		await createByline(primaryName, `primary-writer-${unique}`);
+		await createByline(secondaryName, `secondary-writer-${unique}`);
 
 		await admin.goToNewContent("posts");
 		await admin.waitForLoading();

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -65,8 +65,8 @@ test.describe("Bylines", () => {
 			return body.data.id as string;
 		};
 
-		const firstBylineId = await createByline(primaryName, `primary-writer-${unique}`);
-		const secondBylineId = await createByline(secondaryName, `secondary-writer-${unique}`);
+		const _firstBylineId = await createByline(primaryName, `primary-writer-${unique}`);
+		const _secondBylineId = await createByline(secondaryName, `secondary-writer-${unique}`);
 
 		await admin.goToNewContent("posts");
 		await admin.waitForLoading();

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -25,7 +25,7 @@ import {
 	ArrowSquareOut,
 	ImageBroken,
 } from "@phosphor-icons/react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
 

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -241,8 +241,8 @@ export function ContentTypeEditor({
 	const handleSingularLabelChange = (value: string) => {
 		setLabelSingular(value);
 		if (isNew) {
-			const plural = value ? `${value}s` : "";
-			handleLabelChange(plural);
+			const pluralLabel = value ? `${value}s` : "";
+			handleLabelChange(pluralLabel);
 		}
 	};
 

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -212,7 +212,7 @@ export function MediaPickerModal({
 		queryFn: ({ pageParam }) =>
 			fetchMediaList({
 				mimeType: filters,
-				cursor: pageParam as string | undefined,
+				cursor: pageParam,
 				limit: 100,
 			}),
 		initialPageParam: undefined as string | undefined,

--- a/packages/admin/src/lib/api/client.ts
+++ b/packages/admin/src/lib/api/client.ts
@@ -29,8 +29,8 @@ export async function throwResponseError(res: Response, fallback: string): Promi
 	if (typeof body === "object" && body !== null && "error" in body) {
 		const { error } = body;
 		if (typeof error === "object" && error !== null && "message" in error) {
-			const { message: msg } = error;
-			if (typeof msg === "string") message = msg;
+			const { message: errorMessage } = error;
+			if (typeof errorMessage === "string") message = errorMessage;
 		}
 	}
 	throw new Error(message || `${fallback}: ${res.statusText}`);

--- a/packages/admin/src/lib/api/registry.ts
+++ b/packages/admin/src/lib/api/registry.ts
@@ -29,7 +29,7 @@ import type {
 import { i18n } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 
-import { API_BASE, apiFetch, throwResponseError } from "./client.js";
+import { API_BASE, apiFetch, parseApiResponse, throwResponseError } from "./client.js";
 
 export type { Did, Handle };
 
@@ -359,13 +359,24 @@ interface CachedResolution {
 	expiresAt: number;
 }
 
+function isCachedResolution(value: unknown): value is CachedResolution {
+	if (typeof value !== "object" || value === null) return false;
+	// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- narrowed to non-null object above; field shapes validated below
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.expiresAt === "number" &&
+		typeof candidate.resolution === "object" &&
+		candidate.resolution !== null
+	);
+}
+
 function readHandleCache(did: string): DidHandleResolution | null {
 	if (typeof localStorage === "undefined") return null;
 	try {
 		const raw = localStorage.getItem(`${HANDLE_CACHE_KEY_PREFIX}${did}`);
 		if (!raw) return null;
-		const parsed = JSON.parse(raw) as CachedResolution;
-		if (!parsed || typeof parsed.expiresAt !== "number" || parsed.expiresAt < Date.now()) {
+		const parsed: unknown = JSON.parse(raw);
+		if (!isCachedResolution(parsed) || parsed.expiresAt < Date.now()) {
 			return null;
 		}
 		return parsed.resolution;
@@ -436,9 +447,7 @@ export async function installRegistryPlugin(
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
 	});
-	if (!response.ok) await throwResponseError(response, i18n._(msg`Failed to install plugin`));
-	const json = (await response.json()) as { data: RegistryInstallResult };
-	return json.data;
+	return parseApiResponse<RegistryInstallResult>(response, i18n._(msg`Failed to install plugin`));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -981,7 +981,7 @@ function MediaPage() {
 			queryKey: ["media"],
 			queryFn: ({ pageParam }) =>
 				fetchMediaList({
-					cursor: pageParam as string | undefined,
+					cursor: pageParam,
 					limit: 100,
 				}),
 			initialPageParam: undefined as string | undefined,

--- a/packages/contentful-to-portable-text/src/blocks/code-block.ts
+++ b/packages/contentful-to-portable-text/src/blocks/code-block.ts
@@ -1,12 +1,13 @@
 import type { ArbitraryTypedObject } from "@portabletext/types";
 
+import { getStringField } from "../types.js";
 import type { ContentfulEntry } from "../types.js";
 
 export function transformCodeBlock(entry: ContentfulEntry, key: string): ArbitraryTypedObject {
 	return {
 		_type: "code",
 		_key: key,
-		code: (entry.fields.code as string) ?? "",
-		language: (entry.fields.language as string) ?? "",
+		code: getStringField(entry.fields, "code") ?? "",
+		language: getStringField(entry.fields, "language") ?? "",
 	};
 }

--- a/packages/contentful-to-portable-text/src/blocks/embedded-html.ts
+++ b/packages/contentful-to-portable-text/src/blocks/embedded-html.ts
@@ -1,5 +1,6 @@
 import type { ArbitraryTypedObject } from "@portabletext/types";
 
+import { getStringField } from "../types.js";
 import type { ContentfulEntry } from "../types.js";
 
 /** HTML is preserved verbatim — sanitization is the renderer's responsibility. */
@@ -7,6 +8,6 @@ export function transformEmbeddedHtml(entry: ContentfulEntry, key: string): Arbi
 	return {
 		_type: "htmlBlock",
 		_key: key,
-		html: (entry.fields.customHtml as string) ?? "",
+		html: getStringField(entry.fields, "customHtml") ?? "",
 	};
 }

--- a/packages/contentful-to-portable-text/src/blocks/image-block.ts
+++ b/packages/contentful-to-portable-text/src/blocks/image-block.ts
@@ -1,6 +1,7 @@
 import type { ArbitraryTypedObject } from "@portabletext/types";
 
 import { sanitizeUri } from "../sanitize.js";
+import { getStringField, isContentfulLinkPayload } from "../types.js";
 import type { ContentfulEntry, ContentfulIncludes } from "../types.js";
 
 export function transformImageBlock(
@@ -8,11 +9,12 @@ export function transformImageBlock(
 	includes: ContentfulIncludes,
 	key: string,
 ): ArbitraryTypedObject {
-	const assetLink = entry.fields.assetFile as { sys?: { id?: string } } | undefined;
-	const assetId = assetLink?.sys?.id;
+	const assetLink = entry.fields.assetFile;
+	const assetId = isContentfulLinkPayload(assetLink) ? assetLink.sys.id : undefined;
 	const asset = assetId ? includes.assets.get(assetId) : undefined;
 
 	const src = asset?.url ? (asset.url.startsWith("//") ? `https:${asset.url}` : asset.url) : "";
+	const linkUrl = getStringField(entry.fields, "linkUrl");
 
 	return {
 		_type: "image",
@@ -23,7 +25,7 @@ export function transformImageBlock(
 			width: asset?.width,
 			height: asset?.height,
 		},
-		linkUrl: entry.fields.linkUrl ? sanitizeUri(entry.fields.linkUrl as string) : undefined,
-		size: (entry.fields.size as string) ?? undefined,
+		linkUrl: linkUrl ? sanitizeUri(linkUrl) : undefined,
+		size: getStringField(entry.fields, "size") ?? undefined,
 	};
 }

--- a/packages/contentful-to-portable-text/src/index.ts
+++ b/packages/contentful-to-portable-text/src/index.ts
@@ -48,6 +48,12 @@ import { transformCodeBlock } from "./blocks/code-block.js";
 import { transformEmbeddedHtml } from "./blocks/embedded-html.js";
 import { transformImageBlock } from "./blocks/image-block.js";
 import { sanitizeUri } from "./sanitize.js";
+import {
+	getStringField,
+	isContentfulLinkPayload,
+	isContentfulSysEnvelope,
+	parseAssetFile,
+} from "./types.js";
 import type { ContentfulIncludes, ConvertOptions } from "./types.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -187,13 +193,11 @@ function convertTextBlock(
 	const { children, markDefs } = convertInlineContent(content, includes, options, generateKey);
 
 	// Skip empty paragraphs (Contentful emits these often)
-	if (
-		style === "normal" &&
-		children.length === 1 &&
-		children[0]!._type === "span" &&
-		(children[0] as PortableTextSpan).text === ""
-	) {
-		return null;
+	if (style === "normal" && children.length === 1) {
+		const only = children[0]!;
+		if (only._type === "span" && typeof only.text === "string" && only.text === "") {
+			return null;
+		}
 	}
 
 	return {
@@ -321,8 +325,9 @@ function convertEmbeddedEntry(
 	includes: ContentfulIncludes,
 	generateKey: () => string,
 ): OutputBlock | null {
-	const targetId = (node.data?.target as { sys?: { id?: string } })?.sys?.id;
-	if (!targetId) return null;
+	const target: unknown = node.data?.target;
+	if (!isContentfulLinkPayload(target)) return null;
+	const targetId = target.sys.id;
 
 	const entry = includes.entries.get(targetId);
 	if (!entry) {
@@ -355,8 +360,9 @@ function convertEmbeddedAsset(
 	includes: ContentfulIncludes,
 	generateKey: () => string,
 ): OutputBlock | null {
-	const targetId = (node.data?.target as { sys?: { id?: string } })?.sys?.id;
-	if (!targetId) return null;
+	const target: unknown = node.data?.target;
+	if (!isContentfulLinkPayload(target)) return null;
+	const targetId = target.sys.id;
 
 	const asset = includes.assets.get(targetId);
 	if (!asset) {
@@ -400,7 +406,8 @@ function convertInlineContent(
 				marks,
 			});
 		} else if (node.nodeType === INLINES.HYPERLINK) {
-			const rawUri = (node.data?.uri as string) ?? "";
+			const uri: unknown = node.data?.uri;
+			const rawUri = typeof uri === "string" ? uri : "";
 			const href = sanitizeUri(rawUri);
 			const markKey = generateKey();
 			const isExternal = isExternalLink(href, options.blogHostname);
@@ -431,16 +438,18 @@ function convertInlineContent(
 			node.nodeType === INLINES.ENTRY_HYPERLINK ||
 			node.nodeType === INLINES.ASSET_HYPERLINK
 		) {
-			const targetId = (node.data?.target as { sys?: { id?: string } })?.sys?.id;
+			const target: unknown = node.data?.target;
+			const targetId = isContentfulLinkPayload(target) ? target.sys.id : undefined;
 			let href = "#";
 
 			if (node.nodeType === INLINES.ENTRY_HYPERLINK && targetId) {
 				const entry = includes.entries.get(targetId);
 				if (entry) {
+					const slug = getStringField(entry.fields, "slug");
 					const rawHref = options.entryHrefResolver
 						? options.entryHrefResolver(entry)
-						: entry.fields.slug
-							? `/${entry.fields.slug as string}/`
+						: slug
+							? `/${slug}/`
 							: "#";
 					href = sanitizeUri(rawHref);
 				}
@@ -473,7 +482,8 @@ function convertInlineContent(
 			node.nodeType === INLINES.EMBEDDED_ENTRY ||
 			node.nodeType === INLINES.EMBEDDED_RESOURCE
 		) {
-			const targetId = (node.data?.target as { sys?: { id?: string } })?.sys?.id;
+			const target: unknown = node.data?.target;
+			const targetId = isContentfulLinkPayload(target) ? target.sys.id : undefined;
 			console.warn(
 				`[rich-text-to-pt] Inline ${node.nodeType} encountered (target: ${targetId ?? "unknown"}). ` +
 					`Preserved as custom inline block — consumer should handle or strip.`,
@@ -560,30 +570,21 @@ export function buildIncludes(raw: {
 	const assets = new Map<string, import("./types.js").ContentfulAsset>();
 
 	for (const entry of raw.Entry ?? []) {
-		const sys = entry.sys as { id?: string; contentType?: { sys?: { id?: string } } } | undefined;
-		if (!sys?.id) continue;
-		entries.set(sys.id, {
-			id: sys.id,
-			contentType: sys.contentType?.sys?.id ?? "unknown",
-			fields: (entry.fields as Record<string, unknown>) ?? {},
+		if (!isContentfulSysEnvelope(entry)) continue;
+		entries.set(entry.sys.id, {
+			id: entry.sys.id,
+			contentType: entry.sys.contentType?.sys.id ?? "unknown",
+			fields: entry.fields ?? {},
 		});
 	}
 
 	for (const asset of raw.Asset ?? []) {
-		const sys = asset.sys as { id?: string } | undefined;
-		if (!sys?.id) continue;
-		const fields = asset.fields as Record<string, unknown> | undefined;
-		const file = fields?.file as
-			| {
-					url?: string;
-					contentType?: string;
-					details?: { image?: { width?: number; height?: number } };
-			  }
-			| undefined;
-		assets.set(sys.id, {
-			id: sys.id,
-			title: fields?.title as string | undefined,
-			description: fields?.description as string | undefined,
+		if (!isContentfulSysEnvelope(asset)) continue;
+		const file = parseAssetFile(asset.fields?.file);
+		assets.set(asset.sys.id, {
+			id: asset.sys.id,
+			title: getStringField(asset.fields, "title"),
+			description: getStringField(asset.fields, "description"),
 			url: file?.url ?? "",
 			width: file?.details?.image?.width,
 			height: file?.details?.image?.height,

--- a/packages/contentful-to-portable-text/src/types.ts
+++ b/packages/contentful-to-portable-text/src/types.ts
@@ -28,3 +28,130 @@ export interface ConvertOptions {
 	 */
 	entryHrefResolver?: (entry: ContentfulEntry) => string;
 }
+
+// ── Runtime shapes for Contentful payloads ───────────────────────────────────
+//
+// `@contentful/rich-text-types` types `node.data` loosely (effectively
+// `Record<string, any>`) because the shape of `data.target`, `data.uri`, and
+// related fields depends on the runtime resolution of includes. The guards
+// below validate the runtime shapes we read so the rest of the converter
+// can rely on typed values without scattered casts at every read site.
+
+/**
+ * Contentful link payload (`data.target` on embedded entry/asset nodes,
+ * and on entry/asset hyperlink inlines). Resolved against the includes
+ * map via `sys.id`.
+ */
+export interface ContentfulLinkPayload {
+	sys: { id: string };
+}
+
+/**
+ * Contentful entry/asset envelope (top-level item in an export's
+ * `Entry` / `Asset` arrays). The `sys.contentType.sys.id` chain is only
+ * present on entries.
+ */
+export interface ContentfulSysEnvelope {
+	sys: { id: string; contentType?: { sys: { id: string } } };
+	fields?: Record<string, unknown>;
+}
+
+/**
+ * Contentful asset `fields.file` shape, defined by the Contentful
+ * Delivery API. All members optional because legacy/draft assets may
+ * omit any of them.
+ */
+export interface ContentfulAssetFile {
+	url?: string;
+	contentType?: string;
+	details?: {
+		image?: {
+			width?: number;
+			height?: number;
+		};
+	};
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Type guard for the `{ sys: { id: string } }` link payload Contentful
+ * uses for embedded entries, embedded assets, and entry/asset hyperlinks.
+ */
+export function isContentfulLinkPayload(value: unknown): value is ContentfulLinkPayload {
+	if (!isObject(value)) return false;
+	const sys = value.sys;
+	if (!isObject(sys)) return false;
+	return typeof sys.id === "string";
+}
+
+/**
+ * Type guard for a top-level Contentful entry/asset envelope from an
+ * export's `Entry` / `Asset` arrays. Requires `sys.id`; `contentType`
+ * and `fields` are validated only as far as needed for the converter.
+ */
+export function isContentfulSysEnvelope(value: unknown): value is ContentfulSysEnvelope {
+	if (!isObject(value)) return false;
+	const sys = value.sys;
+	if (!isObject(sys)) return false;
+	if (typeof sys.id !== "string") return false;
+	if (sys.contentType !== undefined) {
+		if (!isObject(sys.contentType)) return false;
+		const ctSys = sys.contentType.sys;
+		if (!isObject(ctSys) || typeof ctSys.id !== "string") return false;
+	}
+	if (value.fields !== undefined && !isObject(value.fields)) return false;
+	return true;
+}
+
+/**
+ * Narrow `fields[key]` to `string | undefined`. Non-strings are treated
+ * as missing — the converter never wants to surface a non-string field
+ * as text.
+ */
+export function getStringField(
+	fields: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const value = fields?.[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Narrow `fields[key]` to a record (object). Used for nested field
+ * shapes like `fields.file` on assets, or the `data.target` link
+ * payload.
+ */
+export function getRecordField(
+	fields: Record<string, unknown> | undefined,
+	key: string,
+): Record<string, unknown> | undefined {
+	const value = fields?.[key];
+	return isObject(value) ? value : undefined;
+}
+
+/**
+ * Parse a Contentful asset `fields.file` value into the typed shape.
+ * Returns `undefined` when the value is missing or not an object;
+ * individual fields are validated and dropped if of the wrong type.
+ */
+export function parseAssetFile(value: unknown): ContentfulAssetFile | undefined {
+	if (!isObject(value)) return undefined;
+	const file: ContentfulAssetFile = {};
+	if (typeof value.url === "string") file.url = value.url;
+	if (typeof value.contentType === "string") file.contentType = value.contentType;
+	if (isObject(value.details)) {
+		const image = isObject(value.details.image) ? value.details.image : undefined;
+		if (image) {
+			file.details = {
+				image: {
+					width: typeof image.width === "number" ? image.width : undefined,
+					height: typeof image.height === "number" ? image.height : undefined,
+				},
+			};
+		}
+	}
+	return file;
+}

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -371,7 +371,7 @@ export async function assertSafeArtifactUrl(urlString: string): Promise<URL> {
 		return await resolveAndValidateExternalUrl(url.href);
 	} catch (err) {
 		if (err instanceof SsrfError) {
-			throw new Error(`Artifact URL rejected: ${err.message}`);
+			throw new Error(`Artifact URL rejected: ${err.message}`, { cause: err });
 		}
 		throw err;
 	}

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -20,7 +20,7 @@ function normalizeMimeFilter(input?: string | readonly string[]): string[] {
 	return arr
 		.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
 		.map((entry) =>
-			entry.endsWith("/") ? entry.toLowerCase() : entry.split(";")[0]!.trim().toLowerCase(),
+			entry.endsWith("/") ? entry.toLowerCase() : entry.split(";")[0].trim().toLowerCase(),
 		);
 }
 

--- a/packages/core/src/media/mime.ts
+++ b/packages/core/src/media/mime.ts
@@ -1,5 +1,5 @@
 export function normalizeMime(mime: string): string {
-	return mime.split(";")[0]!.trim().toLowerCase();
+	return mime.split(";")[0].trim().toLowerCase();
 }
 
 export function matchesMimeAllowlist(mime: string, allowList: readonly string[]): boolean {

--- a/packages/core/src/plugins/adapt-sandbox-entry.ts
+++ b/packages/core/src/plugins/adapt-sandbox-entry.ts
@@ -11,7 +11,7 @@
  */
 
 import type { PluginDescriptor } from "../astro/integration/runtime.js";
-import type { SandboxedPlugin } from "../plugin-types.js";
+import type { RouteEntry, RouteHandler, SandboxedPlugin } from "../plugin-types.js";
 import { PLUGIN_CAPABILITIES, HOOK_NAMES } from "./manifest-schema.js";
 import { normalizeCapabilities } from "./types.js";
 import type {
@@ -96,6 +96,31 @@ function resolveSandboxedHook(entry: AnyHookEntry, pluginId: string): ResolvedHo
 	};
 }
 
+/**
+ * Normalise a `RouteEntry` (bare handler or `{ handler, public?, input? }`
+ * config) to the config form. The `input` schema is intentionally typed
+ * `unknown` in `RouteEntry` — sandboxed plugins describe it loosely
+ * because the strict `z.ZodType<TInput>` constraint of the runtime's
+ * `PluginRoute` only narrows once the route is wired into the router.
+ * The wider type flows through to the runtime which validates at
+ * invocation time.
+ */
+function normalizeRouteEntry(entry: RouteEntry): {
+	handler: RouteHandler;
+	public?: boolean;
+	input?: PluginRoute["input"];
+} {
+	if (typeof entry === "function") {
+		return { handler: entry };
+	}
+	return {
+		handler: entry.handler,
+		public: entry.public,
+		// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- RouteEntry.input is intentionally `unknown` (sandboxed plugins) and validated by the runtime at invocation time
+		input: entry.input as PluginRoute["input"],
+	};
+}
+
 const VALID_CAPABILITIES_SET = new Set<string>(PLUGIN_CAPABILITIES);
 
 const VALID_HOOK_NAMES_SET = new Set<string>(HOOK_NAMES);
@@ -136,9 +161,13 @@ export function adaptSandboxEntry(
 	// Resolve hooks. `SandboxedPlugin.hooks` is keyed by hook name with
 	// per-key entry types; iterating with `Object.entries` collapses
 	// keys to `string`, so we treat each entry as the union `AnyHookEntry`
-	// for the duration of the loop.
+	// for the duration of the loop. The widening from the strict mapped
+	// type to a plain record is sound because each entry still matches
+	// one of the bare-handler / config-object shapes captured by
+	// `AnyHookEntry`.
 	const resolvedHooks: ResolvedPluginHooks = {};
 	if (definition.hooks) {
+		// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- widening the strict mapped type to a string-keyed record for iteration; entries still match AnyHookEntry
 		const hookMap = definition.hooks as Record<string, AnyHookEntry>;
 		for (const [hookName, entry] of Object.entries(hookMap)) {
 			if (!VALID_HOOK_NAMES_SET.has(hookName)) {
@@ -166,49 +195,25 @@ export function adaptSandboxEntry(
 	const resolvedRoutes: Record<string, PluginRoute> = {};
 	if (definition.routes) {
 		for (const [routeName, rawEntry] of Object.entries(definition.routes)) {
-			const isConfig = typeof rawEntry === "object" && rawEntry !== null && "handler" in rawEntry;
-			const handler = isConfig
-				? (rawEntry as { handler: (...args: unknown[]) => Promise<unknown> }).handler
-				: (rawEntry as (...args: unknown[]) => Promise<unknown>);
-			const publicFlag = isConfig ? (rawEntry as { public?: boolean }).public : undefined;
-			const inputSchema = isConfig ? (rawEntry as { input?: unknown }).input : undefined;
+			const normalized = normalizeRouteEntry(rawEntry);
+			const { handler, public: publicFlag, input: inputSchema } = normalized;
 			resolvedRoutes[routeName] = {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- route entry.input is intentionally loosely typed; callers validate at runtime
-				input: inputSchema as PluginRoute["input"],
+				input: inputSchema,
 				public: publicFlag,
 				handler: async (ctx) => {
-					// In-process, `ctx.request` is a real WHATWG `Request`
-					// with a `Headers` object. The author-facing
-					// `SandboxedRequest` type promises a plain
-					// `Record<string, string>` (the shape the sandbox's
-					// serialised form delivers). Normalise so handlers
-					// behave the same in-process and in-isolate.
+					// `ctx.request` is a real WHATWG `Request` (this is the
+					// in-process adapter; the worker-sandbox adapter handles
+					// the serialised case). Flatten `Headers` to the plain
+					// `Record<string, string>` shape that author-facing
+					// `SandboxedRequest` promises so handler bodies are
+					// identical across both adapters.
 					const headers: Record<string, string> = {};
-					if (ctx.request && typeof ctx.request === "object") {
-						const h: unknown = (ctx.request as { headers?: unknown }).headers;
-						if (h && typeof h === "object") {
-							if (typeof (h as Headers).forEach === "function") {
-								(h as Headers).forEach((value, name) => {
-									headers[name] = value;
-								});
-							} else {
-								for (const [name, value] of Object.entries(h as Record<string, string>)) {
-									headers[name] = value;
-								}
-							}
-						}
-					}
+					ctx.request.headers.forEach((value, name) => {
+						headers[name] = value;
+					});
 					const requestShape = {
-						url:
-							(ctx.request as { url?: unknown } | undefined)?.url &&
-							typeof (ctx.request as { url: unknown }).url === "string"
-								? (ctx.request as { url: string }).url
-								: "",
-						method:
-							(ctx.request as { method?: unknown } | undefined)?.method &&
-							typeof (ctx.request as { method: unknown }).method === "string"
-								? (ctx.request as { method: string }).method
-								: "GET",
+						url: ctx.request.url,
+						method: ctx.request.method,
 						headers,
 					};
 					const routeCtx = {

--- a/packages/core/src/registry/config.ts
+++ b/packages/core/src/registry/config.ts
@@ -130,7 +130,7 @@ export function parseDurationSeconds(duration: string | number): number {
 		);
 	}
 
-	const value = parseInt(match[1]!, 10);
+	const value = parseInt(match[1], 10);
 	const unit = match[2];
 
 	switch (unit) {

--- a/packages/plugin-cli/src/build/pipeline.ts
+++ b/packages/plugin-cli/src/build/pipeline.ts
@@ -363,8 +363,8 @@ export async function probeAndAssemble(ctx: ProbeAndAssembleContext): Promise<Re
 			}
 			resolvedPlugin.hooks[hookName] = {
 				handler,
-				priority: (config.priority as number | undefined) ?? 100,
-				timeout: (config.timeout as number | undefined) ?? 5000,
+				priority: config.priority ?? 100,
+				timeout: config.timeout ?? 5000,
 				dependencies: (config.dependencies as string[] | undefined) ?? [],
 				errorPolicy: (config.errorPolicy as string | undefined) ?? "abort",
 				exclusive: (config.exclusive as boolean | undefined) ?? false,

--- a/packages/plugins/marketplace-test/src/plugin.ts
+++ b/packages/plugins/marketplace-test/src/plugin.ts
@@ -24,7 +24,7 @@ export default {
 
 				// Record execution in storage so the registry's install
 				// audit can verify the hook actually ran post-install.
-				await ctx.storage.events!.put(`hook-${Date.now()}`, {
+				await ctx.storage.events.put(`hook-${Date.now()}`, {
 					timestamp: new Date().toISOString(),
 					type: "content:beforeSave",
 					collection: event.collection,
@@ -47,7 +47,7 @@ export default {
 
 		events: {
 			handler: async (_routeCtx, ctx) => {
-				const result = await ctx.storage.events!.query({ limit: 10 });
+				const result = await ctx.storage.events.query({ limit: 10 });
 				return { count: result.items.length, items: result.items };
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

Cleans up 47 of 56 type-aware oxlint warnings across the monorepo. The remaining 9 are all `no-unsafe-type-assertion` warnings in `packages/plugin-cli/src/build/pipeline.ts`, which parses untyped `package.json` and plugin probe output. Those warrant a separate PR introducing Zod schemas at the parse boundary; that work is queued.

Changes by category:

- **`preserve-caught-error` (1)**: add `cause` when re-throwing in `registry.ts` artifact-URL validation.
- **`no-unused-vars` (3)**: drop the stale `Link` import from `ContentEditor.tsx`; prefix two intentionally-side-effect-only e2e variables with `_`.
- **`no-shadow` (2)**: rename locals that shadowed Lingui macros (`msg`, `plural`).
- **`no-unnecessary-type-assertion` (9)**: drop redundant `as Foo | undefined` casts where prior `typeof` checks already narrow the type, and drop `!` non-null assertions in `packages/core` where its tsconfig sets `noUncheckedIndexedAccess: false`. Also drop two `pageParam as string | undefined` casts in admin that were redundant given `initialPageParam`.
- **`atproto-test-utils` (4 warnings cleared via config)**: this package is a test-fixture utility and legitimately produces branded ATProto types via narrowing casts. Added it to the existing test override in `.oxlintrc.json` so the assertion rules don't apply, matching the treatment of in-tree `tests/` directories.
- **`contentful-to-portable-text` (18 warnings → 0)**: added runtime type guards in `types.ts` (`isContentfulLinkPayload`, `isContentfulSysEnvelope`, `parseAssetFile`, `getStringField`, `getRecordField`) and use them throughout. Replaces scattered `as { sys?: { id?: string } }` and `as string` casts with validated narrowing. The walker is unchanged behaviorally; the `buildIncludes` envelope parse is now strict-on-shape (an entry missing `sys.id` is dropped, same as before, but the discriminant is a validated guard rather than a chained optional read).
- **`adapt-sandbox-entry` (6 warnings → 0)**: extracted a `normalizeRouteEntry` helper, simplified the headers normalisation since `ctx.request` is always a real `Request` in the in-process adapter, narrowed the remaining two boundary casts to single `eslint-disable-next-line` comments with rationale (the strict mapped-type → string-keyed-record widening for hook iteration; and the loosely-typed sandboxed `RouteEntry.input` flowing into the runtime's `PluginRoute.input`).
- **`admin/api/registry` (2 warnings → 0)**: use the shared `parseApiResponse<T>` helper for the install endpoint (matching the rest of the file's pattern); the localStorage handle-cache parse now uses an `isCachedResolution` type guard.

No behavior changes for any user. All 4,315 tests across `core`, `admin`, and `contentful-to-portable-text` pass.

I also noticed `pnpm lint` is non-deterministic with `--type-aware`: five consecutive runs at HEAD produced 56, 56, 56, 97, 56. Looks like a threading race in oxlint's type-aware mode. Worth filing upstream separately, not in scope for this PR.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (steady-state: 9 remaining warnings, all in `packages/plugin-cli/src/build/pipeline.ts`, deferred to a Zod-driven follow-up PR)
- [x] `pnpm test` passes (`core`: 3,376; `admin`: 879; `contentful-to-portable-text`: 60)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A, no behavior change
- [ ] User-visible strings in the admin UI are wrapped for translation — N/A
- [ ] I have added a changeset — intentionally skipped, no user-visible behavior change
- [ ] New features link to an approved Discussion — N/A

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (Innie via OpenCode)

## Screenshots / test output

n/a