### PR TITLE
chore: switch kysely to workspace catalog

### DIFF
--- a/.changeset/workerd-kysely-catalog.md
+++ b/.changeset/workerd-kysely-catalog.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/sandbox-workerd": patch
+---
+
+Aligns the `kysely` peer dependency with the rest of the monorepo (`>=0.29.0`) and switches the dev/peer references to the workspace catalog so all packages bump in lockstep going forward.

--- a/packages/auth-atproto/package.json
+++ b/packages/auth-atproto/package.json
@@ -48,6 +48,6 @@
 		"@atcute/identity-resolver": "^1.2.2",
 		"@atcute/oauth-node-client": "^1.1.0",
 		"@emdash-cms/auth": "workspace:*",
-    "kysely": "^0.29.0"
+    "kysely": "catalog:"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -222,7 +222,7 @@
     "image-size": "^2.0.2",
     "jose": "^6.1.3",
     "jpeg-js": "^0.4.4",
-    "kysely": "^0.29.0",
+    "kysely": "catalog:",
     "mime": "^4.1.0",
     "modern-tar": "^0.7.5",
     "picocolors": "^1.1.1",

--- a/packages/workerd/package.json
+++ b/packages/workerd/package.json
@@ -28,7 +28,7 @@
 		"ulidx": "^2.4.1"
 	},
 	"peerDependencies": {
-		"kysely": ">=0.27.0",
+		"kysely": ">=0.29.0",
 		"workerd": ">=1.0.0"
 	},
 	"optionalDependencies": {
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@types/better-sqlite3": "catalog:",
 		"better-sqlite3": "catalog:",
-		"kysely": "^0.27.0",
+		"kysely": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ catalogs:
     jsonc-parser:
       specifier: ^3.3.1
       version: 3.3.1
+    kysely:
+      specifier: ^0.29.0
+      version: 0.29.2
     publint:
       specifier: 0.3.17
       version: 0.3.17
@@ -1175,7 +1178,7 @@ importers:
         specifier: workspace:>=0.14.0
         version: link:../core
       kysely:
-        specifier: ^0.29.0
+        specifier: 'catalog:'
         version: 0.29.2
       react:
         specifier: '>=18'
@@ -1474,7 +1477,7 @@ importers:
         specifier: ^0.4.4
         version: 0.4.4
       kysely:
-        specifier: ^0.29.0
+        specifier: 'catalog:'
         version: 0.29.2
       mime:
         specifier: ^4.1.0
@@ -2032,8 +2035,8 @@ importers:
         specifier: 'catalog:'
         version: 12.8.0
       kysely:
-        specifier: ^0.27.0
-        version: 0.27.6
+        specifier: 'catalog:'
+        version: 0.29.2
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.16.4)(publint@0.3.17)(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,6 +130,7 @@ catalog:
   better-sqlite3: ^12.8.0
   chokidar: ^5.0.0
   jsonc-parser: ^3.3.1
+  kysely: ^0.29.0
   publint: 0.3.17
   react: 19.2.4
   react-dom: 19.2.4


### PR DESCRIPTION
## What does this PR do?

The new `packages/workerd` (`@emdash-cms/sandbox-workerd`, added in #426) declared `kysely` at `^0.27.0`, while the rest of the monorepo has been on `^0.29.0` for a while. That meant `pnpm install` was happy to resolve two different kysely versions side by side.

This PR:

- Adds `kysely: ^0.29.0` to the `pnpm-workspace.yaml` catalog.
- Switches the direct `kysely` references in `emdash`, `@emdash-cms/auth-atproto`, and `@emdash-cms/sandbox-workerd` to `catalog:`.
- Bumps `sandbox-workerd`'s `kysely` peer range from `>=0.27.0` to `>=0.29.0` so it reflects the version actually exercised in CI.
- Leaves the peer-only references in `@emdash-cms/auth` and `@emdash-cms/cloudflare` alone — peers stay as explicit ranges.
- Regenerates `pnpm-lock.yaml`.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

None — package metadata + lockfile only.
