### PR TITLE
feat: bylines i18n support

### DIFF
--- a/.changeset/bylines-i18n.md
+++ b/.changeset/bylines-i18n.md
@@ -25,6 +25,8 @@ Author-inferred bylines (where an entry has no explicit credits but its author i
 
 This is a deliberate behavior change for multilingual sites. The motivation is correctness: chain-walking credits across locales renders the wrong-language bio on translated entries.
 
+The "explicit credit suppresses author fallback" check reads `primary_byline_id` directly from the content row — set by `setContentBylines` iff junction rows exist, backfilled by migration 040 for pre-existing rows. No separate probe against `_emdash_content_bylines` is needed at hydration time; the column is folded into the single per-entry context fetch (`author_id` + `primary_byline_id` in one query). Both monolingual and multilingual sites get the same query count.
+
 ## Identity lookups: chain-walk
 
 `getBylineBySlug(slug, { locale })` walks the configured fallback chain (`resolveLocaleChain`), like `getMenu` and `getTerm`. Author pages for un-translated bylines still render an identity rather than 404'ing. This is conceptually distinct from credit hydration and runs through `requestCached` for per-render dedupe.

--- a/.changeset/bylines-i18n.md
+++ b/.changeset/bylines-i18n.md
@@ -1,0 +1,67 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+"@emdash-cms/auth": minor
+---
+
+Adds first-class i18n support for bylines, mirroring the row-per-locale model already used by menus and taxonomies (PR #916, migrations 036).
+
+## Schema (migration 040)
+
+`_emdash_bylines` gains two columns:
+
+- `locale` — `TEXT NOT NULL DEFAULT 'en'`. Every row now belongs to exactly one locale.
+- `translation_group` — `TEXT NOT NULL`. Shared across every locale variant of a single byline identity. The anchor row's `translation_group` equals its `id`; siblings inherit it.
+
+A partial unique index `idx_bylines_group_locale_unique` enforces one row per `(translation_group, locale)`. The pre-existing `(slug)` unique index becomes `(slug, locale)` to allow the same slug across locales.
+
+Existing rows are backfilled to the configured `defaultLocale` (or `'en'` if i18n isn't configured) with `translation_group = id`. Monolingual sites see no functional change; multilingual sites continue rendering the same byline data at the default locale until editors create translations.
+
+## Credit hydration: strict per-locale
+
+`_emdash_content_bylines.byline_id` now stores the byline's `translation_group`, not its row id. When an entry is rendered, credits are filtered by joining the junction against the byline sibling whose `locale` matches the entry's `locale`. If no sibling exists at the entry's locale, the credit hydrates as empty — there is **no fallback** to other locales' bios.
+
+Author-inferred bylines (where an entry has no explicit credits but its author is linked to a byline) still fall back per-locale and respect the strictness gate: an entry with explicit credits at any locale will not infer from the author even if the explicit credits don't resolve at the rendering locale.
+
+This is a deliberate behavior change for multilingual sites. The motivation is correctness: chain-walking credits across locales renders the wrong-language bio on translated entries.
+
+## Identity lookups: chain-walk
+
+`getBylineBySlug(slug, { locale })` walks the configured fallback chain (`resolveLocaleChain`), like `getMenu` and `getTerm`. Author pages for un-translated bylines still render an identity rather than 404'ing. This is conceptually distinct from credit hydration and runs through `requestCached` for per-render dedupe.
+
+## Admin
+
+- **TranslationsPanel** in the bylines editor lists every configured locale with Edit / Translate buttons. The Translate action POSTs to the new `POST /_emdash/api/admin/bylines/:id/translations` endpoint.
+- **LocaleSwitcher** on `/bylines` filters the list strictly to one locale. Cross-locale navigation via TranslationsPanel routes through `/bylines?locale=…`.
+- The **byline picker** on the content editor is locale-pinned to the entry's locale. Editors only see bylines that will actually hydrate at the entry's locale.
+- The **byline credit empty state** on a locale with no bylines yet shows a CTA linking to `/bylines?locale=…` for inline creation.
+- Translating an entry (`POST /content/:collection` with `translationOf`) calls `copyContentBylines` to inherit the source's credits — these resolve at the new entry's locale via the strict-hydration model, so credits "follow" the content across translations once sibling bylines exist.
+
+## API additions
+
+- `GET /_emdash/api/admin/bylines/:id/translations` — list every sibling row sharing a translation_group.
+- `POST /_emdash/api/admin/bylines/:id/translations` — create a sibling at a target locale. Body defaults (slug, displayName, websiteUrl, avatar) inherit from the source.
+- `POST /_emdash/api/admin/bylines` accepts `translationOf` + `locale` to create a sibling in one call.
+- `GET /_emdash/api/admin/bylines?locale=…` filters strictly.
+- `BylineSummary` gains `locale: string` and `translationGroup: string | null` (additive — existing consumers ignore the new fields).
+
+## Permissions
+
+Two new entries on `@emdash-cms/auth`:
+
+- `bylines:read` — minimum `SUBSCRIBER`.
+- `bylines:manage` — minimum `EDITOR`.
+
+All byline routes (list, get, update, delete, translations) now check these instead of `content:read` / `Role.EDITOR`. Role thresholds are unchanged, so existing users see no permission differences. Custom RBAC configurations that bind to the old strings should add the new permission names.
+
+## Repository
+
+- `BylineRepository` is strict per-locale: `findMany`, `findBySlug`, `findById` accept an optional `locale` and return rows matching that locale (or all locales when omitted, for the manager view).
+- New methods: `listTranslations(id)`, `findByTranslationGroup(group)`, `copyContentBylines(collection, fromId, toId)`.
+- `setContentBylines` deduplicates by `translation_group` after resolving wire row ids, so passing two sibling row ids of the same identity collapses to one credit row.
+- `delete` is sibling-aware: removing one locale variant leaves siblings standing.
+
+## Notable trade-offs
+
+- **Strict hydration over chain-walking** for credits. Chain-walking would render mismatched-language bios on translated content. The honest answer is to show nothing rather than the wrong thing; the picker tells editors which bylines will resolve at the entry's locale, and the empty-state CTA makes creating a sibling a one-click flow.
+- **Schema is row-per-locale**, not a separate `byline_translations` side-table. Matches the existing content / menu / taxonomy convention so query patterns and indexes are consistent across the codebase.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -109,6 +109,13 @@ export interface ContentEditorProps {
 	item?: ContentItem | null;
 	fields: Record<string, FieldDescriptor>;
 	isNew?: boolean;
+	/**
+	 * Locale this entry is bound to. For existing entries this matches
+	 * `item.locale`; for new entries it's the URL `?locale=` (or default).
+	 * Threaded into the byline picker so the empty-state CTA links to the
+	 * right locale on the Bylines manager.
+	 */
+	entryLocale?: string | null;
 	isSaving?: boolean;
 	onSave?: (payload: {
 		data: Record<string, unknown>;
@@ -196,6 +203,7 @@ export function ContentEditor({
 	item,
 	fields,
 	isNew,
+	entryLocale,
 	isSaving,
 	onSave,
 	onAutosave,
@@ -238,6 +246,11 @@ export function ContentEditor({
 		item?.bylines?.map((entry) => ({ bylineId: entry.byline.id, roleLabel: entry.roleLabel })) ??
 			[],
 	);
+	// Only send `bylines` when the user actually touched the editor. Strict
+	// per-locale hydration can return `item.bylines = []` for entries with
+	// copied credits at other locales — sending `[]` on every save would
+	// silently wipe them. Mirrors the `slugTouched` pattern above.
+	const [bylinesTouched, setBylinesTouched] = React.useState(false);
 
 	// Track portableText editor for document outline. Only the "content"
 	// field wires its editor into this slot (see onEditorReady below).
@@ -311,6 +324,7 @@ export function ContentEditor({
 			}),
 		);
 		pendingAutosaveStateRef.current = null;
+		setBylinesTouched(false);
 	}
 
 	// Update form and last saved state when item changes (e.g., after save or restore)
@@ -338,6 +352,7 @@ export function ContentEditor({
 				}),
 			);
 			pendingAutosaveStateRef.current = null;
+			setBylinesTouched(false);
 		}
 	}, [item?.updatedAt, itemDataString, item?.slug, item?.status]);
 
@@ -345,6 +360,7 @@ export function ContentEditor({
 
 	const handleBylinesChange = React.useCallback(
 		(next: BylineCreditInput[]) => {
+			setBylinesTouched(true);
 			if (isNew) {
 				onBylinesChange?.(next);
 				return;
@@ -416,15 +432,19 @@ export function ContentEditor({
 		// Schedule autosave
 		autosaveTimeoutRef.current = setTimeout(() => {
 			if (hasInvalidUrls(formDataRef.current)) return;
-			const payload = {
+			const payload: {
+				data: Record<string, unknown>;
+				slug?: string;
+				bylines?: BylineCreditInput[];
+			} = {
 				data: formDataRef.current,
 				slug: slugRef.current || undefined,
-				bylines: activeBylines,
 			};
+			if (bylinesTouched) payload.bylines = activeBylines;
 			pendingAutosaveStateRef.current = serializeEditorState({
 				data: payload.data,
 				slug: payload.slug || "",
-				bylines: payload.bylines,
+				bylines: activeBylines,
 			});
 			onAutosave(payload);
 		}, AUTOSAVE_DELAY);
@@ -443,6 +463,7 @@ export function ContentEditor({
 		isSaving,
 		isAutosaving,
 		activeBylines,
+		bylinesTouched,
 		hasInvalidUrls,
 	]);
 
@@ -455,11 +476,16 @@ export function ContentEditor({
 			clearTimeout(autosaveTimeoutRef.current);
 			autosaveTimeoutRef.current = null;
 		}
-		onSave?.({
+		const payload: {
+			data: Record<string, unknown>;
+			slug?: string;
+			bylines?: BylineCreditInput[];
+		} = {
 			data: formData,
 			slug: slug || undefined,
-			bylines: activeBylines,
-		});
+		};
+		if (isNew || bylinesTouched) payload.bylines = activeBylines;
+		onSave?.(payload);
 	};
 
 	// Preview URL state
@@ -971,6 +997,10 @@ export function ContentEditor({
 										onChange={handleBylinesChange}
 										onQuickCreate={onQuickCreateByline}
 										onQuickEdit={onQuickEditByline}
+										// Existing entry: use its own locale. New entry: use the
+										// URL `?locale=` (passed in via `entryLocale`).
+										entryLocale={item?.locale ?? entryLocale}
+										i18n={i18n}
 									/>
 								</div>
 							)}
@@ -1894,6 +1924,15 @@ interface BylineCreditsEditorProps {
 		bylineId: string,
 		input: { slug: string; displayName: string },
 	) => Promise<BylineSummary>;
+	/**
+	 * Locale of the entry being edited. When the picker comes back empty and
+	 * the install is multi-locale, the empty-state copy and CTA link are
+	 * scoped to this locale (post-migration 040, the picker is strict
+	 * per-locale — see the bylines manager flow).
+	 */
+	entryLocale?: string | null;
+	/** i18n config from the manifest. When set with >1 locales, the editor renders the locale-scoped empty-state. */
+	i18n?: { defaultLocale: string; locales: string[] } | null;
 }
 
 function BylineCreditsEditor({
@@ -1902,6 +1941,8 @@ function BylineCreditsEditor({
 	onChange,
 	onQuickCreate,
 	onQuickEdit,
+	entryLocale,
+	i18n,
 }: BylineCreditsEditorProps) {
 	const { t } = useLingui();
 	const [selectedBylineId, setSelectedBylineId] = React.useState("");
@@ -1949,8 +1990,32 @@ function BylineCreditsEditor({
 		setEditError(null);
 	};
 
+	// Multi-locale install with no bylines available at the entry's locale:
+	// show an honest empty-state CTA pointing the editor at the byline
+	// manager, scoped to this locale. The picker stays rendered (the
+	// editor can still quick-create) but is empty until a per-locale
+	// variant exists. Mirrors the strict per-locale model from migration
+	// 040 — the picker only offers bylines that will actually hydrate.
+	const isMultiLocale = !!i18n && i18n.locales.length > 1;
+	const showLocaleEmptyState = isMultiLocale && bylines.length === 0 && !!entryLocale;
+
 	return (
 		<div className="space-y-3">
+			{showLocaleEmptyState && (
+				<div className="rounded border border-dashed p-3 text-sm space-y-2">
+					<p className="text-kumo-subtle">
+						{t`No bylines available in ${entryLocale}. Create a variant from the Bylines page before crediting one on this entry.`}
+					</p>
+					<RouterLinkButton
+						to="/bylines"
+						search={{ locale: entryLocale ?? undefined }}
+						variant="secondary"
+						size="sm"
+					>
+						{t`Manage bylines in ${entryLocale}`}
+					</RouterLinkButton>
+				</div>
+			)}
 			<div className="flex gap-2">
 				<Select
 					value={selectedBylineId}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -156,6 +156,8 @@ export interface ContentEditorProps {
 	onAuthorChange?: (authorId: string | null) => void;
 	/** Available byline profiles */
 	availableBylines?: BylineSummary[];
+	/** Whether the parent's byline picker query has resolved. Suppresses the empty-state flash before first fetch. */
+	availableBylinesLoaded?: boolean;
 	/** Selected byline credits (controlled for new entries) */
 	selectedBylines?: BylineCreditInput[];
 	/** Callback when byline credits are changed */
@@ -222,6 +224,7 @@ export function ContentEditor({
 	users,
 	onAuthorChange,
 	availableBylines,
+	availableBylinesLoaded,
 	selectedBylines,
 	onBylinesChange,
 	onQuickCreateByline,
@@ -246,10 +249,10 @@ export function ContentEditor({
 		item?.bylines?.map((entry) => ({ bylineId: entry.byline.id, roleLabel: entry.roleLabel })) ??
 			[],
 	);
-	// Only send `bylines` when the user actually touched the editor. Strict
-	// per-locale hydration can return `item.bylines = []` for entries with
-	// copied credits at other locales — sending `[]` on every save would
-	// silently wipe them. Mirrors the `slugTouched` pattern above.
+	// Gates whether `bylines` is included in the save payload. Untouched
+	// edits must not ship `[]` — strict per-locale hydration can return
+	// empty for entries with credits at other locales, and sending `[]`
+	// would wipe them.
 	const [bylinesTouched, setBylinesTouched] = React.useState(false);
 
 	// Track portableText editor for document outline. Only the "content"
@@ -994,6 +997,7 @@ export function ContentEditor({
 									<BylineCreditsEditor
 										credits={activeBylines}
 										bylines={availableBylines ?? []}
+										bylinesLoaded={availableBylinesLoaded}
 										onChange={handleBylinesChange}
 										onQuickCreate={onQuickCreateByline}
 										onQuickEdit={onQuickEditByline}
@@ -1933,6 +1937,8 @@ interface BylineCreditsEditorProps {
 	entryLocale?: string | null;
 	/** i18n config from the manifest. When set with >1 locales, the editor renders the locale-scoped empty-state. */
 	i18n?: { defaultLocale: string; locales: string[] } | null;
+	/** Suppresses the empty-state until the picker query resolves. Defaults to true. */
+	bylinesLoaded?: boolean;
 }
 
 function BylineCreditsEditor({
@@ -1943,6 +1949,7 @@ function BylineCreditsEditor({
 	onQuickEdit,
 	entryLocale,
 	i18n,
+	bylinesLoaded = true,
 }: BylineCreditsEditorProps) {
 	const { t } = useLingui();
 	const [selectedBylineId, setSelectedBylineId] = React.useState("");
@@ -1990,14 +1997,12 @@ function BylineCreditsEditor({
 		setEditError(null);
 	};
 
-	// Multi-locale install with no bylines available at the entry's locale:
-	// show an honest empty-state CTA pointing the editor at the byline
-	// manager, scoped to this locale. The picker stays rendered (the
-	// editor can still quick-create) but is empty until a per-locale
-	// variant exists. Mirrors the strict per-locale model from migration
-	// 040 — the picker only offers bylines that will actually hydrate.
+	// Multi-locale install with no bylines at the entry's locale: show a
+	// CTA to the byline manager, scoped to that locale. Quick-create
+	// still works inline.
 	const isMultiLocale = !!i18n && i18n.locales.length > 1;
-	const showLocaleEmptyState = isMultiLocale && bylines.length === 0 && !!entryLocale;
+	const showLocaleEmptyState =
+		isMultiLocale && bylinesLoaded && bylines.length === 0 && !!entryLocale;
 
 	return (
 		<div className="space-y-3">

--- a/packages/admin/src/lib/api/bylines.ts
+++ b/packages/admin/src/lib/api/bylines.ts
@@ -20,6 +20,13 @@ export interface BylineSummary {
 	isGuest: boolean;
 	createdAt: string;
 	updatedAt: string;
+	/** Locale this byline row is presented in (migration 040). */
+	locale: string;
+	/**
+	 * Shared across translations of the same byline (migration 040).
+	 * Nullable for backwards compatibility; new rows always populate it.
+	 */
+	translationGroup: string | null;
 }
 
 export interface BylineInput {
@@ -30,6 +37,25 @@ export interface BylineInput {
 	websiteUrl?: string | null;
 	userId?: string | null;
 	isGuest?: boolean;
+	/**
+	 * Locale this byline row belongs to. When omitted, the server uses the
+	 * configured `defaultLocale`.
+	 */
+	locale?: string;
+	/**
+	 * When set, the new row joins the source byline's `translation_group`.
+	 * Requires `locale` (the server returns a validation error otherwise).
+	 */
+	translationOf?: string;
+}
+
+export interface BylineTranslationInput {
+	locale: string;
+	slug?: string;
+	displayName?: string;
+	bio?: string | null;
+	avatarMediaId?: string | null;
+	websiteUrl?: string | null;
 }
 
 export interface BylineCreditInput {
@@ -41,6 +67,7 @@ export async function fetchBylines(options?: {
 	search?: string;
 	isGuest?: boolean;
 	userId?: string;
+	locale?: string;
 	cursor?: string;
 	limit?: number;
 }): Promise<FindManyResult<BylineSummary>> {
@@ -48,6 +75,7 @@ export async function fetchBylines(options?: {
 	if (options?.search) params.set("search", options.search);
 	if (options?.isGuest !== undefined) params.set("isGuest", String(options.isGuest));
 	if (options?.userId) params.set("userId", options.userId);
+	if (options?.locale) params.set("locale", options.locale);
 	if (options?.cursor) params.set("cursor", options.cursor);
 	if (options?.limit) params.set("limit", String(options.limit));
 
@@ -87,4 +115,34 @@ export async function deleteByline(id: string): Promise<void> {
 		method: "DELETE",
 	});
 	if (!response.ok) await throwResponseError(response, i18n._(msg`Failed to delete byline`));
+}
+
+/**
+ * Fetch every translation of a byline (siblings sharing the same
+ * translation_group).
+ */
+export async function fetchBylineTranslations(id: string): Promise<{ items: BylineSummary[] }> {
+	const response = await apiFetch(`${API_BASE}/admin/bylines/${id}/translations`);
+	return parseApiResponse<{ items: BylineSummary[] }>(
+		response,
+		"Failed to fetch byline translations",
+	);
+}
+
+/**
+ * Create a new locale variant of a byline. The new row joins the source's
+ * `translation_group`. Body defaults — slug, display name, avatar, website —
+ * inherit from the source when omitted, so editors only have to fill in the
+ * localized bio (and optionally a localized display name).
+ */
+export async function createBylineTranslation(
+	id: string,
+	input: BylineTranslationInput,
+): Promise<BylineSummary> {
+	const response = await apiFetch(`${API_BASE}/admin/bylines/${id}/translations`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	return parseApiResponse<BylineSummary>(response, "Failed to create byline translation");
 }

--- a/packages/admin/src/lib/api/index.ts
+++ b/packages/admin/src/lib/api/index.ts
@@ -141,12 +141,15 @@ export {
 export {
 	type BylineSummary,
 	type BylineInput,
+	type BylineTranslationInput,
 	type BylineCreditInput,
 	fetchBylines,
 	fetchByline,
 	createByline,
 	updateByline,
 	deleteByline,
+	fetchBylineTranslations,
+	createBylineTranslation,
 } from "./bylines.js";
 
 // Menus

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -467,12 +467,20 @@ function ContentNewPage() {
 		queryFn: fetchManifest,
 	});
 
+	// Locale the picker should scope to. URL `?locale=` wins; otherwise
+	// fall back to the configured defaultLocale. Single-locale installs
+	// resolve to `defaultLocale` too — the server treats that as "use the
+	// configured default" so behaviour matches pre-i18n in that case.
+	const pickerLocale = locale ?? manifest?.i18n?.defaultLocale;
+
+	// Send the resolved picker locale so the new entry's locale matches
+	// the locale the byline picker was scoped to.
 	const createMutation = useMutation({
 		mutationFn: (data: {
 			data: Record<string, unknown>;
 			slug?: string;
 			bylines?: BylineCreditInput[];
-		}) => createContent(collection, { ...data, locale }),
+		}) => createContent(collection, { ...data, locale: pickerLocale }),
 		onSuccess: (result) => {
 			void queryClient.invalidateQueries({ queryKey: ["content", collection] });
 			void navigate({
@@ -484,14 +492,20 @@ function ContentNewPage() {
 
 	const pluginBlocks = React.useMemo(() => (manifest ? getPluginBlocks(manifest) : []), [manifest]);
 
+	// The picker is locale-pinned to the entry being created so editors
+	// only see bylines that will actually hydrate at this locale (per the
+	// strict per-locale model from migration 040). Locale is part of the
+	// query key so switching locales fetches a fresh slice rather than
+	// reusing a stale cache.
 	const { data: bylinesData } = useQuery({
-		queryKey: ["bylines"],
-		queryFn: () => fetchBylines({ limit: 100 }),
+		queryKey: ["bylines", "picker", pickerLocale ?? null],
+		queryFn: () => fetchBylines({ locale: pickerLocale, limit: 100 }),
+		enabled: !!manifest,
 	});
 
 	const createBylineMutation = useMutation({
 		mutationFn: (input: { slug: string; displayName: string }) =>
-			createByline({ ...input, isGuest: true }),
+			createByline({ ...input, isGuest: true, locale: pickerLocale }),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
 		},
@@ -532,6 +546,8 @@ function ContentNewPage() {
 			collectionLabel={collectionConfig.labelSingular || collectionConfig.label}
 			fields={collectionConfig.fields}
 			isNew
+			entryLocale={pickerLocale}
+			i18n={manifest?.i18n}
 			isSaving={createMutation.isPending}
 			onSave={handleSave}
 			pluginBlocks={pluginBlocks}
@@ -660,14 +676,23 @@ function ContentEditPage() {
 		staleTime: 5 * 60 * 1000,
 	});
 
+	// Picker is locale-pinned to the entry being edited. The credit
+	// hydration server-side is strict per locale (migration 040), so the
+	// picker must show only bylines that will actually render at this
+	// locale — otherwise the editor adds a credit that silently vanishes
+	// after autosave. Query disabled until `rawItem.locale` resolves so a
+	// transient `undefined` doesn't populate the cache with default-locale
+	// data.
+	const itemLocale = rawItem?.locale ?? undefined;
 	const { data: bylinesData } = useQuery({
-		queryKey: ["bylines"],
-		queryFn: () => fetchBylines({ limit: 100 }),
+		queryKey: ["bylines", "picker", itemLocale ?? null],
+		queryFn: () => fetchBylines({ locale: itemLocale, limit: 100 }),
+		enabled: !!itemLocale,
 	});
 
 	const createBylineMutation = useMutation({
 		mutationFn: (input: { slug: string; displayName: string }) =>
-			createByline({ ...input, isGuest: true }),
+			createByline({ ...input, isGuest: true, locale: itemLocale }),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
 		},
@@ -1446,10 +1471,25 @@ const usersRoute = createRoute({
 });
 
 // Bylines route
+//
+// `validateSearch` rejects empty-string locale (`?locale=`) — left as `""`
+// it would land in component state and silently drop the locale filter
+// from `fetchBylines`, fetching every locale's rows while the UI thinks
+// it's scoped to one.
+export function parseBylinesLocaleSearch(search: Record<string, unknown>): {
+	locale: string | undefined;
+} {
+	if (typeof search.locale === "string" && search.locale.length > 0) {
+		return { locale: search.locale };
+	}
+	return { locale: undefined };
+}
+
 const bylinesRoute = createRoute({
 	getParentRoute: () => adminLayoutRoute,
 	path: "/bylines",
 	component: BylinesPage,
+	validateSearch: parseBylinesLocaleSearch,
 });
 
 // Content Types routes

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -497,7 +497,7 @@ function ContentNewPage() {
 	// strict per-locale model from migration 040). Locale is part of the
 	// query key so switching locales fetches a fresh slice rather than
 	// reusing a stale cache.
-	const { data: bylinesData } = useQuery({
+	const { data: bylinesData, isSuccess: bylinesLoaded } = useQuery({
 		queryKey: ["bylines", "picker", pickerLocale ?? null],
 		queryFn: () => fetchBylines({ locale: pickerLocale, limit: 100 }),
 		enabled: !!manifest,
@@ -552,6 +552,7 @@ function ContentNewPage() {
 			onSave={handleSave}
 			pluginBlocks={pluginBlocks}
 			availableBylines={bylinesData?.items}
+			availableBylinesLoaded={bylinesLoaded}
 			selectedBylines={selectedBylines}
 			onBylinesChange={setSelectedBylines}
 			onQuickCreateByline={async (input) => {
@@ -684,7 +685,7 @@ function ContentEditPage() {
 	// transient `undefined` doesn't populate the cache with default-locale
 	// data.
 	const itemLocale = rawItem?.locale ?? undefined;
-	const { data: bylinesData } = useQuery({
+	const { data: bylinesData, isSuccess: bylinesLoaded } = useQuery({
 		queryKey: ["bylines", "picker", itemLocale ?? null],
 		queryFn: () => fetchBylines({ locale: itemLocale, limit: 100 }),
 		enabled: !!itemLocale,
@@ -978,6 +979,7 @@ function ContentEditPage() {
 			hasSeo={collectionConfig.hasSeo}
 			onSeoChange={handleSeoChange}
 			availableBylines={bylinesData?.items}
+			availableBylinesLoaded={bylinesLoaded}
 			onQuickCreateByline={async (input) => {
 				const created = await createBylineMutation.mutateAsync(input);
 				return created;

--- a/packages/admin/src/routes/bylines.tsx
+++ b/packages/admin/src/routes/bylines.tsx
@@ -1,19 +1,26 @@
 import { Button, Input, InputArea, Loader, Select, Switch } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import * as React from "react";
 
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { DialogError, getMutationError } from "../components/DialogError.js";
+import { LocaleSwitcher, useI18nConfig } from "../components/LocaleSwitcher.js";
+import { TranslationsPanel } from "../components/TranslationsPanel.js";
 import {
 	createByline,
+	createBylineTranslation,
 	deleteByline,
+	fetchByline,
+	fetchBylineTranslations,
 	fetchBylines,
 	fetchUsers,
 	updateByline,
 	type BylineSummary,
 	type UserListItem,
 } from "../lib/api";
+import { fetchManifest } from "../lib/api/client.js";
 
 interface BylineFormState {
 	slug: string;
@@ -22,6 +29,28 @@ interface BylineFormState {
 	websiteUrl: string;
 	userId: string | null;
 	isGuest: boolean;
+}
+
+export interface LoadMoreSnapshot {
+	search: string;
+	guestFilter: "all" | "guest" | "linked";
+	locale: string | undefined;
+	cursor: string;
+}
+
+/**
+ * True when the load-more snapshot still matches the current filter state.
+ * Used to discard appends from requests whose filters have changed mid-flight.
+ */
+export function loadMoreSnapshotMatches(
+	snapshot: LoadMoreSnapshot,
+	current: Omit<LoadMoreSnapshot, "cursor">,
+): boolean {
+	return (
+		snapshot.search === current.search &&
+		snapshot.guestFilter === current.guestFilter &&
+		snapshot.locale === current.locale
+	);
 }
 
 function toFormState(byline?: BylineSummary | null): BylineFormState {
@@ -54,6 +83,8 @@ function getUserLabel(user: UserListItem): string {
 export function BylinesPage() {
 	const { t } = useLingui();
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const { locale: routeLocale } = useSearch({ from: "/_admin/bylines" });
 	const [search, setSearch] = React.useState("");
 	const [guestFilter, setGuestFilter] = React.useState<"all" | "guest" | "linked">("all");
 	const [selectedId, setSelectedId] = React.useState<string | null>(null);
@@ -61,12 +92,38 @@ export function BylinesPage() {
 	const [allItems, setAllItems] = React.useState<BylineSummary[]>([]);
 	const [nextCursor, setNextCursor] = React.useState<string | undefined>(undefined);
 
+	// Manifest powers the locale switcher: the configured locales + default
+	// locale come from the site's emdash config, exposed on the manifest.
+	const { data: manifest } = useQuery({
+		queryKey: ["manifest"],
+		queryFn: fetchManifest,
+	});
+	const i18n = useI18nConfig(manifest);
+	const isMultiLocale = !!i18n && i18n.locales.length > 1;
+	// `activeLocale` is the URL search param when present, else the default.
+	// Picker on a translated post can be expected to scope to the post's
+	// locale (Phase 4 wires that up); for the bylines manager itself the
+	// active locale just filters the list and seeds new bylines.
+	const activeLocale = routeLocale ?? i18n?.defaultLocale ?? undefined;
+
+	const handleLocaleChange = (locale: string) => {
+		void navigate({
+			to: "/bylines",
+			search: { locale: locale || undefined },
+		});
+		// Switching locales invalidates the previously-selected byline (it
+		// belongs to a different list); clear selection so the editor opens
+		// in "create" mode at the new locale.
+		setSelectedId(null);
+	};
+
 	const { data, isLoading, error } = useQuery({
-		queryKey: ["bylines", search, guestFilter],
+		queryKey: ["bylines", search, guestFilter, activeLocale ?? null],
 		queryFn: () =>
 			fetchBylines({
 				search: search || undefined,
 				isGuest: guestFilter === "all" ? undefined : guestFilter === "guest",
+				locale: activeLocale,
 				limit: 50,
 			}),
 	});
@@ -86,32 +143,56 @@ export function BylinesPage() {
 
 	const users = usersData?.items ?? [];
 
+	// Snapshot filters at click-time and discard the response if the user
+	// changed any of them while the request was in flight — otherwise stale
+	// pages from a different filter set get appended to the visible list.
 	const loadMoreMutation = useMutation({
-		mutationFn: async () => {
-			if (!nextCursor) return null;
-			return fetchBylines({
-				search: search || undefined,
-				isGuest: guestFilter === "all" ? undefined : guestFilter === "guest",
+		mutationFn: async (snapshot: LoadMoreSnapshot) => {
+			const result = await fetchBylines({
+				search: snapshot.search || undefined,
+				isGuest: snapshot.guestFilter === "all" ? undefined : snapshot.guestFilter === "guest",
+				locale: snapshot.locale,
 				limit: 50,
-				cursor: nextCursor,
+				cursor: snapshot.cursor,
 			});
+			return { result, snapshot };
 		},
-		onSuccess: (result) => {
-			if (result) {
-				setAllItems((prev) => [...prev, ...result.items]);
-				setNextCursor(result.nextCursor);
+		onSuccess: ({ result, snapshot }) => {
+			if (!loadMoreSnapshotMatches(snapshot, { search, guestFilter, locale: activeLocale })) {
+				return;
 			}
+			setAllItems((prev) => [...prev, ...result.items]);
+			setNextCursor(result.nextCursor);
 		},
 	});
 
 	const items = allItems;
-	const selected = items.find((item) => item.id === selectedId) ?? null;
+	// The selected row may live in `allItems` (visible at the active locale)
+	// or be a sibling of the open byline reached via TranslationsPanel. Fetch
+	// directly by id so the editor stays consistent when the selection
+	// crosses locale boundaries.
+	const { data: selectedRemote } = useQuery({
+		queryKey: ["byline", selectedId],
+		queryFn: () => (selectedId ? fetchByline(selectedId) : Promise.resolve(null)),
+		enabled: !!selectedId,
+	});
+	const selected = selectedRemote ?? items.find((item) => item.id === selectedId) ?? null;
 
 	const [form, setForm] = React.useState<BylineFormState>(() => toFormState(null));
 
 	React.useEffect(() => {
 		setForm(toFormState(selected));
-	}, [selectedId, selected]);
+	}, [selected]);
+
+	// Translations: only fetched when a multi-locale install has a byline
+	// open. The panel renders one row per configured locale, with Translate
+	// or Edit buttons depending on which siblings exist.
+	const { data: translationsData } = useQuery({
+		queryKey: ["byline-translations", selectedId],
+		queryFn: () =>
+			selectedId ? fetchBylineTranslations(selectedId) : Promise.resolve({ items: [] }),
+		enabled: !!selectedId && isMultiLocale,
+	});
 
 	const createMutation = useMutation({
 		mutationFn: () =>
@@ -122,6 +203,7 @@ export function BylinesPage() {
 				websiteUrl: form.websiteUrl || null,
 				userId: form.userId,
 				isGuest: form.isGuest,
+				locale: activeLocale,
 			}),
 		onSuccess: (created) => {
 			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
@@ -143,6 +225,9 @@ export function BylinesPage() {
 		},
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
+			if (selectedId) {
+				void queryClient.invalidateQueries({ queryKey: ["byline", selectedId] });
+			}
 		},
 	});
 
@@ -155,6 +240,38 @@ export function BylinesPage() {
 			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
 			setSelectedId(null);
 			setShowDeleteConfirm(false);
+		},
+	});
+
+	// Translate-this-byline action: creates a sibling row in the target locale
+	// joined to the same translation_group. We track `pendingTranslationLocale`
+	// so the TranslationsPanel can disable the right button while in flight.
+	const [pendingTranslationLocale, setPendingTranslationLocale] = React.useState<string | null>(
+		null,
+	);
+	const translateMutation = useMutation({
+		mutationFn: (targetLocale: string) => {
+			if (!selectedId) throw new Error("No byline selected");
+			setPendingTranslationLocale(targetLocale);
+			return createBylineTranslation(selectedId, { locale: targetLocale });
+		},
+		onSettled: () => {
+			setPendingTranslationLocale(null);
+		},
+		onSuccess: (created) => {
+			void queryClient.invalidateQueries({ queryKey: ["bylines"] });
+			if (selectedId) {
+				void queryClient.invalidateQueries({
+					queryKey: ["byline-translations", selectedId],
+				});
+			}
+			// Switch the admin locale to the new sibling's locale and open it
+			// in the editor — same flow as menus/taxonomies after Translate.
+			void navigate({
+				to: "/bylines",
+				search: { locale: created.locale },
+			});
+			setSelectedId(created.id);
 		},
 	});
 
@@ -171,159 +288,205 @@ export function BylinesPage() {
 	}
 
 	const isSaving = createMutation.isPending || updateMutation.isPending;
-	const mutationError = createMutation.error || updateMutation.error || deleteMutation.error;
+	const mutationError =
+		createMutation.error || updateMutation.error || deleteMutation.error || translateMutation.error;
 
 	return (
-		<div className="grid grid-cols-1 gap-6 lg:grid-cols-[320px_1fr]">
-			<div className="rounded-lg border p-4">
-				<div className="mb-4 space-y-2">
-					<Input
-						placeholder={t`Search bylines`}
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-					/>
-					<div className="flex items-center gap-2">
-						<div className="flex-1">
-							<Select
-								aria-label={t`Filter byline type`}
-								value={guestFilter}
-								onValueChange={(v) => setGuestFilter((v as "all" | "guest" | "linked") ?? "all")}
-								items={{
-									all: t`All bylines`,
-									guest: t`Guest only`,
-									linked: t`Linked only`,
-								}}
-								className="w-full"
-							/>
-						</div>
-						<Button
-							variant="secondary"
-							onClick={() => {
-								setSelectedId(null);
-								setForm(toFormState(null));
-							}}
-						>
-							{t`New`}
-						</Button>
+		<div className="space-y-4">
+			{isMultiLocale && i18n && activeLocale ? (
+				<div className="flex items-center justify-between">
+					<div>
+						<h1 className="text-2xl font-semibold">{t`Bylines`}</h1>
 					</div>
+					<LocaleSwitcher
+						locales={i18n.locales}
+						defaultLocale={i18n.defaultLocale}
+						value={activeLocale}
+						onChange={handleLocaleChange}
+					/>
 				</div>
+			) : null}
 
-				<div className="space-y-2 max-h-[70vh] overflow-auto">
-					{items.map((item) => {
-						const active = item.id === selectedId;
-						return (
-							<button
-								key={item.id}
-								type="button"
-								onClick={() => setSelectedId(item.id)}
-								className={`w-full rounded border p-3 text-start ${
-									active ? "border-kumo-brand bg-kumo-brand/10" : "border-kumo-line"
-								}`}
-							>
-								<p className="font-medium">{item.displayName}</p>
-								<p className="text-xs text-kumo-subtle">
-									{item.slug}
-									{item.isGuest ? t` - Guest` : item.userId ? t` - Linked` : ""}
-								</p>
-							</button>
-						);
-					})}
-					{items.length === 0 && <p className="text-sm text-kumo-subtle">{t`No bylines found`}</p>}
-					{nextCursor && (
-						<Button
-							variant="secondary"
-							className="w-full mt-2"
-							onClick={() => loadMoreMutation.mutate()}
-							disabled={loadMoreMutation.isPending}
-						>
-							{loadMoreMutation.isPending ? t`Loading...` : t`Load more`}
-						</Button>
-					)}
-				</div>
-			</div>
-
-			<div className="rounded-lg border p-6">
-				<h2 className="text-lg font-semibold mb-4">
-					{selected ? t`Edit ${selected.displayName}` : t`Create byline`}
-				</h2>
-
-				<div className="space-y-4">
-					<Input
-						label={t`Display name`}
-						value={form.displayName}
-						onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
-					/>
-					<Input
-						label={t`Slug`}
-						value={form.slug}
-						onChange={(e) => setForm((prev) => ({ ...prev, slug: e.target.value }))}
-					/>
-					<Input
-						label={t`Website URL`}
-						value={form.websiteUrl}
-						onChange={(e) => setForm((prev) => ({ ...prev, websiteUrl: e.target.value }))}
-					/>
-					<InputArea
-						label={t`Bio`}
-						value={form.bio}
-						onChange={(e) => setForm((prev) => ({ ...prev, bio: e.target.value }))}
-						rows={5}
-					/>
-					<Select
-						label={t`Linked user`}
-						value={form.userId ?? ""}
-						onValueChange={(v) => {
-							const val = (v as string) || null;
-							setForm((prev) => ({
-								...prev,
-								userId: val,
-								isGuest: val ? false : prev.isGuest,
-							}));
-						}}
-						items={{
-							"": t`No linked user`,
-							...Object.fromEntries(users.map((u) => [u.id, getUserLabel(u)])),
-						}}
-						className="w-full"
-					/>
-					<Switch
-						label={t`Guest byline`}
-						checked={form.isGuest}
-						onCheckedChange={(checked) =>
-							setForm((prev) => ({
-								...prev,
-								isGuest: checked,
-								userId: checked ? null : prev.userId,
-							}))
-						}
-					/>
-
-					<DialogError message={getMutationError(mutationError)} />
-
-					<div className="flex gap-2 pt-2">
-						<Button
-							onClick={() => {
-								if (selected) {
-									updateMutation.mutate();
-								} else {
-									createMutation.mutate();
-								}
-							}}
-							disabled={!form.displayName || !form.slug || isSaving}
-						>
-							{isSaving ? t`Saving...` : selected ? t`Save` : t`Create`}
-						</Button>
-
-						{selected && (
+			<div className="grid grid-cols-1 gap-6 lg:grid-cols-[320px_1fr]">
+				<div className="rounded-lg border p-4">
+					<div className="mb-4 space-y-2">
+						<Input
+							placeholder={t`Search bylines`}
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+						<div className="flex items-center gap-2">
+							<div className="flex-1">
+								<Select
+									aria-label={t`Filter byline type`}
+									value={guestFilter}
+									onValueChange={(v) => setGuestFilter((v as "all" | "guest" | "linked") ?? "all")}
+									items={{
+										all: t`All bylines`,
+										guest: t`Guest only`,
+										linked: t`Linked only`,
+									}}
+									className="w-full"
+								/>
+							</div>
 							<Button
-								variant="destructive"
-								onClick={() => setShowDeleteConfirm(true)}
-								disabled={deleteMutation.isPending}
+								variant="secondary"
+								onClick={() => {
+									setSelectedId(null);
+									setForm(toFormState(null));
+								}}
 							>
-								{t`Delete`}
+								{t`New`}
+							</Button>
+						</div>
+					</div>
+
+					<div className="space-y-2 max-h-[70vh] overflow-auto">
+						{items.map((item) => {
+							const active = item.id === selectedId;
+							return (
+								<button
+									key={item.id}
+									type="button"
+									onClick={() => setSelectedId(item.id)}
+									className={`w-full rounded border p-3 text-start ${
+										active ? "border-kumo-brand bg-kumo-brand/10" : "border-kumo-line"
+									}`}
+								>
+									<p className="font-medium">{item.displayName}</p>
+									<p className="text-xs text-kumo-subtle">
+										{item.slug}
+										{item.isGuest ? t` - Guest` : item.userId ? t` - Linked` : ""}
+									</p>
+								</button>
+							);
+						})}
+						{items.length === 0 && (
+							<p className="text-sm text-kumo-subtle">{t`No bylines found`}</p>
+						)}
+						{nextCursor && (
+							<Button
+								variant="secondary"
+								className="w-full mt-2"
+								onClick={() =>
+									loadMoreMutation.mutate({
+										search,
+										guestFilter,
+										locale: activeLocale,
+										cursor: nextCursor,
+									})
+								}
+								disabled={loadMoreMutation.isPending}
+							>
+								{loadMoreMutation.isPending ? t`Loading...` : t`Load more`}
 							</Button>
 						)}
 					</div>
+				</div>
+
+				<div className="rounded-lg border p-6 space-y-6">
+					<h2 className="text-lg font-semibold">
+						{selected ? t`Edit ${selected.displayName}` : t`Create byline`}
+					</h2>
+
+					<div className="space-y-4">
+						<Input
+							label={t`Display name`}
+							value={form.displayName}
+							onChange={(e) => setForm((prev) => ({ ...prev, displayName: e.target.value }))}
+						/>
+						<Input
+							label={t`Slug`}
+							value={form.slug}
+							onChange={(e) => setForm((prev) => ({ ...prev, slug: e.target.value }))}
+						/>
+						<Input
+							label={t`Website URL`}
+							value={form.websiteUrl}
+							onChange={(e) => setForm((prev) => ({ ...prev, websiteUrl: e.target.value }))}
+						/>
+						<InputArea
+							label={t`Bio`}
+							value={form.bio}
+							onChange={(e) => setForm((prev) => ({ ...prev, bio: e.target.value }))}
+							rows={5}
+						/>
+						<Select
+							label={t`Linked user`}
+							value={form.userId ?? ""}
+							onValueChange={(v) => {
+								const val = (v as string) || null;
+								setForm((prev) => ({
+									...prev,
+									userId: val,
+									isGuest: val ? false : prev.isGuest,
+								}));
+							}}
+							items={{
+								"": t`No linked user`,
+								...Object.fromEntries(users.map((u) => [u.id, getUserLabel(u)])),
+							}}
+							className="w-full"
+						/>
+						<Switch
+							label={t`Guest byline`}
+							checked={form.isGuest}
+							onCheckedChange={(checked) =>
+								setForm((prev) => ({
+									...prev,
+									isGuest: checked,
+									userId: checked ? null : prev.userId,
+								}))
+							}
+						/>
+
+						<DialogError message={getMutationError(mutationError)} />
+
+						<div className="flex gap-2 pt-2">
+							<Button
+								onClick={() => {
+									if (selected) {
+										updateMutation.mutate();
+									} else {
+										createMutation.mutate();
+									}
+								}}
+								disabled={!form.displayName || !form.slug || isSaving}
+							>
+								{isSaving ? t`Saving...` : selected ? t`Save` : t`Create`}
+							</Button>
+
+							{selected && (
+								<Button
+									variant="destructive"
+									onClick={() => setShowDeleteConfirm(true)}
+									disabled={deleteMutation.isPending}
+								>
+									{t`Delete`}
+								</Button>
+							)}
+						</div>
+					</div>
+
+					{selected && isMultiLocale && i18n ? (
+						<div className="border-t pt-6">
+							<TranslationsPanel
+								locales={i18n.locales}
+								defaultLocale={i18n.defaultLocale}
+								currentLocale={selected.locale}
+								translations={translationsData?.items ?? []}
+								onOpen={(summary) => {
+									void navigate({
+										to: "/bylines",
+										search: { locale: summary.locale },
+									});
+									setSelectedId(summary.id);
+								}}
+								onCreate={(locale) => translateMutation.mutate(locale)}
+								pendingLocale={pendingTranslationLocale}
+							/>
+						</div>
+					) : null}
 				</div>
 			</div>
 

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -682,6 +682,38 @@ describe("ContentEditor", () => {
 			expect(payload).not.toHaveProperty("bylines");
 		});
 
+		it("suppresses the locale empty-state CTA until the picker query resolves", async () => {
+			const item = makeItem({ data: { title: "Hello", body: "" }, locale: "fr-fr" });
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				currentUser: { id: "u-1", role: 50 },
+				i18n: { defaultLocale: "en", locales: ["en", "fr-fr"] },
+				entryLocale: "fr-fr",
+				availableBylines: [],
+				availableBylinesLoaded: false,
+			});
+
+			await expect
+				.element(screen.getByText(/No bylines available/), { timeout: 100 })
+				.not.toBeInTheDocument();
+		});
+
+		it("shows the locale empty-state CTA once the picker query resolves empty", async () => {
+			const item = makeItem({ data: { title: "Hello", body: "" }, locale: "fr-fr" });
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				currentUser: { id: "u-1", role: 50 },
+				i18n: { defaultLocale: "en", locales: ["en", "fr-fr"] },
+				entryLocale: "fr-fr",
+				availableBylines: [],
+				availableBylinesLoaded: true,
+			});
+
+			await expect.element(screen.getByText(/No bylines available/)).toBeInTheDocument();
+		});
+
 		it("includes bylines: [] in save payload for new entries even when untouched", async () => {
 			const onSave = vi.fn();
 			const screen = await renderEditor({ isNew: true, onSave });

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -660,6 +660,41 @@ describe("ContentEditor", () => {
 			await expect.element(savedBtn).toBeDisabled();
 		});
 
+		// Strict per-locale hydration (migration 040) can return
+		// `item.bylines = []` even when junction rows exist at other
+		// locales (e.g. an FR post that inherited an EN-only byline via
+		// copyContentBylines). Sending `bylines: []` on every save would
+		// silently wipe the copied credit. The editor must omit `bylines`
+		// from the payload unless the user actually touched the editor.
+		it("omits bylines from save payload when the user did not touch the byline editor", async () => {
+			const onSave = vi.fn();
+			const item = makeItem({ data: { title: "Hello", body: "" } });
+			const screen = await renderEditor({ isNew: false, item, onSave });
+
+			const titleInput = screen.getByLabelText("Title");
+			await titleInput.fill("Changed");
+
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
+			await saveBtn.click();
+
+			expect(onSave).toHaveBeenCalledTimes(1);
+			const payload = onSave.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(payload).not.toHaveProperty("bylines");
+		});
+
+		it("includes bylines: [] in save payload for new entries even when untouched", async () => {
+			const onSave = vi.fn();
+			const screen = await renderEditor({ isNew: true, onSave });
+
+			const titleInput = screen.getByLabelText("Title");
+			await titleInput.fill("Brand new");
+
+			const saveBtn = screen.getByRole("button", { name: "Save" }).first();
+			await saveBtn.click();
+
+			expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ bylines: [] }));
+		});
+
 		it("keeps edited values after autosave completes without queuing another autosave", async () => {
 			vi.useFakeTimers();
 

--- a/packages/admin/tests/router-search.test.ts
+++ b/packages/admin/tests/router-search.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBylinesLocaleSearch } from "../src/router";
+
+describe("parseBylinesLocaleSearch", () => {
+	it("returns the locale string when present and non-empty", () => {
+		expect(parseBylinesLocaleSearch({ locale: "de-de" })).toEqual({ locale: "de-de" });
+	});
+
+	it("normalizes empty-string locale to undefined", () => {
+		// `/bylines?locale=` would otherwise leave `locale: ""` in route state.
+		// The bylines API client treats empty string as truthy-omit, so the
+		// page would fetch every locale's rows while UI says one is active.
+		expect(parseBylinesLocaleSearch({ locale: "" })).toEqual({ locale: undefined });
+	});
+
+	it("returns undefined when locale is missing entirely", () => {
+		expect(parseBylinesLocaleSearch({})).toEqual({ locale: undefined });
+	});
+
+	it("returns undefined when locale is not a string", () => {
+		expect(parseBylinesLocaleSearch({ locale: 42 })).toEqual({ locale: undefined });
+		expect(parseBylinesLocaleSearch({ locale: null })).toEqual({ locale: undefined });
+	});
+});

--- a/packages/admin/tests/routes/bylines-load-more.test.ts
+++ b/packages/admin/tests/routes/bylines-load-more.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { loadMoreSnapshotMatches, type LoadMoreSnapshot } from "../../src/routes/bylines";
+
+describe("loadMoreSnapshotMatches", () => {
+	const baseSnapshot: LoadMoreSnapshot = {
+		search: "alice",
+		guestFilter: "all",
+		locale: "en",
+		cursor: "abc",
+	};
+
+	it("returns true when all filters still match", () => {
+		expect(
+			loadMoreSnapshotMatches(baseSnapshot, {
+				search: "alice",
+				guestFilter: "all",
+				locale: "en",
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when the locale changed while the request was in flight", () => {
+		// Click Load more in en → switch to de → request resolves.
+		// English rows must NOT be appended to the German list.
+		expect(
+			loadMoreSnapshotMatches(baseSnapshot, {
+				search: "alice",
+				guestFilter: "all",
+				locale: "de",
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when the search filter changed", () => {
+		expect(
+			loadMoreSnapshotMatches(baseSnapshot, {
+				search: "bob",
+				guestFilter: "all",
+				locale: "en",
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when the guest filter changed", () => {
+		expect(
+			loadMoreSnapshotMatches(baseSnapshot, {
+				search: "alice",
+				guestFilter: "guest",
+				locale: "en",
+			}),
+		).toBe(false);
+	});
+
+	it("does not consider the cursor — different cursors of the same filter set match", () => {
+		// Cursor is part of the request identity, not the filter state.
+		// Pagination cursors evolve as the user pages; that's expected.
+		expect(
+			loadMoreSnapshotMatches(
+				{ ...baseSnapshot, cursor: "xyz" },
+				{ search: "alice", guestFilter: "all", locale: "en" },
+			),
+		).toBe(true);
+	});
+});

--- a/packages/auth/src/rbac.ts
+++ b/packages/auth/src/rbac.ts
@@ -50,6 +50,10 @@ export const Permissions = {
 	"menus:read": Role.SUBSCRIBER,
 	"menus:manage": Role.EDITOR,
 
+	// Bylines
+	"bylines:read": Role.SUBSCRIBER,
+	"bylines:manage": Role.EDITOR,
+
 	// Widgets
 	"widgets:read": Role.SUBSCRIBER,
 	"widgets:manage": Role.EDITOR,

--- a/packages/core/src/api/handlers/bylines.ts
+++ b/packages/core/src/api/handlers/bylines.ts
@@ -1,0 +1,161 @@
+import type { Kysely } from "kysely";
+
+import { BylineRepository, type CreateBylineInput } from "../../database/repositories/byline.js";
+import type { BylineSummary } from "../../database/repositories/types.js";
+import type { Database } from "../../database/types.js";
+import { getI18nConfig } from "../../i18n/config.js";
+import type { ApiResult } from "../types.js";
+
+/**
+ * Reject locales the site doesn't configure. Returns `null` when the locale
+ * is fine (omitted, or matches `locales` in the i18n config, or i18n isn't
+ * configured at all).
+ */
+function rejectUnknownLocale(locale: string | undefined): ApiResult<never> | null {
+	if (!locale) return null;
+	const config = getI18nConfig();
+	if (!config) return null;
+	if (config.locales.includes(locale)) return null;
+	return {
+		success: false,
+		error: {
+			code: "VALIDATION_ERROR",
+			message: `Locale "${locale}" is not configured for this site`,
+		},
+	};
+}
+
+/**
+ * Business-logic helpers for the bylines admin API.
+ *
+ * Mirrors the shape of `packages/core/src/api/handlers/menus.ts`. Route files
+ * stay thin: they parse input, call these handlers, and forward the result via
+ * `unwrapResult`. The repository (`BylineRepository`) is strict per locale; the
+ * handlers add validation and translation-flow guards on top.
+ */
+
+export interface BylineTranslationsResponse {
+	items: BylineSummary[];
+}
+
+/**
+ * List every translation of a byline (by row id). Returns NOT_FOUND when no
+ * row with the given id exists.
+ */
+export async function handleBylineTranslations(
+	db: Kysely<Database>,
+	id: string,
+): Promise<ApiResult<BylineTranslationsResponse>> {
+	try {
+		const repo = new BylineRepository(db);
+		const anchor = await repo.findById(id);
+		if (!anchor) {
+			return {
+				success: false,
+				error: { code: "NOT_FOUND", message: "Byline not found" },
+			};
+		}
+		const items = await repo.listTranslations(id);
+		return { success: true, data: { items } };
+	} catch {
+		return {
+			success: false,
+			error: {
+				code: "BYLINE_TRANSLATIONS_ERROR",
+				message: "Failed to list byline translations",
+			},
+		};
+	}
+}
+
+/**
+ * Create a new byline. When `translationOf` is supplied, the new row joins the
+ * source byline's translation_group (a sibling in the same logical identity).
+ *
+ * Translating from a source row only makes sense when the caller names the
+ * target locale, otherwise we'd silently clone into the configured default,
+ * which is almost never what's intended (and will collide if the source is
+ * already the default-locale row). Mirrors `handleMenuCreate`.
+ */
+export async function handleBylineCreate(
+	db: Kysely<Database>,
+	input: CreateBylineInput,
+): Promise<ApiResult<BylineSummary>> {
+	try {
+		if (input.translationOf && !input.locale) {
+			return {
+				success: false,
+				error: {
+					code: "VALIDATION_ERROR",
+					message: "`locale` is required when `translationOf` is provided",
+				},
+			};
+		}
+
+		const localeErr = rejectUnknownLocale(input.locale);
+		if (localeErr) return localeErr;
+
+		const repo = new BylineRepository(db);
+
+		// Existence check up front so the repo's "Source not found" throw
+		// becomes a clean NOT_FOUND on the API.
+		let sourceGroup: string | undefined;
+		if (input.translationOf) {
+			const source = await repo.findById(input.translationOf);
+			if (!source) {
+				return {
+					success: false,
+					error: {
+						code: "NOT_FOUND",
+						message: "Source byline for translation not found",
+					},
+				};
+			}
+			sourceGroup = source.translationGroup ?? source.id;
+		}
+
+		const effectiveLocale = input.locale ?? getI18nConfig()?.defaultLocale ?? "en";
+
+		// Translation-group guard: the row-per-locale model (PR #916)
+		// allows exactly one row per (translation_group, locale). Reject
+		// here so callers get a clean 409 instead of a UNIQUE constraint
+		// failure from the partial index. The DB constraint is the safety
+		// net; this is the friendly error.
+		if (sourceGroup) {
+			const siblings = await repo.findByTranslationGroup(sourceGroup);
+			if (siblings.some((b) => b.locale === effectiveLocale)) {
+				return {
+					success: false,
+					error: {
+						code: "CONFLICT",
+						message: `Translation already exists in locale "${effectiveLocale}" for this byline`,
+					},
+				};
+			}
+		}
+
+		// Duplicate guard: same (slug, locale) — matches the DB unique key
+		// added in migration 040. Falls back to the configured defaultLocale
+		// when the caller omits `locale`, mirroring the column DEFAULT.
+		const existing = await repo.findBySlug(input.slug, { locale: effectiveLocale });
+		if (existing) {
+			return {
+				success: false,
+				error: {
+					code: "CONFLICT",
+					message: `Byline "${input.slug}" already exists${
+						input.locale ? ` in locale "${input.locale}"` : ""
+					}`,
+				},
+			};
+		}
+
+		const byline = await repo.create(input);
+		return { success: true, data: byline };
+	} catch {
+		return {
+			success: false,
+			error: { code: "BYLINE_CREATE_ERROR", message: "Failed to create byline" },
+		};
+	}
+}

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -130,14 +130,10 @@ async function hydrateBylines(
 		return;
 	}
 
-	// Honor explicit editorial intent: if the entry has any junction row
-	// (even at a different locale), the editor has made an explicit
-	// assignment. Do NOT fall back to author-linked inference, even if the
-	// explicit credit's translation_group has no sibling at this locale.
-	// The credit is preserved in storage; it simply doesn't render until a
-	// sibling is created. Author inference only fires when no junction
-	// rows exist at all.
-	if (await bylineRepo.hasContentBylines(collection, item.id)) {
+	// `primaryBylineId` is set iff junction rows exist; non-null
+	// suppresses author fallback even when the credit doesn't resolve
+	// at this locale.
+	if (item.primaryBylineId) {
 		item.bylines = [];
 		item.byline = null;
 		return;
@@ -206,21 +202,13 @@ async function hydrateBylinesMany(
 		}
 	}
 
-	// 3. For items with no resolved credits at their locale: check
-	//    locale-agnostically whether they have *any* junction rows. Items
-	//    with explicit credits (even at another locale) get no inferred
-	//    fallback. Items with zero junctions are eligible.
+	// 3. Author fallback applies only when no explicit credit exists
+	//    (primaryBylineId null).
 	const fallbackByItem = new Map<string, BylineSummary>();
 	if (itemsNeedingAuthorCheck.length > 0) {
-		const idsToCheck = itemsNeedingAuthorCheck.map((i) => i.id);
-		const hasJunctions = await bylineRepo.hasContentBylinesMany(collection, idsToCheck);
-
-		// Rebucket the eligible items by locale for the author-byline
-		// fallback fetch (strict per locale: a user-linked byline
-		// surfaces only when a sibling exists at the entry's locale).
 		const authorBuckets = new Map<string | null, ContentItem[]>();
 		for (const item of itemsNeedingAuthorCheck) {
-			if (hasJunctions.has(item.id)) continue;
+			if (item.primaryBylineId) continue;
 			const key = item.locale ?? null;
 			const bucket = authorBuckets.get(key);
 			if (bucket) bucket.push(item);

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -15,6 +15,8 @@ import { SeoRepository } from "../../database/repositories/seo.js";
 import {
 	EmDashValidationError,
 	InvalidCursorError,
+	type BylineSummary,
+	type ContentBylineCredit,
 	type ContentItem,
 	type ContentSeo,
 	type ContentSeoInput,
@@ -22,7 +24,7 @@ import {
 import { withTransaction } from "../../database/transaction.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
-import { isI18nEnabled } from "../../i18n/config.js";
+import { getI18nConfig, isI18nEnabled } from "../../i18n/config.js";
 import { invalidateRedirectCache } from "../../redirects/cache.js";
 import { isMissingTableError } from "../../utils/db-errors.js";
 import { encodeRev, validateRev } from "../rev.js";
@@ -116,7 +118,11 @@ async function hydrateBylines(
 	item: ContentItem,
 ): Promise<void> {
 	const bylineRepo = new BylineRepository(db);
-	const bylines = await bylineRepo.getContentBylines(collection, item.id);
+	// Strict per-locale (migration 040): a credit at locale X renders iff a
+	// byline row exists at locale X in the credited translation_group. The
+	// junction itself spans translations; rendering does not fall back.
+	const localeOpt = item.locale ? { locale: item.locale } : undefined;
+	const bylines = await bylineRepo.getContentBylines(collection, item.id, localeOpt);
 
 	if (bylines.length > 0) {
 		item.bylines = bylines.map((c) => ({ ...c, source: "explicit" as const }));
@@ -124,13 +130,25 @@ async function hydrateBylines(
 		return;
 	}
 
-	// Defensive: if primaryBylineId is set but no junction rows exist, it's orphaned
-	if (item.primaryBylineId) {
-		item.primaryBylineId = null;
+	// Honor explicit editorial intent: if the entry has any junction row
+	// (even at a different locale), the editor has made an explicit
+	// assignment. Do NOT fall back to author-linked inference, even if the
+	// explicit credit's translation_group has no sibling at this locale.
+	// The credit is preserved in storage; it simply doesn't render until a
+	// sibling is created. Author inference only fires when no junction
+	// rows exist at all.
+	if (await bylineRepo.hasContentBylines(collection, item.id)) {
+		item.bylines = [];
+		item.byline = null;
+		return;
 	}
 
 	if (item.authorId) {
-		const fallback = await bylineRepo.findByUserId(item.authorId);
+		// Same strict-locale rule as explicit credits: a user-linked byline
+		// renders on the entry only when a sibling exists at the entry's
+		// locale. Without this we'd silently surface the default-locale
+		// row, which contradicts the per-locale model.
+		const fallback = await bylineRepo.findByUserId(item.authorId, localeOpt);
 		if (fallback) {
 			item.bylines = [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }];
 			item.byline = fallback;
@@ -144,6 +162,11 @@ async function hydrateBylines(
 
 /**
  * Batch-hydrate bylines for multiple items using two bulk queries instead of N+1.
+ *
+ * Items may live at different locales (e.g. a list endpoint returning the
+ * translations of an entry). Group by `item.locale` and call the strict
+ * per-locale repo method once per group so each item resolves against its
+ * own locale's byline rows.
  */
 async function hydrateBylinesMany(
 	db: Kysely<Database>,
@@ -154,43 +177,84 @@ async function hydrateBylinesMany(
 
 	const bylineRepo = new BylineRepository(db);
 
-	// 1. Batch fetch all explicit byline credits
-	const contentIds = items.map((i) => i.id);
-	const bylinesMap = await bylineRepo.getContentBylinesMany(collection, contentIds);
-
-	// 2. Collect authorIds that need fallback lookup
-	const fallbackAuthorIds: string[] = [];
+	// 1. Bucket items by locale so we can call the strict-locale repo
+	//    once per bucket. Items with a null/undefined locale (pre-i18n
+	//    rows on a single-locale install) share an "unscoped" bucket.
+	const localeBuckets = new Map<string | null, ContentItem[]>();
 	for (const item of items) {
-		if (!bylinesMap.has(item.id) && item.authorId) {
-			fallbackAuthorIds.push(item.authorId);
+		const key = item.locale ?? null;
+		const bucket = localeBuckets.get(key);
+		if (bucket) bucket.push(item);
+		else localeBuckets.set(key, [item]);
+	}
+
+	// 2. Per-locale: fetch explicit credits. Items whose credits don't
+	//    resolve at this locale go through a locale-agnostic "has any
+	//    junction" check before being considered for author inference —
+	//    explicit editorial intent at any locale beats inferred fallback.
+	const bylinesByItem = new Map<string, ContentBylineCredit[]>();
+	const itemsNeedingAuthorCheck: ContentItem[] = [];
+	for (const [locale, bucket] of localeBuckets) {
+		const localeOpt = locale ? { locale } : undefined;
+		const ids = bucket.map((i) => i.id);
+		const credits = await bylineRepo.getContentBylinesMany(collection, ids, localeOpt);
+		for (const [id, list] of credits) bylinesByItem.set(id, list);
+
+		for (const item of bucket) {
+			if (credits.has(item.id) && credits.get(item.id)!.length > 0) continue;
+			if (item.authorId) itemsNeedingAuthorCheck.push(item);
 		}
 	}
 
-	// 3. Batch fetch user-linked bylines for fallback
-	const uniqueAuthorIds = [...new Set(fallbackAuthorIds)];
-	const authorBylineMap = await bylineRepo.findByUserIds(uniqueAuthorIds);
+	// 3. For items with no resolved credits at their locale: check
+	//    locale-agnostically whether they have *any* junction rows. Items
+	//    with explicit credits (even at another locale) get no inferred
+	//    fallback. Items with zero junctions are eligible.
+	const fallbackByItem = new Map<string, BylineSummary>();
+	if (itemsNeedingAuthorCheck.length > 0) {
+		const idsToCheck = itemsNeedingAuthorCheck.map((i) => i.id);
+		const hasJunctions = await bylineRepo.hasContentBylinesMany(collection, idsToCheck);
 
-	// 4. Assign to each item
+		// Rebucket the eligible items by locale for the author-byline
+		// fallback fetch (strict per locale: a user-linked byline
+		// surfaces only when a sibling exists at the entry's locale).
+		const authorBuckets = new Map<string | null, ContentItem[]>();
+		for (const item of itemsNeedingAuthorCheck) {
+			if (hasJunctions.has(item.id)) continue;
+			const key = item.locale ?? null;
+			const bucket = authorBuckets.get(key);
+			if (bucket) bucket.push(item);
+			else authorBuckets.set(key, [item]);
+		}
+
+		for (const [locale, bucket] of authorBuckets) {
+			const localeOpt = locale ? { locale } : undefined;
+			const authorIds = bucket.map((i) => i.authorId).filter((id): id is string => id !== null);
+			const uniqueAuthorIds = [...new Set(authorIds)];
+			if (uniqueAuthorIds.length === 0) continue;
+			const authorMap = await bylineRepo.findByUserIds(uniqueAuthorIds, localeOpt);
+			for (const item of bucket) {
+				if (!item.authorId) continue;
+				const f = authorMap.get(item.authorId);
+				if (f) fallbackByItem.set(item.id, f);
+			}
+		}
+	}
+
+	// 4. Assign to each item.
 	for (const item of items) {
-		const explicit = bylinesMap.get(item.id);
+		const explicit = bylinesByItem.get(item.id);
 		if (explicit && explicit.length > 0) {
 			item.bylines = explicit.map((c) => ({ ...c, source: "explicit" as const }));
 			item.byline = explicit[0]?.byline ?? null;
 			continue;
 		}
 
-		// Defensive: if primaryBylineId is set but no junction rows exist, it's orphaned
-		if (item.primaryBylineId) {
-			item.primaryBylineId = null;
-		}
-
-		if (item.authorId) {
-			const fallback = authorBylineMap.get(item.authorId);
-			if (fallback) {
-				item.bylines = [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }];
-				item.byline = fallback;
-				continue;
-			}
+		const fallback = fallbackByItem.get(item.id);
+		if (fallback) {
+			item.bylines = [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }];
+			item.byline = fallback;
+			continue;
 		}
 
 		item.bylines = [];
@@ -454,12 +518,16 @@ export async function handleContentCreate(
 			const repo = new ContentRepository(trx);
 			const bylineRepo = new BylineRepository(trx);
 
-			// Auto-generate slug from title/name if not explicitly provided
+			// Default to the configured site locale rather than the repo's
+			// hard-coded "en" — otherwise non-English default-locale sites
+			// silently create entries in a locale the editor never chose.
+			const effectiveLocale = body.locale ?? getI18nConfig()?.defaultLocale;
+
 			let slug: string | null | undefined = body.slug;
 			if (!slug) {
 				const slugSource = getSlugSource(body.data);
 				if (slugSource) {
-					slug = await repo.generateUniqueSlug(collection, slugSource, body.locale);
+					slug = await repo.generateUniqueSlug(collection, slugSource, effectiveLocale);
 				}
 			}
 
@@ -469,28 +537,50 @@ export async function handleContentCreate(
 				data: body.data,
 				status: body.status || "draft",
 				authorId: body.authorId,
-				locale: body.locale,
+				locale: effectiveLocale,
 				translationOf: body.translationOf,
 				createdAt: body.createdAt,
 				publishedAt: body.publishedAt,
 			});
 
 			if (body.bylines !== undefined) {
-				await bylineRepo.setContentBylines(collection, created.id, body.bylines);
-				created.primaryBylineId = body.bylines[0]?.bylineId ?? null;
+				const credits = await bylineRepo.setContentBylines(collection, created.id, body.bylines);
+				// `setContentBylines` translates wire row ids to their
+				// `translation_group` before writing. The response-shape
+				// `primaryBylineId` must match what's now in the DB, so read
+				// it from the returned credit (whose `byline` came from a
+				// hydration round-trip).
+				created.primaryBylineId = credits[0]?.byline.translationGroup ?? null;
 			}
-			await hydrateBylines(trx, collection, created);
 
-			// When this row is a translation of an existing item, inherit the
-			// source's taxonomy assignments. The pivot stores translation_groups
-			// so the copied rows apply to every locale of the translation group
-			// (existing per-locale assignments still resolve correctly in
-			// `getEntryTerms` because the join picks the locale-specific row).
+			// When this row is a translation of an existing item, inherit
+			// the source's taxonomy assignments AND byline credits. Both
+			// pivots store translation_groups (taxonomies post-mig 036,
+			// bylines post-mig 040), so a copied row applies across every
+			// locale of the credited identity — and the locale-strict
+			// hydration below renders the variant that matches the entry's
+			// locale (or nothing if no variant exists yet at this locale,
+			// which is the documented Phase 4 behaviour).
+			//
+			// Explicit `body.bylines` wins — `copyContentBylines` no-ops
+			// when the target already has credits, but the cleaner guard
+			// is to skip the call entirely.
 			if (body.translationOf) {
 				const { TaxonomyRepository } = await import("../../database/repositories/taxonomy.js");
 				const taxRepo = new TaxonomyRepository(trx);
 				await taxRepo.copyEntryTerms(collection, body.translationOf, created.id);
+
+				if (body.bylines === undefined) {
+					await bylineRepo.copyContentBylines(collection, body.translationOf, created.id);
+					// `copyContentBylines` writes the source's primary
+					// pointer onto the new row; reflect it in-memory so the
+					// response includes it before hydrateBylines runs.
+					const source = await repo.findById(collection, body.translationOf);
+					if (source) created.primaryBylineId = source.primaryBylineId;
+				}
 			}
+
+			await hydrateBylines(trx, collection, created);
 
 			// Side-write SEO data if provided
 			if (body.seo && hasSeo) {
@@ -648,8 +738,12 @@ export async function handleContentUpdate(
 			});
 
 			if (body.bylines !== undefined) {
-				await bylineRepo.setContentBylines(collection, resolvedId, body.bylines);
-				updated.primaryBylineId = body.bylines[0]?.bylineId ?? null;
+				const credits = await bylineRepo.setContentBylines(collection, resolvedId, body.bylines);
+				// `setContentBylines` translates wire row ids to their
+				// `translation_group` before writing. Read the in-memory
+				// pointer from the persisted credit so the response shape
+				// matches the DB. See the matching block in handleContentCreate.
+				updated.primaryBylineId = credits[0]?.byline.translationGroup ?? null;
 			}
 
 			// Create auto-redirect when slug changes

--- a/packages/core/src/api/schemas/bylines.ts
+++ b/packages/core/src/api/schemas/bylines.ts
@@ -17,6 +17,14 @@ export const bylineSummarySchema = z
 		isGuest: z.boolean(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
+		/** Locale this byline row is presented in (migration 040). */
+		locale: z.string(),
+		/**
+		 * Shared across translations of the same byline (migration 040).
+		 * Equals `id` for the anchor row; siblings inherit it from their
+		 * source. Nullable in storage for backwards compatibility.
+		 */
+		translationGroup: z.string().nullable(),
 	})
 	.meta({ id: "BylineSummary" });
 
@@ -43,6 +51,12 @@ export const bylinesListQuery = cursorPaginationQuery
 		search: z.string().optional(),
 		isGuest: z.coerce.boolean().optional(),
 		userId: z.string().optional(),
+		/**
+		 * Filter by locale (strict per-locale matching, post-migration 040).
+		 * Rejects empty strings so the picker can't silently fetch the
+		 * unfiltered list when the admin URL has `?locale=` with no value.
+		 */
+		locale: z.string().min(1).optional(),
 	})
 	.meta({ id: "BylinesListQuery" });
 
@@ -58,8 +72,40 @@ export const bylineCreateBody = z
 		websiteUrl: httpUrl.nullish(),
 		userId: z.string().nullish(),
 		isGuest: z.boolean().optional(),
+		/**
+		 * Locale this byline row belongs to. When omitted, the DB DEFAULT (the
+		 * configured `defaultLocale`) is used. Rejects empty strings — an
+		 * empty locale would create rows no resolver requests.
+		 */
+		locale: z.string().min(1).optional(),
+		/**
+		 * When set, the new row joins the source byline's translation_group
+		 * rather than minting a fresh one. Requires `locale`.
+		 */
+		translationOf: z.string().min(1).optional(),
 	})
 	.meta({ id: "BylineCreateBody" });
+
+export const bylineTranslationCreateBody = z
+	.object({
+		locale: z.string().min(1),
+		slug: z
+			.string()
+			.min(1)
+			.regex(bylineSlugPattern, "Slug must contain only lowercase letters, digits, and hyphens")
+			.optional(),
+		displayName: z.string().min(1).optional(),
+		bio: z.string().nullish(),
+		avatarMediaId: z.string().nullish(),
+		websiteUrl: httpUrl.nullish(),
+	})
+	.meta({ id: "BylineTranslationCreateBody" });
+
+export const bylineTranslationsResponseSchema = z
+	.object({
+		items: z.array(bylineSummarySchema),
+	})
+	.meta({ id: "BylineTranslationsResponse" });
 
 export const bylineUpdateBody = z
 	.object({

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -448,6 +448,11 @@ export function injectCoreRoutes(injectRoute: InjectRoute): void {
 	});
 
 	injectRoute({
+		pattern: "/_emdash/api/admin/bylines/[id]/translations",
+		entrypoint: resolveRoute("api/admin/bylines/[id]/translations.ts"),
+	});
+
+	injectRoute({
 		pattern: "/_emdash/api/admin/users/[id]",
 		entrypoint: resolveRoute("api/admin/users/[id]/index.ts"),
 	});

--- a/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/[id]/index.ts
@@ -1,4 +1,3 @@
-import { Role } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
@@ -10,17 +9,9 @@ import { BylineRepository } from "#db/repositories/byline.js";
 
 export const prerender = false;
 
-function requireEditor(user: { role: number } | undefined): Response | null {
-	if (!user || user.role < Role.EDITOR) {
-		return apiError("FORBIDDEN", "Editor privileges required", 403);
-	}
-	return null;
-}
-
 export const GET: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
-	// Read access uses content:read so all authenticated roles can view byline data
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "bylines:read");
 	if (denied) return denied;
 
 	if (!emdash?.db) {
@@ -39,7 +30,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
 export const PUT: APIRoute = async ({ params, request, locals }) => {
 	const { emdash, user } = locals;
-	const denied = requireEditor(user);
+	const denied = requirePerm(user, "bylines:manage");
 	if (denied) return denied;
 
 	if (!emdash?.db) {
@@ -71,7 +62,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 
 export const DELETE: APIRoute = async ({ params, locals }) => {
 	const { emdash, user } = locals;
-	const denied = requireEditor(user);
+	const denied = requirePerm(user, "bylines:manage");
 	if (denied) return denied;
 
 	if (!emdash?.db) {

--- a/packages/core/src/astro/routes/api/admin/bylines/[id]/translations.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/[id]/translations.ts
@@ -1,0 +1,99 @@
+/**
+ * Byline translation endpoints
+ *
+ * GET  /_emdash/api/admin/bylines/:id/translations  — list every translation
+ *                                                     of a byline (siblings
+ *                                                     in the same
+ *                                                     translation_group)
+ * POST /_emdash/api/admin/bylines/:id/translations  — create a new locale
+ *                                                     variant joining the
+ *                                                     source's
+ *                                                     translation_group
+ *                                                     (body: { locale, ... })
+ */
+
+import type { APIRoute } from "astro";
+
+import { requirePerm } from "#api/authorize.js";
+import { handleError, requireDb, unwrapResult } from "#api/error.js";
+import { handleBylineCreate, handleBylineTranslations } from "#api/handlers/bylines.js";
+import { isParseError, parseBody } from "#api/parse.js";
+import { bylineTranslationCreateBody } from "#api/schemas.js";
+import { invalidateBylineCache } from "#bylines/index.js";
+import { BylineRepository } from "#db/repositories/byline.js";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, locals }) => {
+	const { emdash, user } = locals;
+	const id = params.id!;
+
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
+
+	const denied = requirePerm(user, "bylines:read");
+	if (denied) return denied;
+
+	try {
+		const result = await handleBylineTranslations(emdash.db, id);
+		return unwrapResult(result);
+	} catch (error) {
+		return handleError(error, "Failed to fetch byline translations", "BYLINE_TRANSLATIONS_ERROR");
+	}
+};
+
+export const POST: APIRoute = async ({ params, request, locals }) => {
+	const { emdash, user } = locals;
+	const id = params.id!;
+
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
+
+	const denied = requirePerm(user, "bylines:manage");
+	if (denied) return denied;
+
+	try {
+		const body = await parseBody(request, bylineTranslationCreateBody);
+		if (isParseError(body)) return body;
+
+		// Look up the source byline so we can:
+		//  (a) emit a clean 404 when it doesn't exist (route layer);
+		//  (b) fall back to its slug + display_name + avatar/website when
+		//      the body omits them. Editors creating a translation often
+		//      want to keep the slug stable and only enter the localized
+		//      bio/displayName — defaulting saves clicks.
+		const repo = new BylineRepository(emdash.db);
+		const source = await repo.findById(id);
+		if (!source) {
+			return new Response(
+				JSON.stringify({ error: { code: "NOT_FOUND", message: "Byline not found" } }),
+				{ status: 404, headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		const result = await handleBylineCreate(emdash.db, {
+			slug: body.slug ?? source.slug,
+			displayName: body.displayName ?? source.displayName,
+			bio: body.bio ?? null,
+			avatarMediaId: body.avatarMediaId ?? source.avatarMediaId,
+			websiteUrl: body.websiteUrl ?? source.websiteUrl,
+			// Translations don't inherit the source's user_id or guest flag —
+			// the partial unique on (user_id, locale) means a single user can
+			// own one byline per locale, but the editor must opt into linking
+			// the new row by editing it after creation.
+			userId: null,
+			isGuest: source.isGuest,
+			locale: body.locale,
+			translationOf: id,
+		});
+
+		if (result.success) invalidateBylineCache();
+		return unwrapResult(result, 201);
+	} catch (error) {
+		return handleError(
+			error,
+			"Failed to create byline translation",
+			"BYLINE_TRANSLATION_CREATE_ERROR",
+		);
+	}
+};

--- a/packages/core/src/astro/routes/api/admin/bylines/index.ts
+++ b/packages/core/src/astro/routes/api/admin/bylines/index.ts
@@ -1,12 +1,14 @@
-import { Role } from "@emdash-cms/auth";
 import type { APIRoute } from "astro";
 
 import { requirePerm } from "#api/authorize.js";
-import { apiError, apiSuccess, handleError } from "#api/error.js";
+import { apiError, apiSuccess, handleError, unwrapResult } from "#api/error.js";
+import { handleBylineCreate } from "#api/handlers/bylines.js";
 import { isParseError, parseBody, parseQuery } from "#api/parse.js";
 import { bylineCreateBody, bylinesListQuery } from "#api/schemas.js";
 import { invalidateBylineCache } from "#bylines/index.js";
 import { BylineRepository } from "#db/repositories/byline.js";
+
+import { getI18nConfig } from "../../../../../i18n/config.js";
 
 export const prerender = false;
 
@@ -17,12 +19,20 @@ export const GET: APIRoute = async ({ url, locals }) => {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
 
-	// Read access uses content:read so all authenticated roles can view byline data
-	const denied = requirePerm(user, "content:read");
+	const denied = requirePerm(user, "bylines:read");
 	if (denied) return denied;
 
 	const query = parseQuery(url, bylinesListQuery);
 	if (isParseError(query)) return query;
+
+	const i18n = getI18nConfig();
+	if (query.locale && i18n && !i18n.locales.includes(query.locale)) {
+		return apiError(
+			"VALIDATION_ERROR",
+			`Locale "${query.locale}" is not configured for this site`,
+			400,
+		);
+	}
 
 	try {
 		const repo = new BylineRepository(emdash.db);
@@ -30,6 +40,7 @@ export const GET: APIRoute = async ({ url, locals }) => {
 			search: query.search,
 			isGuest: query.isGuest,
 			userId: query.userId,
+			locale: query.locale,
 			cursor: query.cursor,
 			limit: query.limit,
 		});
@@ -47,16 +58,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 	}
 
-	if (!user || user.role < Role.EDITOR) {
-		return apiError("FORBIDDEN", "Editor privileges required", 403);
-	}
+	const denied = requirePerm(user, "bylines:manage");
+	if (denied) return denied;
 
 	const body = await parseBody(request, bylineCreateBody);
 	if (isParseError(body)) return body;
 
 	try {
-		const repo = new BylineRepository(emdash.db);
-		const byline = await repo.create({
+		const result = await handleBylineCreate(emdash.db, {
 			slug: body.slug,
 			displayName: body.displayName,
 			bio: body.bio ?? null,
@@ -64,10 +73,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
 			websiteUrl: body.websiteUrl ?? null,
 			userId: body.userId ?? null,
 			isGuest: body.isGuest,
+			locale: body.locale,
+			translationOf: body.translationOf,
 		});
 
-		invalidateBylineCache();
-		return apiSuccess(byline, 201);
+		if (result.success) invalidateBylineCache();
+		return unwrapResult(result, 201);
 	} catch (error) {
 		return handleError(error, "Failed to create byline", "BYLINE_CREATE_ERROR");
 	}

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -4,6 +4,16 @@
  * Provides functions to query byline profiles and byline credits
  * associated with content entries. Follows the same pattern as
  * the taxonomies runtime API.
+ *
+ * i18n model (migration 040): byline rows are per-locale and share a
+ * `translation_group`. Credits on `_emdash_content_bylines.byline_id` store
+ * the translation_group, so a single credit spans every locale of a byline.
+ *
+ * Hydration is strict per locale: a credit at locale X renders iff a byline
+ * row exists at locale X within the credited translation_group. There is no
+ * read-time fallback. Mirrors `getEntryTerms` and the convention in PR #916.
+ * Locale is passed in by callers — `query.ts` resolves it from the entry's
+ * own `data.locale` for the runtime path.
  */
 
 import { sql } from "kysely";
@@ -11,7 +21,9 @@ import { sql } from "kysely";
 import { BylineRepository } from "../database/repositories/byline.js";
 import type { BylineSummary, ContentBylineCredit } from "../database/repositories/types.js";
 import { validateIdentifier } from "../database/validate.js";
+import { resolveLocaleChain } from "../i18n/resolve.js";
 import { getDb } from "../loader.js";
+import { requestCached } from "../request-cache.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 
 /**
@@ -49,28 +61,60 @@ export async function getByline(id: string): Promise<BylineSummary | null> {
 /**
  * Get a byline by slug.
  *
+ * Standalone identity lookup (e.g. rendering an author profile page). Walks
+ * the configured locale fallback chain — same pattern as `getMenu` and
+ * `getTerm`, see PR #916. Returns the first match found, walking
+ * `[requestedLocale, ...fallbacks, defaultLocale]` in order.
+ *
+ * Note: this is intentionally different from credit hydration on a content
+ * entry (`getEntryBylines`), which is strict per locale with no fallback.
+ * The distinction: identity lookups answer "give me this byline", and
+ * falling back to another locale's display name is acceptable. Credit
+ * hydration answers "what should render on this entry", where falling back
+ * silently surfaces a stale-locale name and contradicts editorial intent.
+ *
  * @example
  * ```ts
  * import { getBylineBySlug } from "emdash";
  *
- * const byline = await getBylineBySlug("jane-doe");
+ * const byline = await getBylineBySlug("jane-doe", { locale: "de-de" });
  * if (byline) {
- *   console.log(byline.displayName); // "Jane Doe"
+ *   console.log(byline.displayName);
  * }
  * ```
  */
-export async function getBylineBySlug(slug: string): Promise<BylineSummary | null> {
-	const db = await getDb();
-	const repo = new BylineRepository(db);
-	return repo.findBySlug(slug);
+export async function getBylineBySlug(
+	slug: string,
+	options?: { locale?: string },
+): Promise<BylineSummary | null> {
+	const chain = resolveLocaleChain(options?.locale);
+	const cacheKey = `byline-by-slug:${slug}:${chain.length > 0 ? chain.join(",") : "*"}`;
+	return requestCached(cacheKey, async () => {
+		const db = await getDb();
+		const repo = new BylineRepository(db);
+
+		if (chain.length === 0) {
+			// No i18n or no resolved locale — fall back to the repo's
+			// "lowest-locale-code" deterministic match.
+			return repo.findBySlug(slug);
+		}
+
+		for (const locale of chain) {
+			const row = await repo.findBySlug(slug, { locale });
+			if (row) return row;
+		}
+		return null;
+	});
 }
 
 /**
  * Get byline credits for a single content entry.
  *
- * Returns explicit byline credits from the junction table. If none exist
- * but the entry has an `authorId`, falls back to the user-linked byline
- * (marked as source: "inferred").
+ * Strict per locale (post-migration 040): a credit renders iff a byline row
+ * exists at the requested locale within the credited translation_group.
+ * Callers wanting fallback behaviour apply it themselves. When `locale` is
+ * omitted, returns every locale variant of every credit on the entry —
+ * useful for admin tooling, not for end-user rendering.
  *
  * Internal: not re-exported from the `emdash` package entry point. Every
  * entry returned by `getEmDashCollection` / `getEmDashEntry` already has
@@ -81,20 +125,31 @@ export async function getBylineBySlug(slug: string): Promise<BylineSummary | nul
 export async function getEntryBylines(
 	collection: string,
 	entryId: string,
+	options?: { locale?: string },
 ): Promise<ContentBylineCredit[]> {
 	validateIdentifier(collection, "collection");
 	const db = await getDb();
 	const repo = new BylineRepository(db);
 
-	const explicit = await repo.getContentBylines(collection, entryId);
+	const localeOpt = options?.locale !== undefined ? { locale: options.locale } : undefined;
+	const explicit = await repo.getContentBylines(collection, entryId, localeOpt);
 	if (explicit.length > 0) {
 		return explicit.map((c) => ({ ...c, source: "explicit" as const }));
 	}
 
-	// Fallback: look up user-linked byline from author_id
+	// Explicit editorial intent at any locale beats inferred author
+	// fallback: if the entry has any junction rows (even at another
+	// locale), don't infer from authorId. The credit is preserved in
+	// storage; it simply doesn't render at this locale until a sibling
+	// is created.
+	if (await repo.hasContentBylines(collection, entryId)) return [];
+
+	// Fallback: look up user-linked byline from author_id. Same strict-locale
+	// rule applies — a user-linked byline surfaces only when a sibling
+	// exists at the requested locale.
 	const authorId = await getAuthorId(db, collection, entryId);
 	if (authorId) {
-		const fallback = await repo.findByUserId(authorId);
+		const fallback = await repo.findByUserId(authorId, localeOpt);
 		if (fallback) {
 			return [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }];
 		}
@@ -109,14 +164,25 @@ export async function getEntryBylines(
  * `authorId` is read directly from the row when computing the inferred-byline
  * fallback — passing it in avoids a redundant `SELECT id, author_id` against
  * the content table after every list/entry fetch.
+ *
+ * `locale` is the entry's own locale (from the `locale` column on the
+ * content row). Required for the strict per-locale byline join — entries at
+ * different locales are bucketed and queried separately so each one resolves
+ * against its own locale's byline rows.
  */
 export interface BylineEntry {
 	id: string;
 	authorId: string | null;
+	locale?: string | null;
 }
 
 /**
- * Batch-fetch byline credits for multiple content entries in a single query.
+ * Batch-fetch byline credits for multiple content entries.
+ *
+ * Per-entry strict-locale hydration: entries are bucketed by `entry.locale`
+ * and each bucket gets a single batched call to the strict-locale repo
+ * method. Items with no `locale` field (legacy / single-locale installs)
+ * share an unscoped bucket.
  *
  * Internal: consumed by `hydrateEntryBylines` in `query.ts` so that every
  * entry returned from `getEmDashCollection` / `getEmDashEntry` already has
@@ -125,7 +191,7 @@ export interface BylineEntry {
  * from the `emdash` package entry point.
  *
  * @param collection - The collection slug (e.g., "posts")
- * @param entries - Entry id + authorId pairs (authorId is already on the row)
+ * @param entries - Entry id + authorId + locale (each entry resolves at its own locale)
  * @returns Map from entry ID to array of byline credits
  */
 export async function getBylinesForEntries(
@@ -145,33 +211,78 @@ export async function getBylinesForEntries(
 
 	const db = await getDb();
 	const repo = new BylineRepository(db);
-	const entryIds = entries.map((e) => e.id);
 
-	// Sites with no bylines get an empty map back for one query — the previous
-	// "has any bylines" probe traded an extra round-trip on every request to
-	// save that one query on empty sites, which is exactly backwards for the
-	// common case. Pre-migration databases (bylines table missing) fall
-	// through to the `isMissingTableError` catch below and return empty.
-	let bylinesMap;
-	try {
-		bylinesMap = await repo.getContentBylinesMany(collection, entryIds);
-	} catch (error) {
-		if (isMissingTableError(error)) return result;
-		throw error;
+	// Bucket entries by locale so each bucket fires a single strict-locale
+	// `getContentBylinesMany` call. Items with no locale field share a
+	// bucket keyed by null (no `WHERE locale = ?` applied — legacy
+	// pre-i18n shape).
+	const buckets = new Map<string | null, BylineEntry[]>();
+	for (const entry of entries) {
+		const key = entry.locale ?? null;
+		const bucket = buckets.get(key);
+		if (bucket) bucket.push(entry);
+		else buckets.set(key, [entry]);
 	}
 
-	const needsFallback = new Map<string, string>();
-	for (const { id, authorId } of entries) {
-		if (!bylinesMap.has(id) && authorId) {
-			needsFallback.set(id, authorId);
+	// Sites with no bylines get an empty map back at the same cost as the
+	// previous "has any bylines" probe, without the extra round-trip.
+	// Pre-migration databases (bylines table missing) fall through to the
+	// `isMissingTableError` catch below and return empty.
+	const explicitByEntry = new Map<string, ContentBylineCredit[]>();
+	const entriesNeedingAuthorCheck: BylineEntry[] = [];
+	for (const [locale, bucket] of buckets) {
+		const localeOpt = locale ? { locale } : undefined;
+		const bucketIds = bucket.map((e) => e.id);
+		let bylinesMap;
+		try {
+			bylinesMap = await repo.getContentBylinesMany(collection, bucketIds, localeOpt);
+		} catch (error) {
+			if (isMissingTableError(error)) return result;
+			throw error;
+		}
+		for (const [id, list] of bylinesMap) explicitByEntry.set(id, list);
+
+		for (const entry of bucket) {
+			const hasResolved = bylinesMap.has(entry.id) && bylinesMap.get(entry.id)!.length > 0;
+			if (hasResolved) continue;
+			if (entry.authorId) entriesNeedingAuthorCheck.push(entry);
 		}
 	}
 
-	const uniqueAuthorIds = [...new Set(needsFallback.values())];
-	const authorBylineMap = await repo.findByUserIds(uniqueAuthorIds);
+	// For entries with no resolved credits at their locale: check
+	// locale-agnostically whether they have *any* junction rows. Entries
+	// with explicit credits (even at another locale) get no inferred
+	// fallback — explicit editorial intent at any locale beats inferred.
+	const fallbackByEntry = new Map<string, BylineSummary>();
+	if (entriesNeedingAuthorCheck.length > 0) {
+		const idsToCheck = entriesNeedingAuthorCheck.map((e) => e.id);
+		const hasJunctions = await repo.hasContentBylinesMany(collection, idsToCheck);
+
+		const authorBuckets = new Map<string | null, BylineEntry[]>();
+		for (const entry of entriesNeedingAuthorCheck) {
+			if (hasJunctions.has(entry.id)) continue;
+			const key = entry.locale ?? null;
+			const bucket = authorBuckets.get(key);
+			if (bucket) bucket.push(entry);
+			else authorBuckets.set(key, [entry]);
+		}
+
+		for (const [locale, bucket] of authorBuckets) {
+			const localeOpt = locale ? { locale } : undefined;
+			const authorIds = bucket.map((e) => e.authorId).filter((id): id is string => id !== null);
+			const uniqueAuthorIds = [...new Set(authorIds)];
+			if (uniqueAuthorIds.length === 0) continue;
+			const authorBylineMap = await repo.findByUserIds(uniqueAuthorIds, localeOpt);
+			for (const entry of bucket) {
+				if (!entry.authorId) continue;
+				const f = authorBylineMap.get(entry.authorId);
+				if (f) fallbackByEntry.set(entry.id, f);
+			}
+		}
+	}
 
 	for (const { id } of entries) {
-		const explicit = bylinesMap.get(id);
+		const explicit = explicitByEntry.get(id);
 		if (explicit && explicit.length > 0) {
 			result.set(
 				id,
@@ -180,12 +291,9 @@ export async function getBylinesForEntries(
 			continue;
 		}
 
-		const authorId = needsFallback.get(id);
-		if (authorId) {
-			const fallback = authorBylineMap.get(authorId);
-			if (fallback) {
-				result.set(id, [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }]);
-			}
+		const fallback = fallbackByEntry.get(id);
+		if (fallback) {
+			result.set(id, [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }]);
 		}
 	}
 

--- a/packages/core/src/bylines/index.ts
+++ b/packages/core/src/bylines/index.ts
@@ -137,19 +137,14 @@ export async function getEntryBylines(
 		return explicit.map((c) => ({ ...c, source: "explicit" as const }));
 	}
 
-	// Explicit editorial intent at any locale beats inferred author
-	// fallback: if the entry has any junction rows (even at another
-	// locale), don't infer from authorId. The credit is preserved in
-	// storage; it simply doesn't render at this locale until a sibling
-	// is created.
-	if (await repo.hasContentBylines(collection, entryId)) return [];
+	// `primary_byline_id` is the explicit-credit sentinel: non-null
+	// suppresses author fallback even when the credit doesn't resolve
+	// at this locale.
+	const ctx = await getEntryContext(db, collection, entryId);
+	if (ctx.primaryBylineId) return [];
 
-	// Fallback: look up user-linked byline from author_id. Same strict-locale
-	// rule applies — a user-linked byline surfaces only when a sibling
-	// exists at the requested locale.
-	const authorId = await getAuthorId(db, collection, entryId);
-	if (authorId) {
-		const fallback = await repo.findByUserId(authorId, localeOpt);
+	if (ctx.authorId) {
+		const fallback = await repo.findByUserId(ctx.authorId, localeOpt);
 		if (fallback) {
 			return [{ byline: fallback, sortOrder: 0, roleLabel: null, source: "inferred" }];
 		}
@@ -159,20 +154,17 @@ export async function getEntryBylines(
 }
 
 /**
- * An entry reference for batch byline lookups.
+ * Entry reference for batch byline lookups. Passing `authorId`,
+ * `primaryBylineId`, and `locale` in directly avoids a per-entry
+ * `SELECT` against the content table during hydration.
  *
- * `authorId` is read directly from the row when computing the inferred-byline
- * fallback — passing it in avoids a redundant `SELECT id, author_id` against
- * the content table after every list/entry fetch.
- *
- * `locale` is the entry's own locale (from the `locale` column on the
- * content row). Required for the strict per-locale byline join — entries at
- * different locales are bucketed and queried separately so each one resolves
- * against its own locale's byline rows.
+ * `primaryBylineId` is the explicit-credit sentinel — non-null suppresses
+ * author fallback. `locale` drives the strict per-locale join.
  */
 export interface BylineEntry {
 	id: string;
 	authorId: string | null;
+	primaryBylineId?: string | null;
 	locale?: string | null;
 }
 
@@ -249,18 +241,13 @@ export async function getBylinesForEntries(
 		}
 	}
 
-	// For entries with no resolved credits at their locale: check
-	// locale-agnostically whether they have *any* junction rows. Entries
-	// with explicit credits (even at another locale) get no inferred
-	// fallback — explicit editorial intent at any locale beats inferred.
+	// Only entries without an explicit credit (primaryBylineId null) are
+	// eligible for author fallback.
 	const fallbackByEntry = new Map<string, BylineSummary>();
 	if (entriesNeedingAuthorCheck.length > 0) {
-		const idsToCheck = entriesNeedingAuthorCheck.map((e) => e.id);
-		const hasJunctions = await repo.hasContentBylinesMany(collection, idsToCheck);
-
 		const authorBuckets = new Map<string | null, BylineEntry[]>();
 		for (const entry of entriesNeedingAuthorCheck) {
-			if (hasJunctions.has(entry.id)) continue;
+			if (entry.primaryBylineId) continue;
 			const key = entry.locale ?? null;
 			const bucket = authorBuckets.get(key);
 			if (bucket) bucket.push(entry);
@@ -300,23 +287,27 @@ export async function getBylinesForEntries(
 	return result;
 }
 
-/**
- * Look up the author_id for a single content entry.
- * Uses raw SQL since we need dynamic table names.
- */
-async function getAuthorId(
+/** Reads `author_id` + `primary_byline_id` for one entry in a single query. */
+async function getEntryContext(
 	db: Awaited<ReturnType<typeof getDb>>,
 	collection: string,
 	entryId: string,
-): Promise<string | null> {
+): Promise<{ authorId: string | null; primaryBylineId: string | null }> {
 	validateIdentifier(collection, "collection");
 	const tableName = `ec_${collection}`;
 
-	const result = await sql<{ author_id: string | null }>`
-		SELECT author_id FROM ${sql.ref(tableName)}
+	const result = await sql<{
+		author_id: string | null;
+		primary_byline_id: string | null;
+	}>`
+		SELECT author_id, primary_byline_id FROM ${sql.ref(tableName)}
 		WHERE id = ${entryId}
 		LIMIT 1
 	`.execute(db);
 
-	return result.rows[0]?.author_id ?? null;
+	const row = result.rows[0];
+	return {
+		authorId: row?.author_id ?? null,
+		primaryBylineId: row?.primary_byline_id ?? null,
+	};
 }

--- a/packages/core/src/database/migrations/040_byline_i18n.ts
+++ b/packages/core/src/database/migrations/040_byline_i18n.ts
@@ -1,0 +1,497 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+import { getI18nConfig } from "../../i18n/config.js";
+import { currentTimestamp, isSqlite, listTablesLike } from "../dialect-helpers.js";
+import { validateIdentifier } from "../validate.js";
+
+/**
+ * i18n for bylines. Adds `locale` + `translation_group` to `_emdash_bylines`
+ * and stores translation_groups (not row ids) in
+ * `_emdash_content_bylines.byline_id` and `ec_*.primary_byline_id`. Backfill
+ * locale and column DEFAULTs use the site's configured defaultLocale.
+ *
+ * Mirrors the row-per-locale + `translation_group` model PR #916 (migration
+ * 036) applied to menus and taxonomies.
+ *
+ * Key consequences of the model:
+ * - `(slug, locale)` is unique on `_emdash_bylines`; a single slug can repeat
+ *   across locales (one row per locale variant of a byline).
+ * - The partial unique on `user_id` widens to `(user_id, locale)` so a CMS
+ *   user can have one byline per locale.
+ * - `_emdash_content_bylines.byline_id` no longer FKs to `_emdash_bylines.id`
+ *   (it holds a `translation_group`, not a row id). The runtime is
+ *   responsible for cascading on byline delete — see `BylineRepository.delete`.
+ *
+ * Hydration is strict per locale (see `BylineRepository.getContentBylines`):
+ * a credit at locale X renders iff a byline row exists at locale X within the
+ * credited translation group. This mirrors `getEntryTerms` and the convention
+ * established by #916. There is no read-time fallback.
+ */
+
+function getDefaultLocale(): string {
+	return getI18nConfig()?.defaultLocale ?? "en";
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	const defaultLocale = getDefaultLocale();
+
+	if (isSqlite(db)) {
+		// Rebuild children before parents to drop FKs that would CASCADE
+		// on D1 (#1021). `_emdash_content_bylines.byline_id` has an FK to
+		// `_emdash_bylines(id) ON DELETE CASCADE` from migration 031.
+		// Stripping it first lets us rebuild `_emdash_bylines` without
+		// risking a cascading wipe of credits on D1.
+		await rebuildContentBylines(db);
+		await rebuildBylines(db, defaultLocale);
+		await remapPrimaryBylineIds(db);
+		return;
+	}
+
+	await pgWidenBylines(db, defaultLocale);
+	await pgDropContentBylinesFk(db);
+	await remapPrimaryBylineIds(db);
+}
+
+async function rebuildContentBylines(db: Kysely<unknown>): Promise<void> {
+	// Drops the FK so `byline_id` can point at a translation_group rather
+	// than a row id. Runs before `rebuildBylines` so the drop is safe on D1.
+	// No remap is needed here: `rebuildBylines` later seeds `translation_group
+	// = id` for every preserved row, so the row-id values we copy resolve as
+	// translation_group references after the migration completes. This coupling
+	// is load-bearing — if the translation_group seed ever changes, this needs
+	// an explicit remap *after* `rebuildBylines` runs.
+	const fks = await sql<{ id: number }>`PRAGMA foreign_key_list(_emdash_content_bylines)`.execute(
+		db,
+	);
+	if (fks.rows.length === 0) return;
+
+	await sql.raw(`DROP TABLE IF EXISTS "_emdash_content_bylines_new"`).execute(db);
+	await db.schema
+		.createTable("_emdash_content_bylines_new")
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("collection_slug", "text", (c) => c.notNull())
+		.addColumn("content_id", "text", (c) => c.notNull())
+		.addColumn("byline_id", "text", (c) => c.notNull())
+		.addColumn("sort_order", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("role_label", "text")
+		.addColumn("created_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.addUniqueConstraint("content_bylines_unique", ["collection_slug", "content_id", "byline_id"])
+		.execute();
+
+	await sql`
+		INSERT INTO _emdash_content_bylines_new
+			(id, collection_slug, content_id, byline_id, sort_order, role_label, created_at)
+		SELECT id, collection_slug, content_id, byline_id, sort_order, role_label, created_at
+		FROM _emdash_content_bylines
+	`.execute(db);
+
+	await db.schema.dropTable("_emdash_content_bylines").execute();
+	await sql`ALTER TABLE _emdash_content_bylines_new RENAME TO _emdash_content_bylines`.execute(db);
+
+	// Indexes from migration 031 dropped with the table; restore.
+	await db.schema
+		.createIndex("idx_content_bylines_content")
+		.on("_emdash_content_bylines")
+		.columns(["collection_slug", "content_id", "sort_order"])
+		.execute();
+	await db.schema
+		.createIndex("idx_content_bylines_byline")
+		.on("_emdash_content_bylines")
+		.column("byline_id")
+		.execute();
+}
+
+async function rebuildBylines(db: Kysely<unknown>, defaultLocale: string): Promise<void> {
+	if (await hasColumn(db, "_emdash_bylines", "locale")) return;
+	await sql.raw(`DROP TABLE IF EXISTS "_emdash_bylines_new"`).execute(db);
+
+	await db.schema
+		.createTable("_emdash_bylines_new")
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("slug", "text", (c) => c.notNull())
+		.addColumn("display_name", "text", (c) => c.notNull())
+		.addColumn("bio", "text")
+		.addColumn("avatar_media_id", "text", (c) => c.references("media.id").onDelete("set null"))
+		.addColumn("website_url", "text")
+		.addColumn("user_id", "text", (c) => c.references("users.id").onDelete("set null"))
+		.addColumn("is_guest", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("created_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.addColumn("updated_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.addColumn("locale", "text", (c) => c.notNull().defaultTo(defaultLocale))
+		.addColumn("translation_group", "text")
+		.addUniqueConstraint("_emdash_bylines_slug_locale_unique", ["slug", "locale"])
+		.execute();
+
+	await sql`
+		INSERT INTO _emdash_bylines_new (
+			id, slug, display_name, bio, avatar_media_id, website_url,
+			user_id, is_guest, created_at, updated_at, locale, translation_group
+		)
+		SELECT
+			id, slug, display_name, bio, avatar_media_id, website_url,
+			user_id, is_guest, created_at, updated_at, ${defaultLocale}, id
+		FROM _emdash_bylines
+	`.execute(db);
+
+	await db.schema.dropTable("_emdash_bylines").execute();
+	await sql`ALTER TABLE _emdash_bylines_new RENAME TO _emdash_bylines`.execute(db);
+
+	// Indexes from migration 031 dropped with the table; restore the
+	// per-slug and per-display-name indexes. The partial unique on
+	// user_id widens to (user_id, locale) so one CMS user can own one
+	// byline per locale.
+	await db.schema.createIndex("idx_bylines_slug").on("_emdash_bylines").column("slug").execute();
+	await db.schema
+		.createIndex("idx_bylines_display_name")
+		.on("_emdash_bylines")
+		.column("display_name")
+		.execute();
+	await sql`
+		CREATE UNIQUE INDEX ${sql.ref("idx_bylines_user_id_locale_unique")}
+		ON ${sql.ref("_emdash_bylines")} (user_id, locale)
+		WHERE user_id IS NOT NULL
+	`.execute(db);
+
+	await db.schema
+		.createIndex("idx__emdash_bylines_locale")
+		.on("_emdash_bylines")
+		.column("locale")
+		.execute();
+	await db.schema
+		.createIndex("idx__emdash_bylines_translation_group")
+		.on("_emdash_bylines")
+		.column("translation_group")
+		.execute();
+
+	// One row per (translation_group, locale): the row-per-locale model
+	// (PR #916) requires that each locale variant of a byline appears
+	// exactly once in its translation group. `UNIQUE(slug, locale)` doesn't
+	// catch the case where two siblings in the same group use different
+	// slugs at the same locale — this partial unique does. `WHERE
+	// translation_group IS NOT NULL` is defensive: post-040 every row has a
+	// value, but the column is nullable in the schema.
+	await sql`
+		CREATE UNIQUE INDEX ${sql.ref("idx_bylines_group_locale_unique")}
+		ON ${sql.ref("_emdash_bylines")} (translation_group, locale)
+		WHERE translation_group IS NOT NULL
+	`.execute(db);
+}
+
+async function remapPrimaryBylineIds(db: Kysely<unknown>): Promise<void> {
+	// Walks every `ec_*` table and remaps `primary_byline_id` (row id →
+	// translation_group). On a fresh install translation_group equals id
+	// for every row, so the values look unchanged — but the column
+	// semantics flip from "FK to _emdash_bylines.id" to "translation_group
+	// in _emdash_bylines.translation_group". Once translations exist, the
+	// remap is meaningful: a credit pointing at the en-row id still
+	// resolves to the same byline group at every locale variant.
+	const collections = await listTablesLike(db, "ec_%");
+	for (const table of collections) {
+		validateIdentifier(table, "content table");
+		await sql`
+			UPDATE ${sql.ref(table)} SET primary_byline_id = (
+				SELECT translation_group FROM _emdash_bylines
+				WHERE _emdash_bylines.id = ${sql.ref(table)}.primary_byline_id
+			)
+			WHERE primary_byline_id IS NOT NULL
+				AND EXISTS (
+					SELECT 1 FROM _emdash_bylines
+					WHERE _emdash_bylines.id = ${sql.ref(table)}.primary_byline_id
+				)
+		`.execute(db);
+	}
+}
+
+async function pgWidenBylines(db: Kysely<unknown>, defaultLocale: string): Promise<void> {
+	const ref = sql.ref("_emdash_bylines");
+	await sql`ALTER TABLE ${ref} ADD COLUMN IF NOT EXISTS locale TEXT NOT NULL DEFAULT ${sql.lit(defaultLocale)}`.execute(
+		db,
+	);
+	await sql`ALTER TABLE ${ref} ADD COLUMN IF NOT EXISTS translation_group TEXT`.execute(db);
+	await sql`UPDATE ${ref} SET translation_group = id WHERE translation_group IS NULL`.execute(db);
+	await sql`CREATE INDEX IF NOT EXISTS ${sql.ref("idx__emdash_bylines_locale")} ON ${ref} (locale)`.execute(
+		db,
+	);
+	await sql`
+		CREATE INDEX IF NOT EXISTS ${sql.ref("idx__emdash_bylines_translation_group")}
+		ON ${ref} (translation_group)
+	`.execute(db);
+
+	// Widen UNIQUE(slug) -> UNIQUE(slug, locale)
+	const slugCons = await sql<{ conname: string }>`
+		SELECT conname FROM pg_constraint c
+		WHERE c.conrelid = '_emdash_bylines'::regclass AND c.contype = 'u'
+			AND array_length(c.conkey, 1) = 1
+			AND (
+				SELECT array_agg(a.attname ORDER BY pos.ord)
+				FROM unnest(c.conkey) WITH ORDINALITY AS pos(attnum, ord)
+				JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = pos.attnum
+			)::text[] = ARRAY['slug']
+	`.execute(db);
+	for (const c of slugCons.rows) {
+		await sql`ALTER TABLE ${ref} DROP CONSTRAINT ${sql.ref(c.conname)}`.execute(db);
+	}
+	await sql`
+		ALTER TABLE ${ref}
+		ADD CONSTRAINT _emdash_bylines_slug_locale_unique UNIQUE (slug, locale)
+	`.execute(db);
+
+	// Replace the partial unique on (user_id) with (user_id, locale).
+	await sql`DROP INDEX IF EXISTS idx_bylines_user_id_unique`.execute(db);
+	await sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS ${sql.ref("idx_bylines_user_id_locale_unique")}
+		ON ${ref} (user_id, locale) WHERE user_id IS NOT NULL
+	`.execute(db);
+
+	// One row per (translation_group, locale): see SQLite branch above.
+	await sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS ${sql.ref("idx_bylines_group_locale_unique")}
+		ON ${ref} (translation_group, locale) WHERE translation_group IS NOT NULL
+	`.execute(db);
+}
+
+async function pgDropContentBylinesFk(db: Kysely<unknown>): Promise<void> {
+	const fks = await sql<{ conname: string }>`
+		SELECT conname FROM pg_constraint
+		WHERE conrelid = '_emdash_content_bylines'::regclass AND contype = 'f'
+	`.execute(db);
+	for (const c of fks.rows) {
+		await sql`ALTER TABLE _emdash_content_bylines DROP CONSTRAINT ${sql.ref(c.conname)}`.execute(
+			db,
+		);
+	}
+}
+
+async function hasColumn(db: Kysely<unknown>, table: string, column: string): Promise<boolean> {
+	const rows = await sql<{ name: string }>`PRAGMA table_info(${sql.ref(table)})`.execute(db);
+	return rows.rows.some((r) => r.name === column);
+}
+
+/**
+ * down() restores the FK on `_emdash_content_bylines.byline_id`. Rows whose
+ * `byline_id` doesn't resolve to a (translation_group, defaultLocale) row in
+ * `_emdash_bylines` would fail the rebuild after other tables are already
+ * stripped — leaving the user mid-rollback. Surface dangling rows up front.
+ */
+async function assertContentBylinesResolve(
+	db: Kysely<unknown>,
+	defaultLocale: string,
+): Promise<void> {
+	const result = await sql<{ count: number | string }>`
+		SELECT COUNT(*) AS count FROM _emdash_content_bylines cb
+		WHERE NOT EXISTS (
+			SELECT 1 FROM _emdash_bylines b
+			WHERE b.translation_group = cb.byline_id AND b.locale = ${defaultLocale}
+		)
+	`.execute(db);
+	const count = Number(result.rows[0]?.count ?? 0);
+	if (count > 0) {
+		throw new Error(
+			`Cannot revert migration 040_byline_i18n: ` +
+				`${count} row(s) in "_emdash_content_bylines" reference a translation_group ` +
+				`with no row in "_emdash_bylines" at locale="${defaultLocale}". ` +
+				`Clean up the dangling credits before rolling back.`,
+		);
+	}
+}
+
+/**
+ * down() is destructive on multi-locale installs (dropping `locale` collapses
+ * translated rows onto an ambiguous unique key). Refuse to run when any row
+ * sits at a locale other than the configured defaultLocale.
+ */
+async function assertSingleLocale(db: Kysely<unknown>, defaultLocale: string): Promise<void> {
+	const result = await sql<{ count: number | string }>`
+		SELECT COUNT(*) AS count FROM _emdash_bylines WHERE locale != ${defaultLocale}
+	`.execute(db);
+	const count = Number(result.rows[0]?.count ?? 0);
+	if (count > 0) {
+		throw new Error(
+			`Cannot revert migration 040_byline_i18n: ` +
+				`${count} row(s) in "_emdash_bylines" use a non-default locale ` +
+				`(defaultLocale="${defaultLocale}"). ` +
+				`Reverting would drop them silently. Export translations first ` +
+				`(or delete them) and re-run the rollback. ` +
+				`See packages/core/src/database/migrations/040_byline_i18n.ts.`,
+		);
+	}
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	const defaultLocale = getDefaultLocale();
+	await assertSingleLocale(db, defaultLocale);
+	await assertContentBylinesResolve(db, defaultLocale);
+
+	if (isSqlite(db)) {
+		// Indexes first to avoid blocking the table rebuilds.
+		await sql.raw(`DROP INDEX IF EXISTS idx__emdash_bylines_locale`).execute(db);
+		await sql.raw(`DROP INDEX IF EXISTS idx__emdash_bylines_translation_group`).execute(db);
+		await sql.raw(`DROP INDEX IF EXISTS idx_bylines_user_id_locale_unique`).execute(db);
+		await sql.raw(`DROP INDEX IF EXISTS idx_bylines_group_locale_unique`).execute(db);
+
+		// Remap `_emdash_content_bylines.byline_id` and `ec_*.primary_byline_id`
+		// from translation_group back to the row id of the defaultLocale
+		// anchor. assertSingleLocale guarantees the mapping is 1:1, so the
+		// rebuilt FK can validate every reference.
+		await remapPrimaryBylineIdsDown(db, defaultLocale);
+		await remapContentBylinesDown(db, defaultLocale);
+
+		// Now safe to rebuild `_emdash_bylines` (strips locale +
+		// translation_group, restores UNIQUE(slug) and the partial unique
+		// on user_id alone).
+		await rebuildBylinesDown(db);
+		// And finally restore the FK on `_emdash_content_bylines.byline_id`.
+		await restoreContentBylinesFk(db);
+		return;
+	}
+
+	await remapPrimaryBylineIdsDown(db, defaultLocale);
+	await sql`
+		UPDATE _emdash_content_bylines
+		SET byline_id = COALESCE(
+			(SELECT b.id FROM _emdash_bylines b
+			 WHERE b.translation_group = _emdash_content_bylines.byline_id
+				 AND b.locale = ${defaultLocale}),
+			byline_id
+		)
+	`.execute(db);
+
+	await sql.raw(`DROP INDEX IF EXISTS idx__emdash_bylines_locale`).execute(db);
+	await sql.raw(`DROP INDEX IF EXISTS idx__emdash_bylines_translation_group`).execute(db);
+	await sql.raw(`DROP INDEX IF EXISTS idx_bylines_user_id_locale_unique`).execute(db);
+	await sql.raw(`DROP INDEX IF EXISTS idx_bylines_group_locale_unique`).execute(db);
+	await sql
+		.raw(
+			`ALTER TABLE "_emdash_bylines" DROP CONSTRAINT IF EXISTS _emdash_bylines_slug_locale_unique`,
+		)
+		.execute(db);
+	await sql.raw(`ALTER TABLE "_emdash_bylines" DROP COLUMN IF EXISTS locale`).execute(db);
+	await sql
+		.raw(`ALTER TABLE "_emdash_bylines" DROP COLUMN IF EXISTS translation_group`)
+		.execute(db);
+	await sql
+		.raw(`ALTER TABLE "_emdash_bylines" ADD CONSTRAINT _emdash_bylines_slug_unique UNIQUE (slug)`)
+		.execute(db);
+	await sql`
+		CREATE UNIQUE INDEX IF NOT EXISTS ${sql.ref("idx_bylines_user_id_unique")}
+		ON _emdash_bylines (user_id) WHERE user_id IS NOT NULL
+	`.execute(db);
+	await sql`
+		ALTER TABLE _emdash_content_bylines
+		ADD CONSTRAINT _emdash_content_bylines_byline_fk
+		FOREIGN KEY (byline_id) REFERENCES _emdash_bylines(id) ON DELETE CASCADE
+	`.execute(db);
+}
+
+async function remapPrimaryBylineIdsDown(
+	db: Kysely<unknown>,
+	defaultLocale: string,
+): Promise<void> {
+	const collections = await listTablesLike(db, "ec_%");
+	for (const table of collections) {
+		validateIdentifier(table, "content table");
+		await sql`
+			UPDATE ${sql.ref(table)}
+			SET primary_byline_id = COALESCE(
+				(SELECT b.id FROM _emdash_bylines b
+				 WHERE b.translation_group = ${sql.ref(table)}.primary_byline_id
+					 AND b.locale = ${defaultLocale}),
+				primary_byline_id
+			)
+			WHERE primary_byline_id IS NOT NULL
+		`.execute(db);
+	}
+}
+
+async function remapContentBylinesDown(db: Kysely<unknown>, defaultLocale: string): Promise<void> {
+	await sql`
+		UPDATE _emdash_content_bylines
+		SET byline_id = COALESCE(
+			(SELECT b.id FROM _emdash_bylines b
+			 WHERE b.translation_group = _emdash_content_bylines.byline_id
+				 AND b.locale = ${defaultLocale}),
+			byline_id
+		)
+	`.execute(db);
+}
+
+async function rebuildBylinesDown(db: Kysely<unknown>): Promise<void> {
+	await sql.raw(`DROP TABLE IF EXISTS "_emdash_bylines_old"`).execute(db);
+	await db.schema
+		.createTable("_emdash_bylines_old")
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("slug", "text", (c) => c.notNull().unique())
+		.addColumn("display_name", "text", (c) => c.notNull())
+		.addColumn("bio", "text")
+		.addColumn("avatar_media_id", "text", (c) => c.references("media.id").onDelete("set null"))
+		.addColumn("website_url", "text")
+		.addColumn("user_id", "text", (c) => c.references("users.id").onDelete("set null"))
+		.addColumn("is_guest", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("created_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.addColumn("updated_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.execute();
+	await sql`
+		INSERT INTO _emdash_bylines_old (
+			id, slug, display_name, bio, avatar_media_id, website_url,
+			user_id, is_guest, created_at, updated_at
+		)
+		SELECT
+			id, slug, display_name, bio, avatar_media_id, website_url,
+			user_id, is_guest, created_at, updated_at
+		FROM _emdash_bylines
+	`.execute(db);
+	await db.schema.dropTable("_emdash_bylines").execute();
+	await sql`ALTER TABLE _emdash_bylines_old RENAME TO _emdash_bylines`.execute(db);
+
+	// Restore the indexes that existed pre-040.
+	await db.schema.createIndex("idx_bylines_slug").on("_emdash_bylines").column("slug").execute();
+	await db.schema
+		.createIndex("idx_bylines_display_name")
+		.on("_emdash_bylines")
+		.column("display_name")
+		.execute();
+	await sql`
+		CREATE UNIQUE INDEX ${sql.ref("idx_bylines_user_id_unique")}
+		ON ${sql.ref("_emdash_bylines")} (user_id)
+		WHERE user_id IS NOT NULL
+	`.execute(db);
+}
+
+async function restoreContentBylinesFk(db: Kysely<unknown>): Promise<void> {
+	await sql.raw(`DROP TABLE IF EXISTS "_emdash_content_bylines_old"`).execute(db);
+	await db.schema
+		.createTable("_emdash_content_bylines_old")
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("collection_slug", "text", (c) => c.notNull())
+		.addColumn("content_id", "text", (c) => c.notNull())
+		.addColumn("byline_id", "text", (c) =>
+			c.notNull().references("_emdash_bylines.id").onDelete("cascade"),
+		)
+		.addColumn("sort_order", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("role_label", "text")
+		.addColumn("created_at", "text", (c) => c.defaultTo(currentTimestamp(db)))
+		.addUniqueConstraint("content_bylines_unique", ["collection_slug", "content_id", "byline_id"])
+		.execute();
+
+	await sql`
+		INSERT INTO _emdash_content_bylines_old
+			(id, collection_slug, content_id, byline_id, sort_order, role_label, created_at)
+		SELECT id, collection_slug, content_id, byline_id, sort_order, role_label, created_at
+		FROM _emdash_content_bylines
+	`.execute(db);
+
+	await db.schema.dropTable("_emdash_content_bylines").execute();
+	await sql`ALTER TABLE _emdash_content_bylines_old RENAME TO _emdash_content_bylines`.execute(db);
+
+	await db.schema
+		.createIndex("idx_content_bylines_content")
+		.on("_emdash_content_bylines")
+		.columns(["collection_slug", "content_id", "sort_order"])
+		.execute();
+	await db.schema
+		.createIndex("idx_content_bylines_byline")
+		.on("_emdash_content_bylines")
+		.column("byline_id")
+		.execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -40,6 +40,7 @@ import * as m036 from "./036_i18n_menus_and_taxonomies.js";
 import * as m037 from "./037_credential_algorithm.js";
 import * as m038 from "./038_registry_plugin_state.js";
 import * as m039 from "./039_fix_fts5_triggers.js";
+import * as m040 from "./040_byline_i18n.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -80,6 +81,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"037_credential_algorithm": m037,
 	"038_registry_plugin_state": m038,
 	"039_fix_fts5_triggers": m039,
+	"040_byline_i18n": m040,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/repositories/byline.ts
+++ b/packages/core/src/database/repositories/byline.ts
@@ -24,6 +24,18 @@ export interface CreateBylineInput {
 	websiteUrl?: string | null;
 	userId?: string | null;
 	isGuest?: boolean;
+	/**
+	 * Locale this byline row belongs to. When omitted, the DB DEFAULT (the
+	 * configured `defaultLocale` after migration 040) is used. Keeps behaviour
+	 * consistent with `TaxonomyRepository.create`.
+	 */
+	locale?: string;
+	/**
+	 * When set, the new row joins the source byline's translation_group rather
+	 * than minting a fresh one. The source must exist; otherwise the create
+	 * throws. Mirrors `TaxonomyRepository.create`.
+	 */
+	translationOf?: string;
 }
 
 export interface UpdateBylineInput {
@@ -53,9 +65,29 @@ function rowToByline(row: BylineRow): BylineSummary {
 		isGuest: row.is_guest === 1,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
+		locale: row.locale,
+		translationGroup: row.translation_group,
 	};
 }
 
+/**
+ * Byline repository for content credits.
+ *
+ * Bylines are per-locale (migration 040). Translations of the same byline
+ * share a `translation_group` ULID. `_emdash_content_bylines.byline_id` and
+ * `ec_*.primary_byline_id` store the translation_group (not a row id) so a
+ * single credit spans every locale variant of a byline.
+ *
+ * The repository does not resolve locale fallbacks on its own — callers
+ * supply the locale they want. Hydration is strict per locale: a credit at
+ * locale X renders iff a byline row exists at locale X within the credited
+ * translation group. This mirrors `TaxonomyRepository.getTermsForEntry` and
+ * the convention established by PR #916.
+ *
+ * Runtime helpers in `packages/core/src/bylines/index.ts` may layer fallback
+ * resolution on top for the "look up one byline by slug" path, but the
+ * relation-hydration methods on this class are always strict.
+ */
 export class BylineRepository {
 	constructor(private db: Kysely<Database>) {}
 
@@ -68,21 +100,28 @@ export class BylineRepository {
 		return row ? rowToByline(row) : null;
 	}
 
-	async findBySlug(slug: string): Promise<BylineSummary | null> {
-		const row = await this.db
-			.selectFrom("_emdash_bylines")
-			.selectAll()
-			.where("slug", "=", slug)
-			.executeTakeFirst();
+	/**
+	 * Find a byline by slug. When `locale` is provided, filter by it strictly.
+	 * When omitted, returns the lowest-locale-code match (deterministic across
+	 * calls). Mirrors `TaxonomyRepository.findBySlug`.
+	 */
+	async findBySlug(slug: string, options?: { locale?: string }): Promise<BylineSummary | null> {
+		let query = this.db.selectFrom("_emdash_bylines").selectAll().where("slug", "=", slug);
+		if (options?.locale !== undefined) query = query.where("locale", "=", options.locale);
+		const row = await query.orderBy("locale", "asc").executeTakeFirst();
 		return row ? rowToByline(row) : null;
 	}
 
-	async findByUserId(userId: string): Promise<BylineSummary | null> {
-		const row = await this.db
-			.selectFrom("_emdash_bylines")
-			.selectAll()
-			.where("user_id", "=", userId)
-			.executeTakeFirst();
+	/**
+	 * Find the byline linked to a CMS user. Post-migration 040 the partial
+	 * unique on user_id is `(user_id, locale)`, so `locale` is required to
+	 * disambiguate when multiple locale variants exist. When omitted, returns
+	 * the lowest-locale-code match.
+	 */
+	async findByUserId(userId: string, options?: { locale?: string }): Promise<BylineSummary | null> {
+		let query = this.db.selectFrom("_emdash_bylines").selectAll().where("user_id", "=", userId);
+		if (options?.locale !== undefined) query = query.where("locale", "=", options.locale);
+		const row = await query.orderBy("locale", "asc").executeTakeFirst();
 		return row ? rowToByline(row) : null;
 	}
 
@@ -90,6 +129,7 @@ export class BylineRepository {
 		search?: string;
 		isGuest?: boolean;
 		userId?: string;
+		locale?: string;
 		cursor?: string;
 		limit?: number;
 	}): Promise<FindManyResult<BylineSummary>> {
@@ -121,6 +161,10 @@ export class BylineRepository {
 			query = query.where("user_id", "=", options.userId);
 		}
 
+		if (options?.locale !== undefined) {
+			query = query.where("locale", "=", options.locale);
+		}
+
 		if (options?.cursor) {
 			const decoded = decodeCursor(options.cursor);
 			query = query.where((eb) =>
@@ -145,9 +189,43 @@ export class BylineRepository {
 		return result;
 	}
 
+	/**
+	 * List every sibling row in `translation_group`. Used by the admin
+	 * `TranslationsPanel` to render one entry per configured locale.
+	 */
+	async listTranslations(id: string): Promise<BylineSummary[]> {
+		const anchor = await this.findById(id);
+		if (!anchor) return [];
+		const group = anchor.translationGroup ?? anchor.id;
+		return this.findByTranslationGroup(group);
+	}
+
+	/**
+	 * Direct lookup by `translation_group`. Returns every locale variant of a
+	 * byline, ordered by locale code (deterministic).
+	 */
+	async findByTranslationGroup(translationGroup: string): Promise<BylineSummary[]> {
+		const rows = await this.db
+			.selectFrom("_emdash_bylines")
+			.selectAll()
+			.where("translation_group", "=", translationGroup)
+			.orderBy("locale", "asc")
+			.execute();
+		return rows.map(rowToByline);
+	}
+
 	async create(input: CreateBylineInput): Promise<BylineSummary> {
 		const id = ulid();
 		const now = new Date().toISOString();
+
+		// translationOf joins the source byline's group; otherwise we mint a
+		// fresh group equal to id (matching migration 040's backfill pattern).
+		let translationGroup: string = id;
+		if (input.translationOf) {
+			const source = await this.findById(input.translationOf);
+			if (!source) throw new Error("Source byline for translation not found");
+			translationGroup = source.translationGroup ?? source.id;
+		}
 
 		await this.db
 			.insertInto("_emdash_bylines")
@@ -162,6 +240,10 @@ export class BylineRepository {
 				is_guest: input.isGuest ? 1 : 0,
 				created_at: now,
 				updated_at: now,
+				// When omitted the DB DEFAULT (configured defaultLocale) is used —
+				// keeps behaviour consistent with TaxonomyRepository.create.
+				...(input.locale !== undefined ? { locale: input.locale } : {}),
+				translation_group: translationGroup,
 			})
 			.execute();
 
@@ -192,14 +274,38 @@ export class BylineRepository {
 		return await this.findById(id);
 	}
 
+	/**
+	 * Delete a byline row. When this row is the last sibling in its
+	 * translation group, also drops every junction row pointing at the group
+	 * and clears `primary_byline_id` references. When other siblings remain
+	 * in the group, junctions and `primary_byline_id` pointers stay intact —
+	 * the credit lives on at other locales.
+	 *
+	 * Migration 040 dropped the FK on `_emdash_content_bylines.byline_id`, so
+	 * this cascade is implemented here in application code.
+	 */
 	async delete(id: string): Promise<boolean> {
 		const existing = await this.findById(id);
 		if (!existing) return false;
 
-		await withTransaction(this.db, async (trx) => {
-			await trx.deleteFrom("_emdash_content_bylines").where("byline_id", "=", id).execute();
+		const group = existing.translationGroup ?? existing.id;
 
+		await withTransaction(this.db, async (trx) => {
 			await trx.deleteFrom("_emdash_bylines").where("id", "=", id).execute();
+
+			// Count remaining siblings in the translation group. If none
+			// remain, purge dependent rows; otherwise leave them intact so
+			// the credit still resolves at other locales.
+			const remaining = await trx
+				.selectFrom("_emdash_bylines")
+				.select(({ fn }) => [fn.count<number>("id").as("count")])
+				.where("translation_group", "=", group)
+				.executeTakeFirst();
+			const remainingCount = Number(remaining?.count ?? 0);
+			if (remainingCount > 0) return;
+
+			// Last sibling gone: cascade in application code.
+			await trx.deleteFrom("_emdash_content_bylines").where("byline_id", "=", group).execute();
 
 			const tableNames = await listTablesLike(trx, "ec_%");
 			for (const tableName of tableNames) {
@@ -207,7 +313,7 @@ export class BylineRepository {
 				await sql`
 					UPDATE ${sql.ref(tableName)}
 					SET primary_byline_id = NULL
-					WHERE primary_byline_id = ${id}
+					WHERE primary_byline_id = ${group}
 				`.execute(trx);
 			}
 		});
@@ -215,13 +321,21 @@ export class BylineRepository {
 		return true;
 	}
 
+	/**
+	 * Strict per-locale credit hydration. Joins `_emdash_content_bylines` to
+	 * `_emdash_bylines` on `translation_group = byline_id`, then filters to
+	 * the requested locale. Credits whose translation group lacks a row at
+	 * the requested locale are omitted — callers wanting fallback behaviour
+	 * apply it themselves. Mirrors `TaxonomyRepository.getTermsForEntry`.
+	 */
 	async getContentBylines(
 		collectionSlug: string,
 		contentId: string,
+		options?: { locale?: string },
 	): Promise<ContentBylineCredit[]> {
-		const rows = await this.db
+		let query = this.db
 			.selectFrom("_emdash_content_bylines as cb")
-			.innerJoin("_emdash_bylines as b", "b.id", "cb.byline_id")
+			.innerJoin("_emdash_bylines as b", "b.translation_group", "cb.byline_id")
 			.select([
 				"cb.sort_order as sort_order",
 				"cb.role_label as role_label",
@@ -235,12 +349,15 @@ export class BylineRepository {
 				"b.is_guest as is_guest",
 				"b.created_at as created_at",
 				"b.updated_at as updated_at",
+				"b.locale as locale",
+				"b.translation_group as translation_group",
 			])
 			.where("cb.collection_slug", "=", collectionSlug)
 			.where("cb.content_id", "=", contentId)
-			.orderBy("cb.sort_order", "asc")
-			.execute();
+			.orderBy("cb.sort_order", "asc");
+		if (options?.locale !== undefined) query = query.where("b.locale", "=", options.locale);
 
+		const rows = await query.execute();
 		return rows.map((row) => ({
 			byline: rowToByline(row),
 			sortOrder: row.sort_order,
@@ -249,21 +366,68 @@ export class BylineRepository {
 	}
 
 	/**
-	 * Batch-fetch byline credits for multiple content items in a single query.
-	 * Returns a Map keyed by contentId.
+	 * Does this entry have any explicit byline credits — at any locale?
+	 *
+	 * Used to disambiguate "no credits exist" (fall back to author-linked
+	 * byline) from "credits exist but don't resolve at the requested locale"
+	 * (strict per-locale model: render no byline). Without this check the
+	 * locale-strict hydration would silently turn a missing translation into
+	 * an author-inferred byline, contradicting editorial intent.
+	 */
+	async hasContentBylines(collectionSlug: string, contentId: string): Promise<boolean> {
+		const row = await this.db
+			.selectFrom("_emdash_content_bylines")
+			.select("id")
+			.where("collection_slug", "=", collectionSlug)
+			.where("content_id", "=", contentId)
+			.limit(1)
+			.executeTakeFirst();
+		return row !== undefined;
+	}
+
+	/**
+	 * Batch variant of `hasContentBylines`. Returns the set of content IDs
+	 * that have at least one junction row (locale-agnostic).
+	 */
+	async hasContentBylinesMany(collectionSlug: string, contentIds: string[]): Promise<Set<string>> {
+		const result = new Set<string>();
+		if (contentIds.length === 0) return result;
+
+		const uniqueContentIds = [...new Set(contentIds)];
+		for (const chunk of chunks(uniqueContentIds, SQL_BATCH_SIZE)) {
+			const rows = await this.db
+				.selectFrom("_emdash_content_bylines")
+				.select("content_id")
+				.distinct()
+				.where("collection_slug", "=", collectionSlug)
+				.where("content_id", "in", chunk)
+				.execute();
+			for (const row of rows) result.add(row.content_id);
+		}
+		return result;
+	}
+
+	/**
+	 * Batch variant of `getContentBylines`. Same strict-per-locale semantics
+	 * applied to the requested locale (single value, not per-entry).
+	 *
+	 * When callers need per-entry-locale filtering (e.g. a list endpoint
+	 * returning entries at mixed locales), they should group the input ids by
+	 * the entry's locale and call this method once per group.
 	 */
 	async getContentBylinesMany(
 		collectionSlug: string,
 		contentIds: string[],
+		options?: { locale?: string },
 	): Promise<Map<string, ContentBylineCredit[]>> {
 		const result = new Map<string, ContentBylineCredit[]>();
 		if (contentIds.length === 0) return result;
 
 		const uniqueContentIds = [...new Set(contentIds)];
 		for (const chunk of chunks(uniqueContentIds, SQL_BATCH_SIZE)) {
-			const rows = await this.db
+			let query = this.db
 				.selectFrom("_emdash_content_bylines as cb")
-				.innerJoin("_emdash_bylines as b", "b.id", "cb.byline_id")
+				.innerJoin("_emdash_bylines as b", "b.translation_group", "cb.byline_id")
 				.select([
 					"cb.content_id as content_id",
 					"cb.sort_order as sort_order",
@@ -278,11 +442,15 @@ export class BylineRepository {
 					"b.is_guest as is_guest",
 					"b.created_at as created_at",
 					"b.updated_at as updated_at",
+					"b.locale as locale",
+					"b.translation_group as translation_group",
 				])
 				.where("cb.collection_slug", "=", collectionSlug)
 				.where("cb.content_id", "in", chunk)
-				.orderBy("cb.sort_order", "asc")
-				.execute();
+				.orderBy("cb.sort_order", "asc");
+			if (options?.locale !== undefined) query = query.where("b.locale", "=", options.locale);
+
+			const rows = await query.execute();
 
 			for (const row of rows) {
 				const contentId = row.content_id;
@@ -305,18 +473,20 @@ export class BylineRepository {
 
 	/**
 	 * Batch-fetch byline profiles linked to user IDs in a single query.
-	 * Returns a Map keyed by userId.
+	 * Strict-locale variant of `findByUserId`.
 	 */
-	async findByUserIds(userIds: string[]): Promise<Map<string, BylineSummary>> {
+	async findByUserIds(
+		userIds: string[],
+		options?: { locale?: string },
+	): Promise<Map<string, BylineSummary>> {
 		const result = new Map<string, BylineSummary>();
 		if (userIds.length === 0) return result;
 
 		for (const chunk of chunks(userIds, SQL_BATCH_SIZE)) {
-			const rows = await this.db
-				.selectFrom("_emdash_bylines")
-				.selectAll()
-				.where("user_id", "in", chunk)
-				.execute();
+			let query = this.db.selectFrom("_emdash_bylines").selectAll().where("user_id", "in", chunk);
+			if (options?.locale !== undefined) query = query.where("locale", "=", options.locale);
+
+			const rows = await query.execute();
 
 			for (const row of rows) {
 				if (row.user_id) {
@@ -327,6 +497,85 @@ export class BylineRepository {
 		return result;
 	}
 
+	/**
+	 * Clone every junction row from `sourceContentId` to `targetContentId`,
+	 * preserving `sort_order` and `role_label`. Used by the content
+	 * translation flow: a newly created translation inherits the source's
+	 * byline credits at the storage level. Because the junction stores
+	 * `translation_group` (not a row id), the copy is locale-agnostic — the
+	 * credits resolve to whichever locale variants of each byline exist when
+	 * the translated entry is hydrated.
+	 *
+	 * No-op when the source has no credits. Skips when the target already
+	 * has credits (idempotent for re-runs).
+	 */
+	async copyContentBylines(
+		collection: string,
+		sourceContentId: string,
+		targetContentId: string,
+	): Promise<void> {
+		validateIdentifier(collection, "collection slug");
+		const tableName = `ec_${collection}`;
+		validateIdentifier(tableName, "content table");
+
+		// Like `setContentBylines`, this method is expected to be called
+		// within a transaction context (content handlers wrap in
+		// withTransaction). All operations use `this.db` directly so an
+		// outer transaction can serialise the copy alongside the create.
+		const existing = await this.db
+			.selectFrom("_emdash_content_bylines")
+			.select("id")
+			.where("collection_slug", "=", collection)
+			.where("content_id", "=", targetContentId)
+			.executeTakeFirst();
+		if (existing) return;
+
+		const sourceRows = await this.db
+			.selectFrom("_emdash_content_bylines")
+			.select(["byline_id", "sort_order", "role_label"])
+			.where("collection_slug", "=", collection)
+			.where("content_id", "=", sourceContentId)
+			.orderBy("sort_order", "asc")
+			.execute();
+		if (sourceRows.length === 0) return;
+
+		const now = new Date().toISOString();
+		await this.db
+			.insertInto("_emdash_content_bylines")
+			.values(
+				sourceRows.map((row) => ({
+					id: ulid(),
+					collection_slug: collection,
+					content_id: targetContentId,
+					byline_id: row.byline_id,
+					sort_order: row.sort_order,
+					role_label: row.role_label,
+					created_at: now,
+				})),
+			)
+			.execute();
+
+		// Mirror primary_byline_id from source so the cached pointer on the
+		// target row matches the junction state we just wrote.
+		const firstByline = sourceRows[0]?.byline_id ?? null;
+		await sql`
+			UPDATE ${sql.ref(tableName)}
+			SET primary_byline_id = ${firstByline}
+			WHERE id = ${targetContentId}
+		`.execute(this.db);
+	}
+
+	/**
+	 * Replace the set of byline credits on a content entry. Accepts row ids
+	 * at the wire (consistent with how the admin sends them), translates
+	 * each to its `translation_group` on write, and stores the group in
+	 * `_emdash_content_bylines.byline_id` and `ec_*.primary_byline_id`.
+	 *
+	 * The returned credits are hydrated with strict-locale matching at the
+	 * locale of the rows the caller supplied (i.e. the locale of the byline
+	 * each `bylineId` resolves to) — adequate for the autosave round-trip,
+	 * which then re-hydrates the entry against its own locale separately.
+	 */
 	async setContentBylines(
 		collectionSlug: string,
 		contentId: string,
@@ -336,29 +585,48 @@ export class BylineRepository {
 		const tableName = `ec_${collectionSlug}`;
 		validateIdentifier(tableName, "content table");
 
-		const seen = new Set<string>();
-		const bylines = inputBylines.filter((item) => {
-			if (seen.has(item.bylineId)) return false;
-			seen.add(item.bylineId);
-			return true;
-		});
+		// Resolve each wire row id to its translation_group up front so we
+		// can (a) validate the rows exist and (b) dedupe by the value that
+		// actually lands in the junction. Deduping by wire row id BEFORE
+		// resolving would let two locale siblings of the same byline slip
+		// through and trigger a UNIQUE(collection, content, byline_id)
+		// failure at insert time. A single SELECT keeps this O(1) DB
+		// calls regardless of how many credits are being set.
+		const idToGroup = new Map<string, string>();
+		if (inputBylines.length > 0) {
+			const wireIds = [...new Set(inputBylines.map((item) => item.bylineId))];
+			const rows = await this.db
+				.selectFrom("_emdash_bylines")
+				.select(["id", "translation_group"])
+				.where("id", "in", wireIds)
+				.execute();
+			if (rows.length !== wireIds.length) {
+				throw new Error("One or more byline IDs do not exist");
+			}
+			for (const row of rows) {
+				idToGroup.set(row.id, row.translation_group ?? row.id);
+			}
+		}
+
+		// Dedupe by translation_group. Preserves the order of first
+		// occurrence so the editor's intent (which sibling appears first)
+		// is honored. `roleLabel` follows the first occurrence too.
+		const seenGroups = new Set<string>();
+		const bylines: Array<ContentBylineInput & { group: string }> = [];
+		for (const item of inputBylines) {
+			const group = idToGroup.get(item.bylineId);
+			if (!group) {
+				throw new Error(`Missing translation_group for byline ${item.bylineId}`);
+			}
+			if (seenGroups.has(group)) continue;
+			seenGroups.add(group);
+			bylines.push({ ...item, group });
+		}
 
 		// This method is expected to be called within a transaction context
 		// (content handlers wrap in withTransaction, seed applies sequentially).
 		// All operations use this.db directly -- callers are responsible for
 		// wrapping in a transaction when atomicity is required.
-		if (bylines.length > 0) {
-			const ids = bylines.map((item) => item.bylineId);
-			const rows = await this.db
-				.selectFrom("_emdash_bylines")
-				.select("id")
-				.where("id", "in", ids)
-				.execute();
-			if (rows.length !== ids.length) {
-				throw new Error("One or more byline IDs do not exist");
-			}
-		}
-
 		await this.db
 			.deleteFrom("_emdash_content_bylines")
 			.where("collection_slug", "=", collectionSlug)
@@ -367,13 +635,14 @@ export class BylineRepository {
 
 		for (let i = 0; i < bylines.length; i++) {
 			const item = bylines[i];
+			if (!item) continue;
 			await this.db
 				.insertInto("_emdash_content_bylines")
 				.values({
 					id: ulid(),
 					collection_slug: collectionSlug,
 					content_id: contentId,
-					byline_id: item.bylineId,
+					byline_id: item.group,
 					sort_order: i,
 					role_label: item.roleLabel ?? null,
 					created_at: new Date().toISOString(),
@@ -381,9 +650,10 @@ export class BylineRepository {
 				.execute();
 		}
 
+		const primaryGroup = bylines[0]?.group ?? null;
 		await sql`
 			UPDATE ${sql.ref(tableName)}
-			SET primary_byline_id = ${bylines[0]?.bylineId ?? null}
+			SET primary_byline_id = ${primaryGroup}
 			WHERE id = ${contentId}
 		`.execute(this.db);
 

--- a/packages/core/src/database/repositories/types.ts
+++ b/packages/core/src/database/repositories/types.ts
@@ -63,6 +63,19 @@ export interface BylineSummary {
 	isGuest: boolean;
 	createdAt: string;
 	updatedAt: string;
+	/**
+	 * Locale this byline row is presented in. Added by migration 040.
+	 * `(slug, locale)` is unique; a single slug can repeat across locales.
+	 */
+	locale: string;
+	/**
+	 * Shared across translations of the same byline. Added by migration 040.
+	 * `_emdash_content_bylines.byline_id` and `ec_*.primary_byline_id` store
+	 * this value, so a credit spans every locale variant of a byline.
+	 * Nullable in storage for backwards compatibility; new rows always
+	 * populate it.
+	 */
+	translationGroup: string | null;
 }
 
 export interface ContentBylineCredit {

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -502,6 +502,21 @@ export interface BylineTable {
 	is_guest: number;
 	created_at: Generated<string>;
 	updated_at: Generated<string>;
+	/**
+	 * Locale this byline row is presented in. Added by migration 040. Backfilled
+	 * to the configured `defaultLocale` for pre-040 rows. `(slug, locale)` is
+	 * unique; the partial unique on `user_id` widens to `(user_id, locale)`.
+	 */
+	locale: Generated<string>;
+	/**
+	 * Shared across translations of the same byline. Added by migration 040.
+	 * Equals `id` for the anchor row; siblings inherit it from their source.
+	 * `_emdash_content_bylines.byline_id` and `ec_*.primary_byline_id` store
+	 * this value rather than a row id, so credits span every locale variant of
+	 * a byline. Nullable in the schema for backwards compatibility; new rows
+	 * always populate it.
+	 */
+	translation_group: string | null;
 }
 
 export interface ContentBylineTable {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -719,16 +719,19 @@ async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]):
 				return {
 					id,
 					authorId: dataStr(data, "authorId") || null,
-					// Read locale from the row so byline hydration matches the
-					// entry's own locale (post-migration 040 — strict per
-					// locale, no read-time fallback). On single-locale installs
-					// the row may not have a locale field, in which case the
-					// downstream bucket uses no `WHERE locale = ?` filter.
+					primaryBylineId: dataStr(data, "primaryBylineId") || null,
 					locale: dataStr(data, "locale") || null,
 				};
 			})
 			.filter(
-				(r): r is { id: string; authorId: string | null; locale: string | null } => r !== null,
+				(
+					r,
+				): r is {
+					id: string;
+					authorId: string | null;
+					primaryBylineId: string | null;
+					locale: string | null;
+				} => r !== null,
 			);
 		if (refs.length === 0) return;
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -715,9 +715,21 @@ async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]):
 			.map((e) => {
 				const data = entryData(e);
 				const id = dataStr(data, "id");
-				return id ? { id, authorId: dataStr(data, "authorId") || null } : null;
+				if (!id) return null;
+				return {
+					id,
+					authorId: dataStr(data, "authorId") || null,
+					// Read locale from the row so byline hydration matches the
+					// entry's own locale (post-migration 040 — strict per
+					// locale, no read-time fallback). On single-locale installs
+					// the row may not have a locale field, in which case the
+					// downstream bucket uses no `WHERE locale = ?` filter.
+					locale: dataStr(data, "locale") || null,
+				};
 			})
-			.filter((r): r is { id: string; authorId: string | null } => r !== null);
+			.filter(
+				(r): r is { id: string; authorId: string | null; locale: string | null } => r !== null,
+			);
 		if (refs.length === 0) return;
 
 		const bylinesMap = await getBylinesForEntries(type, refs);

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -119,6 +119,7 @@ describe("Database Migrations (Integration)", () => {
 			"037_credential_algorithm",
 			"038_registry_plugin_state",
 			"039_fix_fts5_triggers",
+			"040_byline_i18n",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/unit/api/content-handlers.test.ts
+++ b/packages/core/tests/unit/api/content-handlers.test.ts
@@ -9,7 +9,9 @@ import {
 	handleContentUpdate,
 } from "../../../src/api/index.js";
 import { BylineRepository } from "../../../src/database/repositories/byline.js";
+import { UserRepository } from "../../../src/database/repositories/user.js";
 import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
 
@@ -153,6 +155,34 @@ describe("Content Handlers — auto-slug generation", () => {
 			expect(result.data?.item.createdAt).toBe(originalCreated);
 			expect(result.data?.item.publishedAt).toBe(originalPublished);
 		});
+
+		// When the caller omits `locale`, the handler must defer to the
+		// configured site defaultLocale rather than falling back to the
+		// repo's hard-coded "en". Otherwise non-English default-locale
+		// sites silently create entries in a locale the editor never chose.
+		it("defaults to configured i18n defaultLocale when body.locale is omitted", async () => {
+			setI18nConfig({ defaultLocale: "es", locales: ["es", "en"] });
+			try {
+				const result = await handleContentCreate(db, "post", {
+					data: { title: "Hola" },
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data?.item.locale).toBe("es");
+			} finally {
+				setI18nConfig(null);
+			}
+		});
+
+		it("falls back to 'en' when no i18n config is set", async () => {
+			setI18nConfig(null);
+			const result = await handleContentCreate(db, "post", {
+				data: { title: "No i18n" },
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data?.item.locale).toBe("en");
+		});
 	});
 
 	describe("handleContentDuplicate", () => {
@@ -270,6 +300,296 @@ describe("Content Handlers — auto-slug generation", () => {
 			expect(duplicated.success).toBe(true);
 			expect(duplicated.data?.item.byline?.id).toBe(byline.id);
 			expect(duplicated.data?.item.bylines).toHaveLength(1);
+		});
+	});
+
+	describe("byline i18n (migration 040)", () => {
+		it("sets primaryBylineId to the credited byline's translation_group, not the wire row id", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			// Editor credits the fr row on a fr entry. The wire bylineId is
+			// fr.id but the server should store the translation_group (which
+			// equals anchor.id for the anchor sibling). The in-memory
+			// `primaryBylineId` on the response must match what's now in the
+			// DB column.
+			const created = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				bylines: [{ bylineId: fr.id }],
+			});
+
+			expect(created.success).toBe(true);
+			expect(created.data?.item.primaryBylineId).toBe(anchor.id);
+			expect(created.data?.item.primaryBylineId).toBe(anchor.translationGroup);
+			// fr post hydrates with the fr sibling.
+			expect(created.data?.item.byline?.id).toBe(fr.id);
+			expect(created.data?.item.byline?.locale).toBe("fr");
+		});
+
+		it("hydrates the locale-matching sibling on a translated entry", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			// Credit using the anchor (en) wire id on an EN entry, then
+			// translate the entry. The fr-locale entry should hydrate the fr
+			// byline sibling, not the en one.
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				bylines: [{ bylineId: anchor.id }],
+			});
+			expect(enEntry.success).toBe(true);
+			expect(enEntry.data?.item.byline?.locale).toBe("en");
+
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				translationOf: enEntry.data!.item.id,
+			});
+			expect(frEntry.success).toBe(true);
+			expect(frEntry.data?.item.byline?.displayName).toBe("Jeanne");
+			expect(frEntry.data?.item.byline?.locale).toBe("fr");
+		});
+
+		it("hydrates strict per locale — credit absent when no sibling exists at the entry's locale", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const anchor = await bylineRepo.create({
+				slug: "marco",
+				displayName: "Marco",
+				locale: "en",
+			});
+
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				bylines: [{ bylineId: anchor.id }],
+			});
+			expect(enEntry.success).toBe(true);
+
+			// Translate to fr — no fr sibling exists for marco. The credit is
+			// preserved at the DB level (`copyContentBylines` clones the
+			// junction row pointing at marco's translation_group), but
+			// rendering on the fr entry returns nothing because the byline
+			// has no fr sibling.
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				translationOf: enEntry.data!.item.id,
+			});
+			expect(frEntry.success).toBe(true);
+			expect(frEntry.data?.item.bylines).toEqual([]);
+			expect(frEntry.data?.item.byline).toBeNull();
+			// But the DB-level pointer is preserved — the credit will surface
+			// the moment an fr sibling of marco is created.
+			expect(frEntry.data?.item.primaryBylineId).toBe(anchor.id);
+		});
+
+		it("copyContentBylines runs on translationOf when body.bylines is omitted", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				bylines: [{ bylineId: anchor.id }],
+			});
+			expect(enEntry.success).toBe(true);
+
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				translationOf: enEntry.data!.item.id,
+				// No `bylines` field — copy should run.
+			});
+			expect(frEntry.success).toBe(true);
+			expect(frEntry.data?.item.bylines).toHaveLength(1);
+			expect(frEntry.data?.item.byline?.locale).toBe("fr");
+		});
+
+		it("respects explicit body.bylines on translationOf and skips copying", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const a = await bylineRepo.create({ slug: "a", displayName: "A", locale: "en" });
+			const b = await bylineRepo.create({ slug: "b", displayName: "B", locale: "en" });
+			// fr sibling of `b`. The fr entry will be credited with this row.
+			const bFr = await bylineRepo.create({
+				slug: "b",
+				displayName: "B-fr",
+				locale: "fr",
+				translationOf: b.id,
+			});
+
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				bylines: [{ bylineId: a.id }],
+			});
+			expect(enEntry.success).toBe(true);
+
+			// Explicit different byline on the translation — should NOT
+			// inherit from source. The fr entry should credit `b`'s fr
+			// sibling, not `a`.
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				translationOf: enEntry.data!.item.id,
+				bylines: [{ bylineId: bFr.id }],
+			});
+			expect(frEntry.success).toBe(true);
+			expect(frEntry.data?.item.bylines).toHaveLength(1);
+			expect(frEntry.data?.item.byline?.id).toBe(bFr.id);
+		});
+
+		it("does not fall back to author-linked byline when explicit credits exist at another locale", async () => {
+			// Bug 1 regression: strict per-locale hydration returns [] when a
+			// credit's translation_group has no sibling at the entry's
+			// locale, but the old code treated that as "no explicit
+			// credits" and inferred the author byline. The editor's intent
+			// was explicit ("credit Marco, not the article's author") —
+			// silently overriding with an inferred byline is wrong.
+			const userRepo = new UserRepository(db);
+			const author = await userRepo.create({
+				email: "fallback-test@example.com",
+				displayName: "Author Account",
+				role: "editor",
+			});
+			const bylineRepo = new BylineRepository(db);
+			// Author has a fr byline. If we incorrectly fell back, this
+			// would surface on a fr entry that has an unresolved en-only
+			// credit.
+			await bylineRepo.create({
+				slug: "author-fr",
+				displayName: "Auteur",
+				locale: "fr",
+				userId: author.id,
+			});
+
+			const marco = await bylineRepo.create({
+				slug: "marco",
+				displayName: "Marco",
+				locale: "en",
+			});
+
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				authorId: author.id,
+				bylines: [{ bylineId: marco.id }],
+			});
+			expect(enEntry.success).toBe(true);
+
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				authorId: author.id,
+				translationOf: enEntry.data!.item.id,
+			});
+			expect(frEntry.success).toBe(true);
+			// The explicit credit was copied to the fr entry (via
+			// `copyContentBylines`). It doesn't render at fr because marco
+			// has no fr sibling. Author inference must NOT step in — the
+			// editor explicitly named marco, not the author.
+			expect(frEntry.data?.item.bylines).toEqual([]);
+			expect(frEntry.data?.item.byline).toBeNull();
+		});
+
+		it("inferred (author-linked) byline still works when the entry has no explicit credits at all", async () => {
+			// Counterpoint to the previous test: when no junction rows
+			// exist, author inference is the right thing to do — Phase 4
+			// hydration must preserve this fallback for entries that were
+			// never explicitly credited.
+			const userRepo = new UserRepository(db);
+			const author = await userRepo.create({
+				email: "implicit-author@example.com",
+				displayName: "Implicit",
+				role: "editor",
+			});
+			const bylineRepo = new BylineRepository(db);
+			await bylineRepo.create({
+				slug: "implicit",
+				displayName: "Implicit EN",
+				locale: "en",
+				userId: author.id,
+			});
+
+			const created = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				authorId: author.id,
+				// No bylines field — author inference path.
+			});
+			expect(created.success).toBe(true);
+			expect(created.data?.item.bylines).toHaveLength(1);
+			expect(created.data?.item.bylines?.[0]?.source).toBe("inferred");
+			expect(created.data?.item.byline?.displayName).toBe("Implicit EN");
+		});
+
+		it("hydrateBylinesMany resolves each entry against its own locale", async () => {
+			const bylineRepo = new BylineRepository(db);
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			// Two entries at different locales, both credited with the same
+			// translation_group (via the anchor wire id). A list endpoint
+			// returning both at once should hydrate each one against its own
+			// locale.
+			const enEntry = await handleContentCreate(db, "post", {
+				data: { title: "Hello" },
+				locale: "en",
+				bylines: [{ bylineId: anchor.id }],
+			});
+			const frEntry = await handleContentCreate(db, "post", {
+				data: { title: "Bonjour" },
+				locale: "fr",
+				translationOf: enEntry.data!.item.id,
+			});
+			expect(enEntry.success && frEntry.success).toBe(true);
+
+			const listed = await handleContentList(db, "post", {});
+			expect(listed.success).toBe(true);
+			const enItem = listed.data?.items.find((i) => i.id === enEntry.data!.item.id);
+			const frItem = listed.data?.items.find((i) => i.id === frEntry.data!.item.id);
+			expect(enItem?.byline?.locale).toBe("en");
+			expect(frItem?.byline?.locale).toBe("fr");
 		});
 	});
 

--- a/packages/core/tests/unit/api/handlers/bylines.test.ts
+++ b/packages/core/tests/unit/api/handlers/bylines.test.ts
@@ -1,0 +1,298 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	handleBylineCreate,
+	handleBylineTranslations,
+} from "../../../../src/api/handlers/bylines.js";
+import { BylineRepository } from "../../../../src/database/repositories/byline.js";
+import type { Database } from "../../../../src/database/types.js";
+import { setI18nConfig } from "../../../../src/i18n/config.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../../utils/test-db.js";
+
+describe("byline handlers", () => {
+	let db: Kysely<Database>;
+	let repo: BylineRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		repo = new BylineRepository(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	describe("handleBylineTranslations", () => {
+		it("returns every sibling row for an existing byline", async () => {
+			const anchor = await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await repo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const result = await handleBylineTranslations(db, anchor.id);
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.data.items.map((b) => b.locale).toSorted()).toEqual(["en", "fr"]);
+		});
+
+		it("returns NOT_FOUND when the byline does not exist", async () => {
+			const result = await handleBylineTranslations(db, "non-existent-id");
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("NOT_FOUND");
+		});
+
+		it("returns a single-item list when the byline has no siblings", async () => {
+			const anchor = await repo.create({
+				slug: "solo",
+				displayName: "Solo Author",
+			});
+
+			const result = await handleBylineTranslations(db, anchor.id);
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.data.items).toHaveLength(1);
+			expect(result.data.items[0]?.id).toBe(anchor.id);
+		});
+	});
+
+	describe("handleBylineCreate (translationOf)", () => {
+		it("rejects translationOf without locale (handler-level guard)", async () => {
+			const anchor = await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const result = await handleBylineCreate(db, {
+				slug: "jane",
+				displayName: "Jeanne",
+				translationOf: anchor.id,
+				// locale intentionally omitted
+			});
+
+			// Previously this guard lived only at the route boundary, so SDK
+			// callers could clone into the default locale by accident. The
+			// handler now refuses.
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("VALIDATION_ERROR");
+			expect(result.error.message).toMatch(/locale/i);
+			expect(result.error.message).toMatch(/translationOf/i);
+
+			// No sibling row created.
+			const siblings = await repo.listTranslations(anchor.id);
+			expect(siblings).toHaveLength(1);
+		});
+
+		it("creates a sibling row sharing the source's translation_group", async () => {
+			const anchor = await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const result = await handleBylineCreate(db, {
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.data.locale).toBe("fr");
+			expect(result.data.translationGroup).toBe(anchor.translationGroup);
+			expect(result.data.id).not.toBe(anchor.id);
+		});
+
+		it("returns NOT_FOUND when the source byline is missing", async () => {
+			const result = await handleBylineCreate(db, {
+				slug: "ghost",
+				displayName: "Ghost",
+				locale: "fr",
+				translationOf: "non-existent-id",
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("NOT_FOUND");
+			expect(result.error.message).toMatch(/source byline/i);
+		});
+
+		it("returns CONFLICT when a sibling already exists at the target locale", async () => {
+			const anchor = await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await repo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const result = await handleBylineCreate(db, {
+				slug: "jane",
+				displayName: "Jeanne 2",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("CONFLICT");
+			// The translation-group conflict fires before the (slug, locale)
+			// conflict — siblings within the same translation_group are
+			// constrained to one row per locale by the partial unique index.
+			expect(result.error.message).toMatch(/translation already exists/i);
+			expect(result.error.message).toMatch(/fr/);
+		});
+
+		it("returns CONFLICT when translationOf points at a group that already has the target locale, even with a different slug", async () => {
+			const anchor = await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await repo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			// Different slug — the (slug, locale) UNIQUE wouldn't catch this,
+			// but the (translation_group, locale) partial unique + the
+			// handler-level guard should.
+			const result = await handleBylineCreate(db, {
+				slug: "jane-alt",
+				displayName: "Jeanne Alt",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("CONFLICT");
+			expect(result.error.message).toMatch(/translation already exists/i);
+		});
+
+		it("returns CONFLICT when a non-translation byline with the same (slug, locale) exists", async () => {
+			await repo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const result = await handleBylineCreate(db, {
+				slug: "jane",
+				displayName: "Other Jane",
+				// Implicit defaultLocale (no `locale` field) — should still
+				// collide with the existing en row because the handler
+				// resolves the effective locale before the conflict check.
+			});
+
+			expect(result.success).toBe(false);
+			if (result.success) return;
+			expect(result.error.code).toBe("CONFLICT");
+		});
+
+		it("creates an anchor (no translationOf) successfully", async () => {
+			const result = await handleBylineCreate(db, {
+				slug: "ada",
+				displayName: "Ada",
+			});
+			expect(result.success).toBe(true);
+			if (!result.success) return;
+			expect(result.data.translationGroup).toBe(result.data.id);
+		});
+
+		// Schema only enforces non-empty strings; an unknown locale like
+		// "zz" would otherwise create a row no resolver ever asks for.
+		// Validate against the configured locales here.
+		it("rejects a locale that is not in the configured site locales", async () => {
+			setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+			try {
+				const result = await handleBylineCreate(db, {
+					slug: "jane",
+					displayName: "Jane",
+					locale: "zz",
+				});
+				expect(result.success).toBe(false);
+				if (result.success) return;
+				expect(result.error.code).toBe("VALIDATION_ERROR");
+				expect(result.error.message).toMatch(/zz/);
+			} finally {
+				setI18nConfig(null);
+			}
+		});
+
+		it("accepts a configured locale", async () => {
+			setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+			try {
+				const result = await handleBylineCreate(db, {
+					slug: "jane",
+					displayName: "Jane",
+					locale: "fr",
+				});
+				expect(result.success).toBe(true);
+			} finally {
+				setI18nConfig(null);
+			}
+		});
+
+		it("skips locale validation when no i18n config is set", async () => {
+			setI18nConfig(null);
+			const result = await handleBylineCreate(db, {
+				slug: "jane",
+				displayName: "Jane",
+				locale: "anything",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("schema validation (Zod)", () => {
+		it("rejects an empty-string locale on byline create", async () => {
+			const { bylineCreateBody } = await import("../../../../src/api/schemas/bylines.js");
+			const result = bylineCreateBody.safeParse({
+				slug: "x",
+				displayName: "X",
+				locale: "",
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects an empty-string locale on byline list query", async () => {
+			const { bylinesListQuery } = await import("../../../../src/api/schemas/bylines.js");
+			const result = bylinesListQuery.safeParse({ locale: "" });
+			expect(result.success).toBe(false);
+		});
+
+		it("accepts an omitted locale", async () => {
+			const { bylineCreateBody } = await import("../../../../src/api/schemas/bylines.js");
+			const result = bylineCreateBody.safeParse({ slug: "x", displayName: "X" });
+			expect(result.success).toBe(true);
+		});
+
+		it("accepts a non-empty locale", async () => {
+			const { bylineCreateBody } = await import("../../../../src/api/schemas/bylines.js");
+			const result = bylineCreateBody.safeParse({
+				slug: "x",
+				displayName: "X",
+				locale: "de-de",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+});

--- a/packages/core/tests/unit/bylines/bylines-query.test.ts
+++ b/packages/core/tests/unit/bylines/bylines-query.test.ts
@@ -5,6 +5,7 @@ import { BylineRepository } from "../../../src/database/repositories/byline.js";
 import { ContentRepository } from "../../../src/database/repositories/content.js";
 import { UserRepository } from "../../../src/database/repositories/user.js";
 import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
 import { SQL_BATCH_SIZE } from "../../../src/utils/chunks.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
 
@@ -75,6 +76,56 @@ describe("Byline query functions", () => {
 		it("returns null for non-existent slug", async () => {
 			const result = await getBylineBySlug("nobody");
 			expect(result).toBeNull();
+		});
+
+		it("walks the locale fallback chain when the requested locale has no row", async () => {
+			// Identity lookup pattern — mirrors getTerm / getMenu in PR #916.
+			// Locale fallback IS appropriate here ("show me this byline") in
+			// contrast to credit hydration ("what should render on this
+			// entry"), which stays strict.
+			setI18nConfig({ defaultLocale: "en", locales: ["en", "fr", "de"] });
+			try {
+				const anchor = await bylineRepo.create({
+					slug: "jane",
+					displayName: "Jane Doe",
+					locale: "en",
+				});
+				await bylineRepo.create({
+					slug: "jane",
+					displayName: "Jeanne",
+					locale: "fr",
+					translationOf: anchor.id,
+				});
+				// No de sibling. Requesting de falls back through the chain to
+				// the configured defaultLocale (en).
+				const result = await getBylineBySlug("jane", { locale: "de" });
+				expect(result?.locale).toBe("en");
+				expect(result?.displayName).toBe("Jane Doe");
+			} finally {
+				setI18nConfig(null);
+			}
+		});
+
+		it("prefers the requested locale's row when it exists", async () => {
+			setI18nConfig({ defaultLocale: "en", locales: ["en", "fr", "de"] });
+			try {
+				const anchor = await bylineRepo.create({
+					slug: "jane",
+					displayName: "Jane Doe",
+					locale: "en",
+				});
+				await bylineRepo.create({
+					slug: "jane",
+					displayName: "Jeanne",
+					locale: "fr",
+					translationOf: anchor.id,
+				});
+				const result = await getBylineBySlug("jane", { locale: "fr" });
+				expect(result?.locale).toBe("fr");
+				expect(result?.displayName).toBe("Jeanne");
+			} finally {
+				setI18nConfig(null);
+			}
 		});
 	});
 
@@ -306,6 +357,228 @@ describe("Byline query functions", () => {
 		it("returns empty map for empty input", async () => {
 			const result = await getBylinesForEntries("post", []);
 			expect(result.size).toBe(0);
+		});
+	});
+
+	describe("i18n (migration 040) — strict per-locale runtime", () => {
+		it("getEntryBylines({ locale }) returns the sibling at that locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const post = await contentRepo.create({
+				type: "post",
+				slug: "i18n-post",
+				data: { title: "Hi" },
+			});
+			await bylineRepo.setContentBylines("post", post.id, [{ bylineId: anchor.id }]);
+
+			const enCredits = await getEntryBylines("post", post.id, { locale: "en" });
+			const frCredits = await getEntryBylines("post", post.id, { locale: "fr" });
+
+			expect(enCredits[0]?.byline.displayName).toBe("Jane Doe");
+			expect(frCredits[0]?.byline.displayName).toBe("Jeanne");
+		});
+
+		it("getEntryBylines({ locale }) returns [] when no sibling exists at that locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "marco",
+				displayName: "Marco",
+				locale: "en",
+			});
+
+			const post = await contentRepo.create({
+				type: "post",
+				slug: "marco-post",
+				data: { title: "Hi" },
+			});
+			await bylineRepo.setContentBylines("post", post.id, [{ bylineId: anchor.id }]);
+
+			const frCredits = await getEntryBylines("post", post.id, { locale: "fr" });
+			expect(frCredits).toEqual([]);
+		});
+
+		it("getEntryBylines without locale returns every locale variant of the credit", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const post = await contentRepo.create({
+				type: "post",
+				slug: "no-locale",
+				data: { title: "Hi" },
+			});
+			await bylineRepo.setContentBylines("post", post.id, [{ bylineId: anchor.id }]);
+
+			const all = await getEntryBylines("post", post.id);
+			expect(all).toHaveLength(2);
+			expect(all.map((c) => c.byline.locale).toSorted()).toEqual(["en", "fr"]);
+		});
+
+		it("getBylinesForEntries buckets by entry locale and returns each entry's locale match", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const enPost = await contentRepo.create({
+				type: "post",
+				slug: "en-jane",
+				data: { title: "Hello" },
+				locale: "en",
+			});
+			const frPost = await contentRepo.create({
+				type: "post",
+				slug: "fr-jane",
+				data: { title: "Bonjour" },
+				locale: "fr",
+			});
+			await bylineRepo.setContentBylines("post", enPost.id, [{ bylineId: anchor.id }]);
+			await bylineRepo.setContentBylines("post", frPost.id, [{ bylineId: anchor.id }]);
+
+			const result = await getBylinesForEntries("post", [
+				{ id: enPost.id, authorId: null, locale: "en" },
+				{ id: frPost.id, authorId: null, locale: "fr" },
+			]);
+
+			expect(result.get(enPost.id)?.[0]?.byline.locale).toBe("en");
+			expect(result.get(enPost.id)?.[0]?.byline.displayName).toBe("Jane Doe");
+			expect(result.get(frPost.id)?.[0]?.byline.locale).toBe("fr");
+			expect(result.get(frPost.id)?.[0]?.byline.displayName).toBe("Jeanne");
+		});
+
+		it("getBylinesForEntries returns [] for entries whose credit has no sibling at the entry's locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "solo",
+				displayName: "Solo",
+				locale: "en",
+			});
+
+			const frPost = await contentRepo.create({
+				type: "post",
+				slug: "fr-solo",
+				data: { title: "Bonjour" },
+				locale: "fr",
+			});
+			await bylineRepo.setContentBylines("post", frPost.id, [{ bylineId: anchor.id }]);
+
+			const result = await getBylinesForEntries("post", [
+				{ id: frPost.id, authorId: null, locale: "fr" },
+			]);
+			expect(result.get(frPost.id)).toEqual([]);
+		});
+
+		it("does not infer from authorId when entry has explicit credits at another locale", async () => {
+			// Bug 1 regression at the runtime path. Entry credits an en-only
+			// byline; same entry's author has a fr byline. At fr locale,
+			// strict hydration returns []; we must NOT fall back to the
+			// author byline because the editor explicitly named someone
+			// else.
+			const userRepo = new UserRepository(db);
+			const user = await userRepo.create({
+				email: "runtime-fallback@example.com",
+				displayName: "Author",
+				role: "editor",
+			});
+			await bylineRepo.create({
+				slug: "author-fr",
+				displayName: "Auteur",
+				userId: user.id,
+				locale: "fr",
+			});
+
+			const explicit = await bylineRepo.create({
+				slug: "marco",
+				displayName: "Marco",
+				locale: "en",
+			});
+
+			const frPost = await contentRepo.create({
+				type: "post",
+				slug: "fr-post-explicit",
+				data: { title: "Bonjour" },
+				locale: "fr",
+				authorId: user.id,
+			});
+			await bylineRepo.setContentBylines("post", frPost.id, [{ bylineId: explicit.id }]);
+
+			// Single-entry path.
+			const single = await getEntryBylines("post", frPost.id, { locale: "fr" });
+			expect(single).toEqual([]);
+
+			// Batch path.
+			const batch = await getBylinesForEntries("post", [
+				{ id: frPost.id, authorId: frPost.authorId, locale: "fr" },
+			]);
+			expect(batch.get(frPost.id)).toEqual([]);
+		});
+
+		it("inferred (user-linked) byline is strict per locale too", async () => {
+			const userRepo = new UserRepository(db);
+			const user = await userRepo.create({
+				email: "inferred-i18n@example.com",
+				displayName: "Inferred",
+				role: "editor",
+			});
+
+			await bylineRepo.create({
+				slug: "inferred",
+				displayName: "Inferred EN",
+				userId: user.id,
+				locale: "en",
+			});
+
+			const frPost = await contentRepo.create({
+				type: "post",
+				slug: "fr-inferred",
+				data: { title: "Bonjour" },
+				locale: "fr",
+				authorId: user.id,
+			});
+
+			// No fr sibling exists for the user's byline. Strict hydration
+			// returns no inferred credit — same rule as explicit credits.
+			const result = await getBylinesForEntries("post", [
+				{ id: frPost.id, authorId: frPost.authorId, locale: "fr" },
+			]);
+			expect(result.get(frPost.id)).toEqual([]);
+
+			// EN entry by the same author DOES get the inferred byline.
+			const enPost = await contentRepo.create({
+				type: "post",
+				slug: "en-inferred",
+				data: { title: "Hello" },
+				locale: "en",
+				authorId: user.id,
+			});
+			const enResult = await getBylinesForEntries("post", [
+				{ id: enPost.id, authorId: enPost.authorId, locale: "en" },
+			]);
+			expect(enResult.get(enPost.id)?.[0]?.source).toBe("inferred");
+			expect(enResult.get(enPost.id)?.[0]?.byline.locale).toBe("en");
 		});
 	});
 });

--- a/packages/core/tests/unit/bylines/bylines-query.test.ts
+++ b/packages/core/tests/unit/bylines/bylines-query.test.ts
@@ -206,6 +206,75 @@ describe("Byline query functions", () => {
 		});
 	});
 
+	describe("getEntryBylines — explicit credit sentinel", () => {
+		it("suppresses author fallback for cross-locale explicit credits with no i18n config", async () => {
+			setI18nConfig(null);
+
+			const userRepo = new UserRepository(db);
+			const author = await userRepo.create({
+				email: "cross-locale-no-i18n@example.com",
+				displayName: "Author Account",
+				role: "editor",
+			});
+			await bylineRepo.create({
+				slug: "author-en",
+				displayName: "Author EN",
+				userId: author.id,
+				locale: "en",
+			});
+
+			const credited = await bylineRepo.create({
+				slug: "credited",
+				displayName: "Credited FR",
+				locale: "fr",
+			});
+
+			const enPost = await contentRepo.create({
+				type: "post",
+				slug: "en-post-cross-locale",
+				data: { title: "Hello" },
+				locale: "en",
+				authorId: author.id,
+			});
+			await bylineRepo.setContentBylines("post", enPost.id, [{ bylineId: credited.id }]);
+
+			const result = await getEntryBylines("post", enPost.id, { locale: "en" });
+			expect(result).toEqual([]);
+		});
+
+		it("does not run a probe query against _emdash_content_bylines", async () => {
+			setI18nConfig(null);
+
+			const userRepo = new UserRepository(db);
+			const author = await userRepo.create({
+				email: "no-probe@example.com",
+				displayName: "Author",
+				role: "editor",
+			});
+			await bylineRepo.create({
+				slug: "no-probe-author",
+				displayName: "Author Byline",
+				userId: author.id,
+			});
+
+			const post = await contentRepo.create({
+				type: "post",
+				slug: "no-probe-post",
+				data: { title: "No explicit credits" },
+				authorId: author.id,
+			});
+
+			const single = vi.spyOn(BylineRepository.prototype, "hasContentBylines");
+			const batch = vi.spyOn(BylineRepository.prototype, "hasContentBylinesMany");
+			await getEntryBylines("post", post.id);
+			await getBylinesForEntries("post", [
+				{ id: post.id, authorId: author.id, primaryBylineId: null },
+			]);
+			expect(single).not.toHaveBeenCalled();
+			expect(batch).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("getBylinesForEntries", () => {
 		it("batch-fetches byline credits for multiple entries", async () => {
 			const author1 = await bylineRepo.create({
@@ -492,11 +561,6 @@ describe("Byline query functions", () => {
 		});
 
 		it("does not infer from authorId when entry has explicit credits at another locale", async () => {
-			// Bug 1 regression at the runtime path. Entry credits an en-only
-			// byline; same entry's author has a fr byline. At fr locale,
-			// strict hydration returns []; we must NOT fall back to the
-			// author byline because the editor explicitly named someone
-			// else.
 			const userRepo = new UserRepository(db);
 			const user = await userRepo.create({
 				email: "runtime-fallback@example.com",
@@ -525,13 +589,18 @@ describe("Byline query functions", () => {
 			});
 			await bylineRepo.setContentBylines("post", frPost.id, [{ bylineId: explicit.id }]);
 
-			// Single-entry path.
+			const refreshed = await contentRepo.findById("post", frPost.id);
+
 			const single = await getEntryBylines("post", frPost.id, { locale: "fr" });
 			expect(single).toEqual([]);
 
-			// Batch path.
 			const batch = await getBylinesForEntries("post", [
-				{ id: frPost.id, authorId: frPost.authorId, locale: "fr" },
+				{
+					id: frPost.id,
+					authorId: frPost.authorId,
+					primaryBylineId: refreshed?.primaryBylineId ?? null,
+					locale: "fr",
+				},
 			]);
 			expect(batch.get(frPost.id)).toEqual([]);
 		});

--- a/packages/core/tests/unit/database/migrations/040_byline_i18n.test.ts
+++ b/packages/core/tests/unit/database/migrations/040_byline_i18n.test.ts
@@ -1,0 +1,438 @@
+import BetterSqlite3 from "better-sqlite3";
+import type { Kysely } from "kysely";
+import { Kysely as KyselyCtor, SqliteDialect, sql } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createDatabase } from "../../../../src/database/connection.js";
+import { down, up } from "../../../../src/database/migrations/040_byline_i18n.js";
+import type { Database } from "../../../../src/database/types.js";
+import { setI18nConfig } from "../../../../src/i18n/config.js";
+
+/**
+ * Build a Kysely instance backed by better-sqlite3 with foreign keys ON and
+ * `PRAGMA foreign_keys = OFF` made into a no-op. This simulates Cloudflare
+ * D1's behavior, where FKs are always enforced and the standard escape hatch
+ * is silently ignored. Used to verify regressions for #1021 — bugs that only
+ * surface when FK enforcement can't be turned off mid-transaction.
+ */
+function createD1LikeDatabase(): Kysely<Database> {
+	const sqlite = new BetterSqlite3(":memory:");
+	sqlite.pragma("foreign_keys = ON");
+	const originalPrepare = sqlite.prepare.bind(sqlite);
+	sqlite.prepare = ((source: string) => {
+		if (/^\s*PRAGMA\s+foreign_keys\s*=/i.test(source)) {
+			return originalPrepare("SELECT 1") as ReturnType<typeof originalPrepare>;
+		}
+		return originalPrepare(source);
+	}) as typeof sqlite.prepare;
+	const dialect = new SqliteDialect({ database: sqlite });
+	return new KyselyCtor<Database>({ dialect });
+}
+
+/**
+ * Seed the byline tables in their pre-040 shape (matching migration 031's
+ * schema) plus the support tables 040 reads (`_emdash_collections`, `ec_*`,
+ * `users`, `media`).
+ */
+async function seedPreMigrationSchema(db: Kysely<Database>): Promise<void> {
+	await sql`
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			email TEXT
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE media (
+			id TEXT PRIMARY KEY
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_bylines (
+			id TEXT PRIMARY KEY,
+			slug TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL,
+			bio TEXT,
+			avatar_media_id TEXT REFERENCES media(id) ON DELETE SET NULL,
+			website_url TEXT,
+			user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+			is_guest INTEGER NOT NULL DEFAULT 0,
+			created_at TEXT DEFAULT (datetime('now')),
+			updated_at TEXT DEFAULT (datetime('now'))
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE UNIQUE INDEX idx_bylines_user_id_unique
+		ON _emdash_bylines (user_id) WHERE user_id IS NOT NULL
+	`.execute(db);
+	await sql`CREATE INDEX idx_bylines_slug ON _emdash_bylines(slug)`.execute(db);
+	await sql`CREATE INDEX idx_bylines_display_name ON _emdash_bylines(display_name)`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_content_bylines (
+			id TEXT PRIMARY KEY,
+			collection_slug TEXT NOT NULL,
+			content_id TEXT NOT NULL,
+			byline_id TEXT NOT NULL REFERENCES _emdash_bylines(id) ON DELETE CASCADE,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			role_label TEXT,
+			created_at TEXT DEFAULT (datetime('now')),
+			UNIQUE(collection_slug, content_id, byline_id)
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE INDEX idx_content_bylines_content
+		ON _emdash_content_bylines(collection_slug, content_id, sort_order)
+	`.execute(db);
+	await sql`
+		CREATE INDEX idx_content_bylines_byline
+		ON _emdash_content_bylines(byline_id)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE _emdash_collections (
+			slug TEXT PRIMARY KEY
+		)
+	`.execute(db);
+
+	await sql`
+		CREATE TABLE ec_posts (
+			id TEXT PRIMARY KEY,
+			primary_byline_id TEXT
+		)
+	`.execute(db);
+}
+
+describe("040_byline_i18n migration", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = createDatabase({ url: ":memory:" });
+		await seedPreMigrationSchema(db);
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	describe("up()", () => {
+		it("adds locale + translation_group to _emdash_bylines", async () => {
+			await up(db);
+
+			const tables = await db.introspection.getTables();
+			const cols =
+				tables.find((t) => t.name === "_emdash_bylines")?.columns.map((c) => c.name) ?? [];
+			expect(cols).toContain("locale");
+			expect(cols).toContain("translation_group");
+		});
+
+		it("creates locale + translation_group indexes on _emdash_bylines", async () => {
+			await up(db);
+
+			const indexes = await sql<{ name: string }>`
+				SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%'
+			`.execute(db);
+			const names = new Set(indexes.rows.map((r) => r.name));
+
+			expect(names).toContain("idx__emdash_bylines_locale");
+			expect(names).toContain("idx__emdash_bylines_translation_group");
+		});
+
+		it("backfills locale=defaultLocale and translation_group=id for pre-existing rows", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+
+			await up(db);
+
+			const row = await sql<{ locale: string; translation_group: string | null }>`
+				SELECT locale, translation_group FROM _emdash_bylines WHERE id = 'b1'
+			`.execute(db);
+			expect(row.rows[0]?.locale).toBe("en");
+			expect(row.rows[0]?.translation_group).toBe("b1");
+		});
+
+		it("widens the byline unique key from (slug) to (slug, locale)", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await up(db);
+
+			// Same slug, different locale must now be allowed.
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name, locale, translation_group)
+				VALUES ('b2', 'jane', 'Jane Doe DE', 'de', 'b1')
+			`.execute(db);
+
+			// Same slug AND same locale still conflicts.
+			await expect(
+				sql`
+					INSERT INTO _emdash_bylines (id, slug, display_name, locale, translation_group)
+					VALUES ('b3', 'jane', 'Jane Other DE', 'de', 'b1')
+				`.execute(db),
+			).rejects.toThrow();
+		});
+
+		it("widens the user_id partial unique from (user_id) to (user_id, locale)", async () => {
+			await sql`INSERT INTO users (id) VALUES ('u1')`.execute(db);
+			await up(db);
+
+			// One byline per locale per user is allowed.
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name, user_id, locale, translation_group)
+				VALUES ('b1', 'jane', 'Jane Doe', 'u1', 'en', 'b1')
+			`.execute(db);
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name, user_id, locale, translation_group)
+				VALUES ('b2', 'jane', 'Jane Doe DE', 'u1', 'de', 'b1')
+			`.execute(db);
+
+			// Two bylines for the same (user_id, locale) must still fail.
+			await expect(
+				sql`
+					INSERT INTO _emdash_bylines (id, slug, display_name, user_id, locale, translation_group)
+					VALUES ('b3', 'jane-alt', 'Jane Alt', 'u1', 'en', 'b3')
+				`.execute(db),
+			).rejects.toThrow();
+		});
+
+		it("drops the FK on _emdash_content_bylines.byline_id", async () => {
+			await up(db);
+
+			const fks = await sql<{ table: string }>`
+				PRAGMA foreign_key_list(_emdash_content_bylines)
+			`.execute(db);
+			expect(fks.rows).toHaveLength(0);
+		});
+
+		it("preserves _emdash_content_bylines rows on D1 (regression for #1021)", async () => {
+			// On D1 where `PRAGMA foreign_keys = OFF` is a no-op, dropping the
+			// old `_emdash_bylines` table would cascade ON DELETE CASCADE
+			// through the original FK and wipe credits. rebuildContentBylines
+			// strips the FK *before* `_emdash_bylines` is rebuilt so the drop
+			// can't cascade.
+			await db.destroy();
+			db = createD1LikeDatabase();
+			await seedPreMigrationSchema(db);
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await sql`
+				INSERT INTO _emdash_content_bylines (id, collection_slug, content_id, byline_id)
+				VALUES ('cb1', 'posts', 'p1', 'b1')
+			`.execute(db);
+
+			await up(db);
+
+			const count = await sql<{ count: number }>`
+				SELECT COUNT(*) AS count FROM _emdash_content_bylines WHERE content_id = 'p1'
+			`.execute(db);
+			expect(Number(count.rows[0]?.count ?? 0)).toBe(1);
+		});
+
+		it("preserves ec_*.primary_byline_id semantically (row id == translation_group on fresh install)", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await sql`INSERT INTO _emdash_collections (slug) VALUES ('posts')`.execute(db);
+			await sql`
+				INSERT INTO ec_posts (id, primary_byline_id) VALUES ('p1', 'b1')
+			`.execute(db);
+
+			await up(db);
+
+			const row = await sql<{ primary_byline_id: string | null }>`
+				SELECT primary_byline_id FROM ec_posts WHERE id = 'p1'
+			`.execute(db);
+			// Value looks unchanged because translation_group == id on fresh
+			// install, but the semantics flip: this is now a translation_group
+			// reference, not a row id.
+			expect(row.rows[0]?.primary_byline_id).toBe("b1");
+		});
+
+		it("is idempotent (running twice is safe)", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+
+			await up(db);
+			await expect(up(db)).resolves.not.toThrow();
+
+			// Existing row survives both passes.
+			const row = await sql<{ locale: string; translation_group: string | null }>`
+				SELECT locale, translation_group FROM _emdash_bylines WHERE id = 'b1'
+			`.execute(db);
+			expect(row.rows[0]?.locale).toBe("en");
+			expect(row.rows[0]?.translation_group).toBe("b1");
+		});
+
+		it("leaves orphan primary_byline_id pointers untouched", async () => {
+			await sql`INSERT INTO _emdash_collections (slug) VALUES ('posts')`.execute(db);
+			// Post references a byline id that doesn't exist — should not be cleared.
+			await sql`
+				INSERT INTO ec_posts (id, primary_byline_id) VALUES ('p1', 'b-missing')
+			`.execute(db);
+
+			await up(db);
+
+			const row = await sql<{ primary_byline_id: string | null }>`
+				SELECT primary_byline_id FROM ec_posts WHERE id = 'p1'
+			`.execute(db);
+			expect(row.rows[0]?.primary_byline_id).toBe("b-missing");
+		});
+	});
+
+	describe("down()", () => {
+		it("reverts cleanly on a single-locale install", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await up(db);
+
+			await down(db);
+
+			const tables = await db.introspection.getTables();
+			const cols =
+				tables.find((t) => t.name === "_emdash_bylines")?.columns.map((c) => c.name) ?? [];
+			expect(cols).not.toContain("locale");
+			expect(cols).not.toContain("translation_group");
+
+			// Original row survived.
+			const row = await sql<{ slug: string; display_name: string }>`
+				SELECT slug, display_name FROM _emdash_bylines WHERE id = 'b1'
+			`.execute(db);
+			expect(row.rows[0]?.slug).toBe("jane");
+			expect(row.rows[0]?.display_name).toBe("Jane Doe");
+
+			// FK restored on _emdash_content_bylines.byline_id.
+			const fks = await sql<{ table: string }>`
+				PRAGMA foreign_key_list(_emdash_content_bylines)
+			`.execute(db);
+			expect(fks.rows.length).toBeGreaterThan(0);
+		});
+
+		it("refuses to rollback when non-default-locale rows exist", async () => {
+			await up(db);
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name, locale, translation_group)
+				VALUES ('b-fr', 'jane', 'Jeanne', 'fr', 'b-fr')
+			`.execute(db);
+
+			await expect(down(db)).rejects.toThrow(/non-default locale/i);
+
+			// Assertion fired before any destructive work — schema still post-up.
+			const cols = (await db.introspection.getTables())
+				.find((t) => t.name === "_emdash_bylines")
+				?.columns.map((c) => c.name);
+			expect(cols).toContain("locale");
+		});
+
+		it("refuses to rollback when _emdash_content_bylines has dangling rows", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await sql`
+				INSERT INTO _emdash_content_bylines (id, collection_slug, content_id, byline_id)
+				VALUES ('cb1', 'posts', 'p1', 'b1')
+			`.execute(db);
+			await up(db);
+			// Delete the byline row, leaving _emdash_content_bylines pointing at a
+			// translation_group with no anchor row. (Possible because up()
+			// removed the cascading FK.)
+			await sql`DELETE FROM _emdash_bylines WHERE id = 'b1'`.execute(db);
+
+			await expect(down(db)).rejects.toThrow(/_emdash_content_bylines/);
+
+			// Assertion fired before any destructive work.
+			const cols = (await db.introspection.getTables())
+				.find((t) => t.name === "_emdash_bylines")
+				?.columns.map((c) => c.name);
+			expect(cols).toContain("locale");
+		});
+
+		it("preserves _emdash_content_bylines rows on D1 rollback (regression for #1021)", async () => {
+			// down() rebuilds _emdash_bylines before restoring the FK on
+			// _emdash_content_bylines. The intermediate state must not
+			// cascade — neither table has an FK pointing at the other while
+			// the rebuild is in flight.
+			await db.destroy();
+			db = createD1LikeDatabase();
+			await seedPreMigrationSchema(db);
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await sql`
+				INSERT INTO _emdash_content_bylines (id, collection_slug, content_id, byline_id)
+				VALUES ('cb1', 'posts', 'p1', 'b1')
+			`.execute(db);
+			await up(db);
+
+			await down(db);
+
+			const count = await sql<{ count: number }>`
+				SELECT COUNT(*) AS count FROM _emdash_content_bylines WHERE content_id = 'p1'
+			`.execute(db);
+			expect(Number(count.rows[0]?.count ?? 0)).toBe(1);
+		});
+	});
+
+	describe("with non-default locale (defaultLocale='es')", () => {
+		beforeEach(() => {
+			setI18nConfig({ defaultLocale: "es", locales: ["es", "en"] });
+		});
+
+		afterEach(() => {
+			setI18nConfig(null);
+		});
+
+		it("backfills pre-existing rows with the configured defaultLocale", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+
+			await up(db);
+
+			const row = await sql<{ locale: string }>`
+				SELECT locale FROM _emdash_bylines WHERE id = 'b1'
+			`.execute(db);
+			expect(row.rows[0]?.locale).toBe("es");
+		});
+
+		it("rolls back cleanly when only defaultLocale rows exist", async () => {
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name)
+				VALUES ('b1', 'jane', 'Jane Doe')
+			`.execute(db);
+			await up(db);
+
+			await expect(down(db)).resolves.not.toThrow();
+
+			const cols = (await db.introspection.getTables())
+				.find((t) => t.name === "_emdash_bylines")
+				?.columns.map((c) => c.name);
+			expect(cols).not.toContain("locale");
+		});
+
+		it("blocks rollback when rows use a locale other than the configured default", async () => {
+			await up(db);
+			await sql`
+				INSERT INTO _emdash_bylines (id, slug, display_name, locale, translation_group)
+				VALUES ('b-en', 'jane', 'Jane Doe', 'en', 'b-en')
+			`.execute(db);
+
+			await expect(down(db)).rejects.toThrow(/defaultLocale="es"/);
+		});
+	});
+});

--- a/packages/core/tests/unit/database/repositories/byline.test.ts
+++ b/packages/core/tests/unit/database/repositories/byline.test.ts
@@ -253,4 +253,614 @@ describe("BylineRepository", () => {
 		const refreshed = await contentRepo.findById("post", content.id);
 		expect(refreshed?.primaryBylineId).toBeNull();
 	});
+
+	describe("i18n (migration 040)", () => {
+		it("create() mints translation_group equal to id for anchors", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+			});
+
+			expect(anchor.translationGroup).toBe(anchor.id);
+			expect(anchor.locale).toBe("en");
+		});
+
+		it("create({ translationOf }) joins the source's translation_group", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const translation = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			expect(translation.translationGroup).toBe(anchor.id);
+			expect(translation.locale).toBe("fr");
+			expect(translation.id).not.toBe(anchor.id);
+		});
+
+		it("create({ translationOf }) throws when the source byline is missing", async () => {
+			await expect(
+				bylineRepo.create({
+					slug: "ghost",
+					displayName: "Ghost",
+					translationOf: "non-existent-id",
+				}),
+			).rejects.toThrow(/Source byline for translation not found/);
+		});
+
+		it("(slug, locale) is unique — same slug across locales is allowed", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const sibling = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			expect(anchor.slug).toBe(sibling.slug);
+			expect(anchor.translationGroup).toBe(sibling.translationGroup);
+		});
+
+		it("findBySlug filters strictly by locale when provided", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const enHit = await bylineRepo.findBySlug("jane", { locale: "en" });
+			const frHit = await bylineRepo.findBySlug("jane", { locale: "fr" });
+			const deMiss = await bylineRepo.findBySlug("jane", { locale: "de" });
+
+			expect(enHit?.displayName).toBe("Jane Doe");
+			expect(frHit?.displayName).toBe("Jeanne");
+			expect(deMiss).toBeNull();
+		});
+
+		it("findByUserId filters strictly by locale when provided", async () => {
+			const userId = "user-i18n-1";
+			await db
+				.insertInto("users" as any)
+				.values({ id: userId, email: "u@test.com", name: "U", role: 50 })
+				.execute();
+
+			const anchor = await bylineRepo.create({
+				slug: "user-byline",
+				displayName: "User Byline",
+				userId,
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "user-byline",
+				displayName: "User Byline FR",
+				userId,
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const enHit = await bylineRepo.findByUserId(userId, { locale: "en" });
+			const frHit = await bylineRepo.findByUserId(userId, { locale: "fr" });
+			const deMiss = await bylineRepo.findByUserId(userId, { locale: "de" });
+
+			expect(enHit?.displayName).toBe("User Byline");
+			expect(frHit?.displayName).toBe("User Byline FR");
+			expect(deMiss).toBeNull();
+		});
+
+		it("findMany filters strictly by locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+			await bylineRepo.create({
+				slug: "ada",
+				displayName: "Ada",
+				locale: "en",
+			});
+
+			const en = await bylineRepo.findMany({ locale: "en" });
+			const fr = await bylineRepo.findMany({ locale: "fr" });
+			const de = await bylineRepo.findMany({ locale: "de" });
+
+			expect(en.items.map((b) => b.slug).toSorted()).toEqual(["ada", "jane"]);
+			expect(fr.items).toHaveLength(1);
+			expect(fr.items[0]?.displayName).toBe("Jeanne");
+			expect(de.items).toHaveLength(0);
+		});
+
+		it("setContentBylines stores translation_group in the junction (not row id)", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "i18n-credited-post",
+				data: { title: "Credited" },
+			});
+
+			// Editor credits the fr row — server should normalise to the group.
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: fr.id }]);
+
+			const rows = await db
+				.selectFrom("_emdash_content_bylines")
+				.select(["byline_id"])
+				.where("content_id", "=", content.id)
+				.execute();
+			expect(rows[0]?.byline_id).toBe(anchor.id);
+			expect(rows[0]?.byline_id).toBe(anchor.translationGroup);
+		});
+
+		it("setContentBylines sets primary_byline_id to the translation_group", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "i18n-primary-post",
+				data: { title: "Primary" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: fr.id }]);
+
+			const refreshed = await contentRepo.findById("post", content.id);
+			expect(refreshed?.primaryBylineId).toBe(anchor.translationGroup);
+		});
+
+		it("getContentBylines returns the row at the requested locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "i18n-hydrated-post",
+				data: { title: "Hydrated" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: anchor.id }]);
+
+			const enCredits = await bylineRepo.getContentBylines("post", content.id, { locale: "en" });
+			const frCredits = await bylineRepo.getContentBylines("post", content.id, { locale: "fr" });
+
+			expect(enCredits[0]?.byline.displayName).toBe("Jane Doe");
+			expect(frCredits[0]?.byline.displayName).toBe("Jeanne");
+			expect(frCredits[0]?.byline.id).toBe(fr.id);
+		});
+
+		it("getContentBylines is strict — credits with no row at the requested locale are omitted", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "i18n-strict-post",
+				data: { title: "Strict" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: anchor.id }]);
+
+			// No fr row exists for this byline. Strict hydration returns nothing.
+			const frCredits = await bylineRepo.getContentBylines("post", content.id, { locale: "fr" });
+			expect(frCredits).toHaveLength(0);
+
+			// DB-level credit still exists — the junction wasn't dropped, it
+			// just resolves to no presentation at this locale.
+			const junction = await db
+				.selectFrom("_emdash_content_bylines")
+				.select(["byline_id"])
+				.where("content_id", "=", content.id)
+				.execute();
+			expect(junction).toHaveLength(1);
+			expect(junction[0]?.byline_id).toBe(anchor.id);
+		});
+
+		it("getContentBylines without a locale returns every locale variant of the credit", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "i18n-no-locale-post",
+				data: { title: "No locale filter" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: anchor.id }]);
+
+			const all = await bylineRepo.getContentBylines("post", content.id);
+			expect(all).toHaveLength(2);
+			expect(all.map((c) => c.byline.locale).toSorted()).toEqual(["en", "fr"]);
+		});
+
+		it("getContentBylinesMany is strict per requested locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const enPost = await contentRepo.create({
+				type: "post",
+				slug: "en-batch",
+				data: { title: "EN" },
+			});
+			const frPost = await contentRepo.create({
+				type: "post",
+				slug: "fr-batch",
+				data: { title: "FR" },
+			});
+
+			await bylineRepo.setContentBylines("post", enPost.id, [{ bylineId: anchor.id }]);
+			await bylineRepo.setContentBylines("post", frPost.id, [{ bylineId: anchor.id }]);
+
+			const enResult = await bylineRepo.getContentBylinesMany("post", [enPost.id, frPost.id], {
+				locale: "en",
+			});
+			expect(enResult.get(enPost.id)?.[0]?.byline.displayName).toBe("Jane Doe");
+			expect(enResult.get(frPost.id)?.[0]?.byline.displayName).toBe("Jane Doe");
+
+			const frResult = await bylineRepo.getContentBylinesMany("post", [enPost.id, frPost.id], {
+				locale: "fr",
+			});
+			expect(frResult.get(enPost.id)?.[0]?.byline.displayName).toBe("Jeanne");
+			expect(frResult.get(frPost.id)?.[0]?.byline.displayName).toBe("Jeanne");
+		});
+
+		it("copyContentBylines clones junction rows verbatim", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+			});
+			const co = await bylineRepo.create({
+				slug: "co",
+				displayName: "Co-author",
+			});
+
+			const source = await contentRepo.create({
+				type: "post",
+				slug: "src",
+				data: { title: "Source" },
+			});
+			const target = await contentRepo.create({
+				type: "post",
+				slug: "tgt",
+				data: { title: "Target" },
+			});
+
+			await bylineRepo.setContentBylines("post", source.id, [
+				{ bylineId: anchor.id },
+				{ bylineId: co.id, roleLabel: "Editor" },
+			]);
+
+			await bylineRepo.copyContentBylines("post", source.id, target.id);
+
+			const credits = await bylineRepo.getContentBylines("post", target.id, { locale: "en" });
+			expect(credits).toHaveLength(2);
+			expect(credits[0]?.byline.id).toBe(anchor.id);
+			expect(credits[1]?.byline.id).toBe(co.id);
+			expect(credits[1]?.roleLabel).toBe("Editor");
+
+			const tgt = await contentRepo.findById("post", target.id);
+			expect(tgt?.primaryBylineId).toBe(anchor.translationGroup);
+		});
+
+		it("copyContentBylines is a no-op when the target already has credits", async () => {
+			const a = await bylineRepo.create({ slug: "a", displayName: "A" });
+			const b = await bylineRepo.create({ slug: "b", displayName: "B" });
+
+			const source = await contentRepo.create({
+				type: "post",
+				slug: "src-noop",
+				data: { title: "Source" },
+			});
+			const target = await contentRepo.create({
+				type: "post",
+				slug: "tgt-noop",
+				data: { title: "Target" },
+			});
+
+			await bylineRepo.setContentBylines("post", source.id, [{ bylineId: a.id }]);
+			await bylineRepo.setContentBylines("post", target.id, [{ bylineId: b.id }]);
+
+			await bylineRepo.copyContentBylines("post", source.id, target.id);
+
+			const credits = await bylineRepo.getContentBylines("post", target.id);
+			expect(credits).toHaveLength(1);
+			expect(credits[0]?.byline.id).toBe(b.id);
+		});
+
+		it("delete preserves siblings and keeps junction rows when other translations exist", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "delete-sibling",
+				data: { title: "Sibling test" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: anchor.id }]);
+
+			// Delete the FR sibling; junctions and the EN row must survive.
+			const deleted = await bylineRepo.delete(fr.id);
+			expect(deleted).toBe(true);
+
+			const junction = await db
+				.selectFrom("_emdash_content_bylines")
+				.select(["byline_id"])
+				.where("content_id", "=", content.id)
+				.execute();
+			expect(junction).toHaveLength(1);
+
+			const refreshed = await contentRepo.findById("post", content.id);
+			expect(refreshed?.primaryBylineId).toBe(anchor.translationGroup);
+
+			// EN row still exists.
+			expect(await bylineRepo.findById(anchor.id)).not.toBeNull();
+		});
+
+		it("delete cascades junction rows when the last sibling is removed", async () => {
+			const byline = await bylineRepo.create({
+				slug: "solo",
+				displayName: "Solo Author",
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "delete-last",
+				data: { title: "Last sibling" },
+			});
+
+			await bylineRepo.setContentBylines("post", content.id, [{ bylineId: byline.id }]);
+
+			const deleted = await bylineRepo.delete(byline.id);
+			expect(deleted).toBe(true);
+
+			const junction = await db
+				.selectFrom("_emdash_content_bylines")
+				.select(["byline_id"])
+				.where("content_id", "=", content.id)
+				.execute();
+			expect(junction).toHaveLength(0);
+
+			const refreshed = await contentRepo.findById("post", content.id);
+			expect(refreshed?.primaryBylineId).toBeNull();
+		});
+
+		it("listTranslations / findByTranslationGroup return every sibling", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+			const de = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane DE",
+				locale: "de",
+				translationOf: anchor.id,
+			});
+
+			const siblings = await bylineRepo.listTranslations(anchor.id);
+			expect(siblings.map((b) => b.locale).toSorted()).toEqual(["de", "en", "fr"]);
+
+			const byGroup = await bylineRepo.findByTranslationGroup(anchor.translationGroup!);
+			expect(byGroup).toHaveLength(3);
+			expect(byGroup.map((b) => b.id).toSorted()).toEqual([anchor.id, fr.id, de.id].toSorted());
+		});
+
+		it("listTranslations returns [] for a missing byline", async () => {
+			expect(await bylineRepo.listTranslations("does-not-exist")).toEqual([]);
+		});
+
+		it("hasContentBylines distinguishes empty from unresolved-at-locale", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const credited = await contentRepo.create({
+				type: "post",
+				slug: "credited",
+				data: { title: "Credited" },
+			});
+			const uncredited = await contentRepo.create({
+				type: "post",
+				slug: "uncredited",
+				data: { title: "Uncredited" },
+			});
+
+			await bylineRepo.setContentBylines("post", credited.id, [{ bylineId: anchor.id }]);
+
+			// `credited` has explicit junction rows even though they don't
+			// resolve at `fr`. `uncredited` truly has no credits.
+			expect(await bylineRepo.hasContentBylines("post", credited.id)).toBe(true);
+			expect(await bylineRepo.hasContentBylines("post", uncredited.id)).toBe(false);
+
+			// And — strict-locale credit hydration at fr still returns [].
+			const frCredits = await bylineRepo.getContentBylines("post", credited.id, {
+				locale: "fr",
+			});
+			expect(frCredits).toEqual([]);
+		});
+
+		it("hasContentBylinesMany returns the set of credited content ids", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			const a = await contentRepo.create({
+				type: "post",
+				slug: "a",
+				data: { title: "A" },
+			});
+			const b = await contentRepo.create({
+				type: "post",
+				slug: "b",
+				data: { title: "B" },
+			});
+			const c = await contentRepo.create({
+				type: "post",
+				slug: "c",
+				data: { title: "C" },
+			});
+			await bylineRepo.setContentBylines("post", a.id, [{ bylineId: anchor.id }]);
+			await bylineRepo.setContentBylines("post", c.id, [{ bylineId: anchor.id }]);
+
+			const result = await bylineRepo.hasContentBylinesMany("post", [a.id, b.id, c.id]);
+			expect(result.has(a.id)).toBe(true);
+			expect(result.has(b.id)).toBe(false);
+			expect(result.has(c.id)).toBe(true);
+		});
+
+		it("setContentBylines dedupes by translation_group, not wire row id", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+			const fr = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jeanne",
+				locale: "fr",
+				translationOf: anchor.id,
+			});
+
+			const content = await contentRepo.create({
+				type: "post",
+				slug: "dedup-post",
+				data: { title: "Dedup" },
+			});
+
+			// Both sibling row ids passed in — they normalise to the same
+			// translation_group. Without dedup-after-resolve, the second
+			// insert would violate UNIQUE(collection, content, byline_id).
+			const credits = await bylineRepo.setContentBylines("post", content.id, [
+				{ bylineId: anchor.id, roleLabel: "Writer" },
+				{ bylineId: fr.id, roleLabel: "Editor" },
+			]);
+
+			// Exactly one row landed, keyed by translation_group, with the
+			// first occurrence's role_label preserved.
+			const junction = await db
+				.selectFrom("_emdash_content_bylines")
+				.select(["byline_id", "role_label"])
+				.where("content_id", "=", content.id)
+				.execute();
+			expect(junction).toHaveLength(1);
+			expect(junction[0]?.byline_id).toBe(anchor.translationGroup);
+			expect(junction[0]?.role_label).toBe("Writer");
+
+			// `setContentBylines` returns from locale-agnostic
+			// `getContentBylines`, so the 1 junction row joins to every
+			// sibling in the translation_group (2 here: en + fr). The
+			// per-locale hydration in the content handler filters this
+			// down to one row at the entry's locale.
+			expect(credits).toHaveLength(2);
+			expect(credits.map((c) => c.byline.locale).toSorted()).toEqual(["en", "fr"]);
+		});
+
+		it("schema enforces one row per (translation_group, locale)", async () => {
+			const anchor = await bylineRepo.create({
+				slug: "jane",
+				displayName: "Jane Doe",
+				locale: "en",
+			});
+
+			// Same translation_group + same locale, different slug. The
+			// (slug, locale) UNIQUE doesn't catch this — the (group, locale)
+			// partial unique added in migration 040 does.
+			await expect(
+				bylineRepo.create({
+					slug: "jane-alt",
+					displayName: "Jane Alt",
+					locale: "en",
+					translationOf: anchor.id,
+				}),
+			).rejects.toThrow();
+		});
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Adds first-class i18n support to bylines, mirroring the row-per-locale model already in place for content (migration 019), and menus + taxonomies (migration 036, PR #916). Each _emdash_bylines row carries locale and translation_group; siblings sharing a translation_group are the same byline identity in different languages. _emdash_content_bylines.byline_id is remapped to store the referenced byline's translation_group, so a single credit survives content translations and resolves against the active locale at runtime.

Highlights

- Migration 040_byline_i18n — adds locale + translation_group to _emdash_bylines. Idempotent, backfills via configured defaultLocale, partial unique on (translation_group, locale), widens (slug) to (slug, locale).
- Strict per-locale credit hydration — hydrateBylines joins the junction against the sibling matching the entry's locale. No chain-walk for credits. Explicit credit at any locale suppresses author-inferred fallback (gated by hasContentBylines).
- Identity lookups chain-walk — getBylineBySlug walks resolveLocaleChain via requestCached. Author pages for un-translated bylines render the default-locale identity. Deliberately different from credit hydration.
- BylineRepository — strict per-locale (findMany, findBySlug, findById take locale). New: listTranslations, findByTranslationGroup, copyContentBylines, hasContentBylines / hasContentBylinesMany. setContentBylines dedupes by translation_group. delete is sibling-aware.
- REST API — two new endpoints, requireDb on all routes, new bylines:read / bylines:manage permissions (same role thresholds as before):
  - GET /_emdash/api/admin/bylines/:id/translations
  - POST /_emdash/api/admin/bylines/:id/translations
  - GET /_emdash/api/admin/bylines?locale=xx filters strictly
  - POST /_emdash/api/admin/bylines accepts locale + translationOf
- Admin UI
  - TranslationsPanel + LocaleSwitcher on the bylines manager — strict locale filtering, bookmarkable via ?locale=.
  - Byline picker on the content editor is locale-pinned to the entry's locale.
  - Empty state CTA links to /bylines?locale=… for inline creation in the right locale.
  - ContentEditor only sends bylines when the user touched the editor (bylinesTouched, mirrors slugTouched). Prevents silent wipe of copied credits on translation entries.
  - loadMoreMutation snapshots filters at click-time, discards stale in-flight results.
- Locale validation — handlers validate locale against getI18nConfig()?.locales ("zz" → 400). Schemas reject empty-string locales (z.string().min(1).optional()).
Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ **]** `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/403

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<img width="1728" height="997" alt="Screenshot 2026-05-22 at 15 47 51" src="https://github.com/user-attachments/assets/c3358e78-ab71-47e5-abf3-02bdb9a0f568" />

<!-- Optional. Include if the change is visual or if you want to show test results. -->
