### PR TITLE
chore: add engines field to package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -298,5 +298,8 @@
     "wordpress"
   ],
   "author": "Matt Kane",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -325,5 +325,8 @@
     "wordpress"
   ],
   "author": "Matt Kane",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/packages/create-emdash/package.json
+++ b/packages/create-emdash/package.json
@@ -36,5 +36,8 @@
     "type": "git",
     "url": "git+https://github.com/emdash-cms/emdash.git",
     "directory": "packages/create-emdash"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Adds `"engines"` field to `package.json`

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->