### PR TITLE
i18n(zh-CN): Updated Simplified Chinese translation

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -264,13 +264,13 @@ msgstr "{current} / {total}"
 
 #: packages/admin/src/components/ContentList.tsx:506
 msgid "{filteredCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {# 个项目匹配\"{searchQuery}\"} other {# 个项目匹配\"{searchQuery}\"}}"
 
 #. placeholder {0}: hasMore ? "+" : ""
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:517
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {#{0} 个项目} other {#{1} 个项目}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
@@ -306,7 +306,7 @@ msgstr "{pluginName} 需要以下权限："
 
 #: packages/admin/src/components/ContentList.tsx:512
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{total, plural, one {# 个项目} other {# 个项目}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:149
 msgid "{total, plural, one {# total} other {# total}}"
@@ -952,7 +952,7 @@ msgstr "授权中..."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:346
 msgid "Authors"
-msgstr ""
+msgstr "作者"
 
 #: packages/admin/src/components/Redirects.tsx:495
 msgid "auto"
@@ -4169,7 +4169,7 @@ msgstr "新内容类型"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:116
 msgid "New public routes"
-msgstr ""
+msgstr "新增公共路由"
 
 #: packages/admin/src/components/Redirects.tsx:102
 #: packages/admin/src/components/Redirects.tsx:336
@@ -4819,7 +4819,7 @@ msgstr "插件已卸载"
 
 #: packages/admin/src/lib/api/registry.ts:541
 msgid "Plugin update requires re-consent"
-msgstr ""
+msgstr "插件更新需要重新授权"
 
 #: packages/admin/src/components/PluginManager.tsx:257
 msgid "Plugin updated"
@@ -5043,7 +5043,7 @@ msgstr "注册已取消或超时。请重试。"
 
 #: packages/admin/src/components/Sidebar.tsx:221
 msgid "Registry"
-msgstr ""
+msgstr "插件仓库"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:317
 msgid "Release is too new to install"
@@ -5638,7 +5638,7 @@ msgstr "安全审计通过"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:379
 msgid "Security contacts"
-msgstr ""
+msgstr "安全联系方式"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:272
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
@@ -6336,7 +6336,7 @@ msgstr "此区块是从另一个系统导入的。"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:119
 msgid "This update exposes the following routes without authentication:"
-msgstr ""
+msgstr "此更新暴露了以下无需身份验证的路由："
 
 #: packages/admin/src/components/Widgets.tsx:635
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
@@ -6958,11 +6958,11 @@ msgstr "查看站点"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:337
 msgid "View source"
-msgstr ""
+msgstr "查看源码"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:538
 msgid "View the {license} license on spdx.org"
-msgstr ""
+msgstr "在 spdx.org 上查看 {license} 许可证"
 
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Visitors hitting these paths will see an error."


### PR DESCRIPTION
## What does this PR do?

Update 11 missing keys Simplified Chinese translation

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
