### PR TITLE
ci: enable preview builds

### DIFF
--- a/demos/playground/wrangler.jsonc
+++ b/demos/playground/wrangler.jsonc
@@ -2,7 +2,9 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "emdash-playground",
 	"compatibility_date": "2026-02-24",
-	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
 	// Custom entrypoint that exports EmDashPreviewDB
 	"main": "./src/worker.ts",
 	"durable_objects": {
@@ -16,9 +18,12 @@
 	"migrations": [
 		{
 			"tag": "v1",
-			"new_sqlite_classes": ["EmDashPreviewDB"],
+			"new_sqlite_classes": [
+				"EmDashPreviewDB"
+			],
 		},
 	],
+	"preview_urls": true,
 	"observability": {
 		"enabled": true,
 	},
@@ -29,14 +34,6 @@
 			"custom_domain": true,
 		},
 	],
-	// SESSION KV binding. @astrojs/cloudflare 13.2+ injects the SESSION
-	// binding into both the top-level config and `previews.kv_namespaces` for
-	// preview deploys, but with no `id`. `wrangler preview` reads from
-	// `previews.kv_namespaces` and forwards `namespace_id` verbatim -- it has
-	// no auto-provisioning path (unlike `wrangler deploy`), so a binding
-	// without `id` fails with API error 10021. The adapter's customizer skips
-	// re-injecting both fields when the user already defines them, so we
-	// declare both explicitly.
 	"kv_namespaces": [
 		{
 			"binding": "SESSION",
@@ -50,7 +47,13 @@
 				"id": "753be2785dfb4da886e837a90cd9a21a",
 			},
 		],
+		"durable_objects": {
+			"bindings": [
+				{
+					"name": "PLAYGROUND_DB",
+					"class_name": "EmDashPreviewDB",
+				},
+			],
+		},
 	},
-	// No R2 -- media uploads are blocked in playground mode
-	// No D1 -- database is inside the Durable Object
 }

--- a/demos/playground/wrangler.jsonc
+++ b/demos/playground/wrangler.jsonc
@@ -2,9 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "emdash-playground",
 	"compatibility_date": "2026-02-24",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
+	"compatibility_flags": ["nodejs_compat"],
 	// Custom entrypoint that exports EmDashPreviewDB
 	"main": "./src/worker.ts",
 	"durable_objects": {
@@ -18,9 +16,7 @@
 	"migrations": [
 		{
 			"tag": "v1",
-			"new_sqlite_classes": [
-				"EmDashPreviewDB"
-			],
+			"new_sqlite_classes": ["EmDashPreviewDB"],
 		},
 	],
 	"preview_urls": true,


### PR DESCRIPTION
## What does this PR do?

Updates some missing settings to enable preview builds of the playground

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
