### PR TITLE
fix(core): prevent better-sqlite3 import leaking into Postgres server bundle

### DIFF
--- a/.changeset/fix-better-sqlite3-postgres-bundle-leak.md
+++ b/.changeset/fix-better-sqlite3-postgres-bundle-leak.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes Postgres server bundles importing `better-sqlite3`, which crashed production starts (`pnpm preview`, `pnpm start`) with `ERR_MODULE_NOT_FOUND` because the SQLite driver is not installed in Postgres-only deployments. Moved `EmDashDatabaseError` into a new SQLite driver-free `database/errors.ts` and re-exported it from there, so the `better-sqlite3` import doesn't leak into the Postgres build.

--- a/packages/core/src/database/connection.ts
+++ b/packages/core/src/database/connection.ts
@@ -1,22 +1,15 @@
 import BetterSqlite3 from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
 
+import { EmDashDatabaseError } from "./errors.js";
 import { kyselyLogOption } from "./instrumentation.js";
 import type { Database } from "./types.js";
+
+export { EmDashDatabaseError };
 
 export interface DatabaseConfig {
 	url: string;
 	authToken?: string;
-}
-
-export class EmDashDatabaseError extends Error {
-	constructor(
-		message: string,
-		public override cause?: unknown,
-	) {
-		super(message);
-		this.name = "EmDashDatabaseError";
-	}
 }
 
 /**

--- a/packages/core/src/database/errors.ts
+++ b/packages/core/src/database/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Database error types. Kept in their own module (no driver imports) so the
+ * public package barrel can re-export them without dragging native database
+ * drivers into the module graph of consumers that picked a different dialect.
+ */
+export class EmDashDatabaseError extends Error {
+	constructor(
+		message: string,
+		public override cause?: unknown,
+	) {
+		super(message);
+		this.name = "EmDashDatabaseError";
+	}
+}

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -1,4 +1,6 @@
-export { createDatabase, EmDashDatabaseError } from "./connection.js";
+// `createDatabase` is intentionally not re-exported here: it lives in
+// `connection.ts`, which statically imports `better-sqlite3`. See #947.
+export { EmDashDatabaseError } from "./errors.js";
 export type { DatabaseConfig } from "./connection.js";
 export { runMigrations, getMigrationStatus, rollbackMigration } from "./migrations/runner.js";
 export type { MigrationStatus } from "./migrations/runner.js";


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #947 

### Issue

When we build a Postgres-powered emdash site and run pnpm preview, Node crashes with ERR_MODULE_NOT_FOUND: better-sqlite3. This happens because the build output contains an instruction to load the SQLite database driver, even though the site is configured to use Postgres. Postgres-only setups don't install that driver, so startup fails before the site can serve a single request. 

### The fix
A shared error class (`EmDashDatabaseError`) lived inside the file (`packages/core/src/database/index.ts`) that loads SQLite, which dragged the SQLite driver into every emdash build. Moved that error class into its own file (`packages/core/src/database/errors.ts`) with no database driver involved. Now the SQLite driver only gets loaded only for SQLite builds. Postgres builds no longer touch it, and pnpm preview works.

No other behavior changes. I verified that every caller that imports `createDatabase` imports it directly from `packages/core/src/database/connection.ts`, and not from `packages/core/src/database/index.ts` (from where I removed this export)

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
