### PR TITLE
i18n(de): add/update German translations

### DIFF
--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -4185,7 +4185,7 @@ msgstr "{0} erstellen"
 
 #: packages/admin/src/components/ContentEditor.tsx:629
 msgid "New {collectionLabel}"
-msgstr "Neue {collectionLabel}"
+msgstr "Neu: {collectionLabel}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1818
 msgid "New collection"

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -15,11 +15,11 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:359
 msgid " - Guest"
-msgstr ""
+msgstr " - Gast"
 
 #: packages/admin/src/routes/bylines.tsx:359
 msgid " - Linked"
-msgstr ""
+msgstr " - Zugeordnet"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:72
 #: packages/admin/src/components/TranslationsPanel.tsx:76
@@ -28,27 +28,27 @@ msgstr " (Standard)"
 
 #: packages/admin/src/components/MenuEditor.tsx:427
 msgid " (opens in new window)"
-msgstr ""
+msgstr " (öffnet in neuem Fenster)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:782
 #: packages/admin/src/components/MediaPickerModal.tsx:864
 msgid " (selected)"
-msgstr ""
+msgstr " (ausgewählt)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
 msgid ", or open the admin at"
-msgstr ""
+msgstr ", oder öffne den Adminbereich mit"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:309
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
 msgid ": use"
-msgstr ""
+msgstr ": nutze"
 
 #. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
 #: packages/admin/src/components/MediaPickerModal.tsx:722
 msgid "(from {0})"
-msgstr ""
+msgstr "(von {0})"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:352
 msgid "(pre-release)"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:157
 msgid "(synced)"
-msgstr ""
+msgstr "(synchronisiert)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:355
 msgid "(too new)"
@@ -65,7 +65,7 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
 msgid "(with your dev port)."
-msgstr ""
+msgstr "(mit deinem Entwicklungs-Port)"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: orphan.rowCount
@@ -165,89 +165,89 @@ msgstr ""
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
 #: packages/admin/src/components/MenuList.tsx:215
 msgid "{0} • {1}"
-msgstr ""
+msgstr "{0} • {1}"
 
 #. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
 #: packages/admin/src/components/WordPressImport.tsx:1142
 msgid "{0} detected"
-msgstr ""
+msgstr "{0} erkannt"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:110
 msgid "{0} has been deactivated"
-msgstr ""
+msgstr "{0} wurde deaktiviert"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:305
 msgid "{0} has been removed"
-msgstr ""
+msgstr "{0} wurde entfernt"
 
 #. placeholder {0}: plugin.installCount.toLocaleString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:203
 msgid "{0} installs"
-msgstr ""
+msgstr "{0} Installationen"
 
 #. placeholder {0}: plugin.name
 #: packages/admin/src/components/PluginManager.tsx:91
 msgid "{0} is now active"
-msgstr ""
+msgstr "{0} ist jetzt aktiv"
 
 #. placeholder {0}: postType.count
 #. placeholder {1}: postType.suggestedCollection
 #: packages/admin/src/components/WordPressImport.tsx:1809
 msgid "{0} items → {1}"
-msgstr ""
+msgstr "{0} Elemente → {1}"
 
 #. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
 #: packages/admin/src/components/WordPressImport.tsx:1732
 msgid "{0} items will be imported"
-msgstr ""
+msgstr "{0} Elemente werden importiert"
 
 #. placeholder {0}: plugin.capabilities.length
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
 #: packages/admin/src/components/PluginManager.tsx:398
 msgid "{0} permission{1}"
-msgstr ""
+msgstr "{0} Berechtigung{1}"
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:169
 msgid "{0} plugins"
-msgstr ""
+msgstr "{0} Erweiterungen"
 
 #. placeholder {0}: theme.name
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
 msgid "{0} preview"
-msgstr ""
+msgstr "{0} Vorschau"
 
 #. placeholder {0}: SYSTEM_FIELDS.length
 #. placeholder {1}: fields.length
 #. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
 #: packages/admin/src/components/ContentTypeEditor.tsx:574
 msgid "{0} system + {1} custom {2}"
-msgstr ""
+msgstr "{0} System + {1} benutzerdefinierte {2}"
 
 #. placeholder {0}: taxonomy.label
 #: packages/admin/src/components/TaxonomySidebar.tsx:316
 msgid "{0} updated"
-msgstr ""
+msgstr "{0} aktualisiert"
 
 #. placeholder {0}: plugin.name
 #. placeholder {1}: updateInfo?.latest
 #: packages/admin/src/components/PluginManager.tsx:258
 msgid "{0} updated to v{1}"
-msgstr ""
+msgstr "{0} aktualisiert auf v{1}"
 
 #. placeholder {0}: item.filename
 #. placeholder {1}: selected ? t` (selected)` : ""
 #: packages/admin/src/components/MediaPickerModal.tsx:782
 #: packages/admin/src/components/MediaPickerModal.tsx:864
 msgid "{0}{1}"
-msgstr ""
+msgstr "{0}{1}"
 
 #. placeholder {0}: draft.description.length
 #: packages/admin/src/components/SeoPanel.tsx:168
 msgid "{0}/160 characters"
-msgstr ""
+msgstr "{0}/160 Zeichen"
 
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:255
@@ -268,7 +268,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1979
 msgid "{current} of {total}"
-msgstr ""
+msgstr "{current} von {total}"
 
 #: packages/admin/src/components/ContentList.tsx:506
 msgid "{filteredCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
@@ -290,11 +290,11 @@ msgstr "{label} — Übersetzung anzeigen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2279
 msgid "{matchedCount} of {totalCount} assigned"
-msgstr ""
+msgstr "{matchedCount} von {totalCount} zugewiesen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2267
 msgid "{matchedCount} of {totalCount} authors matched by email"
-msgstr ""
+msgstr "{matchedCount} von {totalCount} Autoren erkannt durch E-Mail"
 
 #: packages/admin/src/components/WordPressImport.tsx:1715
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
@@ -306,11 +306,11 @@ msgstr ""
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "{pluginName} is requesting additional permissions:"
-msgstr ""
+msgstr "{pluginName} fragt weitere Berechtigungen an:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:80
 msgid "{pluginName} requires the following permissions:"
-msgstr ""
+msgstr "{pluginName} benötigt die folgenden Berechtigungen:"
 
 #: packages/admin/src/components/ContentList.tsx:512
 msgid "{total, plural, one {# item} other {# items}}"
@@ -349,34 +349,34 @@ msgstr ""
 #: packages/admin/src/components/MediaLibrary.tsx:156
 #: packages/admin/src/components/MediaLibrary.tsx:192
 msgid "{uploaded} uploaded, {failed} failed"
-msgstr ""
+msgstr "{uploaded} hochgeladen, {failed} fehlgeschlagen"
 
 #: packages/admin/src/components/Redirects.tsx:137
 msgid "/new-page or /articles/[slug]"
-msgstr ""
+msgstr "/neue-seite oder /artikel/[slug]"
 
 #: packages/admin/src/components/Redirects.tsx:129
 msgid "/old-page or /blog/[slug]"
-msgstr ""
+msgstr "/alte-seite oder /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:1929
 msgid "• Files are downloaded from your WordPress site"
-msgstr ""
+msgstr "• Dateien werden von deiner WordPress-Seite heruntergeladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1930
 msgid "• Uploaded to your EmDash media storage"
-msgstr ""
+msgstr "• In deine EmDash Medienbibliothek hochgeladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1931
 msgid "• URLs in your content are updated automatically"
-msgstr ""
+msgstr "• URLs in deinen Inhalten werden automatisch aktualisiert"
 
 #: packages/admin/src/components/SetupWizard.tsx:225
 #: packages/admin/src/components/SetupWizard.tsx:277
 #: packages/admin/src/components/SetupWizard.tsx:332
 #: packages/admin/src/components/WordPressImport.tsx:1440
 msgid "← Back"
-msgstr ""
+msgstr "← Zurück"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
 msgid "1 year"
@@ -384,27 +384,28 @@ msgstr "1 Jahr"
 
 #: packages/admin/src/components/WordPressImport.tsx:1361
 msgid "1. Log into your WordPress admin"
-msgstr ""
+msgstr "1. Melde dich in deinem WordPress-Adminbereich an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1114
 msgid "1. Log into your WordPress admin dashboard"
-msgstr ""
+msgstr "1. Melde dich in deinem WordPress-Adminbereich Dashboard an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "2. Go to"
-msgstr ""
+msgstr "2. Gehe zu"
 
 #: packages/admin/src/components/WordPressImport.tsx:1362
 msgid "2. Go to Users → Profile"
-msgstr ""
+msgstr "2. Gehe zu Benutzer → Profil"
 
 #: packages/admin/src/components/WordPressImport.tsx:1363
 msgid "3. Scroll to \"Application Passwords\""
-msgstr ""
+msgstr "3. Scrolle zu \"Anwendungspasswörter\""
 
 #: packages/admin/src/components/WordPressImport.tsx:1118
 msgid "3. Select \"All content\""
-msgstr ""
+msgstr "3. Wähle \"Alle Inhalte\""
+#: TODO: Check WordPress sandbox for exact wording
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
 msgid "30 days"
@@ -412,39 +413,41 @@ msgstr "30 Tage"
 
 #: packages/admin/src/components/Redirects.tsx:150
 msgid "301 Permanent"
-msgstr ""
+msgstr "301 Permanent"
 
 #: packages/admin/src/components/Redirects.tsx:151
 msgid "302 Temporary"
-msgstr ""
+msgstr "302 Temporär"
 
 #: packages/admin/src/components/Redirects.tsx:152
 msgid "307 Temporary (Strict)"
-msgstr ""
+msgstr "307 Temporär (Strikt)"
 
 #: packages/admin/src/components/Redirects.tsx:153
 msgid "308 Permanent (Strict)"
-msgstr ""
+msgstr "308 Permanent (Strikt)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "4. Click \"Download Export File\""
-msgstr ""
+msgstr "4. Klicke \"Lade Export-Datei herunter\""
+#: TODO: Check WordPress sandbox for exact wording
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "4. Enter \"EmDash\" and click \"Add New\""
-msgstr ""
+msgstr "4. Gib \"EmDash\" ein und klicke \"Neu hinzufügen\""
+#: TODO: Check WordPress sandbox for exact wording
 
 #: packages/admin/src/components/Redirects.tsx:368
 msgid "404 Errors"
-msgstr ""
+msgstr "404 Fehler"
 
 #: packages/admin/src/components/WordPressImport.tsx:1365
 msgid "5. Copy the generated password"
-msgstr ""
+msgstr "5. Kopiere das generierte Passwort"
 
 #: packages/admin/src/components/WordPressImport.tsx:1120
 msgid "5. Upload the file here"
-msgstr ""
+msgstr "5. Lade die Datei hier hoch"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
 msgid "7 days"
@@ -456,52 +459,53 @@ msgstr "90 Tage"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:418
 msgid "A brief description of this content type"
-msgstr ""
+msgstr "Eine kurze Beschreibung dieses Inhaltstyps"
 
 #: packages/admin/src/components/Sections.tsx:203
 msgid "A full-width hero banner with heading, text, and CTA button"
-msgstr ""
+msgstr "Ein Hero-Banner in voller Breite mit Überschrift, Text und CTA-Button"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "A short description of your site"
-msgstr ""
+msgstr "Eine kurze Beschreibung deiner Seite"
+#: TODO: Check if Seite or Webseite or Website should be used consistently
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:170
 msgid "Accept & Install"
-msgstr ""
+msgstr "Akzeptieren & Installieren"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:169
 msgid "Accept & Update"
-msgstr ""
+msgstr "Akzeptieren & Aktualisieren"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:206
 msgid "Accept Invite"
-msgstr ""
+msgstr "Einladung annehmen"
 
 #: packages/admin/src/router.tsx:1186
 msgid "Access Denied"
-msgstr ""
+msgstr "Zugriff verboten"
 
 #: packages/admin/src/lib/api/marketplace.ts:224
 #: packages/admin/src/lib/api/marketplace.ts:232
 msgid "Access your media library"
-msgstr ""
+msgstr "Greife auf deine Medienbibliothek zu"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
-msgstr ""
+msgstr "Konto"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:121
 msgid "Account already exists"
-msgstr ""
+msgstr "Konto existiert bereits"
 
 #: packages/admin/src/components/SignupPage.tsx:261
 msgid "Account exists"
-msgstr ""
+msgstr "Konto existiert"
 
 #: packages/admin/src/components/users/UserDetail.tsx:216
 msgid "Account Info"
-msgstr ""
+msgstr "Kontoinformationen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:299
 #: packages/admin/src/components/ContentList.tsx:262
@@ -515,7 +519,7 @@ msgstr "Aktionen"
 #: packages/admin/src/components/users/UserDetail.tsx:206
 #: packages/admin/src/components/users/UserList.tsx:217
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:171
 #: packages/admin/src/components/ContentEditor.tsx:2045
@@ -524,7 +528,8 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:812
 #: packages/admin/src/components/TaxonomySidebar.tsx:439
 msgid "Add"
-msgstr "Hinzufügen"
+msgstr ""
+#: TODO: Direct translation causes issues, e.g. Hinzufügen will render the + Add Tag button to + Hinzufügen Tag
 
 #. placeholder {0}: field.item_label
 #: packages/admin/src/components/PortableTextEditor.tsx:1489
@@ -537,11 +542,11 @@ msgstr ""
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:204
 msgid "Add a new passkey"
-msgstr ""
+msgstr "Neuen Passkey hinzufügen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
 msgid "Add an allowed domain"
-msgstr ""
+msgstr "Erlaubte Domain hinzufügen"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
@@ -569,7 +574,7 @@ msgstr ""
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
 msgid "Add Domain"
-msgstr ""
+msgstr "Domain hinzufügen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:582
 #: packages/admin/src/components/FieldEditor.tsx:342
@@ -665,7 +670,7 @@ msgstr ""
 #: packages/admin/src/components/MenuEditor.tsx:354
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
 msgid "Adding..."
-msgstr ""
+msgstr "Hinzufügen..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1592
 msgid "Additional data to import."
@@ -756,7 +761,7 @@ msgstr ""
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
 msgid "Allowed Domains"
-msgstr ""
+msgstr "Erlaubte Domains"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
@@ -1383,7 +1388,7 @@ msgstr ""
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:158
 msgid "colleague@example.com"
-msgstr ""
+msgstr "max.mustermann@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
@@ -1761,7 +1766,7 @@ msgstr "Inhalte erstellen, aktualisieren und löschen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
-msgstr ""
+msgstr "Erstellt"
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
@@ -1867,11 +1872,11 @@ msgstr ""
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
 msgid "Default Role"
-msgstr ""
+msgstr "Standard Rolle"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
 msgid "Default role:"
-msgstr ""
+msgstr "Standard Rolle:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:180
 msgid "Default social image"
@@ -2114,11 +2119,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr ""
+msgstr "Gerät gebunden"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr ""
+msgstr "An Gerät gebundener Passkey"
 
 #: packages/admin/src/components/SignupPage.tsx:143
 msgid "Didn't receive the email?"
@@ -2130,7 +2135,7 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
-msgstr ""
+msgstr "Deaktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:444
 msgid "Disable plugin"
@@ -2220,19 +2225,19 @@ msgstr ""
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
 msgid "Domain"
-msgstr ""
+msgstr "Domain"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
 msgid "Domain added successfully"
-msgstr ""
+msgstr "Domain erfolgreich hinzugefügt"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
 msgid "Domain removed"
-msgstr ""
+msgstr "Domain entfernt"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
 msgid "Domain updated"
-msgstr ""
+msgstr "Domain aktualisiert"
 
 #: packages/admin/src/components/LoginPage.tsx:332
 msgid "Don't have an account? <0>Sign up</0>"
@@ -2342,7 +2347,8 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:360
 #: packages/admin/src/components/TranslationsPanel.tsx:88
 msgid "Edit"
-msgstr "Bearbeiten"
+msgstr ""
+#: TODO: Direct translation causes issues, e.g. headline of the edit a tag modal
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -2373,7 +2379,7 @@ msgstr "Autorenzeile bearbeiten"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
 msgid "Edit Domain"
-msgstr ""
+msgstr "Domain anpassen"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
@@ -2455,11 +2461,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
-msgstr ""
+msgstr "E-Mail-Adresse bestätigt"
 
 #: packages/admin/src/components/SignupPage.tsx:189
 msgid "Email verified!"
-msgstr ""
+msgstr "E-Mail-Adresse bestätigt!"
 
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:2019
@@ -3548,7 +3554,7 @@ msgstr ""
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
 msgid "Invite User"
-msgstr ""
+msgstr "Nutzer einladen"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
@@ -3627,11 +3633,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
-msgstr ""
+msgstr "Letzte Anmeldung"
 
 #: packages/admin/src/components/users/UserList.tsx:107
 msgid "Last Login"
-msgstr ""
+msgstr "Letzte Anmeldung"
 
 #: packages/admin/src/components/Redirects.tsx:217
 msgid "Last seen"
@@ -3639,11 +3645,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
-msgstr ""
+msgstr "Zuletzt aktualisiert"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:161
 msgid "Last used"
-msgstr ""
+msgstr "Zuletzt "
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
@@ -3884,7 +3890,7 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:174
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr ""
+msgstr "Installierte Erweiterungen verwalten. Aktiviere oder deaktiviere Erweiterungen um ihre Funktionalität zu kontrollieren."
 
 #: packages/admin/src/components/MenuList.tsx:104
 msgid "Manage navigation menus for your site"
@@ -4244,7 +4250,7 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "No"
-msgstr ""
+msgstr "Nein"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:397
@@ -4328,7 +4334,7 @@ msgstr ""
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
 msgid "No domains configured. Users must be invited individually."
-msgstr ""
+msgstr "Keine Domains konfiguriert. Nutzer müssen einzeln eingeladen werden."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:178
 msgid "No email provider configured"
@@ -4429,23 +4435,23 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:194
 msgid "No plugins configured"
-msgstr ""
+msgstr "Keine Erweiterungen konfiguriert"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:173
 msgid "No plugins found"
-msgstr ""
+msgstr "Keine Erweiterungen gefunden"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:117
 msgid "No plugins have been published to this registry yet."
-msgstr ""
+msgstr "In diesem Verzeichnis wurden bislang keine Erweiterungen veröffentlicht"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:116
 msgid "No plugins match \"{debouncedQuery}\"."
-msgstr ""
+msgstr "Keine Erweiterungen stimmen überein mit \"{debouncedQuery}\"."
 
 #: packages/admin/src/components/Sections.tsx:343
 msgid "No preview"
-msgstr ""
+msgstr "Keine Vorschau"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
@@ -5117,11 +5123,11 @@ msgstr ""
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
 msgid "Remove Domain"
-msgstr ""
+msgstr "Domain entfernen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
 msgid "Remove Domain?"
-msgstr ""
+msgstr "Domain entfernen?"
 
 #: packages/admin/src/components/ContentEditor.tsx:1673
 #: packages/admin/src/components/ContentEditor.tsx:1702
@@ -5337,7 +5343,7 @@ msgstr ""
 #: packages/admin/src/components/users/UserDetail.tsx:181
 #: packages/admin/src/components/users/UserList.tsx:101
 msgid "Role"
-msgstr ""
+msgstr "Rolle"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:61
 msgid "Role {role}"
@@ -5379,7 +5385,7 @@ msgstr ""
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 #: packages/admin/src/components/users/UserDetail.tsx:311
 msgid "Save Changes"
-msgstr ""
+msgstr "Änderungen speichern"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:72
 msgid "Save content as draft before publishing"
@@ -5524,7 +5530,7 @@ msgstr "{0} suchen..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
-msgstr ""
+msgstr "Suche anhand von Name oder E-Mail-Adresse"
 
 #: packages/admin/src/routes/bylines.tsx:314
 msgid "Search bylines"
@@ -5800,11 +5806,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr ""
+msgstr "Sende eine Einladung via E-Mail an ein neues Teammitglied."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 msgid "Send Invite"
-msgstr ""
+msgstr "Einladung senden"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 msgid "Send magic link"
@@ -5812,7 +5818,7 @@ msgstr "Magic Link senden"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
-msgstr ""
+msgstr "Wiederherstellungs-Link senden"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
 msgid "Send Test"
@@ -6255,7 +6261,7 @@ msgstr ""
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
-msgstr ""
+msgstr "Dem eingeladenen Nutzer wird diese Rolle zugewiesen sobald er die Registrierung erfolgreich abgeschlossen hat."
 
 #: packages/admin/src/components/LoginPage.tsx:113
 #: packages/admin/src/components/SignupPage.tsx:139
@@ -6659,7 +6665,7 @@ msgstr ""
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
 msgid "Unnamed passkey"
-msgstr ""
+msgstr "Unbenannter Passkey"
 
 #: packages/admin/src/components/ContentEditor.tsx:728
 msgid "Unpublish"
@@ -6718,7 +6724,7 @@ msgstr ""
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
 msgid "Update settings for {0}"
-msgstr ""
+msgstr "Einstellungen für Domain {0} ändern"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Update site settings"
@@ -6922,11 +6928,11 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr ""
+msgstr "Nutzerdetails"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr ""
+msgstr "Nutzer nicht gefunden"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -6936,11 +6942,11 @@ msgstr "Benutzer"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
 msgid "Users from"
-msgstr ""
+msgstr "Nutzer von"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr ""
+msgstr "Nutzer mit E-Mail-Adressen dieser Domains können sich ohne Einladung registrieren. Ihnen wird dann die angegebene Rolle automatisch zugewiesen."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:357
@@ -7147,7 +7153,7 @@ msgstr ""
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr ""
+msgstr "können sich nicht mehr ohne Einladung registrieren. Bereits registrierte Nutzer sind hiervon nicht betroffen."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:184
 msgid "Without an email provider, invite links must be shared manually."
@@ -7167,7 +7173,7 @@ msgstr ""
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -6395,7 +6395,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentEditor.tsx:956
 msgid "This will move the item to trash. You can restore it later from the trash."
-msgstr "Dies verschiebt das Element in den Papierkorb. Sie können es später von dort wiederherstellen."
+msgstr "Dies verschiebt das Element in den Papierkorb. Du kannst es später von dort wiederherstellen."
 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:882

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -207,7 +207,10 @@ msgstr "{0} Elemente werden importiert"
 #. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
 #: packages/admin/src/components/PluginManager.tsx:398
 msgid "{0} permission{1}"
-msgstr "{0} Berechtigung{1}"
+msgstr "{0} Berechtigungen"
+#: This implementation causes issues with languages like German -> the EN plural can come with the letter s added by {1} but e.g. German does not follow this logic.
+#: Temporary fix used above: Omit the {1} and use the plural directly
+#: Suggested fix: Use the ICU plural string for Permission/Permissions -> Berechtigung/Berechtigungen instead
 
 #. placeholder {0}: plugins?.length ?? 0
 #: packages/admin/src/components/PluginManager.tsx:169
@@ -486,7 +489,7 @@ msgstr "Zugriff verweigert"
 #: packages/admin/src/lib/api/marketplace.ts:224
 #: packages/admin/src/lib/api/marketplace.ts:232
 msgid "Access your media library"
-msgstr "Greife auf deine Medienbibliothek zu"
+msgstr "Auf Medienbibliothek zugreifen"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
@@ -1503,7 +1506,7 @@ msgstr "Inhalts-ID:"
 
 #: packages/admin/src/router.tsx:778
 msgid "Content is now live"
-msgstr "Inhalt ist jetzt online verfügbar"
+msgstr "Inhalt ist jetzt öffentlich einsehbar"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "content items"
@@ -2468,7 +2471,8 @@ msgstr "E-Mail-Adresse bestätigt!"
 #. placeholder {0}: block.label
 #: packages/admin/src/components/PortableTextEditor.tsx:2019
 msgid "Embed a {0}"
-msgstr "Ein {0} einbetten"
+msgstr "{0} einbetten"
+#: Temporary fix: Removed the indefinite article "Ein" from the beginning of this string to avoid issues (it will differ based on the value of {0})
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2022
 msgid "Embeds"
@@ -4957,7 +4961,7 @@ msgstr "publiziert"
 #: packages/admin/src/components/Dashboard.tsx:187
 #: packages/admin/src/router.tsx:778
 msgid "Published"
-msgstr "publiziert"
+msgstr "Publiziert"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:327
@@ -5447,7 +5451,7 @@ msgstr "Publizieren planen für"
 
 #: packages/admin/src/components/ContentEditor.tsx:922
 msgid "Schedule for later"
-msgstr "Für später planen"
+msgstr "Später publizieren"
 
 #: packages/admin/src/components/ContentList.tsx:729
 msgid "scheduled"
@@ -6686,7 +6690,7 @@ msgstr "Planung aufheben"
 
 #: packages/admin/src/router.tsx:847
 msgid "Unscheduled"
-msgstr "Ungeplant"
+msgstr "Planung aufgehoben"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -6886,7 +6886,7 @@ msgstr "Nutze [param] oder [...rest] in Pfaden für Musterabgleiche."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:366
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr "Nutze die biometrischen Authentifizierung, den Sicherheitsschlüssel oder die PIN deines Geräts für die Anmeldung."
+msgstr "Nutze die biometrische Authentifizierung, den Sicherheitsschlüssel oder die PIN deines Geräts für die Anmeldung."
 
 #: packages/admin/src/components/LoginPage.tsx:326
 msgid "Use your registered passkey to sign in securely."

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -529,7 +529,7 @@ msgstr "Aktiv"
 #: packages/admin/src/components/TaxonomySidebar.tsx:439
 msgid "Add"
 msgstr ""
-#: TODO: Direct translation causes issues, e.g. Hinzufügen will render the + Add Tag button to + Hinzufügen Tag
+#: TODO: Translation causes issues, e.g. Hinzufügen will render the + Add Tag button to + Hinzufügen Tag
 
 #. placeholder {0}: field.item_label
 #: packages/admin/src/components/PortableTextEditor.tsx:1489
@@ -2349,7 +2349,7 @@ msgstr "z.B., MacBook Pro, iPhone"
 #: packages/admin/src/components/TranslationsPanel.tsx:88
 msgid "Edit"
 msgstr ""
-#: TODO: Direct translation causes issues, e.g. headline of the edit a tag modal
+#: TODO: Translation causes issues, e.g. headline of the edit a tag modal
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -256,15 +256,15 @@ msgstr "{base} to: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:337
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
-msgstr ""
+msgstr "{changedCount, plural, one {# Änderung von nächster Revision} other {# Änderungen von nächster Revision}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1908
 msgid "{count, plural, one {# file} other {# files}}"
-msgstr ""
+msgstr "{count, plural, one {# Datei} other {# Dateien}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2157
 msgid "{count, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{count, plural, one {# Element} other {# Elemente}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1979
 msgid "{current} of {total}"
@@ -272,13 +272,13 @@ msgstr "{current} von {total}"
 
 #: packages/admin/src/components/ContentList.tsx:506
 msgid "{filteredCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {# Element passend zu \"{searchQuery}\"} other {# Elemente passend zu \"{searchQuery}\"}}"
 
 #. placeholder {0}: hasMore ? "+" : ""
 #. placeholder {1}: hasMore ? "+" : ""
 #: packages/admin/src/components/ContentList.tsx:517
 msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
-msgstr ""
+msgstr "{filteredCount, plural, one {#{0} Element} other {#{1} Elemente}}"
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:107
 msgid "{label} — no translation"
@@ -298,11 +298,11 @@ msgstr "{matchedCount} von {totalCount} Autoren erkannt durch E-Mail"
 
 #: packages/admin/src/components/WordPressImport.tsx:1715
 msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
-msgstr ""
+msgstr "{needsNewCollections, plural, one {# neue Kollektion wird erstellt} other {# neue Kollektionen werden erstellt}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1724
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr ""
+msgstr "{needsNewFields, plural, one {Felder werden zu # bestehenden Kollektion hinzuegfügt} other {Felder werden zu # bestehenden Kollektionen hinzuegfügt}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "{pluginName} is requesting additional permissions:"
@@ -314,21 +314,21 @@ msgstr "{pluginName} benötigt die folgenden Berechtigungen:"
 
 #: packages/admin/src/components/ContentList.tsx:512
 msgid "{total, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{total, plural, one {# Element} other {# Elemente}}"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:149
 msgid "{total, plural, one {# total} other {# total}}"
-msgstr ""
+msgstr "{total, plural, one {# insgesamt} other {# insgesamt}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:146
 #: packages/admin/src/components/MediaLibrary.tsx:182
 msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
-msgstr ""
+msgstr "{total, plural, one {Datei hochgeladen} other {# Dateien hochgeladen}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:151
 #: packages/admin/src/components/MediaLibrary.tsx:187
 msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
-msgstr ""
+msgstr "{total, plural, one {Hochladen der Datei ist fehlgeschlagen} other {Hochladen von # Dateien ist fehlgeschlagen}}"
 
 #: packages/admin/src/components/Dashboard.tsx:113
 msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
@@ -340,11 +340,11 @@ msgstr "{totalScheduled, plural, one {# geplant} other {# geplant}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:349
 msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {# unverändertes Element ausblenden} other {# unveränderte Elemente ausblenden}}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:350
 msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
-msgstr ""
+msgstr "{unchangedCount, plural, one {# unverändertes Element einblenden} other {# unveränderte Elemente einblenden}}"
 
 #: packages/admin/src/components/MediaLibrary.tsx:156
 #: packages/admin/src/components/MediaLibrary.tsx:192

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -1559,7 +1559,7 @@ msgstr "Import fortsetzen"
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
 msgid "Contributor"
-msgstr "Mitwirkende"
+msgstr "Mitwirkender"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
 #: packages/admin/src/components/users/InviteUserModal.tsx:134
@@ -3156,11 +3156,11 @@ msgstr "Installiere die"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
-msgstr "Voller Zugriff"
+msgstr "Uneingeschränkter Zugriff"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
 msgid "Full admin access"
-msgstr "Voller Admin-Zugriff"
+msgstr "Uneingeschränkter Zugriff"
 
 #: packages/admin/src/components/Settings.tsx:69
 msgid "General"

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -72,49 +72,49 @@ msgstr "(mit deinem Entwicklungs-Port)"
 #: packages/admin/src/components/ContentTypeList.tsx:69
 #: packages/admin/src/components/RepeaterField.tsx:147
 msgid "{0, plural, one {(# item)} other {(# items)}}"
-msgstr ""
+msgstr "{0, plural, one {(# Element)} other {(# Elemente)}}"
 
 #. placeholder {0}: seedInfo.collections
 #: packages/admin/src/components/SetupWizard.tsx:156
 msgid "{0, plural, one {# collection} other {# collections}}"
-msgstr ""
+msgstr "{0, plural, one {# Kollektion} other {# Kollektionen}}"
 
 #. placeholder {0}: result.affected
 #: packages/admin/src/router.tsx:1166
 msgid "{0, plural, one {# comment updated} other {# comments updated}}"
-msgstr ""
+msgstr "{0, plural, one {# Kommentar aktualisiert} other {# Kommentare aktualisiert}}"
 
 #. placeholder {0}: comments.length
 #: packages/admin/src/components/comments/CommentInbox.tsx:344
 msgid "{0, plural, one {# comment} other {# comments}}"
-msgstr ""
+msgstr "{0, plural, one {# Kommentar} other {# Kommentare}}"
 
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2080
 msgid "{0, plural, one {# content error} other {# content errors}}"
-msgstr ""
+msgstr "{0, plural, one {# Fehler mit Inhalt} other {# Fehler mit Inhalten}}"
 
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2056
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr ""
+msgstr "{0, plural, one {# Inhaltselement importiert} other {# Imhaltselemente importiert}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
 #: packages/admin/src/components/MediaPickerModal.tsx:573
 #: packages/admin/src/components/MenuList.tsx:217
 msgid "{0, plural, one {# item} other {# items}}"
-msgstr ""
+msgstr "{0, plural, one {# Element} other {# Elemente}}"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2085
 msgid "{0, plural, one {# media error} other {# media errors}}"
-msgstr ""
+msgstr "{0, plural, one {# Medienfehler} other {# Medienfehler}}"
 
 #. placeholder {0}: mediaResult.imported.length
 #: packages/admin/src/components/WordPressImport.tsx:2072
 msgid "{0, plural, one {# media file imported} other {# media files imported}}"
-msgstr ""
+msgstr "{0, plural, one {# Mediendatei importiert} other {# Mediendateien importiert}}"
 
 #. placeholder {0}: stats.mediaCount
 #: packages/admin/src/components/Dashboard.tsx:123
@@ -124,32 +124,32 @@ msgstr "{0, plural, one {# Mediendatei} other {# Mediendateien}}"
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1739
 msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
-msgstr ""
+msgstr "{0, plural, one {# Menü wird importiert} other {# Menüs werden importiert}}"
 
 #. placeholder {0}: plugin.capabilities.length
 #: packages/admin/src/components/MarketplaceBrowse.tsx:288
 msgid "{0, plural, one {# permission} other {# permissions}}"
-msgstr ""
+msgstr "{0, plural, one {# Berechtigung} other {# Berechtigungen}}"
 
 #. placeholder {0}: mapping.postCount
 #: packages/admin/src/components/WordPressImport.tsx:2292
 msgid "{0, plural, one {# post} other {# posts}}"
-msgstr ""
+msgstr "{0, plural, one {# Beitrag} other {# Beiträge}}"
 
 #. placeholder {0}: loopRedirectIds.size
 #: packages/admin/src/components/Redirects.tsx:418
 msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
-msgstr ""
+msgstr "{0, plural, one {# Weiterleitung ist Teil einer Schleife.} other {# Weiterleitungen sind Teil einer Schleife.}}"
 
 #. placeholder {0}: selected.size
 #: packages/admin/src/components/comments/CommentInbox.tsx:228
 msgid "{0, plural, one {# selected} other {# selected}}"
-msgstr ""
+msgstr "{0, plural, one {# ausgewählt} other {# ausgewählt}}"
 
 #. placeholder {0}: result.skipped
 #: packages/admin/src/components/WordPressImport.tsx:2064
 msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
-msgstr ""
+msgstr "{0, plural, one {# übersprungen (bereits vorhanden)} other {# übersprungen (bereits vorhanden)}}"
 
 #. placeholder {0}: stats.userCount
 #: packages/admin/src/components/Dashboard.tsx:128
@@ -159,7 +159,7 @@ msgstr "{0, plural, one {# Benutzer} other {# Benutzer}}"
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:576
 msgid "{0, plural, one {field} other {fields}}"
-msgstr ""
+msgstr "{0, plural, one {Feld} other {Felder}}"
 
 #. placeholder {0}: menu.name
 #. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -52,7 +52,7 @@ msgstr "(von {0})"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:352
 msgid "(pre-release)"
-msgstr ""
+msgstr "(Vorabversion)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:157
 msgid "(synced)"
@@ -60,7 +60,7 @@ msgstr "(synchronisiert)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:355
 msgid "(too new)"
-msgstr ""
+msgstr "(zu neu)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
@@ -252,7 +252,7 @@ msgstr "{0}/160 Zeichen"
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:255
 msgid "{base} to: {0}"
-msgstr ""
+msgstr "{base} to: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:337
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
@@ -534,11 +534,11 @@ msgstr ""
 #. placeholder {0}: field.item_label
 #: packages/admin/src/components/PortableTextEditor.tsx:1489
 msgid "Add {0}"
-msgstr ""
+msgstr "{0} hinzufügen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:238
 msgid "Add {label}"
-msgstr ""
+msgstr "{label} hinzufügen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:204
 msgid "Add a new passkey"
@@ -550,26 +550,26 @@ msgstr "Erlaubte Domain hinzufügen"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr ""
+msgstr "Füge mindestens ein Unterfeld hinzu, um die Struktur des wiederholbaren Feldes zu definieren."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2575
 msgid "Add column after"
-msgstr ""
+msgstr "Spalte danach einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2568
 msgid "Add column before"
-msgstr ""
+msgstr "Spalte davor einfügen"
 
 #: packages/admin/src/components/MenuEditor.tsx:291
 #: packages/admin/src/components/MenuEditor.tsx:406
 msgid "Add Content"
-msgstr ""
+msgstr "Inhalt hinzufügen"
 
 #: packages/admin/src/components/MenuEditor.tsx:303
 #: packages/admin/src/components/MenuEditor.tsx:310
 #: packages/admin/src/components/MenuEditor.tsx:409
 msgid "Add Custom Link"
-msgstr ""
+msgstr "Benutzerdefinierten Link hinzufügen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
@@ -580,43 +580,43 @@ msgstr "Domain hinzufügen"
 #: packages/admin/src/components/FieldEditor.tsx:342
 #: packages/admin/src/components/FieldEditor.tsx:659
 msgid "Add Field"
-msgstr ""
+msgstr "Feld hinzufügen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1820
 msgid "Add fields"
-msgstr ""
+msgstr "Felder hinzufügen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:604
 msgid "Add fields to define the structure of your content"
-msgstr ""
+msgstr "Füge Felder hinzu, um die Struktur deiner Inhalte zu definieren"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:607
 msgid "Add First Field"
-msgstr ""
+msgstr "Erstes Feld hinzufügen"
 
 #: packages/admin/src/components/RepeaterField.tsx:169
 msgid "Add First Item"
-msgstr ""
+msgstr "Erstes Element hinzufügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1489
 msgid "Add item"
-msgstr ""
+msgstr "Element hinzufügen"
 
 #: packages/admin/src/components/RepeaterField.tsx:153
 msgid "Add Item"
-msgstr ""
+msgstr "Element hinzufügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2535
 msgid "Add link"
-msgstr ""
+msgstr "Link hinzufügen"
 
 #: packages/admin/src/components/MenuEditor.tsx:399
 msgid "Add links to build your navigation menu"
-msgstr ""
+msgstr "Erstelle dein Navigationsmenü, indem du Links hinzufügst"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:162
 msgid "Add MIME type or extension"
-msgstr ""
+msgstr "MIME-Typ oder Dateiendung hinzufügen"
 
 #: packages/admin/src/components/ContentList.tsx:186
 msgid "Add New"
@@ -625,11 +625,11 @@ msgstr "Neu hinzufügen"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:449
 msgid "Add new {0}"
-msgstr ""
+msgstr "{0} hinzufügen"
 
 #: packages/admin/src/components/SeoPanel.tsx:192
 msgid "Add noindex meta tag"
-msgstr ""
+msgstr "noindex-Meta-Tag hinzufügen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:225
 msgid "Add Passkey"
@@ -641,31 +641,31 @@ msgstr "Füge Erweiterungen deiner astro.config.mjs hinzu um die Funktionalität
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2598
 msgid "Add row after"
-msgstr ""
+msgstr "Zeile darunter einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2591
 msgid "Add row before"
-msgstr ""
+msgstr "Zeile darüber einfügen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:476
 msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
-msgstr ""
+msgstr "SEO-Metadatenfelder hinzufügen (Titel, Beschreibung, Bild) und in die Sitemap aufnehmen"
 
 #: packages/admin/src/components/FieldEditor.tsx:538
 msgid "Add Sub-Field"
-msgstr ""
+msgstr "Untergeordnetes Feld hinzufügen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:237
 msgid "Add tags..."
-msgstr ""
+msgstr "Schlagwörter hinzufügen..."
 
 #: packages/admin/src/components/Widgets.tsx:338
 msgid "Add Widget Area"
-msgstr ""
+msgstr "Widget-Bereich hinzufügen"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr ""
+msgstr "Füge deine Profile von sozialen Medien hinzu. Sie stehen dem Design deiner Website zur Verfügung und können in Kopfzeilen, Fußzeilen oder Autorenbeschreibungen angezeigt werden."
 
 #: packages/admin/src/components/MenuEditor.tsx:354
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
@@ -674,7 +674,7 @@ msgstr "Hinzufügen..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1592
 msgid "Additional data to import."
-msgstr ""
+msgstr "Zusätzliche Daten, die importiert werden sollen."
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
 #: packages/admin/src/components/Sidebar.tsx:454
@@ -692,19 +692,19 @@ msgstr "Administrator"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:224
 msgid "After send:"
-msgstr ""
+msgstr "Nach dem Senden:"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2923
 msgid "Align Center"
-msgstr ""
+msgstr "Zentrieren"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2916
 msgid "Align Left"
-msgstr ""
+msgstr "Linksbündig"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2930
 msgid "Align Right"
-msgstr ""
+msgstr "Rechtsbündig"
 
 #: packages/admin/src/components/ContentList.tsx:213
 msgid "All"
@@ -728,7 +728,7 @@ msgstr "Alle Kommentare benötigen eine Freigabe"
 
 #: packages/admin/src/components/WordPressImport.tsx:2324
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr ""
+msgstr "Alle importierten Inhalte bleiben ohne Zuordnung. Du kannst Autoren später im Inhaltseditor neu zuweisen."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
@@ -741,7 +741,7 @@ msgstr "Alle Rollen"
 
 #: packages/admin/src/components/Sections.tsx:240
 msgid "All Sources"
-msgstr ""
+msgstr "Alle Quellen"
 
 #: packages/admin/src/components/Redirects.tsx:392
 msgid "All statuses"
@@ -765,11 +765,11 @@ msgstr "Erlaubte Domains"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:102
 msgid "Allowed types"
-msgstr ""
+msgstr "Zulässige Dateitypen"
 
 #: packages/admin/src/components/SignupPage.tsx:437
 msgid "Already have an account?"
-msgstr ""
+msgstr "Du hast bereits ein Benutzerkonto?"
 
 #: packages/admin/src/components/PluginManager.tsx:630
 msgid "Also delete plugin storage data"
@@ -777,22 +777,22 @@ msgstr "Auch gespeicherte Daten der Erweiterung löschen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:202
 msgid "Alt text"
-msgstr ""
+msgstr "Alt-Text"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
 #: packages/admin/src/components/MediaDetailPanel.tsx:202
 msgid "Alt Text"
-msgstr ""
+msgstr "Alt-Text"
 
 #: packages/admin/src/components/MediaLibrary.tsx:633
 #: packages/admin/src/components/MediaLibrary.tsx:690
 msgid "Alt text set"
-msgstr ""
+msgstr "Alt-Text festgelegt"
 
 #: packages/admin/src/components/WordPressImport.tsx:1234
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
-msgstr ""
+msgstr "Alternativ kannst du den Export in WordPress unter Werkzeuge → Export erstellen und die Exportdatei hochladen."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:133
 #: packages/admin/src/components/PluginManager.tsx:97
@@ -817,23 +817,23 @@ msgstr ""
 #: packages/admin/src/router.tsx:1172
 #: packages/admin/src/router.tsx:1645
 msgid "An error occurred"
-msgstr ""
+msgstr "Ein Fehler ist aufgetreten"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:217
 msgid "An unknown error occurred"
-msgstr ""
+msgstr "Ein unbekannter Fehler ist aufgetreten"
 
 #: packages/admin/src/components/WordPressImport.tsx:1414
 msgid "Analyzing export file..."
-msgstr ""
+msgstr "Überprüfe die Exportdatei..."
 
 #: packages/admin/src/components/WordPressImport.tsx:735
 msgid "Analyzing WordPress site..."
-msgstr ""
+msgstr "Überprüfe die WordPress-Webseite..."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:105
 msgid "Any media type allowed (subject to global limits)."
-msgstr ""
+msgstr "Alle Medientypen erlaubt (vorbehaltlich globaler Beschränkungen)."
 
 #: packages/admin/src/components/Settings.tsx:109
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
@@ -842,15 +842,15 @@ msgstr "API-Tokens"
 
 #: packages/admin/src/components/Widgets.tsx:375
 msgid "Appears on posts and pages"
-msgstr ""
+msgstr "Wird in Beiträgen und auf Seiten angezeigt"
 
 #: packages/admin/src/components/WordPressImport.tsx:1329
 msgid "Application Password"
-msgstr ""
+msgstr "Anwendungspasswort"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2990
 msgid "Apply"
-msgstr ""
+msgstr "Anwenden"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:144
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:145
@@ -860,7 +860,7 @@ msgstr ""
 #: packages/admin/src/components/PortableTextEditor.tsx:2475
 #: packages/admin/src/components/PortableTextEditor.tsx:2476
 msgid "Apply link"
-msgstr ""
+msgstr "Link erstellen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:148
 #: packages/admin/src/components/comments/CommentInbox.tsx:237
@@ -878,7 +878,7 @@ msgstr "Freigegeben"
 
 #: packages/admin/src/components/FieldEditor.tsx:223
 msgid "Arbitrary JSON data"
-msgstr ""
+msgstr "Beliebige JSON-Daten"
 
 #: packages/admin/src/components/ContentList.tsx:731
 msgid "archived"
@@ -886,21 +886,21 @@ msgstr "archiviert"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 msgid "Archives"
-msgstr ""
+msgstr "Archive"
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr ""
+msgstr "Bist du sicher, dass du „{0}“ löschen möchtest? Dadurch werden auch alle Inhalte in dieser Kollektion gelöscht."
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:660
 msgid "Are you sure you want to delete the \"{0}\" field?"
-msgstr ""
+msgstr "Möchtest du das Feld „{0}“ wirklich entfernen?"
 
 #: packages/admin/src/components/MenuList.tsx:254
 msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
-msgstr ""
+msgstr "Möchtest du dieses Menü wirklich entfernen? Dadurch werden auch alle Menüeinträge entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/WelcomeModal.tsx:53
 msgid "As an administrator, you can invite other users from the Users section."
@@ -908,34 +908,34 @@ msgstr "Als Administrator kannst du im Bereich Benutzer andere Benutzer einladen
 
 #: packages/admin/src/components/WordPressImport.tsx:2262
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr ""
+msgstr "Ordne WordPress-Autoren EmDash-Benutzer zu. Beiträge werden der ausgewählten Person zugewiesen."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:279
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
 msgid "Authentication error: {0}"
-msgstr ""
+msgstr "Anmeldungsfehler: {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:195
 msgid "Authentication error: {error}"
-msgstr "Authentifizierungsfehler: {error}"
+msgstr "Anmeldungsfehler: {error}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:256
 msgid "Authentication failed"
-msgstr ""
+msgstr "Anmeldung fehlgeschlagen"
 
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/SecuritySettings.tsx:129
 msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
-msgstr ""
+msgstr "Die Anmeldung wird von einem externen Anbieter ({0}) verwaltet. Passkey-Einstellungen sind bei externer Authentifizierung nicht verfügbar."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:263
 msgid "Authentication was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "Die Anmeldung wurde abgebrochen oder hat zu lange gedauert. Bitte versuche es erneut."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:77
 #: packages/admin/src/components/comments/CommentInbox.tsx:287
@@ -946,35 +946,35 @@ msgstr "Autor"
 
 #: packages/admin/src/components/WordPressImport.tsx:2277
 msgid "Author Mapping"
-msgstr ""
+msgstr "Autoren-Zuordnung"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:197
 msgid "Authorization denied"
-msgstr ""
+msgstr "Anmeldung abgelehnt"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:105
 msgid "Authorization failed"
-msgstr ""
+msgstr "Anmeldung fehlgeschlagen"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorize"
-msgstr ""
+msgstr "Autorisieren"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:176
 msgid "Authorize Device"
-msgstr ""
+msgstr "Gerät autorisieren"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:259
 msgid "Authorizing..."
-msgstr ""
+msgstr "Autorisieren..."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:458
 msgid "Authors"
-msgstr ""
+msgstr "Autoren"
 
 #: packages/admin/src/components/Redirects.tsx:495
 msgid "auto"
-msgstr ""
+msgstr "automatisch"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Auto (slug change)"
@@ -982,46 +982,46 @@ msgstr "Automatisch (Slug Änderung)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:541
 msgid "Auto-approve authenticated users"
-msgstr ""
+msgstr "Angemeldete Benutzer automatisch freigeben"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:406
 msgid "Auto-generated from name (you can edit)"
-msgstr ""
+msgstr "Automatisch anhand des Namens erstellt (bearbeitbar)"
 
 #: packages/admin/src/router.tsx:766
 msgid "Autosave failed"
-msgstr ""
+msgstr "Automatisches Speichern fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:643
 msgid "Autosave status"
-msgstr ""
+msgstr "Status der automatischen Speicherung"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:647
 msgid "Available media"
-msgstr ""
+msgstr "Verfügbare Medien"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:233
 msgid "Available Providers"
-msgstr ""
+msgstr "Verfügbare Anbieter"
 
 #: packages/admin/src/components/Widgets.tsx:401
 msgid "Available Widgets"
-msgstr ""
+msgstr "Verfügbare Widgets"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:254
 #: packages/admin/src/components/MenuEditor.tsx:275
 #: packages/admin/src/components/WordPressImport.tsx:1349
 #: packages/admin/src/components/WordPressImport.tsx:2333
 msgid "Back"
-msgstr ""
+msgstr "Zurück"
 
 #: packages/admin/src/components/ContentEditor.tsx:612
 msgid "Back to {collectionLabel} list"
-msgstr "Zurück zur Liste ({collectionLabel})"
+msgstr "Zurück zur Kollektion ({collectionLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:336
 msgid "Back to Content Types"
-msgstr ""
+msgstr "Zurück zu Inhaltstypen"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:139
 #: packages/admin/src/components/LoginPage.tsx:117
@@ -1043,11 +1043,11 @@ msgstr "Zurück zu Erweiterungen"
 #: packages/admin/src/components/SectionEditor.tsx:73
 #: packages/admin/src/components/SectionEditor.tsx:174
 msgid "Back to sections"
-msgstr ""
+msgstr "Zurück zu Sektionen"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
-msgstr "Zurück zu den Einstellungen"
+msgstr "Zurück zu Einstellungen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
@@ -1056,11 +1056,11 @@ msgstr "Zurück zu Designs"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:219
 msgid "Before send:"
-msgstr ""
+msgstr "Vor dem Senden:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:233
 msgid "Bing Verification"
-msgstr "Bing Verifikation"
+msgstr "Bing-Verifikation"
 
 #: packages/admin/src/routes/bylines.tsx:409
 msgid "Bio"
@@ -1068,7 +1068,7 @@ msgstr "Bio"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
 msgid "Block actions - drag to reorder, click for menu"
-msgstr ""
+msgstr "Blockaktionen – ziehen zum Neuordnen, klicken für das Menü"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2499
 #: packages/admin/src/components/PortableTextEditor.tsx:2805
@@ -1078,7 +1078,7 @@ msgstr "Fett"
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
 msgid "Boolean"
-msgstr ""
+msgstr "Boolean"
 
 #: packages/admin/src/components/SeoPanel.tsx:169
 msgid "Brief summary shown below the title in search results"
@@ -1099,7 +1099,7 @@ msgstr "Dateien durchsuchen"
 
 #: packages/admin/src/components/PluginManager.tsx:198
 msgid "Browse the"
-msgstr ""
+msgstr "Durchsuche den"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
@@ -1115,7 +1115,7 @@ msgstr "Aufzählungsliste"
 #: packages/admin/src/components/Sidebar.tsx:209
 #: packages/admin/src/routes/bylines.tsx:299
 msgid "Bylines"
-msgstr "Autoren"
+msgstr "Autorenzeilen"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -1180,19 +1180,19 @@ msgstr "Abbrechen (Esc)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
-msgstr ""
+msgstr "Umbenennen abbrechen"
 
 #: packages/admin/src/components/Sections.tsx:407
 msgid "Cannot delete theme sections"
-msgstr ""
+msgstr "Vom Design bereitgestellte Abschnitte können nicht gelöscht werden"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:400
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr ""
+msgstr "Der MIME-Typ kann basierend auf der URL nicht ermittelt werden. Verwende eine URL, die mit einer bekannten Bild-Dateiendung endet (z. B.: .jpg, .png, .webp)."
 
 #: packages/admin/src/components/SeoPanel.tsx:181
 msgid "Canonical URL"
-msgstr ""
+msgstr "Kanonische URL"
 
 #: packages/admin/src/components/PluginManager.tsx:469
 msgid "Capabilities"
@@ -1200,17 +1200,17 @@ msgstr "Fähigkeiten"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:65
 msgid "Capability consent"
-msgstr ""
+msgstr "Zustimmung zu Fähigkeiten"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
 #: packages/admin/src/components/MediaDetailPanel.tsx:210
 msgid "Caption"
-msgstr ""
+msgstr "Bildunterschrift"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:68
 msgid "Captions / Subtitles"
-msgstr ""
+msgstr "Untertitel"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:193
 msgid "Categories"
@@ -1219,7 +1219,7 @@ msgstr "Kategorien"
 #. placeholder {0}: analysis.categories
 #: packages/admin/src/components/WordPressImport.tsx:1621
 msgid "Categories ({0})"
-msgstr ""
+msgstr "Kategorien ({0})"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
@@ -1236,27 +1236,27 @@ msgstr "Ändern"
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr ""
+msgstr "<0>{0}</0> von <1>{1}</1> zu <2>{2}</2> ändern? Die Person verliert dadurch Zugriff auf Funktionen die höhere Berechtigungen erfordern."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:262
 msgid "Change Favicon"
-msgstr ""
+msgstr "Favicon ändern"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:200
 msgid "Change Image"
-msgstr ""
+msgstr "Bild ändern"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:208
 msgid "Change Logo"
-msgstr ""
+msgstr "Logo ändern"
 
 #: packages/admin/src/router.tsx:811
 msgid "Changes discarded"
-msgstr ""
+msgstr "Änderungen verworfen"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:162
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr ""
+msgstr "Trennzeichen zwischen Seitentitel und Webseitenname (z. B. Mein Beitrag | Meine Website)"
 
 #: packages/admin/src/components/PluginManager.tsx:161
 msgid "Check for updates"
@@ -1264,17 +1264,17 @@ msgstr "Nach Aktualisierungen suchen"
 
 #: packages/admin/src/components/WordPressImport.tsx:937
 msgid "Check Site"
-msgstr ""
+msgstr "Webseite prüfen"
 
 #: packages/admin/src/components/LoginPage.tsx:101
 #: packages/admin/src/components/SignupPage.tsx:130
 #: packages/admin/src/components/SignupPage.tsx:400
 msgid "Check your email"
-msgstr "Prüfe deine E-Mail"
+msgstr "Prüfe dein E-Mail-Postfach"
 
 #: packages/admin/src/components/WordPressImport.tsx:701
 msgid "Checking {urlInput}..."
-msgstr ""
+msgstr "Überprüfe {urlInput}..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
@@ -1286,7 +1286,7 @@ msgstr "Wähle wie du dich anmeldest"
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
-msgstr "Wähle deine bevorzugte Admin-Sprache"
+msgstr "Wähle deine bevorzugte Sprache für den Adminbereich"
 
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
@@ -1294,7 +1294,7 @@ msgstr "Filter zurücksetzen"
 
 #: packages/admin/src/components/SignupPage.tsx:138
 msgid "Click the link in the email to continue setting up your account."
-msgstr "Klicke auf den Link in der E-Mail, um die Einrichtung deines Kontos fortzusetzen."
+msgstr "Klicke auf den Link in der E-Mail, um die Einrichtung deines Benutzerkontos fortzusetzen."
 
 #: packages/admin/src/components/LoginPage.tsx:112
 msgid "Click the link in the email to sign in."
@@ -1364,7 +1364,7 @@ msgstr "Kommentare schließen nach (Tage)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
-msgstr ""
+msgstr "Panel schließen"
 
 #: packages/admin/src/components/ContentTypeList.tsx:244
 #: packages/admin/src/components/PortableTextEditor.tsx:2527
@@ -1431,11 +1431,12 @@ msgstr "Kommentare von angemeldeten CMS-Nutzern werden automatisch freigegeben"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Complete signup"
-msgstr ""
+msgstr "Registrierung abschließen"
 
 #: packages/admin/src/components/Widgets.tsx:851
 msgid "Component"
-msgstr ""
+msgstr "Komponente"
+#: TODO: Anderes passendes Wort: Baustein
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Configure Field"
@@ -1485,7 +1486,7 @@ msgstr "Inhaltsblock"
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2188
 msgid "Content Errors ({0})"
-msgstr ""
+msgstr "({0}) Inhaltsfehler"
 
 #: packages/admin/src/components/WordPressImport.tsx:1156
 msgid "Content found:"
@@ -1501,7 +1502,7 @@ msgstr "Der Inhalt wurde auf die ausgewählte Revision aktualisiert."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr "Inhalts ID"
+msgstr "Inhalts ID:"
 
 #: packages/admin/src/router.tsx:778
 msgid "Content is now live"
@@ -1509,7 +1510,7 @@ msgstr "Inhalt ist jetzt online"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "content items"
-msgstr ""
+msgstr "Inhaltselementen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
 msgid "Content Read"
@@ -1517,7 +1518,7 @@ msgstr "Inhalte lesen"
 
 #: packages/admin/src/router.tsx:794
 msgid "Content removed from public view"
-msgstr "Inhalt aus öffentliche Ansicht entfernt"
+msgstr "Inhalt aus öffentlicher Ansicht entfernt"
 
 #: packages/admin/src/router.tsx:848
 msgid "Content reverted to draft"
@@ -1525,7 +1526,7 @@ msgstr "Inhalt zu Entwurf zurückgesetzt"
 
 #: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
-msgstr ""
+msgstr "Momentaufnahme des Inhalts:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1570
 msgid "Content to Import"
@@ -1547,12 +1548,12 @@ msgstr "Inhalte bearbeiten"
 
 #: packages/admin/src/components/SignupPage.tsx:91
 msgid "Continue"
-msgstr ""
+msgstr "Fortfahren"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Continue →"
-msgstr ""
+msgstr "Fortfahren →"
 
 #: packages/admin/src/components/WordPressImport.tsx:2335
 msgid "Continue Import"
@@ -1635,7 +1636,7 @@ msgstr "Eine Aufzählungsliste erstellen"
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:365
 msgid "Create a new {0}"
-msgstr ""
+msgstr "{0} erstellen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:898
 msgid "Create a numbered list"
@@ -1674,7 +1675,7 @@ msgstr "Neues Token erstellen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1340
 msgid "Create one in WordPress: Users → Profile → Application Passwords"
-msgstr ""
+msgstr "Erstelle eines in WordPress: Benutzer → Profil → Anwendungspasswörter"
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
@@ -1700,7 +1701,7 @@ msgstr "Weiterleitungs-Regeln erstellen um URL-Änderungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "Create Schema & Import"
-msgstr ""
+msgstr "Schema erstellen & importieren"
 
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
@@ -1714,7 +1715,7 @@ msgstr "Erstelle Sektionen in der Sektionenbibliothek um sie hier zu nutzen"
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:687
 msgid "Create Taxonomy"
-msgstr ""
+msgstr "Taxonomie erstellen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
@@ -1723,7 +1724,7 @@ msgstr "Token erstellen"
 
 #: packages/admin/src/components/Widgets.tsx:345
 msgid "Create Widget Area"
-msgstr ""
+msgstr "Widget-Bereich erstellen"
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
@@ -1740,7 +1741,7 @@ msgstr "Erstelle dein erstes Element"
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr "Erstelle deine erste benutzerdefinierte Inhaltssektion um zu beginnen"
+msgstr "Erstelle deine erste benutzerdefinierte Inhaltssektion um zu beginnen."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:72
 #: packages/admin/src/components/SignupPage.tsx:211
@@ -1758,7 +1759,7 @@ msgstr "Erstelle, aktualisiere und entferne Navigationsmenüs"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
-msgstr ""
+msgstr "Erstelle, aktualisiere und entferne Taxonomiebegriffe"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
@@ -1801,7 +1802,7 @@ msgstr "Erstelle Kollektionen und Felder..."
 #: packages/admin/src/components/TaxonomyManager.tsx:687
 #: packages/admin/src/components/TaxonomySidebar.tsx:263
 msgid "Creating..."
-msgstr "Wird erstellt..."
+msgstr "Erstellen..."
 
 #: packages/admin/src/components/TranslationsPanel.tsx:78
 msgid "current"
@@ -1821,7 +1822,7 @@ msgstr "Benutzerdefinierte Felder"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:243
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr "Benutzerdefinierte robots.txt-Datei. Leer lassen um den Standard zu nutzen."
+msgstr "Benutzerdefinierte robots.txt-Datei. Leer belassen um den Standard zu nutzen."
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Custom Section"
@@ -1888,7 +1889,7 @@ msgstr "Standardbild für soziale Medien"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:599
 msgid "Define a new taxonomy for classifying content"
-msgstr ""
+msgstr "Erstelle eine neue Taxonomie, um Inhalte zu kategorisieren"
 
 #: packages/admin/src/components/ContentTypeList.tsx:41
 msgid "Define the structure of your content"
@@ -1932,7 +1933,7 @@ msgstr "\"{0}\" entfernen? Dies kann nicht rückgängig gemacht werden."
 #: packages/admin/src/components/TaxonomyManager.tsx:97
 #: packages/admin/src/components/Widgets.tsx:737
 msgid "Delete {0}"
-msgstr ""
+msgstr "{0} entfernen"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:740
@@ -1942,17 +1943,17 @@ msgstr "Feld {0} entfernen"
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:237
 msgid "Delete {0} menu"
-msgstr ""
+msgstr "Menü {0} entfernen"
 
 #. placeholder {0}: area.label
 #: packages/admin/src/components/Widgets.tsx:584
 msgid "Delete {0} widget area"
-msgstr ""
+msgstr "Widget-Bereich {0} entfernen"
 
 #. placeholder {0}: taxonomyDef.labelSingular || "Term"
 #: packages/admin/src/components/TaxonomyManager.tsx:880
 msgid "Delete {0}?"
-msgstr ""
+msgstr "{0} entfernen?"
 
 #: packages/admin/src/routes/bylines.tsx:499
 msgid "Delete Byline?"
@@ -1972,7 +1973,7 @@ msgstr "Inhaltstyp entfernen?"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
-msgstr ""
+msgstr "Einbettung entfernen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:657
 msgid "Delete Field?"
@@ -2031,7 +2032,7 @@ msgstr "Tabelle entfernen"
 
 #: packages/admin/src/components/Widgets.tsx:634
 msgid "Delete Widget Area?"
-msgstr ""
+msgstr "Widget-Bereich entfernen?"
 
 #: packages/admin/src/components/ContentList.tsx:370
 msgid "Deleted"
@@ -2070,7 +2071,7 @@ msgstr "Herabstufen..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
-msgstr ""
+msgstr "Verweigern"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Describe the image..."
@@ -2204,7 +2205,7 @@ msgstr "Anzeigename für den Adminbereich"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
 msgid "Display Size"
-msgstr ""
+msgstr "Anzeigegröße"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
@@ -2299,15 +2300,15 @@ msgstr "Ziehen um Block neu anzuordnen"
 
 #: packages/admin/src/components/Widgets.tsx:624
 msgid "Drag widgets here to add them"
-msgstr ""
+msgstr "Ziehe Widgets hierher, um sie hinzuzufügen"
 
 #: packages/admin/src/components/Widgets.tsx:402
 msgid "Drag widgets into an area to add them"
-msgstr ""
+msgstr "Ziehe Widgets in einen Bereich, um sie hinzuzufügen"
 
 #: packages/admin/src/components/Widgets.tsx:620
 msgid "Drop to add widget"
-msgstr ""
+msgstr "Loslassen, um Widget hinzuzufügen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1427
 msgid "Drop your WordPress export file here"
@@ -2358,12 +2359,12 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:89
 #: packages/admin/src/routes/bylines.tsx:389
 msgid "Edit {0}"
-msgstr ""
+msgstr "{0} bearbeiten"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:732
 msgid "Edit {0} field"
-msgstr ""
+msgstr "Feld {0} bearbeiten"
 
 #: packages/admin/src/components/ContentEditor.tsx:629
 msgid "Edit {collectionLabel}"
@@ -2379,7 +2380,7 @@ msgstr "Autorenzeile bearbeiten"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
 msgid "Edit Domain"
-msgstr "Domain anpassen"
+msgstr "Domain bearbeiten"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
@@ -2575,11 +2576,11 @@ msgstr "Fehler"
 
 #: packages/admin/src/components/Widgets.tsx:174
 msgid "Error adding widget"
-msgstr ""
+msgstr "Fehler beim Hinzufügen des Widgets"
 
 #: packages/admin/src/components/Widgets.tsx:235
 msgid "Error reordering widgets"
-msgstr ""
+msgstr "Fehler beim Neuordnen der Widgets"
 
 #: packages/admin/src/components/SectionEditor.tsx:52
 msgid "Error saving section"
@@ -2587,11 +2588,11 @@ msgstr "Fehler beim Speichern der Sektion"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Error updating widget"
-msgstr ""
+msgstr "Fehler beim Aktualisieren des Widgets"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:415
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "Alle veröffentlichten Versionen dieser Erweiterung wurden zurückgezogen oder konnten nicht verifiziert werden. Schau später noch einmal vorbei oder kontaktiere den Herausgeber."
 
 #: packages/admin/src/components/WordPressImport.tsx:1846
 msgid "Exists"
@@ -2603,7 +2604,7 @@ msgstr "Ablenkungsfreien Modus verlassen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3036
 msgid "Exit Spotlight Mode"
-msgstr ""
+msgstr "Fokusmodus verlassen"
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "Expand"
@@ -2636,7 +2637,7 @@ msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:343
 msgid "Fail"
-msgstr ""
+msgstr "Nicht bestanden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1966
 msgid "Failed"
@@ -2672,7 +2673,7 @@ msgstr "Erstellen einiger Kollektionen fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:456
 msgid "Failed to create term"
-msgstr ""
+msgstr "Begriff konnte nicht erstellt werden"
 
 #: packages/admin/src/router.tsx:883
 msgid "Failed to create translation"
@@ -2711,7 +2712,7 @@ msgstr "Entfernen des Felds fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:338
 msgid "Failed to delete from provider"
-msgstr ""
+msgstr "Entfernen des Mediums beim Speicheranbieter fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:215
 msgid "Failed to delete media"
@@ -2739,15 +2740,15 @@ msgstr "Entfernen der Sektion fehlgeschlagen"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr ""
+msgstr "Entfernen des Begriffs fehlgeschlagen"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
-msgstr ""
+msgstr "Entfernen des Widgets fehlgeschlagen"
 
 #: packages/admin/src/lib/api/widgets.ts:108
 msgid "Failed to delete widget area"
-msgstr ""
+msgstr "Entfernen des Widget-Bereichs fehlgeschlagen"
 
 #: packages/admin/src/components/PluginManager.tsx:115
 msgid "Failed to disable plugin"
@@ -2767,7 +2768,7 @@ msgstr "Ausblenden der Willkommensnachricht fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:383
 msgid "Failed to duplicate"
-msgstr "Klonen fehlgeschlagen"
+msgstr "Duplizieren fehlgeschlagen"
 
 #: packages/admin/src/components/PluginManager.tsx:96
 msgid "Failed to enable plugin"
@@ -2788,7 +2789,7 @@ msgstr "Abruf der Kollektion fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:81
 msgid "Failed to fetch entry terms"
-msgstr ""
+msgstr "Abrufen der Begriffe des Eintrags fehlgeschlagen"
 
 #: packages/admin/src/lib/api/client.ts:208
 msgid "Failed to fetch manifest"
@@ -2806,11 +2807,11 @@ msgstr "Abruf der Revision fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr "Abruf des Setup-Status fehlgeschlagen"
+msgstr "Abruf des Einrichtungs-Status fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:65
 msgid "Failed to fetch terms"
-msgstr ""
+msgstr "Abruf der Begriffe fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:88
 #: packages/admin/src/lib/api/users.ts:93
@@ -2821,11 +2822,11 @@ msgstr "Abruf des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
 msgid "Failed to generate preview"
-msgstr "Generierung der Vorschau fehlgeschlagen"
+msgstr "Erstellung der Vorschau fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr "Generierung der Vorschau-URL fehlgeschlagen"
+msgstr "Erstellung der Vorschau-URL fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
@@ -2893,7 +2894,7 @@ msgstr "Laden der Revisionen fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr "Laden des Setup fehlgeschlagen"
+msgstr "Laden des Setups fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
@@ -2906,7 +2907,7 @@ msgstr "Laden der Benutzer fehlgeschlagen: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
-msgstr ""
+msgstr "Laden des Widgets fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:1171
 msgid "Failed to perform bulk action"
@@ -2922,7 +2923,7 @@ msgstr "Vorbereiten des Imports fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:782
 msgid "Failed to publish"
-msgstr "Veröffentlichen fehlgeschlagen"
+msgstr "Publizieren fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
 msgid "Failed to remove domain"
@@ -2943,7 +2944,7 @@ msgstr "Neuanordnung der Felder fehlgeschlagen"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr ""
+msgstr "Neuanordnung der Widgets fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:355
 msgid "Failed to restore"
@@ -2951,7 +2952,7 @@ msgstr "Wiederherstellen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:249
 msgid "Failed to restore content"
-msgstr "Wiederherstellung des Inhalts fehlgeschlagen"
+msgstr "Wiederherstellen des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:484
 #: packages/admin/src/lib/api/content.ts:489
@@ -2984,7 +2985,7 @@ msgstr "Planen fehlgeschlagen"
 #: packages/admin/src/components/LoginPage.tsx:70
 #: packages/admin/src/components/LoginPage.tsx:75
 msgid "Failed to send magic link"
-msgstr "Magic Link konnte nicht gesendet werden"
+msgstr "Senden des Magic Links fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
@@ -3000,7 +3001,7 @@ msgstr "Senden der Bestätigungs-E-Mail fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:100
 msgid "Failed to set entry terms"
-msgstr ""
+msgstr "Setzen der Begriffe des Eintrags fehlgeschlagen"
 
 #: packages/admin/src/lib/api/marketplace.ts:192
 #: packages/admin/src/lib/api/registry.ts:594
@@ -3018,11 +3019,11 @@ msgstr "Aufheben der Planung fehlgeschlagen"
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:320
 msgid "Failed to update {0}"
-msgstr ""
+msgstr "Aktualisieren von {0} fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2216
 msgid "Failed to update byline"
-msgstr "Autorenzeile konnte nicht aktualisiert werden"
+msgstr "Aktualisieren der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
 msgid "Failed to update domain"
@@ -3047,7 +3048,7 @@ msgstr "Verifizieren der Anmeldung fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr "Verifizierung der Registrierung fehlgeschlagen"
+msgstr "Verifizieren der Registrierung fehlgeschlagen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:236
 #: packages/admin/src/components/settings/GeneralSettings.tsx:242
@@ -3110,7 +3111,7 @@ msgstr "Dateiname kann nach Hochladen nicht mehr geändert werden"
 
 #: packages/admin/src/components/WordPressImport.tsx:2172
 msgid "files imported"
-msgstr ""
+msgstr "Dateien importiert"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
@@ -3154,7 +3155,7 @@ msgstr "Führe einen Export von WordPress durch, um alle Inhalte einschließlich
 
 #: packages/admin/src/components/WordPressImport.tsx:1046
 msgid "For the best import experience, install the"
-msgstr ""
+msgstr "Für einen reibungslosen Import, installiere die"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3200,7 +3201,7 @@ msgstr "Google Verifizierung"
 
 #: packages/admin/src/components/MediaLibrary.tsx:238
 msgid "Grid view"
-msgstr ""
+msgstr "Rasteransicht"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "Group (optional)"
@@ -3239,15 +3240,15 @@ msgstr "Höhe"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
-msgstr ""
+msgstr "Hero-Banner"
 
 #: packages/admin/src/components/SectionEditor.tsx:271
 msgid "hero, banner, cta"
-msgstr ""
+msgstr "hero, banner, cta"
 
 #: packages/admin/src/components/SeoPanel.tsx:191
 msgid "Hide from search engines"
-msgstr "Vor Suchmaschinen verstecken"
+msgstr "Vor Suchmaschinen verbergen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Hide token"
@@ -3264,19 +3265,19 @@ msgstr "Aufrufe"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "Home"
-msgstr ""
+msgstr "Startseite"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
 msgid "Homepage"
-msgstr ""
+msgstr "Startseite"
 
 #: packages/admin/src/components/PluginManager.tsx:384
 msgid "Hooks"
-msgstr ""
+msgstr "Hooks"
 
 #: packages/admin/src/components/WordPressImport.tsx:1359
 msgid "How to create an Application Password"
-msgstr ""
+msgstr "Wie ein Anwendungspasswort erstellt wird"
 
 #: packages/admin/src/components/MenuEditor.tsx:337
 msgid "https://example.com or /about"
@@ -3333,7 +3334,7 @@ msgstr "Bild-URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:2176
 msgid "image URLs updated in"
-msgstr ""
+msgstr "Bild-URLs aktualisiert in"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 msgid "Images"
@@ -6141,7 +6142,7 @@ msgstr "Statuscode"
 #: packages/admin/src/components/PortableTextEditor.tsx:2520
 #: packages/admin/src/components/PortableTextEditor.tsx:2826
 msgid "Strikethrough"
-msgstr "Durchgestrichen"
+msgstr "Durchstreichen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1591
 msgid "Structure"
@@ -6548,7 +6549,7 @@ msgstr "Papierkorb ist leer."
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 msgid "True/false toggle"
-msgstr "Ja/Nein Schalter"
+msgstr "Boolean-Schalter"
 
 #: packages/admin/src/components/MediaLibrary.tsx:378
 #: packages/admin/src/components/MediaPickerModal.tsx:628

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -252,7 +252,7 @@ msgstr "{0}/160 Zeichen"
 #. placeholder {0}: allowedHosts.join(", ")
 #: packages/admin/src/lib/api/marketplace.ts:255
 msgid "{base} to: {0}"
-msgstr "{base} to: {0}"
+msgstr "{base} zu: {0}"
 
 #: packages/admin/src/components/RevisionHistory.tsx:337
 msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
@@ -302,7 +302,7 @@ msgstr "{needsNewCollections, plural, one {# neue Kollektion wird erstellt} othe
 
 #: packages/admin/src/components/WordPressImport.tsx:1724
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr "{needsNewFields, plural, one {Felder werden zu # bestehenden Kollektion hinzugefügt} other {Felder werden zu # bestehenden Kollektionen hinzugefügt}}"
+msgstr "{needsNewFields, plural, one {Felder werden zu # bestehender Kollektion hinzugefügt} other {Felder werden zu # bestehenden Kollektionen hinzugefügt}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "{pluginName} is requesting additional permissions:"
@@ -361,7 +361,7 @@ msgstr "/alte-seite oder /blog/[slug]"
 
 #: packages/admin/src/components/WordPressImport.tsx:1929
 msgid "• Files are downloaded from your WordPress site"
-msgstr "• Dateien werden von deiner WordPress-Seite heruntergeladen"
+msgstr "• Dateien werden von deiner WordPress-Webseite heruntergeladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1930
 msgid "• Uploaded to your EmDash media storage"
@@ -437,7 +437,7 @@ msgstr "4. Gib \"EmDash\" ein und klicke \"Neu hinzufügen\""
 
 #: packages/admin/src/components/Redirects.tsx:368
 msgid "404 Errors"
-msgstr "404 Fehler"
+msgstr "404-Fehler"
 
 #: packages/admin/src/components/WordPressImport.tsx:1365
 msgid "5. Copy the generated password"
@@ -465,7 +465,7 @@ msgstr "Ein Hero-Banner in voller Breite mit Überschrift, Text und CTA-Button"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "A short description of your site"
-msgstr "Eine kurze Beschreibung deiner Seite"
+msgstr "Eine kurze Beschreibung deiner Webseite"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:170
 msgid "Accept & Install"
@@ -481,7 +481,7 @@ msgstr "Einladung annehmen"
 
 #: packages/admin/src/router.tsx:1186
 msgid "Access Denied"
-msgstr "Zugriff verboten"
+msgstr "Zugriff verweigert"
 
 #: packages/admin/src/lib/api/marketplace.ts:224
 #: packages/admin/src/lib/api/marketplace.ts:232
@@ -634,7 +634,7 @@ msgstr "Passkey hinzufügen"
 
 #: packages/admin/src/components/PluginManager.tsx:205
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr "Füge Erweiterungen deiner astro.config.mjs hinzu um die Funktionalität von EmDash zu erweitern."
+msgstr "Füge deiner astro.config.mjs Erweiterungen hinzu, um die Funktionalität von EmDash zu erweitern."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2598
 msgid "Add row after"
@@ -662,7 +662,7 @@ msgstr "Widget-Bereich hinzufügen"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr "Füge deine Profile von sozialen Medien hinzu. Sie stehen dem Design deiner Webseite zur Verfügung und können in Kopfzeilen, Fußzeilen oder Autorenbeschreibungen angezeigt werden."
+msgstr "Füge deine Social-Media-Profile hinzu. Sie stehen dem Design deiner Webseite zur Verfügung und können in Kopfzeilen, Fußzeilen oder Autorenbeschreibungen angezeigt werden."
 
 #: packages/admin/src/components/MenuEditor.tsx:354
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
@@ -754,7 +754,7 @@ msgstr "Benutzern von bestimmten Domains die Registrierung erlauben"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:497
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr "Erlaube Benutzern Kommentare zu den Inhalten dieser Kollektion hinzuzufügen"
+msgstr "Erlaube Besuchern, Kommentare zu den Inhalten dieser Kollektion hinzuzufügen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
 msgid "Allowed Domains"
@@ -847,12 +847,12 @@ msgstr "Anwendungspasswort"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2990
 msgid "Apply"
-msgstr "Erstellen"
+msgstr "Anwenden"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:144
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:145
 msgid "Apply language"
-msgstr ""
+msgstr "Sprache speichern"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2475
 #: packages/admin/src/components/PortableTextEditor.tsx:2476
@@ -905,7 +905,7 @@ msgstr "Als Administrator kannst du im Bereich Benutzer andere Benutzer einladen
 
 #: packages/admin/src/components/WordPressImport.tsx:2262
 msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
-msgstr "Ordne WordPress-Autoren EmDash-Benutzer zu. Beiträge werden der ausgewählten Person zugewiesen."
+msgstr "Ordne WordPress-Autoren EmDash-Benutzern zu. Beiträge werden der ausgewählten Person zugewiesen."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 msgid "Audio"
@@ -975,7 +975,7 @@ msgstr "automatisch"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Auto (slug change)"
-msgstr "Automatisch (Slug Änderung)"
+msgstr "Automatisch (Slug-Änderung)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:541
 msgid "Auto-approve authenticated users"
@@ -1040,7 +1040,7 @@ msgstr "Zurück zu Erweiterungen"
 #: packages/admin/src/components/SectionEditor.tsx:73
 #: packages/admin/src/components/SectionEditor.tsx:174
 msgid "Back to sections"
-msgstr "Zurück zu Abschnitte"
+msgstr "Zurück zu Abschnitten"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
@@ -1079,15 +1079,15 @@ msgstr "Boolean"
 
 #: packages/admin/src/components/SeoPanel.tsx:169
 msgid "Brief summary shown below the title in search results"
-msgstr "Kurze Zusammenfassung die unter dem Titel in den Suchergebnissen gezeigt wird"
+msgstr "Kurze Zusammenfassung, die unter dem Titel in den Suchergebnissen gezeigt wird"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:71
 msgid "Browse and install plugins published to the decentralized registry."
-msgstr "Durchsuche und installiere Erweiterungen die im dezentralen Verzeichnis veröffentlicht wurden."
+msgstr "Durchsuche und installiere Erweiterungen, die im dezentralen Verzeichnis veröffentlicht wurden."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:88
 msgid "Browse and install plugins to extend your site."
-msgstr "Durchsuche und installiere Erweiterungen um deine Webseite zu erweitern."
+msgstr "Durchsuche und installiere Erweiterungen, um deine Webseite zu erweitern."
 
 #: packages/admin/src/components/WordPressImport.tsx:966
 #: packages/admin/src/components/WordPressImport.tsx:1433
@@ -1124,7 +1124,7 @@ msgstr "Kann alle Inhalte verwalten"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:31
 msgid "Can publish own content"
-msgstr "Kann eigene Inhalte veröffentlichen"
+msgstr "Kann eigene Inhalte publizieren"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:19
 msgid "Can view content"
@@ -1185,7 +1185,7 @@ msgstr "Vom Design bereitgestellte Abschnitte können nicht gelöscht werden"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:400
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr "Der MIME-Typ kann basierend auf der URL nicht ermittelt werden. Verwende eine URL, die mit einer bekannten Bild-Dateiendung endet (z.B.: .jpg, .png, .webp)."
+msgstr "Der MIME-Typ kann basierend auf der URL nicht ermittelt werden. Verwende eine URL, die mit einer bekannten Bilddateiendung endet (z. B. .jpg, .png, .webp)."
 
 #: packages/admin/src/components/SeoPanel.tsx:181
 msgid "Canonical URL"
@@ -1233,7 +1233,7 @@ msgstr "Ändern"
 #. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
 #: packages/admin/src/routes/users.tsx:296
 msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
-msgstr "<0>{0}</0> von <1>{1}</1> zu <2>{2}</2> ändern? Die Person verliert dadurch Zugriff auf Funktionen die höhere Berechtigungen erfordern."
+msgstr "<0>{0}</0> von <1>{1}</1> zu <2>{2}</2> ändern? Die Person verliert dadurch Zugriff auf Funktionen, die höhere Berechtigungen erfordern."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:262
 msgid "Change Favicon"
@@ -1253,7 +1253,7 @@ msgstr "Änderungen verworfen"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:162
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr "Trennzeichen zwischen Seitentitel und Webseitenname (z.B.: Mein Beitrag | Meine Webseite)"
+msgstr "Trennzeichen zwischen Seitentitel und Webseitenname (z. B. Mein Beitrag | Meine Webseite)"
 
 #: packages/admin/src/components/PluginManager.tsx:161
 msgid "Check for updates"
@@ -1279,7 +1279,7 @@ msgstr "Überprüfe Authentifizierung..."
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr "Wähle wie du dich anmeldest"
+msgstr "Wähle, wie du dich anmelden möchtest"
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
@@ -1424,7 +1424,7 @@ msgstr "Kommentare"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:544
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr "Kommentare von angemeldeten CMS-Nutzern werden automatisch freigegeben"
+msgstr "Kommentare von angemeldeten CMS-Benutzern werden automatisch freigegeben"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Complete signup"
@@ -1454,7 +1454,7 @@ msgstr "Verbinden & Analysieren"
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1296
 msgid "Connect to {0}"
-msgstr "Zu {0} verbinden"
+msgstr "Mit {0} verbinden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1212
 msgid "Connect with WordPress"
@@ -1483,7 +1483,7 @@ msgstr "Inhaltsblock"
 #. placeholder {0}: result.errors.length
 #: packages/admin/src/components/WordPressImport.tsx:2188
 msgid "Content Errors ({0})"
-msgstr "({0}) Inhaltsfehler"
+msgstr "Inhaltsfehler ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:1156
 msgid "Content found:"
@@ -1491,7 +1491,7 @@ msgstr "Inhalte gefunden:"
 
 #: packages/admin/src/router.tsx:830
 msgid "Content has been scheduled for publishing"
-msgstr "Die Veröffentlichung des Inhalts wurde geplant"
+msgstr "Die Publizierung des Inhalts wurde geplant"
 
 #: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
@@ -1499,7 +1499,7 @@ msgstr "Der Inhalt wurde auf die ausgewählte Revision aktualisiert."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr "Inhalts ID:"
+msgstr "Inhalts-ID:"
 
 #: packages/admin/src/router.tsx:778
 msgid "Content is now live"
@@ -1694,7 +1694,7 @@ msgstr "Weiterleitung für diesen Pfad erstellen"
 
 #: packages/admin/src/components/Redirects.tsx:435
 msgid "Create redirect rules to manage URL changes."
-msgstr "Weiterleitungsregeln erstellen um URL-Änderungen zu verwalten."
+msgstr "Weiterleitungsregeln erstellen, um URL-Änderungen zu verwalten."
 
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "Create Schema & Import"
@@ -1707,7 +1707,7 @@ msgstr "Abschnitt erstellen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:109
 msgid "Create sections in the Sections library to use them here"
-msgstr "Erstelle Abschnitte in der Sammlung deiner Abschnitte um sie hier zu nutzen"
+msgstr "Erstelle Abschnitte in der Kollektion deiner Abschnitte, um sie hier zu nutzen"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:687
@@ -1729,7 +1729,7 @@ msgstr "Erstelle dein Benutzerkonto"
 
 #: packages/admin/src/components/MenuList.tsx:187
 msgid "Create your first navigation menu to get started"
-msgstr "Erstelle dein erstes Navigationsmenü um zu beginnen"
+msgstr "Erstelle dein erstes Navigationsmenü, um zu beginnen"
 
 #: packages/admin/src/components/ContentList.tsx:286
 #: packages/admin/src/components/ContentTypeList.tsx:122
@@ -1738,7 +1738,7 @@ msgstr "Erstelle einen ersten Inhalt."
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr "Erstelle deinen ersten benutzerdefinierten Inhaltsabschnitt um zu beginnen."
+msgstr "Erstelle deinen ersten benutzerdefinierten Inhaltsabschnitt, um zu beginnen."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:72
 #: packages/admin/src/components/SignupPage.tsx:211
@@ -1819,7 +1819,7 @@ msgstr "Benutzerdefinierte Felder"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:243
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr "Benutzerdefinierte robots.txt-Datei. Leer belassen um den Standard zu nutzen."
+msgstr "Benutzerdefinierte robots.txt-Datei. Leer lassen, um den Standard zu nutzen."
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Custom Section"
@@ -1870,11 +1870,11 @@ msgstr "Deklarierte Berechtigungen"
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
 msgid "Default Role"
-msgstr "Standard Rolle"
+msgstr "Standardrolle"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
 msgid "Default role:"
-msgstr "Standard Rolle:"
+msgstr "Standardrolle:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:180
 msgid "Default social image"
@@ -2082,7 +2082,7 @@ msgstr "Beschreibe dieses Bild für die Barrierefreiheit"
 
 #: packages/admin/src/components/SectionEditor.tsx:262
 msgid "Describe what this section is for..."
-msgstr "Beschreibe wofür dieser Abschnitt genutzt wird..."
+msgstr "Beschreibe, wofür dieser Abschnitt genutzt wird..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:415
 #: packages/admin/src/components/SectionEditor.tsx:259
@@ -2117,11 +2117,11 @@ msgstr "Geräte-Code"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr "Geräte-gebunden"
+msgstr "Gerätegebunden"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
-msgstr "An Gerät gebundener Passkey"
+msgstr "An ein Gerät gebundener Passkey"
 
 #: packages/admin/src/components/SignupPage.tsx:143
 msgid "Didn't receive the email?"
@@ -2145,11 +2145,11 @@ msgstr "Weiterleitung deaktivieren"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr "Nutzer deaktivieren"
+msgstr "Benutzer deaktivieren"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr "Nutzer deaktivieren?"
+msgstr "Benutzer deaktivieren?"
 
 #: packages/admin/src/components/PluginManager.tsx:353
 #: packages/admin/src/components/Redirects.tsx:392
@@ -2165,7 +2165,7 @@ msgstr "Deaktiviert:"
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr "Den Nutzer <0>{0}</0> zu deaktivieren verhindert, dass er sich anmelden kann, bis er wieder aktiviert wird. Die von diesem Nutzer erstellten Inhalte bleiben bestehen."
+msgstr "Den Benutzer <0>{0}</0> zu deaktivieren verhindert, dass er sich anmelden kann, bis er wieder aktiviert wird. Die von diesem Benutzer erstellten Inhalte bleiben bestehen."
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
@@ -2289,11 +2289,11 @@ msgstr "Ziehen zum Neuanordnen"
 #: packages/admin/src/components/ContentTypeEditor.tsx:707
 #: packages/admin/src/components/Widgets.tsx:722
 msgid "Drag to reorder {0}"
-msgstr "Ziehen um {0} neu anzuordnen"
+msgstr "Ziehen, um {0} neu anzuordnen"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:335
 msgid "Drag to reorder block"
-msgstr "Ziehen um Block neu anzuordnen"
+msgstr "Ziehen, um den Block neu anzuordnen"
 
 #: packages/admin/src/components/Widgets.tsx:624
 msgid "Drag widgets here to add them"
@@ -2321,19 +2321,19 @@ msgstr "{title} duplizieren"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr "z.B.: application/zip oder .pdf"
+msgstr "z. B. application/zip oder .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "e.g. import, blog"
-msgstr "z.B.: importiert, blog"
+msgstr "z. B. importiert, blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
 msgid "e.g., CI/CD Pipeline"
-msgstr "z.B.: CI/CD-Pipeline"
+msgstr "z. B. CI/CD-Pipeline"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr "z.B.: MacBook Pro, iPhone"
+msgstr "z. B. MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentEditor.tsx:2075
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2455,7 +2455,7 @@ msgstr "E-Mail-Anbieter aktiv"
 #: packages/admin/src/components/settings/EmailSettings.tsx:85
 #: packages/admin/src/components/settings/EmailSettings.tsx:100
 msgid "Email Settings"
-msgstr "E-Mail Einstellungen"
+msgstr "E-Mail-Einstellungen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
@@ -2492,7 +2492,7 @@ msgstr "Kommentare aktivieren"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
-msgstr "Volltextsuche für diese Sammlung aktivieren"
+msgstr "Volltextsuche für diese Kollektion aktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:444
 msgid "Enable plugin"
@@ -2500,7 +2500,7 @@ msgstr "Erweiterung aktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:478
 msgid "Enable redirect"
-msgstr "Weiterleitungen aktivieren"
+msgstr "Weiterleitung aktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:168
 #: packages/admin/src/components/Redirects.tsx:392
@@ -2519,7 +2519,7 @@ msgstr "Gib eine URL (https://…) oder einen relativen Pfad (/…) ein"
 
 #: packages/admin/src/components/ContentEditor.tsx:1474
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr "Gib eine gültige URL ein (z.B.: https://beispiel.de)"
+msgstr "Gib eine gültige URL ein (z. B. https://beispiel.de)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1219
 msgid "Enter credentials manually"
@@ -2573,19 +2573,19 @@ msgstr "Fehler"
 
 #: packages/admin/src/components/Widgets.tsx:174
 msgid "Error adding widget"
-msgstr "Fehler beim Hinzufügen des Widgets"
+msgstr "Hinzufügen des Widgets fehlgeschlagen"
 
 #: packages/admin/src/components/Widgets.tsx:235
 msgid "Error reordering widgets"
-msgstr "Fehler beim Neuordnen der Widgets"
+msgstr "Neuanordnen der Widgets fehlgeschlagen"
 
 #: packages/admin/src/components/SectionEditor.tsx:52
 msgid "Error saving section"
-msgstr "Fehler beim Speichern des Abschnitts"
+msgstr "Speichern des Abschnitts fehlgeschlagen"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Error updating widget"
-msgstr "Fehler beim Aktualisieren des Widgets"
+msgstr "Aktualisieren des Widgets fehlgeschlagen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:415
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
@@ -2658,11 +2658,11 @@ msgstr "Kommunikation mit Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr "Erstellung des Administrators fehlgeschlagen"
+msgstr "Erstellen des Administrators fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2166
 msgid "Failed to create byline"
-msgstr "Erstellung der Autorenzeile fehlgeschlagen"
+msgstr "Erstellen der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
@@ -2670,7 +2670,7 @@ msgstr "Erstellen einiger Kollektionen fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:456
 msgid "Failed to create term"
-msgstr "Begriff konnte nicht erstellt werden"
+msgstr "Erstellen des Begriffs fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:883
 msgid "Failed to create translation"
@@ -2709,11 +2709,11 @@ msgstr "Entfernen des Felds fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:338
 msgid "Failed to delete from provider"
-msgstr "Entfernen des Mediums beim Speicheranbieter fehlgeschlagen"
+msgstr "Entfernen der Datei beim Speicheranbieter fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:215
 msgid "Failed to delete media"
-msgstr "Entfernen des Mediums fehlgeschlagen"
+msgstr "Entfernen der Datei fehlgeschlagen"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
@@ -2749,7 +2749,7 @@ msgstr "Entfernen des Widget-Bereichs fehlgeschlagen"
 
 #: packages/admin/src/components/PluginManager.tsx:115
 msgid "Failed to disable plugin"
-msgstr "Deaktivierung der Erweiterung fehlgeschlagen"
+msgstr "Deaktivieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
@@ -2769,20 +2769,20 @@ msgstr "Duplizieren fehlgeschlagen"
 
 #: packages/admin/src/components/PluginManager.tsx:96
 msgid "Failed to enable plugin"
-msgstr "Aktivierung der Erweiterung fehlgeschlagen"
+msgstr "Aktivieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr "Aktivierung des Benutzers fehlgeschlagen"
+msgstr "Aktivieren des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:295
 msgid "Failed to execute import"
-msgstr "Ausführung des Imports fehlgeschlagen"
+msgstr "Ausführen des Imports fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
 msgid "Failed to fetch collection"
-msgstr "Abruf der Kollektion fehlgeschlagen"
+msgstr "Abrufen der Kollektion fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:81
 msgid "Failed to fetch entry terms"
@@ -2790,62 +2790,62 @@ msgstr "Abrufen der Begriffe des Eintrags fehlgeschlagen"
 
 #: packages/admin/src/lib/api/client.ts:208
 msgid "Failed to fetch manifest"
-msgstr "Abruf des Manifests fehlgeschlagen"
+msgstr "Abrufen des Manifests fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:59
 #: packages/admin/src/lib/api/plugins.ts:63
 msgid "Failed to fetch plugin"
-msgstr "Abruf der Erweiterung fehlgeschlagen"
+msgstr "Abrufen der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:462
 #: packages/admin/src/lib/api/content.ts:467
 msgid "Failed to fetch revision"
-msgstr "Abruf der Revision fehlgeschlagen"
+msgstr "Abrufen der Revision fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr "Abruf des Einrichtungs-Status fehlgeschlagen"
+msgstr "Abrufen des Einrichtungs-Status fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:65
 msgid "Failed to fetch terms"
-msgstr "Abruf der Begriffe fehlgeschlagen"
+msgstr "Abrufen der Begriffe fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:88
 #: packages/admin/src/lib/api/users.ts:93
 #: packages/admin/src/router.tsx:667
 #: packages/admin/src/router.tsx:1077
 msgid "Failed to fetch user"
-msgstr "Abruf des Benutzers fehlgeschlagen"
+msgstr "Abrufen des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
 msgid "Failed to generate preview"
-msgstr "Erstellung der Vorschau fehlgeschlagen"
+msgstr "Erstellen der Vorschau fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr "Erstellung der Vorschau-URL fehlgeschlagen"
+msgstr "Erstellen der Vorschau-URL fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr "Abruf der Authentifizierungsoptionen fehlgeschlagen"
+msgstr "Abrufen der Authentifizierungsoptionen fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr "Abruf der Registrierungsoptionen fehlgeschlagen"
+msgstr "Abrufen der Registrierungsoptionen fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:386
 msgid "Failed to import from WordPress"
-msgstr "Import von WordPress fehlgeschlagen"
+msgstr "Importieren von WordPress fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:319
 #: packages/admin/src/lib/api/import.ts:256
 msgid "Failed to import media"
-msgstr "Import von Medien fehlgeschlagen"
+msgstr "Importieren von Medien fehlgeschlagen"
 
 #: packages/admin/src/lib/api/marketplace.ts:160
 #: packages/admin/src/lib/api/registry.ts:455
 msgid "Failed to install plugin"
-msgstr "Installation der Erweiterung fehlgeschlagen"
+msgstr "Installieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:246
 msgid "Failed to load admin"
@@ -2891,7 +2891,7 @@ msgstr "Laden der Revisionen fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr "Laden der Einrichtung fehlgeschlagen"
+msgstr "Laden des Einrichtungsassistenten fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
@@ -2912,7 +2912,7 @@ msgstr "Ausführen der Massenoperation fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:260
 msgid "Failed to permanently delete content"
-msgstr "Entgültiges Entfernen des Inhalts fehlgeschlagen"
+msgstr "Endgültiges Entfernen des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:276
 msgid "Failed to prepare import"
@@ -2937,11 +2937,11 @@ msgstr "Umbenennen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:293
 msgid "Failed to reorder fields"
-msgstr "Neuanordnung der Felder fehlgeschlagen"
+msgstr "Neuanordnen der Felder fehlgeschlagen"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
-msgstr "Neuanordnung der Widgets fehlgeschlagen"
+msgstr "Neuanordnen der Widgets fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:355
 msgid "Failed to restore"
@@ -2958,7 +2958,7 @@ msgstr "Wiederherstellen der Revision fehlgeschlagen"
 
 #: packages/admin/src/lib/api/api-tokens.ts:98
 msgid "Failed to revoke API token"
-msgstr "Widerrufen des API-Token fehlgeschlagen"
+msgstr "Widerrufen des API-Tokens fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:332
 msgid "Failed to rewrite URLs"
@@ -2982,7 +2982,7 @@ msgstr "Planen fehlgeschlagen"
 #: packages/admin/src/components/LoginPage.tsx:70
 #: packages/admin/src/components/LoginPage.tsx:75
 msgid "Failed to send magic link"
-msgstr "Senden des Magic Links fehlgeschlagen"
+msgstr "Senden des Anmeldelinks fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
@@ -3066,11 +3066,11 @@ msgstr "Abrufen von Inhalten über die EmDash-Exporter-API."
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr "Feld-Bezeichnung"
+msgstr "Feldbezeichnung"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr "Feld-Bezeichnung"
+msgstr "Feldbezeichnung"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
@@ -3095,7 +3095,7 @@ msgstr "Datei {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "File from media library"
-msgstr "Datei aus Medienbibliothek"
+msgstr "Datei aus der Medienbibliothek"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:428
@@ -3104,7 +3104,7 @@ msgstr "Dateiname"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:196
 msgid "Filename cannot be changed after upload"
-msgstr "Dateiname kann nach Hochladen nicht mehr geändert werden"
+msgstr "Dateiname kann nach dem Hochladen nicht mehr geändert werden"
 
 #: packages/admin/src/components/WordPressImport.tsx:2172
 msgid "files imported"
@@ -3112,7 +3112,7 @@ msgstr "Dateien importiert"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
-msgstr "Nach Fähigkeit filtern"
+msgstr "Nach Berechtigung filtern"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:177
 msgid "Filter by collection"
@@ -3185,7 +3185,7 @@ msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr "Gib diesem Passkey einen Namen um ihn später leichter wiederzuerkennen."
+msgstr "Gib diesem Passkey einen Namen, um ihn später leichter wiederzuerkennen."
 
 #: packages/admin/src/components/WordPressImport.tsx:2224
 #: packages/admin/src/router.tsx:1846
@@ -3206,7 +3206,7 @@ msgstr "Gruppe (optional)"
 
 #: packages/admin/src/routes/bylines.tsx:432
 msgid "Guest byline"
-msgstr "Gast Autorenzeile"
+msgstr "Gast-Autorenzeile"
 
 #: packages/admin/src/routes/bylines.tsx:326
 msgid "Guest only"
@@ -3366,11 +3366,11 @@ msgstr "Import abgeschlossen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2111
 msgid "Import Completed with Errors"
-msgstr "Import mit Fehlern angeschlossen"
+msgstr "Import mit Fehlern abgeschlossen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Import failed"
-msgstr "Import fehlgeschlagen"
+msgstr "Importieren fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:617
 msgid "Import from WordPress"
@@ -3390,7 +3390,7 @@ msgstr "Importiere Beiträge, Seiten und benutzerdefinierte Inhaltstypen von Wor
 
 #: packages/admin/src/components/WordPressImport.tsx:1650
 msgid "Import site configuration from WordPress."
-msgstr "Importiere Seitenkonfiguration von WordPress."
+msgstr "Importiere Webseitenkonfiguration von WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1203
 msgid "Import via EmDash Exporter"
@@ -3494,7 +3494,7 @@ msgstr "Installieren"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:181
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr "Installiere und aktiviere eine E-Mail-Anbieter-Erweiterung, um E-Mail-Funktionen wie Einladungen, Magic Links und die Passwortwiederherstellung zu nutzen."
+msgstr "Installiere und aktiviere eine E-Mail-Anbieter-Erweiterung, um E-Mail-Funktionen wie Einladungen, Anmeldelinks und die Passwortwiederherstellung zu nutzen."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:187
 msgid "Install blocked"
@@ -3510,7 +3510,7 @@ msgstr "Installiert"
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:496
 msgid "Installed from marketplace (v{0})"
-msgstr "Installiert von Marktplatz (v{0})"
+msgstr "Von Marktplatz installiert (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:515
 msgid "Installed:"
@@ -3552,11 +3552,11 @@ msgstr "Einladungs-Link erstellt"
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
 msgid "Invite User"
-msgstr "Nutzer einladen"
+msgstr "Benutzer einladen"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr "Lade deinen erstes Teammitglied ein"
+msgstr "Lade dein erstes Teammitglied ein"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2506
 #: packages/admin/src/components/PortableTextEditor.tsx:2812
@@ -3888,7 +3888,7 @@ msgstr "Verwalte Widgets für Inhalte in deinen Widget-Bereichen"
 
 #: packages/admin/src/components/PluginManager.tsx:174
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
-msgstr "Installierte Erweiterungen verwalten. Aktiviere oder deaktiviere Erweiterungen um ihre Funktionalität zu kontrollieren."
+msgstr "Installierte Erweiterungen verwalten. Aktiviere oder deaktiviere Erweiterungen, um ihre Funktionalität zu kontrollieren."
 
 #: packages/admin/src/components/MenuList.tsx:104
 msgid "Manage navigation menus for your site"
@@ -4088,7 +4088,7 @@ msgstr "Bearbeitet"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Modify collection schemas"
-msgstr "Sammlungsschemata ändern oder entfernen"
+msgstr "Kollektionsschemata ändern oder entfernen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -4263,11 +4263,11 @@ msgstr "Noch keine {0} vorhanden."
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:828
 msgid "No {0} yet. Create one to get started."
-msgstr "Noch keine {0} vorhanden. Erstelle einen Begriff um loszulegen."
+msgstr "Noch keine {0} vorhanden. Erstelle einen Begriff, um loszulegen."
 
 #: packages/admin/src/components/Redirects.tsx:208
 msgid "No 404 errors recorded yet."
-msgstr "Noch keine 404 Fehler aufgezeichnet."
+msgstr "Noch keine 404-Fehler aufgezeichnet."
 
 #: packages/admin/src/components/MediaLibrary.tsx:633
 #: packages/admin/src/components/MediaLibrary.tsx:690
@@ -4296,7 +4296,7 @@ msgstr "Keine Autorenzeile ausgewählt."
 
 #: packages/admin/src/components/Dashboard.tsx:172
 msgid "No collections configured"
-msgstr "Keine Sammlungen konfiguriert"
+msgstr "Keine Kollektionen konfiguriert"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:546
 msgid "No comments awaiting moderation."
@@ -4332,7 +4332,7 @@ msgstr "Keine detaillierte Beschreibung verfügbar."
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
 msgid "No domains configured. Users must be invited individually."
-msgstr "Keine Domains konfiguriert. Nutzer müssen einzeln eingeladen werden."
+msgstr "Keine Domains konfiguriert. Benutzer müssen einzeln eingeladen werden."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:178
 msgid "No email provider configured"
@@ -4381,7 +4381,7 @@ msgstr "Kein zugeordneter Benutzer"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:134
 msgid "No matches"
-msgstr ""
+msgstr "Keine Treffer"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
@@ -4453,7 +4453,7 @@ msgstr "Keine Vorschau"
 
 #: packages/admin/src/components/Dashboard.tsx:236
 msgid "No recent activity"
-msgstr "Keine neuesten Aktivitäten"
+msgstr "Keine aktuellen Aktivitäten"
 
 #: packages/admin/src/components/Redirects.tsx:434
 msgid "No redirects yet"
@@ -4511,7 +4511,7 @@ msgstr "Noch keine Benutzer."
 
 #: packages/admin/src/components/Widgets.tsx:434
 msgid "No widget areas yet. Create one to get started."
-msgstr "Noch keine Widget-Bereiche vorhanden. Erstelle einen um loszulegen."
+msgstr "Noch keine Widget-Bereiche vorhanden. Erstelle einen, um loszulegen."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:416
 #: packages/admin/src/components/TaxonomyManager.tsx:422
@@ -4544,7 +4544,7 @@ msgstr "auf einem benutzerdefinierten Hostnamen wird nicht als sicher behandelt,
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr "Autorisiere nur Codes die du wiedererkennst."
+msgstr "Autorisiere nur Codes, die du wiedererkennst."
 
 #: packages/admin/src/components/SignupPage.tsx:96
 msgid "Only email addresses from allowed domains can sign up."
@@ -4685,11 +4685,11 @@ msgstr "Passkey erfolgreich hinzugefügt"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr "Passkey Name"
+msgstr "Passkey-Name"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr "Passkey Name (optional)"
+msgstr "Passkey-Name (optional)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
@@ -4747,7 +4747,7 @@ msgstr "Muster (Regex)"
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:437
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr "Muster zur Generierung von URLs, z.B.: /blog/{0}"
+msgstr "Muster zur Generierung von URLs, z. B. /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:433
@@ -4843,7 +4843,7 @@ msgstr "Erweiterung für deine WordPress-Webseite, um von einem reibungslosen Im
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:75
 msgid "Plugin Permissions"
-msgstr "Erweiterungs-Berechtigungen"
+msgstr "Erweiterungsberechtigungen"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:70
 msgid "Plugin Registry"
@@ -4856,7 +4856,7 @@ msgstr "Erweiterung antwortete mit {0}: {text}"
 
 #: packages/admin/src/components/PluginManager.tsx:304
 msgid "Plugin uninstalled"
-msgstr "Erweiterung dfeinstalliert"
+msgstr "Erweiterung deinstalliert"
 
 #: packages/admin/src/lib/api/registry.ts:546
 msgid "Plugin update requires re-consent"
@@ -4864,7 +4864,7 @@ msgstr "Aktualisierung der Erweiterung erfordert erneute Zustimmung"
 
 #: packages/admin/src/components/PluginManager.tsx:257
 msgid "Plugin updated"
-msgstr "Erweiterungen aktualisiert"
+msgstr "Erweiterung aktualisiert"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:134
@@ -4989,7 +4989,7 @@ msgstr "Zitat"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
 msgid "Read collection schemas"
-msgstr "Sammlungsschemata lesen"
+msgstr "Kollektionsschemata lesen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
 msgid "Read content entries"
@@ -5080,7 +5080,7 @@ msgstr "Registrierter Benutzer"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr "Registrierung fehlgeschlagen"
+msgstr "Registrieren fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
@@ -5166,7 +5166,7 @@ msgstr "Passkey entfernen?"
 
 #: packages/admin/src/components/FieldEditor.tsx:610
 msgid "Remove sub-field"
-msgstr Untergeordnetes Feld entfernen"
+msgstr "Untergeordnetes Feld entfernen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
 msgid "Remove this image from the document?"
@@ -5259,7 +5259,7 @@ msgstr "{title} wiederherstellen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
-msgstr "Wiederherstellung fehlgeschlagen"
+msgstr "Wiederherstellen fehlgeschlagen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
@@ -5469,7 +5469,7 @@ msgstr "Schema-Änderungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Schema preparation failed"
-msgstr "Schema-Vorbereitung fehlgeschlagen"
+msgstr "Vorbereiten des Schemas fehlgeschlagen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
 msgid "Schema Read"
@@ -5807,7 +5807,7 @@ msgstr "Teste deine Installation und den Versandprozess, indem du eine Test-E-Ma
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
-msgstr "Sende eine Einladung via E-Mail an ein neues Teammitglied."
+msgstr "Sende eine Einladung per E-Mail an ein neues Teammitglied."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 msgid "Send Invite"
@@ -5815,7 +5815,7 @@ msgstr "Einladung senden"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 msgid "Send magic link"
-msgstr "Magic Link senden"
+msgstr "Anmeldelink senden"
 
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Send Recovery Link"
@@ -5823,11 +5823,11 @@ msgstr "Wiederherstellungs-Link senden"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
 msgid "Send Test"
-msgstr "Sende Test"
+msgstr "Test senden"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:136
 msgid "Send Test Email"
-msgstr "Sende Test-E-Mail"
+msgstr "Test-E-Mail senden"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
@@ -5869,15 +5869,15 @@ msgstr "Lege eine benutzerdefinierte Anzeigegröße für dieses Bild fest."
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:170
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:174
 msgid "Set language"
-msgstr ""
+msgstr "Sprache speichern"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:171
 msgid "Set language (current: {label})"
-msgstr ""
+msgstr "Sprache speichern (aktuell: {label})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:531
 msgid "Set to 0 to never close comments automatically."
-msgstr "Auf 0 setzen um Kommentare nie automatisch zu schließen."
+msgstr "Auf 0 setzen, um Kommentare nie automatisch zu schließen."
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
@@ -5911,11 +5911,11 @@ msgstr "Einstellungen erfolgreich gespeichert"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr "Einrichtung fehlgeschlagen"
+msgstr "Einrichten fehlgeschlagen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr "Teile diesen Link mit dem eingeladenen Nutzer"
+msgstr "Teile diesen Link mit dem eingeladenen Benutzer"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
@@ -5995,7 +5995,7 @@ msgstr "Webseiten-Identität, Logo, Favicon und Leseeinstellungen"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 msgid "Site Settings"
-msgstr "Webseiten Einstellungen"
+msgstr "Webseiten-Einstellungen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:156
 #: packages/admin/src/components/SetupWizard.tsx:116
@@ -6078,7 +6078,7 @@ msgstr "Einige Inhaltstypen können nicht importiert werden"
 #: packages/admin/src/components/InviteAcceptPage.tsx:122
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Something went wrong"
-msgstr "Etwas ist schief gelaufen"
+msgstr "Etwas ist schiefgelaufen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:123
 msgid "Sort plugins"
@@ -6118,7 +6118,7 @@ msgstr "Spotlight-Modus"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr Tabellendokumente"
+msgstr "Tabellendokumente"
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
@@ -6160,7 +6160,7 @@ msgstr "Synchronisiert"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr "Passkeys synchronisiert"
+msgstr "Synchronisierter Passkey"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:768
 msgid "System"
@@ -6211,7 +6211,7 @@ msgstr "Taxonomien verwalten"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:896
 msgid "Taxonomy created"
-msgstr "Erstelle Taxonomien"
+msgstr "Taxonomie erstellt"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:783
 msgid "Taxonomy not found:"
@@ -6262,7 +6262,7 @@ msgstr "Die folgenden Tabellen enthalten Inhalte, sind jedoch nicht als Kollekti
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
-msgstr "Dem eingeladenen Nutzer wird diese Rolle zugewiesen sobald er die Registrierung erfolgreich abgeschlossen hat."
+msgstr "Dem eingeladenen Benutzer wird diese Rolle zugewiesen, sobald er die Registrierung erfolgreich abgeschlossen hat."
 
 #: packages/admin/src/components/LoginPage.tsx:113
 #: packages/admin/src/components/SignupPage.tsx:139
@@ -6271,7 +6271,7 @@ msgstr "Der Link ist 15 Minuten lang gültig."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:177
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr "Der Marktplatz ist leer. Bitte versuche es später erneut um neue Erweiterungen zu entdecken."
+msgstr "Der Marktplatz ist leer. Bitte versuche es später erneut, um neue Erweiterungen zu entdecken."
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "The menu has been deleted."
@@ -6337,7 +6337,7 @@ msgstr "Diese Kollektion ist im Code definiert. Einige Einstellungen können hie
 
 #: packages/admin/src/components/MediaPickerModal.tsx:405
 msgid "This field does not accept {sniffedMime} files."
-msgstr "Dieses Feld akzeptiert keine {sniffedMime} Dateien."
+msgstr "Dieses Feld akzeptiert keine {sniffedMime}-Dateien."
 
 #: packages/admin/src/components/ContentEditor.tsx:1734
 #: packages/admin/src/components/ContentEditor.tsx:1907
@@ -6407,7 +6407,7 @@ msgstr "Dies verschiebt das Element in den Papierkorb. Du kannst es später von 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:882
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr "Hierdurch wird \"{0}\" endgültig und aus allen Inhalten entfernt."
+msgstr "Hierdurch wird \"{0}\" endgültig gelöscht und aus allen Inhalten entfernt."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
@@ -6416,11 +6416,11 @@ msgstr "Hierdurch wird \"{0}\" endgültig entfernt. Dieser Vorgang kann nicht r�
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr "Kommentar permanent entfernen. Diese Aktion kann nicht rückgängig gemacht werden."
+msgstr "Dieser Kommentar wird endgültig entfernt. Diese Aktion kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/PluginManager.tsx:625
 msgid "This will remove the plugin and its bundle from your site."
-msgstr "Hierdurch werden die Erweiterung und sein Bundle von deiner Webseite entfernt."
+msgstr "Hierdurch werden die Erweiterung und ihr Bundle von deiner Webseite entfernt."
 
 #: packages/admin/src/components/ContentEditor.tsx:699
 msgid "This will revert to the published version. Your draft changes will be lost."
@@ -6436,7 +6436,7 @@ msgstr "Zeitzone"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr "Zeitzone für Anzeige eines Datums (z.B.: Europe/Berlin)"
+msgstr "Zeitzone für die Anzeige von Datumsangaben (z. B. Europe/Berlin)"
 
 #: packages/admin/src/components/ContentList.tsx:239
 #: packages/admin/src/components/ContentList.tsx:367
@@ -6605,7 +6605,7 @@ msgstr "Typkonflikt ({0})"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
 msgid "Unable to reach marketplace"
-msgstr "Verbindung mit Marktplatz fehlgeschlagen"
+msgstr "Verbinden mit dem Marktplatz fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2236
 #: packages/admin/src/components/ContentEditor.tsx:2251
@@ -6725,7 +6725,7 @@ msgstr "Feld aktualisieren"
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
 msgid "Update settings for {0}"
-msgstr "Einstellungen für Domain {0} ändern"
+msgstr "Einstellungen für {0} ändern"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Update site settings"
@@ -6734,7 +6734,7 @@ msgstr "Webseiten-Einstellungen ändern"
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:364
 msgid "Update the {0} details"
-msgstr "Aktualisiere die {0} Details"
+msgstr "Aktualisiere Details zu {0}"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Update this redirect rule."
@@ -6769,7 +6769,7 @@ msgstr "Hochladen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:140
 msgid "Upload a file to get started"
-msgstr "Lade eine Datei hoch um zu beginnen"
+msgstr "Lade eine Datei hoch, um zu beginnen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1230
 msgid "Upload an export file"
@@ -6777,7 +6777,7 @@ msgstr "Lade eine Export-Datei hoch"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:141
 msgid "Upload an image to get started"
-msgstr "Lade ein Bild hoch um zu beginnen"
+msgstr "Lade ein Bild hoch, um zu beginnen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Upload and delete media"
@@ -6799,7 +6799,7 @@ msgstr "Hochladen fehlgeschlagen: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:598
 msgid "Upload file"
-msgstr "Bild hochladen"
+msgstr "Datei hochladen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:142
 msgid "Upload File"
@@ -6819,7 +6819,7 @@ msgstr "Bild hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
 msgid "Upload images, videos, and documents to get started."
-msgstr "Lade Bilder, Videos und Dokumente hoch um zu beginnen."
+msgstr "Lade Bilder, Videos und Dokumente hoch, um zu beginnen."
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
@@ -6827,12 +6827,12 @@ msgstr "Medien hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:380
 msgid "Upload media to get started"
-msgstr "Lade Medien hoch um zu beginnen"
+msgstr "Lade Medien hoch, um zu beginnen"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:320
 msgid "Upload to {0}"
-msgstr "Hochladen zu {0}"
+msgstr "Zu {0} hochladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:960
 msgid "Upload WordPress export file"
@@ -6876,7 +6876,7 @@ msgstr "URL-freundlicher Bezeichner"
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr "URL-freundliche Kennung (z.B.: \"hauptbereich\", \"fusszeile\")"
+msgstr "URL-freundliche Kennung (z. B. \"hauptbereich\", \"fusszeile\")"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
@@ -6904,7 +6904,7 @@ msgstr "Wird als Hauptbild für diesen Beitrag auf Listenseiten und am Anfang de
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:206
 msgid "Used by screen readers and when image fails to load"
-msgstr "Wird von Bildschirmleseprogrammen verwendet und wenn das Bild nicht geladen werden kann"
+msgstr "Wird von Bildschirmleseprogrammen verwendet und angezeigt, wenn das Bild nicht geladen werden kann"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:410
 msgid "Used in URLs and API endpoints"
@@ -6929,11 +6929,11 @@ msgstr "Der Benutzerzugriff wird von einem externen Anbieter verwaltet ({0}). Do
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
-msgstr "Nutzerdetails"
+msgstr "Benutzerdetails"
 
 #: packages/admin/src/components/users/UserDetail.tsx:296
 msgid "User not found"
-msgstr "Nutzer nicht gefunden"
+msgstr "Benutzer nicht gefunden"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:211
 #: packages/admin/src/components/Sidebar.tsx:214
@@ -6943,11 +6943,11 @@ msgstr "Benutzer"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
 msgid "Users from"
-msgstr "Nutzer von"
+msgstr "Benutzer von"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
 msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
-msgstr "Nutzer mit E-Mail-Adressen dieser Domains können sich ohne Einladung registrieren. Ihnen wird dann die angegebene Rolle automatisch zugewiesen."
+msgstr "Benutzer mit E-Mail-Adressen dieser Domains können sich ohne Einladung registrieren. Ihnen wird anschließend die angegebene Rolle automatisch zugewiesen."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:357
@@ -7035,7 +7035,7 @@ msgstr "Warnung"
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1105
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr "Wir konnten keine Verbindung zu einer WordPress-Webseite unter {0} herstellen. Dies könnte bedeuten, dass es sich nicht um eine WordPress-Webseite handelt, die REST-API deaktiviert ist oder die Webseite nicht erreichbar ist."
+msgstr "Wir konnten keine Verbindung zu einer WordPress-Webseite unter {0} herstellen. Dies könnte bedeuten, dass es sich nicht um eine WordPress-Webseite handelt, dass die REST-API deaktiviert ist oder dass die Webseite nicht erreichbar ist."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:396
 msgid "We couldn't verify this publisher's identity"
@@ -7134,7 +7134,7 @@ msgstr "Widget-Titel"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Widget updated"
-msgstr Widget aktualisiert"
+msgstr "Widget aktualisiert"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
 #: packages/admin/src/components/PluginManager.tsx:378
@@ -7154,7 +7154,7 @@ msgstr "Wird erstellt"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
-msgstr "können sich nicht mehr ohne Einladung registrieren. Bereits registrierte Nutzer sind hiervon nicht betroffen."
+msgstr "können sich nicht mehr ohne Einladung registrieren. Bereits registrierte Benutzer sind hiervon nicht betroffen."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:184
 msgid "Without an email provider, invite links must be shared manually."
@@ -7198,11 +7198,11 @@ msgstr "Du kannst deine eigene Rolle nicht ändern"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
-msgstr "Du hast vollen Zugriff, um diese Webseite zu verwalten, einschließlich Benutzer, Einstellungen und aller Inhalte."
+msgstr "Du hast vollen Zugriff, um diese Webseite einschließlich Benutzern, Einstellungen und aller Inhalte zu verwalten."
 
 #: packages/admin/src/router.tsx:1187
 msgid "You need Editor permissions to moderate comments."
-msgstr "Du benötigst Redakteur-Berechtigungen um Kommentare zu moderieren."
+msgstr "Du benötigst Redakteur-Berechtigungen, um Kommentare zu moderieren."
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:206
@@ -7211,7 +7211,7 @@ msgstr "Du kannst dich nicht mehr als \"{0}\" anmelden. Dieser Vorgang kann nich
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:207
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr "Du kannst diesen Passkey nicht mehr nutzen um dich anzumelden. Dieser Vorgang kann nicht rückgängig gemacht werden."
+msgstr "Du kannst diesen Passkey nicht mehr nutzen, um dich anzumelden. Dieser Vorgang kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:52
@@ -7301,7 +7301,7 @@ msgstr "Deine Webseite erlaubt die Installation von Versionen erst, wenn diese m
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:135
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "Dein Twitter-/X-Benutzername (z.B.: @benutzername)"
+msgstr "Dein Twitter-/X-Benutzername (z. B. @benutzername)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1898
@@ -7310,7 +7310,7 @@ msgstr "Dein WordPress-Export enthält {0} Mediendateien."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:165
 msgid "Your YouTube channel ID or handle"
-msgstr "Deine YouTube-Kanal-ID oder dein Nutzername"
+msgstr "Deine YouTube-Kanal-ID oder dein Benutzername"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:162
 msgid "YouTube"

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -28,7 +28,7 @@ msgstr " (Standard)"
 
 #: packages/admin/src/components/MenuEditor.tsx:427
 msgid " (opens in new window)"
-msgstr " (öffnet in neuem Fenster)"
+msgstr " (öffnet in neuem Tab)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:782
 #: packages/admin/src/components/MediaPickerModal.tsx:864
@@ -97,7 +97,7 @@ msgstr "{0, plural, one {# Fehler mit Inhalt} other {# Fehler mit Inhalten}}"
 #. placeholder {0}: result.imported
 #: packages/admin/src/components/WordPressImport.tsx:2056
 msgid "{0, plural, one {# content item imported} other {# content items imported}}"
-msgstr "{0, plural, one {# Inhaltselement importiert} other {# Imhaltselemente importiert}}"
+msgstr "{0, plural, one {# Inhaltselement importiert} other {# Inhaltselemente importiert}}"
 
 #. placeholder {0}: items.length
 #. placeholder {0}: menu.itemCount ?? 0
@@ -302,7 +302,7 @@ msgstr "{needsNewCollections, plural, one {# neue Kollektion wird erstellt} othe
 
 #: packages/admin/src/components/WordPressImport.tsx:1724
 msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
-msgstr "{needsNewFields, plural, one {Felder werden zu # bestehenden Kollektion hinzuegfügt} other {Felder werden zu # bestehenden Kollektionen hinzuegfügt}}"
+msgstr "{needsNewFields, plural, one {Felder werden zu # bestehenden Kollektion hinzugefügt} other {Felder werden zu # bestehenden Kollektionen hinzugefügt}}"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:79
 msgid "{pluginName} is requesting additional permissions:"
@@ -365,7 +365,7 @@ msgstr "• Dateien werden von deiner WordPress-Seite heruntergeladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1930
 msgid "• Uploaded to your EmDash media storage"
-msgstr "• In deine EmDash Medienbibliothek hochgeladen"
+msgstr "• In deine EmDash-Medienbibliothek hochgeladen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1931
 msgid "• URLs in your content are updated automatically"
@@ -388,7 +388,7 @@ msgstr "1. Melde dich in deinem WordPress-Adminbereich an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1114
 msgid "1. Log into your WordPress admin dashboard"
-msgstr "1. Melde dich in deinem WordPress-Adminbereich Dashboard an"
+msgstr "1. Melde dich in deinem WordPress-Dashboard an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "2. Go to"
@@ -429,13 +429,11 @@ msgstr "308 Permanent (Strikt)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1119
 msgid "4. Click \"Download Export File\""
-msgstr "4. Klicke \"Lade Export-Datei herunter\""
-#: TODO: Check WordPress sandbox for exact wording
+msgstr "4. Klicke \"Export-Datei herunterladen\""
 
 #: packages/admin/src/components/WordPressImport.tsx:1364
 msgid "4. Enter \"EmDash\" and click \"Add New\""
 msgstr "4. Gib \"EmDash\" ein und klicke \"Neu hinzufügen\""
-#: TODO: Check WordPress sandbox for exact wording
 
 #: packages/admin/src/components/Redirects.tsx:368
 msgid "404 Errors"
@@ -468,7 +466,6 @@ msgstr "Ein Hero-Banner in voller Breite mit Überschrift, Text und CTA-Button"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:165
 msgid "A short description of your site"
 msgstr "Eine kurze Beschreibung deiner Seite"
-#: TODO: Check if Seite or Webseite or Website should be used consistently
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:170
 msgid "Accept & Install"
@@ -550,7 +547,7 @@ msgstr "Erlaubte Domain hinzufügen"
 
 #: packages/admin/src/components/FieldEditor.tsx:544
 msgid "Add at least one sub-field to define the repeater structure."
-msgstr "Füge mindestens ein Unterfeld hinzu, um die Struktur des wiederholbaren Feldes zu definieren."
+msgstr "Füge mindestens ein untergeordnetes Feld hinzu, um die Struktur des wiederholbaren Feldes zu definieren."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2575
 msgid "Add column after"
@@ -665,7 +662,7 @@ msgstr "Widget-Bereich hinzufügen"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr "Füge deine Profile von sozialen Medien hinzu. Sie stehen dem Design deiner Website zur Verfügung und können in Kopfzeilen, Fußzeilen oder Autorenbeschreibungen angezeigt werden."
+msgstr "Füge deine Profile von sozialen Medien hinzu. Sie stehen dem Design deiner Webseite zur Verfügung und können in Kopfzeilen, Fußzeilen oder Autorenbeschreibungen angezeigt werden."
 
 #: packages/admin/src/components/MenuEditor.tsx:354
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
@@ -716,7 +713,7 @@ msgstr "Alle Autorenzeilen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
-msgstr "Alle Fähigkeiten"
+msgstr "Alle Berechtigungen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:133
 msgid "All collections"
@@ -728,7 +725,7 @@ msgstr "Alle Kommentare benötigen eine Freigabe"
 
 #: packages/admin/src/components/WordPressImport.tsx:2324
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
-msgstr "Alle importierten Inhalte bleiben ohne Zuordnung. Du kannst Autoren später im Inhaltseditor neu zuweisen."
+msgstr "Alle importierten Inhalte bleiben ohne Zuordnung. Du kannst Autoren(zeilen) später im Inhaltseditor neu zuweisen."
 
 #: packages/admin/src/components/LocaleSwitcher.tsx:68
 msgid "All locales"
@@ -773,7 +770,7 @@ msgstr "Du hast bereits ein Benutzerkonto?"
 
 #: packages/admin/src/components/PluginManager.tsx:630
 msgid "Also delete plugin storage data"
-msgstr "Auch gespeicherte Daten der Erweiterung löschen"
+msgstr "Auch gespeicherte Daten der Erweiterung entfernen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:202
 msgid "Alt text"
@@ -788,7 +785,7 @@ msgstr "Alt-Text"
 #: packages/admin/src/components/MediaLibrary.tsx:633
 #: packages/admin/src/components/MediaLibrary.tsx:690
 msgid "Alt text set"
-msgstr "Alt-Text festgelegt"
+msgstr "Alt-Text vorhanden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1234
 msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
@@ -850,7 +847,7 @@ msgstr "Anwendungspasswort"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2990
 msgid "Apply"
-msgstr "Anwenden"
+msgstr "Erstellen"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:144
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:145
@@ -891,7 +888,7 @@ msgstr "Archive"
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
 msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
-msgstr "Bist du sicher, dass du „{0}“ löschen möchtest? Dadurch werden auch alle Inhalte in dieser Kollektion gelöscht."
+msgstr "Bist du sicher, dass du „{0}“ entfernen möchtest? Dadurch werden auch alle Inhalte in dieser Kollektion entfernt."
 
 #. placeholder {0}: deleteFieldTarget.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:660
@@ -1043,7 +1040,7 @@ msgstr "Zurück zu Erweiterungen"
 #: packages/admin/src/components/SectionEditor.tsx:73
 #: packages/admin/src/components/SectionEditor.tsx:174
 msgid "Back to sections"
-msgstr "Zurück zu Sektionen"
+msgstr "Zurück zu Abschnitte"
 
 #: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
 msgid "Back to settings"
@@ -1060,7 +1057,7 @@ msgstr "Vor dem Senden:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:233
 msgid "Bing Verification"
-msgstr "Bing-Verifikation"
+msgstr "Bing-Verifizierung"
 
 #: packages/admin/src/routes/bylines.tsx:409
 msgid "Bio"
@@ -1188,7 +1185,7 @@ msgstr "Vom Design bereitgestellte Abschnitte können nicht gelöscht werden"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:400
 msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
-msgstr "Der MIME-Typ kann basierend auf der URL nicht ermittelt werden. Verwende eine URL, die mit einer bekannten Bild-Dateiendung endet (z. B.: .jpg, .png, .webp)."
+msgstr "Der MIME-Typ kann basierend auf der URL nicht ermittelt werden. Verwende eine URL, die mit einer bekannten Bild-Dateiendung endet (z.B.: .jpg, .png, .webp)."
 
 #: packages/admin/src/components/SeoPanel.tsx:181
 msgid "Canonical URL"
@@ -1196,11 +1193,11 @@ msgstr "Kanonische URL"
 
 #: packages/admin/src/components/PluginManager.tsx:469
 msgid "Capabilities"
-msgstr "Fähigkeiten"
+msgstr "Berechtigungen"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:65
 msgid "Capability consent"
-msgstr "Zustimmung zu Fähigkeiten"
+msgstr "Zustimmung zu Berechtigungen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
@@ -1256,7 +1253,7 @@ msgstr "Änderungen verworfen"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:162
 msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
-msgstr "Trennzeichen zwischen Seitentitel und Webseitenname (z. B. Mein Beitrag | Meine Website)"
+msgstr "Trennzeichen zwischen Seitentitel und Webseitenname (z.B.: Mein Beitrag | Meine Webseite)"
 
 #: packages/admin/src/components/PluginManager.tsx:161
 msgid "Check for updates"
@@ -1490,7 +1487,7 @@ msgstr "({0}) Inhaltsfehler"
 
 #: packages/admin/src/components/WordPressImport.tsx:1156
 msgid "Content found:"
-msgstr "Inhalt gefunden:"
+msgstr "Inhalte gefunden:"
 
 #: packages/admin/src/router.tsx:830
 msgid "Content has been scheduled for publishing"
@@ -1506,7 +1503,7 @@ msgstr "Inhalts ID:"
 
 #: packages/admin/src/router.tsx:778
 msgid "Content is now live"
-msgstr "Inhalt ist jetzt online"
+msgstr "Inhalt ist jetzt online verfügbar"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "content items"
@@ -1518,7 +1515,7 @@ msgstr "Inhalte lesen"
 
 #: packages/admin/src/router.tsx:794
 msgid "Content removed from public view"
-msgstr "Inhalt aus öffentlicher Ansicht entfernt"
+msgstr "Inhalt ist nicht mehr öffentlich einsehbar"
 
 #: packages/admin/src/router.tsx:848
 msgid "Content reverted to draft"
@@ -1631,7 +1628,7 @@ msgstr "\"{trimmedInput}\" erstellen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:888
 msgid "Create a bullet list"
-msgstr "Eine Aufzählungsliste erstellen"
+msgstr "Eine Aufzählungsliste einfügen"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:365
@@ -1640,7 +1637,7 @@ msgstr "{0} erstellen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:898
 msgid "Create a numbered list"
-msgstr "Eine nummerierte Liste erstellen"
+msgstr "Eine nummerierte Liste einfügen"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:81
 #: packages/admin/src/components/SignupPage.tsx:220
@@ -1697,7 +1694,7 @@ msgstr "Weiterleitung für diesen Pfad erstellen"
 
 #: packages/admin/src/components/Redirects.tsx:435
 msgid "Create redirect rules to manage URL changes."
-msgstr "Weiterleitungs-Regeln erstellen um URL-Änderungen"
+msgstr "Weiterleitungsregeln erstellen um URL-Änderungen zu verwalten."
 
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "Create Schema & Import"
@@ -1706,11 +1703,11 @@ msgstr "Schema erstellen & importieren"
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
 msgid "Create Section"
-msgstr "Sektion erstellen"
+msgstr "Abschnitt erstellen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:109
 msgid "Create sections in the Sections library to use them here"
-msgstr "Erstelle Sektionen in der Sektionenbibliothek um sie hier zu nutzen"
+msgstr "Erstelle Abschnitte in der Sammlung deiner Abschnitte um sie hier zu nutzen"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:687
@@ -1737,11 +1734,11 @@ msgstr "Erstelle dein erstes Navigationsmenü um zu beginnen"
 #: packages/admin/src/components/ContentList.tsx:286
 #: packages/admin/src/components/ContentTypeList.tsx:122
 msgid "Create your first one"
-msgstr "Erstelle dein erstes Element"
+msgstr "Erstelle einen ersten Inhalt."
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr "Erstelle deine erste benutzerdefinierte Inhaltssektion um zu beginnen."
+msgstr "Erstelle deinen ersten benutzerdefinierten Inhaltsabschnitt um zu beginnen."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:72
 #: packages/admin/src/components/SignupPage.tsx:211
@@ -1751,15 +1748,15 @@ msgstr "Erstelle deinen Passkey"
 #: packages/admin/src/lib/api/marketplace.ts:223
 #: packages/admin/src/lib/api/marketplace.ts:231
 msgid "Create, update, and delete content"
-msgstr "Erstelle, aktualisiere und entferne Inhalte"
+msgstr "Erstelle, aktualisiere oder entferne Inhalte"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Create, update, and delete navigation menus"
-msgstr "Erstelle, aktualisiere und entferne Navigationsmenüs"
+msgstr "Erstelle, aktualisiere oder entferne Navigationsmenüs"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
-msgstr "Erstelle, aktualisiere und entferne Taxonomiebegriffe"
+msgstr "Erstelle, aktualisiere oder entferne Taxonomiebegriffe"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
@@ -1826,7 +1823,7 @@ msgstr "Benutzerdefinierte robots.txt-Datei. Leer belassen um den Standard zu nu
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Custom Section"
-msgstr "Benutzerdefinierte Sektion"
+msgstr "Benutzerdefinierter Abschnitt"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -1986,7 +1983,7 @@ msgstr "Bild entfernen"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:253
 msgid "Delete Media?"
-msgstr "Medium entfernen?"
+msgstr "Datei entfernen?"
 
 #: packages/admin/src/components/MenuList.tsx:253
 msgid "Delete Menu"
@@ -2024,7 +2021,7 @@ msgstr "Zeile entfernen"
 
 #: packages/admin/src/components/Sections.tsx:296
 msgid "Delete Section?"
-msgstr "Sektion entfernen?"
+msgstr "Abschnitt entfernen?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2618
 msgid "Delete table"
@@ -2085,7 +2082,7 @@ msgstr "Beschreibe dieses Bild für die Barrierefreiheit"
 
 #: packages/admin/src/components/SectionEditor.tsx:262
 msgid "Describe what this section is for..."
-msgstr "Beschreibe wofür diese Sektion genutzt wird..."
+msgstr "Beschreibe wofür dieser Abschnitt genutzt wird..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:415
 #: packages/admin/src/components/SectionEditor.tsx:259
@@ -2181,7 +2178,7 @@ msgstr "Änderungen verwerfen"
 
 #: packages/admin/src/components/ContentEditor.tsx:696
 msgid "Discard draft changes?"
-msgstr "Vorläufige Änderungen verwerfen?"
+msgstr "Änderungen verwerfen?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
@@ -2268,7 +2265,7 @@ msgstr "Entwurf"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:119
 msgid "draft, published, or archived"
-msgstr "Entwurf, veröffentlicht oder archiviert"
+msgstr "Entwurf, publiziert oder archiviert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:71
 #: packages/admin/src/components/Dashboard.tsx:188
@@ -2324,19 +2321,19 @@ msgstr "{title} duplizieren"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr "z.B. application/zip oder .pdf"
+msgstr "z.B.: application/zip oder .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "e.g. import, blog"
-msgstr "z.B. importiert, blog"
+msgstr "z.B.: importiert, blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
 msgid "e.g., CI/CD Pipeline"
-msgstr "z. B., CI/CD-Pipeline"
+msgstr "z.B.: CI/CD-Pipeline"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr "z.B., MacBook Pro, iPhone"
+msgstr "z.B.: MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentEditor.tsx:2075
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2522,7 +2519,7 @@ msgstr "Gib eine URL (https://…) oder einen relativen Pfad (/…) ein"
 
 #: packages/admin/src/components/ContentEditor.tsx:1474
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr "Gib eine gültige URL ein (z. B. https://beispiel.de)"
+msgstr "Gib eine gültige URL ein (z.B.: https://beispiel.de)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1219
 msgid "Enter credentials manually"
@@ -2584,7 +2581,7 @@ msgstr "Fehler beim Neuordnen der Widgets"
 
 #: packages/admin/src/components/SectionEditor.tsx:52
 msgid "Error saving section"
-msgstr "Fehler beim Speichern der Sektion"
+msgstr "Fehler beim Speichern des Abschnitts"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Error updating widget"
@@ -2736,7 +2733,7 @@ msgstr "Entfernen der Weiterleitung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr "Entfernen der Sektion fehlgeschlagen"
+msgstr "Entfernen des Abschnitts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
@@ -2915,7 +2912,7 @@ msgstr "Ausführen der Massenoperation fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:260
 msgid "Failed to permanently delete content"
-msgstr "Entgültiges Löschen des Inhalts fehlgeschlagen"
+msgstr "Entgültiges Entfernen des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:276
 msgid "Failed to prepare import"
@@ -2961,7 +2958,7 @@ msgstr "Wiederherstellen der Revision fehlgeschlagen"
 
 #: packages/admin/src/lib/api/api-tokens.ts:98
 msgid "Failed to revoke API token"
-msgstr "Widerrufen des API-Tokens fehlgeschlagen"
+msgstr "Widerrufen des API-Token fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:332
 msgid "Failed to rewrite URLs"
@@ -3057,11 +3054,11 @@ msgstr "Favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1022
 msgid "Feature"
-msgstr "Fähigkeit"
+msgstr "Funktion"
 
 #: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
-msgstr "Fähigkeiten"
+msgstr "Funktionen"
 
 #: packages/admin/src/components/WordPressImport.tsx:736
 msgid "Fetching content from the EmDash Exporter API."
@@ -3085,7 +3082,7 @@ msgstr "Felder"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Fields created:"
-msgstr "Felder erstellt:"
+msgstr "Erstellte Felder:"
 
 #: packages/admin/src/components/FieldEditor.tsx:210
 msgid "File"
@@ -3155,7 +3152,7 @@ msgstr "Führe einen Export von WordPress durch, um alle Inhalte einschließlich
 
 #: packages/admin/src/components/WordPressImport.tsx:1046
 msgid "For the best import experience, install the"
-msgstr "Für einen reibungslosen Import, installiere die"
+msgstr "Installiere die"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3197,7 +3194,7 @@ msgstr "Zum Dashboard"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:227
 msgid "Google Verification"
-msgstr "Google Verifizierung"
+msgstr "Google-Verifizierung"
 
 #: packages/admin/src/components/MediaLibrary.tsx:238
 msgid "Grid view"
@@ -3334,7 +3331,7 @@ msgstr "Bild-URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:2176
 msgid "image URLs updated in"
-msgstr "Bild-URLs aktualisiert in"
+msgstr "Bild-URLs angepasst in"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 msgid "Images"
@@ -3361,7 +3358,7 @@ msgstr "Weitere Datei importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:1016
 msgid "Import Capabilities"
-msgstr "Fähigkeiten importieren"
+msgstr "Funktionen importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:2110
 msgid "Import Complete"
@@ -3480,7 +3477,7 @@ msgstr "Link einfügen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:57
 msgid "Insert Section"
-msgstr "Sektion einfügen"
+msgstr "Abschnitt einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2903
 msgid "Insert Table"
@@ -3626,7 +3623,7 @@ msgstr "Sprache"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:858
 msgid "Large section heading"
-msgstr "Große Abschnittsüberschrift"
+msgstr "Eine große Abschnittsüberschrift einfügen"
 
 #: packages/admin/src/components/PluginManager.tsx:521
 msgid "Last enabled:"
@@ -3704,7 +3701,7 @@ msgstr "Nur Zugeordnete"
 
 #: packages/admin/src/routes/bylines.tsx:415
 msgid "Linked user"
-msgstr "Zugeordneter Nutzer"
+msgstr "Zugeordneter Benutzer"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:156
 msgid "LinkedIn"
@@ -3777,7 +3774,7 @@ msgstr "Lade Weiterleitungen..."
 #: packages/admin/src/components/SectionPickerModal.tsx:94
 #: packages/admin/src/components/Sections.tsx:252
 msgid "Loading sections..."
-msgstr "Lade Sektionen..."
+msgstr "Lade Abschnitte..."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:104
 #: packages/admin/src/components/settings/SeoSettings.tsx:108
@@ -3899,7 +3896,7 @@ msgstr "Verwalte Navigationsmenüs für deine Webseite"
 
 #: packages/admin/src/components/Redirects.tsx:333
 msgid "Manage URL redirects and view 404 errors."
-msgstr "Verwalte URL-Weiterleitungen und sieh nach 404 Fehlern."
+msgstr "Verwalte URL-Weiterleitungen und prüfe 404-Fehler."
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
@@ -3943,7 +3940,7 @@ msgstr "Max. Länge"
 
 #: packages/admin/src/components/FieldEditor.tsx:500
 msgid "Max Value"
-msgstr "Maximalwert"
+msgstr "Max. Wert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1992
 #: packages/admin/src/components/Sidebar.tsx:188
@@ -3988,7 +3985,7 @@ msgstr "Medien bearbeiten"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:868
 msgid "Medium section heading"
-msgstr "Mittlere Abschnittsüberschrift"
+msgstr "Eine mittlere Abschnittsüberschrift einfügen"
 
 #: packages/admin/src/components/Widgets.tsx:102
 #: packages/admin/src/components/Widgets.tsx:834
@@ -4047,7 +4044,7 @@ msgstr "Menüs ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Menus Manage"
-msgstr "Verwalte Menüs"
+msgstr "Menüs verwalten"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Meta Description"
@@ -4071,11 +4068,11 @@ msgstr "Min. Elemente"
 
 #: packages/admin/src/components/FieldEditor.tsx:463
 msgid "Min Length"
-msgstr "Minimallänge"
+msgstr "Min. Länge"
 
 #: packages/admin/src/components/FieldEditor.tsx:493
 msgid "Min Value"
-msgstr "Minimalwert"
+msgstr "Min. Wert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:506
 msgid "Moderation"
@@ -4091,7 +4088,7 @@ msgstr "Bearbeitet"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Modify collection schemas"
-msgstr "Sammlungsschemata ändern"
+msgstr "Sammlungsschemata ändern oder entfernen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -4099,7 +4096,7 @@ msgstr "Am beliebtesten"
 
 #: packages/admin/src/components/ContentList.tsx:613
 msgid "Move \"{title}\" to trash? You can restore it later."
-msgstr "\"{title}\" in den Papierkorb verschieben? Du kannst es später wiederherstellen."
+msgstr "\"{title}\" in den Papierkorb verschieben? Ein späteres Wiederherstellen ist möglich."
 
 #: packages/admin/src/components/ContentList.tsx:604
 msgid "Move {title} to trash"
@@ -4210,7 +4207,7 @@ msgstr "Neue Weiterleitung"
 
 #: packages/admin/src/components/Sections.tsx:143
 msgid "New Section"
-msgstr "Neue Sektion"
+msgstr "Neuer Abschnitt"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
@@ -4279,7 +4276,7 @@ msgstr "Kein Alt-Text"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
 msgid "No API tokens yet. Create one to get started."
-msgstr "Noch keine API-Tokens. Erstelle eins, um loszulegen."
+msgstr "Noch keine API-Tokens. Erstelle ein Token, um loszulegen."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No approved comments yet."
@@ -4303,7 +4300,7 @@ msgstr "Keine Sammlungen konfiguriert"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:546
 msgid "No comments awaiting moderation."
-msgstr "Keine Kommentare erwarten eine Moderation."
+msgstr "Keine Kommentare erfordern eine Moderation."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:542
 msgid "No comments match your search."
@@ -4485,16 +4482,16 @@ msgstr "Noch keine Revisionen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:107
 msgid "No sections available"
-msgstr "Keine Sektionen verfügbar"
+msgstr "Keine Abschnitte verfügbar"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:101
 #: packages/admin/src/components/Sections.tsx:259
 msgid "No sections found"
-msgstr "Keine Sektionen gefunden"
+msgstr "Keine Abschnitte gefunden"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "No sections yet"
-msgstr "Noch keine Sektionen"
+msgstr "Noch keine Abschnitte"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:548
 msgid "No spam comments."
@@ -4750,7 +4747,7 @@ msgstr "Muster (Regex)"
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:437
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr "Muster zur Generierung von URLs, z. B. /blog/{0}"
+msgstr "Muster zur Generierung von URLs, z.B.: /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:433
@@ -4776,11 +4773,11 @@ msgstr "Ausstehende Änderungen"
 
 #: packages/admin/src/components/ContentList.tsx:684
 msgid "Permanently delete \"{title}\"? This cannot be undone."
-msgstr "\"{title}\" endgültig löschen? Dies kann nicht rückgängig gemacht werden."
+msgstr "\"{title}\" endgültig entfernen? Dies kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/ContentList.tsx:673
 msgid "Permanently delete {title}"
-msgstr "{title} endgültig löschen"
+msgstr "{title} endgültig entfernen"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:274
 msgid "Permissions"
@@ -4842,7 +4839,7 @@ msgstr "Erweiterung nicht gefunden. Möglicherweise ist die Herausgeber-ID oder 
 
 #: packages/admin/src/components/WordPressImport.tsx:1048
 msgid "plugin on your WordPress site."
-msgstr "Erweiterung für deine WordPress-Webseite."
+msgstr "Erweiterung für deine WordPress-Webseite, um von einem reibungslosen Import zu profitieren."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:75
 msgid "Plugin Permissions"
@@ -4960,12 +4957,12 @@ msgstr "publiziert"
 #: packages/admin/src/components/Dashboard.tsx:187
 #: packages/admin/src/router.tsx:778
 msgid "Published"
-msgstr "Publiziert"
+msgstr "publiziert"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:327
 msgid "Published {0}"
-msgstr "Veröffentlicht am {0}"
+msgstr "Publiziert am {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -4977,7 +4974,7 @@ msgstr "Publiziert von"
 
 #: packages/admin/src/components/ContentEditor.tsx:2115
 msgid "Quick create byline"
-msgstr "Autorenzeile schnell erstellen"
+msgstr "Neue Autorenzeile erstellen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:167
 #: packages/admin/src/components/editor/ImageNode.tsx:168
@@ -5446,7 +5443,7 @@ msgstr "Planen"
 
 #: packages/admin/src/components/ContentEditor.tsx:885
 msgid "Schedule for"
-msgstr "Planen für"
+msgstr "Publizieren planen für"
 
 #: packages/admin/src/components/ContentEditor.tsx:922
 msgid "Schedule for later"
@@ -5581,7 +5578,7 @@ msgstr "Erweiterungen durchsuchen..."
 #: packages/admin/src/components/SectionPickerModal.tsx:81
 #: packages/admin/src/components/Sections.tsx:226
 msgid "Search sections..."
-msgstr "Sektionen durchsuchen..."
+msgstr "Abschnitte durchsuchen..."
 
 #: packages/admin/src/components/Redirects.tsx:383
 msgid "Search source or destination..."
@@ -5615,27 +5612,27 @@ msgstr "Abschnitt"
 
 #: packages/admin/src/components/SectionEditor.tsx:82
 msgid "Section \"{slug}\" could not be found."
-msgstr "Sektion \"{slug}\" konnte nicht gefunden werden."
+msgstr "Abschnitt \"{slug}\" konnte nicht gefunden werden."
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
-msgstr "Sektion erstellt"
+msgstr "Abschnitt erstellt"
 
 #: packages/admin/src/components/Sections.tsx:107
 msgid "Section deleted"
-msgstr "Sektion entfernt"
+msgstr "Abschnitt entfernt"
 
 #: packages/admin/src/components/SectionEditor.tsx:233
 msgid "Section Details"
-msgstr "Sektionsdetails"
+msgstr "Abschnittsdetails"
 
 #: packages/admin/src/components/SectionEditor.tsx:78
 msgid "Section Not Found"
-msgstr "Sektion nicht gefunden"
+msgstr "Abschnitt nicht gefunden"
 
 #: packages/admin/src/components/SectionEditor.tsx:44
 msgid "Section saved"
-msgstr "Sektion gespeichert"
+msgstr "Abschnitt gespeichert"
 
 #: packages/admin/src/components/SectionEditor.tsx:239
 msgid "Section title"
@@ -5949,7 +5946,7 @@ msgstr "Stattdessen anmelden"
 
 #: packages/admin/src/components/LoginPage.tsx:232
 msgid "Sign in to your site"
-msgstr "Melde dich bei deiner Website an"
+msgstr "Melde dich bei deiner Webseite an"
 
 #. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
 #. placeholder {0}: provider.label
@@ -6054,7 +6051,7 @@ msgstr "Slug wurde in Zwischenablage kopiert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:878
 msgid "Small section heading"
-msgstr "Kleine Abschnittsüberschrift"
+msgstr "Eine kleine Abschnittsüberschrift einfügen"
 
 #: packages/admin/src/components/Settings.tsx:75
 #: packages/admin/src/components/settings/SocialSettings.tsx:78
@@ -6068,7 +6065,7 @@ msgstr "Links zu sozialen Medien gespeichert"
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
-msgstr "Links zu Social-Media-Profilen"
+msgstr "Links zu Profilen in sozialen Netzwerken"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:126
 msgid "Social Profiles"
@@ -6210,7 +6207,7 @@ msgstr "Taxonomien"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
 msgid "Taxonomies Manage"
-msgstr "Verwalte Taxonomien"
+msgstr "Taxonomien verwalten"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:896
 msgid "Taxonomy created"
@@ -6319,7 +6316,7 @@ msgstr "Design nicht gefunden"
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Theme Section"
-msgstr "Design Sektion"
+msgstr "Design-Abschnitt"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
@@ -6349,7 +6346,7 @@ msgstr "Das ist ein Pflichtfeld"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "This is a custom section."
-msgstr "Das ist eine benutzerdefinierte Sektion."
+msgstr "Das ist ein benutzerdefinierter Abschnitt."
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "This is a WordPress site."
@@ -6385,11 +6382,11 @@ msgstr "Hierdurch wird das Autorenprofil entfernt. Links zu Autorenbeiträgen un
 
 #: packages/admin/src/components/SectionEditor.tsx:283
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr "Diese Sektion wird vom Design bereitgestellt. Durch das Bearbeiten wird eine benutzerdefinierte Kopie erstellt, die die Version des Designs überschreibt."
+msgstr "Das ist ein vom Design bereitgestellter Abschnitt. Durch das Bearbeiten wird eine benutzerdefinierte Kopie erstellt, die die Version des Designs überschreibt."
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "This section was imported from another system."
-msgstr "Diese Sektion wurde von einem anderen System importiert."
+msgstr "Dieser Abschnitt wurde von einem anderen System importiert."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:119
 msgid "This update exposes the following routes without authentication:"
@@ -6419,7 +6416,7 @@ msgstr "Hierdurch wird \"{0}\" endgültig entfernt. Dieser Vorgang kann nicht r�
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr "Kommentar permanent löschen. Diese Aktion kann nicht rückgängig gemacht werden."
+msgstr "Kommentar permanent entfernen. Diese Aktion kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/PluginManager.tsx:625
 msgid "This will remove the plugin and its bundle from your site."
@@ -6427,7 +6424,7 @@ msgstr "Hierdurch werden die Erweiterung und sein Bundle von deiner Webseite ent
 
 #: packages/admin/src/components/ContentEditor.tsx:699
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr "Dies setzt alles auf die publizierte Version zurück. Deine Entwurfsänderungen gehen verloren."
+msgstr "Dies setzt den Inhalt auf die bereits publizierte Version zurück. Deine Entwurfsänderungen gehen verloren."
 
 #: packages/admin/src/components/SetupWizard.tsx:131
 msgid "Thoughts, tutorials, and more"
@@ -6439,7 +6436,7 @@ msgstr "Zeitzone"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr "Zeitzone für Anzeige eines Datums (z.B. Europe/Berlin)"
+msgstr "Zeitzone für Anzeige eines Datums (z.B.: Europe/Berlin)"
 
 #: packages/admin/src/components/ContentList.tsx:239
 #: packages/admin/src/components/ContentList.tsx:367
@@ -6732,7 +6729,7 @@ msgstr "Einstellungen für Domain {0} ändern"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Update site settings"
-msgstr "Webseiten-Einstellungen aktualisieren"
+msgstr "Webseiten-Einstellungen ändern"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:364
@@ -6784,7 +6781,7 @@ msgstr "Lade ein Bild hoch um zu beginnen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Upload and delete media"
-msgstr "Medien hochladen und entfernen"
+msgstr "Mediendateien hochladen oder entfernen"
 
 #: packages/admin/src/lib/api/marketplace.ts:225
 #: packages/admin/src/lib/api/marketplace.ts:233
@@ -6879,11 +6876,11 @@ msgstr "URL-freundlicher Bezeichner"
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr "URL-freundliche Kennung (z.B., \"hauptbereich\", \"fusszeile\")"
+msgstr "URL-freundliche Kennung (z.B.: \"hauptbereich\", \"fusszeile\")"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr "Nutze [param] oder [...rest] in Pfaden für Musterabgleiche."
+msgstr "Nutze [param] oder [...rest] in Pfaden für Musterabgleiche (Regex)."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:366
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
@@ -7008,11 +7005,11 @@ msgstr "Ansichtsmodus"
 
 #: packages/admin/src/components/ContentList.tsx:577
 msgid "View published {title}"
-msgstr "Veröffentlichten {title} ansehen"
+msgstr "{title} (publiziert) ansehen"
 
 #: packages/admin/src/components/Header.tsx:51
 msgid "View Site"
-msgstr "Website ansehen"
+msgstr "Webseite ansehen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:449
 msgid "View source"
@@ -7038,7 +7035,7 @@ msgstr "Warnung"
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1105
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr "Wir konnten keine Verbindung zu einer WordPress-Website unter {0} herstellen. Dies könnte bedeuten, dass es sich nicht um eine WordPress-Website handelt, die REST-API deaktiviert ist oder die Website nicht erreichbar ist."
+msgstr "Wir konnten keine Verbindung zu einer WordPress-Webseite unter {0} herstellen. Dies könnte bedeuten, dass es sich nicht um eine WordPress-Webseite handelt, die REST-API deaktiviert ist oder die Webseite nicht erreichbar ist."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:396
 msgid "We couldn't verify this publisher's identity"
@@ -7046,7 +7043,7 @@ msgstr "Wir konnten die Identität dieses Herausgebers nicht überprüfen"
 
 #: packages/admin/src/components/WordPressImport.tsx:926
 msgid "We'll check what import options are available for your site."
-msgstr "Wir prüfen, welche Importoptionen für Ihre Website verfügbar sind."
+msgstr "Wir prüfen, welche Importoptionen für deine Webseite verfügbar sind."
 
 #: packages/admin/src/components/LoginPage.tsx:323
 msgid "We'll send you a link to sign in without a password."
@@ -7100,7 +7097,7 @@ msgstr "Wann der Eintrag zuletzt geändert wurde"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:137
 msgid "When the entry was published"
-msgstr "Wann der Eintrag veröffentlicht wurde"
+msgstr "Wann der Eintrag publiziert wurde"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:656
 msgid "Which content types can use this taxonomy"
@@ -7193,7 +7190,7 @@ msgstr "Du kannst Inhalte, Medien, Menüs und Taxonomien verwalten."
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
-msgstr "Du kannst die Website ansehen und mitwirken."
+msgstr "Du kannst die Webseite ansehen und mitwirken."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
@@ -7201,7 +7198,7 @@ msgstr "Du kannst deine eigene Rolle nicht ändern"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
-msgstr "Du hast vollen Zugriff, um diese Website zu verwalten, einschließlich Benutzer, Einstellungen und aller Inhalte."
+msgstr "Du hast vollen Zugriff, um diese Webseite zu verwalten, einschließlich Benutzer, Einstellungen und aller Inhalte."
 
 #: packages/admin/src/router.tsx:1187
 msgid "You need Editor permissions to moderate comments."
@@ -7270,7 +7267,7 @@ msgstr "Deine E-Mail-Adresse"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:147
 msgid "Your Facebook page or profile username"
-msgstr "Deine Facebook-Seite oder -Profilname"
+msgstr "Deine Facebook-Seite oder dein Profilname"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:141
 msgid "Your GitHub username"
@@ -7304,7 +7301,7 @@ msgstr "Deine Webseite erlaubt die Installation von Versionen erst, wenn diese m
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:135
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr "Dein Twitter-/X-Benutzername (z. B. @benutzername)"
+msgstr "Dein Twitter-/X-Benutzername (z.B.: @benutzername)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1898

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -493,7 +493,7 @@ msgstr "Greife auf deine Medienbibliothek zu"
 
 #: packages/admin/src/components/SetupWizard.tsx:354
 msgid "Account"
-msgstr "Konto"
+msgstr "Benutzerkonto"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:121
 msgid "Account already exists"
@@ -1388,7 +1388,7 @@ msgstr "Details einklappen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:158
 msgid "colleague@example.com"
-msgstr "max.mustermann@example.com"
+msgstr "max.mustermann@beispiel.de"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
@@ -2522,7 +2522,7 @@ msgstr "Gib eine URL (https://…) oder einen relativen Pfad (/…) ein"
 
 #: packages/admin/src/components/ContentEditor.tsx:1474
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr "Gib eine gültige URL ein (z. B. https://example.com)"
+msgstr "Gib eine gültige URL ein (z. B. https://beispiel.de)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1219
 msgid "Enter credentials manually"
@@ -2894,7 +2894,7 @@ msgstr "Laden der Revisionen fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr "Laden des Setups fehlgeschlagen"
+msgstr "Laden der Einrichtung fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
@@ -3069,11 +3069,11 @@ msgstr "Abrufen von Inhalten über die EmDash-Exporter-API."
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr "Feld-Label"
+msgstr "Feld-Bezeichnung"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr "Feld-Label"
+msgstr "Feld-Bezeichnung"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
@@ -3281,11 +3281,11 @@ msgstr "Wie ein Anwendungspasswort erstellt wird"
 
 #: packages/admin/src/components/MenuEditor.tsx:337
 msgid "https://example.com or /about"
-msgstr "https://example.com oder /ueber"
+msgstr "https://beispiel.de oder /ueber"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:495
 msgid "https://example.com/image.jpg"
-msgstr "https://example.com/bild.jpg"
+msgstr "https://beispiel.de/bild.jpg"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:241
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:143
@@ -3349,11 +3349,11 @@ msgstr "Import"
 #. placeholder {0}: postType.name
 #: packages/admin/src/components/WordPressImport.tsx:1794
 msgid "Import {0}"
-msgstr ""
+msgstr "Importiere {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1205
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr "Importiere alle Inhalte direkt, einschließlich Entwürfe, benutzerdefinierte Beitragstypen, ACF-Felder und SEO-Daten. Es ist kein Dateidownload erforderlich."
+msgstr "Importiere alle Inhalte direkt, einschließlich Entwürfe, benutzerdefinierte Inhaltstypen, ACF-Felder und SEO-Daten. Es ist kein Dateidownload erforderlich."
 
 #: packages/admin/src/components/WordPressImport.tsx:2222
 msgid "Import Another File"
@@ -3417,7 +3417,7 @@ msgstr "Importiere Medien"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
-msgstr "Beispielinhalte einfügen (empfohlen für neue Webseiten)"
+msgstr "Beispielinhalte nutzen (empfohlen für neue Webseiten)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1816
 msgid "Incompatible"
@@ -3426,7 +3426,7 @@ msgstr "Inkompatibel"
 #. placeholder {0}: formatDate(release.indexedAt)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:325
 msgid "indexed {0}"
-msgstr "indexiert {0}"
+msgstr "indexiert am {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2833
 msgid "Inline Code"
@@ -3564,25 +3564,25 @@ msgstr "Lade deinen erstes Teammitglied ein"
 #: packages/admin/src/components/PortableTextEditor.tsx:2506
 #: packages/admin/src/components/PortableTextEditor.tsx:2812
 msgid "Italic"
-msgstr ""
+msgstr "Kursiv"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:1651
 #: packages/admin/src/components/RepeaterField.tsx:234
 msgid "Item {0}"
-msgstr ""
+msgstr "Element {0}"
 
 #: packages/admin/src/components/MenuEditor.tsx:121
 msgid "Item added"
-msgstr ""
+msgstr "Element hinzugefügt"
 
 #: packages/admin/src/components/MenuEditor.tsx:133
 msgid "Item deleted"
-msgstr ""
+msgstr "Element entfernt"
 
 #: packages/admin/src/components/MenuEditor.tsx:158
 msgid "Item updated"
-msgstr ""
+msgstr "Element aktualisiert"
 
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:205
@@ -3607,15 +3607,15 @@ msgstr "Stichwörter"
 #: packages/admin/src/components/TaxonomyManager.tsx:621
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Label"
-msgstr "Label"
+msgstr "Bezeichnung"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:394
 msgid "Label (Plural)"
-msgstr "Label (Plural)"
+msgstr "Bezeichnung (Plural)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:386
 msgid "Label (Singular)"
-msgstr "Label (Singular)"
+msgstr "Bezeichnung (Singular)"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:125
 #: packages/admin/src/components/LoginPage.tsx:345
@@ -3691,7 +3691,7 @@ msgstr "Link abgelaufen"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "Link to another content item"
-msgstr ""
+msgstr "Link zu anderem Inhaltselement"
 
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
@@ -3716,11 +3716,11 @@ msgstr "Links"
 
 #: packages/admin/src/components/MediaLibrary.tsx:247
 msgid "List view"
-msgstr ""
+msgstr "Listenansicht"
 
 #: packages/admin/src/components/ContentEditor.tsx:744
 msgid "Live View"
-msgstr "Live-Vorschau"
+msgstr "Live-Ansicht"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:236
 #: packages/admin/src/components/MarketplaceBrowse.tsx:198
@@ -3787,11 +3787,11 @@ msgstr "Lade Einstellungen..."
 
 #: packages/admin/src/components/SetupWizard.tsx:528
 msgid "Loading setup..."
-msgstr "Lade Setup..."
+msgstr "Lade Einrichtung..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:825
 msgid "Loading terms..."
-msgstr ""
+msgstr "Lade Begriffe..."
 
 #: packages/admin/src/components/Widgets.tsx:310
 msgid "Loading widgets..."
@@ -3829,7 +3829,7 @@ msgstr "Sprache"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Lock aspect ratio"
-msgstr ""
+msgstr "Seitenverhältnis sperren"
 
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
@@ -3847,7 +3847,7 @@ msgstr "Logo & Favicon"
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
 msgid "Long Text"
-msgstr ""
+msgstr "Langtext"
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
@@ -3859,7 +3859,7 @@ msgstr "Nur Kleinbuchstaben, Zahlen und Unterstriche, beginnend mit einem Buchst
 
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Main Sidebar"
-msgstr ""
+msgstr "Primäre Seitenleiste"
 
 #: packages/admin/src/lib/api/marketplace.ts:227
 #: packages/admin/src/lib/api/marketplace.ts:235
@@ -3879,15 +3879,15 @@ msgstr "Verwalten"
 #. placeholder {1}: taxonomyDef.collections.join(", ")
 #: packages/admin/src/components/TaxonomyManager.tsx:796
 msgid "Manage {0} for {1}"
-msgstr ""
+msgstr "{0} für {1} verwalten"
 
 #: packages/admin/src/components/ContentEditor.tsx:2020
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "Autorenzeilen in {entryLocale} verwalten"
 
 #: packages/admin/src/components/Widgets.tsx:326
 msgid "Manage content widgets in your widget areas"
-msgstr ""
+msgstr "Verwalte Widgets für Inhalte in deinen Widget-Bereichen"
 
 #: packages/admin/src/components/PluginManager.tsx:174
 msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
@@ -3935,15 +3935,15 @@ msgstr "Marktplatz"
 
 #: packages/admin/src/components/FieldEditor.tsx:626
 msgid "Max Items"
-msgstr ""
+msgstr "Max. Elemente"
 
 #: packages/admin/src/components/FieldEditor.tsx:470
 msgid "Max Length"
-msgstr ""
+msgstr "Max. Länge"
 
 #: packages/admin/src/components/FieldEditor.tsx:500
 msgid "Max Value"
-msgstr ""
+msgstr "Maximalwert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1992
 #: packages/admin/src/components/Sidebar.tsx:188
@@ -4067,15 +4067,15 @@ msgstr "Meta-Titel, Beschreibungen und Bilder für soziale Medien"
 
 #: packages/admin/src/components/FieldEditor.tsx:619
 msgid "Min Items"
-msgstr ""
+msgstr "Min. Elemente"
 
 #: packages/admin/src/components/FieldEditor.tsx:463
 msgid "Min Length"
-msgstr ""
+msgstr "Minimallänge"
 
 #: packages/admin/src/components/FieldEditor.tsx:493
 msgid "Min Value"
-msgstr ""
+msgstr "Minimalwert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:506
 msgid "Moderation"
@@ -4083,7 +4083,7 @@ msgstr "Moderation"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
-msgstr ""
+msgstr "Moderationsdaten"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:211
 msgid "Modified"
@@ -4107,7 +4107,7 @@ msgstr "{title} in den Papierkorb verschieben"
 
 #: packages/admin/src/components/MenuEditor.tsx:443
 msgid "Move down"
-msgstr ""
+msgstr "Nach unten verschieben"
 
 #: packages/admin/src/components/ContentEditor.tsx:947
 #: packages/admin/src/components/ContentEditor.tsx:969
@@ -4122,7 +4122,7 @@ msgstr "In den Papierkorb verschieben?"
 
 #: packages/admin/src/components/MenuEditor.tsx:434
 msgid "Move up"
-msgstr ""
+msgstr "Nach oben verschieben"
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
@@ -4130,11 +4130,11 @@ msgstr "Mehrfachauswahl"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 msgid "Multi-line plain text"
-msgstr ""
+msgstr "Mehrzeilige Texteingabe"
 
 #: packages/admin/src/components/FieldEditor.tsx:193
 msgid "Multiple choices from options"
-msgstr ""
+msgstr "Mehrfachauswahl aus Optionen"
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
@@ -4154,7 +4154,7 @@ msgstr "Name"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:556
 msgid "Name and label are required"
-msgstr "Name und Label sind erforderlich"
+msgstr "Name und Bezeichnung sind erforderlich"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:562
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
@@ -4184,7 +4184,7 @@ msgstr "NEU"
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:427
 msgid "New {0}"
-msgstr ""
+msgstr "{0} erstellen"
 
 #: packages/admin/src/components/ContentEditor.tsx:629
 msgid "New {collectionLabel}"
@@ -4201,7 +4201,7 @@ msgstr "Neuer Inhaltstyp"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:116
 msgid "New public routes"
-msgstr ""
+msgstr "Neue öffentliche Routen"
 
 #: packages/admin/src/components/Redirects.tsx:102
 #: packages/admin/src/components/Redirects.tsx:336
@@ -4218,14 +4218,14 @@ msgstr "neuer Tab"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:809
 msgid "New Taxonomy"
-msgstr ""
+msgstr "Neue Taxonomie"
 
 #: packages/admin/src/components/MenuEditor.tsx:343
 #: packages/admin/src/components/MenuEditor.tsx:346
 #: packages/admin/src/components/MenuEditor.tsx:514
 #: packages/admin/src/components/MenuEditor.tsx:517
 msgid "New window"
-msgstr "Neues Fenster"
+msgstr "Neuer Tab"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
@@ -4234,11 +4234,11 @@ msgstr "Neueste"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:390
 msgid "News"
-msgstr ""
+msgstr "News"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
 msgid "Next"
-msgstr ""
+msgstr "Nächstes"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:371
 #: packages/admin/src/components/ContentList.tsx:342
@@ -4256,7 +4256,7 @@ msgstr "Nein"
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:397
 msgid "No {0} available."
-msgstr ""
+msgstr "Keine {0} verfügbar."
 
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:279
@@ -4266,7 +4266,7 @@ msgstr "Noch keine {0} vorhanden."
 #. placeholder {0}: taxonomyDef.label.toLowerCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:828
 msgid "No {0} yet. Create one to get started."
-msgstr ""
+msgstr "Noch keine {0} vorhanden. Erstelle einen Begriff um loszulegen."
 
 #: packages/admin/src/components/Redirects.tsx:208
 msgid "No 404 errors recorded yet."
@@ -4275,7 +4275,7 @@ msgstr "Noch keine 404 Fehler aufgezeichnet."
 #: packages/admin/src/components/MediaLibrary.tsx:633
 #: packages/admin/src/components/MediaLibrary.tsx:690
 msgid "No alt text"
-msgstr ""
+msgstr "Kein Alt-Text"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
 msgid "No API tokens yet. Create one to get started."
@@ -4287,7 +4287,7 @@ msgstr "Noch keine freigegebenen Kommentare."
 
 #: packages/admin/src/components/ContentEditor.tsx:2012
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "Keine Autorenzeile in {entryLocale} verfügbar. Erstelle zuerst auf der Seite Autorenzeilen eine Variante, bevor du sie diesem Eintrag zuweist."
 
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "No bylines found"
@@ -4363,7 +4363,7 @@ msgstr "Keine Überschriften im Dokument"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:413
 msgid "No installable releases"
-msgstr ""
+msgstr "Keine installierbaren Versionen"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:159
 msgid "No invite token provided"
@@ -4372,7 +4372,7 @@ msgstr "Kein Einladungs-Token angegeben"
 #: packages/admin/src/components/PortableTextEditor.tsx:1574
 #: packages/admin/src/components/RepeaterField.tsx:160
 msgid "No items yet"
-msgstr ""
+msgstr "Noch keine Elemente"
 
 #: packages/admin/src/components/FieldEditor.tsx:630
 msgid "No limit"
@@ -4393,7 +4393,7 @@ msgstr "Für dieses Benutzerkonto wurde kein passender Passkey gefunden."
 #: packages/admin/src/components/FieldEditor.tsx:474
 #: packages/admin/src/components/FieldEditor.tsx:504
 msgid "No maximum"
-msgstr ""
+msgstr "Kein Maximum"
 
 #: packages/admin/src/components/MediaLibrary.tsx:381
 #: packages/admin/src/components/MediaPickerModal.tsx:631
@@ -4420,7 +4420,7 @@ msgstr "Noch keine Menüs"
 #: packages/admin/src/components/FieldEditor.tsx:467
 #: packages/admin/src/components/FieldEditor.tsx:497
 msgid "No minimum"
-msgstr ""
+msgstr "Kein Minimum"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
@@ -4514,12 +4514,12 @@ msgstr "Noch keine Benutzer."
 
 #: packages/admin/src/components/Widgets.tsx:434
 msgid "No widget areas yet. Create one to get started."
-msgstr ""
+msgstr "Noch keine Widget-Bereiche vorhanden. Erstelle einen um loszulegen."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:416
 #: packages/admin/src/components/TaxonomyManager.tsx:422
 msgid "None (top level)"
-msgstr ""
+msgstr "Keine"
 
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
@@ -4538,12 +4538,12 @@ msgstr "Nummerierte Liste"
 
 #: packages/admin/src/components/SeoImageField.tsx:41
 msgid "OG Image"
-msgstr ""
+msgstr "OG-Bild"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:314
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
 msgid "on a custom hostname is not treated as secure, even on loopback."
-msgstr ""
+msgstr "auf einem benutzerdefinierten Hostnamen wird nicht als sicher behandelt, auch nicht bei Loopback-Adressen."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
@@ -4612,11 +4612,11 @@ msgstr "Optionen (eine pro Zeile)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:519
 msgid "or choose from library"
-msgstr ""
+msgstr "oder wähle aus der Bibliothek"
 
 #: packages/admin/src/components/WordPressImport.tsx:1429
 msgid "Or click to browse. Accepts .xml files exported from WordPress."
-msgstr ""
+msgstr "Oder wähle per Klick eine Datei aus. Unterstützt .xml-Dateien aus einem WordPress-Export."
 
 #: packages/admin/src/components/LoginPage.tsx:261
 #: packages/admin/src/components/SetupWizard.tsx:310
@@ -4629,7 +4629,7 @@ msgstr "Oder lade eine Export-Datei hoch"
 
 #: packages/admin/src/components/WordPressImport.tsx:949
 msgid "or upload directly"
-msgstr ""
+msgstr "oder lade sie direkt hoch"
 
 #: packages/admin/src/components/MenuEditor.tsx:173
 msgid "Order saved"
@@ -4671,7 +4671,7 @@ msgstr "Absatz"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:412
 msgid "Parent"
-msgstr ""
+msgstr "Übergeordnetes Element"
 
 #: packages/admin/src/components/Redirects.tsx:483
 #: packages/admin/src/components/Redirects.tsx:489
@@ -4680,7 +4680,7 @@ msgstr "Teil einer Weiterleitungsschleife"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:322
 msgid "Pass"
-msgstr ""
+msgstr "Bestanden"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:98
 msgid "Passkey added successfully"
@@ -4733,7 +4733,7 @@ msgstr "Passkeys sind hier nicht verfügbar"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
 msgid "Passkeys require a"
-msgstr ""
+msgstr "Passkeys erfordern einen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
@@ -4793,7 +4793,7 @@ msgstr "Wähle eine beliebige Methode, um dein Administratorkonto anzulegen."
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:313
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
 msgid "Plain"
-msgstr ""
+msgstr "Einfaches"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:133
 msgid "Please ask your administrator to send a new invite."
@@ -4842,7 +4842,7 @@ msgstr "Erweiterung nicht gefunden. Möglicherweise ist die Herausgeber-ID oder 
 
 #: packages/admin/src/components/WordPressImport.tsx:1048
 msgid "plugin on your WordPress site."
-msgstr ""
+msgstr "Erweiterung für deine WordPress-Webseite."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:75
 msgid "Plugin Permissions"
@@ -4863,7 +4863,7 @@ msgstr "Erweiterung dfeinstalliert"
 
 #: packages/admin/src/lib/api/registry.ts:546
 msgid "Plugin update requires re-consent"
-msgstr ""
+msgstr "Aktualisierung der Erweiterung erfordert erneute Zustimmung"
 
 #: packages/admin/src/components/PluginManager.tsx:257
 msgid "Plugin updated"
@@ -4892,7 +4892,7 @@ msgstr "Beiträge pro Seite"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:327
 msgid "Pre-release"
-msgstr ""
+msgstr "Vorabversion"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
@@ -4923,7 +4923,7 @@ msgstr "Entwurf-Vorschau"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
 msgid "Previous"
-msgstr ""
+msgstr "Vorheriges"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:352
 #: packages/admin/src/components/ContentList.tsx:330
@@ -4932,7 +4932,7 @@ msgstr "Vorherige Seite"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:446
 msgid "Previous screenshot"
-msgstr ""
+msgstr "Vorheriges Bildschirmfoto"
 
 #: packages/admin/src/components/MenuList.tsx:166
 msgid "Primary Navigation"
@@ -4965,7 +4965,7 @@ msgstr "Publiziert"
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:327
 msgid "Published {0}"
-msgstr ""
+msgstr "Veröffentlicht am {0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
@@ -4982,7 +4982,7 @@ msgstr "Autorenzeile schnell erstellen"
 #: packages/admin/src/components/editor/ImageNode.tsx:167
 #: packages/admin/src/components/editor/ImageNode.tsx:168
 msgid "Quick edit alt text"
-msgstr ""
+msgstr "Alt-Text direkt bearbeiten"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:85
 #: packages/admin/src/components/PortableTextEditor.tsx:907
@@ -5091,7 +5091,7 @@ msgstr "Die Registrierung wurde abgebrochen oder ist abgelaufen. Bitte versuche 
 
 #: packages/admin/src/components/Sidebar.tsx:221
 msgid "Registry"
-msgstr ""
+msgstr "Verzeichnis"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:429
 msgid "Release is too new to install"
@@ -5152,7 +5152,7 @@ msgstr "Bild entfernen?"
 #: packages/admin/src/components/PortableTextEditor.tsx:1690
 #: packages/admin/src/components/RepeaterField.tsx:270
 msgid "Remove item {0}"
-msgstr ""
+msgstr "Element {0} entfernen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2487
 #: packages/admin/src/components/PortableTextEditor.tsx:2488
@@ -5169,7 +5169,7 @@ msgstr "Passkey entfernen?"
 
 #: packages/admin/src/components/FieldEditor.tsx:610
 msgid "Remove sub-field"
-msgstr ""
+msgstr Untergeordnetes Feld entfernen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
 msgid "Remove this image from the document?"
@@ -5178,7 +5178,7 @@ msgstr "Dieses Bild vom Dokument entfernen?"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
 #: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
-msgstr "Entferne..."
+msgstr "Entfernen..."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:176
 msgid "Rename"
@@ -5195,11 +5195,11 @@ msgstr "Passkey umbenennen"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
-msgstr ""
+msgstr "Wiederholbares Feld"
 
 #: packages/admin/src/components/FieldEditor.tsx:241
 msgid "Repeating group of fields"
-msgstr ""
+msgstr "Wiederholbare Gruppe von Feldern"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
@@ -5362,7 +5362,7 @@ msgstr "Rollenbezeichnung"
 #: packages/admin/src/components/MenuEditor.tsx:514
 #: packages/admin/src/components/MenuEditor.tsx:516
 msgid "Same window"
-msgstr ""
+msgstr "Aktueller Tab"
 
 #: packages/admin/src/components/ContentEditor.tsx:2222
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
@@ -5380,11 +5380,11 @@ msgstr "Speichern"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:416
 msgid "Save (Enter)"
-msgstr ""
+msgstr "Speichern (Enter)"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:236
 msgid "Save alt text"
-msgstr ""
+msgstr "Alt-Text speichern"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 #: packages/admin/src/components/users/UserDetail.tsx:311
@@ -5497,26 +5497,26 @@ msgstr "Bereiche: {0}"
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
 msgid "Screenshot {0}"
-msgstr ""
+msgstr "Bildschirmfoto {0}"
 
 #. placeholder {0}: index + 1
 #. placeholder {1}: screenshots.length
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:454
 msgid "Screenshot {0} of {1}"
-msgstr ""
+msgstr "Bildschirmfoto {0} von {1}"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:247
 msgid "Screenshot blurred due to image audit"
-msgstr ""
+msgstr "Bildschirmfoto ist aufgrund einer Bildprüfung unscharf"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:432
 msgid "Screenshot viewer"
-msgstr ""
+msgstr "Bildschirmfoto-Ansicht"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:234
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
 msgid "Screenshots"
-msgstr ""
+msgstr "Bildschirmfotos"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 msgid "Search"
@@ -5650,7 +5650,7 @@ msgstr "Abschnitte"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:308
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
 msgid "secure context"
-msgstr ""
+msgstr "sicherer Kontext"
 
 #: packages/admin/src/components/SetupWizard.tsx:561
 msgid "Secure your account"
@@ -5686,7 +5686,7 @@ msgstr "Sicherheitsüberprüfung bestanden"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:491
 msgid "Security contacts"
-msgstr ""
+msgstr "Sicherheitskontakte"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:272
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
@@ -5702,7 +5702,7 @@ msgstr "Sicherheitseinstellungen"
 #: packages/admin/src/components/FieldEditor.tsx:186
 #: packages/admin/src/components/FieldEditor.tsx:585
 msgid "Select"
-msgstr "Auswählen"
+msgstr "Einfachauswahl"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
 #: packages/admin/src/components/ContentEditor.tsx:1730
@@ -5734,7 +5734,7 @@ msgstr "Autorenzeile auswählen..."
 #. placeholder {0}: comment.authorName
 #: packages/admin/src/components/comments/CommentInbox.tsx:456
 msgid "Select comment by {0}"
-msgstr ""
+msgstr "Kommentar von {0} auswählen"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
@@ -5779,11 +5779,11 @@ msgstr "Medium auswählen"
 
 #: packages/admin/src/components/SeoImageField.tsx:70
 msgid "Select OG image"
-msgstr ""
+msgstr "OG-Bild auswählen"
 
 #: packages/admin/src/components/SeoImageField.tsx:82
 msgid "Select OG Image"
-msgstr ""
+msgstr "OG-Bild auswählen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1571
 msgid "Select which content types to import."
@@ -5806,7 +5806,7 @@ msgstr "Selbstregistrierungs-Domains"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:139
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr "Sende eine Test-E-Mail durch die gesamte Pipeline, um die E-Mail-Konfiguration zu überprüfen."
+msgstr "Teste deine Installation und den Versandprozess, indem du eine Test-E-Mail sendest."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
@@ -5839,7 +5839,7 @@ msgstr "Sende Test-E-Mail"
 #: packages/admin/src/components/users/InviteUserModal.tsx:203
 #: packages/admin/src/components/users/UserDetail.tsx:332
 msgid "Sending..."
-msgstr "Wird gesendet..."
+msgstr "Senden..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1043
 #: packages/admin/src/components/ContentTypeEditor.tsx:474
@@ -5858,7 +5858,7 @@ msgstr "SEO-Einstellungen (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:57
 msgid "SEO settings saved"
-msgstr "SEO-Einstellungen angepasst"
+msgstr "SEO-Einstellungen gespeichert"
 
 #: packages/admin/src/components/SeoPanel.tsx:154
 msgid "SEO Title"
@@ -5867,7 +5867,7 @@ msgstr "SEO-Titel"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
 msgid "Set a custom display size for this image instance."
-msgstr "Lege eine benutzerdefinierte Anzeigegröße für diese Bildinstanz fest."
+msgstr "Lege eine benutzerdefinierte Anzeigegröße für dieses Bild fest."
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:170
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:174
@@ -5884,11 +5884,11 @@ msgstr "Auf 0 setzen um Kommentare nie automatisch zu schließen."
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
-msgstr ""
+msgstr "Richte deine Webseite ein"
 
 #: packages/admin/src/components/SetupWizard.tsx:150
 msgid "Setting up..."
-msgstr ""
+msgstr "Einrichten..."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:235
 #: packages/admin/src/components/ContentTypeEditor.tsx:383
@@ -5914,7 +5914,7 @@ msgstr "Einstellungen erfolgreich gespeichert"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr "Setup fehlgeschlagen"
+msgstr "Einrichtung fehlgeschlagen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
@@ -5978,7 +5978,7 @@ msgstr "Angemeldet als {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
-msgstr ""
+msgstr "Einzelauswahl aus Optionen"
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 msgid "Single line text input"
@@ -6027,7 +6027,7 @@ msgstr "Größe:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1940
 msgid "Skip Media Import"
-msgstr ""
+msgstr "Medienimport überspringen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1965
 msgid "Skipped"
@@ -6064,7 +6064,7 @@ msgstr "Soziale Netzwerke"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:48
 msgid "Social links saved"
-msgstr ""
+msgstr "Links zu sozialen Medien gespeichert"
 
 #: packages/admin/src/components/Settings.tsx:76
 msgid "Social media profile links"
@@ -6121,7 +6121,7 @@ msgstr "Spotlight-Modus"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
-msgstr ""
+msgstr Tabellendokumente"
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
@@ -6150,7 +6150,7 @@ msgstr "Struktur"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
-msgstr ""
+msgstr "Untergeordnete Felder"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:18
 #: packages/admin/src/components/WelcomeModal.tsx:29
@@ -6163,7 +6163,7 @@ msgstr "Synchronisiert"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
-msgstr ""
+msgstr "Passkeys synchronisiert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:768
 msgid "System"
@@ -6184,68 +6184,68 @@ msgstr "Tabelle"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:162
 #: packages/admin/src/components/SetupWizard.tsx:127
 msgid "Tagline"
-msgstr ""
+msgstr "Slogan"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:202
 msgid "Tags"
-msgstr "Tags"
+msgstr "Schlagwörter"
 
 #. placeholder {0}: analysis.tags
 #: packages/admin/src/components/WordPressImport.tsx:1633
 msgid "Tags ({0})"
-msgstr ""
+msgstr "Schlagwörter ({0})"
 
 #: packages/admin/src/components/MenuEditor.tsx:340
 #: packages/admin/src/components/MenuEditor.tsx:511
 msgid "Target"
-msgstr ""
+msgstr "Ziel"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:172
 msgid "Target locale"
-msgstr ""
+msgstr "Zielsprache"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:495
 msgid "Taxonomies"
-msgstr ""
+msgstr "Taxonomien"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
 msgid "Taxonomies Manage"
-msgstr ""
+msgstr "Verwalte Taxonomien"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:896
 msgid "Taxonomy created"
-msgstr ""
+msgstr "Erstelle Taxonomien"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:783
 msgid "Taxonomy not found:"
-msgstr ""
+msgstr "Taxonomie nicht gefunden:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:159
 msgid "Taxonomy: {taxonomyName}"
-msgstr ""
+msgstr "Taxonomie: {taxonomyName}"
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr "Template:"
+msgstr "Vorlage:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:360
 #: packages/admin/src/components/TaxonomyManager.tsx:812
 msgid "Term"
-msgstr ""
+msgstr "Begriff"
 
 #. placeholder {0}: term.label
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:757
 msgid "Term \"{0}\" created in {1}."
-msgstr ""
+msgstr "Begriff \"{0}\" in {1} erstellt."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:739
 msgid "Term deleted"
-msgstr ""
+msgstr "Begriff entfernt"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "test@example.com"
-msgstr "test@example.com"
+msgstr "test@beispiel.de"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2796
 msgid "Text formatting"
@@ -6393,11 +6393,11 @@ msgstr "Diese Sektion wurde von einem anderen System importiert."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:119
 msgid "This update exposes the following routes without authentication:"
-msgstr ""
+msgstr "Dieses Update macht die folgenden Routen ohne Authentifizierung zugänglich:"
 
 #: packages/admin/src/components/Widgets.tsx:635
 msgid "This will delete the widget area and all its widgets. This action cannot be undone."
-msgstr ""
+msgstr "Dadurch werden der Widget-Bereich und alle darin enthaltenen Widgets gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
@@ -6410,7 +6410,7 @@ msgstr "Dies verschiebt das Element in den Papierkorb. Du kannst es später von 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:882
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr "Hierdurch wird \"{0}\" endgültig entfernt und aus allen Inhalten entfernt."
+msgstr "Hierdurch wird \"{0}\" endgültig und aus allen Inhalten entfernt."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
@@ -6464,7 +6464,7 @@ msgstr "zum Schließen"
 
 #: packages/admin/src/components/PluginManager.tsx:202
 msgid "to install plugins, or add them to your astro.config.mjs."
-msgstr ""
+msgstr "um Erweiterungen zu installieren. Alternativ kannst du sie zu deiner astro.config.mjs-Datei hinzufügen."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:460
 msgid "to select"
@@ -6472,12 +6472,12 @@ msgstr "zum Auswählen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2612
 msgid "Toggle header row"
-msgstr ""
+msgstr "Als Kopfzeile festlegen/aufheben"
 
 #: packages/admin/src/components/ThemeToggle.tsx:30
 #: packages/admin/src/components/ThemeToggle.tsx:41
 msgid "Toggle theme (current: {label})"
-msgstr "Theme umschalten (aktuell: {label})"
+msgstr "Design umschalten (aktuell: {label})"
 
 #. placeholder {0}: newToken.info.name
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
@@ -6664,7 +6664,7 @@ msgstr "Unbekannte Rolle"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
 msgid "Unlock aspect ratio"
-msgstr ""
+msgstr "Seitenverhältnis entsperren"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:152
 #: packages/admin/src/components/users/UserDetail.tsx:254
@@ -6694,7 +6694,7 @@ msgstr "Ungeplant"
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
 msgid "Unsupported widget element type: {0}"
-msgstr ""
+msgstr "Nicht unterstützter Widget-Elementtyp: {0}"
 
 #: packages/admin/src/components/Dashboard.tsx:249
 msgid "Untitled"
@@ -6707,7 +6707,7 @@ msgstr "Unbenannte Datei"
 #: packages/admin/src/components/Widgets.tsx:466
 #: packages/admin/src/components/Widgets.tsx:729
 msgid "Untitled Widget"
-msgstr ""
+msgstr "Unbenanntes Widget"
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
@@ -6928,7 +6928,7 @@ msgstr "Benutzer"
 #. placeholder {0}: manifest?.authMode
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
 msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
-msgstr ""
+msgstr "Der Benutzerzugriff wird von einem externen Anbieter verwaltet ({0}). Domain-Einstellungen für die Selbstregistrierung sind bei externer Authentifizierung nicht verfügbar."
 
 #: packages/admin/src/components/users/UserDetail.tsx:116
 msgid "User Details"
@@ -7004,7 +7004,7 @@ msgstr "Im Marktplatz anzeigen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:233
 msgid "View mode"
-msgstr ""
+msgstr "Ansichtsmodus"
 
 #: packages/admin/src/components/ContentList.tsx:577
 msgid "View published {title}"
@@ -7016,11 +7016,11 @@ msgstr "Website ansehen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:449
 msgid "View source"
-msgstr ""
+msgstr "Quellcode anzeigen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:681
 msgid "View the {license} license on spdx.org"
-msgstr ""
+msgstr "{license}-Lizenz auf spdx.org anzeigen"
 
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Visitors hitting these paths will see an error."
@@ -7033,7 +7033,7 @@ msgstr "Warte auf Passkey..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:333
 msgid "Warn"
-msgstr ""
+msgstr "Warnung"
 
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1105
@@ -7084,11 +7084,11 @@ msgstr "Willkommen bei EmDash!"
 
 #: packages/admin/src/components/WordPressImport.tsx:1927
 msgid "What happens when you import:"
-msgstr ""
+msgstr "Was bei einem Import passiert:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1710
 msgid "What will happen when you import"
-msgstr "Was beim Importieren passiert:"
+msgstr "Was beim Importieren passieren wird:"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
@@ -7104,40 +7104,40 @@ msgstr "Wann der Eintrag veröffentlicht wurde"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:656
 msgid "Which content types can use this taxonomy"
-msgstr ""
+msgstr "Welche Inhaltstypen können diese Taxonomie nutzen"
 
 #: packages/admin/src/components/FieldEditor.tsx:169
 msgid "Whole number"
-msgstr ""
+msgstr "Ganze Zahl"
 
 #: packages/admin/src/components/Widgets.tsx:722
 #: packages/admin/src/components/Widgets.tsx:737
 msgid "widget"
-msgstr ""
+msgstr "Widget"
 
 #: packages/admin/src/components/Widgets.tsx:170
 msgid "Widget added"
-msgstr ""
+msgstr "Widget hinzugefügt"
 
 #: packages/admin/src/components/Widgets.tsx:158
 msgid "Widget area created"
-msgstr ""
+msgstr "Widget-Bereich erstellt"
 
 #: packages/admin/src/components/Widgets.tsx:565
 msgid "Widget area deleted"
-msgstr ""
+msgstr "Widget-Bereich entfernt"
 
 #: packages/admin/src/components/Widgets.tsx:685
 msgid "Widget deleted"
-msgstr ""
+msgstr "Widget entfernt"
 
 #: packages/admin/src/components/Widgets.tsx:814
 msgid "Widget title"
-msgstr ""
+msgstr "Widget-Titel"
 
 #: packages/admin/src/components/Widgets.tsx:700
 msgid "Widget updated"
-msgstr ""
+msgstr Widget aktualisiert"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:169
 #: packages/admin/src/components/PluginManager.tsx:378
@@ -7149,11 +7149,11 @@ msgstr "Widgets"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
 msgid "Width"
-msgstr ""
+msgstr "Breite"
 
 #: packages/admin/src/components/WordPressImport.tsx:1850
 msgid "Will create"
-msgstr ""
+msgstr "Wird erstellt"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
 msgid "will no longer be able to sign up without an invite. Existing users are not affected."
@@ -7169,7 +7169,7 @@ msgstr "WordPress-Benutzername"
 
 #: packages/admin/src/components/Widgets.tsx:824
 msgid "Write widget content..."
-msgstr ""
+msgstr "Erstelle Widget-Inhalte..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1023
 msgid "WXR File"
@@ -7248,11 +7248,11 @@ msgstr "du@unternehmen.de"
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:336
 #: packages/admin/src/components/SetupWizard.tsx:201
 msgid "you@example.com"
-msgstr "du@example.com"
+msgstr "du@beispiel.de"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
-msgstr "Dein Konto wurde erfolgreich erstellt."
+msgstr "Dein Benutzerkonto wurde erfolgreich erstellt."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:318
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -633,11 +633,11 @@ msgstr ""
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:225
 msgid "Add Passkey"
-msgstr ""
+msgstr "Passkey hinzufügen"
 
 #: packages/admin/src/components/PluginManager.tsx:205
 msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
-msgstr ""
+msgstr "Füge Erweiterungen deiner astro.config.mjs hinzu um die Funktionalität von EmDash zu erweitern."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2598
 msgid "Add row after"
@@ -712,19 +712,19 @@ msgstr "Alle"
 
 #: packages/admin/src/routes/bylines.tsx:325
 msgid "All bylines"
-msgstr ""
+msgstr "Alle Autorenzeilen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:108
 msgid "All capabilities"
-msgstr ""
+msgstr "Alle Fähigkeiten"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:133
 msgid "All collections"
-msgstr ""
+msgstr "Alle Kollektionen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:63
 msgid "All comments require approval"
-msgstr ""
+msgstr "Alle Kommentare benötigen eine Freigabe"
 
 #: packages/admin/src/components/WordPressImport.tsx:2324
 msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
@@ -745,11 +745,11 @@ msgstr ""
 
 #: packages/admin/src/components/Redirects.tsx:392
 msgid "All statuses"
-msgstr ""
+msgstr "Alle Status"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "All types"
-msgstr ""
+msgstr "Alle Typen"
 
 #: packages/admin/src/components/Settings.tsx:99
 msgid "Allow users from specific domains to sign up"
@@ -757,7 +757,7 @@ msgstr "Benutzern von bestimmten Domains die Registrierung erlauben"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:497
 msgid "Allow visitors to leave comments on this collection's content"
-msgstr ""
+msgstr "Erlaube Benutzern Kommentare zu den Inhalten dieser Kollektion hinzuzufügen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
 msgid "Allowed Domains"
@@ -773,7 +773,7 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:630
 msgid "Also delete plugin storage data"
-msgstr ""
+msgstr "Auch gespeicherte Daten der Erweiterung löschen"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:202
 msgid "Alt text"
@@ -866,15 +866,15 @@ msgstr ""
 #: packages/admin/src/components/comments/CommentInbox.tsx:237
 #: packages/admin/src/components/comments/CommentInbox.tsx:489
 msgid "Approve"
-msgstr ""
+msgstr "Freigeben"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:195
 msgid "approved"
-msgstr ""
+msgstr "freigegeben"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:202
 msgid "Approved"
-msgstr ""
+msgstr "Freigegeben"
 
 #: packages/admin/src/components/FieldEditor.tsx:223
 msgid "Arbitrary JSON data"
@@ -978,7 +978,7 @@ msgstr ""
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Auto (slug change)"
-msgstr ""
+msgstr "Automatisch (Slug Änderung)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:541
 msgid "Auto-approve authenticated users"
@@ -1034,11 +1034,11 @@ msgstr "Zurück zur Anmeldung"
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:116
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:392
 msgid "Back to marketplace"
-msgstr ""
+msgstr "Zurück zum Marktplatz"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:559
 msgid "Back to plugins"
-msgstr ""
+msgstr "Zurück zu Erweiterungen"
 
 #: packages/admin/src/components/SectionEditor.tsx:73
 #: packages/admin/src/components/SectionEditor.tsx:174
@@ -1052,7 +1052,7 @@ msgstr "Zurück zu den Einstellungen"
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
 msgid "Back to Themes"
-msgstr ""
+msgstr "Zurück zu Designs"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:219
 msgid "Before send:"
@@ -1060,11 +1060,11 @@ msgstr ""
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:233
 msgid "Bing Verification"
-msgstr ""
+msgstr "Bing Verifikation"
 
 #: packages/admin/src/routes/bylines.tsx:409
 msgid "Bio"
-msgstr ""
+msgstr "Bio"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
 msgid "Block actions - drag to reorder, click for menu"
@@ -1073,7 +1073,7 @@ msgstr ""
 #: packages/admin/src/components/PortableTextEditor.tsx:2499
 #: packages/admin/src/components/PortableTextEditor.tsx:2805
 msgid "Bold"
-msgstr ""
+msgstr "Fett"
 
 #: packages/admin/src/components/FieldEditor.tsx:174
 #: packages/admin/src/components/FieldEditor.tsx:583
@@ -1082,20 +1082,20 @@ msgstr ""
 
 #: packages/admin/src/components/SeoPanel.tsx:169
 msgid "Brief summary shown below the title in search results"
-msgstr ""
+msgstr "Kurze Zusammenfassung die unter dem Titel in den Suchergebnissen gezeigt wird"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:71
 msgid "Browse and install plugins published to the decentralized registry."
-msgstr ""
+msgstr "Durchsuche und installiere Erweiterungen die im dezentralen Verzeichnis veröffentlicht wurden."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:88
 msgid "Browse and install plugins to extend your site."
-msgstr ""
+msgstr "Durchsuche und installiere Erweiterungen um deine Webseite zu erweitern."
 
 #: packages/admin/src/components/WordPressImport.tsx:966
 #: packages/admin/src/components/WordPressImport.tsx:1433
 msgid "Browse Files"
-msgstr ""
+msgstr "Dateien durchsuchen"
 
 #: packages/admin/src/components/PluginManager.tsx:198
 msgid "Browse the"
@@ -1103,7 +1103,7 @@ msgstr ""
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
 msgid "Browse themes and preview them with your own content."
-msgstr ""
+msgstr "Durchsuche Designs und erhalte eine Vorschau mit deinen eigenen Inhalten."
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:101
 #: packages/admin/src/components/PortableTextEditor.tsx:887
@@ -1176,7 +1176,7 @@ msgstr "Abbrechen"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:405
 msgid "Cancel (Esc)"
-msgstr ""
+msgstr "Abbrechen (Esc)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:146
 msgid "Cancel rename"
@@ -1196,7 +1196,7 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:469
 msgid "Capabilities"
-msgstr ""
+msgstr "Fähigkeiten"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:65
 msgid "Capability consent"
@@ -1260,7 +1260,7 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:161
 msgid "Check for updates"
-msgstr ""
+msgstr "Nach Aktualisierungen suchen"
 
 #: packages/admin/src/components/WordPressImport.tsx:937
 msgid "Check Site"
@@ -1278,11 +1278,11 @@ msgstr ""
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:155
 msgid "Checking authentication..."
-msgstr ""
+msgstr "Überprüfe Authentifizierung..."
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
-msgstr ""
+msgstr "Wähle wie du dich anmeldest"
 
 #: packages/admin/src/components/Settings.tsx:130
 msgid "Choose your preferred admin language"
@@ -1290,11 +1290,11 @@ msgstr "Wähle deine bevorzugte Admin-Sprache"
 
 #: packages/admin/src/components/users/UserList.tsx:129
 msgid "Clear filters"
-msgstr ""
+msgstr "Filter zurücksetzen"
 
 #: packages/admin/src/components/SignupPage.tsx:138
 msgid "Click the link in the email to continue setting up your account."
-msgstr ""
+msgstr "Klicke auf den Link in der E-Mail, um die Einrichtung deines Kontos fortzusetzen."
 
 #: packages/admin/src/components/LoginPage.tsx:112
 msgid "Click the link in the email to sign in."
@@ -1360,7 +1360,7 @@ msgstr "Schließen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:520
 msgid "Close comments after (days)"
-msgstr ""
+msgstr "Kommentare schließen nach (Tage)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:121
 msgid "Close panel"
@@ -1370,7 +1370,7 @@ msgstr ""
 #: packages/admin/src/components/PortableTextEditor.tsx:2527
 #: packages/admin/src/components/Redirects.tsx:443
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:93
 #: packages/admin/src/components/PortableTextEditor.tsx:917
@@ -1380,11 +1380,11 @@ msgstr "Code-Block"
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "Collapse"
-msgstr ""
+msgstr "Einklappen"
 
 #: packages/admin/src/components/PluginManager.tsx:450
 msgid "Collapse details"
-msgstr ""
+msgstr "Details einklappen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:158
 msgid "colleague@example.com"
@@ -1392,32 +1392,32 @@ msgstr "max.mustermann@example.com"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:156
 msgid "Collection"
-msgstr ""
+msgstr "Kollektion"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:106
 msgid "Collection:"
-msgstr ""
+msgstr "Kollektion:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:654
 msgid "Collections"
-msgstr ""
+msgstr "Kollektionen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2133
 msgid "Collections created:"
-msgstr ""
+msgstr "Erstellte Kollektionen:"
 
 #: packages/admin/src/components/SectionEditor.tsx:273
 msgid "Comma-separated keywords for search."
-msgstr ""
+msgstr "Durch Kommas getrennte Suchbegriffe."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:95
 #: packages/admin/src/components/comments/CommentInbox.tsx:290
 msgid "Comment"
-msgstr ""
+msgstr "Kommentar"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:58
 msgid "Comment Detail"
-msgstr ""
+msgstr "Kommentardetails"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:146
 #: packages/admin/src/components/ContentTypeEditor.tsx:487
@@ -1427,7 +1427,7 @@ msgstr "Kommentare"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:544
 msgid "Comments from logged-in CMS users are approved automatically"
-msgstr ""
+msgstr "Kommentare von angemeldeten CMS-Nutzern werden automatisch freigegeben"
 
 #: packages/admin/src/components/SignupPage.tsx:401
 msgid "Complete signup"
@@ -1439,7 +1439,7 @@ msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Configure Field"
-msgstr ""
+msgstr "Feld konfigurieren"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
 msgid "Confirm"
@@ -1447,25 +1447,25 @@ msgstr "Bestätigen"
 
 #: packages/admin/src/components/WordPressImport.tsx:627
 msgid "Connect"
-msgstr ""
+msgstr "Verbinden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1346
 msgid "Connect & Analyze"
-msgstr ""
+msgstr "Verbinden & Analysieren"
 
 #. placeholder {0}: siteTitle || "WordPress"
 #: packages/admin/src/components/WordPressImport.tsx:1296
 msgid "Connect to {0}"
-msgstr ""
+msgstr "Zu {0} verbinden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1212
 msgid "Connect with WordPress"
-msgstr ""
+msgstr "Mit WordPress verbinden"
 
 #. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
 #: packages/admin/src/components/users/UserDetail.tsx:286
 msgid "Connected {0}"
-msgstr ""
+msgstr "{0} verbunden"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:365
 #: packages/admin/src/components/comments/CommentDetail.tsx:103
@@ -1489,23 +1489,23 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1156
 msgid "Content found:"
-msgstr ""
+msgstr "Inhalt gefunden:"
 
 #: packages/admin/src/router.tsx:830
 msgid "Content has been scheduled for publishing"
-msgstr ""
+msgstr "Die Veröffentlichung des Inhalts wurde geplant"
 
 #: packages/admin/src/components/RevisionHistory.tsx:131
 msgid "Content has been updated to the selected revision."
-msgstr ""
+msgstr "Der Inhalt wurde auf die ausgewählte Revision aktualisiert."
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:110
 msgid "Content ID:"
-msgstr ""
+msgstr "Inhalts ID"
 
 #: packages/admin/src/router.tsx:778
 msgid "Content is now live"
-msgstr ""
+msgstr "Inhalt ist jetzt online"
 
 #: packages/admin/src/components/WordPressImport.tsx:2177
 msgid "content items"
@@ -1517,11 +1517,11 @@ msgstr "Inhalte lesen"
 
 #: packages/admin/src/router.tsx:794
 msgid "Content removed from public view"
-msgstr ""
+msgstr "Inhalt aus öffentliche Ansicht entfernt"
 
 #: packages/admin/src/router.tsx:848
 msgid "Content reverted to draft"
-msgstr ""
+msgstr "Inhalt zu Entwurf zurückgesetzt"
 
 #: packages/admin/src/components/RevisionHistory.tsx:296
 msgid "Content snapshot:"
@@ -1529,7 +1529,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1570
 msgid "Content to Import"
-msgstr ""
+msgstr "Zu importierender Inhalt"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:185
 #: packages/admin/src/components/ContentTypeList.tsx:40
@@ -1539,7 +1539,7 @@ msgstr "Inhaltstypen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2116
 msgid "Content was skipped because it already exists"
-msgstr ""
+msgstr "Inhalt wurde übersprungen, da er bereits vorhanden ist"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
 msgid "Content Write"
@@ -1556,7 +1556,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:2335
 msgid "Continue Import"
-msgstr ""
+msgstr "Import fortsetzen"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:24
 #: packages/admin/src/components/WelcomeModal.tsx:28
@@ -1571,15 +1571,15 @@ msgstr "In die Zwischenablage kopiert"
 #. placeholder {0}: section.slug
 #: packages/admin/src/components/Sections.tsx:399
 msgid "Copy {0} to clipboard"
-msgstr ""
+msgstr "{0} in die Zwischenablage kopieren"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:124
 msgid "Copy invite link"
-msgstr ""
+msgstr "Einladungslink kopieren"
 
 #: packages/admin/src/components/Sections.tsx:398
 msgid "Copy slug"
-msgstr ""
+msgstr "Slug kopieren"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
 msgid "Copy this token now — it won't be shown again."
@@ -1592,27 +1592,27 @@ msgstr "Token kopieren"
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:322
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:323
 msgid "Copy URL"
-msgstr ""
+msgstr "URL kopieren"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:138
 msgid "Could not copy automatically. Please select the URL above and copy manually."
-msgstr ""
+msgstr "Das Kopieren ist nicht automatisch möglich. Bitte markiere die obige URL und kopiere sie manuell."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:426
 msgid "Could not load image from URL"
-msgstr ""
+msgstr "Konnte das Bild von der URL nicht laden"
 
 #: packages/admin/src/components/WordPressImport.tsx:1103
 msgid "Couldn't detect WordPress"
-msgstr ""
+msgstr "WordPress wurde nicht erkannt"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
-msgstr ""
+msgstr "\"{draft}\" konnte keinem MIME-Typ zugeordnet werden. Gib den MIME-Typ direkt ein."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:820
 msgid "Count"
-msgstr ""
+msgstr "Anzahl"
 
 #: packages/admin/src/components/ContentEditor.tsx:2172
 #: packages/admin/src/components/MenuList.tsx:175
@@ -1626,7 +1626,7 @@ msgstr "Erstellen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:263
 msgid "Create \"{trimmedInput}\""
-msgstr ""
+msgstr "\"{trimmedInput}\" erstellen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:888
 msgid "Create a bullet list"
@@ -1644,11 +1644,11 @@ msgstr "Eine nummerierte Liste erstellen"
 #: packages/admin/src/components/InviteAcceptPage.tsx:81
 #: packages/admin/src/components/SignupPage.tsx:220
 msgid "Create Account"
-msgstr ""
+msgstr "Benutzerkonto erstellen"
 
 #: packages/admin/src/components/SignupPage.tsx:399
 msgid "Create an account"
-msgstr ""
+msgstr "Erstelle ein Benutzerkonto"
 
 #: packages/admin/src/components/ContentEditor.tsx:2120
 #: packages/admin/src/routes/bylines.tsx:389
@@ -1657,16 +1657,16 @@ msgstr "Autorenzeile erstellen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 msgid "Create Content Type"
-msgstr ""
+msgstr "Inhaltstyp erstellen"
 
 #: packages/admin/src/components/MenuList.tsx:126
 #: packages/admin/src/components/MenuList.tsx:189
 msgid "Create Menu"
-msgstr ""
+msgstr "Menü erstellen"
 
 #: packages/admin/src/components/MenuList.tsx:133
 msgid "Create New Menu"
-msgstr ""
+msgstr "Neues Menü erstellen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
 msgid "Create New Token"
@@ -1678,7 +1678,7 @@ msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:298
 msgid "Create Passkey"
-msgstr ""
+msgstr "Passkey erstellen"
 
 #: packages/admin/src/components/Settings.tsx:110
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
@@ -1688,15 +1688,15 @@ msgstr "Persönliche Zugangstokens für programmatischen API-Zugriff erstellen"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:238
 msgid "Create redirect for {0}"
-msgstr ""
+msgstr "Weiterleitung für {0} erstellen"
 
 #: packages/admin/src/components/Redirects.tsx:237
 msgid "Create redirect for this path"
-msgstr ""
+msgstr "Weiterleitung für diesen Pfad erstellen"
 
 #: packages/admin/src/components/Redirects.tsx:435
 msgid "Create redirect rules to manage URL changes."
-msgstr ""
+msgstr "Weiterleitungs-Regeln erstellen um URL-Änderungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1757
 msgid "Create Schema & Import"
@@ -1705,11 +1705,11 @@ msgstr ""
 #: packages/admin/src/components/Sections.tsx:150
 #: packages/admin/src/components/Sections.tsx:270
 msgid "Create Section"
-msgstr ""
+msgstr "Sektion erstellen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:109
 msgid "Create sections in the Sections library to use them here"
-msgstr ""
+msgstr "Erstelle Sektionen in der Sektionenbibliothek um sie hier zu nutzen"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:596
 #: packages/admin/src/components/TaxonomyManager.tsx:687
@@ -1727,11 +1727,11 @@ msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:560
 msgid "Create your account"
-msgstr ""
+msgstr "Erstelle dein Benutzerkonto"
 
 #: packages/admin/src/components/MenuList.tsx:187
 msgid "Create your first navigation menu to get started"
-msgstr ""
+msgstr "Erstelle dein erstes Navigationsmenü um zu beginnen"
 
 #: packages/admin/src/components/ContentList.tsx:286
 #: packages/admin/src/components/ContentTypeList.tsx:122
@@ -1740,21 +1740,21 @@ msgstr "Erstelle dein erstes Element"
 
 #: packages/admin/src/components/Sections.tsx:267
 msgid "Create your first reusable content section to get started."
-msgstr ""
+msgstr "Erstelle deine erste benutzerdefinierte Inhaltssektion um zu beginnen"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:72
 #: packages/admin/src/components/SignupPage.tsx:211
 msgid "Create your passkey"
-msgstr ""
+msgstr "Erstelle deinen Passkey"
 
 #: packages/admin/src/lib/api/marketplace.ts:223
 #: packages/admin/src/lib/api/marketplace.ts:231
 msgid "Create, update, and delete content"
-msgstr ""
+msgstr "Erstelle, aktualisiere und entferne Inhalte"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Create, update, and delete navigation menus"
-msgstr ""
+msgstr "Erstelle, aktualisiere und entferne Navigationsmenüs"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
@@ -1762,7 +1762,7 @@ msgstr ""
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
-msgstr "Inhalte erstellen, aktualisieren und löschen"
+msgstr "Erstelle, aktualisiere und entferne Inhalte"
 
 #: packages/admin/src/components/users/UserDetail.tsx:219
 msgid "Created"
@@ -1778,7 +1778,7 @@ msgstr "Erstellt am {0}"
 #. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
 #: packages/admin/src/router.tsx:878
 msgid "Created {0} translation"
-msgstr ""
+msgstr "Übersetzung {0} erstellt"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:123
 msgid "Created At"
@@ -1791,7 +1791,7 @@ msgstr "Erstellt: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:812
 msgid "Creating collections and fields..."
-msgstr ""
+msgstr "Erstelle Kollektionen und Felder..."
 
 #: packages/admin/src/components/ContentEditor.tsx:2172
 #: packages/admin/src/components/MenuList.tsx:175
@@ -1809,23 +1809,23 @@ msgstr "aktuell"
 
 #: packages/admin/src/components/RevisionHistory.tsx:264
 msgid "Current"
-msgstr ""
+msgstr "Aktuell"
 
 #: packages/admin/src/components/Sections.tsx:46
 msgid "Custom"
-msgstr ""
+msgstr "Benutzerdefiniert"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:614
 msgid "Custom Fields"
-msgstr ""
+msgstr "Benutzerdefinierte Felder"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:243
 msgid "Custom robots.txt content. Leave empty to use the default."
-msgstr ""
+msgstr "Benutzerdefinierte robots.txt-Datei. Leer lassen um den Standard zu nutzen."
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Custom Section"
-msgstr ""
+msgstr "Benutzerdefinierte Sektion"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "dark"
@@ -1851,23 +1851,23 @@ msgstr "Datum"
 #: packages/admin/src/components/FieldEditor.tsx:180
 #: packages/admin/src/components/FieldEditor.tsx:584
 msgid "Date & Time"
-msgstr ""
+msgstr "Datum & Zeit"
 
 #: packages/admin/src/components/FieldEditor.tsx:181
 msgid "Date and time picker"
-msgstr ""
+msgstr "Datums- und Uhrzeitauswahl"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:304
 msgid "Date Format"
-msgstr ""
+msgstr "Datumsformat"
 
 #: packages/admin/src/components/FieldEditor.tsx:163
 msgid "Decimal number"
-msgstr ""
+msgstr "Dezimalzahl"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:523
 msgid "Declared permissions"
-msgstr ""
+msgstr "Deklarierte Berechtigungen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
@@ -1880,11 +1880,11 @@ msgstr "Standard Rolle:"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:180
 msgid "Default social image"
-msgstr ""
+msgstr "Standardbild für soziale Medien"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:171
 msgid "Default Social Image"
-msgstr ""
+msgstr "Standardbild für soziale Medien"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:599
 msgid "Define a new taxonomy for classifying content"
@@ -1892,11 +1892,11 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeList.tsx:41
 msgid "Define the structure of your content"
-msgstr ""
+msgstr "Definiere die Struktur deiner Inhalte"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:361
 msgid "Defined in code"
-msgstr ""
+msgstr "Definiert mittels Code"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:267
 #: packages/admin/src/components/comments/CommentInbox.tsx:407
@@ -1916,12 +1916,12 @@ msgstr ""
 #: packages/admin/src/routes/bylines.tsx:465
 #: packages/admin/src/routes/bylines.tsx:501
 msgid "Delete"
-msgstr ""
+msgstr "Entfernen"
 
 #. placeholder {0}: item.filename
 #: packages/admin/src/components/MediaDetailPanel.tsx:254
 msgid "Delete \"{0}\"? This cannot be undone."
-msgstr ""
+msgstr "\"{0}\" entfernen? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: collection.label
 #. placeholder {0}: domain.domain
@@ -1937,7 +1937,7 @@ msgstr ""
 #. placeholder {0}: field.label
 #: packages/admin/src/components/ContentTypeEditor.tsx:740
 msgid "Delete {0} field"
-msgstr ""
+msgstr "Feld {0} entfernen"
 
 #. placeholder {0}: menu.name
 #: packages/admin/src/components/MenuList.tsx:237
@@ -1956,19 +1956,19 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:499
 msgid "Delete Byline?"
-msgstr ""
+msgstr "Autorenzeile entfernen?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2582
 msgid "Delete column"
-msgstr ""
+msgstr "Spalte entfernen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:405
 msgid "Delete Comment?"
-msgstr ""
+msgstr "Kommentar entfernen?"
 
 #: packages/admin/src/components/ContentTypeList.tsx:142
 msgid "Delete Content Type?"
-msgstr ""
+msgstr "Inhaltstyp entfernen?"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:379
 msgid "Delete embed"
@@ -1976,58 +1976,58 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:657
 msgid "Delete Field?"
-msgstr ""
+msgstr "Feld entfernen?"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:191
 #: packages/admin/src/components/editor/ImageNode.tsx:192
 msgid "Delete image"
-msgstr ""
+msgstr "Bild entfernen"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:253
 msgid "Delete Media?"
-msgstr ""
+msgstr "Medium entfernen?"
 
 #: packages/admin/src/components/MenuList.tsx:253
 msgid "Delete Menu"
-msgstr ""
+msgstr "Menü entfernen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:525
 msgid "Delete permanently"
-msgstr ""
+msgstr "Endgültig entfernen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:182
 #: packages/admin/src/components/ContentList.tsx:701
 msgid "Delete Permanently"
-msgstr "Endgültig löschen"
+msgstr "Endgültig entfernen"
 
 #: packages/admin/src/components/ContentList.tsx:681
 msgid "Delete Permanently?"
-msgstr "Endgültig löschen?"
+msgstr "Endgültig entfernen?"
 
 #: packages/admin/src/components/Redirects.tsx:509
 msgid "Delete redirect"
-msgstr ""
+msgstr "Weiterleitung entfernen"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:510
 msgid "Delete redirect {0}"
-msgstr ""
+msgstr "Weiterleitung {0} entfernen"
 
 #: packages/admin/src/components/Redirects.tsx:550
 msgid "Delete Redirect?"
-msgstr ""
+msgstr "Weiterleitung entfernen?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2603
 msgid "Delete row"
-msgstr ""
+msgstr "Zeile entfernen"
 
 #: packages/admin/src/components/Sections.tsx:296
 msgid "Delete Section?"
-msgstr ""
+msgstr "Sektion entfernen?"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2618
 msgid "Delete table"
-msgstr ""
+msgstr "Tabelle entfernen"
 
 #: packages/admin/src/components/Widgets.tsx:634
 msgid "Delete Widget Area?"
@@ -2035,7 +2035,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentList.tsx:370
 msgid "Deleted"
-msgstr "Gelöscht"
+msgstr "Entfernt"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
 #: packages/admin/src/components/ContentTypeEditor.tsx:664
@@ -2049,24 +2049,24 @@ msgstr "Gelöscht"
 #: packages/admin/src/components/Widgets.tsx:637
 #: packages/admin/src/routes/bylines.tsx:502
 msgid "Deleting..."
-msgstr ""
+msgstr "Entfernen..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
 msgid "Demo"
-msgstr ""
+msgstr "Demo"
 
 #: packages/admin/src/routes/users.tsx:303
 msgid "Demote User"
-msgstr ""
+msgstr "Benutzer herabstufen"
 
 #: packages/admin/src/routes/users.tsx:294
 msgid "Demote User?"
-msgstr ""
+msgstr "Benutzer herabstufen?"
 
 #: packages/admin/src/routes/users.tsx:304
 msgid "Demoting..."
-msgstr ""
+msgstr "Herabstufen..."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:270
 msgid "Deny"
@@ -2074,52 +2074,52 @@ msgstr ""
 
 #: packages/admin/src/components/editor/ImageNode.tsx:209
 msgid "Describe the image..."
-msgstr ""
+msgstr "Beschreibe das Bild..."
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
 #: packages/admin/src/components/MediaDetailPanel.tsx:205
 msgid "Describe this image for accessibility"
-msgstr ""
+msgstr "Beschreibe dieses Bild für die Barrierefreiheit"
 
 #: packages/admin/src/components/SectionEditor.tsx:262
 msgid "Describe what this section is for..."
-msgstr ""
+msgstr "Beschreibe wofür diese Sektion genutzt wird..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:415
 #: packages/admin/src/components/SectionEditor.tsx:259
 #: packages/admin/src/components/Sections.tsx:200
 #: packages/admin/src/components/Widgets.tsx:373
 msgid "Description"
-msgstr ""
+msgstr "Beschreibung"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:432
 msgid "Description (optional)"
-msgstr ""
+msgstr "Beschreibung (optional)"
 
 #: packages/admin/src/components/Redirects.tsx:442
 msgid "Destination"
-msgstr ""
+msgstr "Ziel"
 
 #: packages/admin/src/components/Redirects.tsx:136
 msgid "Destination path"
-msgstr ""
+msgstr "Zielpfad"
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "details"
-msgstr ""
+msgstr "Details"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:186
 msgid "Device authorized"
-msgstr ""
+msgstr "Gerät autorisiert"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:229
 msgid "Device code"
-msgstr ""
+msgstr "Geräte-Code"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Device-bound"
-msgstr "Gerät gebunden"
+msgstr "Geräte-gebunden"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Device-bound passkey"
@@ -2127,11 +2127,11 @@ msgstr "An Gerät gebundener Passkey"
 
 #: packages/admin/src/components/SignupPage.tsx:143
 msgid "Didn't receive the email?"
-msgstr ""
+msgstr "E-Mail nicht erhalten?"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:176
 msgid "Dimensions:"
-msgstr ""
+msgstr "Abmessungen:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Disable"
@@ -2139,39 +2139,39 @@ msgstr "Deaktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:444
 msgid "Disable plugin"
-msgstr ""
+msgstr "Erweiterung deaktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:478
 msgid "Disable redirect"
-msgstr ""
+msgstr "Weiterleitung deaktivieren"
 
 #: packages/admin/src/routes/users.tsx:279
 msgid "Disable User"
-msgstr ""
+msgstr "Nutzer deaktivieren"
 
 #: packages/admin/src/routes/users.tsx:272
 msgid "Disable User?"
-msgstr ""
+msgstr "Nutzer deaktivieren?"
 
 #: packages/admin/src/components/PluginManager.tsx:353
 #: packages/admin/src/components/Redirects.tsx:392
 #: packages/admin/src/components/users/UserDetail.tsx:201
 #: packages/admin/src/components/users/UserList.tsx:212
 msgid "Disabled"
-msgstr ""
+msgstr "Deaktiviert"
 
 #: packages/admin/src/components/PluginManager.tsx:527
 msgid "Disabled:"
-msgstr ""
+msgstr "Deaktiviert:"
 
 #. placeholder {0}: selectedUser?.name || selectedUser?.email
 #: packages/admin/src/routes/users.tsx:274
 msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
-msgstr ""
+msgstr "Den Nutzer <0>{0}</0> zu deaktivieren verhindert, dass er sich anmelden kann, bis er wieder aktiviert wird. Die von diesem Nutzer erstellten Inhalte bleiben bestehen."
 
 #: packages/admin/src/routes/users.tsx:280
 msgid "Disabling..."
-msgstr ""
+msgstr "Deaktivieren..."
 
 #: packages/admin/src/components/ContentEditor.tsx:690
 #: packages/admin/src/components/ContentEditor.tsx:712
@@ -2180,7 +2180,7 @@ msgstr "Änderungen verwerfen"
 
 #: packages/admin/src/components/ContentEditor.tsx:696
 msgid "Discard draft changes?"
-msgstr "Änderungen am Entwurf verwerfen?"
+msgstr "Vorläufige Änderungen verwerfen?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
@@ -2199,7 +2199,7 @@ msgstr "Anzeigename"
 
 #: packages/admin/src/components/MenuList.tsx:167
 msgid "Display name for admin interface"
-msgstr ""
+msgstr "Anzeigename für den Adminbereich"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
@@ -2209,7 +2209,7 @@ msgstr ""
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
 msgid "Displayed below the image as a visible caption."
-msgstr ""
+msgstr "Wird unterhalb des Bildes als sichtbare Bildunterschrift angezeigt."
 
 #: packages/admin/src/components/ContentEditor.tsx:666
 msgid "Distraction-free mode (⌘⇧\\)"
@@ -2221,7 +2221,7 @@ msgstr "Trennlinie"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 msgid "Documents"
-msgstr ""
+msgstr "Dokumente"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
 msgid "Domain"
@@ -2246,7 +2246,7 @@ msgstr "Noch kein Konto? <0>Registrieren</0>"
 #: packages/admin/src/components/users/InviteUserModal.tsx:144
 #: packages/admin/src/components/WordPressImport.tsx:1964
 msgid "Done"
-msgstr ""
+msgstr "Erledigt"
 
 #: packages/admin/src/components/ContentEditor.tsx:2066
 msgid "Down"
@@ -2254,7 +2254,7 @@ msgstr "Runter"
 
 #: packages/admin/src/components/WordPressImport.tsx:1962
 msgid "Downloading"
-msgstr ""
+msgstr "Herunterladen"
 
 #: packages/admin/src/components/ContentList.tsx:727
 msgid "draft"
@@ -2276,26 +2276,26 @@ msgstr "Entwürfe"
 
 #: packages/admin/src/components/WordPressImport.tsx:961
 msgid "Drag and drop or click to browse (.xml)"
-msgstr ""
+msgstr "Durchsuchen mittels Drag & Drop oder per Klick (.xml)"
 
 #: packages/admin/src/components/Widgets.tsx:620
 msgid "Drag here to add"
-msgstr ""
+msgstr "Hierher ziehen, um hinzuzufügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1665
 msgid "Drag to reorder"
-msgstr ""
+msgstr "Ziehen zum Neuanordnen"
 
 #. placeholder {0}: field.label
 #. placeholder {0}: widget.title ?? t`widget`
 #: packages/admin/src/components/ContentTypeEditor.tsx:707
 #: packages/admin/src/components/Widgets.tsx:722
 msgid "Drag to reorder {0}"
-msgstr ""
+msgstr "Ziehen um {0} neu anzuordnen"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:335
 msgid "Drag to reorder block"
-msgstr ""
+msgstr "Ziehen um Block neu anzuordnen"
 
 #: packages/admin/src/components/Widgets.tsx:624
 msgid "Drag widgets here to add them"
@@ -2311,11 +2311,11 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1427
 msgid "Drop your WordPress export file here"
-msgstr ""
+msgstr "Lade deine WordPress-Exportdatei hier hoch"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:289
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplizieren"
 
 #: packages/admin/src/components/ContentList.tsx:592
 msgid "Duplicate {title}"
@@ -2323,19 +2323,19 @@ msgstr "{title} duplizieren"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:161
 msgid "e.g. application/zip or .pdf"
-msgstr ""
+msgstr "z.B. application/zip oder .pdf"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "e.g. import, blog"
-msgstr ""
+msgstr "z.B. importiert, blog"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
 msgid "e.g., CI/CD Pipeline"
-msgstr "z. B. CI/CD-Pipeline"
+msgstr "z. B., CI/CD-Pipeline"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
 msgid "e.g., MacBook Pro, iPhone"
-msgstr ""
+msgstr "z.B., MacBook Pro, iPhone"
 
 #: packages/admin/src/components/ContentEditor.tsx:2075
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
@@ -2383,37 +2383,37 @@ msgstr "Domain anpassen"
 
 #: packages/admin/src/components/FieldEditor.tsx:342
 msgid "Edit Field"
-msgstr ""
+msgstr "Feld bearbeiten"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2535
 msgid "Edit link"
-msgstr ""
+msgstr "Link bearbeiten"
 
 #: packages/admin/src/components/MenuEditor.tsx:478
 msgid "Edit Menu Item"
-msgstr ""
+msgstr "Menüeintrag bearbeiten"
 
 #: packages/admin/src/components/MenuEditor.tsx:282
 msgid "Edit menu items"
-msgstr ""
+msgstr "Menüeintrag bearbeiten"
 
 #: packages/admin/src/components/Redirects.tsx:501
 msgid "Edit redirect"
-msgstr ""
+msgstr "Weiterleitung bearbeiten"
 
 #: packages/admin/src/components/Redirects.tsx:102
 msgid "Edit Redirect"
-msgstr ""
+msgstr "Weiterleitung bearbeiten"
 
 #. placeholder {0}: r.source
 #: packages/admin/src/components/Redirects.tsx:502
 msgid "Edit redirect {0}"
-msgstr ""
+msgstr "Weiterleitung {0} bearbeiten"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:367
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:368
 msgid "Edit URL"
-msgstr ""
+msgstr "URL bearbeiten"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:36
 #: packages/admin/src/components/WelcomeModal.tsx:26
@@ -2429,7 +2429,7 @@ msgstr "E-Mail"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:332
 msgid "Email (optional)"
-msgstr ""
+msgstr "E-Mail (optional)"
 
 #: packages/admin/src/components/LoginPage.tsx:126
 #: packages/admin/src/components/SignupPage.tsx:66
@@ -2440,24 +2440,24 @@ msgstr "E-Mail-Adresse"
 #: packages/admin/src/components/SetupWizard.tsx:179
 #: packages/admin/src/components/SignupPage.tsx:49
 msgid "Email is required"
-msgstr ""
+msgstr "E-Mail-Adresse ist erforderlich"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:215
 msgid "Email Middleware"
-msgstr ""
+msgstr "E-Mail-Middleware"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:125
 msgid "Email Pipeline"
-msgstr ""
+msgstr "E-Mail-Pipeline"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:199
 msgid "Email provider active"
-msgstr ""
+msgstr "E-Mail-Anbieter aktiv"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:85
 #: packages/admin/src/components/settings/EmailSettings.tsx:100
 msgid "Email Settings"
-msgstr ""
+msgstr "E-Mail Einstellungen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:235
 msgid "Email verified"
@@ -2478,19 +2478,19 @@ msgstr "Einbettungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1047
 msgid "EmDash Exporter"
-msgstr ""
+msgstr "EmDash-Exporter"
 
 #: packages/admin/src/components/WordPressImport.tsx:1146
 msgid "EmDash Exporter plugin detected! You can import directly."
-msgstr ""
+msgstr "EmDash-Exporter-Erweiterung erkannt! Du kannst direkt importieren."
 
 #: packages/admin/src/components/users/UserDetail.tsx:319
 msgid "Enable"
-msgstr ""
+msgstr "Aktivieren"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:495
 msgid "Enable comments"
-msgstr ""
+msgstr "Kommentare aktivieren"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:87
 msgid "Enable full-text search on this collection"
@@ -2498,16 +2498,16 @@ msgstr "Volltextsuche für diese Sammlung aktivieren"
 
 #: packages/admin/src/components/PluginManager.tsx:444
 msgid "Enable plugin"
-msgstr ""
+msgstr "Erweiterung aktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:478
 msgid "Enable redirect"
-msgstr ""
+msgstr "Weiterleitungen aktivieren"
 
 #: packages/admin/src/components/Redirects.tsx:168
 #: packages/admin/src/components/Redirects.tsx:392
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiviert"
 
 #. placeholder {0}: label.toLowerCase()
 #: packages/admin/src/components/ContentEditor.tsx:1226
@@ -2517,15 +2517,15 @@ msgstr "{0} eingeben..."
 #: packages/admin/src/components/MenuEditor.tsx:336
 #: packages/admin/src/components/MenuEditor.tsx:506
 msgid "Enter a URL (https://…) or a relative path (/…)"
-msgstr ""
+msgstr "Gib eine URL (https://…) oder einen relativen Pfad (/…) ein"
 
 #: packages/admin/src/components/ContentEditor.tsx:1474
 msgid "Enter a valid URL (e.g. https://example.com)"
-msgstr ""
+msgstr "Gib eine gültige URL ein (z. B. https://example.com)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1219
 msgid "Enter credentials manually"
-msgstr ""
+msgstr "Anmeldedaten manuell eingeben"
 
 #: packages/admin/src/components/ContentEditor.tsx:665
 msgid "Enter distraction-free mode"
@@ -2533,7 +2533,7 @@ msgstr "Ablenkungsfreien Modus aktivieren"
 
 #: packages/admin/src/components/users/UserDetail.tsx:158
 msgid "Enter email"
-msgstr ""
+msgstr "E-Mail-Adresse eingeben"
 
 #: packages/admin/src/components/ContentEditor.tsx:1248
 msgid "Enter markdown content..."
@@ -2541,28 +2541,28 @@ msgstr "Markdown-Inhalt eingeben..."
 
 #: packages/admin/src/components/users/UserDetail.tsx:151
 msgid "Enter name"
-msgstr ""
+msgstr "Name eingeben"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:177
 msgid "Enter the code from your terminal"
-msgstr ""
+msgstr "Gib den Code ein, der in deinem Terminal angezeigt wird"
 
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:123
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:132
 msgid "Enter URL..."
-msgstr ""
+msgstr "URL eingeben..."
 
 #: packages/admin/src/components/LoginPage.tsx:325
 msgid "Enter your handle to sign in."
-msgstr ""
+msgstr "Gib deinen Benutzernamen ein, um dich anzumelden."
 
 #: packages/admin/src/components/WordPressImport.tsx:1298
 msgid "Enter your WordPress credentials to import content directly."
-msgstr ""
+msgstr "Gib deine WordPress-Anmeldedaten ein, um Inhalte direkt zu importieren."
 
 #: packages/admin/src/components/WordPressImport.tsx:924
 msgid "Enter your WordPress site URL"
-msgstr ""
+msgstr "Gib die URL deiner WordPress-Webseite ein"
 
 #: packages/admin/src/components/MenuEditor.tsx:101
 #: packages/admin/src/components/MenuEditor.tsx:139
@@ -2571,7 +2571,7 @@ msgstr ""
 #: packages/admin/src/components/Widgets.tsx:689
 #: packages/admin/src/router.tsx:1826
 msgid "Error"
-msgstr ""
+msgstr "Fehler"
 
 #: packages/admin/src/components/Widgets.tsx:174
 msgid "Error adding widget"
@@ -2583,7 +2583,7 @@ msgstr ""
 
 #: packages/admin/src/components/SectionEditor.tsx:52
 msgid "Error saving section"
-msgstr ""
+msgstr "Fehler beim Speichern der Sektion"
 
 #: packages/admin/src/components/Widgets.tsx:704
 msgid "Error updating widget"
@@ -2595,7 +2595,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1846
 msgid "Exists"
-msgstr ""
+msgstr "Existiert"
 
 #: packages/admin/src/components/ContentEditor.tsx:623
 msgid "Exit distraction-free mode"
@@ -2607,11 +2607,11 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:456
 msgid "Expand"
-msgstr ""
+msgstr "Anzeigen"
 
 #: packages/admin/src/components/PluginManager.tsx:450
 msgid "Expand details"
-msgstr ""
+msgstr "Details anzeigen"
 
 #. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
@@ -2624,15 +2624,15 @@ msgstr "Ablauf"
 
 #: packages/admin/src/components/WordPressImport.tsx:1112
 msgid "Export from WordPress manually"
-msgstr ""
+msgstr "Manueller Export von WordPress"
 
 #: packages/admin/src/components/WordPressImport.tsx:1236
 msgid "Export your content from WordPress to import everything including drafts."
-msgstr ""
+msgstr "Exportiere deine Inhalte aus WordPress, um alles einschließlich der Entwürfe zu importieren."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:144
 msgid "Facebook"
-msgstr ""
+msgstr "Facebook"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:343
 msgid "Fail"
@@ -2640,35 +2640,35 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1966
 msgid "Failed"
-msgstr ""
+msgstr "Fehlgeschlagen"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:189
 msgid "Failed security audit"
-msgstr ""
+msgstr "Sicherheitsüberprüfung nicht bestanden"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
 msgid "Failed to add domain"
-msgstr ""
+msgstr "Hinzufügen der Domain fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:367
 msgid "Failed to analyze WordPress site"
-msgstr ""
+msgstr "Analyse der WordPress-Webseite fehlgeschlagen"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:54
 msgid "Failed to communicate with plugin"
-msgstr ""
+msgstr "Kommunikation mit Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
-msgstr ""
+msgstr "Erstellung des Administrators fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2166
 msgid "Failed to create byline"
-msgstr "Autorenzeile konnte nicht erstellt werden"
+msgstr "Erstellung der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
-msgstr ""
+msgstr "Erstellen einiger Kollektionen fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:456
 msgid "Failed to create term"
@@ -2676,38 +2676,38 @@ msgstr ""
 
 #: packages/admin/src/router.tsx:883
 msgid "Failed to create translation"
-msgstr ""
+msgstr "Erstellen der Übersetzung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:340
 #: packages/admin/src/router.tsx:369
 #: packages/admin/src/router.tsx:903
 msgid "Failed to delete"
-msgstr ""
+msgstr "Entfernen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:345
 msgid "Failed to delete allowed domain"
-msgstr ""
+msgstr "Entfernen der erlaubten Domain fehlgeschlagen"
 
 #: packages/admin/src/lib/api/bylines.ts:117
 msgid "Failed to delete byline"
-msgstr ""
+msgstr "Entfernen der Autorenzeile fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:222
 msgid "Failed to delete collection"
-msgstr ""
+msgstr "Entfernen der Kollektion fehlgeschlagen"
 
 #: packages/admin/src/lib/api/comments.ts:111
 #: packages/admin/src/router.tsx:1146
 msgid "Failed to delete comment"
-msgstr ""
+msgstr "Entfernen des Kommentars fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:217
 msgid "Failed to delete content"
-msgstr ""
+msgstr "Entfernen des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:278
 msgid "Failed to delete field"
-msgstr ""
+msgstr "Entfernen des Felds fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:338
 msgid "Failed to delete from provider"
@@ -2715,27 +2715,27 @@ msgstr ""
 
 #: packages/admin/src/lib/api/media.ts:215
 msgid "Failed to delete media"
-msgstr ""
+msgstr "Entfernen des Mediums fehlgeschlagen"
 
 #: packages/admin/src/lib/api/menus.ts:163
 msgid "Failed to delete menu"
-msgstr ""
+msgstr "Entfernen des Menüs fehlgeschlagen"
 
 #: packages/admin/src/lib/api/menus.ts:217
 msgid "Failed to delete menu item"
-msgstr ""
+msgstr "Entfernen des Menüeintrags fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:256
 msgid "Failed to delete passkey"
-msgstr ""
+msgstr "Entfernen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/lib/api/redirects.ts:111
 msgid "Failed to delete redirect"
-msgstr ""
+msgstr "Entfernen der Weiterleitung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/sections.ts:110
 msgid "Failed to delete section"
-msgstr ""
+msgstr "Entfernen der Sektion fehlgeschlagen"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
@@ -2751,40 +2751,40 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:115
 msgid "Failed to disable plugin"
-msgstr ""
+msgstr "Deaktivierung der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
-msgstr ""
+msgstr "Deaktivieren des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:817
 msgid "Failed to discard changes"
-msgstr ""
+msgstr "Verwerfen der Änderungen fehlgeschlagen"
 
 #: packages/admin/src/components/WelcomeModal.tsx:70
 msgid "Failed to dismiss welcome"
-msgstr ""
+msgstr "Ausblenden der Willkommensnachricht fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:383
 msgid "Failed to duplicate"
-msgstr ""
+msgstr "Klonen fehlgeschlagen"
 
 #: packages/admin/src/components/PluginManager.tsx:96
 msgid "Failed to enable plugin"
-msgstr ""
+msgstr "Aktivierung der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
-msgstr ""
+msgstr "Aktivierung des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:295
 msgid "Failed to execute import"
-msgstr ""
+msgstr "Ausführung des Imports fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
 msgid "Failed to fetch collection"
-msgstr ""
+msgstr "Abruf der Kollektion fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:81
 msgid "Failed to fetch entry terms"
@@ -2792,21 +2792,21 @@ msgstr ""
 
 #: packages/admin/src/lib/api/client.ts:208
 msgid "Failed to fetch manifest"
-msgstr ""
+msgstr "Abruf des Manifests fehlgeschlagen"
 
 #: packages/admin/src/lib/api/plugins.ts:59
 #: packages/admin/src/lib/api/plugins.ts:63
 msgid "Failed to fetch plugin"
-msgstr ""
+msgstr "Abruf der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:462
 #: packages/admin/src/lib/api/content.ts:467
 msgid "Failed to fetch revision"
-msgstr ""
+msgstr "Abruf der Revision fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
-msgstr ""
+msgstr "Abruf des Setup-Status fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:65
 msgid "Failed to fetch terms"
@@ -2817,92 +2817,92 @@ msgstr ""
 #: packages/admin/src/router.tsx:667
 #: packages/admin/src/router.tsx:1077
 msgid "Failed to fetch user"
-msgstr ""
+msgstr "Abruf des Benutzers fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
 msgid "Failed to generate preview"
-msgstr ""
+msgstr "Generierung der Vorschau fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
 msgid "Failed to generate preview URL"
-msgstr ""
+msgstr "Generierung der Vorschau-URL fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:176
 msgid "Failed to get authentication options"
-msgstr ""
+msgstr "Abruf der Authentifizierungsoptionen fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
 msgid "Failed to get registration options"
-msgstr ""
+msgstr "Abruf der Registrierungsoptionen fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:386
 msgid "Failed to import from WordPress"
-msgstr ""
+msgstr "Import von WordPress fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:319
 #: packages/admin/src/lib/api/import.ts:256
 msgid "Failed to import media"
-msgstr ""
+msgstr "Import von Medien fehlgeschlagen"
 
 #: packages/admin/src/lib/api/marketplace.ts:160
 #: packages/admin/src/lib/api/registry.ts:455
 msgid "Failed to install plugin"
-msgstr ""
+msgstr "Installation der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:246
 msgid "Failed to load admin"
-msgstr ""
+msgstr "Laden des Adminbereichs fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
 msgid "Failed to load allowed domains"
-msgstr ""
+msgstr "Laden erlaubter Domains fehlgeschlagen"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/routes/bylines.tsx:287
 msgid "Failed to load bylines: {0}"
-msgstr ""
+msgstr "Laden der Autorenzeilen fehlgeschlagen: {0}"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:89
 msgid "Failed to load email settings"
-msgstr ""
+msgstr "Laden der E-Mail-Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:409
 msgid "Failed to load image"
-msgstr ""
+msgstr "Laden des Bildes fehlgeschlagen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:144
 msgid "Failed to load passkeys"
-msgstr ""
+msgstr "Laden der Passkeys fehlgeschlagen"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:111
 msgid "Failed to load plugin"
-msgstr ""
+msgstr "Laden der Erweiterung fehlgeschlagen"
 
 #. placeholder {0}: error.message
 #: packages/admin/src/components/PluginManager.tsx:144
 msgid "Failed to load plugins: {0}"
-msgstr ""
+msgstr "Laden der Erweiterungen fehlgeschlagen: {0}"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:95
 msgid "Failed to load plugins. The registry aggregator may be unreachable."
-msgstr ""
+msgstr "Laden der Erweiterungen fehlgeschlagen. Der Verzeichnisaggregator ist möglicherweise nicht erreichbar."
 
 #: packages/admin/src/components/RevisionHistory.tsx:180
 msgid "Failed to load revisions"
-msgstr ""
+msgstr "Laden der Revisionen fehlgeschlagen"
 
 #: packages/admin/src/components/SetupWizard.tsx:541
 msgid "Failed to load setup"
-msgstr ""
+msgstr "Laden des Setup fehlgeschlagen"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
 msgid "Failed to load theme"
-msgstr ""
+msgstr "Laden des Designs fehlgeschlagen"
 
 #. placeholder {0}: usersQuery.error.message
 #: packages/admin/src/routes/users.tsx:205
 msgid "Failed to load users: {0}"
-msgstr ""
+msgstr "Laden der Benutzer fehlgeschlagen: {0}"
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:46
 msgid "Failed to load widget"
@@ -2910,36 +2910,36 @@ msgstr ""
 
 #: packages/admin/src/router.tsx:1171
 msgid "Failed to perform bulk action"
-msgstr ""
+msgstr "Ausführen der Massenoperation fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:260
 msgid "Failed to permanently delete content"
-msgstr ""
+msgstr "Entgültiges Löschen des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:276
 msgid "Failed to prepare import"
-msgstr ""
+msgstr "Vorbereiten des Imports fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:782
 msgid "Failed to publish"
-msgstr ""
+msgstr "Veröffentlichen fehlgeschlagen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
 msgid "Failed to remove domain"
-msgstr ""
+msgstr "Entfernen der Domain fehlgeschlagen"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:99
 #: packages/admin/src/components/settings/SecuritySettings.tsx:82
 msgid "Failed to remove passkey"
-msgstr ""
+msgstr "Entfernen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:66
 msgid "Failed to rename passkey"
-msgstr ""
+msgstr "Umbenennen des Passkeys fehlgeschlagen"
 
 #: packages/admin/src/lib/api/schema.ts:293
 msgid "Failed to reorder fields"
-msgstr ""
+msgstr "Neuanordnung der Felder fehlgeschlagen"
 
 #: packages/admin/src/lib/api/widgets.ts:158
 msgid "Failed to reorder widgets"
@@ -2947,39 +2947,39 @@ msgstr ""
 
 #: packages/admin/src/router.tsx:355
 msgid "Failed to restore"
-msgstr ""
+msgstr "Wiederherstellen fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:249
 msgid "Failed to restore content"
-msgstr ""
+msgstr "Wiederherstellung des Inhalts fehlgeschlagen"
 
 #: packages/admin/src/lib/api/content.ts:484
 #: packages/admin/src/lib/api/content.ts:489
 msgid "Failed to restore revision"
-msgstr ""
+msgstr "Wiederherstellen der Revision fehlgeschlagen"
 
 #: packages/admin/src/lib/api/api-tokens.ts:98
 msgid "Failed to revoke API token"
-msgstr ""
+msgstr "Widerrufen des API-Tokens fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:332
 msgid "Failed to rewrite URLs"
-msgstr ""
+msgstr "Umschreiben der URLs fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:735
 #: packages/admin/src/router.tsx:1644
 msgid "Failed to save"
-msgstr ""
+msgstr "Speichern fehlgeschlagen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:58
 #: packages/admin/src/components/settings/SeoSettings.tsx:62
 #: packages/admin/src/components/settings/SocialSettings.tsx:53
 msgid "Failed to save settings"
-msgstr ""
+msgstr "Speichern der Einstellungen fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:835
 msgid "Failed to schedule"
-msgstr ""
+msgstr "Planen fehlgeschlagen"
 
 #: packages/admin/src/components/LoginPage.tsx:70
 #: packages/admin/src/components/LoginPage.tsx:75
@@ -2988,15 +2988,15 @@ msgstr "Magic Link konnte nicht gesendet werden"
 
 #: packages/admin/src/lib/api/users.ts:128
 msgid "Failed to send recovery link"
-msgstr ""
+msgstr "Senden des Wiederherstellungs-Links fehlgeschlagen"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:61
 msgid "Failed to send test email"
-msgstr ""
+msgstr "Senden der Test-E-Mail fehlgeschlagen"
 
 #: packages/admin/src/components/SignupPage.tsx:349
 msgid "Failed to send verification email"
-msgstr ""
+msgstr "Senden der Bestätigungs-E-Mail fehlgeschlagen"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:100
 msgid "Failed to set entry terms"
@@ -3005,15 +3005,15 @@ msgstr ""
 #: packages/admin/src/lib/api/marketplace.ts:192
 #: packages/admin/src/lib/api/registry.ts:594
 msgid "Failed to uninstall plugin"
-msgstr ""
+msgstr "Deinstallieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:798
 msgid "Failed to unpublish"
-msgstr ""
+msgstr "Depublizieren fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:853
 msgid "Failed to unschedule"
-msgstr ""
+msgstr "Aufheben der Planung fehlgeschlagen"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:320
@@ -3026,87 +3026,87 @@ msgstr "Autorenzeile konnte nicht aktualisiert werden"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
 msgid "Failed to update domain"
-msgstr ""
+msgstr "Aktualisieren der Domain fehlgeschlagen"
 
 #: packages/admin/src/lib/api/marketplace.ts:176
 #: packages/admin/src/lib/api/registry.ts:526
 msgid "Failed to update plugin"
-msgstr ""
+msgstr "Aktualisieren der Erweiterung fehlgeschlagen"
 
 #: packages/admin/src/router.tsx:1130
 msgid "Failed to update status"
-msgstr ""
+msgstr "Aktualisieren des Status fehlgeschlagen"
 
 #: packages/admin/src/lib/api/media.ts:132
 msgid "Failed to upload file"
-msgstr ""
+msgstr "Hochladen der Datei fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:250
 msgid "Failed to verify authentication"
-msgstr ""
+msgstr "Verifizieren der Anmeldung fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
 msgid "Failed to verify registration"
-msgstr ""
+msgstr "Verifizierung der Registrierung fehlgeschlagen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:236
 #: packages/admin/src/components/settings/GeneralSettings.tsx:242
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 #: packages/admin/src/components/WordPressImport.tsx:1022
 msgid "Feature"
-msgstr ""
+msgstr "Fähigkeit"
 
 #: packages/admin/src/components/ContentTypeList.tsx:103
 msgid "Features"
-msgstr ""
+msgstr "Fähigkeiten"
 
 #: packages/admin/src/components/WordPressImport.tsx:736
 msgid "Fetching content from the EmDash Exporter API."
-msgstr ""
+msgstr "Abrufen von Inhalten über die EmDash-Exporter-API."
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
-msgstr ""
+msgstr "Feld-Label"
 
 #: packages/admin/src/components/FieldEditor.tsx:414
 msgid "Field Label"
-msgstr ""
+msgstr "Feld-Label"
 
 #: packages/admin/src/components/FieldEditor.tsx:426
 msgid "Field slugs cannot be changed after creation"
-msgstr ""
+msgstr "Feldnamen können nach der Erstellung nicht mehr geändert werden"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:572
 msgid "Fields"
-msgstr ""
+msgstr "Felder"
 
 #: packages/admin/src/components/WordPressImport.tsx:2139
 msgid "Fields created:"
-msgstr ""
+msgstr "Felder erstellt:"
 
 #: packages/admin/src/components/FieldEditor.tsx:210
 msgid "File"
-msgstr ""
+msgstr "Datei"
 
 #. placeholder {0}: progress.current
 #: packages/admin/src/components/WordPressImport.tsx:1994
 msgid "File {0}"
-msgstr ""
+msgstr "Datei {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:211
 msgid "File from media library"
-msgstr ""
+msgstr "Datei aus Medienbibliothek"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:192
 #: packages/admin/src/components/MediaLibrary.tsx:428
 msgid "Filename"
-msgstr ""
+msgstr "Dateiname"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:196
 msgid "Filename cannot be changed after upload"
-msgstr ""
+msgstr "Dateiname kann nach Hochladen nicht mehr geändert werden"
 
 #: packages/admin/src/components/WordPressImport.tsx:2172
 msgid "files imported"
@@ -3114,43 +3114,43 @@ msgstr ""
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
-msgstr ""
+msgstr "Nach Fähigkeit filtern"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:177
 msgid "Filter by collection"
-msgstr ""
+msgstr "Nach Kollektion filtern"
 
 #: packages/admin/src/components/users/UserList.tsx:82
 msgid "Filter by role"
-msgstr ""
+msgstr "Nach Rolle filtern"
 
 #: packages/admin/src/components/Sections.tsx:245
 msgid "Filter by source"
-msgstr ""
+msgstr "Nach Quelle filtern"
 
 #: packages/admin/src/components/Redirects.tsx:393
 msgid "Filter by status"
-msgstr ""
+msgstr "Nach Status filtern"
 
 #: packages/admin/src/components/Redirects.tsx:399
 msgid "Filter by type"
-msgstr ""
+msgstr "Nach Typ filtern"
 
 #: packages/admin/src/routes/bylines.tsx:321
 msgid "Filter byline type"
-msgstr ""
+msgstr "Autorenzeilen-Typ filtern"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:64
 msgid "First-time commenters only"
-msgstr ""
+msgstr "Nur Erstkommentatoren"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:69
 msgid "Fonts"
-msgstr ""
+msgstr "Schriftarten"
 
 #: packages/admin/src/components/WordPressImport.tsx:1237
 msgid "For a complete import including drafts and all content, export from WordPress."
-msgstr ""
+msgstr "Führe einen Export von WordPress durch, um alle Inhalte einschließlich Entwürfe vollständig zu importieren."
 
 #: packages/admin/src/components/WordPressImport.tsx:1046
 msgid "For the best import experience, install the"
@@ -3171,11 +3171,11 @@ msgstr "Allgemein"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:101
 #: packages/admin/src/components/settings/GeneralSettings.tsx:129
 msgid "General Settings"
-msgstr ""
+msgstr "Allgemeine Einstellungen"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:624
 msgid "Genres"
-msgstr ""
+msgstr "Genres"
 
 #: packages/admin/src/components/WelcomeModal.tsx:143
 msgid "Get Started"
@@ -3183,20 +3183,20 @@ msgstr "Los geht's"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:138
 msgid "GitHub"
-msgstr ""
+msgstr "GitHub"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
 msgid "Give this passkey a name to help you identify it later."
-msgstr ""
+msgstr "Gib diesem Passkey einen Namen um ihn später leichter wiederzuerkennen."
 
 #: packages/admin/src/components/WordPressImport.tsx:2224
 #: packages/admin/src/router.tsx:1846
 msgid "Go to Dashboard"
-msgstr ""
+msgstr "Zum Dashboard"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:227
 msgid "Google Verification"
-msgstr ""
+msgstr "Google Verifizierung"
 
 #: packages/admin/src/components/MediaLibrary.tsx:238
 msgid "Grid view"
@@ -3204,15 +3204,15 @@ msgstr ""
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "Group (optional)"
-msgstr ""
+msgstr "Gruppe (optional)"
 
 #: packages/admin/src/routes/bylines.tsx:432
 msgid "Guest byline"
-msgstr ""
+msgstr "Gast Autorenzeile"
 
 #: packages/admin/src/routes/bylines.tsx:326
 msgid "Guest only"
-msgstr ""
+msgstr "Nur Gäste"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:61
 #: packages/admin/src/components/PortableTextEditor.tsx:857
@@ -3235,7 +3235,7 @@ msgstr "Überschrift 3"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
 msgid "Height"
-msgstr ""
+msgstr "Höhe"
 
 #: packages/admin/src/components/Sections.tsx:180
 msgid "Hero Banner"
@@ -3247,7 +3247,7 @@ msgstr ""
 
 #: packages/admin/src/components/SeoPanel.tsx:191
 msgid "Hide from search engines"
-msgstr ""
+msgstr "Vor Suchmaschinen verstecken"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Hide token"
@@ -3255,12 +3255,12 @@ msgstr "Token ausblenden"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:647
 msgid "Hierarchical (like categories, with parent/child relationships)"
-msgstr ""
+msgstr "Hierarchisch (wie Kategorien, mit Über-/Unterordnungsbeziehungen)"
 
 #: packages/admin/src/components/Redirects.tsx:216
 #: packages/admin/src/components/Redirects.tsx:444
 msgid "Hits"
-msgstr ""
+msgstr "Aufrufe"
 
 #: packages/admin/src/components/MenuEditor.tsx:329
 msgid "Home"
@@ -3280,16 +3280,16 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:337
 msgid "https://example.com or /about"
-msgstr ""
+msgstr "https://example.com oder /ueber"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:495
 msgid "https://example.com/image.jpg"
-msgstr ""
+msgstr "https://example.com/bild.jpg"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:241
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:143
 msgid "Icon blurred due to image audit"
-msgstr ""
+msgstr "Symbol ist aufgrund einer Bildprüfung unscharf"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:105
 msgid "ID"
@@ -3297,7 +3297,7 @@ msgstr "ID"
 
 #: packages/admin/src/components/LoginPage.tsx:103
 msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
-msgstr "Wenn es ein Konto für <0>{email}</0> gibt, haben wir dir einen Anmeldelink geschickt."
+msgstr "Wenn es ein Konto für <0>{email}</0> gibt, haben wir einen Anmeldelink gesendet."
 
 #: packages/admin/src/components/FieldEditor.tsx:204
 #: packages/admin/src/components/PortableTextEditor.tsx:1988
@@ -3306,30 +3306,30 @@ msgstr "Bild"
 
 #: packages/admin/src/components/FieldEditor.tsx:205
 msgid "Image from media library"
-msgstr ""
+msgstr "Bild aus Medienbibliothek"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
 #: packages/admin/src/components/ContentEditor.tsx:1656
 msgid "Image not found"
-msgstr ""
+msgstr "Bild nicht gefunden"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:179
 #: packages/admin/src/components/editor/ImageNode.tsx:180
 msgid "Image settings"
-msgstr ""
+msgstr "Bildeinstellungen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
 msgid "Image Settings"
-msgstr ""
+msgstr "Bildeinstellungen"
 
 #: packages/admin/src/components/SeoImageField.tsx:75
 msgid "Image shown when this page is shared on social media"
-msgstr ""
+msgstr "Bild, das angezeigt wird, wenn diese Seite in sozialen Medien geteilt wird"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:496
 msgid "Image URL"
-msgstr ""
+msgstr "Bild-URL"
 
 #: packages/admin/src/components/WordPressImport.tsx:2176
 msgid "image URLs updated in"
@@ -3337,7 +3337,7 @@ msgstr ""
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:61
 msgid "Images"
-msgstr ""
+msgstr "Bilder"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:227
 #: packages/admin/src/components/Sidebar.tsx:244
@@ -3352,90 +3352,90 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1205
 msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
-msgstr ""
+msgstr "Importiere alle Inhalte direkt, einschließlich Entwürfe, benutzerdefinierte Beitragstypen, ACF-Felder und SEO-Daten. Es ist kein Dateidownload erforderlich."
 
 #: packages/admin/src/components/WordPressImport.tsx:2222
 msgid "Import Another File"
-msgstr ""
+msgstr "Weitere Datei importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:1016
 msgid "Import Capabilities"
-msgstr ""
+msgstr "Fähigkeiten importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:2110
 msgid "Import Complete"
-msgstr ""
+msgstr "Import abgeschlossen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2111
 msgid "Import Completed with Errors"
-msgstr ""
+msgstr "Import mit Fehlern angeschlossen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Import failed"
-msgstr ""
+msgstr "Import fehlgeschlagen"
 
 #: packages/admin/src/components/WordPressImport.tsx:617
 msgid "Import from WordPress"
-msgstr ""
+msgstr "Von WordPress importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:1943
 msgid "Import Media"
-msgstr ""
+msgstr "Medien importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:1896
 msgid "Import Media Files"
-msgstr ""
+msgstr "Mediendateien importieren"
 
 #: packages/admin/src/components/WordPressImport.tsx:619
 msgid "Import posts, pages, and custom post types from WordPress."
-msgstr ""
+msgstr "Importiere Beiträge, Seiten und benutzerdefinierte Inhaltstypen von WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1650
 msgid "Import site configuration from WordPress."
-msgstr ""
+msgstr "Importiere Seitenkonfiguration von WordPress."
 
 #: packages/admin/src/components/WordPressImport.tsx:1203
 msgid "Import via EmDash Exporter"
-msgstr ""
+msgstr "Importiere mittels EmDash-Exporter"
 
 #: packages/admin/src/components/Sections.tsx:47
 msgid "Imported"
-msgstr ""
+msgstr "Importiert"
 
 #: packages/admin/src/components/WordPressImport.tsx:2150
 msgid "Imported by Collection"
-msgstr ""
+msgstr "Nach Kollektion importiert"
 
 #: packages/admin/src/components/WordPressImport.tsx:820
 msgid "Importing content..."
-msgstr ""
+msgstr "Importiere Inhalte..."
 
 #: packages/admin/src/components/WordPressImport.tsx:1975
 msgid "Importing Media"
-msgstr ""
+msgstr "Importiere Medien"
 
 #: packages/admin/src/components/SetupWizard.tsx:138
 msgid "Include sample content (recommended for new sites)"
-msgstr ""
+msgstr "Beispielinhalte einfügen (empfohlen für neue Webseiten)"
 
 #: packages/admin/src/components/WordPressImport.tsx:1816
 msgid "Incompatible"
-msgstr ""
+msgstr "Inkompatibel"
 
 #. placeholder {0}: formatDate(release.indexedAt)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:325
 msgid "indexed {0}"
-msgstr ""
+msgstr "indexiert {0}"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2833
 msgid "Inline Code"
-msgstr ""
+msgstr "Inline-Code"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:507
 #: packages/admin/src/components/MediaPickerModal.tsx:732
 #: packages/admin/src/components/PortableTextEditor.tsx:1270
 msgid "Insert"
-msgstr ""
+msgstr "Einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:908
 msgid "Insert a blockquote"
@@ -3455,7 +3455,7 @@ msgstr "Einen wiederverwendbaren Abschnitt einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:938
 msgid "Insert a table"
-msgstr ""
+msgstr "Eine Tabelle einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1989
 msgid "Insert an image"
@@ -3463,93 +3463,93 @@ msgstr "Ein Bild einfügen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:489
 msgid "Insert from URL"
-msgstr ""
+msgstr "Von URL einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3003
 msgid "Insert Horizontal Rule"
-msgstr ""
+msgstr "Horizontale Linie einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2998
 msgid "Insert Image"
-msgstr ""
+msgstr "Bild einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2945
 msgid "Insert Link"
-msgstr ""
+msgstr "Link einfügen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:57
 msgid "Insert Section"
-msgstr ""
+msgstr "Sektion einfügen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2903
 msgid "Insert Table"
-msgstr ""
+msgstr "Tabelle einfügen"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:150
 msgid "Instagram"
-msgstr ""
+msgstr "Instagram"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:193
 #: packages/admin/src/components/RegistryPluginDetail.tsx:373
 msgid "Install"
-msgstr ""
+msgstr "Installieren"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:181
 msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
-msgstr ""
+msgstr "Installiere und aktiviere eine E-Mail-Anbieter-Erweiterung, um E-Mail-Funktionen wie Einladungen, Magic Links und die Passwortwiederherstellung zu nutzen."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:187
 msgid "Install blocked"
-msgstr ""
+msgstr "Installation blockiert"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:261
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:174
 #: packages/admin/src/components/RegistryBrowse.tsx:198
 #: packages/admin/src/components/RegistryPluginDetail.tsx:365
 msgid "Installed"
-msgstr ""
+msgstr "Installiert"
 
 #. placeholder {0}: plugin.marketplaceVersion || plugin.version
 #: packages/admin/src/components/PluginManager.tsx:496
 msgid "Installed from marketplace (v{0})"
-msgstr ""
+msgstr "Installiert von Marktplatz (v{0})"
 
 #: packages/admin/src/components/PluginManager.tsx:515
 msgid "Installed:"
-msgstr ""
+msgstr "Installiert:"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:167
 msgid "Installing..."
-msgstr ""
+msgstr "Installieren..."
 
 #: packages/admin/src/components/FieldEditor.tsx:168
 #: packages/admin/src/components/FieldEditor.tsx:582
 msgid "Integer"
-msgstr ""
+msgstr "Zahl"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:119
 msgid "Invalid invite link"
-msgstr ""
+msgstr "Ungültiger Einladungslink"
 
 #: packages/admin/src/components/ContentEditor.tsx:1543
 msgid "Invalid JSON"
-msgstr ""
+msgstr "Ungültiges JSON"
 
 #: packages/admin/src/components/SignupPage.tsx:259
 msgid "Invalid link"
-msgstr ""
+msgstr "Ungültiger Link"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:207
 msgid "Invite Error"
-msgstr ""
+msgstr "Einladungsfehler"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:117
 msgid "Invite expired"
-msgstr ""
+msgstr "Einladung abgelaufen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 msgid "Invite Link Created"
-msgstr ""
+msgstr "Einladungs-Link erstellt"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:79
 #: packages/admin/src/components/users/UserList.tsx:56
@@ -3558,7 +3558,7 @@ msgstr "Nutzer einladen"
 
 #: packages/admin/src/components/users/UserList.tsx:140
 msgid "Invite your first team member"
-msgstr ""
+msgstr "Lade deinen erstes Teammitglied ein"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2506
 #: packages/admin/src/components/PortableTextEditor.tsx:2812
@@ -3586,17 +3586,17 @@ msgstr ""
 #: packages/admin/src/components/SetupWizard.tsx:213
 #: packages/admin/src/components/SignupPage.tsx:205
 msgid "Jane Doe"
-msgstr ""
+msgstr "Max Mustermann"
 
 #: packages/admin/src/components/FieldEditor.tsx:222
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:294
 #: packages/admin/src/components/SectionEditor.tsx:268
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
 msgid "Keywords"
-msgstr ""
+msgstr "Stichwörter"
 
 #: packages/admin/src/components/FieldEditor.tsx:411
 #: packages/admin/src/components/FieldEditor.tsx:553
@@ -3606,15 +3606,15 @@ msgstr ""
 #: packages/admin/src/components/TaxonomyManager.tsx:621
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:394
 msgid "Label (Plural)"
-msgstr ""
+msgstr "Label (Plural)"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:386
 msgid "Label (Singular)"
-msgstr ""
+msgstr "Label (Singular)"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:125
 #: packages/admin/src/components/LoginPage.tsx:345
@@ -3629,7 +3629,7 @@ msgstr "Große Abschnittsüberschrift"
 
 #: packages/admin/src/components/PluginManager.tsx:521
 msgid "Last enabled:"
-msgstr ""
+msgstr "Zuletzt aktiviert:"
 
 #: packages/admin/src/components/users/UserDetail.tsx:227
 msgid "Last login"
@@ -3641,7 +3641,7 @@ msgstr "Letzte Anmeldung"
 
 #: packages/admin/src/components/Redirects.tsx:217
 msgid "Last seen"
-msgstr ""
+msgstr "Zuletzt aufgerufen"
 
 #: packages/admin/src/components/users/UserDetail.tsx:223
 msgid "Last updated"
@@ -3649,7 +3649,7 @@ msgstr "Zuletzt aktualisiert"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:161
 msgid "Last used"
-msgstr "Zuletzt "
+msgstr "Zuletzt genutzt"
 
 #. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
@@ -3660,21 +3660,21 @@ msgstr "Zuletzt verwendet am {0}"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:341
 msgid "Leave blank to use a discoverable passkey."
-msgstr ""
+msgstr "Lass das Feld leer, um einen auswählbaren Passkey zu verwenden."
 
 #: packages/admin/src/components/WordPressImport.tsx:2303
 msgid "Leave unassigned"
-msgstr ""
+msgstr "Nicht zugewiesen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:88
 #: packages/admin/src/components/MediaLibrary.tsx:208
 #: packages/admin/src/components/MediaLibrary.tsx:320
 msgid "Library"
-msgstr ""
+msgstr "Bibliothek"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
 msgid "License"
-msgstr ""
+msgstr "Lizenz"
 
 #: packages/admin/src/components/ThemeToggle.tsx:22
 msgid "light"
@@ -3686,7 +3686,7 @@ msgstr "Hell"
 
 #: packages/admin/src/components/SignupPage.tsx:257
 msgid "Link expired"
-msgstr ""
+msgstr "Link abgelaufen"
 
 #: packages/admin/src/components/FieldEditor.tsx:217
 msgid "Link to another content item"
@@ -3695,23 +3695,23 @@ msgstr ""
 #. placeholder {0}: user.oauthAccounts.length
 #: packages/admin/src/components/users/UserDetail.tsx:276
 msgid "Linked Accounts ({0})"
-msgstr ""
+msgstr "Verbundene Konten ({0})"
 
 #: packages/admin/src/routes/bylines.tsx:327
 msgid "Linked only"
-msgstr ""
+msgstr "Nur Zugeordnete"
 
 #: packages/admin/src/routes/bylines.tsx:415
 msgid "Linked user"
-msgstr ""
+msgstr "Zugeordneter Nutzer"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:156
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
 msgid "Links"
-msgstr ""
+msgstr "Links"
 
 #: packages/admin/src/components/MediaLibrary.tsx:247
 msgid "List view"
@@ -3727,7 +3727,7 @@ msgstr "Live-Vorschau"
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
 #: packages/admin/src/routes/bylines.tsx:381
 msgid "Load more"
-msgstr ""
+msgstr "Mehr laden"
 
 #: packages/admin/src/components/ContentList.tsx:354
 #: packages/admin/src/components/ContentList.tsx:411
@@ -3739,54 +3739,54 @@ msgstr "Mehr laden"
 
 #: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
-msgstr ""
+msgstr "Lade Kollektionen..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:307
 msgid "Loading comments..."
-msgstr ""
+msgstr "Lade Kommentare..."
 
 #: packages/admin/src/router.tsx:1815
 msgid "Loading configuration..."
-msgstr ""
+msgstr "Lade Konfiguration..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:164
 msgid "Loading content..."
-msgstr ""
+msgstr "Lade Inhalt..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2333
 msgid "Loading editor..."
-msgstr ""
+msgstr "Lade Editor..."
 
 #: packages/admin/src/components/MenuEditor.tsx:255
 msgid "Loading menu..."
-msgstr ""
+msgstr "Lade Menü..."
 
 #: packages/admin/src/components/MenuList.tsx:94
 msgid "Loading menus..."
-msgstr ""
+msgstr "Lade Menüs..."
 
 #: packages/admin/src/components/PluginManager.tsx:135
 msgid "Loading plugins..."
-msgstr ""
+msgstr "Lade Erweiterungen..."
 
 #: packages/admin/src/components/Redirects.tsx:430
 msgid "Loading redirects..."
-msgstr ""
+msgstr "Lade Weiterleitungen..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:94
 #: packages/admin/src/components/Sections.tsx:252
 msgid "Loading sections..."
-msgstr ""
+msgstr "Lade Sektionen..."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:104
 #: packages/admin/src/components/settings/SeoSettings.tsx:108
 #: packages/admin/src/components/settings/SocialSettings.tsx:81
 msgid "Loading settings..."
-msgstr ""
+msgstr "Lade Einstellungen..."
 
 #: packages/admin/src/components/SetupWizard.tsx:528
 msgid "Loading setup..."
-msgstr ""
+msgstr "Lade Setup..."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:825
 msgid "Loading terms..."
@@ -3794,7 +3794,7 @@ msgstr ""
 
 #: packages/admin/src/components/Widgets.tsx:310
 msgid "Loading widgets..."
-msgstr ""
+msgstr "Lade Widgets..."
 
 #: packages/admin/src/components/ContentList.tsx:272
 #: packages/admin/src/components/ContentList.tsx:354
@@ -3816,7 +3816,7 @@ msgstr ""
 #: packages/admin/src/components/WelcomeModal.tsx:143
 #: packages/admin/src/routes/bylines.tsx:381
 msgid "Loading..."
-msgstr "Wird geladen..."
+msgstr "Laden..."
 
 #: packages/admin/src/components/ContentList.tsx:252
 #: packages/admin/src/components/LocaleSwitcher.tsx:60
@@ -3837,11 +3837,11 @@ msgstr "Abmelden"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:182
 #: packages/admin/src/components/settings/GeneralSettings.tsx:188
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: packages/admin/src/components/WordPressImport.tsx:1668
 msgid "Logo & favicon"
-msgstr ""
+msgstr "Logo & Favicon"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
@@ -3850,11 +3850,11 @@ msgstr ""
 
 #: packages/admin/src/components/Sections.tsx:193
 msgid "Lowercase letters, numbers, and hyphens only"
-msgstr ""
+msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:639
 msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
-msgstr ""
+msgstr "Nur Kleinbuchstaben, Zahlen und Unterstriche, beginnend mit einem Buchstaben"
 
 #: packages/admin/src/components/Widgets.tsx:371
 msgid "Main Sidebar"
@@ -3863,12 +3863,12 @@ msgstr ""
 #: packages/admin/src/lib/api/marketplace.ts:227
 #: packages/admin/src/lib/api/marketplace.ts:235
 msgid "Make network requests"
-msgstr ""
+msgstr "Netzwerkanfragen senden"
 
 #: packages/admin/src/lib/api/marketplace.ts:228
 #: packages/admin/src/lib/api/marketplace.ts:236
 msgid "Make network requests to any host (unrestricted)"
-msgstr ""
+msgstr "Netzwerkanfragen an beliebige Hosts senden (uneingeschränkt)"
 
 #: packages/admin/src/components/Sidebar.tsx:442
 msgid "Manage"
@@ -3894,11 +3894,11 @@ msgstr "Installierte Erweiterungen verwalten. Aktiviere oder deaktiviere Erweite
 
 #: packages/admin/src/components/MenuList.tsx:104
 msgid "Manage navigation menus for your site"
-msgstr ""
+msgstr "Verwalte Navigationsmenüs für deine Webseite"
 
 #: packages/admin/src/components/Redirects.tsx:333
 msgid "Manage URL redirects and view 404 errors."
-msgstr ""
+msgstr "Verwalte URL-Weiterleitungen und sieh nach 404 Fehlern."
 
 #: packages/admin/src/components/Settings.tsx:93
 msgid "Manage your passkeys and authentication"
@@ -3906,24 +3906,24 @@ msgstr "Passkeys und Authentifizierung verwalten"
 
 #: packages/admin/src/components/Redirects.tsx:398
 msgid "Manual"
-msgstr ""
+msgstr "Manuell"
 
 #: packages/admin/src/components/WordPressImport.tsx:2260
 msgid "Map Authors"
-msgstr ""
+msgstr "Autoren zuordnen"
 
 #. placeholder {0}: mapping.wpLogin
 #: packages/admin/src/components/WordPressImport.tsx:2308
 msgid "Map WordPress user {0} to EmDash user"
-msgstr ""
+msgstr "Ordne dem WordPress-Benutzer {0} einen EmDash-Benutzer zu"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:501
 msgid "Mark as spam"
-msgstr ""
+msgstr "Als Spam markieren"
 
 #: packages/admin/src/components/PluginManager.tsx:200
 msgid "marketplace"
-msgstr ""
+msgstr "Marktplatz"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:87
 #: packages/admin/src/components/PluginManager.tsx:166
@@ -3953,24 +3953,24 @@ msgstr "Medien"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:130
 msgid "Media Details"
-msgstr ""
+msgstr "Mediendetails"
 
 #. placeholder {0}: mediaResult.failed.length
 #: packages/admin/src/components/WordPressImport.tsx:2206
 msgid "Media Errors ({0})"
-msgstr ""
+msgstr "Medienfehler ({0})"
 
 #: packages/admin/src/components/WordPressImport.tsx:2168
 msgid "Media Import"
-msgstr ""
+msgstr "Medienimport"
 
 #: packages/admin/src/components/WordPressImport.tsx:2109
 msgid "Media Import Complete"
-msgstr ""
+msgstr "Medienimport abgeschlossen"
 
 #: packages/admin/src/components/WordPressImport.tsx:2120
 msgid "Media import was skipped"
-msgstr ""
+msgstr "Medienimport wurde übersprungen"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:154
 #: packages/admin/src/components/MediaLibrary.tsx:232
@@ -3998,40 +3998,40 @@ msgstr "Menü"
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:90
 msgid "Menu \"{0}\" ({1}) created."
-msgstr ""
+msgstr "Menü \"{0}\" ({1}) erstellt."
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:55
 msgid "Menu \"{0}\" has been created."
-msgstr ""
+msgstr "Menü \"{0}\" wurde erstellt."
 
 #: packages/admin/src/components/MenuList.tsx:54
 msgid "Menu created"
-msgstr ""
+msgstr "Menü erstellt"
 
 #: packages/admin/src/components/MenuList.tsx:74
 msgid "Menu deleted"
-msgstr ""
+msgstr "Menü entfernt"
 
 #: packages/admin/src/components/MenuEditor.tsx:121
 msgid "Menu item has been added."
-msgstr ""
+msgstr "Menüpunkt wurde hinzugefügt."
 
 #: packages/admin/src/components/MenuEditor.tsx:134
 msgid "Menu item has been deleted."
-msgstr ""
+msgstr "Menüpunkt wurde entfernt."
 
 #: packages/admin/src/components/MenuEditor.tsx:159
 msgid "Menu item has been updated."
-msgstr ""
+msgstr "Menüpunkt wurde aktualisiert."
 
 #: packages/admin/src/components/MenuEditor.tsx:263
 msgid "Menu not found"
-msgstr ""
+msgstr "Menü nicht gefunden"
 
 #: packages/admin/src/components/MenuEditor.tsx:174
 msgid "Menu order has been updated."
-msgstr ""
+msgstr "Menüsortierung wurde aktualisiert."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:161
 #: packages/admin/src/components/MenuList.tsx:103
@@ -4042,27 +4042,27 @@ msgstr "Menüs"
 #. placeholder {0}: navMenus.length
 #: packages/admin/src/components/WordPressImport.tsx:1604
 msgid "Menus ({0})"
-msgstr ""
+msgstr "Menüs ({0})"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
 msgid "Menus Manage"
-msgstr ""
+msgstr "Verwalte Menüs"
 
 #: packages/admin/src/components/SeoPanel.tsx:165
 msgid "Meta Description"
-msgstr ""
+msgstr "Meta-Beschreibung"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:236
 msgid "Meta tag content for Bing Webmaster Tools verification"
-msgstr ""
+msgstr "Inhalt des Meta-Tags für die Verifizierung in den Bing Webmaster Tools"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:230
 msgid "Meta tag content for Google Search Console verification"
-msgstr ""
+msgstr "Inhalt des Meta-Tags für die Verifizierung in der Google Search Console"
 
 #: packages/admin/src/components/WordPressImport.tsx:1681
 msgid "Meta titles, descriptions, and social images"
-msgstr ""
+msgstr "Meta-Titel, Beschreibungen und Bilder für soziale Medien"
 
 #: packages/admin/src/components/FieldEditor.tsx:619
 msgid "Min Items"
@@ -4078,7 +4078,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:506
 msgid "Moderation"
-msgstr ""
+msgstr "Moderation"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:129
 msgid "Moderation Signals"
@@ -4086,7 +4086,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:211
 msgid "Modified"
-msgstr ""
+msgstr "Bearbeitet"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Modify collection schemas"
@@ -4094,7 +4094,7 @@ msgstr "Sammlungsschemata ändern"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
-msgstr ""
+msgstr "Am beliebtesten"
 
 #: packages/admin/src/components/ContentList.tsx:613
 msgid "Move \"{title}\" to trash? You can restore it later."
@@ -4125,7 +4125,7 @@ msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:192
 msgid "Multi Select"
-msgstr ""
+msgstr "Mehrfachauswahl"
 
 #: packages/admin/src/components/FieldEditor.tsx:157
 msgid "Multi-line plain text"
@@ -4137,7 +4137,7 @@ msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:120
 msgid "My Awesome Blog"
-msgstr ""
+msgstr "Mein wunderbarer Blog"
 
 #: packages/admin/src/components/ContentTypeList.tsx:94
 #: packages/admin/src/components/MarketplaceBrowse.tsx:45
@@ -4149,15 +4149,15 @@ msgstr ""
 #: packages/admin/src/components/users/UserDetail.tsx:148
 #: packages/admin/src/components/Widgets.tsx:365
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:556
 msgid "Name and label are required"
-msgstr ""
+msgstr "Name und Label sind erforderlich"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:562
 msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
-msgstr ""
+msgstr "Der Name muss mit einem Buchstaben beginnen und darf nur Kleinbuchstaben, Zahlen und Unterstriche enthalten"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:335
 msgid "Navigation"
@@ -4166,19 +4166,19 @@ msgstr "Navigation"
 #: packages/admin/src/components/users/UserDetail.tsx:231
 #: packages/admin/src/components/users/UserList.tsx:185
 msgid "Never"
-msgstr ""
+msgstr "Nie"
 
 #: packages/admin/src/router.tsx:878
 msgid "new"
-msgstr ""
+msgstr "neu"
 
 #: packages/admin/src/routes/bylines.tsx:339
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:106
 msgid "NEW"
-msgstr ""
+msgstr "NEU"
 
 #. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:427
@@ -4191,12 +4191,12 @@ msgstr "Neue {collectionLabel}"
 
 #: packages/admin/src/components/WordPressImport.tsx:1818
 msgid "New collection"
-msgstr ""
+msgstr "Neue Kollektion"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:355
 #: packages/admin/src/components/ContentTypeList.tsx:44
 msgid "New Content Type"
-msgstr ""
+msgstr "Neuer Inhaltstyp"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:116
 msgid "New public routes"
@@ -4205,11 +4205,11 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:102
 #: packages/admin/src/components/Redirects.tsx:336
 msgid "New Redirect"
-msgstr ""
+msgstr "Neue Weiterleitung"
 
 #: packages/admin/src/components/Sections.tsx:143
 msgid "New Section"
-msgstr ""
+msgstr "Neue Sektion"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:466
 msgid "new tab"
@@ -4224,12 +4224,12 @@ msgstr ""
 #: packages/admin/src/components/MenuEditor.tsx:514
 #: packages/admin/src/components/MenuEditor.tsx:517
 msgid "New window"
-msgstr ""
+msgstr "Neues Fenster"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:44
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
 msgid "Newest"
-msgstr ""
+msgstr "Neueste"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:390
 msgid "News"
@@ -4246,7 +4246,7 @@ msgstr "Nächste Seite"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:464
 msgid "Next screenshot"
-msgstr ""
+msgstr "Nächstes Bild"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "No"
@@ -4269,7 +4269,7 @@ msgstr ""
 
 #: packages/admin/src/components/Redirects.tsx:208
 msgid "No 404 errors recorded yet."
-msgstr ""
+msgstr "Noch keine 404 Fehler aufgezeichnet."
 
 #: packages/admin/src/components/MediaLibrary.tsx:633
 #: packages/admin/src/components/MediaLibrary.tsx:690
@@ -4282,7 +4282,7 @@ msgstr "Noch keine API-Tokens. Erstelle eins, um loszulegen."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:547
 msgid "No approved comments yet."
-msgstr ""
+msgstr "Noch keine freigegebenen Kommentare."
 
 #: packages/admin/src/components/ContentEditor.tsx:2012
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
@@ -4290,11 +4290,11 @@ msgstr ""
 
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "No bylines found"
-msgstr ""
+msgstr "Keine Autorenzeile gefunden"
 
 #: packages/admin/src/components/ContentEditor.tsx:2107
 msgid "No bylines selected."
-msgstr "Keine Autorenzeilen ausgewählt."
+msgstr "Keine Autorenzeile ausgewählt."
 
 #: packages/admin/src/components/Dashboard.tsx:172
 msgid "No collections configured"
@@ -4302,35 +4302,35 @@ msgstr "Keine Sammlungen konfiguriert"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:546
 msgid "No comments awaiting moderation."
-msgstr ""
+msgstr "Keine Kommentare erwarten eine Moderation."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:542
 msgid "No comments match your search."
-msgstr ""
+msgstr "Keine Kommentare entsprechen deiner Suche."
 
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:80
 msgid "No content"
-msgstr ""
+msgstr "Kein Inhalt"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:171
 msgid "No content found"
-msgstr ""
+msgstr "Kein Inhalt gefunden"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:177
 msgid "No content in this collection"
-msgstr ""
+msgstr "Kein Inhalt in dieser Kollektion"
 
 #: packages/admin/src/components/ContentTypeList.tsx:120
 msgid "No content types yet."
-msgstr ""
+msgstr "Noch keine Inhaltstypen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:603
 msgid "No custom fields yet"
-msgstr ""
+msgstr "Noch keine benutzerdefinierten Felder"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:265
 msgid "No detailed description available."
-msgstr ""
+msgstr "Keine detaillierte Beschreibung verfügbar."
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
 msgid "No domains configured. Users must be invited individually."
@@ -4338,15 +4338,15 @@ msgstr "Keine Domains konfiguriert. Nutzer müssen einzeln eingeladen werden."
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:178
 msgid "No email provider configured"
-msgstr ""
+msgstr "Kein E-Mail-Anbieter konfiguriert"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:83
 msgid "No email provider configured. Share this link manually."
-msgstr ""
+msgstr "Kein E-Mail-Anbieter konfiguriert. Teile diesen Link eigenhändig."
 
 #: packages/admin/src/components/WordPressImport.tsx:2322
 msgid "No EmDash users found"
-msgstr ""
+msgstr "Keine EmDash-Benutzer gefunden"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
 msgid "No expiry"
@@ -4354,11 +4354,11 @@ msgstr "Kein Ablaufdatum"
 
 #: packages/admin/src/components/RevisionHistory.tsx:327
 msgid "No fields to compare"
-msgstr ""
+msgstr "Keine Felder zu vergleichen"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:189
 msgid "No headings in document"
-msgstr ""
+msgstr "Keine Überschriften im Dokument"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:413
 msgid "No installable releases"
@@ -4366,7 +4366,7 @@ msgstr ""
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:159
 msgid "No invite token provided"
-msgstr ""
+msgstr "Kein Einladungs-Token angegeben"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1574
 #: packages/admin/src/components/RepeaterField.tsx:160
@@ -4375,11 +4375,11 @@ msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:630
 msgid "No limit"
-msgstr ""
+msgstr "Kein Limit"
 
 #: packages/admin/src/routes/bylines.tsx:426
 msgid "No linked user"
-msgstr ""
+msgstr "Kein zugeordneter Benutzer"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:134
 msgid "No matches"
@@ -4387,7 +4387,7 @@ msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
-msgstr ""
+msgstr "Für dieses Benutzerkonto wurde kein passender Passkey gefunden."
 
 #: packages/admin/src/components/FieldEditor.tsx:474
 #: packages/admin/src/components/FieldEditor.tsx:504
@@ -4397,24 +4397,24 @@ msgstr ""
 #: packages/admin/src/components/MediaLibrary.tsx:381
 #: packages/admin/src/components/MediaPickerModal.tsx:631
 msgid "No media available from this provider"
-msgstr ""
+msgstr "Von diesem Anbieter ist kein Medium verfügbar"
 
 #: packages/admin/src/components/MediaLibrary.tsx:375
 #: packages/admin/src/components/MediaPickerModal.tsx:625
 msgid "No media found"
-msgstr ""
+msgstr "Kein Medium gefunden"
 
 #: packages/admin/src/components/MediaLibrary.tsx:364
 msgid "No media yet"
-msgstr ""
+msgstr "Noch kein Medium"
 
 #: packages/admin/src/components/MenuEditor.tsx:398
 msgid "No menu items yet"
-msgstr ""
+msgstr "Noch kein Menüeintrag"
 
 #: packages/admin/src/components/MenuList.tsx:186
 msgid "No menus yet"
-msgstr ""
+msgstr "Noch keine Menüs"
 
 #: packages/admin/src/components/FieldEditor.tsx:467
 #: packages/admin/src/components/FieldEditor.tsx:497
@@ -4423,15 +4423,15 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:65
 msgid "No moderation (auto-approve all)"
-msgstr ""
+msgstr "Keine Moderation (alle automatisch freigeben)"
 
 #: packages/admin/src/components/users/UserDetail.tsx:248
 msgid "No passkeys registered"
-msgstr ""
+msgstr "Keine Passkeys registriert"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:195
 msgid "No passkeys registered yet."
-msgstr ""
+msgstr "Noch keine Passkeys registriert."
 
 #: packages/admin/src/components/PluginManager.tsx:194
 msgid "No plugins configured"
@@ -4443,7 +4443,7 @@ msgstr "Keine Erweiterungen gefunden"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:117
 msgid "No plugins have been published to this registry yet."
-msgstr "In diesem Verzeichnis wurden bislang keine Erweiterungen veröffentlicht"
+msgstr "In diesem Verzeichnis wurden bislang keine Erweiterungen veröffentlicht."
 
 #: packages/admin/src/components/RegistryBrowse.tsx:116
 msgid "No plugins match \"{debouncedQuery}\"."
@@ -4459,7 +4459,7 @@ msgstr "Keine neuesten Aktivitäten"
 
 #: packages/admin/src/components/Redirects.tsx:434
 msgid "No redirects yet"
-msgstr ""
+msgstr "Noch keine Weiterleitungen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:1132
 msgid "No results"
@@ -4468,7 +4468,7 @@ msgstr "Keine Ergebnisse"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:176
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
 msgid "No results for \"{debouncedQuery}\". Try a different search term."
-msgstr ""
+msgstr "Keine Ergebnisse für \"{debouncedQuery}\". Versuche es mit einem anderen Suchbegriff."
 
 #: packages/admin/src/components/ContentList.tsx:293
 msgid "No results for \"{searchQuery}\""
@@ -4480,36 +4480,36 @@ msgstr "Keine Ergebnisse gefunden"
 
 #: packages/admin/src/components/RevisionHistory.tsx:183
 msgid "No revisions yet"
-msgstr ""
+msgstr "Noch keine Revisionen"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:107
 msgid "No sections available"
-msgstr ""
+msgstr "Keine Sektionen verfügbar"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:101
 #: packages/admin/src/components/Sections.tsx:259
 msgid "No sections found"
-msgstr ""
+msgstr "Keine Sektionen gefunden"
 
 #: packages/admin/src/components/Sections.tsx:265
 msgid "No sections yet"
-msgstr ""
+msgstr "Noch keine Sektionen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:548
 msgid "No spam comments."
-msgstr ""
+msgstr "Keine Spam-Kommentare."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
 msgid "No themes found"
-msgstr ""
+msgstr "Keine Designs gefunden"
 
 #: packages/admin/src/components/users/UserList.tsx:120
 msgid "No users found matching your filters."
-msgstr ""
+msgstr "Keine Benutzer entsprechen deinen Filtern."
 
 #: packages/admin/src/components/users/UserList.tsx:134
 msgid "No users yet."
-msgstr ""
+msgstr "Noch keine Benutzer."
 
 #: packages/admin/src/components/Widgets.tsx:434
 msgid "No widget areas yet. Create one to get started."
@@ -4523,11 +4523,11 @@ msgstr ""
 #: packages/admin/src/components/FieldEditor.tsx:162
 #: packages/admin/src/components/FieldEditor.tsx:581
 msgid "Number"
-msgstr ""
+msgstr "Zahl"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:301
 msgid "Number of posts to show per page on list views"
-msgstr ""
+msgstr "Anzahl der Beiträge, die pro Seite in der Listenansicht angezeigt werden sollen"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:109
 #: packages/admin/src/components/PortableTextEditor.tsx:897
@@ -4546,23 +4546,23 @@ msgstr ""
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:278
 msgid "Only authorize codes you recognize."
-msgstr ""
+msgstr "Autorisiere nur Codes die du wiedererkennst."
 
 #: packages/admin/src/components/SignupPage.tsx:96
 msgid "Only email addresses from allowed domains can sign up."
-msgstr ""
+msgstr "Nur E-Mail-Adressen von erlaubten Domains können sich registrieren."
 
 #: packages/admin/src/components/MenuList.tsx:159
 msgid "Only lowercase letters, numbers, and hyphens"
-msgstr ""
+msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:106
 msgid "Only the listed MIME types will be accepted for this field."
-msgstr ""
+msgstr "Für dieses Feld werden nur die aufgeführten MIME-Typen akzeptiert."
 
 #: packages/admin/src/components/SignupPage.tsx:402
 msgid "Oops!"
-msgstr ""
+msgstr "Uups!"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
@@ -4571,11 +4571,11 @@ msgstr ""
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:333
 #: packages/admin/src/components/editor/PluginBlockNode.tsx:334
 msgid "Open in new tab"
-msgstr ""
+msgstr "In neuem Tab öffnen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1373
 msgid "Open WordPress Profile"
-msgstr ""
+msgstr "WordPress-Profil öffnen"
 
 #: packages/admin/src/components/FieldEditor.tsx:515
 msgid ""
@@ -4583,28 +4583,31 @@ msgid ""
 "Option 2\n"
 "Option 3"
 msgstr ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
 msgid "Optional caption displayed below the image"
-msgstr ""
+msgstr "Optionale Bildunterschrift, die unterhalb des Bildes angezeigt wird"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:213
 msgid "Optional caption for display"
-msgstr ""
+msgstr "Optionale Bildunterschrift"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:435
 msgid "Optional description"
-msgstr ""
+msgstr "Optionale Beschreibung"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
 msgid "Optional tooltip on hover"
-msgstr ""
+msgstr "Optionaler Tooltip beim Darüberfahren mit der Maus"
 
 #: packages/admin/src/components/FieldEditor.tsx:512
 msgid "Options (one per line)"
-msgstr ""
+msgstr "Optionen (eine pro Zeile)"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:519
 msgid "or choose from library"
@@ -4621,7 +4624,7 @@ msgstr "Oder fortfahren mit"
 
 #: packages/admin/src/components/WordPressImport.tsx:1230
 msgid "Or upload an export file"
-msgstr ""
+msgstr "Oder lade eine Export-Datei hoch"
 
 #: packages/admin/src/components/WordPressImport.tsx:949
 msgid "or upload directly"
@@ -4629,20 +4632,20 @@ msgstr ""
 
 #: packages/admin/src/components/MenuEditor.tsx:173
 msgid "Order saved"
-msgstr ""
+msgstr "Reihenfolge gespeichert"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
 msgid "Original:"
-msgstr ""
+msgstr "Original:"
 
 #: packages/admin/src/components/editor/DocumentOutline.tsx:181
 msgid "Outline"
-msgstr ""
+msgstr "Gliederung"
 
 #: packages/admin/src/components/SeoPanel.tsx:155
 msgid "Overrides the page title in search engine results"
-msgstr ""
+msgstr "Überschreibt den Seitentitel in den Suchmaschinenergebnissen"
 
 #: packages/admin/src/components/ContentEditor.tsx:984
 msgid "Ownership"
@@ -4650,16 +4653,16 @@ msgstr "Besitz"
 
 #: packages/admin/src/components/PluginManager.tsx:505
 msgid "Package"
-msgstr ""
+msgstr "Paket"
 
 #: packages/admin/src/router.tsx:1841
 msgid "Page Not Found"
-msgstr ""
+msgstr "Seite nicht gefunden"
 
 #: packages/admin/src/components/PluginManager.tsx:372
 #: packages/admin/src/components/WordPressImport.tsx:1167
 msgid "Pages"
-msgstr ""
+msgstr "Seiten"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:53
 msgid "Paragraph"
@@ -4672,7 +4675,7 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:483
 #: packages/admin/src/components/Redirects.tsx:489
 msgid "Part of a redirect loop"
-msgstr ""
+msgstr "Teil einer Weiterleitungsschleife"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:322
 msgid "Pass"
@@ -4680,51 +4683,51 @@ msgstr ""
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:98
 msgid "Passkey added successfully"
-msgstr ""
+msgstr "Passkey erfolgreich hinzugefügt"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:129
 msgid "Passkey name"
-msgstr ""
+msgstr "Passkey Name"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
 msgid "Passkey Name (optional)"
-msgstr ""
+msgstr "Passkey Name (optional)"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
 msgid "Passkey registered successfully!"
-msgstr ""
+msgstr "Passkey erfolgreich registriert!"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:76
 msgid "Passkey removed"
-msgstr ""
+msgstr "Passkey entfernt"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:60
 msgid "Passkey renamed"
-msgstr ""
+msgstr "Passkey umbenannt"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:177
 #: packages/admin/src/components/users/UserList.tsx:110
 msgid "Passkeys"
-msgstr ""
+msgstr "Passkeys"
 
 #. placeholder {0}: user.credentials.length
 #: packages/admin/src/components/users/UserDetail.tsx:245
 msgid "Passkeys ({0})"
-msgstr ""
+msgstr "Passkeys ({0})"
 
 #: packages/admin/src/components/settings/SecuritySettings.tsx:181
 msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
-msgstr ""
+msgstr "Passkeys sind eine sichere, passwortlose Methode, sich bei deinem Benutzerkonto anzumelden. Du kannst mehrere Passkeys für verschiedene Geräte registrieren."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:74
 #: packages/admin/src/components/SignupPage.tsx:213
 msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
-msgstr ""
+msgstr "Passkeys sind eine sichere, passwortlose Methode, sich mithilfe der biometrischen Daten, der PIN oder des Sicherheitsschlüssels deines Geräts anzumelden."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:303
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
 msgid "Passkeys Not Available Here"
-msgstr ""
+msgstr "Passkeys sind hier nicht verfügbar"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:307
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
@@ -4733,29 +4736,29 @@ msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:158
 msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
-msgstr ""
+msgstr "Passkeys erfordern HTTPS oder http://localhost (mit deinem Port); dieser Hostname stellt keinen sicheren Browserkontext dar."
 
 #: packages/admin/src/components/Redirects.tsx:215
 msgid "Path"
-msgstr ""
+msgstr "Pfad"
 
 #: packages/admin/src/components/FieldEditor.tsx:479
 msgid "Pattern (Regex)"
-msgstr ""
+msgstr "Muster (Regex)"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:437
 msgid "Pattern for generating URLs, e.g. /blog/{0}"
-msgstr ""
+msgstr "Muster zur Generierung von URLs, z. B. /blog/{0}"
 
 #. placeholder {0}: "{slug}"
 #: packages/admin/src/components/ContentTypeEditor.tsx:433
 msgid "Pattern must include a {0} placeholder"
-msgstr ""
+msgstr "Das Muster muss den Platzhalter {0} enthalten"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:62
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:196
 #: packages/admin/src/components/ContentList.tsx:750
@@ -4764,7 +4767,7 @@ msgstr "ausstehend"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:197
 msgid "Pending"
-msgstr ""
+msgstr "Ausstehend"
 
 #: packages/admin/src/components/ContentEditor.tsx:859
 msgid "Pending changes"
@@ -4780,11 +4783,11 @@ msgstr "{title} endgültig löschen"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:274
 msgid "Permissions"
-msgstr ""
+msgstr "Berechtigungen"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
-msgstr ""
+msgstr "Wähle eine beliebige Methode, um dein Administratorkonto anzulegen."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:313
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
@@ -4793,48 +4796,48 @@ msgstr ""
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:133
 msgid "Please ask your administrator to send a new invite."
-msgstr ""
+msgstr "Bitte deinen Administrator, dir eine neue Einladung zu senden."
 
 #: packages/admin/src/components/SetupWizard.tsx:181
 msgid "Please enter a valid email"
-msgstr ""
+msgstr "Gib eine gültige E-Mail-Adresse an"
 
 #: packages/admin/src/components/SignupPage.tsx:54
 msgid "Please enter a valid email address"
-msgstr ""
+msgstr "Gib eine gültige E-Mail-Adresse an"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:386
 msgid "Please enter a valid URL"
-msgstr ""
+msgstr "Bitte gib eine gültige URL an"
 
 #: packages/admin/src/components/WordPressImport.tsx:1024
 msgid "Plugin"
-msgstr ""
+msgstr "Erweiterung"
 
 #: packages/admin/src/components/PluginManager.tsx:109
 msgid "Plugin disabled"
-msgstr ""
+msgstr "Erweiterung deaktiviert"
 
 #: packages/admin/src/components/PluginManager.tsx:90
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Erweiterung aktiviert"
 
 #: packages/admin/src/components/SandboxedPluginPage.tsx:89
 msgid "Plugin Error"
-msgstr ""
+msgstr "Fehler mit der Erweiterung"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginWidget.tsx:37
 msgid "Plugin error ({0})"
-msgstr ""
+msgstr "Fehler mit der Erweiterung ({0})"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:113
 msgid "Plugin not found"
-msgstr ""
+msgstr "Erweiterung nicht gefunden"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:293
 msgid "Plugin not found. The publisher handle or slug may be incorrect."
-msgstr ""
+msgstr "Erweiterung nicht gefunden. Möglicherweise ist die Herausgeber-ID oder der Slug falsch."
 
 #: packages/admin/src/components/WordPressImport.tsx:1048
 msgid "plugin on your WordPress site."
@@ -4842,20 +4845,20 @@ msgstr ""
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:75
 msgid "Plugin Permissions"
-msgstr ""
+msgstr "Erweiterungs-Berechtigungen"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:70
 msgid "Plugin Registry"
-msgstr ""
+msgstr "Erweiterungsverzeichnis"
 
 #. placeholder {0}: response.status
 #: packages/admin/src/components/SandboxedPluginPage.tsx:40
 msgid "Plugin responded with {0}: {text}"
-msgstr ""
+msgstr "Erweiterung antwortete mit {0}: {text}"
 
 #: packages/admin/src/components/PluginManager.tsx:304
 msgid "Plugin uninstalled"
-msgstr ""
+msgstr "Erweiterung dfeinstalliert"
 
 #: packages/admin/src/lib/api/registry.ts:546
 msgid "Plugin update requires re-consent"
@@ -4863,7 +4866,7 @@ msgstr ""
 
 #: packages/admin/src/components/PluginManager.tsx:257
 msgid "Plugin updated"
-msgstr ""
+msgstr "Erweiterungen aktualisiert"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:134
@@ -4872,19 +4875,19 @@ msgstr ""
 #: packages/admin/src/components/Sidebar.tsx:215
 #: packages/admin/src/components/Sidebar.tsx:466
 msgid "Plugins"
-msgstr "Plugins"
+msgstr "Erweiterungen"
 
 #: packages/admin/src/components/SeoPanel.tsx:182
 msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
-msgstr ""
+msgstr "Leitet Suchmaschinen auf die Originalversion dieser Seite weiter, falls sie von einer anderen URL dupliziert wurde"
 
 #: packages/admin/src/components/WordPressImport.tsx:1161
 msgid "Posts"
-msgstr ""
+msgstr "Beiträge"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:295
 msgid "Posts Per Page"
-msgstr ""
+msgstr "Beiträge pro Seite"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:327
 msgid "Pre-release"
@@ -4892,16 +4895,16 @@ msgstr ""
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
-msgstr ""
+msgstr "Registrierung vorbereiten..."
 
 #: packages/admin/src/components/WordPressImport.tsx:2020
 msgid "Preparing to download files from WordPress..."
-msgstr ""
+msgstr "Vorbereiten zum Herunterladen von Dateien von WordPress..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:166
 #: packages/admin/src/components/SetupWizard.tsx:233
 msgid "Preparing..."
-msgstr ""
+msgstr "Vorbereiten..."
 
 #: packages/admin/src/components/ContentEditor.tsx:679
 #: packages/admin/src/components/ContentTypeEditor.tsx:81
@@ -4911,7 +4914,7 @@ msgstr "Vorschau"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:82
 msgid "Preview content before publishing"
-msgstr "Inhalt vor dem Veröffentlichen ansehen"
+msgstr "Inhalt vor dem Publizieren ansehen"
 
 #: packages/admin/src/components/ContentEditor.tsx:679
 msgid "Preview draft"
@@ -4932,31 +4935,31 @@ msgstr ""
 
 #: packages/admin/src/components/MenuList.tsx:166
 msgid "Primary Navigation"
-msgstr ""
+msgstr "Hauptnavigation"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:202
 msgid "Provider:"
-msgstr ""
+msgstr "Anbieter:"
 
 #: packages/admin/src/components/ContentEditor.tsx:734
 #: packages/admin/src/components/ContentEditor.tsx:840
 msgid "Publish"
-msgstr "Veröffentlichen"
+msgstr "Publizieren"
 
 #: packages/admin/src/components/ContentEditor.tsx:724
 msgid "Publish changes"
-msgstr "Änderungen veröffentlichen"
+msgstr "Änderungen publizieren"
 
 #: packages/admin/src/components/ContentList.tsx:725
 msgid "published"
-msgstr "veröffentlicht"
+msgstr "publiziert"
 
 #: packages/admin/src/components/ContentEditor.tsx:855
 #: packages/admin/src/components/ContentPickerModal.tsx:209
 #: packages/admin/src/components/Dashboard.tsx:187
 #: packages/admin/src/router.tsx:778
 msgid "Published"
-msgstr "Veröffentlicht"
+msgstr "Publiziert"
 
 #. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:327
@@ -4965,11 +4968,11 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:135
 msgid "Published At"
-msgstr "Veröffentlicht am"
+msgstr "Publiziert am"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:319
 msgid "Published by"
-msgstr ""
+msgstr "Publiziert von"
 
 #: packages/admin/src/components/ContentEditor.tsx:2115
 msgid "Quick create byline"
@@ -5000,25 +5003,25 @@ msgstr "Mediendateien lesen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
 msgid "Read site settings"
-msgstr ""
+msgstr "Webseiten-Einstellungen lesen"
 
 #: packages/admin/src/lib/api/marketplace.ts:226
 #: packages/admin/src/lib/api/marketplace.ts:234
 msgid "Read user accounts"
-msgstr ""
+msgstr "Benutzerkonten lesen"
 
 #: packages/admin/src/lib/api/marketplace.ts:222
 #: packages/admin/src/lib/api/marketplace.ts:230
 msgid "Read your content"
-msgstr ""
+msgstr "Deine Inhalte lesen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:292
 msgid "Reading"
-msgstr ""
+msgstr "Lesen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1822
 msgid "Ready"
-msgstr ""
+msgstr "Bereit"
 
 #: packages/admin/src/components/Dashboard.tsx:228
 msgid "Recent Activity"
@@ -5027,24 +5030,24 @@ msgstr "Neueste Aktivitäten"
 #: packages/admin/src/components/MarketplaceBrowse.tsx:43
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
 msgid "Recently Updated"
-msgstr ""
+msgstr "Kürzlich aktualisiert"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:144
 msgid "Recipient email"
-msgstr ""
+msgstr "E-Mail-Adresse des Empfängers"
 
 #. placeholder {0}: user.email
 #: packages/admin/src/components/users/UserDetail.tsx:336
 msgid "Recovery link sent to {0}"
-msgstr ""
+msgstr "Link zur Wiederherstellung wurde an {0} gesendet"
 
 #: packages/admin/src/components/Redirects.tsx:416
 msgid "Redirect loop detected"
-msgstr ""
+msgstr "Weiterleitungsschleife erkannt"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:163
 msgid "Redirecting to login..."
-msgstr ""
+msgstr "Weiterleiten zur Anmeldung..."
 
 #: packages/admin/src/components/Redirects.tsx:332
 #: packages/admin/src/components/Redirects.tsx:351
@@ -5054,36 +5057,36 @@ msgstr "Weiterleitungen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3023
 msgid "Redo"
-msgstr ""
+msgstr "Wiederholen"
 
 #: packages/admin/src/components/FieldEditor.tsx:216
 msgid "Reference"
-msgstr ""
+msgstr "Referenz"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:251
 msgid "Referenced favicon unavailable."
-msgstr ""
+msgstr "Das angegebene Favicon ist nicht verfügbar."
 
 #: packages/admin/src/components/ContentTypeList.tsx:78
 msgid "Register"
-msgstr ""
+msgstr "Registrieren"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
 #: packages/admin/src/components/settings/SecuritySettings.tsx:220
 msgid "Register Passkey"
-msgstr ""
+msgstr "Passkey registrieren"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:83
 msgid "Registered user"
-msgstr ""
+msgstr "Registrierter Benutzer"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
 msgid "Registration failed"
-msgstr ""
+msgstr "Registrierung fehlgeschlagen"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
 msgid "Registration was cancelled or timed out. Please try again."
-msgstr ""
+msgstr "Die Registrierung wurde abgebrochen oder ist abgelaufen. Bitte versuche es erneut."
 
 #: packages/admin/src/components/Sidebar.tsx:221
 msgid "Registry"
@@ -5091,7 +5094,7 @@ msgstr ""
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:429
 msgid "Release is too new to install"
-msgstr ""
+msgstr "Die Version ist zu neu, um installiert zu werden"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
@@ -5111,15 +5114,15 @@ msgstr "Entfernen"
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 #: packages/admin/src/components/TaxonomySidebar.tsx:222
 msgid "Remove {0}"
-msgstr ""
+msgstr "{0} entfernen"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:145
 msgid "Remove {entry}"
-msgstr ""
+msgstr "{entry} entfernen"
 
 #: packages/admin/src/components/ContentEditor.tsx:1876
 msgid "Remove {label}"
-msgstr ""
+msgstr "{label} entfernen"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
 msgid "Remove Domain"
@@ -5138,11 +5141,11 @@ msgstr "Bild entfernen"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
 msgid "Remove Image"
-msgstr ""
+msgstr "Bild entfernen"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
 msgid "Remove Image?"
-msgstr ""
+msgstr "Bild entfernen?"
 
 #. placeholder {0}: index + 1
 #: packages/admin/src/components/PortableTextEditor.tsx:1690
@@ -5153,15 +5156,15 @@ msgstr ""
 #: packages/admin/src/components/PortableTextEditor.tsx:2487
 #: packages/admin/src/components/PortableTextEditor.tsx:2488
 msgid "Remove link"
-msgstr ""
+msgstr "Link entfernen"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:188
 msgid "Remove passkey"
-msgstr ""
+msgstr "Passkey entfernen"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:203
 msgid "Remove passkey?"
-msgstr ""
+msgstr "Passkey entfernen?"
 
 #: packages/admin/src/components/FieldEditor.tsx:610
 msgid "Remove sub-field"
@@ -5169,25 +5172,25 @@ msgstr ""
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
 msgid "Remove this image from the document?"
-msgstr ""
+msgstr "Dieses Bild vom Dokument entfernen?"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
 #: packages/admin/src/components/settings/PasskeyItem.tsx:210
 msgid "Removing..."
-msgstr ""
+msgstr "Entferne..."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:176
 msgid "Rename"
-msgstr ""
+msgstr "Umbenennen"
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename {0}"
-msgstr ""
+msgstr "Umbenennen von {0}"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:177
 msgid "Rename passkey"
-msgstr ""
+msgstr "Passkey umbenennen"
 
 #: packages/admin/src/components/FieldEditor.tsx:240
 msgid "Repeater"
@@ -5201,56 +5204,56 @@ msgstr ""
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
 msgid "Replace Image"
-msgstr ""
+msgstr "Bild ersetzen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:117
 msgid "Reply to:"
-msgstr ""
+msgstr "Antworten an:"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
 msgid "Repository"
-msgstr ""
+msgstr "Repository"
 
 #: packages/admin/src/components/SignupPage.tsx:273
 msgid "Request a new link"
-msgstr ""
+msgstr "Einen neuen Link anfragen"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:721
 #: packages/admin/src/components/FieldEditor.tsx:437
 #: packages/admin/src/components/FieldEditor.tsx:592
 msgid "Required"
-msgstr ""
+msgstr "Erforderlich"
 
 #: packages/admin/src/components/WordPressImport.tsx:1835
 msgid "Required fields:"
-msgstr ""
+msgstr "Erforderliche Felder:"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
 msgid "Required for accessibility. Describes the image for screen readers."
-msgstr ""
+msgstr "Für die Barrierefreiheit erforderlich. Beschreibt das Bild für Bildschirmleseprogramme."
 
 #. placeholder {0}: latest.minEmDashVersion
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:325
 msgid "Requires EmDash {0}"
-msgstr ""
+msgstr "Benötigt EmDash {0}"
 
 #: packages/admin/src/components/SignupPage.tsx:154
 msgid "Resend email"
-msgstr ""
+msgstr "E-Mail erneut senden"
 
 #: packages/admin/src/components/SignupPage.tsx:153
 msgid "Resend in {resendCooldown}s"
-msgstr ""
+msgstr "In {resendCooldown} Sekunden erneut senden"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
 msgid "Reset to original"
-msgstr ""
+msgstr "Original wiederherstellen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:220
 msgid "Restore"
-msgstr ""
+msgstr "Wiederherstellen"
 
 #: packages/admin/src/components/ContentList.tsx:661
 msgid "Restore {title}"
@@ -5258,51 +5261,51 @@ msgstr "{title} wiederherstellen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:136
 msgid "Restore failed"
-msgstr ""
+msgstr "Wiederherstellung fehlgeschlagen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:214
 msgid "Restore Revision?"
-msgstr ""
+msgstr "Revision wiederherstellen?"
 
 #: packages/admin/src/components/RevisionHistory.tsx:281
 #: packages/admin/src/components/RevisionHistory.tsx:282
 msgid "Restore this version"
-msgstr ""
+msgstr "Diese Version wiederherstellen"
 
 #. placeholder {0}: formatFullDate(restoreTarget.createdAt)
 #: packages/admin/src/components/RevisionHistory.tsx:217
 msgid "Restore this version from {0}? This will update the current content to this revision's data."
-msgstr ""
+msgstr "Diese Version aus {0} wiederherstellen? Dadurch werden die aktuellen Inhalte auf den Stand dieser Revision aktualisiert."
 
 #: packages/admin/src/components/RevisionHistory.tsx:221
 msgid "Restoring..."
-msgstr ""
+msgstr "Wiederherstellen..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:141
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
 #: packages/admin/src/router.tsx:1829
 msgid "Retry"
-msgstr ""
+msgstr "Erneut versuchen"
 
 #: packages/admin/src/components/Sections.tsx:136
 msgid "Reusable content blocks you can insert into any content"
-msgstr ""
+msgstr "Wiederverwendbare Inhaltsblöcke, die du in jeden beliebigen Inhalt einfügen kannst"
 
 #: packages/admin/src/router.tsx:812
 msgid "Reverted to published version"
-msgstr ""
+msgstr "Zur publizierten Version zurückgesetzt"
 
 #: packages/admin/src/components/WordPressImport.tsx:650
 msgid "Review"
-msgstr ""
+msgstr "Überprüfen"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:75
 msgid "Review New Permissions"
-msgstr ""
+msgstr "Neue Berechtigungen überprüfen"
 
 #: packages/admin/src/components/RevisionHistory.tsx:130
 msgid "Revision restored"
-msgstr ""
+msgstr "Revision wiederhergestellt"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:76
 #: packages/admin/src/components/RevisionHistory.tsx:161
@@ -5319,11 +5322,11 @@ msgstr "Widerrufen?"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
 msgid "Revoking..."
-msgstr "Wird widerrufen..."
+msgstr "Widerrufen..."
 
 #: packages/admin/src/components/FieldEditor.tsx:198
 msgid "Rich Text"
-msgstr ""
+msgstr "Rich Text"
 
 #: packages/admin/src/components/Widgets.tsx:97
 msgid "Rich text content"
@@ -5331,12 +5334,12 @@ msgstr "Rich-Text-Inhalt"
 
 #: packages/admin/src/components/FieldEditor.tsx:199
 msgid "Rich text editor"
-msgstr ""
+msgstr "Rich-Text-Editor"
 
 #. placeholder {0}: latest.audit.riskScore
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:312
 msgid "Risk score: {0}/100"
-msgstr ""
+msgstr "Risikobewertung: {0}/100"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:166
 #: packages/admin/src/components/users/UserDetail.tsx:169
@@ -5389,26 +5392,26 @@ msgstr "Änderungen speichern"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:72
 msgid "Save content as draft before publishing"
-msgstr "Inhalt vor dem Veröffentlichen als Entwurf speichern"
+msgstr "Inhalt vor dem Publizieren als Entwurf speichern"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:137
 msgid "Save name"
-msgstr ""
+msgstr "Name speichern"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:126
 #: packages/admin/src/components/settings/SeoSettings.tsx:251
 msgid "Save SEO Settings"
-msgstr ""
+msgstr "SEO-Einstellungen speichern"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:125
 #: packages/admin/src/components/settings/GeneralSettings.tsx:321
 msgid "Save Settings"
-msgstr ""
+msgstr "Einstellungen speichern"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:99
 #: packages/admin/src/components/settings/SocialSettings.tsx:173
 msgid "Save Social Links"
-msgstr ""
+msgstr "Social-Media-Links speichern"
 
 #: packages/admin/src/components/ContentEditor.tsx:654
 #: packages/admin/src/components/SaveButton.tsx:42
@@ -5434,7 +5437,7 @@ msgstr "Gespeichert"
 #: packages/admin/src/components/Widgets.tsx:894
 #: packages/admin/src/routes/bylines.tsx:456
 msgid "Saving..."
-msgstr "Wird gespeichert..."
+msgstr "Speichern..."
 
 #: packages/admin/src/components/ContentEditor.tsx:899
 msgid "Schedule"
@@ -5464,11 +5467,11 @@ msgstr "Geplant für: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2128
 msgid "Schema Changes"
-msgstr ""
+msgstr "Schema-Änderungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1538
 msgid "Schema preparation failed"
-msgstr ""
+msgstr "Schema-Vorbereitung fehlgeschlagen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
 msgid "Schema Read"
@@ -5526,7 +5529,7 @@ msgstr "{0} suchen"
 #. placeholder {0}: collectionLabel.toLowerCase()
 #: packages/admin/src/components/ContentList.tsx:196
 msgid "Search {0}..."
-msgstr "{0} suchen..."
+msgstr "{0} durchsuchen..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
@@ -5534,23 +5537,23 @@ msgstr "Suche anhand von Name oder E-Mail-Adresse"
 
 #: packages/admin/src/routes/bylines.tsx:314
 msgid "Search bylines"
-msgstr ""
+msgstr "Autorenzeilen durchsuchen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:163
 msgid "Search comments"
-msgstr ""
+msgstr "Kommentare durchsuchen"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:162
 msgid "Search comments..."
-msgstr ""
+msgstr "Kommentare durchsuchen..."
 
 #: packages/admin/src/components/ContentPickerModal.tsx:141
 msgid "Search content..."
-msgstr ""
+msgstr "Inhalte durchsuchen..."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:155
 msgid "Search Engine Optimization"
-msgstr ""
+msgstr "Suchmaschinenoptimierung"
 
 #: packages/admin/src/components/Settings.tsx:82
 msgid "Search engine optimization and verification"
@@ -5558,7 +5561,7 @@ msgstr "Suchmaschinenoptimierung und Verifizierung"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:565
 msgid "Search media"
-msgstr ""
+msgstr "Medien durchsuchen"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:425
 msgid "Search pages and content..."
@@ -5567,43 +5570,43 @@ msgstr "Seiten und Inhalte durchsuchen..."
 #: packages/admin/src/components/MarketplaceBrowse.tsx:101
 #: packages/admin/src/components/RegistryBrowse.tsx:84
 msgid "Search plugins"
-msgstr ""
+msgstr "Erweiterungen durchsuchen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:97
 #: packages/admin/src/components/RegistryBrowse.tsx:80
 msgid "Search plugins..."
-msgstr ""
+msgstr "Erweiterungen durchsuchen..."
 
 #: packages/admin/src/components/SectionPickerModal.tsx:81
 #: packages/admin/src/components/Sections.tsx:226
 msgid "Search sections..."
-msgstr ""
+msgstr "Sektionen durchsuchen..."
 
 #: packages/admin/src/components/Redirects.tsx:383
 msgid "Search source or destination..."
-msgstr ""
+msgstr "Suche nach Quelle oder Ziel..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
 msgid "Search themes"
-msgstr ""
+msgstr "Designs durchsuchen"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
 msgid "Search themes..."
-msgstr ""
+msgstr "Designs durchsuchen..."
 
 #: packages/admin/src/components/users/UserList.tsx:73
 msgid "Search users"
-msgstr ""
+msgstr "Benutzer durchsuchen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:342
 #: packages/admin/src/components/MediaPickerModal.tsx:564
 msgid "Search..."
-msgstr ""
+msgstr "Suchen..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:723
 #: packages/admin/src/components/FieldEditor.tsx:452
 msgid "Searchable"
-msgstr ""
+msgstr "Durchsuchbar"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2002
 msgid "Section"
@@ -5611,31 +5614,31 @@ msgstr "Abschnitt"
 
 #: packages/admin/src/components/SectionEditor.tsx:82
 msgid "Section \"{slug}\" could not be found."
-msgstr ""
+msgstr "Sektion \"{slug}\" konnte nicht gefunden werden."
 
 #: packages/admin/src/components/Sections.tsx:93
 msgid "Section created"
-msgstr ""
+msgstr "Sektion erstellt"
 
 #: packages/admin/src/components/Sections.tsx:107
 msgid "Section deleted"
-msgstr ""
+msgstr "Sektion entfernt"
 
 #: packages/admin/src/components/SectionEditor.tsx:233
 msgid "Section Details"
-msgstr ""
+msgstr "Sektionsdetails"
 
 #: packages/admin/src/components/SectionEditor.tsx:78
 msgid "Section Not Found"
-msgstr ""
+msgstr "Sektion nicht gefunden"
 
 #: packages/admin/src/components/SectionEditor.tsx:44
 msgid "Section saved"
-msgstr ""
+msgstr "Sektion gespeichert"
 
 #: packages/admin/src/components/SectionEditor.tsx:239
 msgid "Section title"
-msgstr ""
+msgstr "Abschnittstitel"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:177
 #: packages/admin/src/components/Sections.tsx:134
@@ -5650,7 +5653,7 @@ msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:561
 msgid "Secure your account"
-msgstr ""
+msgstr "Schütze dein Benutzerkonto"
 
 #: packages/admin/src/components/Settings.tsx:92
 msgid "Security"
@@ -5658,27 +5661,27 @@ msgstr "Sicherheit"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:308
 msgid "Security Audit"
-msgstr ""
+msgstr "Sicherheitsüberprüfung"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:340
 msgid "Security audit failed"
-msgstr ""
+msgstr "Sicherheitsüberprüfung nicht bestanden"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:330
 msgid "Security audit flagged concerns"
-msgstr ""
+msgstr "Bei der Sicherheitsüberprüfung wurden Probleme festgestellt"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:148
 msgid "Security audit flagged potential concerns with this plugin."
-msgstr ""
+msgstr "Bei der Sicherheitsüberprüfung wurden mögliche Probleme mit dieser Erweiterung festgestellt."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:149
 msgid "Security audit flagged this plugin as potentially unsafe."
-msgstr ""
+msgstr "Bei der Sicherheitsüberprüfung wurde diese Erweiterung als potenziell unsicher eingestuft."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:319
 msgid "Security audit passed"
-msgstr ""
+msgstr "Sicherheitsüberprüfung bestanden"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:491
 msgid "Security contacts"
@@ -5687,7 +5690,7 @@ msgstr ""
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:272
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
 msgid "Security error. Make sure you're on a secure connection."
-msgstr ""
+msgstr "Sicherheitsfehler. Bitte stelle sicher, dass du eine sichere Verbindung verwendest."
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:243
 #: packages/admin/src/components/Header.tsx:85
@@ -5698,7 +5701,7 @@ msgstr "Sicherheitseinstellungen"
 #: packages/admin/src/components/FieldEditor.tsx:186
 #: packages/admin/src/components/FieldEditor.tsx:585
 msgid "Select"
-msgstr ""
+msgstr "Auswählen"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
 #: packages/admin/src/components/ContentEditor.tsx:1730
@@ -5709,19 +5712,19 @@ msgstr "{label} auswählen"
 
 #: packages/admin/src/components/Widgets.tsx:871
 msgid "Select a component..."
-msgstr ""
+msgstr "Eine Komponente auswählen..."
 
 #: packages/admin/src/components/Widgets.tsx:839
 msgid "Select a menu..."
-msgstr ""
+msgstr "Ein Menü auswählen..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:283
 msgid "Select all"
-msgstr ""
+msgstr "Alle auswählen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2032
 msgid "Select byline"
-msgstr ""
+msgstr "Autorenzeile auswählen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2029
 msgid "Select byline..."
@@ -5734,24 +5737,24 @@ msgstr ""
 
 #: packages/admin/src/components/ContentPickerModal.tsx:117
 msgid "Select Content"
-msgstr ""
+msgstr "Inhalt auswählen"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:268
 msgid "Select Default Social Image"
-msgstr ""
+msgstr "Standardbild für soziale Medien auswählen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:283
 #: packages/admin/src/components/settings/GeneralSettings.tsx:344
 msgid "Select Favicon"
-msgstr ""
+msgstr "Favicon auswählen"
 
 #: packages/admin/src/components/ContentEditor.tsx:1892
 msgid "Select file"
-msgstr ""
+msgstr "Datei auswählen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:138
 msgid "Select File"
-msgstr ""
+msgstr "Datei auswählen"
 
 #: packages/admin/src/components/ContentEditor.tsx:1718
 msgid "Select image"
@@ -5762,16 +5765,16 @@ msgstr "Bild auswählen"
 #: packages/admin/src/components/PortableTextEditor.tsx:3048
 #: packages/admin/src/components/settings/SeoSettings.tsx:221
 msgid "Select Image"
-msgstr ""
+msgstr "Bild auswählen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:229
 #: packages/admin/src/components/settings/GeneralSettings.tsx:336
 msgid "Select Logo"
-msgstr ""
+msgstr "Logo auswählen"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
 msgid "Select media"
-msgstr ""
+msgstr "Medium auswählen"
 
 #: packages/admin/src/components/SeoImageField.tsx:70
 msgid "Select OG image"
@@ -5783,17 +5786,17 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1571
 msgid "Select which content types to import."
-msgstr ""
+msgstr "Wähle aus, welche Inhaltstypen importiert werden sollen."
 
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:108
 #: packages/admin/src/components/PortableTextEditor.tsx:1785
 #: packages/admin/src/components/RepeaterField.tsx:361
 msgid "Select..."
-msgstr ""
+msgstr "Wähle..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:719
 msgid "Selected:"
-msgstr ""
+msgstr "Ausgewählt:"
 
 #: packages/admin/src/components/Settings.tsx:98
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
@@ -5802,7 +5805,7 @@ msgstr "Selbstregistrierungs-Domains"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:139
 msgid "Send a test email through the full pipeline to verify your email configuration."
-msgstr ""
+msgstr "Sende eine Test-E-Mail durch die gesamte Pipeline, um die E-Mail-Konfiguration zu überprüfen."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:84
 msgid "Send an invitation email to a new team member."
@@ -5822,11 +5825,11 @@ msgstr "Wiederherstellungs-Link senden"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
 msgid "Send Test"
-msgstr ""
+msgstr "Sende Test"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:136
 msgid "Send Test Email"
-msgstr ""
+msgstr "Sende Test-E-Mail"
 
 #: packages/admin/src/components/LoginPage.tsx:149
 #: packages/admin/src/components/settings/EmailSettings.tsx:153
@@ -5846,24 +5849,24 @@ msgstr "SEO"
 #: packages/admin/src/components/settings/SeoSettings.tsx:105
 #: packages/admin/src/components/settings/SeoSettings.tsx:130
 msgid "SEO Settings"
-msgstr ""
+msgstr "SEO-Einstellungen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1679
 msgid "SEO settings (Yoast)"
-msgstr ""
+msgstr "SEO-Einstellungen (Yoast)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:57
 msgid "SEO settings saved"
-msgstr ""
+msgstr "SEO-Einstellungen angepasst"
 
 #: packages/admin/src/components/SeoPanel.tsx:154
 msgid "SEO Title"
-msgstr ""
+msgstr "SEO-Titel"
 
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
 msgid "Set a custom display size for this image instance."
-msgstr ""
+msgstr "Lege eine benutzerdefinierte Anzeigegröße für diese Bildinstanz fest."
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:170
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:174
@@ -5876,7 +5879,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:531
 msgid "Set to 0 to never close comments automatically."
-msgstr ""
+msgstr "Auf 0 setzen um Kommentare nie automatisch zu schließen."
 
 #: packages/admin/src/components/SetupWizard.tsx:559
 msgid "Set up your site"
@@ -5898,28 +5901,28 @@ msgstr "Einstellungen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
 msgid "Settings Manage"
-msgstr ""
+msgstr "Einstellungen verwalten"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
 msgid "Settings Read"
-msgstr ""
+msgstr "Einstellungen lesen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:53
 msgid "Settings saved successfully"
-msgstr ""
+msgstr "Einstellungen erfolgreich gespeichert"
 
 #: packages/admin/src/components/SetupWizard.tsx:468
 msgid "Setup failed"
-msgstr ""
+msgstr "Setup fehlgeschlagen"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:109
 msgid "Share this link with the invited user"
-msgstr ""
+msgstr "Teile diesen Link mit dem eingeladenen Nutzer"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
 msgid "Short Text"
-msgstr ""
+msgstr "Kurztext"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
 msgid "Show token"
@@ -5928,20 +5931,20 @@ msgstr "Token anzeigen"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
 msgid "Shown when hovering over the image."
-msgstr ""
+msgstr "Wird angezeigt, wenn man mit der Maus über das Bild fährt."
 
 #: packages/admin/src/components/SignupPage.tsx:439
 msgid "Sign in"
-msgstr ""
+msgstr "Anmelden"
 
 #: packages/admin/src/components/SetupWizard.tsx:355
 msgid "Sign In"
-msgstr ""
+msgstr "Anmelden"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:129
 #: packages/admin/src/components/SignupPage.tsx:269
 msgid "Sign in instead"
-msgstr ""
+msgstr "Stattdessen anmelden"
 
 #: packages/admin/src/components/LoginPage.tsx:232
 msgid "Sign in to your site"
@@ -5952,7 +5955,7 @@ msgstr "Melde dich bei deiner Website an"
 #: packages/admin/src/components/LoginPage.tsx:231
 #: packages/admin/src/components/SetupWizard.tsx:264
 msgid "Sign in with {0}"
-msgstr ""
+msgstr "Anmelden mit {0}"
 
 #: packages/admin/src/components/LoginPage.tsx:229
 msgid "Sign in with email"
@@ -5970,7 +5973,7 @@ msgstr "Mit Passkey anmelden"
 #. placeholder {0}: user.email
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:190
 msgid "Signed in as {0}"
-msgstr ""
+msgstr "Angemeldet als {0}"
 
 #: packages/admin/src/components/FieldEditor.tsx:187
 msgid "Single choice from options"
@@ -5978,48 +5981,48 @@ msgstr ""
 
 #: packages/admin/src/components/FieldEditor.tsx:151
 msgid "Single line text input"
-msgstr ""
+msgstr "Einzeilige Texteingabe"
 
 #: packages/admin/src/components/SetupWizard.tsx:353
 msgid "Site"
-msgstr ""
+msgstr "Webseite"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:153
 msgid "Site Identity"
-msgstr ""
+msgstr "Webseiten-Identität"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr "Website-Identität, Logo, Favicon und Leseeinstellungen"
+msgstr "Webseiten-Identität, Logo, Favicon und Leseeinstellungen"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 msgid "Site Settings"
-msgstr ""
+msgstr "Webseiten Einstellungen"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:156
 #: packages/admin/src/components/SetupWizard.tsx:116
 msgid "Site Title"
-msgstr ""
+msgstr "Webseitentitel"
 
 #: packages/admin/src/components/WordPressImport.tsx:1659
 msgid "Site title & tagline"
-msgstr ""
+msgstr "Webseitentitel & Slogan"
 
 #: packages/admin/src/components/SetupWizard.tsx:100
 msgid "Site title is required"
-msgstr ""
+msgstr "Webseitentitel ist erforderlich"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:168
 msgid "Site URL"
-msgstr ""
+msgstr "Webseiten-URL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:430
 msgid "Size"
-msgstr ""
+msgstr "Größe"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:170
 msgid "Size:"
-msgstr ""
+msgstr "Größe:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1940
 msgid "Skip Media Import"
@@ -6027,7 +6030,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1965
 msgid "Skipped"
-msgstr ""
+msgstr "Übersprungen"
 
 #: packages/admin/src/components/ContentEditor.tsx:843
 #: packages/admin/src/components/ContentEditor.tsx:2131
@@ -6046,7 +6049,7 @@ msgstr "Slug"
 
 #: packages/admin/src/components/Sections.tsx:124
 msgid "Slug copied to clipboard"
-msgstr ""
+msgstr "Slug wurde in Zwischenablage kopiert"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:878
 msgid "Small section heading"
@@ -6068,24 +6071,24 @@ msgstr "Links zu Social-Media-Profilen"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:126
 msgid "Social Profiles"
-msgstr ""
+msgstr "Profile in sozialen Netzwerken"
 
 #: packages/admin/src/components/WordPressImport.tsx:1696
 msgid "Some content types cannot be imported"
-msgstr ""
+msgstr "Einige Inhaltstypen können nicht importiert werden"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:122
 #: packages/admin/src/components/SignupPage.tsx:262
 msgid "Something went wrong"
-msgstr ""
+msgstr "Etwas ist schief gelaufen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:123
 msgid "Sort plugins"
-msgstr ""
+msgstr "Erweiterungen sortieren"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
 msgid "Sort themes"
-msgstr ""
+msgstr "Designs sortieren"
 
 #: packages/admin/src/components/ContentTypeList.tsx:100
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
@@ -6095,25 +6098,25 @@ msgstr ""
 #: packages/admin/src/components/Redirects.tsx:440
 #: packages/admin/src/components/SectionEditor.tsx:279
 msgid "Source"
-msgstr ""
+msgstr "Quelle"
 
 #: packages/admin/src/components/Redirects.tsx:128
 msgid "Source path"
-msgstr ""
+msgstr "Quellpfad"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:197
 msgid "spam"
-msgstr ""
+msgstr "Spam"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:159
 #: packages/admin/src/components/comments/CommentInbox.tsx:207
 #: packages/admin/src/components/comments/CommentInbox.tsx:247
 msgid "Spam"
-msgstr ""
+msgstr "Spam"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3036
 msgid "Spotlight Mode"
-msgstr ""
+msgstr "Spotlight-Modus"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:64
 msgid "Spreadsheets"
@@ -6121,7 +6124,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
-msgstr ""
+msgstr "Import starten"
 
 #: packages/admin/src/components/ContentEditor.tsx:849
 #: packages/admin/src/components/ContentList.tsx:245
@@ -6133,16 +6136,16 @@ msgstr "Status"
 
 #: packages/admin/src/components/Redirects.tsx:146
 msgid "Status code"
-msgstr ""
+msgstr "Statuscode"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2520
 #: packages/admin/src/components/PortableTextEditor.tsx:2826
 msgid "Strikethrough"
-msgstr ""
+msgstr "Durchgestrichen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1591
 msgid "Structure"
-msgstr ""
+msgstr "Struktur"
 
 #: packages/admin/src/components/FieldEditor.tsx:523
 msgid "Sub-Fields"
@@ -6155,7 +6158,7 @@ msgstr "Abonnent"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
-msgstr ""
+msgstr "Synchronisiert"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:104
 msgid "Synced passkey"
@@ -6163,7 +6166,7 @@ msgstr ""
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:768
 msgid "System"
-msgstr ""
+msgstr "System"
 
 #: packages/admin/src/components/ThemeToggle.tsx:24
 msgid "System ({resolvedLabel})"
@@ -6171,11 +6174,11 @@ msgstr "System ({resolvedLabel})"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:590
 msgid "System Fields"
-msgstr ""
+msgstr "Systemfelder"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:937
 msgid "Table"
-msgstr ""
+msgstr "Tabelle"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:162
 #: packages/admin/src/components/SetupWizard.tsx:127
@@ -6222,7 +6225,7 @@ msgstr ""
 
 #: packages/admin/src/components/SetupWizard.tsx:155
 msgid "Template:"
-msgstr ""
+msgstr "Template:"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:360
 #: packages/admin/src/components/TaxonomyManager.tsx:812
@@ -6241,23 +6244,23 @@ msgstr ""
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:148
 msgid "test@example.com"
-msgstr ""
+msgstr "test@example.com"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2796
 msgid "Text formatting"
-msgstr ""
+msgstr "Textformatierung"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:198
 msgid "The device will not be granted access."
-msgstr ""
+msgstr "Dem Gerät wird kein Zugriff gewährt."
 
 #: packages/admin/src/components/WordPressImport.tsx:1698
 msgid "The existing collection has fields with incompatible types."
-msgstr ""
+msgstr "Die vorhandene Kollektion enthält Felder mit inkompatiblen Typen."
 
 #: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr ""
+msgstr "Die folgenden Tabellen enthalten Inhalte, sind jedoch nicht als Kollektionen registriert. Registriere sie, um diese Inhalte im Adminbereich zu verwalten."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
@@ -6266,126 +6269,126 @@ msgstr "Dem eingeladenen Nutzer wird diese Rolle zugewiesen sobald er die Regist
 #: packages/admin/src/components/LoginPage.tsx:113
 #: packages/admin/src/components/SignupPage.tsx:139
 msgid "The link will expire in 15 minutes."
-msgstr "Der Link ist 15 Minuten gültig."
+msgstr "Der Link ist 15 Minuten lang gültig."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:177
 msgid "The marketplace is empty. Check back later for new plugins."
-msgstr ""
+msgstr "Der Marktplatz ist leer. Bitte versuche es später erneut um neue Erweiterungen zu entdecken."
 
 #: packages/admin/src/components/MenuList.tsx:75
 msgid "The menu has been deleted."
-msgstr ""
+msgstr "Das Menü wurde entfernt."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:159
 msgid "The name of your site, used in the header and metadata"
-msgstr ""
+msgstr "Der Name deiner Webseite, der in der Kopfzeile und in den Metadaten verwendet wird"
 
 #: packages/admin/src/router.tsx:1843
 msgid "The page you're looking for doesn't exist."
-msgstr ""
+msgstr "Diese Seite existiert nicht."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:172
 msgid "The public URL of your site (used for canonical links and sitemaps)"
-msgstr ""
+msgstr "Die öffentliche URL deiner Webseite (wird für kanonische Links und Sitemaps verwendet)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:189
 msgid "The referenced image is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "Das angegebene Bild ist nicht mehr verfügbar. Wähle ein neues Bild aus oder entferne den Verweis."
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:197
 msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
-msgstr ""
+msgstr "Das angegebene Logo ist nicht mehr verfügbar. Wähle ein neues Logo aus oder entferne den Verweis."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
-msgstr ""
+msgstr "Der Design-Marktplatz ist leer. Bitte versuche es später erneut."
 
 #: packages/admin/src/components/Sections.tsx:45
 msgid "Theme"
-msgstr ""
+msgstr "Design"
 
 #. placeholder {0}: section.themeId
 #: packages/admin/src/components/SectionEditor.tsx:292
 msgid "Theme ID: {0}"
-msgstr ""
+msgstr "Design-ID: {0}"
 
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
 msgid "Theme not found"
-msgstr ""
+msgstr "Design nicht gefunden"
 
 #: packages/admin/src/components/SectionEditor.tsx:184
 msgid "Theme Section"
-msgstr ""
+msgstr "Design Sektion"
 
 #: packages/admin/src/components/Sections.tsx:300
 msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
-msgstr ""
+msgstr "Vom Design bereitgestellte Abschnitte können nicht gelöscht werden. Bearbeite den Abschnitt, um eine eigene Kopie zu erstellen, und entferne diese anschließend."
 
 #: packages/admin/src/components/ThemeToggle.tsx:32
 msgid "Theme: {label}"
-msgstr "Theme: {label}"
+msgstr "Design: {label}"
 
 #: packages/admin/src/components/Sidebar.tsx:237
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
 msgid "Themes"
-msgstr "Themes"
+msgstr "Designs"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:372
 msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
-msgstr ""
+msgstr "Diese Kollektion ist im Code definiert. Einige Einstellungen können hier nicht geändert werden. Bearbeite deine „live.config.ts“-Datei, um das Schema anzupassen."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:405
 msgid "This field does not accept {sniffedMime} files."
-msgstr ""
+msgstr "Dieses Feld akzeptiert keine {sniffedMime} Dateien."
 
 #: packages/admin/src/components/ContentEditor.tsx:1734
 #: packages/admin/src/components/ContentEditor.tsx:1907
 msgid "This field is required"
-msgstr "Dies ist ein Pflichtfeld"
+msgstr "Das ist ein Pflichtfeld"
 
 #: packages/admin/src/components/SectionEditor.tsx:286
 msgid "This is a custom section."
-msgstr ""
+msgstr "Das ist eine benutzerdefinierte Sektion."
 
 #: packages/admin/src/components/WordPressImport.tsx:1147
 msgid "This is a WordPress site."
-msgstr ""
+msgstr "Das ist eine WordPress-Webseite."
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:112
 msgid "This link expires in 7 days and can only be used once."
-msgstr ""
+msgstr "Dieser Link verfällt in 7 Tagen und kann nur einmalig genutzt werden."
 
 #: packages/admin/src/components/WordPressImport.tsx:821
 msgid "This may take a while for large exports."
-msgstr ""
+msgstr "Bei umfangreichen Exporten kann dies eine Weile dauern."
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
 msgid "This passkey is already registered on this device."
-msgstr ""
+msgstr "Dieser Passkey ist bereits mit diesem Gerät registriert."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:277
 msgid "This plugin requires no special permissions."
-msgstr ""
+msgstr "Diese Erweiterung benötigt keine speziellen Berechtigungen."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:398
 msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
-msgstr ""
+msgstr "Dieser Herausgeber beansprucht einen Namen, dessen Eigentumsrechte er nicht nachweisen kann – möglicherweise gibt er sich als jemand anderes aus. Die Installation ist deaktiviert. Wenn du den Herausgeber kennst und ihm vertraust, bitte ihn, seine Identitätsangaben zu korrigieren, bevor du es erneut versuchst."
 
 #: packages/admin/src/components/Redirects.tsx:551
 msgid "This redirect rule will be permanently removed."
-msgstr ""
+msgstr "Diese Weiterleitungsregel wird endgültig gelöscht."
 
 #: packages/admin/src/routes/bylines.tsx:500
 msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
-msgstr ""
+msgstr "Hierdurch wird das Autorenprofil entfernt. Links zu Autorenbeiträgen und Verweise werden ebenfalls entfernt."
 
 #: packages/admin/src/components/SectionEditor.tsx:283
 msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
-msgstr ""
+msgstr "Diese Sektion wird vom Design bereitgestellt. Durch das Bearbeiten wird eine benutzerdefinierte Kopie erstellt, die die Version des Designs überschreibt."
 
 #: packages/admin/src/components/SectionEditor.tsx:288
 msgid "This section was imported from another system."
-msgstr ""
+msgstr "Diese Sektion wurde von einem anderen System importiert."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:119
 msgid "This update exposes the following routes without authentication:"
@@ -6397,7 +6400,7 @@ msgstr ""
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:276
 msgid "This will grant CLI access with your permissions."
-msgstr ""
+msgstr "Hierdurch wird CLI-Zugriff mit deinen Berechtigungen gewährt."
 
 #: packages/admin/src/components/ContentEditor.tsx:956
 msgid "This will move the item to trash. You can restore it later from the trash."
@@ -6406,36 +6409,36 @@ msgstr "Dies verschiebt das Element in den Papierkorb. Du kannst es später von 
 #. placeholder {0}: deleteTarget?.label
 #: packages/admin/src/components/TaxonomyManager.tsx:882
 msgid "This will permanently delete \"{0}\" and remove it from all content."
-msgstr ""
+msgstr "Hierdurch wird \"{0}\" endgültig entfernt und aus allen Inhalten entfernt."
 
 #. placeholder {0}: sectionToDelete?.title
 #: packages/admin/src/components/Sections.tsx:304
 msgid "This will permanently delete \"{0}\". This action cannot be undone."
-msgstr ""
+msgstr "Hierdurch wird \"{0}\" endgültig entfernt. Dieser Vorgang kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:406
 msgid "This will permanently delete this comment. This action cannot be undone."
-msgstr ""
+msgstr "Kommentar permanent löschen. Diese Aktion kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/PluginManager.tsx:625
 msgid "This will remove the plugin and its bundle from your site."
-msgstr ""
+msgstr "Hierdurch werden die Erweiterung und sein Bundle von deiner Webseite entfernt."
 
 #: packages/admin/src/components/ContentEditor.tsx:699
 msgid "This will revert to the published version. Your draft changes will be lost."
-msgstr "Dies setzt alles auf die veröffentlichte Version zurück. Deine Entwurfsänderungen gehen verloren."
+msgstr "Dies setzt alles auf die publizierte Version zurück. Deine Entwurfsänderungen gehen verloren."
 
 #: packages/admin/src/components/SetupWizard.tsx:131
 msgid "Thoughts, tutorials, and more"
-msgstr ""
+msgstr "Gedanken, Anleitungen und mehr"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:310
 msgid "Timezone"
-msgstr ""
+msgstr "Zeitzone"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:313
 msgid "Timezone for displaying dates (e.g., America/New_York)"
-msgstr ""
+msgstr "Zeitzone für Anzeige eines Datums (z.B. Europe/Berlin)"
 
 #: packages/admin/src/components/ContentList.tsx:239
 #: packages/admin/src/components/ContentList.tsx:367
@@ -6448,11 +6451,11 @@ msgstr "Titel"
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
 #: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
 msgid "Title (Tooltip)"
-msgstr ""
+msgstr "Titel (Tooltip)"
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:159
 msgid "Title Separator"
-msgstr ""
+msgstr "Titel-Trennzeichen"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
@@ -6486,7 +6489,7 @@ msgstr "Token-Name"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "Tools → Export"
-msgstr ""
+msgstr "Werkzeuge → Export"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:77
 msgid "Track content history"
@@ -6501,23 +6504,23 @@ msgstr "Übersetzen"
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:156
 msgid "Translate \"{0}\""
-msgstr ""
+msgstr "Übersetze \"{0}\""
 
 #. placeholder {0}: term.label
 #: packages/admin/src/components/TaxonomyManager.tsx:80
 msgid "Translate {0}"
-msgstr ""
+msgstr "Übersetze {0}"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:194
 #: packages/admin/src/components/TranslationsPanel.tsx:99
 msgid "Translating..."
-msgstr ""
+msgstr "Übersetze..."
 
 #: packages/admin/src/components/MenuEditor.tsx:89
 #: packages/admin/src/components/TaxonomyManager.tsx:756
 #: packages/admin/src/router.tsx:877
 msgid "Translation created"
-msgstr ""
+msgstr "Übersetzung erstellt"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:56
 msgid "Translations"
@@ -6525,7 +6528,7 @@ msgstr "Übersetzungen"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:198
 msgid "trash"
-msgstr ""
+msgstr "Papierkorb"
 
 #: packages/admin/src/components/comments/CommentDetail.tsx:170
 #: packages/admin/src/components/comments/CommentInbox.tsx:216
@@ -6541,70 +6544,70 @@ msgstr "Papierkorb ist leer"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:549
 msgid "Trash is empty."
-msgstr ""
+msgstr "Papierkorb ist leer."
 
 #: packages/admin/src/components/FieldEditor.tsx:175
 msgid "True/false toggle"
-msgstr ""
+msgstr "Ja/Nein Schalter"
 
 #: packages/admin/src/components/MediaLibrary.tsx:378
 #: packages/admin/src/components/MediaPickerModal.tsx:628
 msgid "Try a different search term"
-msgstr ""
+msgstr "Versuche einen anderen Suchbegriff"
 
 #: packages/admin/src/components/ContentPickerModal.tsx:172
 #: packages/admin/src/components/SectionPickerModal.tsx:102
 msgid "Try adjusting your search"
-msgstr ""
+msgstr "Versuche deine Suche anzupassen"
 
 #: packages/admin/src/components/Sections.tsx:260
 msgid "Try adjusting your search or filters."
-msgstr ""
+msgstr "Versuche deine Suche oder die Filter anzupassen."
 
 #: packages/admin/src/routes/users.tsx:210
 msgid "Try again"
-msgstr ""
+msgstr "Versuche es erneut"
 
 #: packages/admin/src/components/WordPressImport.tsx:1421
 msgid "Try Again"
-msgstr ""
+msgstr "Versuche es erneut"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:207
 msgid "Try another code"
-msgstr ""
+msgstr "Versuche es mit einem anderen Code"
 
 #: packages/admin/src/components/WordPressImport.tsx:1125
 #: packages/admin/src/components/WordPressImport.tsx:1247
 msgid "Try Another URL"
-msgstr ""
+msgstr "Versuche es mit einer anderen URL"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
 msgid "Try with my data"
-msgstr ""
+msgstr "Mit meinen Daten versuchen"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:279
 msgid "Turn into"
-msgstr ""
+msgstr "Umwandeln in"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:132
 msgid "Twitter"
-msgstr ""
+msgstr "Twitter"
 
 #: packages/admin/src/components/FieldEditor.tsx:571
 #: packages/admin/src/components/MediaLibrary.tsx:429
 msgid "Type"
-msgstr ""
+msgstr "Typ"
 
 #. placeholder {0}: status.existingType
 #: packages/admin/src/components/WordPressImport.tsx:1854
 msgid "Type mismatch ({0})"
-msgstr ""
+msgstr "Typkonflikt ({0})"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
 msgid "Unable to reach marketplace"
-msgstr ""
+msgstr "Verbindung mit Marktplatz fehlgeschlagen"
 
 #: packages/admin/src/components/ContentEditor.tsx:2236
 #: packages/admin/src/components/ContentEditor.tsx:2251
@@ -6614,34 +6617,34 @@ msgstr "Nicht zugewiesen"
 #: packages/admin/src/components/PortableTextEditor.tsx:2513
 #: packages/admin/src/components/PortableTextEditor.tsx:2819
 msgid "Underline"
-msgstr ""
+msgstr "Unterstreichen"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3016
 msgid "Undo"
-msgstr ""
+msgstr "Rückgängig"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:181
 #: packages/admin/src/components/PluginManager.tsx:543
 #: packages/admin/src/components/PluginManager.tsx:639
 msgid "Uninstall"
-msgstr ""
+msgstr "Deinstallieren"
 
 #: packages/admin/src/components/PluginManager.tsx:623
 msgid "Uninstall {pluginName}?"
-msgstr ""
+msgstr "{pluginName} deinstallieren?"
 
 #: packages/admin/src/components/PluginManager.tsx:618
 msgid "Uninstall confirmation"
-msgstr ""
+msgstr "Deinstallationsbestätigung"
 
 #: packages/admin/src/components/PluginManager.tsx:639
 msgid "Uninstalling..."
-msgstr ""
+msgstr "Deinstallieren..."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:722
 #: packages/admin/src/components/FieldEditor.tsx:442
 msgid "Unique"
-msgstr ""
+msgstr "Einzigartig"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:107
 msgid "Unique identifier (ULID)"
@@ -6669,15 +6672,15 @@ msgstr "Unbenannter Passkey"
 
 #: packages/admin/src/components/ContentEditor.tsx:728
 msgid "Unpublish"
-msgstr "Unveröffentlicht machen"
+msgstr "Depublizieren"
 
 #: packages/admin/src/router.tsx:794
 msgid "Unpublished"
-msgstr ""
+msgstr "Depubliziert"
 
 #: packages/admin/src/components/ContentTypeList.tsx:55
 msgid "Unregistered Content Tables Found"
-msgstr ""
+msgstr "Unregistrierte Inhaltstabellen gefunden"
 
 #: packages/admin/src/components/ContentEditor.tsx:874
 msgid "Unschedule"
@@ -6685,7 +6688,7 @@ msgstr "Planung aufheben"
 
 #: packages/admin/src/router.tsx:847
 msgid "Unscheduled"
-msgstr ""
+msgstr "Ungeplant"
 
 #. placeholder {0}: (element as { type: string }).type
 #: packages/admin/src/components/BlockKitFieldWidget.tsx:128
@@ -6694,11 +6697,11 @@ msgstr ""
 
 #: packages/admin/src/components/Dashboard.tsx:249
 msgid "Untitled"
-msgstr "Ohne Titel"
+msgstr "Unbenannt"
 
 #: packages/admin/src/components/ContentEditor.tsx:1810
 msgid "Untitled file"
-msgstr ""
+msgstr "Unbenannte Datei"
 
 #: packages/admin/src/components/Widgets.tsx:466
 #: packages/admin/src/components/Widgets.tsx:729
@@ -6707,7 +6710,7 @@ msgstr ""
 
 #: packages/admin/src/components/PublisherHandle.tsx:145
 msgid "Unverified publisher"
-msgstr ""
+msgstr "Unverifizierter Herausgeber"
 
 #: packages/admin/src/components/ContentEditor.tsx:2063
 msgid "Up"
@@ -6715,11 +6718,11 @@ msgstr "Hoch"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:476
 msgid "Update"
-msgstr ""
+msgstr "Aktualisieren"
 
 #: packages/admin/src/components/FieldEditor.tsx:659
 msgid "Update Field"
-msgstr ""
+msgstr "Feld aktualisieren"
 
 #. placeholder {0}: editingDomain?.domain
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
@@ -6728,21 +6731,21 @@ msgstr "Einstellungen für Domain {0} ändern"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
 msgid "Update site settings"
-msgstr ""
+msgstr "Webseiten-Einstellungen aktualisieren"
 
 #. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
 #: packages/admin/src/components/TaxonomyManager.tsx:364
 msgid "Update the {0} details"
-msgstr ""
+msgstr "Aktualisiere die {0} Details"
 
 #: packages/admin/src/components/Redirects.tsx:106
 msgid "Update this redirect rule."
-msgstr ""
+msgstr "Ändere diese Weiterleitungsregel."
 
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:413
 msgid "Update to v{0}"
-msgstr ""
+msgstr "Aktualisieren auf v{0}"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:129
 msgid "Updated At"
@@ -6755,70 +6758,70 @@ msgstr "Aktualisiert: {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:844
 msgid "Updating content URLs..."
-msgstr ""
+msgstr "Inhalts-URLs aktualisieren..."
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:166
 #: packages/admin/src/components/PluginManager.tsx:413
 msgid "Updating..."
-msgstr ""
+msgstr "Aktualisieren..."
 
 #: packages/admin/src/components/MediaPickerModal.tsx:586
 msgid "Upload"
-msgstr ""
+msgstr "Hochladen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:140
 msgid "Upload a file to get started"
-msgstr ""
+msgstr "Lade eine Datei hoch um zu beginnen"
 
 #: packages/admin/src/components/WordPressImport.tsx:1230
 msgid "Upload an export file"
-msgstr ""
+msgstr "Lade eine Export-Datei hoch"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:141
 msgid "Upload an image to get started"
-msgstr ""
+msgstr "Lade ein Bild hoch um zu beginnen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Upload and delete media"
-msgstr "Medien hochladen und löschen"
+msgstr "Medien hochladen und entfernen"
 
 #: packages/admin/src/lib/api/marketplace.ts:225
 #: packages/admin/src/lib/api/marketplace.ts:233
 msgid "Upload and manage media"
-msgstr ""
+msgstr "Medien hochladen und verwalten"
 
 #: packages/admin/src/components/WordPressImport.tsx:1123
 #: packages/admin/src/components/WordPressImport.tsx:1244
 msgid "Upload Export File"
-msgstr ""
+msgstr "Lade Export-Datei hoch"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:606
 msgid "Upload failed: {uploadError}"
-msgstr ""
+msgstr "Hochladen fehlgeschlagen: {uploadError}"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:598
 msgid "Upload file"
-msgstr ""
+msgstr "Bild hochladen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:142
 msgid "Upload File"
-msgstr ""
+msgstr "Datei hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:329
 msgid "Upload files"
-msgstr ""
+msgstr "Dateien hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:369
 msgid "Upload Files"
-msgstr ""
+msgstr "Dateien hochladen"
 
 #: packages/admin/src/components/MediaPickerModal.tsx:142
 msgid "Upload Image"
-msgstr ""
+msgstr "Bild hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:366
 msgid "Upload images, videos, and documents to get started."
-msgstr ""
+msgstr "Lade Bilder, Videos und Dokumente hoch um zu beginnen."
 
 #: packages/admin/src/components/Dashboard.tsx:89
 msgid "Upload Media"
@@ -6826,35 +6829,35 @@ msgstr "Medien hochladen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:380
 msgid "Upload media to get started"
-msgstr ""
+msgstr "Lade Medien hoch um zu beginnen"
 
 #. placeholder {0}: activeProviderInfo?.name || t`Library`
 #: packages/admin/src/components/MediaLibrary.tsx:320
 msgid "Upload to {0}"
-msgstr ""
+msgstr "Hochladen zu {0}"
 
 #: packages/admin/src/components/WordPressImport.tsx:960
 msgid "Upload WordPress export file"
-msgstr ""
+msgstr "Lade WordPress-Export-Datei hoch"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:184
 msgid "Uploaded:"
-msgstr ""
+msgstr "Hochgeladen:"
 
 #: packages/admin/src/components/WordPressImport.tsx:1963
 msgid "Uploading"
-msgstr ""
+msgstr "Hochladen"
 
 #. placeholder {0}: uploadState.progress.current
 #. placeholder {1}: uploadState.progress.total
 #: packages/admin/src/components/MediaLibrary.tsx:295
 msgid "Uploading {0}/{1}..."
-msgstr ""
+msgstr "Lade {0}/{1} hoch..."
 
 #: packages/admin/src/components/MediaLibrary.tsx:296
 #: packages/admin/src/components/MediaPickerModal.tsx:586
 msgid "Uploading..."
-msgstr ""
+msgstr "Hochladen..."
 
 #: packages/admin/src/components/FieldEditor.tsx:234
 #: packages/admin/src/components/FieldEditor.tsx:586
@@ -6862,11 +6865,11 @@ msgstr ""
 #: packages/admin/src/components/MenuEditor.tsx:501
 #: packages/admin/src/components/PortableTextEditor.tsx:2952
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:425
 msgid "URL Pattern"
-msgstr ""
+msgstr "URL-Muster"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:113
 #: packages/admin/src/components/FieldEditor.tsx:229
@@ -6875,15 +6878,15 @@ msgstr "URL-freundlicher Bezeichner"
 
 #: packages/admin/src/components/MenuList.tsx:162
 msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
-msgstr ""
+msgstr "URL-freundliche Kennung (z.B., \"hauptbereich\", \"fusszeile\")"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."
-msgstr ""
+msgstr "Nutze [param] oder [...rest] in Pfaden für Musterabgleiche."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:366
 msgid "Use your device's biometric authentication, security key, or PIN to sign in."
-msgstr ""
+msgstr "Nutze die biometrischen Authentifizierung, den Sicherheitsschlüssel oder die PIN deines Geräts für die Anmeldung."
 
 #: packages/admin/src/components/LoginPage.tsx:326
 msgid "Use your registered passkey to sign in securely."
@@ -6891,11 +6894,11 @@ msgstr "Verwende deinen registrierten Passkey, um dich sicher anzumelden."
 
 #: packages/admin/src/components/settings/SeoSettings.tsx:173
 msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
-msgstr ""
+msgstr "Wird als Standard-Open-Graph-Bild verwendet, wenn eine Seite kein Bild enthält. Empfohlene Größe: 1200×630."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:642
 msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
-msgstr ""
+msgstr "Wird als Kennung verwendet. Nur Kleinbuchstaben, Ziffern und Unterstriche."
 
 #: packages/admin/src/components/ContentEditor.tsx:1325
 msgid "Used as the main visual for this post on listing pages and at the top of the post"
@@ -6903,16 +6906,16 @@ msgstr "Wird als Hauptbild für diesen Beitrag auf Listenseiten und am Anfang de
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:206
 msgid "Used by screen readers and when image fails to load"
-msgstr ""
+msgstr "Wird von Bildschirmleseprogrammen verwendet und wenn das Bild nicht geladen werden kann"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:410
 msgid "Used in URLs and API endpoints"
-msgstr ""
+msgstr "Wird in URLs und API-Endpunkten verwendet"
 
 #: packages/admin/src/components/SectionEditor.tsx:254
 #: packages/admin/src/components/Sections.tsx:196
 msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
-msgstr ""
+msgstr "Dient der Kennzeichnung dieses Abschnitts. Nur Kleinbuchstaben, Zahlen und Bindestriche."
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:223
 #: packages/admin/src/components/Header.tsx:37
@@ -6951,44 +6954,44 @@ msgstr "Nutzer mit E-Mail-Adressen dieser Domains können sich ohne Einladung re
 #. placeholder {0}: updateInfo.latest
 #: packages/admin/src/components/PluginManager.tsx:357
 msgid "v{0} available"
-msgstr ""
+msgstr "v{0} verfügbar"
 
 #: packages/admin/src/components/FieldEditor.tsx:460
 #: packages/admin/src/components/FieldEditor.tsx:490
 msgid "Validation"
-msgstr ""
+msgstr "Validierung"
 
 #: packages/admin/src/components/RegistryBrowse.tsx:186
 #: packages/admin/src/components/RegistryPluginDetail.tsx:314
 msgid "Verified publisher"
-msgstr ""
+msgstr "Verifizierter Herausgeber"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:194
 msgid "Verifying your invite..."
-msgstr ""
+msgstr "Verifiziere deine Einladung..."
 
 #: packages/admin/src/components/SignupPage.tsx:386
 msgid "Verifying your link..."
-msgstr ""
+msgstr "Verifiziere deinen Link..."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:213
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
 msgid "Verifying..."
-msgstr ""
+msgstr "Verifiziere..."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:321
 #: packages/admin/src/components/RegistryPluginDetail.tsx:334
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 #. placeholder {0}: release.version
 #: packages/admin/src/components/RegistryPluginDetail.tsx:325
 msgid "Version {0}"
-msgstr ""
+msgstr "Version {0}"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:67
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 #: packages/admin/src/components/Settings.tsx:116
 msgid "View email provider status and send test emails"
@@ -6996,7 +6999,7 @@ msgstr "E-Mail-Anbieter-Status anzeigen und Test-E-Mails senden"
 
 #: packages/admin/src/components/PluginManager.tsx:425
 msgid "View in Marketplace"
-msgstr ""
+msgstr "Im Marktplatz anzeigen"
 
 #: packages/admin/src/components/MediaLibrary.tsx:233
 msgid "View mode"
@@ -7020,12 +7023,12 @@ msgstr ""
 
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Visitors hitting these paths will see an error."
-msgstr ""
+msgstr "Besucher, die diese Pfade aufrufen, erhalten eine Fehlermeldung."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
 msgid "Waiting for passkey..."
-msgstr ""
+msgstr "Warte auf Passkey..."
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:333
 msgid "Warn"
@@ -7034,15 +7037,15 @@ msgstr ""
 #. placeholder {0}: result.url
 #: packages/admin/src/components/WordPressImport.tsx:1105
 msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
-msgstr ""
+msgstr "Wir konnten keine Verbindung zu einer WordPress-Website unter {0} herstellen. Dies könnte bedeuten, dass es sich nicht um eine WordPress-Website handelt, die REST-API deaktiviert ist oder die Website nicht erreichbar ist."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:396
 msgid "We couldn't verify this publisher's identity"
-msgstr ""
+msgstr "Wir konnten die Identität dieses Herausgebers nicht überprüfen"
 
 #: packages/admin/src/components/WordPressImport.tsx:926
 msgid "We'll check what import options are available for your site."
-msgstr ""
+msgstr "Wir prüfen, welche Importoptionen für Ihre Website verfügbar sind."
 
 #: packages/admin/src/components/LoginPage.tsx:323
 msgid "We'll send you a link to sign in without a password."
@@ -7050,25 +7053,25 @@ msgstr "Wir schicken dir einen Link, um dich ohne Passwort anzumelden."
 
 #: packages/admin/src/components/SignupPage.tsx:132
 msgid "We've sent a verification link to"
-msgstr ""
+msgstr "Wir haben einen Bestätigungslink gesendet an"
 
 #: packages/admin/src/components/FieldEditor.tsx:235
 msgid "Web address"
-msgstr ""
+msgstr "Web-Adresse"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:159
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
 msgid "WebAuthn is not supported in this browser"
-msgstr ""
+msgstr "WebAuthn wird von diesem Browser nicht unterstützt"
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:226
 #: packages/admin/src/components/RegistryPluginDetail.tsx:474
 msgid "Website"
-msgstr ""
+msgstr "Webseite"
 
 #: packages/admin/src/routes/bylines.tsx:404
 msgid "Website URL"
-msgstr ""
+msgstr "Webseiten-URL"
 
 #: packages/admin/src/components/WelcomeModal.tsx:96
 msgid "Welcome to EmDash, {firstName}!"
@@ -7084,7 +7087,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1710
 msgid "What will happen when you import"
-msgstr ""
+msgstr "Was beim Importieren passiert:"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:125
 msgid "When the entry was created"
@@ -7157,11 +7160,11 @@ msgstr "können sich nicht mehr ohne Einladung registrieren. Bereits registriert
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:184
 msgid "Without an email provider, invite links must be shared manually."
-msgstr ""
+msgstr "Ohne E-Mail-Anbieter müssen Einladungslinks eigenhändig geteilt werden."
 
 #: packages/admin/src/components/WordPressImport.tsx:1315
 msgid "WordPress Username"
-msgstr ""
+msgstr "WordPress-Benutzername"
 
 #: packages/admin/src/components/Widgets.tsx:824
 msgid "Write widget content..."
@@ -7169,7 +7172,7 @@ msgstr ""
 
 #: packages/admin/src/components/WordPressImport.tsx:1023
 msgid "WXR File"
-msgstr ""
+msgstr "WXR-Datei"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 msgid "Yes"
@@ -7177,7 +7180,7 @@ msgstr "Ja"
 
 #: packages/admin/src/components/DeviceAuthorizePage.tsx:188
 msgid "You can close this page and return to your terminal."
-msgstr ""
+msgstr "Du kannst diese Seite schließen und zu deinem Terminal zurückkehren."
 
 #: packages/admin/src/components/WelcomeModal.tsx:43
 msgid "You can create and edit your own content."
@@ -7193,7 +7196,7 @@ msgstr "Du kannst die Website ansehen und mitwirken."
 
 #: packages/admin/src/components/users/UserDetail.tsx:175
 msgid "You cannot change your own role"
-msgstr ""
+msgstr "Du kannst deine eigene Rolle nicht ändern"
 
 #: packages/admin/src/components/WelcomeModal.tsx:41
 msgid "You have full access to manage this site, including users, settings, and all content."
@@ -7201,50 +7204,50 @@ msgstr "Du hast vollen Zugriff, um diese Website zu verwalten, einschließlich B
 
 #: packages/admin/src/router.tsx:1187
 msgid "You need Editor permissions to moderate comments."
-msgstr ""
+msgstr "Du benötigst Redakteur-Berechtigungen um Kommentare zu moderieren."
 
 #. placeholder {0}: passkey.name
 #: packages/admin/src/components/settings/PasskeyItem.tsx:206
 msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Du kannst dich nicht mehr als \"{0}\" anmelden. Dieser Vorgang kann nicht rückgängig gemacht werden."
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:207
 msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
-msgstr ""
+msgstr "Du kannst diesen Passkey nicht mehr nutzen um dich anzumelden. Dieser Vorgang kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: inviteData.roleName
 #: packages/admin/src/components/InviteAcceptPage.tsx:52
 msgid "You'll be joining as <0>{0}</0>"
-msgstr ""
+msgstr "Du trittst als <0>{0}</0> bei"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
 msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
-msgstr ""
+msgstr "Du wirst aufgefordert, die biometrische Authentifizierung, den Sicherheitsschlüssel oder die PIN deines Geräts zu verwenden."
 
 #: packages/admin/src/components/WordPressImport.tsx:1208
 msgid "You'll be redirected to WordPress to authorize the connection."
-msgstr ""
+msgstr "Du wirst zu WordPress weitergeleitet, um die Verbindung zu autorisieren."
 
 #: packages/admin/src/components/SignupPage.tsx:191
 msgid "You'll be signing up as"
-msgstr ""
+msgstr "Du wirst dich registrieren als"
 
 #: packages/admin/src/components/SetupWizard.tsx:564
 msgid "You're signed in via Cloudflare Access"
-msgstr ""
+msgstr "Du bist über Cloudflare Access angemeldet"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:50
 msgid "You've been invited!"
-msgstr ""
+msgstr "Du wurdest eingeladen!"
 
 #: packages/admin/src/components/SignupPage.tsx:70
 msgid "you@company.com"
-msgstr ""
+msgstr "du@unternehmen.de"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:336
 #: packages/admin/src/components/SetupWizard.tsx:201
 msgid "you@example.com"
-msgstr ""
+msgstr "du@example.com"
 
 #: packages/admin/src/components/WelcomeModal.tsx:39
 msgid "Your account has been created successfully."
@@ -7253,41 +7256,41 @@ msgstr "Dein Konto wurde erfolgreich erstellt."
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:318
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
 msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
-msgstr ""
+msgstr "Dein Browser unterstützt keine Passkeys. Bitte verwende einen modernen Browser wie Chrome, Safari, Firefox oder Edge."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:269
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
 msgid "Your device doesn't support the required security features."
-msgstr ""
+msgstr "Dein Gerät unterstützt die erforderlichen Sicherheitsfunktionen nicht."
 
 #: packages/admin/src/components/SetupWizard.tsx:197
 msgid "Your Email"
-msgstr ""
+msgstr "Deine E-Mail-Adresse"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:147
 msgid "Your Facebook page or profile username"
-msgstr ""
+msgstr "Deine Facebook-Seite oder -Profilname"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:141
 msgid "Your GitHub username"
-msgstr ""
+msgstr "Dein GitHub-Benutzername"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:153
 msgid "Your Instagram username"
-msgstr ""
+msgstr "Dein Instagram-Benutzername"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:159
 msgid "Your LinkedIn profile username"
-msgstr ""
+msgstr "Dein LinkedIn-Profil-Benutzername"
 
 #: packages/admin/src/components/SetupWizard.tsx:209
 msgid "Your Name"
-msgstr ""
+msgstr "Dein Name"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:62
 #: packages/admin/src/components/SignupPage.tsx:201
 msgid "Your name (optional)"
-msgstr ""
+msgstr "Dein Name (optional)"
 
 #: packages/admin/src/components/WelcomeModal.tsx:40
 msgid "Your Role"
@@ -7296,21 +7299,21 @@ msgstr "Deine Rolle"
 #. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
 #: packages/admin/src/components/RegistryPluginDetail.tsx:431
 msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
-msgstr ""
+msgstr "Deine Webseite erlaubt die Installation von Versionen erst, wenn diese mindestens {0} alt sind. Diese Version wird zu einem späteren Zeitpunkt installierbar sein."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:135
 msgid "Your Twitter/X handle (e.g., @username)"
-msgstr ""
+msgstr "Dein Twitter-/X-Benutzername (z. B. @benutzername)"
 
 #. placeholder {0}: attachments.count
 #: packages/admin/src/components/WordPressImport.tsx:1898
 msgid "Your WordPress export contains {0} media files."
-msgstr ""
+msgstr "Dein WordPress-Export enthält {0} Mediendateien."
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:165
 msgid "Your YouTube channel ID or handle"
-msgstr ""
+msgstr "Deine YouTube-Kanal-ID oder dein Nutzername"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:162
 msgid "YouTube"
-msgstr ""
+msgstr "YouTube"

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -5480,12 +5480,12 @@ msgstr "Schema bearbeiten"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
 msgid "Scopes"
-msgstr "Berechtigungen"
+msgstr "Bereiche"
 
 #. placeholder {0}: token.scopes.join(", ")
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
 msgid "Scopes: {0}"
-msgstr "Berechtigungen: {0}"
+msgstr "Bereiche: {0}"
 
 #. placeholder {0}: i + 1
 #. placeholder {0}: index + 1

--- a/packages/admin/src/locales/de/messages.po
+++ b/packages/admin/src/locales/de/messages.po
@@ -1751,15 +1751,15 @@ msgstr "Erstelle deinen Passkey"
 #: packages/admin/src/lib/api/marketplace.ts:223
 #: packages/admin/src/lib/api/marketplace.ts:231
 msgid "Create, update, and delete content"
-msgstr "Erstelle, aktualisiere oder entferne Inhalte"
+msgstr "Erstelle, aktualisiere und entferne Inhalte"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
 msgid "Create, update, and delete navigation menus"
-msgstr "Erstelle, aktualisiere oder entferne Navigationsmenüs"
+msgstr "Erstelle, aktualisiere und entferne Navigationsmenüs"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
-msgstr "Erstelle, aktualisiere oder entferne Taxonomiebegriffe"
+msgstr "Erstelle, aktualisiere und entferne Taxonomiebegriffe"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
@@ -4092,7 +4092,7 @@ msgstr "Bearbeitet"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
 msgid "Modify collection schemas"
-msgstr "Kollektionsschemata ändern oder entfernen"
+msgstr "Kollektionsschemata ändern und entfernen"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:42
 msgid "Most Popular"
@@ -6785,7 +6785,7 @@ msgstr "Lade ein Bild hoch, um zu beginnen"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
 msgid "Upload and delete media"
-msgstr "Mediendateien hochladen oder entfernen"
+msgstr "Mediendateien hochladen und entfernen"
 
 #: packages/admin/src/lib/api/marketplace.ts:225
 #: packages/admin/src/lib/api/marketplace.ts:233


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

- This PR adds missing translations for the German language
- Current German coverage (estimate) of this PR: 99% (100% is not yet possible because 2 msgid's are causing issues, see below)
- T.W.I.M.C. I am a native German speaker/writer/citizen :D
- I also updated some already existing (GER) translations because they were either not well phrased or incorrect
- I checked the translations live/using the local demo setup to be aware of the context
- All translations are using the informal "du/dich" wording instead of the very formal "sie/ihr" form. Reason being:
  - "du/dich" establishes are warm/welcoming feel as soon as a user starts using EmDash.
  - I ensured that while using it, the professional tone of EmDash as a software users are supposed to trust is being incorporated. The German language allows this without the need to use the formal "sie/ihr" form.
  - The writing form ("sie" vs. "du") can be adjusted anytime in case the maintainers feel the need to do so (I'm happy to take care of it - although I prefer the informal version for the reason stated above).
- I avoided a mixture of both languages (EN/DE) wherever possible.
  - Example: The translation of "Plugin" for this projects context is "Erweiterung". As someone working in IT, I do not feel happy with this because I am used to English words like "Plugin" - because of my job. However, we should not make the mistake and follow this approach. This would potentially limit the German speaking users of EmDash to folks who do not have issues with a heavy mixture of English and German (=usually IT/Tech folks). Instead, we should aim to provide a native German translation. Result: Folks like me who do prefer the English translation will use it, but folks who do not feel comfortable with English can switch EmDash to German without still being presented with English terms all over the place.

### My ToDo's prior to requesting a review
- [x] Finalize German translations
- [x] Review all already existing translations again and correct them if necessary (e.g. grammar, wording, ...)
- [x] Perform a final check for consistency to ensure the translations do not differ in the same admin area/context
- [x] Complete the PR checklist below
- [x] If required: rebase my branch to get the latest changes and resolve potential conflicts
- [x] Leave the draft stage of this PR by requesting a review

### Issues found

> Feel free to let me know if you would like me to create an issue and/or a PR to fix this.

The [`msgid "Add"`](https://github.com/pitscher/emdash/blob/5c57bc0a3ece8db5a9cd715bc67c198671cd030a/packages/admin/src/locales/de/messages.po#L530) & [`msgid "Edit"`](https://github.com/pitscher/emdash/blob/5c57bc0a3ece8db5a9cd715bc67c198671cd030a/packages/admin/src/locales/de/messages.po#L2343) cannot be translated into German.

Additionally, the [`msgid "{0} permission{1}"`](https://github.com/pitscher/emdash/blob/i18n/de/packages/admin/src/locales/de/messages.po#L209) needs to be reworked as it currently does not allow the German plural to be used. I implemented a temporary fix and added a comment to keep track of this.

**See the pictures at the end of this PR description to better understand the issue**


Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) - not applicable
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
Correct would be: "+ Category hinzufügen" or "+ {collectionLabel} hinzufügen"
The issue is that `msgid "Add"` & `msgid "Edit"` are not flexible enough to cover this case. Additionally, they are used at many other places (like editing already existing taxonomies).
<img width="368" height="354" alt="Screenshot 2026-05-29 at 23 51 32" src="https://github.com/user-attachments/assets/5826cea2-7c7e-4e87-a067-09d940e4f61d" />
<img width="419" height="364" alt="Screenshot 2026-05-30 at 00 04 42" src="https://github.com/user-attachments/assets/dbfb5153-e2ec-4b16-8421-6bf4664a6fb8" />

<img width="544" height="567" alt="Screenshot 2026-05-29 at 23 54 29" src="https://github.com/user-attachments/assets/92e8d60a-3d6c-4aeb-9002-fa543e0fc426" />
<img width="540" height="556" alt="Screenshot 2026-05-30 at 00 05 39" src="https://github.com/user-attachments/assets/e234813b-8ea4-4edb-affb-fb2b73384107" />

<img width="445" height="194" alt="Screenshot 2026-05-30 at 14 53 01" src="https://github.com/user-attachments/assets/363eef2b-1d34-4922-acfa-390d49b18de9" />