### PR TITLE
i18n(id): complete Indonesian translation (7 strings)

### DIFF
--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -52,7 +52,7 @@ msgstr "(dari {0})"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:352
 msgid "(pre-release)"
-msgstr ""
+msgstr "(pra-rilis)"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:157
 msgid "(synced)"
@@ -60,7 +60,7 @@ msgstr "(disinkronkan)"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:355
 msgid "(too new)"
-msgstr ""
+msgstr "(terlalu baru)"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
@@ -2578,7 +2578,7 @@ msgstr "Gagal memperbarui widget"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:415
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "Setiap rilis yang dipublikasikan dari plugin ini telah ditarik atau tidak dapat diverifikasi. Periksa kembali nanti, atau hubungi penerbit."
 
 #: packages/admin/src/components/WordPressImport.tsx:1846
 msgid "Exists"
@@ -3868,7 +3868,7 @@ msgstr "Kelola {0} untuk {1}"
 
 #: packages/admin/src/components/ContentEditor.tsx:2020
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "Kelola byline di {entryLocale}"
 
 #: packages/admin/src/components/Widgets.tsx:326
 msgid "Manage content widgets in your widget areas"
@@ -4272,7 +4272,7 @@ msgstr "Belum ada komentar disetujui."
 
 #: packages/admin/src/components/ContentEditor.tsx:2012
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "Tidak ada byline yang tersedia di {entryLocale}. Buat varian dari halaman Byline sebelum menambahkan satu pada entri ini."
 
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "No bylines found"
@@ -4348,7 +4348,7 @@ msgstr "Tidak ada judul di dokumen"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:413
 msgid "No installable releases"
-msgstr ""
+msgstr "Tidak ada rilis yang dapat diinstal"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:159
 msgid "No invite token provided"
@@ -4873,7 +4873,7 @@ msgstr "Pos Per Halaman"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:327
 msgid "Pre-release"
-msgstr ""
+msgstr "Pra-rilis"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."


### PR DESCRIPTION
## What does this PR do?

Completes the Indonesian (Bahasa Indonesia) locale by translating the 7 remaining untranslated strings, bringing the `id` locale to 100% coverage (1,603/1,603 strings).

These strings were introduced by two PRs merged after the last `id` translation update:
- feat(registry): version picker on plugin detail (#1034) — 5 strings
- feat: bylines i18n support (#1146) — 2 strings

Closes ahliweb/emdash-awcms#18

### Translations

| English | Indonesian |
|---|---|
| `(pre-release)` | `(pra-rilis)` |
| `(too new)` | `(terlalu baru)` |
| `Pre-release` | `Pra-rilis` |
| `No installable releases` | `Tidak ada rilis yang dapat diinstal` |
| `Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher.` | `Setiap rilis yang dipublikasikan dari plugin ini telah ditarik atau tidak dapat diverifikasi. Periksa kembali nanti, atau hubungi penerbit.` |
| `Manage bylines in {entryLocale}` | `Kelola byline di {entryLocale}` |
| `No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry.` | `Tidak ada byline yang tersedia di {entryLocale}. Buat varian dari halaman Byline sebelum menambahkan satu pada entri ini.` |

All translations follow the existing catalog conventions in `id/messages.po` — "byline" is kept as a system term, template variables like `{entryLocale}` are preserved, and terminology matches the established Indonesian patterns already in the file.


## Type of change

- [x] Translation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude (OpenCode + DeepSeek V4 Pro)