### PR TITLE
fix(mcp): inline seo + bylines schemas to avoid $ref indirection in content tools

### DIFF
--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -14,7 +14,27 @@ import { canActOnOwn, hasPermission, Role } from "@emdash-cms/auth";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { contentBylineInputSchema, contentSeoInput } from "#api/schemas.js";
+import {
+	contentBylineInputSchema as _contentBylineInputSchema,
+	contentSeoInput as _contentSeoInput,
+} from "#api/schemas.js";
+
+// Inline the .meta({ id })-tagged schemas so zod 4's toJSONSchema()
+// emits them as `type: "object"` at the use site instead of
+// `allOf:[{ $ref: "#/definitions/..." }]`. Strict MCP clients (Claude
+// Desktop, Anthropic SDK) marshal tool arguments by walking
+// `properties[name].type` and silently drop properties without a
+// top-level type — symptom is the `seo` and `bylines` args silently
+// vanishing on content_create/content_update while `data` (untagged,
+// inlined) goes through. Re-wrapping `.shape` preserves every
+// field-level validation (including the httpUrl refinement on
+// canonical) but loses the parent's id tag.
+//
+// REST and OpenAPI routes import the originals directly from
+// #api/schemas.js — they want the $ref-able named schema for their
+// generated documentation. Only this MCP path strips the tag.
+const contentSeoInput = z.object(_contentSeoInput.shape);
+const contentBylineInputSchema = z.object(_contentBylineInputSchema.shape);
 
 import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";


### PR DESCRIPTION
## Summary

`contentSeoInput` and `contentBylineInputSchema` are decorated with `.meta({ id: ... })`. When the MCP server passes them through `z.toJSONSchema()` to produce the tool input schemas for `content_create` and `content_update`, zod 4 lifts them into `definitions` and emits the property as:

```json
{
  "seo": {
    "allOf": [{ "$ref": "#/definitions/ContentSeoInput" }]
  }
}
```

Technically valid JSON Schema, but **strict MCP clients (Claude Desktop, recent Anthropic SDK builds)** marshal tool-call arguments by walking `properties[name].type`. A property without a top-level `type` silently drops the argument — no error, no warning.

## Symptom

Agents calling `content_update` with both `data` and `seo` get the `data` write through (no `.meta`, inlines fine with `type: "object"`) and the `seo` write **silently ignored**.

```json
{
  "name": "content_update",
  "arguments": {
    "id": "01K...",
    "data": { "title": "X" },
    "seo": { "title": "SEO X", "description": "SEO desc" }
  }
}
```

`data.title` lands. `seo.title` and `seo.description` don't. The `_emdash_seo` row stays at whatever it was before — completely opaque to the caller.

## Fix

Inline the schema shapes via `z.object(<schema>.shape)` inside the MCP tool definitions. This preserves every field-level validation (including the `httpUrl` refinement on `canonical`) but loses the parent's `.meta` tag, so `toJSONSchema()` emits the property as `{ type: "object", properties: { ... } }` — strict clients accept it.

REST and OpenAPI routes continue importing the originals from `#api/schemas.js` — those paths benefit from the named `$ref` for generated documentation. **Only the MCP path strips the tag.**

## Why not just remove `.meta` from the schema?

`contentSeoInput` is also used in `packages/core/src/api/schemas/content.ts` lines 43 and 61 (inside `createContentInput` / `updateContentInput`), and referenced from REST handlers. The `.meta({ id })` is deliberate for OpenAPI doc generation. Stripping it at the source would regress those consumers. Keeping the fix MCP-local preserves the existing pattern.

## Long-term cleanup (separate PR if you'd like)

If you'd prefer one schema for everything, add a helper:

```ts
// In #api/schemas.js
export function forMcp<T extends z.ZodObject<z.ZodRawShape>>(s: T) {
  return z.object(s.shape);
}
```

Then MCP call sites become:

```ts
import { forMcp } from "#api/schemas.js";
seo: forMcp(contentSeoInput).optional().describe(...)
```

…which keeps the intent obvious.

## Test plan

Suggested addition (not included in this PR — happy to add if you'd like):

```ts
import { z } from "zod";
import { contentSeoInput as upstream } from "../../src/api/schemas/content";

describe("contentSeoInput when inlined for MCP", () => {
  it("emits an inline object schema, not allOf:$ref", () => {
    const inlined = z.object(upstream.shape);
    const schema = z.toJSONSchema(inlined);
    expect(schema.type).toBe("object");
    expect(schema.$ref).toBeUndefined();
    expect(schema.allOf).toBeUndefined();
  });
});
```

## Reference

We currently carry this fix as a `patch-package` patch in a downstream fork: https://github.com/abhishekshankar/abhishek-shankar.com-emdash/blob/master/patches/emdash%2B0.9.0.patch — happy to delete it once this lands.