### PR TITLE
fix(seo): buildMediaUrl handles root-relative paths without doubling the API prefix

### DIFF
--- a/.changeset/puny-badgers-drop.md
+++ b/.changeset/puny-badgers-drop.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+fix(seo): buildMediaUrl handles root-relative paths without doubling the API prefix

--- a/packages/core/src/seo/index.ts
+++ b/packages/core/src/seo/index.ts
@@ -176,9 +176,7 @@ function buildMediaUrl(imageRef: string, siteUrl?: string): string {
 	// "${siteUrl}/_emdash/api/media/file//_emdash/api/media/file/<id>"
 	// which 404s and breaks <meta property="og:image">.
 	if (imageRef.startsWith("/")) {
-		return siteUrl
-			? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}`
-			: imageRef;
+		return siteUrl ? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}` : imageRef;
 	}
 
 	// Bare media_id — build the full media API path

--- a/packages/core/src/seo/index.ts
+++ b/packages/core/src/seo/index.ts
@@ -170,7 +170,18 @@ function buildMediaUrl(imageRef: string, siteUrl?: string): string {
 		return imageRef;
 	}
 
-	// Build from media API path
+	// Root-relative path — the CMS SEO panel stores seo_image as
+	// "/_emdash/api/media/file/01KS....svg" (already includes the API
+	// prefix). Without this branch we'd re-prefix and produce
+	// "${siteUrl}/_emdash/api/media/file//_emdash/api/media/file/<id>"
+	// which 404s and breaks <meta property="og:image">.
+	if (imageRef.startsWith("/")) {
+		return siteUrl
+			? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}`
+			: imageRef;
+	}
+
+	// Bare media_id — build the full media API path
 	const mediaPath = `/_emdash/api/media/file/${imageRef}`;
 	if (siteUrl) {
 		return `${siteUrl.replace(TRAILING_SLASH_RE, "")}${mediaPath}`;

--- a/packages/core/tests/unit/seo/get-seo-meta.test.ts
+++ b/packages/core/tests/unit/seo/get-seo-meta.test.ts
@@ -25,28 +25,18 @@ describe("getSeoMeta ogImage URL building", () => {
 			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
 			{ siteUrl: SITE },
 		);
-		expect(meta.ogImage).toBe(
-			"https://example.com/_emdash/api/media/file/01KS.svg",
-		);
+		expect(meta.ogImage).toBe("https://example.com/_emdash/api/media/file/01KS.svg");
 		expect(meta.ogImage).not.toContain("//_emdash");
 	});
 
 	it("returns root-relative paths as-is when no siteUrl is provided", () => {
-		const meta = getSeoMeta(
-			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
-			{},
-		);
+		const meta = getSeoMeta({ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} }, {});
 		expect(meta.ogImage).toBe("/_emdash/api/media/file/01KS.svg");
 	});
 
 	it("builds the full API path from a bare media_id", () => {
-		const meta = getSeoMeta(
-			{ seo: { image: "01KS" }, data: {} },
-			{ siteUrl: SITE },
-		);
-		expect(meta.ogImage).toBe(
-			"https://example.com/_emdash/api/media/file/01KS",
-		);
+		const meta = getSeoMeta({ seo: { image: "01KS" }, data: {} }, { siteUrl: SITE });
+		expect(meta.ogImage).toBe("https://example.com/_emdash/api/media/file/01KS");
 	});
 
 	it("strips trailing slash from siteUrl before joining a root-relative path", () => {
@@ -54,8 +44,6 @@ describe("getSeoMeta ogImage URL building", () => {
 			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
 			{ siteUrl: "https://example.com/" },
 		);
-		expect(meta.ogImage).toBe(
-			"https://example.com/_emdash/api/media/file/01KS.svg",
-		);
+		expect(meta.ogImage).toBe("https://example.com/_emdash/api/media/file/01KS.svg");
 	});
 });

--- a/packages/core/tests/unit/seo/get-seo-meta.test.ts
+++ b/packages/core/tests/unit/seo/get-seo-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import { getSeoMeta } from "../../../src/seo/index.js";
+
+// Lightweight unit tests for the getSeoMeta + buildMediaUrl path.
+// These don't touch the DB — they exercise the URL-building logic
+// directly via getSeoMeta's ogImage output.
+
+describe("getSeoMeta ogImage URL building", () => {
+	const SITE = "https://example.com";
+
+	it("returns absolute URLs as-is (no prefix doubling)", () => {
+		const meta = getSeoMeta(
+			{ seo: { image: "https://cdn.example.com/x.jpg" }, data: {} },
+			{ siteUrl: SITE },
+		);
+		expect(meta.ogImage).toBe("https://cdn.example.com/x.jpg");
+	});
+
+	it("joins root-relative paths with siteUrl without re-prefixing the API path", () => {
+		// Regression test: the CMS SEO panel stores seo_image as a
+		// root-relative path that already includes /_emdash/api/media/file/.
+		// Before the fix this produced "...media/file//_emdash/api/media/file/..."
+		const meta = getSeoMeta(
+			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
+			{ siteUrl: SITE },
+		);
+		expect(meta.ogImage).toBe(
+			"https://example.com/_emdash/api/media/file/01KS.svg",
+		);
+		expect(meta.ogImage).not.toContain("//_emdash");
+	});
+
+	it("returns root-relative paths as-is when no siteUrl is provided", () => {
+		const meta = getSeoMeta(
+			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
+			{},
+		);
+		expect(meta.ogImage).toBe("/_emdash/api/media/file/01KS.svg");
+	});
+
+	it("builds the full API path from a bare media_id", () => {
+		const meta = getSeoMeta(
+			{ seo: { image: "01KS" }, data: {} },
+			{ siteUrl: SITE },
+		);
+		expect(meta.ogImage).toBe(
+			"https://example.com/_emdash/api/media/file/01KS",
+		);
+	});
+
+	it("strips trailing slash from siteUrl before joining a root-relative path", () => {
+		const meta = getSeoMeta(
+			{ seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
+			{ siteUrl: "https://example.com/" },
+		);
+		expect(meta.ogImage).toBe(
+			"https://example.com/_emdash/api/media/file/01KS.svg",
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`buildMediaUrl(imageRef, siteUrl)` in `packages/core/src/seo/index.ts` currently handles two cases:

1. Absolute URL (`https://...`) → returned as-is
2. Anything else → treated as a bare `media_id` and built as `${siteUrl}/_emdash/api/media/file/${imageRef}`

But the CMS SEO panel stores `seo_image` as a **root-relative path** that *already includes* the API prefix, e.g. `/_emdash/api/media/file/01KS...svg`. Branch 2 fires and produces:

```
https://example.com/_emdash/api/media/file//_emdash/api/media/file/01KS.svg
                                          ^^ doubled
```

…which 404s and breaks `<meta property="og:image">` for every post that used the SEO panel to set an image.

**Fix:** add a third branch BEFORE the bare-`media_id` branch that detects root-relative inputs (`imageRef.startsWith("/")`) and joins them with the host directly — no API-prefix re-prepending.

```ts
if (imageRef.startsWith("/")) {
  return siteUrl
    ? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}`
    : imageRef;
}
```

### Repro

```ts
import { getSeoMeta } from "emdash/seo";

const meta = getSeoMeta(
  { seo: { image: "/_emdash/api/media/file/01KS.svg" }, data: {} },
  { siteUrl: "https://example.com" },
);

console.log(meta.ogImage);
// before: "https://example.com/_emdash/api/media/file//_emdash/api/media/file/01KS.svg"
// after:  "https://example.com/_emdash/api/media/file/01KS.svg"
```

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — N/A, internal `seo` helper, no user-visible strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`patch` to `emdash`)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... — N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code (Claude Opus)

## Screenshots / test output

New unit tests at `packages/core/tests/unit/seo/get-seo-meta.test.ts` cover:

- Absolute URLs pass through unchanged
- Root-relative paths join with `siteUrl` without doubling the prefix
- Root-relative paths returned as-is when no `siteUrl`
- Bare `media_id` still builds the full API path
- Trailing slash on `siteUrl` is stripped before joining

These don't need DB setup — direct unit tests against `getSeoMeta`.

---

### Bonus (separate PR if you'd like)

The same logic gets re-implemented by user code that needs to resolve media references outside of `getSeoMeta` (avatar URLs, JSON-LD `ImageObject.url`, list-page thumbnails). Those sites currently either reach for `import { buildMediaUrl } from "emdash/seo"` (fails — not exported) or re-implement the logic inline and drift.

Exporting `buildMediaUrl` would be a one-line addition:

```diff
-export { getContentSeo, getSeoMeta };
+export { buildMediaUrl, getContentSeo, getSeoMeta };
```

Happy to file as a follow-up.

### Reference

We currently carry this fix as a `patch-package` patch in a downstream fork: https://github.com/abhishekshankar/abhishek-shankar.com-emdash/blob/master/patches/emdash%2B0.9.0.patch — happy to delete it once this lands.
