### PR TITLE
feat: language picker for code blocks

### DIFF
--- a/.changeset/code-block-language-picker.md
+++ b/.changeset/code-block-language-picker.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": minor
+"emdash": minor
+---
+
+Code blocks in the rich text editor now have an inline language picker. Hover over any code block to reveal a chip in the corner; click it to enter a language (free-form input with curated suggestions for ~30 common languages including TypeScript, Python, Bash, Rust, Astro, SQL, and more). Aliases resolve automatically -- typing `ts` stores `typescript`, `c++` stores `cpp`, etc. The existing markdown shortcut (typing ` ```html ` followed by a space or Enter) continues to pre-populate the language. The chosen language persists on the Portable Text `language` field and is emitted as a `language-{id}` class on the rendered `<pre>` so frontend syntax highlighters can pick it up. The visual (in-place) editor gets the same picker UI.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -48,6 +48,7 @@
     "@tanstack/react-router": "catalog:",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-character-count": "catalog:",
+    "@tiptap/extension-code-block": "catalog:",
     "@tiptap/extension-drag-handle": "catalog:",
     "@tiptap/extension-drag-handle-react": "catalog:",
     "@tiptap/extension-dropcursor": "catalog:",

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -91,6 +91,7 @@ import type { Section } from "../lib/api";
 import { cn } from "../lib/utils";
 import { CaretNext } from "./ArrowIcons.js";
 import { BlockKitMediaPickerField } from "./BlockKitMediaPickerField";
+import { CodeBlockExtension } from "./editor/CodeBlockNode";
 import { DragHandleWrapper } from "./editor/DragHandleWrapper";
 import { ImageExtension } from "./editor/ImageNode";
 import { MarkdownLinkExtension } from "./editor/MarkdownLinkExtension";
@@ -2074,6 +2075,8 @@ export function PortableTextEditor({
 					color: "#3b82f6",
 					width: 2,
 				},
+				// Replaced with CodeBlockExtension below (adds language picker node view).
+				codeBlock: false,
 				// StarterKit v3 includes Link and Underline
 				link: {
 					openOnClick: false,
@@ -2084,6 +2087,7 @@ export function PortableTextEditor({
 				},
 				underline: {},
 			}),
+			CodeBlockExtension,
 			ImageExtension,
 			MarkdownLinkExtension,
 			PluginBlockExtension,

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -1,0 +1,181 @@
+/**
+ * Code block node with language picker.
+ *
+ * Wraps the base `@tiptap/extension-code-block` with a React node view that
+ * overlays a small language chip in the top-right corner. Clicking the chip
+ * opens a popover with a free-form input plus a datalist of curated
+ * language suggestions. The value is persisted on the node's `language`
+ * attribute and round-trips through Portable Text as `block.language`.
+ *
+ * The picker accepts arbitrary strings (not restricted to the curated list)
+ * so that less common languages can still be used. Free-form input is
+ * normalized to lowercase via `normalizeLanguage` to keep `language-{id}`
+ * CSS classes stable.
+ */
+
+import { Button, Input } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { Check, X } from "@phosphor-icons/react";
+import CodeBlock from "@tiptap/extension-code-block";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import * as React from "react";
+
+import { CODE_BLOCK_LANGUAGES, languageLabel, normalizeLanguage } from "./codeBlockLanguages";
+
+const DATALIST_ID = "emdash-code-block-languages";
+
+function CodeBlockLanguageDatalist() {
+	return (
+		<datalist id={DATALIST_ID}>
+			{CODE_BLOCK_LANGUAGES.map((lang) => (
+				<option key={lang.id} value={lang.id} label={lang.label} />
+			))}
+		</datalist>
+	);
+}
+
+function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
+	const { t } = useLingui();
+	const [isEditing, setIsEditing] = React.useState(false);
+	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
+	const [draft, setDraft] = React.useState(storedLanguage);
+	const inputRef = React.useRef<HTMLInputElement>(null);
+	const popoverRef = React.useRef<HTMLDivElement>(null);
+
+	// Sync draft when the stored language changes from outside the node view
+	// (e.g. another collaborator edits the attribute, or the editor reloads
+	// content). Don't clobber an in-progress edit.
+	React.useEffect(() => {
+		if (!isEditing) {
+			setDraft(storedLanguage);
+		}
+	}, [storedLanguage, isEditing]);
+
+	const openPicker = React.useCallback(() => {
+		setDraft(storedLanguage);
+		setIsEditing(true);
+		// Focus after state update so the input exists in the DOM.
+		setTimeout(() => inputRef.current?.focus(), 0);
+	}, [storedLanguage]);
+
+	const closePicker = React.useCallback(() => {
+		setIsEditing(false);
+		setDraft(storedLanguage);
+	}, [storedLanguage]);
+
+	const commit = React.useCallback(() => {
+		const next = normalizeLanguage(draft);
+		updateAttributes({ language: next ?? null });
+		setIsEditing(false);
+	}, [draft, updateAttributes]);
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			commit();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			closePicker();
+		}
+	};
+
+	// Close on outside click while the popover is open.
+	React.useEffect(() => {
+		if (!isEditing) return undefined;
+		const onMouseDown = (event: MouseEvent) => {
+			const target = event.target instanceof Node ? event.target : null;
+			if (popoverRef.current && target && !popoverRef.current.contains(target)) {
+				closePicker();
+			}
+		};
+		document.addEventListener("mousedown", onMouseDown);
+		return () => document.removeEventListener("mousedown", onMouseDown);
+	}, [isEditing, closePicker]);
+
+	const label = languageLabel(storedLanguage);
+	// Chip is always rendered (so it can be discovered via hover) but its
+	// opacity is controlled by CSS: invisible by default, visible on hover,
+	// when this block is selected, when the picker is open, or when the
+	// block already has a language set.
+	const chipPersistent = isEditing || Boolean(storedLanguage) || selected;
+
+	return (
+		<NodeViewWrapper className="relative my-4 group" data-language={storedLanguage || undefined}>
+			<CodeBlockLanguageDatalist />
+			<pre className="emdash-code-block">
+				<NodeViewContent<"code"> as="code" />
+			</pre>
+
+			<div className="absolute top-2 end-2 select-none" contentEditable={false}>
+				{isEditing ? (
+					<div
+						ref={popoverRef}
+						className="flex items-center gap-1 rounded-md border bg-kumo-overlay p-1 shadow-lg"
+					>
+						<Input
+							ref={inputRef}
+							type="text"
+							list={DATALIST_ID}
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onKeyDown={handleKeyDown}
+							placeholder={t`Language`}
+							aria-label={t`Language`}
+							className="h-7 w-40 text-xs"
+						/>
+						<Button
+							type="button"
+							variant="ghost"
+							shape="square"
+							className="h-7 w-7"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={commit}
+							title={t`Apply language`}
+							aria-label={t`Apply language`}
+						>
+							<Check className="h-4 w-4" />
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							shape="square"
+							className="h-7 w-7"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={closePicker}
+							title={t`Cancel`}
+							aria-label={t`Cancel`}
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					</div>
+				) : (
+						<button
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={openPicker}
+							className="rounded-md border bg-kumo-overlay/90 px-2 py-1 text-xs text-kumo-subtle opacity-0 transition-opacity hover:text-kumo-strong group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-kumo-brand data-[persistent=true]:opacity-100"
+							data-persistent={chipPersistent ? "true" : "false"}
+							title={t`Set language`}
+							aria-label={t`Set language (current: ${label})`}
+						>
+							{storedLanguage ? label : t`Set language`}
+						</button>
+				)}
+			</div>
+		</NodeViewWrapper>
+	);
+}
+
+/**
+ * TipTap extension: code block with an inline language picker node view.
+ *
+ * Drop-in replacement for StarterKit's default `codeBlock`. Configure
+ * `StarterKit.configure({ codeBlock: false })` and add this extension to
+ * the editor's extensions array.
+ */
+export const CodeBlockExtension = CodeBlock.extend({
+	addNodeView() {
+		return ReactNodeViewRenderer(CodeBlockNodeView);
+	},
+});

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -3,17 +3,18 @@
  *
  * Wraps the base `@tiptap/extension-code-block` with a React node view that
  * overlays a small language chip in the top-right corner. Clicking the chip
- * opens a popover with a free-form input plus a datalist of curated
- * language suggestions. The value is persisted on the node's `language`
- * attribute and round-trips through Portable Text as `block.language`.
+ * opens a popover with a Kumo Autocomplete: a free-form text input plus a
+ * filtered list of curated language suggestions. The value is persisted on
+ * the node's `language` attribute and round-trips through Portable Text as
+ * `block.language`.
  *
  * The picker accepts arbitrary strings (not restricted to the curated list)
  * so that less common languages can still be used. Free-form input is
- * normalized to lowercase via `normalizeLanguage` to keep `language-{id}`
- * CSS classes stable.
+ * sanitized to a single safe CSS class token via `normalizeLanguage` so the
+ * frontend's `language-{id}` class stays well-formed.
  */
 
-import { Button, Input } from "@cloudflare/kumo";
+import { Autocomplete, Button } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { Check, X } from "@phosphor-icons/react";
 import CodeBlock from "@tiptap/extension-code-block";
@@ -23,24 +24,23 @@ import * as React from "react";
 
 import { CODE_BLOCK_LANGUAGES, languageLabel, normalizeLanguage } from "./codeBlockLanguages";
 
-const DATALIST_ID = "emdash-code-block-languages";
+const LANGUAGE_ITEMS = CODE_BLOCK_LANGUAGES.map((l) => l.label);
 
-function CodeBlockLanguageDatalist() {
-	return (
-		<datalist id={DATALIST_ID}>
-			{CODE_BLOCK_LANGUAGES.map((lang) => (
-				<option key={lang.id} value={lang.id} label={lang.label} />
-			))}
-		</datalist>
-	);
+function filterLanguages(item: string, query: string) {
+	if (!query) return true;
+	const needle = query.toLowerCase();
+	const lang = CODE_BLOCK_LANGUAGES.find((l) => l.label === item);
+	if (!lang) return false;
+	if (lang.label.toLowerCase().includes(needle)) return true;
+	if (lang.id.toLowerCase().includes(needle)) return true;
+	return lang.aliases?.some((alias) => alias.toLowerCase().includes(needle)) ?? false;
 }
 
 function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
 	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
-	const [draft, setDraft] = React.useState(storedLanguage);
-	const inputRef = React.useRef<HTMLInputElement>(null);
+	const [draft, setDraft] = React.useState(() => languageLabel(storedLanguage));
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 
 	// Sync draft when the stored language changes from outside the node view
@@ -48,29 +48,31 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 	// content). Don't clobber an in-progress edit.
 	React.useEffect(() => {
 		if (!isEditing) {
-			setDraft(storedLanguage);
+			setDraft(languageLabel(storedLanguage));
 		}
 	}, [storedLanguage, isEditing]);
 
 	const openPicker = React.useCallback(() => {
-		setDraft(storedLanguage);
+		setDraft(storedLanguage ? languageLabel(storedLanguage) : "");
 		setIsEditing(true);
-		// Focus after state update so the input exists in the DOM.
-		setTimeout(() => inputRef.current?.focus(), 0);
 	}, [storedLanguage]);
 
 	const closePicker = React.useCallback(() => {
 		setIsEditing(false);
-		setDraft(storedLanguage);
+		setDraft(languageLabel(storedLanguage));
 	}, [storedLanguage]);
 
-	const commit = React.useCallback(() => {
-		const next = normalizeLanguage(draft);
-		updateAttributes({ language: next ?? null });
-		setIsEditing(false);
-	}, [draft, updateAttributes]);
+	const commit = React.useCallback(
+		(value?: string) => {
+			const raw = value ?? draft;
+			const next = normalizeLanguage(raw);
+			updateAttributes({ language: next ?? null });
+			setIsEditing(false);
+		},
+		[draft, updateAttributes],
+	);
 
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
 			commit();
@@ -94,43 +96,51 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 	}, [isEditing, closePicker]);
 
 	const label = languageLabel(storedLanguage);
-	// Chip is always rendered (so it can be discovered via hover) but its
+	// The chip is always rendered (so it can be discovered via hover) but its
 	// opacity is controlled by CSS: invisible by default, visible on hover,
 	// when this block is selected, when the picker is open, or when the
-	// block already has a language set.
+	// block already has a language set. When hidden, also remove it from the
+	// tab order so it doesn't trap keyboard focus.
 	const chipPersistent = isEditing || Boolean(storedLanguage) || selected;
 
 	return (
-		<NodeViewWrapper className="relative my-4 group" data-language={storedLanguage || undefined}>
-			<CodeBlockLanguageDatalist />
+		<NodeViewWrapper className="group relative my-4" data-language={storedLanguage || undefined}>
 			<pre className="emdash-code-block">
 				<NodeViewContent<"code"> as="code" />
 			</pre>
 
-			<div className="absolute top-2 end-2 select-none" contentEditable={false}>
+			<div className="absolute end-2 top-2 select-none" contentEditable={false}>
 				{isEditing ? (
 					<div
 						ref={popoverRef}
 						className="flex items-center gap-1 rounded-md border bg-kumo-overlay p-1 shadow-lg"
+						onKeyDown={handleKeyDown}
 					>
-						<Input
-							ref={inputRef}
-							type="text"
-							list={DATALIST_ID}
+						<Autocomplete
+							items={LANGUAGE_ITEMS}
 							value={draft}
-							onChange={(e) => setDraft(e.target.value)}
-							onKeyDown={handleKeyDown}
-							placeholder={t`Language`}
-							aria-label={t`Language`}
-							className="h-7 w-40 text-xs"
-						/>
+							onValueChange={(next: string) => setDraft(next)}
+							filter={filterLanguages}
+						>
+							<Autocomplete.InputGroup size="sm" placeholder={t`Language`} />
+							<Autocomplete.Content sideOffset={4}>
+								<Autocomplete.List>
+									{(item: string) => (
+										<Autocomplete.Item key={item} value={item}>
+											{item}
+										</Autocomplete.Item>
+									)}
+								</Autocomplete.List>
+								<Autocomplete.Empty>{t`No matches`}</Autocomplete.Empty>
+							</Autocomplete.Content>
+						</Autocomplete>
 						<Button
 							type="button"
 							variant="ghost"
 							shape="square"
 							className="h-7 w-7"
 							onMouseDown={(e) => e.preventDefault()}
-							onClick={commit}
+							onClick={() => commit()}
 							title={t`Apply language`}
 							aria-label={t`Apply language`}
 						>
@@ -150,17 +160,19 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 						</Button>
 					</div>
 				) : (
-						<button
-							type="button"
-							onMouseDown={(e) => e.preventDefault()}
-							onClick={openPicker}
-							className="rounded-md border bg-kumo-overlay/90 px-2 py-1 text-xs text-kumo-subtle opacity-0 transition-opacity hover:text-kumo-strong group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-kumo-brand data-[persistent=true]:opacity-100"
-							data-persistent={chipPersistent ? "true" : "false"}
-							title={t`Set language`}
-							aria-label={t`Set language (current: ${label})`}
-						>
-							{storedLanguage ? label : t`Set language`}
-						</button>
+					<button
+						type="button"
+						tabIndex={chipPersistent ? 0 : -1}
+						onMouseDown={(e) => e.preventDefault()}
+						onClick={openPicker}
+						className="rounded-md border bg-kumo-overlay/90 px-2 py-1 text-xs text-kumo-subtle opacity-0 transition-opacity hover:text-kumo-strong focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-kumo-brand group-hover:opacity-100 data-[persistent=true]:opacity-100"
+						data-persistent={chipPersistent ? "true" : "false"}
+						title={t`Set language`}
+						aria-label={t`Set language (current: ${label})`}
+						aria-hidden={chipPersistent ? undefined : true}
+					>
+						{storedLanguage ? label : t`Set language`}
+					</button>
 				)}
 			</div>
 		</NodeViewWrapper>

--- a/packages/admin/src/components/editor/codeBlockLanguages.ts
+++ b/packages/admin/src/components/editor/codeBlockLanguages.ts
@@ -73,18 +73,38 @@ export function findLanguage(value: string | null | undefined): CodeBlockLanguag
 
 /**
  * Normalize a user-entered language string to a canonical id where possible.
- * Unknown inputs are returned trimmed and lowercased so they round-trip
- * predictably and produce stable `language-{id}` class names.
+ * Unknown inputs are sanitized to a single safe class token: lowercased,
+ * trimmed, with any character outside `[a-z0-9_-]` (including whitespace,
+ * dots, slashes, etc.) collapsed to `-`. This keeps the stored value safe
+ * to interpolate into a `language-{id}` CSS class without splitting on
+ * whitespace.
  *
- * Returns `undefined` for empty/whitespace input.
+ * Examples:
+ *   normalizeLanguage("TypeScript")   -> "typescript" (canonical id)
+ *   normalizeLanguage("ts")           -> "typescript" (alias)
+ *   normalizeLanguage("Objective C")  -> "objective-c" (sanitized)
+ *   normalizeLanguage("F#")           -> "f-" (sanitized)
+ *   normalizeLanguage("")             -> undefined
  */
+// Hoisted to module scope to avoid re-compilation on every call.
+const DISALLOWED_CHARS_RE = /[^a-z0-9_-]+/g;
+const LEADING_TRAILING_HYPHENS_RE = /^-+|-+$/g;
+
 export function normalizeLanguage(value: string | null | undefined): string | undefined {
 	if (!value) return undefined;
 	const trimmed = value.trim();
 	if (!trimmed) return undefined;
 	const match = findLanguage(trimmed);
 	if (match) return match.id;
-	return trimmed.toLowerCase();
+	// Sanitize unknown input: lowercase, then collapse runs of disallowed
+	// characters into a single `-` so the result is always a single CSS class
+	// token. We deliberately don't return `undefined` on collisions here --
+	// callers can compare the sanitized result with the input if they need to.
+	const sanitized = trimmed
+		.toLowerCase()
+		.replace(DISALLOWED_CHARS_RE, "-")
+		.replace(LEADING_TRAILING_HYPHENS_RE, "");
+	return sanitized || undefined;
 }
 
 /**

--- a/packages/admin/src/components/editor/codeBlockLanguages.ts
+++ b/packages/admin/src/components/editor/codeBlockLanguages.ts
@@ -1,0 +1,99 @@
+/**
+ * Curated list of code block languages.
+ *
+ * Used as suggestions in the editor's language picker. The picker accepts
+ * free-form text, so this is a starting point, not a restriction. The `id`
+ * is the canonical identifier persisted in the Portable Text `language`
+ * field and emitted as a `language-{id}` CSS class on the frontend.
+ *
+ * Aliases let common variants ("typescript", "ts") resolve to the same id.
+ * Frontend highlighters (shipped in a follow-up PR) will use this map to
+ * normalize unknown inputs.
+ */
+
+export interface CodeBlockLanguage {
+	/** Canonical identifier persisted in storage and emitted as `language-{id}`. */
+	id: string;
+	/** Human-readable label shown in the picker. */
+	label: string;
+	/** Alternative identifiers (typed by the user) that resolve to this language. */
+	aliases?: string[];
+}
+
+export const CODE_BLOCK_LANGUAGES: readonly CodeBlockLanguage[] = [
+	{ id: "plaintext", label: "Plain text", aliases: ["text", "plain", "txt"] },
+	{ id: "astro", label: "Astro" },
+	{ id: "bash", label: "Bash", aliases: ["sh", "shell", "zsh"] },
+	{ id: "c", label: "C" },
+	{ id: "cpp", label: "C++", aliases: ["c++"] },
+	{ id: "csharp", label: "C#", aliases: ["cs", "c#"] },
+	{ id: "css", label: "CSS" },
+	{ id: "diff", label: "Diff", aliases: ["patch"] },
+	{ id: "dockerfile", label: "Dockerfile", aliases: ["docker"] },
+	{ id: "go", label: "Go", aliases: ["golang"] },
+	{ id: "graphql", label: "GraphQL", aliases: ["gql"] },
+	{ id: "html", label: "HTML" },
+	{ id: "java", label: "Java" },
+	{ id: "javascript", label: "JavaScript", aliases: ["js"] },
+	{ id: "json", label: "JSON" },
+	{ id: "jsx", label: "JSX" },
+	{ id: "kotlin", label: "Kotlin", aliases: ["kt"] },
+	{ id: "markdown", label: "Markdown", aliases: ["md"] },
+	{ id: "mdx", label: "MDX" },
+	{ id: "php", label: "PHP" },
+	{ id: "python", label: "Python", aliases: ["py"] },
+	{ id: "ruby", label: "Ruby", aliases: ["rb"] },
+	{ id: "rust", label: "Rust", aliases: ["rs"] },
+	{ id: "scss", label: "SCSS", aliases: ["sass"] },
+	{ id: "sql", label: "SQL" },
+	{ id: "svelte", label: "Svelte" },
+	{ id: "swift", label: "Swift" },
+	{ id: "toml", label: "TOML" },
+	{ id: "tsx", label: "TSX" },
+	{ id: "typescript", label: "TypeScript", aliases: ["ts"] },
+	{ id: "vue", label: "Vue" },
+	{ id: "xml", label: "XML" },
+	{ id: "yaml", label: "YAML", aliases: ["yml"] },
+];
+
+/**
+ * Look up a language by id or alias. Case-insensitive.
+ * Returns the canonical entry, or `null` if not found in the curated list.
+ */
+export function findLanguage(value: string | null | undefined): CodeBlockLanguage | null {
+	if (!value) return null;
+	const needle = value.trim().toLowerCase();
+	if (!needle) return null;
+	for (const lang of CODE_BLOCK_LANGUAGES) {
+		if (lang.id === needle) return lang;
+		if (lang.aliases?.includes(needle)) return lang;
+	}
+	return null;
+}
+
+/**
+ * Normalize a user-entered language string to a canonical id where possible.
+ * Unknown inputs are returned trimmed and lowercased so they round-trip
+ * predictably and produce stable `language-{id}` class names.
+ *
+ * Returns `undefined` for empty/whitespace input.
+ */
+export function normalizeLanguage(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	const match = findLanguage(trimmed);
+	if (match) return match.id;
+	return trimmed.toLowerCase();
+}
+
+/**
+ * Human-readable label for a stored language id. Falls back to the id itself
+ * for unknown values so the editor never shows "undefined".
+ */
+export function languageLabel(value: string | null | undefined): string {
+	if (!value) return "Plain text";
+	const match = findLanguage(value);
+	if (match) return match.label;
+	return value;
+}

--- a/packages/admin/tests/editor/CodeBlockNode.test.ts
+++ b/packages/admin/tests/editor/CodeBlockNode.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the custom CodeBlockExtension (language picker node view).
+ *
+ * Verifies that:
+ *   - The extension keeps the canonical `codeBlock` schema name so existing
+ *     code that calls `editor.isActive("codeBlock")` keeps working.
+ *   - The `language` attribute is settable and round-trips through getJSON.
+ *   - StarterKit's backtick input rule still fires when our extension is
+ *     swapped in (since we extend the base extension rather than replace
+ *     it). We can't drive real keyboard input in jsdom, so we verify the
+ *     rule's regex is registered via the extension's inputRules schema.
+ */
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { CodeBlockExtension } from "../../src/components/editor/CodeBlockNode";
+
+describe("CodeBlockExtension", () => {
+	let editor: Editor;
+
+	beforeEach(() => {
+		editor = new Editor({
+			extensions: [
+				StarterKit.configure({
+					heading: { levels: [1, 2, 3] },
+					codeBlock: false,
+				}),
+				CodeBlockExtension,
+			],
+			content: "",
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+	});
+
+	it("registers the codeBlock schema node", () => {
+		expect(editor.schema.nodes.codeBlock).toBeDefined();
+	});
+
+	it("registers under the name 'codeBlock' so isActive lookups keep working", () => {
+		const ext = editor.extensionManager.extensions.find((e) => e.name === "codeBlock");
+		expect(ext).toBeDefined();
+	});
+
+	it("toggleCodeBlock activates the node", () => {
+		editor.commands.toggleCodeBlock();
+		expect(editor.isActive("codeBlock")).toBe(true);
+	});
+
+	it("language attribute round-trips through the editor state", () => {
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: "html" },
+			content: [{ type: "text", text: "<p>hi</p>" }],
+		});
+		const json = editor.getJSON();
+		const node = json.content?.find((n) => n.type === "codeBlock");
+		expect(node).toBeDefined();
+		expect((node as { attrs?: { language?: string } }).attrs?.language).toBe("html");
+	});
+
+	it("updateAttributes can change the language on an existing code block", () => {
+		editor.commands.insertContent({
+			type: "codeBlock",
+			attrs: { language: null },
+			content: [{ type: "text", text: "x" }],
+		});
+		editor.commands.setNodeSelection(0);
+		editor.commands.updateAttributes("codeBlock", { language: "typescript" });
+		const node = editor.getJSON().content?.find((n) => n.type === "codeBlock");
+		expect((node as { attrs?: { language?: string } }).attrs?.language).toBe("typescript");
+	});
+});

--- a/packages/admin/tests/editor/codeBlockLanguages.test.ts
+++ b/packages/admin/tests/editor/codeBlockLanguages.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the code block language helpers.
+ *
+ * Covers id/alias lookup, normalization of free-form input, and human-readable
+ * label fallback. These are the helpers backing the editor's language picker
+ * and the round-trip between user input and the stored `language` attribute.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+	CODE_BLOCK_LANGUAGES,
+	findLanguage,
+	languageLabel,
+	normalizeLanguage,
+} from "../../src/components/editor/codeBlockLanguages";
+
+describe("findLanguage", () => {
+	it("returns the canonical entry for a known id", () => {
+		const ts = findLanguage("typescript");
+		expect(ts?.id).toBe("typescript");
+		expect(ts?.label).toBe("TypeScript");
+	});
+
+	it("resolves aliases to the canonical entry", () => {
+		expect(findLanguage("ts")?.id).toBe("typescript");
+		expect(findLanguage("js")?.id).toBe("javascript");
+		expect(findLanguage("sh")?.id).toBe("bash");
+		expect(findLanguage("c++")?.id).toBe("cpp");
+		expect(findLanguage("c#")?.id).toBe("csharp");
+		expect(findLanguage("md")?.id).toBe("markdown");
+		expect(findLanguage("yml")?.id).toBe("yaml");
+	});
+
+	it("is case-insensitive", () => {
+		expect(findLanguage("TypeScript")?.id).toBe("typescript");
+		expect(findLanguage("HTML")?.id).toBe("html");
+		expect(findLanguage("  Python  ")?.id).toBe("python");
+	});
+
+	it("returns null for unknown or empty input", () => {
+		expect(findLanguage("brainfuck")).toBeNull();
+		expect(findLanguage("")).toBeNull();
+		expect(findLanguage(null)).toBeNull();
+		expect(findLanguage(undefined)).toBeNull();
+		expect(findLanguage("   ")).toBeNull();
+	});
+
+	it("has no duplicate ids or aliases in the curated list", () => {
+		const seen = new Set<string>();
+		for (const lang of CODE_BLOCK_LANGUAGES) {
+			expect(seen.has(lang.id), `duplicate id: ${lang.id}`).toBe(false);
+			seen.add(lang.id);
+			for (const alias of lang.aliases ?? []) {
+				expect(seen.has(alias), `duplicate alias: ${alias}`).toBe(false);
+				seen.add(alias);
+			}
+		}
+	});
+});
+
+describe("normalizeLanguage", () => {
+	it("returns the canonical id for a known language or alias", () => {
+		expect(normalizeLanguage("ts")).toBe("typescript");
+		expect(normalizeLanguage("TypeScript")).toBe("typescript");
+		expect(normalizeLanguage("c++")).toBe("cpp");
+	});
+
+	it("lowercases and trims unknown input so class names stay stable", () => {
+		expect(normalizeLanguage("  Brainfuck  ")).toBe("brainfuck");
+		expect(normalizeLanguage("Erlang")).toBe("erlang");
+	});
+
+	it("returns undefined for empty input", () => {
+		expect(normalizeLanguage("")).toBeUndefined();
+		expect(normalizeLanguage(null)).toBeUndefined();
+		expect(normalizeLanguage(undefined)).toBeUndefined();
+		expect(normalizeLanguage("   ")).toBeUndefined();
+	});
+});
+
+describe("languageLabel", () => {
+	it("returns the curated label for known languages", () => {
+		expect(languageLabel("typescript")).toBe("TypeScript");
+		expect(languageLabel("ts")).toBe("TypeScript");
+		expect(languageLabel("cpp")).toBe("C++");
+	});
+
+	it("falls back to the raw id for unknown languages", () => {
+		expect(languageLabel("brainfuck")).toBe("brainfuck");
+	});
+
+	it("returns a friendly default for empty input", () => {
+		expect(languageLabel(null)).toBe("Plain text");
+		expect(languageLabel(undefined)).toBe("Plain text");
+		expect(languageLabel("")).toBe("Plain text");
+	});
+});

--- a/packages/admin/tests/editor/codeBlockLanguages.test.ts
+++ b/packages/admin/tests/editor/codeBlockLanguages.test.ts
@@ -71,6 +71,39 @@ describe("normalizeLanguage", () => {
 		expect(normalizeLanguage("Erlang")).toBe("erlang");
 	});
 
+	it("collapses internal whitespace so the value remains a single class token", () => {
+		// Frontend renders `<pre class="language-${id}">`; whitespace would
+		// split that into two classes (`language-objective c`), so unknown
+		// inputs with spaces are joined with a single hyphen.
+		expect(normalizeLanguage("Objective C")).toBe("objective-c");
+		expect(normalizeLanguage("My  Lang")).toBe("my-lang");
+		expect(normalizeLanguage("Pure\tScript")).toBe("pure-script");
+		expect(normalizeLanguage("a\nb")).toBe("a-b");
+	});
+
+	it("strips other characters that would break a CSS class token", () => {
+		// Dots, slashes, and other punctuation get collapsed to `-`.
+		expect(normalizeLanguage("foo.bar")).toBe("foo-bar");
+		expect(normalizeLanguage("a/b")).toBe("a-b");
+		expect(normalizeLanguage("plain!text")).toBe("plain-text");
+	});
+
+	it("preserves hyphens and underscores in unknown input", () => {
+		expect(normalizeLanguage("my-lang")).toBe("my-lang");
+		expect(normalizeLanguage("my_lang")).toBe("my_lang");
+	});
+
+	it("trims leading and trailing hyphens introduced by sanitization", () => {
+		expect(normalizeLanguage("@swift")).toBe("swift");
+		expect(normalizeLanguage("rust!")).toBe("rust");
+		expect(normalizeLanguage("---x---")).toBe("x");
+	});
+
+	it("returns undefined for input that sanitizes to an empty string", () => {
+		expect(normalizeLanguage("!!!")).toBeUndefined();
+		expect(normalizeLanguage("@@@")).toBeUndefined();
+	});
+
 	it("returns undefined for empty input", () => {
 		expect(normalizeLanguage("")).toBeUndefined();
 		expect(normalizeLanguage(null)).toBeUndefined();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -201,6 +201,7 @@
     "@oslojs/encoding": "catalog:",
     "@portabletext/toolkit": "^5.0.1",
     "@tiptap/core": "catalog:",
+    "@tiptap/extension-code-block": "catalog:",
     "@tiptap/extension-focus": "catalog:",
     "@tiptap/extension-image": "catalog:",
     "@tiptap/extension-link": "catalog:",

--- a/packages/core/src/components/InlinePortableTextEditor.tsx
+++ b/packages/core/src/components/InlinePortableTextEditor.tsx
@@ -26,6 +26,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 
 import { computeThumbnailSize } from "../media/thumbnail.js";
+import { InlineCodeBlockExtension } from "./inline-code-block.js";
 
 // ── Portable Text types ────────────────────────────────────────────
 
@@ -1765,7 +1766,10 @@ export function InlinePortableTextEditor({
 			StarterKit.configure({
 				heading: { levels: [1, 2, 3] },
 				dropcursor: { color: "#3b82f6", width: 2 },
+				// Replaced with InlineCodeBlockExtension below (adds language picker).
+				codeBlock: false,
 			}),
+			InlineCodeBlockExtension,
 			Image.extend({
 				addAttributes() {
 					return {

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -58,8 +58,6 @@ const CODE_BLOCK_LANGUAGES: readonly CodeBlockLanguage[] = [
 	{ id: "yaml", label: "YAML", aliases: ["yml"] },
 ];
 
-const DATALIST_ID = "emdash-inline-code-block-languages";
-
 function findLanguage(value: string | null | undefined): CodeBlockLanguage | null {
 	if (!value) return null;
 	const needle = value.trim().toLowerCase();
@@ -71,13 +69,24 @@ function findLanguage(value: string | null | undefined): CodeBlockLanguage | nul
 	return null;
 }
 
+// Hoisted to module scope to avoid re-compilation on every call.
+const DISALLOWED_CHARS_RE = /[^a-z0-9_-]+/g;
+const LEADING_TRAILING_HYPHENS_RE = /^-+|-+$/g;
+
 function normalizeLanguage(value: string | null | undefined): string | undefined {
 	if (!value) return undefined;
 	const trimmed = value.trim();
 	if (!trimmed) return undefined;
 	const match = findLanguage(trimmed);
 	if (match) return match.id;
-	return trimmed.toLowerCase();
+	// Sanitize unknown input: lowercase, then collapse runs of disallowed
+	// characters into a single `-` so the result is always a single CSS class
+	// token (the frontend renders `language-{id}` on the <pre>/<code>).
+	const sanitized = trimmed
+		.toLowerCase()
+		.replace(DISALLOWED_CHARS_RE, "-")
+		.replace(LEADING_TRAILING_HYPHENS_RE, "");
+	return sanitized || undefined;
 }
 
 function languageLabel(value: string | null | undefined): string {
@@ -87,9 +96,9 @@ function languageLabel(value: string | null | undefined): string {
 	return value;
 }
 
-function CodeBlockLanguageDatalist() {
+function CodeBlockLanguageDatalist({ id }: { id: string }) {
 	return (
-		<datalist id={DATALIST_ID}>
+		<datalist id={id}>
 			{CODE_BLOCK_LANGUAGES.map((lang) => (
 				<option key={lang.id} value={lang.id} label={lang.label} />
 			))}
@@ -154,6 +163,9 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
 	const [draft, setDraft] = React.useState(storedLanguage);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const popoverRef = React.useRef<HTMLDivElement>(null);
+	// Per-instance datalist id so multiple code blocks (or multiple inline
+	// editors) on the same page don't create duplicate DOM ids.
+	const datalistId = React.useId();
 
 	React.useEffect(() => {
 		if (!isEditing) {
@@ -211,7 +223,7 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
 			onMouseEnter={() => setIsHovered(true)}
 			onMouseLeave={() => setIsHovered(false)}
 		>
-			<CodeBlockLanguageDatalist />
+			<CodeBlockLanguageDatalist id={datalistId} />
 			<pre className="emdash-code-block">
 				<NodeViewContent<"code"> as="code" />
 			</pre>
@@ -228,6 +240,12 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
 					pointerEvents: chipVisible ? "auto" : "none",
 					transition: "opacity 0.15s",
 				}}
+				// When the chip is hidden, also remove it from the tab order so
+				// keyboard users don't land on an invisible focus target.
+				// `inert` would be cleaner but isn't available on JSX HTMLDivElement
+				// types yet; aria-hidden + tabIndex on the button below cover the
+				// same need.
+				aria-hidden={chipVisible ? undefined : true}
 			>
 				{isEditing ? (
 					<div
@@ -246,12 +264,12 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
 						<input
 							ref={inputRef}
 							type="text"
-							list={DATALIST_ID}
+							list={datalistId}
 							value={draft}
 							onChange={(e) => setDraft(e.target.value)}
 							onKeyDown={handleKeyDown}
-								placeholder="Language"
-								aria-label="Language"
+							placeholder="Language"
+							aria-label="Language"
 							style={{
 								height: "1.75rem",
 								width: "10rem",
@@ -287,10 +305,11 @@ function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewP
 				) : (
 					<button
 						type="button"
+						tabIndex={chipVisible ? 0 : -1}
 						onMouseDown={(e) => e.preventDefault()}
 						onClick={openPicker}
-							title="Set language"
-							aria-label={`Set language (current: ${label})`}
+						title="Set language"
+						aria-label={`Set language (current: ${label})`}
 						className="emdash-inline-code-block-chip"
 						style={{
 							padding: "0.125rem 0.5rem",

--- a/packages/core/src/components/inline-code-block.tsx
+++ b/packages/core/src/components/inline-code-block.tsx
@@ -1,0 +1,324 @@
+/**
+ * Code block node view for the inline (visual editing) Portable Text editor.
+ *
+ * Mirrors the admin editor's `CodeBlockNode` but with no Kumo/Lingui deps,
+ * so it can ship as part of the SSR runtime. Wraps the base
+ * `@tiptap/extension-code-block` and overlays a small inline language picker
+ * in the top-right corner of each code block.
+ *
+ * Keep the language list in sync with
+ * `packages/admin/src/components/editor/codeBlockLanguages.ts`. Duplicated
+ * here so packages/core stays independent of the admin package.
+ */
+
+import CodeBlock from "@tiptap/extension-code-block";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import * as React from "react";
+
+interface CodeBlockLanguage {
+	id: string;
+	label: string;
+	aliases?: string[];
+}
+
+const CODE_BLOCK_LANGUAGES: readonly CodeBlockLanguage[] = [
+	{ id: "plaintext", label: "Plain text", aliases: ["text", "plain", "txt"] },
+	{ id: "astro", label: "Astro" },
+	{ id: "bash", label: "Bash", aliases: ["sh", "shell", "zsh"] },
+	{ id: "c", label: "C" },
+	{ id: "cpp", label: "C++", aliases: ["c++"] },
+	{ id: "csharp", label: "C#", aliases: ["cs", "c#"] },
+	{ id: "css", label: "CSS" },
+	{ id: "diff", label: "Diff", aliases: ["patch"] },
+	{ id: "dockerfile", label: "Dockerfile", aliases: ["docker"] },
+	{ id: "go", label: "Go", aliases: ["golang"] },
+	{ id: "graphql", label: "GraphQL", aliases: ["gql"] },
+	{ id: "html", label: "HTML" },
+	{ id: "java", label: "Java" },
+	{ id: "javascript", label: "JavaScript", aliases: ["js"] },
+	{ id: "json", label: "JSON" },
+	{ id: "jsx", label: "JSX" },
+	{ id: "kotlin", label: "Kotlin", aliases: ["kt"] },
+	{ id: "markdown", label: "Markdown", aliases: ["md"] },
+	{ id: "mdx", label: "MDX" },
+	{ id: "php", label: "PHP" },
+	{ id: "python", label: "Python", aliases: ["py"] },
+	{ id: "ruby", label: "Ruby", aliases: ["rb"] },
+	{ id: "rust", label: "Rust", aliases: ["rs"] },
+	{ id: "scss", label: "SCSS", aliases: ["sass"] },
+	{ id: "sql", label: "SQL" },
+	{ id: "svelte", label: "Svelte" },
+	{ id: "swift", label: "Swift" },
+	{ id: "toml", label: "TOML" },
+	{ id: "tsx", label: "TSX" },
+	{ id: "typescript", label: "TypeScript", aliases: ["ts"] },
+	{ id: "vue", label: "Vue" },
+	{ id: "xml", label: "XML" },
+	{ id: "yaml", label: "YAML", aliases: ["yml"] },
+];
+
+const DATALIST_ID = "emdash-inline-code-block-languages";
+
+function findLanguage(value: string | null | undefined): CodeBlockLanguage | null {
+	if (!value) return null;
+	const needle = value.trim().toLowerCase();
+	if (!needle) return null;
+	for (const lang of CODE_BLOCK_LANGUAGES) {
+		if (lang.id === needle) return lang;
+		if (lang.aliases?.includes(needle)) return lang;
+	}
+	return null;
+}
+
+function normalizeLanguage(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	const match = findLanguage(trimmed);
+	if (match) return match.id;
+	return trimmed.toLowerCase();
+}
+
+function languageLabel(value: string | null | undefined): string {
+	if (!value) return "Plain text";
+	const match = findLanguage(value);
+	if (match) return match.label;
+	return value;
+}
+
+function CodeBlockLanguageDatalist() {
+	return (
+		<datalist id={DATALIST_ID}>
+			{CODE_BLOCK_LANGUAGES.map((lang) => (
+				<option key={lang.id} value={lang.id} label={lang.label} />
+			))}
+		</datalist>
+	);
+}
+
+const iconButtonStyle: React.CSSProperties = {
+	height: "1.75rem",
+	width: "1.75rem",
+	display: "inline-flex",
+	alignItems: "center",
+	justifyContent: "center",
+	border: "none",
+	background: "transparent",
+	cursor: "pointer",
+	color: "inherit",
+	borderRadius: "0.25rem",
+};
+
+function CheckIcon() {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<polyline points="20 6 9 17 4 12" />
+		</svg>
+	);
+}
+
+function XIcon() {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<line x1="18" y1="6" x2="6" y2="18" />
+			<line x1="6" y1="6" x2="18" y2="18" />
+		</svg>
+	);
+}
+
+function InlineCodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
+	const [isEditing, setIsEditing] = React.useState(false);
+	const [isHovered, setIsHovered] = React.useState(false);
+	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
+	const [draft, setDraft] = React.useState(storedLanguage);
+	const inputRef = React.useRef<HTMLInputElement>(null);
+	const popoverRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		if (!isEditing) {
+			setDraft(storedLanguage);
+		}
+	}, [storedLanguage, isEditing]);
+
+	const openPicker = React.useCallback(() => {
+		setDraft(storedLanguage);
+		setIsEditing(true);
+		setTimeout(() => inputRef.current?.focus(), 0);
+	}, [storedLanguage]);
+
+	const closePicker = React.useCallback(() => {
+		setIsEditing(false);
+		setDraft(storedLanguage);
+	}, [storedLanguage]);
+
+	const commit = React.useCallback(() => {
+		const next = normalizeLanguage(draft);
+		updateAttributes({ language: next ?? null });
+		setIsEditing(false);
+	}, [draft, updateAttributes]);
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			commit();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			closePicker();
+		}
+	};
+
+	React.useEffect(() => {
+		if (!isEditing) return undefined;
+		const onMouseDown = (event: MouseEvent) => {
+			const target = event.target instanceof Node ? event.target : null;
+			if (popoverRef.current && target && !popoverRef.current.contains(target)) {
+				closePicker();
+			}
+		};
+		document.addEventListener("mousedown", onMouseDown);
+		return () => document.removeEventListener("mousedown", onMouseDown);
+	}, [isEditing, closePicker]);
+
+	const label = languageLabel(storedLanguage);
+	const chipVisible = isHovered || selected || isEditing || Boolean(storedLanguage);
+
+	return (
+		<NodeViewWrapper
+			className="emdash-inline-code-block"
+			data-language={storedLanguage || undefined}
+			style={{ position: "relative", margin: "1rem 0" }}
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+		>
+			<CodeBlockLanguageDatalist />
+			<pre className="emdash-code-block">
+				<NodeViewContent<"code"> as="code" />
+			</pre>
+
+			<div
+				contentEditable={false}
+				style={{
+					position: "absolute",
+					top: "0.5rem",
+					insetInlineEnd: "0.5rem",
+					userSelect: "none",
+					zIndex: 1,
+					opacity: chipVisible ? 1 : 0,
+					pointerEvents: chipVisible ? "auto" : "none",
+					transition: "opacity 0.15s",
+				}}
+			>
+				{isEditing ? (
+					<div
+						ref={popoverRef}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "0.25rem",
+							padding: "0.25rem",
+							borderRadius: "0.375rem",
+							border: "1px solid rgba(0,0,0,0.1)",
+							background: "var(--emdash-inline-bg, #ffffff)",
+							boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+						}}
+					>
+						<input
+							ref={inputRef}
+							type="text"
+							list={DATALIST_ID}
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onKeyDown={handleKeyDown}
+								placeholder="Language"
+								aria-label="Language"
+							style={{
+								height: "1.75rem",
+								width: "10rem",
+								fontSize: "0.75rem",
+								padding: "0 0.5rem",
+								border: "1px solid rgba(0,0,0,0.15)",
+								borderRadius: "0.25rem",
+								background: "transparent",
+								color: "inherit",
+							}}
+						/>
+						<button
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={commit}
+							title="Apply language"
+							aria-label="Apply language"
+							style={iconButtonStyle}
+						>
+							<CheckIcon />
+						</button>
+						<button
+							type="button"
+							onMouseDown={(e) => e.preventDefault()}
+							onClick={closePicker}
+							title="Cancel"
+							aria-label="Cancel"
+							style={iconButtonStyle}
+						>
+							<XIcon />
+						</button>
+					</div>
+				) : (
+					<button
+						type="button"
+						onMouseDown={(e) => e.preventDefault()}
+						onClick={openPicker}
+							title="Set language"
+							aria-label={`Set language (current: ${label})`}
+						className="emdash-inline-code-block-chip"
+						style={{
+							padding: "0.125rem 0.5rem",
+							fontSize: "0.75rem",
+							borderRadius: "0.375rem",
+							border: "1px solid rgba(0,0,0,0.1)",
+							background: "rgba(255,255,255,0.9)",
+							color: "rgba(0,0,0,0.6)",
+							cursor: "pointer",
+						}}
+					>
+						{storedLanguage ? label : "Set language"}
+					</button>
+				)}
+			</div>
+		</NodeViewWrapper>
+	);
+}
+
+/**
+ * Code block extension with inline language picker for the visual editor.
+ *
+ * Use as a drop-in replacement for StarterKit's default `codeBlock`:
+ * configure `StarterKit.configure({ codeBlock: false })` and add this
+ * extension to the editor.
+ */
+export const InlineCodeBlockExtension = CodeBlock.extend({
+	addNodeView() {
+		return ReactNodeViewRenderer(InlineCodeBlockNodeView);
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ catalogs:
     '@tiptap/extension-character-count':
       specifier: ^3.20.0
       version: 3.20.0
+    '@tiptap/extension-code-block':
+      specifier: ^3.20.0
+      version: 3.20.0
     '@tiptap/extension-drag-handle':
       specifier: ^3.20.0
       version: 3.20.0
@@ -928,6 +931,9 @@ importers:
       '@tiptap/extension-character-count':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))
+      '@tiptap/extension-code-block':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-drag-handle':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/extension-collaboration@3.19.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
@@ -1410,6 +1416,9 @@ importers:
       '@tiptap/core':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/extension-code-block':
+        specifier: 'catalog:'
+        version: 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/extension-focus':
         specifier: 'catalog:'
         version: 3.20.0(@tiptap/extensions@3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,6 +102,7 @@ catalog:
   "@tanstack/react-router": 1.163.2
   "@tiptap/core": ^3.20.0
   "@tiptap/extension-character-count": ^3.20.0
+  "@tiptap/extension-code-block": ^3.20.0
   "@tiptap/extension-drag-handle": ^3.20.0
   "@tiptap/extension-drag-handle-react": ^3.20.0
   "@tiptap/extension-dropcursor": ^3.20.0


### PR DESCRIPTION
## What does this PR do?

Adds an inline language picker to code blocks in both the admin rich text editor and the inline visual editor.

- Hover any code block to reveal a small chip in the top-right corner
- Click it to open a popover with a free-form input and a curated suggestions datalist (~30 languages: TypeScript, Python, Rust, Astro, SQL, Bash, etc.)
- Aliases normalize on commit: typing `ts` stores `typescript`, `c++` stores `cpp`, `md` stores `markdown`, etc.
- The existing triple-backtick markdown shortcut continues to pre-populate the language (` ```html ` + space creates a code block already set to HTML)
- Storage and frontend rendering are unchanged: the `language` attribute round-trips through Portable Text and emits as `language-{id}` on the rendered `<pre>` / `<code>`, ready for any frontend highlighter

Configurable syntax highlighting will land in a follow-up PR. This one just wires up the storage path end-to-end.

## Type of change

- [x] Feature

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (908 admin tests, 3453 core tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (16 new tests covering alias resolution, normalization, node view round-trip)
- [x] User-visible strings in the admin UI are wrapped for translation
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots

<!-- Drop screenshots from /tmp/cb-{hover,picker,typescript,prepop2}.png here -->

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://code-blocks-language-picker-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `code-blocks-language-picker`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
