### PR TITLE
chore: bump @cloudflare/kumo to 2.3

### DIFF
--- a/.changeset/bump-kumo-to-2.x.md
+++ b/.changeset/bump-kumo-to-2.x.md
@@ -1,0 +1,7 @@
+---
+"@emdash-cms/admin": patch
+"@emdash-cms/blocks": patch
+"@emdash-cms/auth-atproto": patch
+---
+
+Bumps `@cloudflare/kumo` from 1.16 to 2.3. Two internal call sites picked up breaking API changes from Kumo 2.0: `Collapsible` is now a compound component (`Collapsible.Root` / `.DefaultTrigger` / `.DefaultPanel` instead of `<Collapsible label=...>`), used by the accordion block; and `ChartPalette.color()` was renamed to `ChartPalette.categorical()` in the chart block. No public API changes -- consumers see identical behaviour. Tests in `@emdash-cms/admin` that asserted on `Button`'s native `title` attribute now read `aria-label` instead, because Kumo 2 wraps `<Button title>` in a Tooltip popup rather than setting the DOM attribute.

--- a/e2e/tests/redirects.spec.ts
+++ b/e2e/tests/redirects.spec.ts
@@ -73,8 +73,10 @@ test.describe("Redirects", () => {
 			// Wait for the redirect to appear
 			await expect(page.locator("text=/edit-source").first()).toBeVisible();
 
-			// Click the edit button on that row (use .first() to avoid ancestor div ambiguity)
-			await page.locator('button[title="Edit redirect"]').first().click();
+			// Click the edit button on that row (use .first() to avoid ancestor div ambiguity).
+			// Kumo 2.x renders <Button title> as a Tooltip popup rather than a DOM
+			// title attribute; aria-label is on the button itself.
+			await page.locator('button[aria-label^="Edit redirect"]').first().click();
 
 			// Edit dialog should open
 			await expect(page.locator('[role="dialog"]')).toBeVisible();
@@ -110,8 +112,9 @@ test.describe("Redirects", () => {
 			// Wait for it to appear
 			await expect(page.locator("text=/to-delete").first()).toBeVisible();
 
-			// Click the delete button on that row (use .first() to avoid ancestor div ambiguity)
-			await page.locator('button[title="Delete redirect"]').first().click();
+			// Click the delete button on that row (use .first() to avoid ancestor div ambiguity).
+			// See note above re: Kumo 2.x Button title -> Tooltip.
+			await page.locator('button[aria-label^="Delete redirect"]').first().click();
 
 			// Confirm deletion in the ConfirmDialog
 			await expect(page.locator('[role="dialog"]')).toBeVisible();

--- a/e2e/tests/revisions.spec.ts
+++ b/e2e/tests/revisions.spec.ts
@@ -286,9 +286,11 @@ test.describe("Revisions", () => {
 		const revisionItems = page.locator(".rounded-md.border.p-3");
 		await expect(revisionItems.first()).toBeVisible({ timeout: 10000 });
 
-		// Find the restore button on the older revision (not the "Current" one)
-		// The restore button uses ArrowCounterClockwise icon and title="Restore this version"
-		const restoreButton = page.locator('button[title="Restore this version"]').first();
+		// Find the restore button on the older revision (not the "Current" one).
+		// The restore button uses ArrowCounterClockwise icon. Kumo 2.x renders
+		// <Button title> as a Tooltip popup rather than a DOM title attribute,
+		// so we locate by aria-label instead.
+		const restoreButton = page.locator('button[aria-label="Restore this version"]').first();
 		await expect(restoreButton).toBeVisible({ timeout: 5000 });
 
 		// Click restore -- this opens a ConfirmDialog

--- a/packages/admin/tests/components/Header.test.tsx
+++ b/packages/admin/tests/components/Header.test.tsx
@@ -53,7 +53,7 @@ const { Header } = await import("../../src/components/Header");
 // Constants
 // ---------------------------------------------------------------------------
 
-const THEME_BUTTON_REGEX = /Theme:/;
+const THEME_BUTTON_REGEX = /Toggle theme/;
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
 	const qc = new QueryClient({
@@ -80,8 +80,9 @@ describe("Header", () => {
 				<Header />
 			</TestWrapper>,
 		);
-		// ThemeToggle renders a button with title containing "Theme:"
-		const themeButton = screen.getByTitle(THEME_BUTTON_REGEX);
+		// ThemeToggle renders a button with aria-label "Toggle theme (current: …)"
+		// (Kumo 2.x wraps `<Button title>` as a Tooltip popup, not a DOM title.)
+		const themeButton = screen.getByLabelText(THEME_BUTTON_REGEX);
 		await expect.element(themeButton).toBeInTheDocument();
 	});
 

--- a/packages/admin/tests/components/Sections.test.tsx
+++ b/packages/admin/tests/components/Sections.test.tsx
@@ -162,8 +162,10 @@ describe("Sections", () => {
 			</Wrapper>,
 		);
 		await expect.element(screen.getByText("Call to Action")).toBeInTheDocument();
-		// Click delete on the user section
-		const deleteButton = screen.getByTitle("Delete");
+		// Click delete on the user section. Kumo 2.x wraps `<Button title>` as
+		// a Tooltip popup rather than a DOM `title` attribute, so we locate the
+		// button by its aria-label instead.
+		const deleteButton = screen.getByLabelText("Delete Call to Action");
 		await deleteButton.click();
 		await expect.element(screen.getByText("Delete Section?")).toBeInTheDocument();
 		await expect.element(screen.getByText(DELETE_SECTION_MSG_REGEX)).toBeInTheDocument();
@@ -186,7 +188,11 @@ describe("Sections", () => {
 			</Wrapper>,
 		);
 		await expect.element(screen.getByText("Hero Section")).toBeInTheDocument();
-		const deleteButton = screen.getByTitle("Cannot delete theme sections");
+		// Kumo 2.x's `<Button title>` is rendered as a Tooltip popup, not a DOM
+		// `title`. Locate the button by aria-label and assert the disabled state
+		// directly; the "Cannot delete theme sections" copy is now in the
+		// hover Tooltip rather than a queryable attribute.
+		const deleteButton = screen.getByLabelText("Delete Hero Section");
 		await expect.element(deleteButton).toBeDisabled();
 	});
 

--- a/packages/admin/tests/components/ThemeToggle.test.tsx
+++ b/packages/admin/tests/components/ThemeToggle.test.tsx
@@ -19,19 +19,22 @@ describe("ThemeToggle", () => {
 		document.documentElement.removeAttribute("data-theme");
 	});
 
+	// Kumo 2.x's <Button title="..."> wraps the button in a Tooltip popup
+	// rather than setting the native `title` attribute. The current theme is
+	// also exposed in `aria-label`, which is what these assertions read.
+
 	it("renders with system theme by default", async () => {
 		const screen = await render(<TestThemeToggle />);
 		const button = screen.getByRole("button");
 		await expect.element(button).toBeInTheDocument();
-		// System theme shows Monitor icon - check the title
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("System"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("System"));
 	});
 
 	it("cycles from system to light on click", async () => {
 		const screen = await render(<TestThemeToggle />);
 		const button = screen.getByRole("button");
 		await button.click();
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("Light"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("Light"));
 	});
 
 	it("cycles through system -> light -> dark -> system", async () => {
@@ -39,19 +42,19 @@ describe("ThemeToggle", () => {
 		const button = screen.getByRole("button");
 
 		// Start: system
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("System"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("System"));
 
 		// Click 1: light
 		await button.click();
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("Light"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("Light"));
 
 		// Click 2: dark
 		await button.click();
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("Dark"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("Dark"));
 
 		// Click 3: back to system
 		await button.click();
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("System"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("System"));
 	});
 
 	it("persists theme to localStorage", async () => {
@@ -64,6 +67,6 @@ describe("ThemeToggle", () => {
 	it("starts with light theme when defaultTheme is light", async () => {
 		const screen = await render(<TestThemeToggle defaultTheme="light" />);
 		const button = screen.getByRole("button");
-		await expect.element(button).toHaveAttribute("title", expect.stringContaining("Light"));
+		await expect.element(button).toHaveAttribute("aria-label", expect.stringContaining("Light"));
 	});
 });

--- a/packages/blocks/src/blocks/accordion.tsx
+++ b/packages/blocks/src/blocks/accordion.tsx
@@ -14,8 +14,11 @@ export function AccordionBlockComponent({
 	const [open, setOpen] = useState(block.default_open ?? false);
 
 	return (
-		<Collapsible label={block.label} open={open} onOpenChange={setOpen}>
-			<BlockRenderer blocks={block.blocks} onAction={onAction} />
-		</Collapsible>
+		<Collapsible.Root open={open} onOpenChange={setOpen} data-testid="collapsible" data-open={open}>
+			<Collapsible.DefaultTrigger>{block.label}</Collapsible.DefaultTrigger>
+			<Collapsible.DefaultPanel>
+				<BlockRenderer blocks={block.blocks} onAction={onAction} />
+			</Collapsible.DefaultPanel>
+		</Collapsible.Root>
 	);
 }

--- a/packages/blocks/src/blocks/chart.tsx
+++ b/packages/blocks/src/blocks/chart.tsx
@@ -100,7 +100,7 @@ function TimeseriesChartBlock({ block, isDarkMode }: { block: ChartBlock; isDark
 			config.series.map((s, i) => ({
 				name: escapeHtml(s.name),
 				data: s.data,
-				color: s.color ?? ChartPalette.color(i, isDarkMode),
+				color: s.color ?? ChartPalette.categorical(i, isDarkMode),
 			})),
 		[config.series, isDarkMode],
 	);

--- a/packages/blocks/tests/renderer.test.tsx
+++ b/packages/blocks/tests/renderer.test.tsx
@@ -7,6 +7,13 @@ import type { Block, BlockInteraction } from "../src/types.js";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
+// Shared between the Collapsible.* mocks so DefaultTrigger / DefaultPanel can
+// react to open state set on Collapsible.Root.
+const CollapsibleContext = React.createContext<{
+	open?: boolean;
+	onOpenChange?: (next: boolean) => void;
+}>({});
+
 vi.mock("@cloudflare/kumo", () => ({
 	Button: ({ children, onClick, variant, type }: any) => (
 		<button onClick={onClick} data-variant={variant} type={type || "button"}>
@@ -159,13 +166,48 @@ vi.mock("@cloudflare/kumo", () => ({
 			</label>
 		),
 	},
-	Collapsible: ({ children, label, open, onOpenChange }: any) => (
-		<div data-testid="collapsible" data-open={open ? "true" : "false"}>
-			<button type="button" onClick={() => onOpenChange?.(!open)}>
-				{label}
-			</button>
-			{open && <div data-testid="collapsible-content">{children}</div>}
-		</div>
+	Collapsible: Object.assign(
+		// `Collapsible` is also `Collapsible.Root` in Kumo 2.x.
+		({ children, open, onOpenChange, ...rest }: any) => (
+			<div data-testid="collapsible" data-open={open ? "true" : "false"} {...rest}>
+				<CollapsibleContext.Provider value={{ open, onOpenChange }}>
+					{children}
+				</CollapsibleContext.Provider>
+			</div>
+		),
+		{
+			Root: ({ children, open, onOpenChange, ...rest }: any) => (
+				<div data-testid="collapsible" data-open={open ? "true" : "false"} {...rest}>
+					<CollapsibleContext.Provider value={{ open, onOpenChange }}>
+						{children}
+					</CollapsibleContext.Provider>
+				</div>
+			),
+			Trigger: ({ children }: any) => {
+				const ctx = React.useContext(CollapsibleContext);
+				return (
+					<button type="button" onClick={() => ctx.onOpenChange?.(!ctx.open)}>
+						{children}
+					</button>
+				);
+			},
+			DefaultTrigger: ({ children }: any) => {
+				const ctx = React.useContext(CollapsibleContext);
+				return (
+					<button type="button" onClick={() => ctx.onOpenChange?.(!ctx.open)}>
+						{children}
+					</button>
+				);
+			},
+			Panel: ({ children }: any) => {
+				const ctx = React.useContext(CollapsibleContext);
+				return ctx.open ? <div data-testid="collapsible-content">{children}</div> : null;
+			},
+			DefaultPanel: ({ children }: any) => {
+				const ctx = React.useContext(CollapsibleContext);
+				return ctx.open ? <div data-testid="collapsible-content">{children}</div> : null;
+			},
+		},
 	),
 	Combobox: Object.assign(
 		({ children, label }: any) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^0.9.1
       version: 0.9.1
     '@cloudflare/kumo':
-      specifier: ^1.16.0
-      version: 1.16.0
+      specifier: ^2.3.0
+      version: 2.3.0
     '@cloudflare/vite-plugin':
       specifier: ^1.36.3
       version: 1.36.3
@@ -657,7 +657,7 @@ importers:
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
       agents:
         specifier: ^0.12.0
-        version: 0.12.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/workers-types@4.20260305.1)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))(zod@4.4.1)
+        version: 0.12.0(@babel/core@7.29.0)(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260305.1)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))(zod@4.4.1)
       astro:
         specifier: ^6.1.3
         version: 6.1.3(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.55.2)(typescript@6.0.3)(yaml@2.8.2)
@@ -885,7 +885,7 @@ importers:
         version: 1.3.0
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1189,7 +1189,7 @@ importers:
         version: 1.2.10
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -1201,7 +1201,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: 'catalog:'
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1256,7 +1256,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@emdash-cms/blocks':
         specifier: workspace:*
         version: link:..
@@ -1745,7 +1745,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1848,7 +1848,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1885,7 +1885,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2934,6 +2934,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -2954,19 +2958,25 @@ packages:
     resolution: {integrity: sha512-4kdqcjyxo/8RQ8ayjms47HCWZIF5981oE5nIenbfThKDxWXtEHKipAOWlflpPJzZx9y/JWYQkp18Awr7VuepFg==}
     engines: {node: '>= 18'}
 
-  '@base-ui/react@1.2.0':
-    resolution: {integrity: sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
+      '@date-fns/tz': ^1.2.0
       '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
       '@types/react':
         optional: true
+      date-fns:
+        optional: true
 
-  '@base-ui/utils@0.2.5':
-    resolution: {integrity: sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -3069,8 +3079,8 @@ packages:
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
     engines: {node: '>= 20.12.0'}
 
-  '@cloudflare/kumo@1.16.0':
-    resolution: {integrity: sha512-uCrj7jGPvdXj8lrdQBfMGKzV3JTDi7hUBsLf4jpirD7QHvZMsGe6XuU+KKvQFqDTmj5ELXQVES4YVoducxZ7Tg==}
+  '@cloudflare/kumo@2.3.0':
+    resolution: {integrity: sha512-Nw3JzTIj3KDyl/d2+vXwSGXiu+E/NgL08Cqn/lxJkyc7tTEwBY3UgTFWNE9RHakCPo161LgZRysZuHy2YmOIPg==}
     hasBin: true
     peerDependencies:
       '@phosphor-icons/react': ^2.1.10
@@ -7957,10 +7967,6 @@ packages:
     peerDependencies:
       kysely: '*'
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
-
   kysely@0.29.2:
     resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
     engines: {node: '>=22.0.0'}
@@ -11820,6 +11826,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -11850,22 +11858,23 @@ snapshots:
 
   '@badrap/valita@0.4.6': {}
 
-  '@base-ui/react@1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@base-ui/utils': 0.2.5(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@floating-ui/utils': 0.2.11
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
+      '@date-fns/tz': 1.4.1
       '@types/react': 19.2.14
+      date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.5(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.11
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -12075,9 +12084,9 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@cloudflare/kumo@1.16.0(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)':
+  '@cloudflare/kumo@2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)':
     dependencies:
-      '@base-ui/react': 1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@shikijs/langs': 4.0.2
       '@shikijs/themes': 4.0.2
@@ -12092,8 +12101,10 @@ snapshots:
     optionalDependencies:
       zod: 4.4.1
     transitivePeerDependencies:
+      - '@date-fns/tz'
       - '@emotion/is-prop-valid'
       - '@types/react'
+      - date-fns
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
@@ -13601,13 +13612,13 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.18
     optionalDependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -15272,12 +15283,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agents@0.12.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/workers-types@4.20260305.1)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))(zod@4.4.1):
+  agents@0.12.0(@babel/core@7.29.0)(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260305.1)(@x402/core@2.8.0)(@x402/evm@2.8.0(typescript@6.0.3))(ai@6.0.172(zod@4.4.1))(react@19.2.4)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))(zod@4.4.1):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.0-rc.18)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
       ai: 6.0.172(zod@4.4.1)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
@@ -17573,8 +17584,6 @@ snapshots:
   kysely-d1@0.4.0(kysely@0.29.2):
     dependencies:
       kysely: 0.29.2
-
-  kysely@0.27.6: {}
 
   kysely@0.29.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,7 +83,7 @@ catalog:
   "@atcute/xrpc-server-cloudflare": ^2.0.0
   "@atproto/crypto": ^0.4.5
   "@atproto/repo": ^0.9.1
-  "@cloudflare/kumo": ^1.16.0
+  "@cloudflare/kumo": ^2.3.0
   "@cloudflare/vite-plugin": ^1.36.3
   "@cloudflare/vitest-pool-workers": ^0.16.3
   "@cloudflare/workers-types": ^4.20260305.1


### PR DESCRIPTION
## What does this PR do?

Bumps `@cloudflare/kumo` from 1.16 to 2.3. Notably picks up the new `Autocomplete` component (added in 2.0; unblocks a future migration from the native `<datalist>` picker shipped in #1176).

### Breaking changes handled in this PR

Two internal call sites needed updates:

- **Accordion block (`packages/blocks`)** — `Collapsible` refactored to a compound component in Kumo 2.0. Migrated from `<Collapsible label=...>` to `<Collapsible.Root><Collapsible.DefaultTrigger>...<Collapsible.DefaultPanel>...`. The `@cloudflare/kumo` mock in the blocks renderer tests was updated to match the new compound shape.
- **Chart block (`packages/blocks`)** — `ChartPalette.color()` was renamed to `ChartPalette.categorical()`.

### Test updates

`<Button title="...">` in Kumo 2 wraps the button in a Tooltip popup rather than setting a DOM `title` attribute (see [kumo changelog: "Add `title` prop to `Button` — wraps the button in a `Tooltip`"](https://github.com/cloudflare/kumo/blob/main/CHANGELOG.md)). Three admin tests that asserted on `title`/`getByTitle` now read `aria-label` / `getByLabelText` instead — the underlying components already expose accurate aria-labels, so the assertions are equivalent.

### What I checked

- All workspace typechecks pass (except the pre-existing `plugin-cli` failure on `main`).
- `pnpm test` — 892 admin + 96 blocks + 30 auth-atproto + 3453 core, all green.
- `pnpm lint:json` returns 0 diagnostics.
- `pnpm format` applied.
- No other Kumo components in our code use the deprecated/removed APIs (`Checkbox.onChange`, `Switch.Group`, heading-variant `<Text>`).

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (test updates for new Tooltip behavior; renderer mock updated for compound Collapsible)
- [x] User-visible strings in the admin UI are wrapped for translation
- [x] I have added a changeset (patch for admin, blocks, auth-atproto)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://chore-bump-kumo-to-2-x-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `chore/bump-kumo-to-2.x`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

