### PR TITLE
fix(cloudflare): extract email callback to fix PluginBridge chunk split — sandboxed plugins now load

### DIFF
--- a/.changeset/fix-plugin-bridge-chunk.md
+++ b/.changeset/fix-plugin-bridge-chunk.md
@@ -1,0 +1,9 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fix config-based sandboxed plugins never loading because `PluginBridge` was `null` via `cloudflare:workers` exports.
+
+**Root cause:** `runner.ts` imported `setEmailSendCallback` directly from `bridge.ts`. This caused `bridge.ts` to be shared between the worker entry path and the runtime/middleware path, so Rollup bundled it into a shared chunk. The resulting `entry.mjs` had `export { bf as PluginBridge }` (a re-export from a chunk) rather than an inline class definition. Cloudflare's `import { exports } from "cloudflare:workers"` only exposes `WorkerEntrypoint` subclasses defined **inline** in the entry module — re-exports from chunks resolve to `null`.
+
+**Fix:** Extract the `emailSendCallback` state and `setEmailSendCallback` / `getEmailSendCallback` functions into a new `email-callback.ts` module. `runner.ts` now imports from `./email-callback.js` instead of `./bridge.js`, breaking the cross-path dependency. With `bridge.ts` only reachable from the worker entry path, Rollup inlines `PluginBridge` directly into `entry.mjs`, making `exports.PluginBridge` resolvable.

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -38,7 +38,6 @@ const SYSTEM_COLUMNS = new Set([
 	"draft_revision_id",
 ]);
 
-
 /**
  * Serialize a value for D1 storage.
  * Mirrors core's serializeValue: objects/arrays → JSON strings,

--- a/packages/cloudflare/src/sandbox/bridge.ts
+++ b/packages/cloudflare/src/sandbox/bridge.ts
@@ -9,12 +9,12 @@
 
 import type { D1Database } from "@cloudflare/workers-types";
 import { WorkerEntrypoint } from "cloudflare:workers";
-import type { SandboxEmailSendCallback } from "emdash";
 import { ulid, PluginStorageRepository } from "emdash";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
 
 import { sandboxHttpFetch } from "./bridge-http.js";
+import { getEmailSendCallback } from "./email-callback.js";
 
 /** Regex to validate collection names (prevent SQL injection) */
 const COLLECTION_NAME_REGEX = /^[a-z][a-z0-9_]*$/;
@@ -38,24 +38,6 @@ const SYSTEM_COLUMNS = new Set([
 	"draft_revision_id",
 ]);
 
-/**
- * Module-level email send callback.
- *
- * The bridge runs in the host process (same worker), so we can use a
- * module-level callback that the runner sets before creating bridge bindings.
- * This avoids the need to pass non-serializable functions through props.
- *
- * @see runner.ts setEmailSendCallback()
- */
-let emailSendCallback: SandboxEmailSendCallback | null = null;
-
-/**
- * Set the email send callback for all bridge instances.
- * Called by the runner when the EmailPipeline is available.
- */
-export function setEmailSendCallback(callback: SandboxEmailSendCallback | null): void {
-	emailSendCallback = callback;
-}
 
 /**
  * Serialize a value for D1 storage.
@@ -988,6 +970,7 @@ export class PluginBridge extends WorkerEntrypoint<PluginBridgeEnv, PluginBridge
 		if (!capabilities.includes("email:send")) {
 			throw new Error("Missing capability: email:send");
 		}
+		const emailSendCallback = getEmailSendCallback();
 		if (!emailSendCallback) {
 			throw new Error("Email is not configured. No email provider is available.");
 		}

--- a/packages/cloudflare/src/sandbox/email-callback.ts
+++ b/packages/cloudflare/src/sandbox/email-callback.ts
@@ -1,0 +1,33 @@
+/**
+ * Email send callback state — shared between the sandbox runner and PluginBridge.
+ *
+ * Keeping this in its own module breaks the direct dependency of runner.ts on
+ * bridge.ts. With that dependency severed, Rollup's tree-shaker sees that
+ * bridge.ts (and therefore PluginBridge) is only reachable from the worker
+ * entry-point export (`export { PluginBridge } from "@emdash-cms/cloudflare/sandbox"`),
+ * so it bundles bridge.ts directly into entry.mjs rather than pulling it into a
+ * shared chunk.  That matters because Cloudflare's
+ * `import { exports } from "cloudflare:workers"` only exposes WorkerEntrypoint
+ * subclasses that are **defined inline** in the entry module — re-exports from
+ * chunks return null.
+ */
+
+import type { SandboxEmailSendCallback } from "emdash";
+
+let emailSendCallback: SandboxEmailSendCallback | null = null;
+
+/**
+ * Set the email send callback for all bridge instances.
+ * Called by the sandbox runner when the EmailPipeline is available.
+ */
+export function setEmailSendCallback(callback: SandboxEmailSendCallback | null): void {
+	emailSendCallback = callback;
+}
+
+/**
+ * Get the current email send callback.
+ * Used by PluginBridge.emailSend to invoke the host-side email sender.
+ */
+export function getEmailSendCallback(): SandboxEmailSendCallback | null {
+	return emailSendCallback;
+}

--- a/packages/cloudflare/src/sandbox/index.ts
+++ b/packages/cloudflare/src/sandbox/index.ts
@@ -9,5 +9,6 @@
  */
 
 export { CloudflareSandboxRunner, createSandboxRunner, type PluginBridgeProps } from "./runner.js";
-export { PluginBridge, setEmailSendCallback, type PluginBridgeEnv } from "./bridge.js";
+export { PluginBridge, type PluginBridgeEnv } from "./bridge.js";
+export { setEmailSendCallback } from "./email-callback.js";
 export { generatePluginWrapper } from "./wrapper.js";

--- a/packages/cloudflare/src/sandbox/runner.ts
+++ b/packages/cloudflare/src/sandbox/runner.ts
@@ -23,7 +23,7 @@ import {
 	type PluginManifest,
 } from "emdash";
 
-import { setEmailSendCallback } from "./bridge.js";
+import { setEmailSendCallback } from "./email-callback.js";
 import type { WorkerLoader, WorkerStub, PluginBridgeBinding, WorkerLoaderLimits } from "./types.js";
 import { generatePluginWrapper } from "./wrapper.js";
 


### PR DESCRIPTION
Fixes #1183

## Problem

Config-based sandboxed plugins (`sandboxed: [...]` in `astro.config.mjs`) never loaded — `exports.PluginBridge` was always `null`.

**Root cause:** `runner.ts` imported `setEmailSendCallback` from `bridge.ts`. This caused `bridge.ts` to be reachable from two paths in the bundle:

1. **Worker entry path:** `worker.ts → @emdash-cms/cloudflare/sandbox → bridge.ts` (for `PluginBridge`)
2. **Runtime/middleware path:** `runner.ts → bridge.ts` (for `setEmailSendCallback`)

Rollup therefore put `bridge.ts` in a shared chunk. The resulting `entry.mjs` had:
```js
export { bf as PluginBridge }  // re-export from chunk
```
instead of an inline class definition.

Cloudflare's `import { exports } from "cloudflare:workers"` only exposes `WorkerEntrypoint` subclasses that are **defined inline** in the entry module. Re-exports from chunks resolve to `null` — so every attempt to instantiate the bridge via the Worker Loader binding silently failed.

## Fix

Extract the email callback state into a new `packages/cloudflare/src/sandbox/email-callback.ts` module:

```
email-callback.ts   ← emailSendCallback state + setEmailSendCallback + getEmailSendCallback
bridge.ts           ← imports getEmailSendCallback from email-callback.ts
runner.ts           ← imports setEmailSendCallback from email-callback.ts (not bridge.ts ✓)
index.ts            ← re-exports setEmailSendCallback from email-callback.ts
```

With `runner.ts` no longer importing from `bridge.ts`, there's no cross-path share. Rollup inlines `bridge.ts` directly into `entry.mjs`, so `exports.PluginBridge` is the live class and sandboxed plugins load correctly.

`email-callback.ts` itself becomes a shared chunk (imported by both `runner.ts` and `bridge.ts`), but that's fine — it contains no `WorkerEntrypoint` code, so being in a shared chunk has no effect on Cloudflare's `exports` API.

## Changes

| File | Change |
|------|--------|
| `packages/cloudflare/src/sandbox/email-callback.ts` | **New** — extracted email callback state/functions |
| `packages/cloudflare/src/sandbox/bridge.ts` | Remove `emailSendCallback` state + `setEmailSendCallback`; import `getEmailSendCallback` from new module |
| `packages/cloudflare/src/sandbox/runner.ts` | Import `setEmailSendCallback` from `./email-callback.js` instead of `./bridge.js` |
| `packages/cloudflare/src/sandbox/index.ts` | Re-export `setEmailSendCallback` from `./email-callback.js` |
| `.changeset/fix-plugin-bridge-chunk.md` | Patch changeset for `@emdash-cms/cloudflare` |