### PR TITLE
fix: extract image URL from stored MediaValue JSON during WordPress i…

### DIFF
--- a/.changeset/wp-featured-image-rewrite.md
+++ b/.changeset/wp-featured-image-rewrite.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix WordPress import leaving `featured_image` (and other image/file fields) pointing at the original WordPress URL after media download. The rewrite step passed the whole stored MediaValue JSON to the URL matcher instead of its inner `src`, so the field was never rewritten to the local R2 URL even though the file existed in the media table. Inline content images were unaffected.

--- a/packages/core/src/astro/routes/api/import/wordpress/rewrite-url-helpers.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/rewrite-url-helpers.ts
@@ -28,6 +28,28 @@ export function buildBaseUrlMap(urlMap: Record<string, string>): Map<string, str
 }
 
 /**
+ * Extract the URL to match from a stored media field value.
+ *
+ * Image/file columns hold a JSON-stringified MediaValue
+ * (e.g. `{"provider":"external","id":"","src":"https://.../hero.jpg"}`), but legacy
+ * rows may hold a bare URL string. Returns the inner `src` for a MediaValue, otherwise
+ * the value unchanged. Without this, the whole JSON blob is passed to findMatchingUrl()
+ * and the embedded URL is never matched.
+ */
+export function extractMediaUrl(value: string): string {
+	try {
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- shape validated below
+		const parsed = JSON.parse(value) as { src?: unknown };
+		if (parsed && typeof parsed.src === "string") {
+			return parsed.src;
+		}
+	} catch {
+		// Not JSON — treat the column value as a bare URL.
+	}
+	return value;
+}
+
+/**
  * Find matching new URL for a given URL, checking exact, base, and WordPress image-size matches
  */
 export function findMatchingUrl(

--- a/packages/core/src/astro/routes/api/import/wordpress/rewrite-urls.ts
+++ b/packages/core/src/astro/routes/api/import/wordpress/rewrite-urls.ts
@@ -24,6 +24,7 @@ import type { EmDashHandlers } from "#types";
 
 import {
 	buildBaseUrlMap,
+	extractMediaUrl,
 	findMatchingUrl,
 	rewritePortableTextUrls,
 	rewriteStringUrls,
@@ -174,8 +175,10 @@ async function rewriteUrls(
 					const value = row[field.slug];
 					if (!value || typeof value !== "string") continue;
 
-					// Try to find a matching rewritten URL
-					const newUrl = findMatchingUrl(value, urlMap, baseMap);
+					// Values are stored as JSON MediaValue objects (e.g. featured_image from
+					// import normalizes to {"provider":"external","src":"<wp url>"}). Match on the
+					// inner `src`, falling back to the raw value for legacy bare-URL rows.
+					const newUrl = findMatchingUrl(extractMediaUrl(value), urlMap, baseMap);
 					if (newUrl) {
 						// Normalize into a proper MediaValue instead of storing a bare URL
 						try {

--- a/packages/core/tests/unit/import/wordpress-featured-image-rewrite.test.ts
+++ b/packages/core/tests/unit/import/wordpress-featured-image-rewrite.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildBaseUrlMap,
+	extractMediaUrl,
+	findMatchingUrl,
+} from "../../../src/astro/routes/api/import/wordpress/rewrite-url-helpers.js";
+
+/**
+ * Regression for bug report: featured_image not rewritten to local R2 after WordPress import.
+ *
+ * During import, `featured_image` is normalized (media/normalize.ts) and stored in the
+ * `ec_*` image column as a JSON-stringified MediaValue:
+ *   {"provider":"external","id":"","src":"https://wp-domain/.../hero.jpg"}
+ *
+ * The rewrite-urls route (rewrite-urls.ts) used to pass that whole JSON string to
+ * findMatchingUrl(), which expects a bare URL, so the embedded `src` was never matched and
+ * the field kept pointing at WordPress. The fix extracts `.src` via extractMediaUrl() first.
+ *
+ * Inline content images were unaffected because they go through rewritePortableTextUrls(),
+ * which reaches into each block's asset.url before matching.
+ */
+describe("WordPress import — featured_image rewrite", () => {
+	const wpUrl = "https://wp-domain.example/wp-content/uploads/2026/01/hero.jpg";
+	const localUrl = "/_emdash/api/media/file/01KRNQM2P18GQD1TKDWEPHC9VG.jpg";
+	const urlMap = { [wpUrl]: localUrl };
+	const baseMap = buildBaseUrlMap(urlMap);
+
+	// Exactly what the image column holds after import (normalized MediaValue).
+	const storedFeaturedImage = JSON.stringify({
+		provider: "external",
+		id: "",
+		src: wpUrl,
+	});
+
+	it("extracts the inner src from a stored MediaValue JSON", () => {
+		expect(extractMediaUrl(storedFeaturedImage)).toBe(wpUrl);
+	});
+
+	it("returns a bare URL string unchanged (legacy rows)", () => {
+		expect(extractMediaUrl(wpUrl)).toBe(wpUrl);
+	});
+
+	it("leaves a non-MediaValue JSON string untouched", () => {
+		expect(extractMediaUrl('{"foo":"bar"}')).toBe('{"foo":"bar"}');
+	});
+
+	it("rewrites a stored featured_image MediaValue to the local URL", () => {
+		// This mirrors the mediaFields loop: extract, then match.
+		const match = findMatchingUrl(extractMediaUrl(storedFeaturedImage), urlMap, baseMap);
+		expect(match).toBe(localUrl);
+	});
+
+	it("still rewrites a WordPress size-suffixed variant inside a stored MediaValue", () => {
+		const variant = JSON.stringify({
+			provider: "external",
+			id: "",
+			src: "https://wp-domain.example/wp-content/uploads/2026/01/hero-1024x695.jpg",
+		});
+		const match = findMatchingUrl(extractMediaUrl(variant), urlMap, baseMap);
+		expect(match).toBe(localUrl);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes WordPress import leaving `featured_image` (and any `image`/`file` field) pointing at the original WordPress URL after media download, even though the file was already downloaded to R2 and present in the media table.

Root cause: the `rewrite-urls` step reads `image`/`file` columns as raw text. Those columns hold a JSON-stringified `MediaValue` (for example `{"provider":"external","id":"","src":"https://wp/.../hero.jpg"}`). The code passed that whole JSON blob to `findMatchingUrl()`, which expects a bare URL — so `new URL(...)` throws, nothing matches, and the field is never rewritten. Inline content images were unaffected because they match through `rewritePortableTextUrls()`, which reaches into each block's `asset.url` first.

Fix: add `extractMediaUrl()` to pull the inner `src` out of a stored `MediaValue` (falling back to the raw value for legacy bare-URL rows) and use it before matching. The existing `normalizeMediaValue()` call then rewrites the field to a local `MediaValue`. Covers all `image`/`file` fields, not just `featured_image`.

This fixes future imports. Rows imported before this change are not rewritten, since the step only runs during an import. A second, separate UI issue (Featured Image picker unresponsive in the admin) was reported alongside this and is not addressed here.

Closes https://github.com/emdash-cms/emdash/issues/1051

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

Targeted regression test plus full core suite:

    Test Files  219 passed (219)
         Tests  3458 passed (3458)