### PR TITLE
i18n(zh-CN): Update Simplified Chinese translation

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -52,7 +52,7 @@ msgstr "（来自 {0}）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:352
 msgid "(pre-release)"
-msgstr ""
+msgstr "（预发布）"
 
 #: packages/admin/src/components/settings/PasskeyItem.tsx:157
 msgid "(synced)"
@@ -60,7 +60,7 @@ msgstr "（已同步）"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:355
 msgid "(too new)"
-msgstr ""
+msgstr "（版本过高）"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:312
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
@@ -850,7 +850,7 @@ msgstr "应用"
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:144
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:145
 msgid "Apply language"
-msgstr ""
+msgstr "应用语言"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2475
 #: packages/admin/src/components/PortableTextEditor.tsx:2476
@@ -2585,7 +2585,7 @@ msgstr "更新小部件时出错"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:415
 msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
-msgstr ""
+msgstr "此插件的每个已发布版本均已撤回或无法验证。请稍后查看，或联系发布者。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1846
 msgid "Exists"
@@ -3876,7 +3876,7 @@ msgstr "管理 {1} 的 {0}"
 
 #: packages/admin/src/components/ContentEditor.tsx:2020
 msgid "Manage bylines in {entryLocale}"
-msgstr ""
+msgstr "在 {entryLocale} 中管理署名"
 
 #: packages/admin/src/components/Widgets.tsx:326
 msgid "Manage content widgets in your widget areas"
@@ -4280,7 +4280,7 @@ msgstr "暂无已审核评论。"
 
 #: packages/admin/src/components/ContentEditor.tsx:2012
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
-msgstr ""
+msgstr "在 {entryLocale} 中没有可用的署名。请先从署名页面创建一个变体，然后再在此条目中署名。"
 
 #: packages/admin/src/routes/bylines.tsx:365
 msgid "No bylines found"
@@ -4356,7 +4356,7 @@ msgstr "文档中无标题"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:413
 msgid "No installable releases"
-msgstr ""
+msgstr "无可安装的版本"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:159
 msgid "No invite token provided"
@@ -4377,7 +4377,7 @@ msgstr "无关联用户"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:134
 msgid "No matches"
-msgstr ""
+msgstr "无匹配项"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
@@ -4885,7 +4885,7 @@ msgstr "每页文章数"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:327
 msgid "Pre-release"
-msgstr ""
+msgstr "预发布"
 
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
 msgid "Preparing registration..."
@@ -5865,11 +5865,11 @@ msgstr "为此图片实例设置自定义显示尺寸。"
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:170
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:174
 msgid "Set language"
-msgstr ""
+msgstr "设置语言"
 
 #: packages/admin/src/components/editor/CodeBlockNode.tsx:171
 msgid "Set language (current: {label})"
-msgstr ""
+msgstr "设置语言（当前：{label}）"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:531
 msgid "Set to 0 to never close comments automatically."


### PR DESCRIPTION
## What does this PR do?

Update 11 missing Simplified Chinese translations



## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
