### PR TITLE
fix(ci): run flue from repo root, not .flue

### DIFF
--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -233,7 +233,22 @@ jobs:
           # result to stdout. Send stderr to a separate file so we can
           # surface Flue's progress in the workflow log without
           # contaminating the JSON we parse.
-          pnpm --dir .flue exec flue run investigate \
+          # Run `flue run` from the repo root (not from .flue/). Two
+          # reasons:
+          #   1. Flue resolves `--root .flue` relative to the caller's
+          #      cwd. `pnpm --dir .flue` would compose to `.flue/.flue`
+          #      and the build fails with "No agent or workflow files
+          #      found." (Observed on the first live run.)
+          #   2. The agent's `local()` sandbox inherits process.cwd()
+          #      as its working directory. We want that to be the
+          #      EmDash repo root so the agent's bash tool can `pnpm
+          #      test`, `git`, `gh issue view`, etc. against the
+          #      EmDash checkout.
+          #
+          # Invoke the flue binary directly from .flue/'s installed
+          # node_modules; pnpm's `--dir` semantics are exactly what
+          # broke us originally.
+          .flue/node_modules/.bin/flue run investigate \
             --target node \
             --root .flue \
             --payload "$PAYLOAD" \

--- a/.github/workflows/reporter-reply.yml
+++ b/.github/workflows/reporter-reply.yml
@@ -191,7 +191,10 @@ jobs:
           set -o pipefail
           PAYLOAD="$(cat /tmp/classify-payload.json)"
           set +e
-          pnpm --dir .flue exec flue run classify-reply \
+          # See investigate.yml's "Run Flue investigate agent" step
+          # for why we invoke the binary directly rather than via
+          # `pnpm --dir`. Same --root resolution bug.
+          .flue/node_modules/.bin/flue run classify-reply \
             --target node \
             --root .flue \
             --payload "$PAYLOAD" \


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1090. The first live `investigate.yml` run after merge ([on issue #1200](https://github.com/emdash-cms/emdash/actions/runs/26603799087/job/78448353101)) failed at the agent step with:

```
[flue] Build failed: [flue] No agent or workflow files found.
Expected at: /home/runner/work/emdash/emdash/.flue/.flue/agents/
          or /home/runner/work/emdash/emdash/.flue/.flue/workflows/
```

Note the doubled `.flue/.flue`. The workflow ran flue via:

```
pnpm --dir .flue exec flue run ... --root .flue
```

`pnpm --dir .flue` sets the working directory to `.flue/`, then Flue resolved `--root .flue` relative to that cwd, composing to `.flue/.flue`.

A secondary reason to run from the repo root: the agent's `local()` sandbox inherits `process.cwd()` as its working directory. The bash tool needs to run `pnpm test`, `gh issue view`, etc. against the EmDash checkout, not against `.flue/`.

**Fix:** invoke the flue binary directly from `.flue/`'s installed `node_modules`, leaving cwd as `$GITHUB_WORKSPACE` (repo root). `--root .flue` then resolves to `<repo-root>/.flue` correctly.

Verified locally with the same invocation — the build discovers both workflows and runs `investigate` through to the API-key check (only CI has the gateway creds).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (no test surface changed)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests — N/A
- [x] User-visible strings — N/A
- [ ] Changeset — N/A, CI tooling
- [ ] Discussion — N/A, bug fix in CI tooling

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7 (opencode)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-triage-cwd-and-flue-root-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/triage-cwd-and-flue-root`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
