### PR TITLE
fix(triage): write result to a file instead of scraping stdout

### DIFF
--- a/.flue/workflows/investigate.ts
+++ b/.flue/workflows/investigate.ts
@@ -29,6 +29,8 @@
 // passed into the sandbox env. The orchestrator's app token lives in
 // the workflow YAML and never crosses into this agent process.
 
+import { writeFileSync } from "node:fs";
+
 import { createAgent, type FlueContext } from "@flue/runtime";
 import { local } from "@flue/runtime/node";
 import * as v from "valibot";
@@ -249,7 +251,33 @@ function pickReproduceSkill(area: IssueClassification["area"]) {
 
 // ---------- run() ----------
 
-export async function run({
+/**
+ * Persist the structured result to a file so the GitHub Actions
+ * orchestrator can read it directly. `flue run` interleaves build-log
+ * lines on stdout and pretty-prints the returned result, so scraping
+ * the result back out of stdout is fragile. Writing the assembled
+ * result object to a known path makes the handoff deterministic.
+ *
+ * The path comes from `INVESTIGATE_RESULT_PATH` (set by the workflow);
+ * when it is unset -- local prototyping via run-local.ts -- we skip the
+ * write and rely on the returned value. Only a clean completion writes
+ * the file; a thrown error leaves no file, which the orchestrator
+ * treats as a failed run.
+ */
+export async function run(ctx: FlueContext<InvestigatePayload>): Promise<InvestigateResult> {
+	const result = await runImpl(ctx);
+	const path = process.env.INVESTIGATE_RESULT_PATH;
+	if (path) {
+		try {
+			writeFileSync(path, JSON.stringify(result));
+		} catch (error) {
+			console.error("[investigate] failed to write result file:", error);
+		}
+	}
+	return result;
+}
+
+async function runImpl({
 	init,
 	payload,
 	log,

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -237,6 +237,10 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_KEY: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.number }}
+          # The workflow writes its assembled result here on clean
+          # completion; the parse step reads it directly instead of
+          # scraping the result back out of stdout.
+          INVESTIGATE_RESULT_PATH: /tmp/agent-result.json
         run: |
           set -o pipefail
           PAYLOAD="$(cat /tmp/agent-payload.json)"
@@ -285,32 +289,22 @@ jobs:
           AGENT_EXIT: ${{ steps.agent.outputs.exit }}
         run: |
           set -euo pipefail
-          if [[ "${AGENT_EXIT:-1}" != "0" ]] || [[ ! -s /tmp/agent-stdout.json ]]; then
+          # The workflow writes its assembled result to
+          # /tmp/agent-result.json (INVESTIGATE_RESULT_PATH) on clean
+          # completion. A non-zero exit or a missing/empty file means the
+          # run did not finish -- treat it as failed.
+          if [[ "${AGENT_EXIT:-1}" != "0" ]] || [[ ! -s /tmp/agent-result.json ]]; then
             echo "outcome=failed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Flue may interleave non-JSON log lines on stdout. Slurp-mode
-          # (`jq -s`) fails hard on any non-JSON content. Instead, scan
-          # the stream and keep only the last well-formed JSON object.
-          # Two strategies in order: prefer the last line that parses as
-          # a JSON object (`flue run` emits the workflow result as a
-          # single line), then fall back to the whole stream parse.
-          RESULT=""
-          while IFS= read -r line; do
-            if printf '%s' "$line" | jq -e 'type == "object"' >/dev/null 2>&1; then
-              RESULT="$line"
-            fi
-          done < /tmp/agent-stdout.json
-          if [[ -z "$RESULT" ]]; then
-            # Fallback: try slurp parse (handles pretty-printed multi-line JSON).
-            RESULT="$(jq -cs 'map(select(type == "object")) | last // empty' < /tmp/agent-stdout.json 2>/dev/null || true)"
-          fi
-          if [[ -z "$RESULT" ]] || [[ "$RESULT" == "null" ]]; then
-            echo "::warning::could not parse any JSON object from agent stdout"
+          # Defensive: confirm the file is a single JSON object before the
+          # downstream `jq` reads. The workflow controls this file, so a
+          # malformed one indicates a bug, not adversarial input.
+          if ! jq -e 'type == "object"' /tmp/agent-result.json >/dev/null 2>&1; then
+            echo "::warning::result file is not a JSON object"
             echo "outcome=failed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          printf '%s' "$RESULT" > /tmp/agent-result.json
 
           SKIPPED="$(jq -r '.skipped // false' /tmp/agent-result.json)"
           REPRODUCED="$(jq -r '.reproduced // false' /tmp/agent-result.json)"


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1207. The investigation bot's parse step scraped the agent
step's stdout for the result: it scanned for the last line that parsed as
a JSON object, with a `jq -cs` slurp fallback. Both are fragile.

`flue run` prints build-log lines (`[flue] Building: ...`) to stdout
*before* the workflow result and pretty-prints the result across many
lines. So no single line is a complete JSON object (the line scan fails)
and the slurp fallback chokes on the leading non-JSON lines. Run
[26628678991](https://github.com/emdash-cms/emdash/actions/runs/26628678991/job/78471700642)
produced a complete, correct result (it diagnosed #1200's root cause) that
the workflow then failed to parse for exactly this reason.

Fix: the workflow writes its assembled result object to
`INVESTIGATE_RESULT_PATH` (`/tmp/agent-result.json`) on clean completion,
and the parse step reads that file directly. No stdout scanning. A missing
or empty file (thrown error / crash) still maps to a failed run.

This keeps the read-only-agent + orchestrator-does-writes security model:
the result is still data assembled by the workflow, not the agent writing
to GitHub directly.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm typecheck` passes (`.flue` workspace)
- [x] `flue build` passes
- [x] No `messages.po` changes
- [x] No changeset needed (no published package touched)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8