### PR TITLE
feat: PR review-state labels and review-queue CLI

### DIFF
--- a/.github/scripts/review-queue.mjs
+++ b/.github/scripts/review-queue.mjs
@@ -128,7 +128,8 @@ function fetchOpenPrs(repo) {
 		"--state",
 		"open",
 		"--limit",
-		"200",
+		// gh's effective max; avoids silently omitting PRs from list / --needs-review.
+		"1000",
 		"--json",
 		"number,title,labels,createdAt,updatedAt,author,isDraft,mergeable,reviewDecision,statusCheckRollup",
 	]);
@@ -245,7 +246,12 @@ function main() {
 	const rest = [];
 	for (let i = 0; i < argv.length; i++) {
 		if (argv[i] === "--repo") {
-			repoOverride = argv[i + 1];
+			const value = argv[i + 1];
+			if (!value || value.startsWith("-")) {
+				console.error("--repo requires a value, e.g. --repo owner/name");
+				process.exit(1);
+			}
+			repoOverride = value;
 			i++;
 			continue;
 		}

--- a/.github/scripts/review-queue.mjs
+++ b/.github/scripts/review-queue.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+// review-queue.mjs -- maintainer CLI for the review/* label workflow.
+//
+// Zero external deps: only node: builtins, shelling out to `gh`.
+//
+// Usage:
+//   node .github/scripts/review-queue.mjs [list]            List open PRs grouped by review state.
+//   node .github/scripts/review-queue.mjs request <pr>...   Post `/review` on one or more PRs.
+//   node .github/scripts/review-queue.mjs request --needs-review
+//                                                           Post `/review` on every PR labeled
+//                                                           review/needs-review.
+//   node .github/scripts/review-queue.mjs --help            Show this help.
+//
+// Options:
+//   --repo <owner/name>   Target repo (default: detected via `gh repo view`).
+//
+// Requires an authenticated `gh` CLI.
+
+import { spawnSync } from "node:child_process";
+
+// --- gh helpers -------------------------------------------------------------
+
+// Run a gh command, returning stdout. On non-zero exit, print stderr and exit 1.
+function gh(args) {
+	const result = spawnSync("gh", args, { encoding: "utf8" });
+	if (result.error) {
+		console.error(`Failed to run gh: ${result.error.message}`);
+		process.exit(1);
+	}
+	if (result.status !== 0) {
+		const stderr = (result.stderr || "").trim();
+		console.error(stderr || `gh exited with status ${result.status}`);
+		process.exit(1);
+	}
+	return result.stdout;
+}
+
+function detectRepo() {
+	const out = gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]);
+	return out.trim();
+}
+
+// --- review state derivation ------------------------------------------------
+
+const STATE_ORDER = ["needs-rereview", "needs-review", "awaiting-author", "approved", "unlabeled"];
+
+// PR number argument: optional leading "#", then digits.
+const PR_NUMBER_RE = /^#?\d+$/;
+const PR_HASH_RE = /^#/;
+
+// Derive a PR's review state from its review/* label.
+function reviewState(pr) {
+	const labels = new Set((pr.labels || []).map((l) => l.name));
+	for (const state of STATE_ORDER) {
+		if (state === "unlabeled") continue;
+		if (labels.has(`review/${state}`)) return state;
+	}
+	return "unlabeled";
+}
+
+// Collect the size/* and area/* labels for display.
+function tagLabels(pr) {
+	return (pr.labels || [])
+		.map((l) => l.name)
+		.filter((n) => n.startsWith("size/") || n.startsWith("area/"));
+}
+
+// Derive a coarse CI status from the statusCheckRollup array.
+function ciStatus(pr) {
+	const rollup = pr.statusCheckRollup || [];
+	if (rollup.length === 0) return "none";
+	let pending = false;
+	let failed = false;
+	for (const check of rollup) {
+		// Check runs use `status` + `conclusion`; status contexts use `state`.
+		const conclusion = (check.conclusion || "").toUpperCase();
+		const status = (check.status || "").toUpperCase();
+		const state = (check.state || "").toUpperCase();
+
+		if (status && status !== "COMPLETED") {
+			// IN_PROGRESS, QUEUED, PENDING, WAITING, etc.
+			pending = true;
+			continue;
+		}
+		if (
+			["FAILURE", "TIMED_OUT", "CANCELLED", "ERROR", "ACTION_REQUIRED", "STARTUP_FAILURE"].includes(
+				conclusion,
+			)
+		) {
+			failed = true;
+			continue;
+		}
+		if (["FAILURE", "ERROR"].includes(state)) {
+			failed = true;
+			continue;
+		}
+		if (["PENDING", "EXPECTED"].includes(state)) {
+			pending = true;
+			continue;
+		}
+		// SUCCESS / NEUTRAL / SKIPPED count as pass.
+	}
+	if (failed) return "fail";
+	if (pending) return "pending";
+	return "pass";
+}
+
+function ageInDays(createdAt) {
+	const created = new Date(createdAt).getTime();
+	if (Number.isNaN(created)) return 0;
+	return Math.floor((Date.now() - created) / (24 * 60 * 60 * 1000));
+}
+
+function truncate(str, max) {
+	const s = str || "";
+	if (s.length <= max) return s;
+	return s.slice(0, max - 1) + "\u2026";
+}
+
+// --- commands ---------------------------------------------------------------
+
+function fetchOpenPrs(repo) {
+	const out = gh([
+		"pr",
+		"list",
+		"--repo",
+		repo,
+		"--state",
+		"open",
+		"--limit",
+		"200",
+		"--json",
+		"number,title,labels,createdAt,updatedAt,author,isDraft,mergeable,reviewDecision,statusCheckRollup",
+	]);
+	try {
+		return JSON.parse(out);
+	} catch (e) {
+		console.error(`Could not parse gh output: ${e.message}`);
+		process.exit(1);
+	}
+}
+
+function cmdList(repo) {
+	const prs = fetchOpenPrs(repo);
+
+	// Bucket PRs by derived state.
+	const groups = new Map(STATE_ORDER.map((s) => [s, []]));
+	for (const pr of prs) {
+		groups.get(reviewState(pr)).push(pr);
+	}
+
+	console.log(`Open PRs in ${repo}: ${prs.length}`);
+	console.log("");
+
+	for (const state of STATE_ORDER) {
+		const bucket = groups.get(state);
+		console.log(`== ${state} (${bucket.length}) ==`);
+		if (bucket.length === 0) {
+			console.log("  (none)");
+			console.log("");
+			continue;
+		}
+		// Sort oldest-first within a group so the most stale floats to the top.
+		bucket.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+		for (const pr of bucket) {
+			const num = `#${pr.number}`.padEnd(6);
+			const title = truncate(pr.title, 60).padEnd(60);
+			const author = `(${pr.author?.login || "unknown"})`.padEnd(20);
+			const tags = tagLabels(pr).join(",");
+			const tagCol = `[${tags}]`.padEnd(24);
+			const age = `${ageInDays(pr.createdAt)}d`.padEnd(5);
+			const ci = `CI:${ciStatus(pr)}`.padEnd(11);
+			const mergeable = (pr.mergeable || "UNKNOWN").toLowerCase();
+			console.log(`  ${num} ${title} ${author} ${tagCol} ${age} ${ci} ${mergeable}`);
+		}
+		console.log("");
+	}
+}
+
+function postReview(repo, number) {
+	gh(["pr", "comment", String(number), "--repo", repo, "--body", "/review"]);
+	console.log(`Requested review on #${number}`);
+}
+
+function cmdRequest(repo, args) {
+	if (args.includes("--needs-review")) {
+		const prs = fetchOpenPrs(repo);
+		const targets = prs.filter((pr) =>
+			(pr.labels || []).some((l) => l.name === "review/needs-review"),
+		);
+		if (targets.length === 0) {
+			console.log("No PRs labeled review/needs-review.");
+			return;
+		}
+		console.log(
+			`Requesting review on ${targets.length} PR(s): ${targets.map((p) => `#${p.number}`).join(", ")}`,
+		);
+		for (const pr of targets) {
+			postReview(repo, pr.number);
+		}
+		return;
+	}
+
+	const numbers = args.filter((a) => PR_NUMBER_RE.test(a)).map((a) => a.replace(PR_HASH_RE, ""));
+	if (numbers.length === 0) {
+		console.error("request: provide one or more PR numbers, or --needs-review");
+		process.exit(1);
+	}
+	for (const number of numbers) {
+		postReview(repo, number);
+	}
+}
+
+function printHelp() {
+	console.log(
+		[
+			"review-queue.mjs -- maintainer CLI for the review/* label workflow",
+			"",
+			"Usage:",
+			"  review-queue.mjs [list]                  List open PRs grouped by review state",
+			"  review-queue.mjs request <pr>...         Post /review on one or more PRs",
+			"  review-queue.mjs request --needs-review  Post /review on every review/needs-review PR",
+			"  review-queue.mjs --help                  Show this help",
+			"",
+			"Options:",
+			"  --repo <owner/name>   Target repo (default: detected via gh repo view)",
+			"",
+			"Requires an authenticated gh CLI.",
+		].join("\n"),
+	);
+}
+
+// --- arg parsing ------------------------------------------------------------
+
+function main() {
+	const argv = process.argv.slice(2);
+
+	if (argv.includes("--help") || argv.includes("-h")) {
+		printHelp();
+		return;
+	}
+
+	// Pull out --repo <value> if present; the rest are positional.
+	let repoOverride;
+	const rest = [];
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--repo") {
+			repoOverride = argv[i + 1];
+			i++;
+			continue;
+		}
+		rest.push(argv[i]);
+	}
+
+	const repo = repoOverride || detectRepo();
+	const command = rest[0] || "list";
+
+	switch (command) {
+		case "list":
+			cmdList(repo);
+			break;
+		case "request":
+			cmdRequest(repo, rest.slice(1));
+			break;
+		default:
+			console.error(`Unknown command: ${command}`);
+			printHelp();
+			process.exit(1);
+	}
+}
+
+main();

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -1,0 +1,217 @@
+name: Review State
+
+# Event-driven interpreter that maintains four mutually-exclusive review/*
+# labels on open PRs so maintainers can see review status at a glance.
+# Pure actions/github-script: no checkout, no secrets, no agent.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  schedule:
+    # Backstop sweep so state stays correct even if an event was missed.
+    - cron: "15 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  review-state:
+    name: Update review state labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    concurrency:
+      group: review-state-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: false
+    steps:
+      - name: Apply review state labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // The four mutually-exclusive review states.
+            const stateLabels = {
+              'review/needs-review': {
+                color: 'fbca04',
+                description: 'No maintainer or bot review yet',
+              },
+              'review/awaiting-author': {
+                color: 'c5def5',
+                description: 'Reviewed; waiting on the author to respond',
+              },
+              'review/needs-rereview': {
+                color: 'd93f0b',
+                description: 'Author pushed changes since the last review',
+              },
+              'review/approved': {
+                color: '0e8a16',
+                description: 'Approved; no new commits since',
+              },
+            };
+            const stateNames = Object.keys(stateLabels);
+
+            // --- Ensure the four labels exist (mirrors pr-sweep.yml) ---
+            const existingLabels = new Set();
+            for await (const response of github.paginate.iterator(
+              github.rest.issues.listLabelsForRepo,
+              { owner, repo, per_page: 100 }
+            )) {
+              for (const label of response.data) {
+                existingLabels.add(label.name);
+              }
+            }
+            for (const [name, meta] of Object.entries(stateLabels)) {
+              if (!existingLabels.has(name)) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: meta.color,
+                  description: meta.description,
+                });
+              }
+            }
+
+            // Remove a label, ignoring 404 if it's already gone (mirrors pr-sweep.yml).
+            async function safeRemoveLabel(prNumber, name) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name,
+                });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            // --- Determine the set of PRs to process ---
+            let prs;
+            if (
+              context.eventName === 'pull_request_target' ||
+              context.eventName === 'pull_request_review'
+            ) {
+              prs = [context.payload.pull_request];
+            } else {
+              // schedule / workflow_dispatch: sweep every open PR.
+              prs = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+            }
+
+            core.info(`Processing ${prs.length} PR(s) for review state`);
+
+            for (const pr of prs) {
+              if (!pr) continue;
+              try {
+                const currentLabels = new Set((pr.labels || []).map(l => l.name));
+
+                // Drafts get no review state: strip any review/* labels and move on.
+                if (pr.draft === true) {
+                  for (const name of stateNames) {
+                    if (currentLabels.has(name)) {
+                      await safeRemoveLabel(pr.number, name);
+                    }
+                  }
+                  core.info(`#${pr.number}: draft, cleared review state`);
+                  continue;
+                }
+
+                // Skip bot-authored PRs entirely (no labeling).
+                if (pr.user && pr.user.type === 'Bot') {
+                  core.info(`#${pr.number}: bot author, skipping`);
+                  continue;
+                }
+
+                // --- Qualifying reviews ---
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  per_page: 100,
+                });
+                const qualifying = reviews.filter(review =>
+                  review.user &&
+                  review.user.login !== pr.user.login &&
+                  (
+                    review.user.type === 'Bot' ||
+                    ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(review.author_association)
+                  ) &&
+                  ['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED'].includes(review.state)
+                );
+
+                let lastReview = null;
+                for (const review of qualifying) {
+                  if (
+                    !lastReview ||
+                    new Date(review.submitted_at) > new Date(lastReview.submitted_at)
+                  ) {
+                    lastReview = review;
+                  }
+                }
+
+                // --- Last non-merge commit ---
+                // Merge commits (parents > 1) are "Update branch" / `git merge main`
+                // and must NOT count as the author making changes.
+                const commits = await github.paginate(github.rest.pulls.listCommits, {
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  per_page: 100,
+                });
+                let lastCommitAt;
+                for (const commit of commits) {
+                  if (commit.parents && commit.parents.length > 1) continue;
+                  const committed = commit.commit?.committer?.date;
+                  if (!committed) continue;
+                  if (!lastCommitAt || new Date(committed) > new Date(lastCommitAt)) {
+                    lastCommitAt = committed;
+                  }
+                }
+
+                // --- Decide the state ---
+                let desired;
+                if (!lastReview) {
+                  desired = 'review/needs-review';
+                } else if (
+                  lastCommitAt &&
+                  new Date(lastCommitAt) > new Date(lastReview.submitted_at)
+                ) {
+                  desired = 'review/needs-rereview';
+                } else if (lastReview.state === 'APPROVED') {
+                  desired = 'review/approved';
+                } else {
+                  desired = 'review/awaiting-author';
+                }
+
+                // --- Apply: add the chosen label, remove the other three ---
+                if (!currentLabels.has(desired)) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: pr.number,
+                    labels: [desired],
+                  });
+                }
+                for (const name of stateNames) {
+                  if (name !== desired && currentLabels.has(name)) {
+                    await safeRemoveLabel(pr.number, name);
+                  }
+                }
+
+                core.info(`#${pr.number}: ${desired}`);
+              } catch (e) {
+                core.warning(`#${pr.number}: failed to update review state: ${e.message}`);
+              }
+            }

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: write
     concurrency:
-      group: review-state-${{ github.event.pull_request.number || github.run_id }}
+      group: review-state-${{ github.event.pull_request.number || 'sweep' }}
       cancel-in-progress: false
     steps:
       - name: Apply review state labels
@@ -48,7 +48,7 @@ jobs:
               },
               'review/needs-rereview': {
                 color: 'd93f0b',
-                description: 'Author pushed changes since the last review',
+                description: 'New commits since the last review',
               },
               'review/approved': {
                 color: '0e8a16',
@@ -162,8 +162,9 @@ jobs:
                 }
 
                 // --- Last non-merge commit ---
-                // Merge commits (parents > 1) are "Update branch" / `git merge main`
-                // and must NOT count as the author making changes.
+                // Only NON-merge commits count as new work. Merge commits (parents > 1)
+                // are "Update branch" / `git merge main`, so syncing a branch with main
+                // does not flip a reviewed PR back to needs-rereview.
                 const commits = await github.paginate(github.rest.pulls.listCommits, {
                   owner,
                   repo,

--- a/.github/workflows/review-state.yml
+++ b/.github/workflows/review-state.yml
@@ -182,6 +182,19 @@ jobs:
                 }
 
                 // --- Decide the state ---
+                // lastReview may be a COMMENTED review; approvals should still win unless a later
+                // decision review (APPROVED/CHANGES_REQUESTED) supersedes them.
+                let lastDecisionReview = null;
+                for (const review of qualifying) {
+                  if (review.state === 'COMMENTED') continue;
+                  if (
+                    !lastDecisionReview ||
+                    new Date(review.submitted_at) > new Date(lastDecisionReview.submitted_at)
+                  ) {
+                    lastDecisionReview = review;
+                  }
+                }
+
                 let desired;
                 if (!lastReview) {
                   desired = 'review/needs-review';
@@ -190,7 +203,7 @@ jobs:
                   new Date(lastCommitAt) > new Date(lastReview.submitted_at)
                 ) {
                   desired = 'review/needs-rereview';
-                } else if (lastReview.state === 'APPROVED') {
+                } else if (lastDecisionReview?.state === 'APPROVED') {
                   desired = 'review/approved';
                 } else {
                   desired = 'review/awaiting-author';

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -27,6 +27,8 @@ rules:
       # author) via github-script. They never check out PR code.
       - pr-compliance.yml
       - pr-triage.yml
+      # review-state only reads PR and review metadata via github-script to set review/* labels; it never checks out or runs PR code.
+      - review-state.yml
       # query-counts-apply uses workflow_run to apply snapshot updates that
       # were computed in the untrusted `query-counts` workflow. The trusted
       # workflow only consumes the artifact JSON, verifies the head SHA, and


### PR DESCRIPTION
## What does this PR do?

Adds two pieces of PR review-tracking tooling. No change to the app or any published package; CI and maintainer tooling only.

- **`review-state.yml`**: an event-driven `actions/github-script` workflow that maintains four mutually-exclusive `review/*` labels on open, non-draft, human-authored PRs so review status is visible at a glance:
  - `review/needs-review`: no qualifying maintainer or bot review yet
  - `review/awaiting-author`: reviewed, waiting on the author to respond
  - `review/needs-rereview`: author pushed changes since the last review
  - `review/approved`: approved, no new commits since

  State is derived per PR from qualifying reviews (a maintainer or bot, not the author) and the latest commit. `needs-rereview` keys off a new **non-merge** commit after the last review; merge commits ("Update branch" / `git merge main`) are intentionally excluded, so syncing a branch with main does not flip a reviewed PR back. Triggers on `pull_request_target`, `pull_request_review`, a 6 hour `schedule` backstop, and `workflow_dispatch`. Minimal permissions, no checkout, and no untrusted event data is interpolated into shell (all handling is inside `github-script`). The action is pinned by SHA.

- **`review-queue.mjs`**: a zero-dependency Node CLI wrapping `gh`. `list` (default) shows open PRs grouped by review state with author, size/area labels, age, CI status, and mergeability. `request <pr>...` and `request --needs-review` post `/review`.

This is the first of a small series. Auto-requesting review on external PRs, and migrating the reviewer to a Flue-based harness, are intentionally separate follow-up PRs.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- n/a: no TypeScript changed (a workflow YAML and a standalone .mjs) -->
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: no test suite for a CI workflow / gh-wrapper CLI -->
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a -->
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs. <!-- n/a: no admin UI -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a: no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: chore, not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code, model/tool: Claude Opus 4.8 (OpenCode)

## Screenshots / test output

- `pnpm lint:json` diagnostics count unchanged from baseline (no new diagnostics introduced).
- Workflow YAML validated (`yaml.safe_load`).
- `node .github/scripts/review-queue.mjs list` ran against `emdash-cms/emdash` and listed all open PRs grouped by state without error.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-review-state-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/review-state`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
