### PR TITLE
fix(admin): keep rich-text formatting toolbar visible on long posts

### DIFF
--- a/.changeset/fix-sticky-editor-toolbar.md
+++ b/.changeset/fix-sticky-editor-toolbar.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+The rich-text editor formatting toolbar now stays pinned to the top of the editing area while scrolling through long posts, instead of scrolling out of view. The toolbar uses `position: sticky` and the editor wrapper switched from `overflow-hidden` to `overflow-clip` so corners stay clipped without creating a nested scroll container that would break sticky positioning. Distraction-free / minimal editors (e.g. Widgets) are unaffected since they don't render the toolbar.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2338,7 +2338,7 @@ export function PortableTextEditor({
 	return (
 		<div
 			className={cn(
-				"border rounded-lg overflow-hidden",
+				"border rounded-lg overflow-clip",
 				minimal && "border-0 rounded-none -mx-4",
 				focusMode === "spotlight" && "spotlight-mode",
 				className,
@@ -2794,7 +2794,7 @@ function EditorToolbar({
 			ref={toolbarRef}
 			role="toolbar"
 			aria-label={t`Text formatting`}
-			className="border-b bg-kumo-tint/50 p-1 flex flex-wrap gap-0.5"
+			className="sticky top-0 z-10 border-b bg-kumo-tint p-1 flex flex-wrap gap-0.5"
 			onKeyDown={handleKeyDown}
 		>
 			{/* Text formatting */}

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -2794,7 +2794,7 @@ function EditorToolbar({
 			ref={toolbarRef}
 			role="toolbar"
 			aria-label={t`Text formatting`}
-			className="sticky top-0 z-10 border-b bg-kumo-tint p-1 flex flex-wrap gap-0.5"
+			className="sticky -top-6 z-10 border-b bg-kumo-tint p-1 flex flex-wrap gap-0.5"
 			onKeyDown={handleKeyDown}
 		>
 			{/* Text formatting */}


### PR DESCRIPTION
## What does this PR do?

Closes #1192.

When editing long posts, the WYSIWYG formatting toolbar scrolled out of the viewport, forcing users to scroll back up to apply formatting.

**Fix:**
- Make the `EditorToolbar` root `sticky` with an opaque `bg-kumo-tint` so content doesn't bleed through.
- Switch the editor wrapper from `overflow-hidden` to `overflow-clip` — `overflow-hidden` established a nested scroll container that broke sticky positioning; `overflow-clip` still clips the rounded corners without doing so.
- The scroll container is the admin shell `<main>`, which carries `p-6` padding; the toolbar uses `-top-6` so it pins flush to the top of the scroll area (cancelling that padding) rather than leaving a gap where scrolled content shows through.
- Minimal/distraction-free editors (e.g. Widgets) don't render the toolbar and are unaffected.

**Testing:** `pnpm lint:quick` clean, `@emdash-cms/admin` typecheck passes. CSS-only change, verified in-browser (LTR, RTL/Arabic, and unscrolled) — toolbar pins flush with no gap, rounded corners intact, bubble/slash menus still layer above it.

**Manual verification:**
1. Edit a post and paste lots of content into the Content field.
2. Scroll down. Expect the formatting toolbar to stay pinned at the top of the editing area, opaque, buttons clickable, with no gap above it.
3. Confirm bubble/slash menus still appear above it; verify in an RTL locale (Arabic).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code, review-fix commits)

## Screenshots / test output

Before (gap above toolbar) → after (flush) verified in-browser; see review thread.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-1192-sticky-editor-toolbar-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/1192-sticky-editor-toolbar`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
