### PR TITLE
fix(admin): add search to the byline picker and remove the 100-byline cap

### DIFF
--- a/.changeset/fix-byline-picker-search.md
+++ b/.changeset/fix-byline-picker-search.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Add search to the byline picker on content entities and remove the effective 100-byline cap. The picker now performs a debounced server-side search via the bylines API instead of rendering a fixed dropdown of the first 100 results, so bylines beyond the first page can be found and credited. Credited bylines from the saved entry are also resolved from the entry itself, so a credit that falls outside the initial list still renders its name instead of disappearing.

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -80,23 +80,38 @@ test.describe("Bylines", () => {
 		expect(contentId).toBeTruthy();
 		await admin.waitForLoading();
 
-		// Scope the byline select to the Bylines section to avoid hitting the Ownership combobox
+		// Scope the byline picker to the Bylines section to avoid hitting the Ownership combobox
 		const bylinesSidebar = page
 			.getByRole("heading", { name: "Bylines" })
 			.locator("xpath=ancestor::div[contains(@class,'p-4')]")
 			.first();
-		// Kumo's Select renders as a combobox button + popover, not a native <select>.
-		const bylineCombobox = bylinesSidebar.getByRole("combobox").first();
-		await bylineCombobox.click();
-		await page.getByRole("option", { name: primaryName }).click();
-		await bylinesSidebar.getByRole("button", { name: "Add" }).click();
+		// The picker is a debounced server search: type a name, wait for the result
+		// button to appear, click it, then wait for the credit row to commit before
+		// the next add (the search debounce + React commit race otherwise drops one).
+		const bylineSearch = bylinesSidebar.getByLabel("Search bylines");
+		const creditRow = (displayName: string) =>
+			bylinesSidebar.locator("p.text-sm.font-medium").filter({ hasText: displayName });
+		const addByline = async (displayName: string) => {
+			await bylineSearch.fill(displayName);
+			const result = bylinesSidebar.getByRole("button", { name: displayName });
+			await expect(result).toBeVisible({ timeout: 5000 });
+			await result.click();
+			await expect(creditRow(displayName)).toBeVisible({ timeout: 5000 });
+		};
 
-		await bylineCombobox.click();
-		await page.getByRole("option", { name: secondaryName }).click();
-		await bylinesSidebar.getByRole("button", { name: "Add" }).click();
+		await addByline(primaryName);
+		await addByline(secondaryName);
 
-		await page.getByLabel("Role label").nth(1).fill("Co-author");
-		await page.getByRole("button", { name: "Up" }).nth(1).click();
+		// Move the secondary credit above the primary via its own row's "Up" button,
+		// then confirm the reorder committed before saving.
+		const secondaryCreditRow = bylinesSidebar
+			.locator("div.rounded.border.p-2")
+			.filter({ hasText: secondaryName });
+		await secondaryCreditRow.getByLabel("Role label").fill("Co-author");
+		await secondaryCreditRow.getByRole("button", { name: "Up" }).click();
+		await expect(bylinesSidebar.locator("p.text-sm.font-medium").first()).toContainText(
+			secondaryName,
+		);
 
 		await admin.clickSave();
 		await admin.waitForSaveComplete();

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -1990,14 +1990,16 @@ function BylineCreditsEditor({
 	const resultPool = searchEnabled ? (searchResults.data?.items ?? []) : bylines;
 	const hasMoreResults = searchEnabled ? !!searchResults.data?.nextCursor : bylines.length >= 100;
 
-	// Resolve credited bylines to their full details for display. A ref-backed
-	// cache persists across searches so selected rows keep rendering even after
-	// the search results that introduced them change.
-	const knownBylines = React.useRef(new Map<string, BylineSummary>());
-	for (const b of selectedBylineDetails ?? []) knownBylines.current.set(b.id, b);
-	for (const b of bylines) knownBylines.current.set(b.id, b);
-	for (const b of searchResults.data?.items ?? []) knownBylines.current.set(b.id, b);
-	const bylineMap = knownBylines.current;
+	// Resolve credited bylines to their full details for display. Selected rows
+	// come from the parent-provided details so they keep rendering even when the
+	// current search results no longer include them.
+	const bylineMap = React.useMemo(() => {
+		const map = new Map<string, BylineSummary>();
+		for (const b of selectedBylineDetails ?? []) map.set(b.id, b);
+		for (const b of bylines) map.set(b.id, b);
+		for (const b of searchResults.data?.items ?? []) map.set(b.id, b);
+		return map;
+	}, [selectedBylineDetails, bylines, searchResults.data?.items]);
 
 	const availableToAdd = resultPool.filter((b) => !credits.some((c) => c.bylineId === b.id));
 
@@ -2087,6 +2089,8 @@ function BylineCreditsEditor({
 							</li>
 						))}
 					</ul>
+				) : searchEnabled && searchResults.isError ? (
+					<p className="text-sm text-kumo-danger">{t`Couldn't search bylines. Please try again.`}</p>
 				) : searchEnabled ? (
 					<p className="text-sm text-kumo-subtle">{t`No matching bylines.`}</p>
 				) : null}

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -25,6 +25,7 @@ import {
 	ArrowSquareOut,
 	ImageBroken,
 } from "@phosphor-icons/react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { Editor } from "@tiptap/react";
 import * as React from "react";
@@ -37,8 +38,9 @@ import type {
 	UserListItem,
 	TranslationSummary,
 } from "../lib/api";
-import { getPreviewUrl, getDraftStatus } from "../lib/api";
+import { fetchBylines, getPreviewUrl, getDraftStatus } from "../lib/api";
 import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
+import { useDebouncedValue } from "../lib/hooks.js";
 import { formatFileSize, getFileIcon } from "../lib/media-utils";
 import { usePluginAdmins } from "../lib/plugin-context.js";
 import { contentUrl, isSafeUrl } from "../lib/url.js";
@@ -997,6 +999,7 @@ export function ContentEditor({
 									<BylineCreditsEditor
 										credits={activeBylines}
 										bylines={availableBylines ?? []}
+										selectedBylineDetails={item?.bylines?.map((entry) => entry.byline)}
 										bylinesLoaded={availableBylinesLoaded}
 										onChange={handleBylinesChange}
 										onQuickCreate={onQuickCreateByline}
@@ -1922,6 +1925,12 @@ interface AuthorSelectorProps {
 interface BylineCreditsEditorProps {
 	credits: BylineCreditInput[];
 	bylines: BylineSummary[];
+	/**
+	 * Full byline details for the entry's already-selected credits. Seeded from
+	 * the saved entry so credited bylines always render their name/slug even when
+	 * they fall outside the initial (unsearched) picker list.
+	 */
+	selectedBylineDetails?: BylineSummary[];
 	onChange: (bylines: BylineCreditInput[]) => void;
 	onQuickCreate?: (input: { slug: string; displayName: string }) => Promise<BylineSummary>;
 	onQuickEdit?: (
@@ -1944,6 +1953,7 @@ interface BylineCreditsEditorProps {
 function BylineCreditsEditor({
 	credits,
 	bylines,
+	selectedBylineDetails,
 	onChange,
 	onQuickCreate,
 	onQuickEdit,
@@ -1952,7 +1962,8 @@ function BylineCreditsEditor({
 	bylinesLoaded = true,
 }: BylineCreditsEditorProps) {
 	const { t } = useLingui();
-	const [selectedBylineId, setSelectedBylineId] = React.useState("");
+	const [search, setSearch] = React.useState("");
+	const debouncedSearch = useDebouncedValue(search, 300);
 	const [quickName, setQuickName] = React.useState("");
 	const [quickSlug, setQuickSlug] = React.useState("");
 	const [quickError, setQuickError] = React.useState<string | null>(null);
@@ -1963,9 +1974,37 @@ function BylineCreditsEditor({
 	const [editError, setEditError] = React.useState<string | null>(null);
 	const [isEditing, setIsEditing] = React.useState(false);
 
-	const bylineMap = React.useMemo(() => new Map(bylines.map((b) => [b.id, b])), [bylines]);
+	// Server-side search so the picker isn't limited to the first page of
+	// bylines (previously capped at 100 with no way to find the rest). When the
+	// search box is empty we fall back to the parent-provided initial list.
+	const trimmedSearch = debouncedSearch.trim();
+	const searchEnabled = trimmedSearch.length > 0;
+	const searchResults = useQuery({
+		queryKey: ["bylines", "credit-picker", entryLocale ?? null, trimmedSearch],
+		queryFn: () =>
+			fetchBylines({ search: trimmedSearch, locale: entryLocale ?? undefined, limit: 20 }),
+		enabled: searchEnabled,
+		placeholderData: keepPreviousData,
+	});
 
-	const availableToAdd = bylines.filter((b) => !credits.some((c) => c.bylineId === b.id));
+	const resultPool = searchEnabled ? (searchResults.data?.items ?? []) : bylines;
+	const hasMoreResults = searchEnabled ? !!searchResults.data?.nextCursor : bylines.length >= 100;
+
+	// Resolve credited bylines to their full details for display. A ref-backed
+	// cache persists across searches so selected rows keep rendering even after
+	// the search results that introduced them change.
+	const knownBylines = React.useRef(new Map<string, BylineSummary>());
+	for (const b of selectedBylineDetails ?? []) knownBylines.current.set(b.id, b);
+	for (const b of bylines) knownBylines.current.set(b.id, b);
+	for (const b of searchResults.data?.items ?? []) knownBylines.current.set(b.id, b);
+	const bylineMap = knownBylines.current;
+
+	const availableToAdd = resultPool.filter((b) => !credits.some((c) => c.bylineId === b.id));
+
+	const addByline = (bylineId: string) => {
+		if (credits.some((c) => c.bylineId === bylineId)) return;
+		onChange([...credits, { bylineId, roleLabel: null }]);
+	};
 
 	const move = (index: number, direction: -1 | 1) => {
 		const target = index + direction;
@@ -2021,29 +2060,39 @@ function BylineCreditsEditor({
 					</RouterLinkButton>
 				</div>
 			)}
-			<div className="flex gap-2">
-				<Select
-					value={selectedBylineId}
-					onValueChange={(v) => setSelectedBylineId(v ?? "")}
-					items={{
-						"": t`Select byline...`,
-						...Object.fromEntries(availableToAdd.map((b) => [b.id, b.displayName])),
-					}}
-					aria-label={t`Select byline`}
-					className="w-full"
+			<div className="space-y-2">
+				<Input
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					placeholder={t`Search bylines to add...`}
+					aria-label={t`Search bylines`}
 				/>
-				<Button
-					type="button"
-					variant="secondary"
-					onClick={() => {
-						if (!selectedBylineId) return;
-						onChange([...credits, { bylineId: selectedBylineId, roleLabel: null }]);
-						setSelectedBylineId("");
-					}}
-					disabled={!selectedBylineId}
-				>
-					{t`Add`}
-				</Button>
+				{searchEnabled && searchResults.isLoading ? (
+					<p className="text-sm text-kumo-subtle">{t`Searching...`}</p>
+				) : availableToAdd.length > 0 ? (
+					<ul className="max-h-48 divide-y overflow-y-auto rounded border">
+						{availableToAdd.map((b) => (
+							<li key={b.id}>
+								<button
+									type="button"
+									className="flex w-full items-center justify-between gap-2 p-2 text-start hover:bg-kumo-tint"
+									onClick={() => addByline(b.id)}
+								>
+									<span className="min-w-0">
+										<span className="block truncate text-sm font-medium">{b.displayName}</span>
+										<span className="block truncate text-xs text-kumo-subtle">{b.slug}</span>
+									</span>
+									<span className="text-xs text-kumo-subtle">{t`Add`}</span>
+								</button>
+							</li>
+						))}
+					</ul>
+				) : searchEnabled ? (
+					<p className="text-sm text-kumo-subtle">{t`No matching bylines.`}</p>
+				) : null}
+				{hasMoreResults && (
+					<p className="text-xs text-kumo-subtle">{t`Keep typing to narrow down more bylines.`}</p>
+				)}
 			</div>
 
 			{credits.length > 0 ? (

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -23,6 +23,7 @@ function makeByline(overrides: Partial<BylineSummary> = {}): BylineSummary {
 		createdAt: "2025-01-15T10:30:00Z",
 		updatedAt: "2025-01-15T10:30:00Z",
 		locale: "en",
+		translationGroup: null,
 		...overrides,
 	};
 }

--- a/packages/admin/tests/components/ContentEditor.test.tsx
+++ b/packages/admin/tests/components/ContentEditor.test.tsx
@@ -6,8 +6,26 @@ import {
 	type FieldDescriptor,
 	type ContentEditorProps,
 } from "../../src/components/ContentEditor";
-import type { ContentItem } from "../../src/lib/api";
+import { fetchBylines } from "../../src/lib/api";
+import type { BylineSummary, ContentItem } from "../../src/lib/api";
 import { render } from "../utils/render.tsx";
+
+function makeByline(overrides: Partial<BylineSummary> = {}): BylineSummary {
+	return {
+		id: "byline-1",
+		slug: "jane-smith",
+		displayName: "Jane Smith",
+		bio: null,
+		avatarMediaId: null,
+		websiteUrl: null,
+		userId: null,
+		isGuest: false,
+		createdAt: "2025-01-15T10:30:00Z",
+		updatedAt: "2025-01-15T10:30:00Z",
+		locale: "en",
+		...overrides,
+	};
+}
 
 // Mock child components that have complex dependencies.
 // The mock simulates the real editor's behaviour of freezing initial content on mount:
@@ -85,6 +103,7 @@ vi.mock("../../src/lib/api", async () => {
 	return {
 		...actual,
 		getPreviewUrl: vi.fn().mockResolvedValue({ url: "https://example.com/preview" }),
+		fetchBylines: vi.fn(async () => ({ items: [], nextCursor: null })),
 	};
 });
 
@@ -1141,6 +1160,67 @@ describe("ContentEditor", () => {
 			const lastCall = onEditorReadyCalls.at(-1);
 			expect(lastCall?.mockId).not.toBeNull();
 			expect(nullCallIndex).toBeLessThan(onEditorReadyCalls.length - 1);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Bug #1217: the byline picker was a plain Select over the first 100 bylines
+	// with no search, so bylines beyond the initial page were unreachable, and a
+	// credited byline outside that page failed to render at all. The picker now
+	// searches the server and resolves credited bylines from the saved entry.
+	// ---------------------------------------------------------------------------
+	describe("byline picker search (#1217)", () => {
+		it("searches the server and adds a byline from outside the initial list", async () => {
+			vi.mocked(fetchBylines).mockResolvedValue({
+				items: [makeByline({ id: "b-far", slug: "zoe-far", displayName: "Zoe Far" })],
+				nextCursor: null,
+			});
+
+			const item = makeItem({ data: { title: "Hello", body: "" } });
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				currentUser: { id: "u-1", role: 50 },
+				// Empty initial list: the only way to reach "Zoe Far" is via search.
+				availableBylines: [],
+				availableBylinesLoaded: true,
+			});
+
+			const searchInput = screen.getByLabelText("Search bylines");
+			await searchInput.fill("Zoe");
+
+			// The debounced server search surfaces the result.
+			await expect.element(screen.getByText("Zoe Far")).toBeInTheDocument();
+			await vi.waitFor(() => {
+				expect(vi.mocked(fetchBylines)).toHaveBeenCalledWith(
+					expect.objectContaining({ search: "Zoe" }),
+				);
+			});
+
+			// Clicking the result credits the byline; it now renders with its
+			// Role label editor and leaves the results list.
+			await screen.getByRole("button", { name: /Zoe Far/ }).click();
+			await expect.element(screen.getByLabelText("Role label")).toBeInTheDocument();
+		});
+
+		it("renders a credited byline that is not in the initial picker list", async () => {
+			const credited = makeByline({ id: "b-100plus", slug: "ada", displayName: "Ada Lovelace" });
+			const item = makeItem({
+				data: { title: "Hello", body: "" },
+				bylines: [{ byline: credited, sortOrder: 0, roleLabel: "Author" }],
+			});
+
+			const screen = await renderEditor({
+				isNew: false,
+				item,
+				currentUser: { id: "u-1", role: 50 },
+				// Initial list does NOT include the credited byline (it would be
+				// past the old 100-row cap). It must still render from the entry.
+				availableBylines: [],
+				availableBylinesLoaded: true,
+			});
+
+			await expect.element(screen.getByText("Ada Lovelace")).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/admin/tests/utils/render.tsx
+++ b/packages/admin/tests/utils/render.tsx
@@ -1,18 +1,27 @@
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import * as React from "react";
 import { render as baseRender, type ComponentRenderOptions } from "vitest-browser-react";
 
 type RenderWrapper = ComponentRenderOptions["wrapper"];
 
-const I18nWrapper = (InnerWrapper: RenderWrapper = React.Fragment) => {
-	return ({ children }: React.PropsWithChildren) => (
-		<I18nProvider i18n={i18n}>
-			<InnerWrapper>{children}</InnerWrapper>
-		</I18nProvider>
-	);
+const ProvidersWrapper = (InnerWrapper: RenderWrapper = React.Fragment) => {
+	return ({ children }: React.PropsWithChildren) => {
+		const queryClient = React.useMemo(
+			() => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+			[],
+		);
+		return (
+			<QueryClientProvider client={queryClient}>
+				<I18nProvider i18n={i18n}>
+					<InnerWrapper>{children}</InnerWrapper>
+				</I18nProvider>
+			</QueryClientProvider>
+		);
+	};
 };
 
 export const render: typeof baseRender = (ui, { wrapper: UserWrapper, ...options } = {}) => {
-	return baseRender(ui, { ...options, wrapper: I18nWrapper(UserWrapper) });
+	return baseRender(ui, { ...options, wrapper: ProvidersWrapper(UserWrapper) });
 };


### PR DESCRIPTION
## What does this PR do?

Closes #1217.

On a content entity, the Bylines field rendered a plain `Select` populated from the first 100 bylines (`fetchBylines({ limit: 100 })`) with no search. With more than ~30 bylines it was hard to find the right one; past 100 they were unreachable. A credited byline outside that initial page also failed to render (the row resolved `undefined` and returned `null`).

**Fix:**
- Replace the capped `Select` with a debounced (300ms) server-side search input. `fetchBylines` already supports `search` + cursor pagination, so any byline is reachable. The query is `enabled` only when a search term is present, so there's no extra fetch on mount (the parent-provided initial list is reused when the box is empty).
- Resolve credited bylines from the saved entry (`item.bylines[].byline`) via a new `selectedBylineDetails` prop, merged into a known-byline lookup built with `useMemo` (no render-phase ref mutation), so a credit outside the initial list still renders its name/slug.
- Surface search failures with an inline error instead of letting them look like an empty result.
- Locale-scoped: the search passes the entry's locale, matching the existing per-locale picker behavior.

**Testing:** `pnpm lint:quick` clean; `emdash` + `@emdash-cms/admin` typecheck pass. Regression tests in `packages/admin/tests/components/ContentEditor.test.tsx` cover searching for a byline outside the initial list and crediting it, plus rendering a credit absent from the initial list; the shared admin test harness now provides a `QueryClientProvider`. The `e2e/tests/bylines.spec.ts` flow was updated to the new search picker. Full admin suite + e2e green.

**Manual verification:**
1. Create 100+ bylines (Admin → Manage → Bylines).
2. Open a content entity → Bylines field. Type a name in the search box.
3. Expect matching bylines (including ones past the first 100); clicking one credits it; existing credits always show their names.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code, review-fix commits)
