### PR TITLE
fix: add filename search and type filtering to the media library

### DIFF
--- a/.changeset/fix-media-search.md
+++ b/.changeset/fix-media-search.md
@@ -1,0 +1,6 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+---
+
+Add search and filtering to the media library (#1221). The media list endpoint now accepts a `q` parameter for a case-insensitive filename substring search (which also matches extensions, with LIKE wildcards escaped), alongside the existing `mimeType` filter. The Media Library page gains a filename search box and a type filter (images / video / audio / documents), and the media picker in the content editor now searches the local library by filename too. Previously neither surface could search or filter local media, which made large libraries hard to navigate.

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Loader } from "@cloudflare/kumo";
+import { Button, Input, Loader, Select } from "@cloudflare/kumo";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Upload, Image, SquaresFour, List, MagnifyingGlass, Check, X } from "@phosphor-icons/react";
@@ -13,9 +13,26 @@ import {
 	fetchProviderMedia,
 	uploadToProvider,
 } from "../lib/api";
+import { useDebouncedValue } from "../lib/hooks.js";
 import { providerItemToMediaItem, getFileIcon, formatFileSize } from "../lib/media-utils";
 import { cn } from "../lib/utils";
 import { MediaDetailPanel } from "./MediaDetailPanel";
+
+/** Maps a coarse type-filter choice to the media list's `mimeType` filter. */
+function mimeForTypeFilter(value: string): string | string[] | undefined {
+	switch (value) {
+		case "image":
+			return "image/";
+		case "video":
+			return "video/";
+		case "audio":
+			return "audio/";
+		case "document":
+			return ["application/", "text/"];
+		default:
+			return undefined;
+	}
+}
 
 export interface MediaLibraryProps {
 	items?: MediaItem[];
@@ -28,6 +45,10 @@ export interface MediaLibraryProps {
 	hasMore?: boolean;
 	/** Triggered to fetch the next page of local-library items */
 	onLoadMore?: () => void;
+	/** Called (debounced) with the filename search term for the local library. */
+	onLocalSearchChange?: (q: string) => void;
+	/** Called with the MIME filter for the local library (undefined = all types). */
+	onLocalMimeFilterChange?: (mimeType: string | string[] | undefined) => void;
 }
 
 /**
@@ -41,12 +62,22 @@ export function MediaLibrary({
 	onItemUpdated,
 	hasMore,
 	onLoadMore,
+	onLocalSearchChange,
+	onLocalMimeFilterChange,
 }: MediaLibraryProps) {
 	const { t } = useLingui();
 	const [viewMode, setViewMode] = React.useState<"grid" | "list">("grid");
 	const [selectedItem, setSelectedItem] = React.useState<MediaItem | null>(null);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");
 	const [searchQuery, setSearchQuery] = React.useState("");
+	const [localTypeFilter, setLocalTypeFilter] = React.useState("all");
+	// Debounced filename search reported up for the local library's server query.
+	const debouncedSearch = useDebouncedValue(searchQuery, 300);
+	React.useEffect(() => {
+		if (activeProvider === "local" && onLocalSearchChange) {
+			onLocalSearchChange(debouncedSearch.trim());
+		}
+	}, [debouncedSearch, activeProvider, onLocalSearchChange]);
 	const [uploadState, setUploadState] = React.useState<{
 		status: "idle" | "uploading" | "success" | "error";
 		message?: string;
@@ -333,17 +364,39 @@ export function MediaLibrary({
 				</div>
 			</div>
 
-			{/* Search (for providers that support it) */}
-			{canSearch && (
-				<div className="relative max-w-sm">
-					<MagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
-					<Input
-						type="search"
-						placeholder={t`Search...`}
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-						className="ps-9"
-					/>
+			{/* Search — providers that support it, plus the local library
+			    (filename/extension search + type filter, handled server-side). */}
+			{(canSearch || activeProvider === "local") && (
+				<div className="flex flex-wrap items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<MagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
+						<Input
+							type="search"
+							placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
+							aria-label={t`Search media`}
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e.target.value)}
+							className="ps-9"
+						/>
+					</div>
+					{activeProvider === "local" && (
+						<Select
+							value={localTypeFilter}
+							onValueChange={(v) => {
+								const next = v ?? "all";
+								setLocalTypeFilter(next);
+								onLocalMimeFilterChange?.(mimeForTypeFilter(next));
+							}}
+							items={{
+								all: t`All types`,
+								image: t`Images`,
+								video: t`Video`,
+								audio: t`Audio`,
+								document: t`Documents`,
+							}}
+							aria-label={t`Filter by type`}
+						/>
+					)}
 				</div>
 			)}
 

--- a/packages/admin/src/components/MediaLibrary.tsx
+++ b/packages/admin/src/components/MediaLibrary.tsx
@@ -9,6 +9,7 @@ import {
 	type MediaItem,
 	type MediaProviderInfo,
 	type MediaProviderItem,
+	MEDIA_SEARCH_MAX_LENGTH,
 	fetchMediaProviders,
 	fetchProviderMedia,
 	uploadToProvider,
@@ -376,6 +377,7 @@ export function MediaLibrary({
 							aria-label={t`Search media`}
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
+							maxLength={MEDIA_SEARCH_MAX_LENGTH}
 							className="ps-9"
 						/>
 					</div>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -204,6 +204,9 @@ export function MediaPickerModal({
 
 	// Fetch local media list (cursor-paginated so libraries beyond the
 	// first page remain selectable from the picker, not just the first 50).
+	// setQueryData is exact-match, so the optimistic dimension update below
+	// must share this exact key with the query that populates it.
+	const mediaQueryKey = ["media", filters?.join(",") ?? "", debouncedSearch.trim()];
 	const {
 		data: localData,
 		isLoading: localLoading,
@@ -211,7 +214,7 @@ export function MediaPickerModal({
 		hasNextPage: hasNextLocalPage,
 		isFetchingNextPage: isFetchingNextLocalPage,
 	} = useInfiniteQuery({
-		queryKey: ["media", filters?.join(",") ?? "", debouncedSearch.trim()],
+		queryKey: mediaQueryKey,
 		queryFn: ({ pageParam }) =>
 			fetchMediaList({
 				mimeType: filters,
@@ -282,7 +285,7 @@ export function MediaPickerModal({
 			updateMedia(id, { width, height }),
 		onSuccess: (_updated, { id, width, height }) => {
 			queryClient.setQueryData(
-				["media", filters?.join(",") ?? ""],
+				mediaQueryKey,
 				(
 					old:
 						| {

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -15,6 +15,7 @@ import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tansta
 import * as React from "react";
 
 import {
+	MEDIA_SEARCH_MAX_LENGTH,
 	fetchMediaList,
 	fetchMediaProviders,
 	fetchProviderMedia,
@@ -573,6 +574,7 @@ export function MediaPickerModal({
 								aria-label={t`Search media`}
 								value={searchQuery}
 								onChange={(e) => setSearchQuery(e.target.value)}
+								maxLength={MEDIA_SEARCH_MAX_LENGTH}
 								className="ps-9"
 							/>
 						</div>

--- a/packages/admin/src/components/MediaPickerModal.tsx
+++ b/packages/admin/src/components/MediaPickerModal.tsx
@@ -25,6 +25,7 @@ import {
 	type MediaProviderInfo,
 	type MediaProviderItem,
 } from "../lib/api";
+import { useDebouncedValue } from "../lib/hooks.js";
 import { providerItemToMediaItem, getFileIcon } from "../lib/media-utils";
 import { matchesMimeAllowlist, mimeFromUrl } from "../lib/mime-utils.js";
 import { cn } from "../lib/utils";
@@ -145,6 +146,8 @@ export function MediaPickerModal({
 	const [selectedItem, setSelectedItem] = React.useState<SelectedMedia | null>(null);
 	const [activeProvider, setActiveProvider] = React.useState<string>("local");
 	const [searchQuery, setSearchQuery] = React.useState("");
+	// Debounced for the local library's server-side filename search.
+	const debouncedSearch = useDebouncedValue(searchQuery, 300);
 	const fileInputRef = React.useRef<HTMLInputElement>(null);
 
 	// URL input state
@@ -208,12 +211,13 @@ export function MediaPickerModal({
 		hasNextPage: hasNextLocalPage,
 		isFetchingNextPage: isFetchingNextLocalPage,
 	} = useInfiniteQuery({
-		queryKey: ["media", filters?.join(",") ?? ""],
+		queryKey: ["media", filters?.join(",") ?? "", debouncedSearch.trim()],
 		queryFn: ({ pageParam }) =>
 			fetchMediaList({
 				mimeType: filters,
 				cursor: pageParam,
 				limit: 100,
+				search: debouncedSearch.trim() || undefined,
 			}),
 		initialPageParam: undefined as string | undefined,
 		getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -555,13 +559,14 @@ export function MediaPickerModal({
 
 				{/* Toolbar */}
 				<div className="flex items-center justify-between pb-3 gap-4">
-					{/* Search (if provider supports it) */}
-					{canSearch ? (
+					{/* Search — providers that support it, plus the local library
+					    (filename/extension search, handled server-side). */}
+					{canSearch || activeProvider === "local" ? (
 						<div className="relative flex-1 max-w-xs">
 							<MagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-kumo-subtle" />
 							<Input
 								type="search"
-								placeholder={t`Search...`}
+								placeholder={activeProvider === "local" ? t`Search by filename...` : t`Search...`}
 								aria-label={t`Search media`}
 								value={searchQuery}
 								onChange={(e) => setSearchQuery(e.target.value)}

--- a/packages/admin/src/lib/api/index.ts
+++ b/packages/admin/src/lib/api/index.ts
@@ -58,6 +58,7 @@ export {
 	type MediaProviderCapabilities,
 	type MediaProviderInfo,
 	type MediaProviderItem,
+	MEDIA_SEARCH_MAX_LENGTH,
 	fetchMediaList,
 	uploadMedia,
 	deleteMedia,

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -13,6 +13,17 @@ import {
 	type FindManyResult,
 } from "./client.js";
 
+/**
+ * Maximum length of the media filename search term. Mirrors the server-side
+ * zod schema (`q: z.string().trim().min(1).max(200)`); keep in sync.
+ */
+export const MEDIA_SEARCH_MAX_LENGTH = 200;
+
+/** Trim and clamp a search term to the server-accepted range. */
+export function normalizeMediaSearch(value: string | undefined | null): string {
+	return (value ?? "").trim().slice(0, MEDIA_SEARCH_MAX_LENGTH);
+}
+
 export interface MediaItem {
 	id: string;
 	filename: string;
@@ -49,7 +60,12 @@ export async function fetchMediaList(options?: {
 		const value = Array.isArray(options.mimeType) ? options.mimeType.join(",") : options.mimeType;
 		if (value) params.set("mimeType", value);
 	}
-	if (options?.search) params.set("q", options.search);
+	if (options?.search) {
+		// Trim and clamp to the server's accepted range so a long or
+		// whitespace-only term can't trigger an avoidable 400.
+		const q = normalizeMediaSearch(options.search);
+		if (q) params.set("q", q);
+	}
 
 	const url = `${API_BASE}/media${params.toString() ? `?${params}` : ""}`;
 	const response = await apiFetch(url);

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -39,6 +39,8 @@ export async function fetchMediaList(options?: {
 	cursor?: string;
 	limit?: number;
 	mimeType?: string | string[];
+	/** Case-insensitive filename substring search (also matches extensions). */
+	search?: string;
 }): Promise<FindManyResult<MediaItem>> {
 	const params = new URLSearchParams();
 	if (options?.cursor) params.set("cursor", options.cursor);
@@ -47,6 +49,7 @@ export async function fetchMediaList(options?: {
 		const value = Array.isArray(options.mimeType) ? options.mimeType.join(",") : options.mimeType;
 		if (value) params.set("mimeType", value);
 	}
+	if (options?.search) params.set("q", options.search);
 
 	const url = `${API_BASE}/media${params.toString() ? `?${params}` : ""}`;
 	const response = await apiFetch(url);

--- a/packages/admin/src/router.tsx
+++ b/packages/admin/src/router.tsx
@@ -1003,13 +1003,20 @@ const mediaRoute = createRoute({
 function MediaPage() {
 	const queryClient = useQueryClient();
 
+	// Filename search + MIME type filter for the local library (server-side).
+	const [search, setSearch] = React.useState("");
+	const [mimeFilter, setMimeFilter] = React.useState<string | string[] | undefined>(undefined);
+	const mimeKey = Array.isArray(mimeFilter) ? mimeFilter.join(",") : (mimeFilter ?? "");
+
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } =
 		useInfiniteQuery({
-			queryKey: ["media"],
+			queryKey: ["media", { search, mime: mimeKey }],
 			queryFn: ({ pageParam }) =>
 				fetchMediaList({
 					cursor: pageParam,
 					limit: 100,
+					search: search || undefined,
+					mimeType: mimeFilter,
 				}),
 			initialPageParam: undefined as string | undefined,
 			getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -1045,6 +1052,8 @@ function MediaPage() {
 			onLoadMore={() => void fetchNextPage()}
 			onUpload={(file) => uploadMutation.mutate(file)}
 			onDelete={(id) => deleteMutation.mutate(id)}
+			onLocalSearchChange={setSearch}
+			onLocalMimeFilterChange={setMimeFilter}
 		/>
 	);
 }

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -218,4 +218,31 @@ describe("MediaLibrary", () => {
 			await expect.element(screen.getByAltText("first-page.jpg")).toBeInTheDocument();
 		});
 	});
+
+	// #1221: the local library gained filename search + a type filter.
+	describe("local search and filter", () => {
+		it("reports the debounced filename query upward", async () => {
+			const onLocalSearchChange = vi.fn();
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({ items, onLocalSearchChange });
+
+			await screen.getByRole("searchbox", { name: "Search media" }).fill("vacation");
+
+			await vi.waitFor(() => {
+				expect(onLocalSearchChange).toHaveBeenCalledWith("vacation");
+			});
+		});
+
+		it("reports a MIME filter when a type is chosen", async () => {
+			const onLocalMimeFilterChange = vi.fn();
+			const items = [makeMediaItem({ id: "1", filename: "a.jpg" })];
+			const screen = await renderLibrary({ items, onLocalMimeFilterChange });
+
+			// Open the type filter and choose Images.
+			await screen.getByRole("combobox", { name: "Filter by type" }).click();
+			await screen.getByRole("option", { name: "Images" }).click();
+
+			expect(onLocalMimeFilterChange).toHaveBeenCalledWith("image/");
+		});
+	});
 });

--- a/packages/admin/tests/components/MediaLibrary.test.tsx
+++ b/packages/admin/tests/components/MediaLibrary.test.tsx
@@ -105,7 +105,7 @@ describe("MediaLibrary", () => {
 			await expect.element(screen.getByText("test.jpg")).toBeInTheDocument();
 			// Table headers should be visible
 			await expect.element(screen.getByText("Filename")).toBeInTheDocument();
-			await expect.element(screen.getByText("Type")).toBeInTheDocument();
+			await expect.element(screen.getByText("Type", { exact: true })).toBeInTheDocument();
 			await expect.element(screen.getByText("Size")).toBeInTheDocument();
 		});
 	});

--- a/packages/admin/tests/lib/media-search.test.ts
+++ b/packages/admin/tests/lib/media-search.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+
+import { MEDIA_SEARCH_MAX_LENGTH, normalizeMediaSearch } from "../../src/lib/api/media";
+
+describe("normalizeMediaSearch", () => {
+	it("trims surrounding whitespace", () => {
+		expect(normalizeMediaSearch("  hero.png  ")).toBe("hero.png");
+	});
+
+	it("returns an empty string for nullish or whitespace-only input", () => {
+		expect(normalizeMediaSearch(undefined)).toBe("");
+		expect(normalizeMediaSearch(null)).toBe("");
+		expect(normalizeMediaSearch("   ")).toBe("");
+	});
+
+	it("clamps to the server-accepted maximum length to avoid 400s", () => {
+		const long = "a".repeat(MEDIA_SEARCH_MAX_LENGTH + 50);
+		const result = normalizeMediaSearch(long);
+		expect(result).toHaveLength(MEDIA_SEARCH_MAX_LENGTH);
+	});
+
+	it("leaves a normal term untouched", () => {
+		expect(normalizeMediaSearch("logo")).toBe("logo");
+	});
+});

--- a/packages/core/src/api/handlers/media.ts
+++ b/packages/core/src/api/handlers/media.ts
@@ -27,6 +27,7 @@ export async function handleMediaList(
 		cursor?: string;
 		limit?: number;
 		mimeType?: string | readonly string[];
+		q?: string;
 	},
 ): Promise<ApiResult<MediaListResponse>> {
 	try {
@@ -35,6 +36,7 @@ export async function handleMediaList(
 			cursor: params.cursor,
 			limit: Math.min(params.limit || 50, 100),
 			mimeType: params.mimeType,
+			q: params.q,
 		});
 
 		return {

--- a/packages/core/src/api/schemas/media.ts
+++ b/packages/core/src/api/schemas/media.ts
@@ -21,6 +21,8 @@ const mimeTypeFilter = z
 export const mediaListQuery = cursorPaginationQuery
 	.extend({
 		mimeType: mimeTypeFilter,
+		/** Case-insensitive filename substring search (also matches extensions). */
+		q: z.string().trim().min(1).max(200).optional(),
 	})
 	.meta({ id: "MediaListQuery" });
 

--- a/packages/core/src/astro/routes/api/media.ts
+++ b/packages/core/src/astro/routes/api/media.ts
@@ -56,6 +56,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
 		cursor: query.cursor,
 		limit: query.limit,
 		mimeType: query.mimeType,
+		q: query.q,
 	});
 
 	if (!result.success) {

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -81,7 +81,12 @@ export interface FindManyMediaOptions {
 	/** Filter by MIME type. Pass a string for a single prefix/exact, or an array to match any. Strings ending with "/" are treated as LIKE prefix matches; others are exact equality. */
 	mimeType?: string | readonly string[];
 	status?: MediaStatus | "all"; // Filter by status, defaults to "ready"
+	/** Case-insensitive substring matched against the filename (covers filename and extension). */
+	q?: string;
 }
+
+// LIKE wildcards that must be escaped so user search input is matched literally.
+const LIKE_WILDCARD_RE = /[\\%_]/g;
 
 /**
  * Media repository for database operations
@@ -248,6 +253,18 @@ export class MediaRepository {
 		const mimeFilters = normalizeMimeFilter(options.mimeType);
 		if (mimeFilters.length > 0) {
 			query = query.where((eb) => mimeMatchExpr(eb, mimeFilters));
+		}
+
+		// Case-insensitive filename substring search (also matches extensions).
+		// LIKE wildcards in the term are escaped so they're treated literally.
+		const term = options.q?.trim();
+		if (term) {
+			const pattern = `%${term.replace(LIKE_WILDCARD_RE, (c) => `\\${c}`)}%`;
+			query = query.where(
+				sql<string>`lower(filename)`,
+				"like",
+				sql<string>`lower(${pattern}) escape '\\'`,
+			);
 		}
 
 		// Default to only showing ready items

--- a/packages/core/src/database/repositories/media.ts
+++ b/packages/core/src/database/repositories/media.ts
@@ -85,9 +85,6 @@ export interface FindManyMediaOptions {
 	q?: string;
 }
 
-// LIKE wildcards that must be escaped so user search input is matched literally.
-const LIKE_WILDCARD_RE = /[\\%_]/g;
-
 /**
  * Media repository for database operations
  */
@@ -259,7 +256,7 @@ export class MediaRepository {
 		// LIKE wildcards in the term are escaped so they're treated literally.
 		const term = options.q?.trim();
 		if (term) {
-			const pattern = `%${term.replace(LIKE_WILDCARD_RE, (c) => `\\${c}`)}%`;
+			const pattern = `%${escapeLike(term)}%`;
 			query = query.where(
 				sql<string>`lower(filename)`,
 				"like",

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2554,6 +2554,7 @@ export class EmDashRuntime {
 		cursor?: string;
 		limit?: number;
 		mimeType?: string | readonly string[];
+		q?: string;
 	}) {
 		return handleMediaList(this.db, params);
 	}

--- a/packages/core/tests/integration/database/media-filename-search.test.ts
+++ b/packages/core/tests/integration/database/media-filename-search.test.ts
@@ -1,0 +1,65 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+
+import { MediaRepository } from "../../../src/database/repositories/media.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+// #1221: the media library lacked filename search. The repository now accepts
+// a case-insensitive `q` substring filter against the filename.
+describeEachDialect("MediaRepository.findMany filename search (#1221)", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+		const repo = new MediaRepository(ctx.db);
+		await repo.create({
+			filename: "Summer-Vacation.png",
+			mimeType: "image/png",
+			storageKey: "1.png",
+		});
+		await repo.create({
+			filename: "invoice-2024.pdf",
+			mimeType: "application/pdf",
+			storageKey: "2.pdf",
+		});
+		await repo.create({ filename: "logo.svg", mimeType: "image/svg+xml", storageKey: "3.svg" });
+		await repo.create({
+			filename: "100%_complete.png",
+			mimeType: "image/png",
+			storageKey: "4.png",
+		});
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("matches a filename substring case-insensitively", async () => {
+		const repo = new MediaRepository(ctx.db);
+		const result = await repo.findMany({ q: "vacation" });
+		expect(result.items.map((i) => i.filename)).toEqual(["Summer-Vacation.png"]);
+	});
+
+	it("matches by extension", async () => {
+		const repo = new MediaRepository(ctx.db);
+		const result = await repo.findMany({ q: ".pdf" });
+		expect(result.items.map((i) => i.filename)).toEqual(["invoice-2024.pdf"]);
+	});
+
+	it("combines with the mimeType filter", async () => {
+		const repo = new MediaRepository(ctx.db);
+		const result = await repo.findMany({ q: "logo", mimeType: "image/" });
+		expect(result.items.map((i) => i.filename)).toEqual(["logo.svg"]);
+	});
+
+	it("treats LIKE wildcards in the query literally", async () => {
+		const repo = new MediaRepository(ctx.db);
+		// "100%" must match only the literal "100%_complete.png", not every row.
+		const result = await repo.findMany({ q: "100%" });
+		expect(result.items.map((i) => i.filename)).toEqual(["100%_complete.png"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Closes #1221.

Media items couldn't be searched or filtered — on the Media Library page (`/_emdash/admin/media`) or in the content-editor media picker. With large libraries this made finding an asset impractical. The issue asked for search by file type, extension, and filename.

**Fix:**

*Backend (`emdash`)*
- `mediaListQuery` gains an optional `q` (trimmed, 1–200 chars).
- `MediaRepository.findMany` applies a case-insensitive `lower(filename) LIKE %q%` filter (SQLite/Postgres parity), with LIKE wildcards (`% _ \`) in the term escaped via `ESCAPE '\'` (reusing the existing `escapeLike` helper). A filename substring covers both **filename** and **extension** (e.g. `.png`); the existing `mimeType` filter covers **file type**.
- Threaded through `handleMediaList`, the runtime, and the `GET /_emdash/api/media` route.

*Admin (`@emdash-cms/admin`)*
- `fetchMediaList` sends `q`.
- Media Library page: a filename search box (debounced 300ms) + a type filter Select (All / Images / Video / Audio / Documents → mapped to `mimeType`).
- Media picker (`MediaPickerModal`): its search box now also shows for the local library and drives a debounced `q`. The optimistic dimensions cache update now shares the exact infinite-query key (search term included) so it lands on the live cache entry instead of silently no-opping.

**Testing:** `packages/core/tests/integration/database/media-filename-search.test.ts` (`describeEachDialect`): substring + case-insensitive, extension match, combined with `mimeType`, wildcard-escape. `MediaLibrary` tests cover query/MIME-filter reporting (the grid/list-toggle assertion was made exact so it no longer collides with the "All types" label). Full core suite green; `pnpm lint:json` clean; `emdash` + `@emdash-cms/admin` typecheck pass.

**Manual verification:**
1. Media page with many assets → type part of a filename (or an extension like `.png`); list filters. Change the type filter; list narrows by kind.
2. In a content entity, open the media picker → search the local library by filename.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code, review-fix commits)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-1221-media-search-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/1221-media-search`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
