### PR TITLE
chore(triage): rename triage state labels to triage/*, add project sync

### DIFF
--- a/.flue/PLAN.md
+++ b/.flue/PLAN.md
@@ -31,9 +31,9 @@ Browser access (`agent-browser` against `pnpm dev`) shifts ~6 admin-UI issues fr
 
 One label triggers the bot. The bot then manages its own label as the investigation progresses. Labels are mutually exclusive on a single issue.
 
-| Label                   | Set by     | Meaning                                              |
-| ----------------------- | ---------- | ---------------------------------------------------- |
-| `bot:repro`             | Maintainer | Investigation requested                              |
+| Label                      | Set by     | Meaning                                              |
+| -------------------------- | ---------- | ---------------------------------------------------- |
+| `bot:repro`                | Maintainer | Investigation requested                              |
 | `triage/reproducing`       | Bot        | Investigation in progress                            |
 | `triage/reproduced`        | Bot        | Reproduced; no fix attempted (low confidence)        |
 | `triage/awaiting-reporter` | Bot        | Reproduced + fix attempted; reporter asked to verify |

--- a/.flue/PLAN.md
+++ b/.flue/PLAN.md
@@ -34,13 +34,13 @@ One label triggers the bot. The bot then manages its own label as the investigat
 | Label                   | Set by     | Meaning                                              |
 | ----------------------- | ---------- | ---------------------------------------------------- |
 | `bot:repro`             | Maintainer | Investigation requested                              |
-| `bot:reproducing`       | Bot        | Investigation in progress                            |
-| `bot:reproduced`        | Bot        | Reproduced; no fix attempted (low confidence)        |
-| `bot:awaiting-reporter` | Bot        | Reproduced + fix attempted; reporter asked to verify |
-| `bot:verified`          | Bot        | Reporter confirmed; PR opened                        |
-| `bot:not-reproduced`    | Bot        | Could not observe the reported behaviour             |
-| `bot:skipped`           | Bot        | Declined (needs user data, host-specific, etc.)      |
-| `bot:failed`            | Bot        | Gave up after retries                                |
+| `triage/reproducing`       | Bot        | Investigation in progress                            |
+| `triage/reproduced`        | Bot        | Reproduced; no fix attempted (low confidence)        |
+| `triage/awaiting-reporter` | Bot        | Reproduced + fix attempted; reporter asked to verify |
+| `triage/verified`          | Bot        | Reporter confirmed; PR opened                        |
+| `triage/not-reproduced`    | Bot        | Could not observe the reported behaviour             |
+| `triage/skipped`           | Bot        | Declined (needs user data, host-specific, etc.)      |
+| `triage/failed`            | Bot        | Gave up after retries                                |
 
 A GitHub Project board mirrors these as columns via saved label queries. One-time UI setup; the bot does not touch the board directly.
 
@@ -55,7 +55,7 @@ Triggered by `issues.labeled` with `bot:repro`. Runs the Flue `investigate` work
 Steps:
 
 1. Mint App installation token (scoped: `issues: write, contents: write, pull-requests: write` on this repo only).
-2. Workflow YAML transitions label: `bot:repro` → `bot:reproducing`.
+2. Workflow YAML transitions label: `bot:repro` → `triage/reproducing`.
 3. Checkout, setup pnpm + node, install, build.
 4. `pnpm exec flue run investigate` with payload `{ issueNumber, issueTitle, issueBody, owner, repo, retryContext? }`.
 5. Workflow YAML reads structured output JSON; pushes branches; posts comment; transitions label to terminal state.
@@ -69,22 +69,22 @@ Bot's stages inside the workflow (each a separate skill, structured output betwe
 
 Terminal label after a run:
 
-- Reproduce skipped → `bot:skipped`
-- Reproduce returned `reproduced: false` → `bot:not-reproduced`
-- Verify returned `intended-behavior` → `bot:reproduced` (with explanation in comment)
-- Fix attempted and `fixed: false` → `bot:reproduced`
-- Fix attempted and `fixed: true` → `bot:awaiting-reporter`
+- Reproduce skipped → `triage/skipped`
+- Reproduce returned `reproduced: false` → `triage/not-reproduced`
+- Verify returned `intended-behavior` → `triage/reproduced` (with explanation in comment)
+- Fix attempted and `fixed: false` → `triage/reproduced`
+- Fix attempted and `fixed: true` → `triage/awaiting-reporter`
 
 ### 2. `reporter-reply.yml`
 
-Triggered by `issue_comment.created`. Filters: issue carries `bot:awaiting-reporter`, comment author is the issue author.
+Triggered by `issue_comment.created`. Filters: issue carries `triage/awaiting-reporter`, comment author is the issue author.
 
 Steps:
 
 1. Mint App token.
 2. Classify the reply with a cheap kimi call: `positive | negative | unclear`.
-3. **positive** — open PR from `bot/fix-<n>`. Apply `bot:verified`. Remove `bot:awaiting-reporter`. Comment on the new PR with the reporter quote.
-4. **negative** — increment retry counter (stored in a hidden HTML comment on the issue, or in a per-issue gist; TBD during build). If < 3 retries, re-invoke `investigate.yml` via `workflow_dispatch` with `retryContext: <reporter comment body>`. If ≥ 3, apply `bot:failed` and ping the maintainer who originally added `bot:repro`.
+3. **positive** — open PR from `bot/fix-<n>`. Apply `triage/verified`. Remove `triage/awaiting-reporter`. Comment on the new PR with the reporter quote.
+4. **negative** — increment retry counter (stored in a hidden HTML comment on the issue, or in a per-issue gist; TBD during build). If < 3 retries, re-invoke `investigate.yml` via `workflow_dispatch` with `retryContext: <reporter comment body>`. If ≥ 3, apply `triage/failed` and ping the maintainer who originally added `bot:repro`.
 5. **unclear** — post a one-sentence clarifying question. No state change.
 
 ### 3. `bot-cleanup.yml`

--- a/.flue/README.md
+++ b/.flue/README.md
@@ -21,9 +21,9 @@ The orchestrator (`.github/workflows/investigate.yml`) reads the structured JSON
 
 ## Trigger and label state
 
-| Label                   | Set by     | Meaning                                          |
-| ----------------------- | ---------- | ------------------------------------------------ |
-| `bot:repro`             | Maintainer | Investigation requested                          |
+| Label                      | Set by     | Meaning                                          |
+| -------------------------- | ---------- | ------------------------------------------------ |
+| `bot:repro`                | Maintainer | Investigation requested                          |
 | `triage/reproducing`       | Bot        | Investigation in progress                        |
 | `triage/reproduced`        | Bot        | Reproduced; no fix attempted (or fix abandoned)  |
 | `triage/awaiting-reporter` | Bot        | Fix pushed; reporter asked to verify             |

--- a/.flue/README.md
+++ b/.flue/README.md
@@ -24,13 +24,13 @@ The orchestrator (`.github/workflows/investigate.yml`) reads the structured JSON
 | Label                   | Set by     | Meaning                                          |
 | ----------------------- | ---------- | ------------------------------------------------ |
 | `bot:repro`             | Maintainer | Investigation requested                          |
-| `bot:reproducing`       | Bot        | Investigation in progress                        |
-| `bot:reproduced`        | Bot        | Reproduced; no fix attempted (or fix abandoned)  |
-| `bot:awaiting-reporter` | Bot        | Fix pushed; reporter asked to verify             |
-| `bot:verified`          | Bot        | Reporter confirmed; PR opened                    |
-| `bot:not-reproduced`    | Bot        | Could not observe the reported behaviour         |
-| `bot:skipped`           | Bot        | Declined (non-bug, requires external data, etc.) |
-| `bot:failed`            | Bot        | Gave up after retries                            |
+| `triage/reproducing`       | Bot        | Investigation in progress                        |
+| `triage/reproduced`        | Bot        | Reproduced; no fix attempted (or fix abandoned)  |
+| `triage/awaiting-reporter` | Bot        | Fix pushed; reporter asked to verify             |
+| `triage/verified`          | Bot        | Reporter confirmed; PR opened                    |
+| `triage/not-reproduced`    | Bot        | Could not observe the reported behaviour         |
+| `triage/skipped`           | Bot        | Declined (non-bug, requires external data, etc.) |
+| `triage/failed`            | Bot        | Gave up after retries                            |
 
 The bot owns every label except `bot:repro`. Maintainers don't manage state directly — they trigger by adding `bot:repro` and re-trigger by removing/re-adding it.
 
@@ -103,7 +103,7 @@ The fixtures directory holds five real issues from the queue (#1021, #1042, #104
 
 1. **GitHub App.** The bot uses an existing App (the same one `bonk.yml`, `review.yml`, `release.yml`, `auto-format.yml` use). The `APP_ID` and `APP_PRIVATE_KEY` repository secrets already exist. The App's installation must include the `issues: write`, `contents: write`, and `pull_requests: write` permissions on `emdash-cms/emdash`.
 2. **Labels.** `investigate.yml`'s first step does `gh label create --force` for each of the eight `bot:*` labels. No manual setup needed; the labels appear after the first run.
-3. **GitHub Project board (optional).** Create a project in the UI with one column per `bot:*` label and a saved query like `repo:emdash-cms/emdash label:bot:reproducing` per column. The bot moves labels; cards follow automatically. Not required for the bot to function.
+3. **GitHub Project board (optional).** Create a project in the UI with one column per `bot:*` label and a saved query like `repo:emdash-cms/emdash label:triage/reproducing` per column. The bot moves labels; cards follow automatically. Not required for the bot to function.
 
 ## What this PR does not do
 

--- a/.flue/workflows/classify-reply.ts
+++ b/.flue/workflows/classify-reply.ts
@@ -1,7 +1,7 @@
 // Classify a reporter's reply to the bot's verification ask.
 //
 // Triggered by .github/workflows/reporter-reply.yml when the issue
-// author comments on an issue that has the `bot:awaiting-reporter`
+// author comments on an issue that has the `triage/awaiting-reporter`
 // label. The workflow YAML reads the classification from this run's
 // output and decides whether to open a PR, retry, or ask for
 // clarification.

--- a/.github/workflows/bot-cleanup.yml
+++ b/.github/workflows/bot-cleanup.yml
@@ -55,7 +55,7 @@ jobs:
           ART_BRANCH="bot/artifacts-${ISSUE_NUMBER}"
 
           # bot/fix-N MAY have an open PR pointing at it (the bot
-          # opens one after `bot:verified`). Deleting the ref would
+          # opens one after `triage/verified`). Deleting the ref would
           # invalidate that PR. Two close paths to worry about:
           #
           #  - PR merged -> issue auto-closes via "Closes #N" -> we

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -125,41 +125,17 @@ jobs:
             echo "reporter=${REPORTER}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Ensure bot labels exist
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -eu
-          # color/description tuples; one bot:* label per row.
-          # repro     = work scheduled, not yet started
-          # reproducing = investigation in progress
-          # reproduced  = bug confirmed, no fix yet
-          # awaiting-reporter = fix pushed, waiting on reporter verification
-          # verified  = reporter confirmed, PR opened
-          # not-reproduced = could not reproduce
-          # skipped   = agent declined (out of scope, missing info)
-          # failed    = bot crashed or hit retry cap
-          gh label create "bot:repro"             --force --color 1d76db --description "Maintainer asked the bot to reproduce this" --repo emdash-cms/emdash
-          gh label create "bot:reproducing"       --force --color fbca04 --description "Bot is currently investigating"              --repo emdash-cms/emdash
-          gh label create "bot:reproduced"        --force --color d93f0b --description "Bot reproduced the bug"                       --repo emdash-cms/emdash
-          gh label create "bot:awaiting-reporter" --force --color c2e0c6 --description "Fix pushed, waiting on reporter to verify"    --repo emdash-cms/emdash
-          gh label create "bot:verified"          --force --color 0e8a16 --description "Reporter verified the fix"                    --repo emdash-cms/emdash
-          gh label create "bot:not-reproduced"    --force --color bfdadc --description "Bot could not reproduce"                      --repo emdash-cms/emdash
-          gh label create "bot:skipped"           --force --color e4e669 --description "Bot declined to investigate"                  --repo emdash-cms/emdash
-          gh label create "bot:failed"            --force --color b60205 --description "Bot crashed or hit the retry cap"             --repo emdash-cms/emdash
-
-      - name: Transition label to bot:reproducing
+      - name: Transition label to triage/reproducing
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ steps.ctx.outputs.number }}
         run: |
           set -euo pipefail
           # Remove any existing bot:* label; swallow 404s (label may not be present).
-          for L in bot:repro bot:reproducing bot:reproduced bot:awaiting-reporter bot:verified bot:not-reproduced bot:skipped bot:failed; do
+          for L in bot:repro triage/reproducing triage/reproduced triage/awaiting-reporter triage/verified triage/not-reproduced triage/skipped triage/failed; do
             gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "$L" >/dev/null 2>&1 || true
           done
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --add-label "bot:reproducing"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --add-label "triage/reproducing"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -334,7 +310,7 @@ jobs:
         run: |
           set -euo pipefail
           REASON="$(jq -r '.reason // .notes // "No reason provided."' /tmp/agent-result.json)"
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:reproducing" --add-label "bot:skipped"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/reproducing" --add-label "triage/skipped"
           {
             echo "The investigation bot declined to reproduce this issue."
             echo
@@ -354,7 +330,7 @@ jobs:
         run: |
           set -euo pipefail
           ATTEMPTS="$(jq -r '.attempts // "The bot tried the steps described in the issue but could not trigger the bug."' /tmp/agent-result.json)"
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:reproducing" --add-label "bot:not-reproduced"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/reproducing" --add-label "triage/not-reproduced"
           {
             echo "The investigation bot could not reproduce this issue."
             echo
@@ -378,7 +354,7 @@ jobs:
         run: |
           set -euo pipefail
           NOTES="$(jq -r '.notes // ""' /tmp/agent-result.json)"
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:reproducing" --add-label "bot:reproduced"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/reproducing" --add-label "triage/reproduced"
           {
             echo "The investigation bot reproduced the described behavior, but it appears to be intended."
             echo
@@ -402,7 +378,7 @@ jobs:
         run: |
           set -euo pipefail
           NOTES="$(jq -r '.notes // ""' /tmp/agent-result.json)"
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:reproducing" --add-label "bot:reproduced"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/reproducing" --add-label "triage/reproduced"
           {
             echo "The investigation bot reproduced this issue."
             echo
@@ -557,19 +533,19 @@ jobs:
 
           # Order matters: post the ask comment FIRST, transition the
           # label only after the comment succeeds. If we flipped to
-          # `bot:awaiting-reporter` before posting and the comment
+          # `triage/awaiting-reporter` before posting and the comment
           # then failed, reporter-reply.yml would see an issue in the
           # awaiting state with no current `bot-ask` marker, treat
           # every future reply as stale, and the issue would be stuck
           # until a maintainer noticed.
           if ! gh issue comment "$ISSUE_NUMBER" --repo emdash-cms/emdash --body-file /tmp/comment.md; then
-            echo "::warning::ask-comment post failed; transitioning to bot:failed instead of bot:awaiting-reporter"
+            echo "::warning::ask-comment post failed; transitioning to triage/failed instead of triage/awaiting-reporter"
             gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash \
-              --remove-label "bot:reproducing" --add-label "bot:failed" || true
+              --remove-label "triage/reproducing" --add-label "triage/failed" || true
             exit 1
           fi
           gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash \
-            --remove-label "bot:reproducing" --add-label "bot:awaiting-reporter"
+            --remove-label "triage/reproducing" --add-label "triage/awaiting-reporter"
 
       # ----- Outcome branches: agent failed / no parseable result -----
 
@@ -584,7 +560,7 @@ jobs:
             echo "No issue number resolved; nothing to comment on."
             exit 0
           fi
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:reproducing" --add-label "bot:failed" || true
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/reproducing" --add-label "triage/failed" || true
           {
             echo "The investigation bot ran into a problem and could not complete."
             echo

--- a/.github/workflows/reporter-reply.yml
+++ b/.github/workflows/reporter-reply.yml
@@ -1,6 +1,6 @@
 name: Reporter Reply
 
-# When an issue is in the `bot:awaiting-reporter` state and the original
+# When an issue is in the `triage/awaiting-reporter` state and the original
 # reporter comments, classify the reply (positive / negative / unclear) via
 # a small Flue classifier workflow and act on the result.
 
@@ -18,13 +18,13 @@ jobs:
     # Only fire if:
     #  - the comment is on an issue (not a PR -- issue_comment fires for both)
     #  - the comment author is the original issue author
-    #  - the issue is currently in the bot:awaiting-reporter state
+    #  - the issue is currently in the triage/awaiting-reporter state
     #
     # The `contains(...)` check is on the event payload's label
     # snapshot. Known small race: in `investigate.yml`'s reproduced+
     # fixed path, the ask comment is posted before the label flip --
     # a reply created in that 1-2 second window has a label snapshot
-    # without `bot:awaiting-reporter` and is dropped here. The live-
+    # without `triage/awaiting-reporter` and is dropped here. The live-
     # check step also gates on labels, so even loosening this `if:`
     # would not catch it. Accepted as known minor; a reporter cannot
     # reply that fast in practice, and the next reply would be picked
@@ -32,7 +32,7 @@ jobs:
     if: >-
       github.event.issue.pull_request == null
       && github.event.comment.user.login == github.event.issue.user.login
-      && contains(github.event.issue.labels.*.name, 'bot:awaiting-reporter')
+      && contains(github.event.issue.labels.*.name, 'triage/awaiting-reporter')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
@@ -58,7 +58,7 @@ jobs:
 
       # Re-verify live state before any expensive work. Three checks:
       #
-      #   1. The issue is currently `bot:awaiting-reporter`. The job's
+      #   1. The issue is currently `triage/awaiting-reporter`. The job's
       #      `if:` gate uses `github.event.issue.labels`, which is the
       #      label snapshot at event dispatch time. Two replies in
       #      quick succession would both pass the gate; concurrency
@@ -83,8 +83,8 @@ jobs:
           set -euo pipefail
 
           LABELS="$(gh api "/repos/emdash-cms/emdash/issues/${ISSUE_NUMBER}" --jq '[.labels[].name] | join(",")')"
-          if ! grep -q 'bot:awaiting-reporter' <<<"$LABELS"; then
-            echo "::notice::issue #${ISSUE_NUMBER} is no longer in bot:awaiting-reporter (live labels: ${LABELS}); skipping stale reply event"
+          if ! grep -q 'triage/awaiting-reporter' <<<"$LABELS"; then
+            echo "::notice::issue #${ISSUE_NUMBER} is no longer in triage/awaiting-reporter (live labels: ${LABELS}); skipping stale reply event"
             echo "stale=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -274,8 +274,8 @@ jobs:
           # `gh pr create` is idempotent-ish: if a PR already exists for
           # this branch, it errors. Detect, fall back to listing the
           # existing PR for the branch. If we can't find ANY PR URL,
-          # do not flip to bot:verified -- that state implies a real
-          # PR exists. Instead leave on bot:awaiting-reporter and ping
+          # do not flip to triage/verified -- that state implies a real
+          # PR exists. Instead leave on triage/awaiting-reporter and ping
           # the maintainer, since the fix branch may have been deleted
           # by bot-cleanup.yml or by a manual purge.
           set +e
@@ -302,7 +302,7 @@ jobs:
             # No PR exists. Do NOT mark verified -- that implies a PR.
             # Surface the failure so a maintainer can recover.
             gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash \
-              --remove-label "bot:awaiting-reporter" --add-label "bot:failed"
+              --remove-label "triage/awaiting-reporter" --add-label "triage/failed"
             {
               echo "The reporter confirmed the fix, but the bot could not open a PR (branch \`${FIX_BRANCH}\` may have been deleted)."
               echo
@@ -312,7 +312,7 @@ jobs:
             exit 0
           fi
 
-          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:awaiting-reporter" --add-label "bot:verified"
+          gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/awaiting-reporter" --add-label "triage/verified"
 
           {
             echo "Thanks for confirming. A PR is open: ${PR_URL}"
@@ -372,7 +372,7 @@ jobs:
             LABELER="$(gh api "/repos/emdash-cms/emdash/issues/${ISSUE_NUMBER}/events" --paginate \
               --jq '[.[] | select(.event == "labeled" and .label.name == "bot:repro") | .actor.login] | last // ""')"
 
-            gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "bot:awaiting-reporter" --add-label "bot:failed"
+            gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash --remove-label "triage/awaiting-reporter" --add-label "triage/failed"
             {
               echo "<!-- bot-retry-count: ${NEXT} -->"
               echo "The bot has tried ${MAX} times and the reporter still indicates the fix does not work. A human maintainer needs to take this from here."
@@ -389,7 +389,7 @@ jobs:
           # for recovery: if dispatch fails, the label stays put
           # (so a maintainer can re-trigger by removing + re-adding
           # `bot:repro` manually) rather than getting stuck in a
-          # `bot:reproducing` state with no investigation running.
+          # `triage/reproducing` state with no investigation running.
           set +e
           gh workflow run investigate.yml \
             --repo "$REPO_FULL" \
@@ -401,13 +401,13 @@ jobs:
 
           if [[ $DISPATCH_EXIT -ne 0 ]]; then
             # Surface the failure on the issue so a maintainer can
-            # decide what to do. Leave the label on bot:awaiting-reporter
+            # decide what to do. Leave the label on triage/awaiting-reporter
             # so the maintainer's manual `bot:repro` re-application
             # works as expected.
-            echo "::warning::workflow_dispatch failed (exit ${DISPATCH_EXIT}); leaving label on bot:awaiting-reporter"
+            echo "::warning::workflow_dispatch failed (exit ${DISPATCH_EXIT}); leaving label on triage/awaiting-reporter"
             {
               echo "<!-- bot-retry-count: ${NEXT} -->"
-              echo "I tried to re-run the investigation but the dispatch failed. A maintainer can re-trigger by removing the \`bot:awaiting-reporter\` label and re-adding \`bot:repro\`."
+              echo "I tried to re-run the investigation but the dispatch failed. A maintainer can re-trigger by removing the \`triage/awaiting-reporter\` label and re-adding \`bot:repro\`."
             } > /tmp/comment.md
             gh issue comment "$ISSUE_NUMBER" --repo emdash-cms/emdash --body-file /tmp/comment.md
             exit 0
@@ -417,19 +417,19 @@ jobs:
           # in-flight investigation can claim the issue state and a
           # second reply during that window passes through the live-
           # label check to a no-op. The dispatched investigate.yml
-          # will see `bot:reproducing` and leave it as-is at its
-          # transition step (which moves bot:repro -> bot:reproducing
+          # will see `triage/reproducing` and leave it as-is at its
+          # transition step (which moves bot:repro -> triage/reproducing
           # idempotently via --remove-label || true).
           #
           # Retry the flip up to 3 times: a transient API hiccup that
-          # leaves bot:awaiting-reporter visible opens a window for a
+          # leaves triage/awaiting-reporter visible opens a window for a
           # duplicate retry. After 3 failures, the dispatched
           # investigation will flip the label itself when it runs,
           # which closes the window at the cost of a small race.
           FLIP_OK=false
           for ATTEMPT in 1 2 3; do
             if gh issue edit "$ISSUE_NUMBER" --repo emdash-cms/emdash \
-              --remove-label "bot:awaiting-reporter" --add-label "bot:reproducing"; then
+              --remove-label "triage/awaiting-reporter" --add-label "triage/reproducing"; then
               FLIP_OK=true
               break
             fi

--- a/.github/workflows/triage-project-sync.yml
+++ b/.github/workflows/triage-project-sync.yml
@@ -1,0 +1,153 @@
+# Mirrors an issue's triage state onto the "Auto-Triage" Projects v2 board.
+#
+# Reactive and decoupled from the triage bot: it watches label changes and,
+# whenever a `bot:repro` (trigger) or `triage/*` (state) label is added or
+# removed, recomputes the issue's canonical triage state from its CURRENT
+# labels and sets the board's "Triage State" single-select field. The triage
+# workflows just move labels as they always have; this never writes back to
+# them.
+#
+# Auth: mints an emdashbot App installation token (same APP_ID / APP_PRIVATE_KEY
+# secrets the other bot workflows use). The App needs organization "Projects:
+# Read and write" for the project mutations.
+
+name: Triage project sync
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  workflow_dispatch: # one-shot backfill of issues already carrying triage labels
+
+concurrency:
+  # Serialize per issue so rapid reproducing -> reproduced transitions don't race.
+  group: triage-project-sync-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # Skip PRs (issues.labeled fires for PRs too); always run the manual backfill.
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.pull_request == null
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Sync triage state to project
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const PROJECT_NUMBER = 3;
+            const FIELD_NAME = "Triage State";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Triage label -> board option name.
+            const STATE_BY_LABEL = {
+              "bot:repro": "Queued",
+              "triage/reproducing": "Reproducing",
+              "triage/reproduced": "Reproduced",
+              "triage/awaiting-reporter": "Awaiting reporter",
+              "triage/verified": "Verified",
+              "triage/not-reproduced": "Not reproduced",
+              "triage/failed": "Failed",
+              "triage/skipped": "Skipped",
+            };
+            // When several are present, the most advanced/terminal one wins.
+            const PRECEDENCE = [
+              "triage/verified",
+              "triage/awaiting-reporter",
+              "triage/reproduced",
+              "triage/not-reproduced",
+              "triage/failed",
+              "triage/skipped",
+              "triage/reproducing",
+              "bot:repro",
+            ];
+            const pickState = (labels) => {
+              for (const l of PRECEDENCE) if (labels.includes(l)) return STATE_BY_LABEL[l];
+              return null;
+            };
+            const labelNames = (iss) =>
+              (iss.labels || []).map((l) => (typeof l === "string" ? l : l.name));
+
+            // Resolve the project, the single-select field, and its options.
+            const projData = await github.graphql(
+              `query($owner:String!, $num:Int!, $field:String!) {
+                organization(login:$owner) {
+                  projectV2(number:$num) {
+                    id
+                    field(name:$field) {
+                      ... on ProjectV2SingleSelectField { id options { id name } }
+                    }
+                  }
+                }
+              }`,
+              { owner, num: PROJECT_NUMBER, field: FIELD_NAME },
+            );
+            const project = projData.organization.projectV2;
+            if (!project || !project.field) {
+              core.setFailed(`Project #${PROJECT_NUMBER} or field "${FIELD_NAME}" not found`);
+              return;
+            }
+            const fieldId = project.field.id;
+            const optionId = (name) => project.field.options.find((o) => o.name === name)?.id;
+
+            // Build the work list.
+            let issues = [];
+            if (context.eventName === "workflow_dispatch") {
+              const all = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: "all",
+                per_page: 100,
+              });
+              issues = all.filter(
+                (iss) =>
+                  !iss.pull_request &&
+                  labelNames(iss).some((l) => l === "bot:repro" || l.startsWith("triage/")),
+              );
+            } else {
+              const iss = context.payload.issue;
+              if (!iss || iss.pull_request) return;
+              issues = [iss];
+            }
+
+            for (const iss of issues) {
+              const stateName = pickState(labelNames(iss));
+              if (!stateName) {
+                core.info(`#${iss.number}: no triage label; skipping`);
+                continue;
+              }
+              const optId = optionId(stateName);
+              if (!optId) {
+                core.warning(`#${iss.number}: no board option named "${stateName}"`);
+                continue;
+              }
+              // Idempotent: returns the existing item if the issue is already added.
+              const added = await github.graphql(
+                `mutation($project:ID!, $content:ID!) {
+                  addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } }
+                }`,
+                { project: project.id, content: iss.node_id },
+              );
+              const itemId = added.addProjectV2ItemById.item.id;
+              await github.graphql(
+                `mutation($project:ID!, $item:ID!, $field:ID!, $opt:String!) {
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId:$project, itemId:$item, fieldId:$field,
+                    value:{ singleSelectOptionId:$opt }
+                  }) { projectV2Item { id } }
+                }`,
+                { project: project.id, item: itemId, field: fieldId, opt: optId },
+              );
+              core.info(`#${iss.number} -> ${stateName}`);
+            }

--- a/.github/workflows/triage-project-sync.yml
+++ b/.github/workflows/triage-project-sync.yml
@@ -38,7 +38,13 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # owner + repositories: org-scoped for Projects, but limited to this
+          # one repo. permission-*: least privilege, just what the sync needs
+          # (org Projects write; issues read for the workflow_dispatch backfill).
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-organization-projects: write
+          permission-issues: read
 
       - name: Sync triage state to project
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## What does this PR do?

Splits the triage bot's labels per the repo convention (`slash` = descriptive state, `colon` = action/trigger), matching the `review/*` + `bot:review` split already used by the PR reviewer.

The `bot:repro` **trigger** stays; the **state** labels become `triage/*`:

| before | after |
|---|---|
| `bot:reproducing` | `triage/reproducing` |
| `bot:reproduced` | `triage/reproduced` |
| `bot:awaiting-reporter` | `triage/awaiting-reporter` |
| `bot:verified` | `triage/verified` |
| `bot:not-reproduced` | `triage/not-reproduced` |
| `bot:failed` | `triage/failed` |
| `bot:skipped` | `triage/skipped` |

Changes:

- Rename across `investigate.yml`, `reporter-reply.yml`, the Flue classifier comment, and the `.flue` docs.
- **Drop the per-run "ensure labels exist" step** in `investigate.yml`. Labels are managed once as repo labels; applying them is enough, and recreating them every run was noise.
- **Add `triage-project-sync.yml`.** On `issues` label add/remove it recomputes the issue's canonical triage state from its *current* labels (by precedence) and sets the **Triage State** single-select field on the new **Auto-Triage** Projects v2 board (project #3). It's decoupled from the triage bot (only reads labels, never writes back) and authed with the same emdashbot app token (`APP_ID`/`APP_PRIVATE_KEY`) the other bot workflows use. Includes a `workflow_dispatch` backfill.

## Required out-of-band steps

1. **Add org "Projects: Read and write" to the emdashbot App** and approve the permission update on the install. The sync workflow's project mutations fail until this is granted (triage itself is unaffected).
2. **Post-merge: rename the live labels** (`gh label edit bot:<state> --name triage/<state>`, which preserves existing issue associations). Must happen after merge since `issues`-triggered workflows run from `main`; I'll do this immediately on merge.

The Auto-Triage project (#3) and its "Triage State" field/options already exist.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Workflow YAML validated (parses cleanly); label rename verified (no `bot:<state>` left, `bot:repro` trigger intact)
- [ ] `pnpm lint` / `pnpm test` -- N/A: CI workflow + label changes only, no package code.
- [ ] Changeset -- N/A: no published package changes.

## AI-generated code disclosure

- [x] This PR includes AI-generated code -- model/tool: Claude Opus 4.8 (opencode)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://chore-triage-state-labels-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `chore/triage-state-labels`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
