### PR TITLE
Fix(admin): make localized action labels word-order safe

### DIFF
--- a/.changeset/fix-i18n-source-strings.md
+++ b/.changeset/fix-i18n-source-strings.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes admin UI translations for permission counts and action labels so languages can use their correct plural forms and word order

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -7,8 +7,8 @@
  */
 
 import { Badge, Button, Checkbox, Switch, Toast } from "@cloudflare/kumo";
-import { useLingui } from "@lingui/react/macro";
 import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import {
 	PuzzlePiece,
 	Gear,

--- a/packages/admin/src/components/PluginManager.tsx
+++ b/packages/admin/src/components/PluginManager.tsx
@@ -8,6 +8,7 @@
 
 import { Badge, Button, Checkbox, Switch, Toast } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
+import { plural } from "@lingui/core/macro";
 import {
 	PuzzlePiece,
 	Gear,
@@ -395,7 +396,10 @@ function PluginCard({
 										.join(", ")}
 								>
 									<ShieldCheck className="h-3 w-3" />
-									{t`${plugin.capabilities.length} permission${plugin.capabilities.length !== 1 ? "s" : ""}`}
+									{plural(plugin.capabilities.length, {
+										one: "# permission",
+										other: "# permissions",
+									})}
 								</span>
 							)}
 						</div>

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -1267,7 +1267,7 @@ function PluginBlockModal({
 			<Dialog className="p-6" size={dialogSize}>
 				<div className="flex items-start justify-between gap-4 mb-4">
 					<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-						{isEditing ? t`Edit` : t`Insert`} {block?.label || ""}
+						{isEditing ? t`Edit ${block?.label || ""}` : t`Insert ${block?.label || ""}`}
 					</Dialog.Title>
 					<Dialog.Close
 						aria-label={t`Close`}

--- a/packages/admin/src/components/TaxonomyManager.tsx
+++ b/packages/admin/src/components/TaxonomyManager.tsx
@@ -357,7 +357,9 @@ function TermFormDialog({
 					<div className="flex items-start justify-between gap-4 mb-4">
 						<div className="flex flex-col space-y-1.5">
 							<Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
-								{term ? t`Edit` : t`Add`} {taxonomyDef.labelSingular || t`Term`}
+								{term
+									? t`Edit ${taxonomyDef.labelSingular || t`Term`}`
+									: t`Add ${taxonomyDef.labelSingular || t`Term`}`}
 							</Dialog.Title>
 							<Dialog.Description className="text-sm text-kumo-subtle">
 								{term
@@ -809,7 +811,7 @@ export function TaxonomyManager({ taxonomyName }: TaxonomyManagerProps) {
 						{t`New Taxonomy`}
 					</Button>
 					<Button icon={<Plus />} onClick={() => setFormOpen(true)}>
-						{t`Add`} {taxonomyDef.labelSingular || t`Term`}
+						{t`Add ${taxonomyDef.labelSingular || t`Term`}`}
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up of the PR: https://github.com/emdash-cms/emdash/pull/1161 (aligned with @ascorbic)
It fixes issues in the components `PluginManager` & `TaxonomyManager`& `PortableTextEditor`.
It will result in the `messages.po` files getting updated with:
1. a new `msgid "Insert {0}"` entry
2. other changes to the comments of `.po` files because already existing `msgid`'s are being reused

### Heads Up for maintainers of other languages
I am "just" a German native speaker. However, it seems like the issues this PR fixes impacted other translations (aside German), too. The English suffix approach for `permission` might interfere with Portuguese, Indonesian, Japanese, Korean and Chinese and it might bypass Polish and Arabic plural rules.
**--> You might want to check your translations.**

### Potential follow-up
While taking care of this fix, I spotted even more hard-coded strings that are missing a translation across the entire admin UI. I propose to create a new PR to cover this if I get a maintainer approval for this plan. Additionally, I'd like to get a pointer for the scope of such a potential PR: should I just attempt to cover all missing strings in one shot (=1 PR, guess this might be a nightmare to review) or shall I do this by component (1 component = 1 PR, might be easier to review)?

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) - opted against it because (1) there are no other comparable test for such language changes and (2) I did not want to introduce a new test for such a small fix
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: used Codex + GPT 5.5 to challenge my approach <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
### Fixed: List of plugins -> correct plural for "permission" (German singular "Berechtigung", plural "Berechtigungen")
<img width="519" height="305" alt="Screenshot 2026-05-31 at 15 48 36" src="https://github.com/user-attachments/assets/98f52013-091c-4377-ad20-1bff8b9695c5" />

### Fixed: Word-order in portable text editor -> add/edit a form -> modal headline (install first party "form" plugin + create a new form + add new form to a post / edit an already added form using the portable text editor)
<img width="519" height="305" alt="Screenshot 2026-05-31 at 15 49 38" src="https://github.com/user-attachments/assets/e14ca961-77f5-4790-9119-be2f2ff78baf" />
<img width="519" height="305" alt="Screenshot 2026-05-31 at 15 49 48" src="https://github.com/user-attachments/assets/4ad62201-54fd-478b-8c22-ab2e3ce9d588" />

### Pictures of passing tests for `PluginManager` & `TaxonomyManager`& `PortableTextEditor`
<img width="654" height="365" alt="Screenshot 2026-05-31 at 16 01 06" src="https://github.com/user-attachments/assets/a2286f5f-0366-414b-8259-7dfa2f6f773d" />
<img width="658" height="267" alt="Screenshot 2026-05-31 at 16 01 20" src="https://github.com/user-attachments/assets/0e7c5025-ada3-4e6a-9f79-2b27c73d6e9a" />
<img width="636" height="279" alt="Screenshot 2026-05-31 at 16 01 43" src="https://github.com/user-attachments/assets/159c852b-f10f-4e5b-b2e9-2f02b696f36f" />
