### PR TITLE
i18n(th): add Thai (ไทย) translation

### DIFF
--- a/.changeset/thai-admin-locale.md
+++ b/.changeset/thai-admin-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds Thai (ไทย) locale to the admin UI.

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -46,6 +46,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)
 	{ code: "es-ES", label: "Español (España)", enabled: true }, // Spanish (Spain) - BCP 47
+	{ code: "th", label: "ไทย", enabled: true }, // Thai
 	// Pseudo-locale for i18n testing - never enabled in the admin UI by default.
 	// Set EMDASH_PSEUDO_LOCALE=1 in .env to expose it in the locale switcher (dev only).
 	{ code: "pseudo", label: "Pseudo", enabled: false },

--- a/packages/admin/src/locales/th/messages.po
+++ b/packages/admin/src/locales/th/messages.po
@@ -1,0 +1,7304 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-05-31 21:09+0700\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: th\n"
+
+#: packages/admin/src/routes/bylines.tsx:359
+msgid " - Guest"
+msgstr " - ผู้เยี่ยมชม"
+
+#: packages/admin/src/routes/bylines.tsx:359
+msgid " - Linked"
+msgstr " - เชื่อมโยงแล้ว"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:76
+msgid " (default)"
+msgstr " (ค่าเริ่มต้น)"
+
+#: packages/admin/src/components/MenuEditor.tsx:427
+msgid " (opens in new window)"
+msgstr " (เปิดในหน้าต่างใหม่)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:782
+#: packages/admin/src/components/MediaPickerModal.tsx:864
+msgid " (selected)"
+msgstr " (เลือกแล้ว)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", หรือเปิดหน้าผู้ดูแลระบบที่"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": ใช้"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:722
+msgid "(from {0})"
+msgstr "(จาก {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:352
+msgid "(pre-release)"
+msgstr "(รุ่นก่อนเผยแพร่)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(ซิงค์แล้ว)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:355
+msgid "(too new)"
+msgstr "(ใหม่เกินไป)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(พร้อมพอร์ต dev ของคุณ)"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:147
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# รายการ)} other {(# รายการ)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# คอลเลกชัน} other {# คอลเลกชัน}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1166
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {อัปเดตความคิดเห็น # รายการ} other {อัปเดตความคิดเห็น # รายการ}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# ความคิดเห็น} other {# ความคิดเห็น}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2080
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {ข้อผิดพลาดเนื้อหา # รายการ} other {ข้อผิดพลาดเนื้อหา # รายการ}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2056
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {นำเข้าเนื้อหา # รายการแล้ว} other {นำเข้าเนื้อหา # รายการแล้ว}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# รายการ} other {# รายการ}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2085
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {ข้อผิดพลาดมีเดีย # รายการ} other {ข้อผิดพลาดมีเดีย # รายการ}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {นำเข้าไฟล์มีเดีย # ไฟล์แล้ว} other {นำเข้าไฟล์มีเดีย # ไฟล์แล้ว}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr "{0, plural, one {ไฟล์มีเดีย # ไฟล์} other {ไฟล์มีเดีย # ไฟล์}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1739
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {จะนำเข้าเมนู # รายการ} other {จะนำเข้าเมนู # รายการ}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# สิทธิ์} other {# สิทธิ์}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2292
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# โพสต์} other {# โพสต์}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {การเปลี่ยนเส้นทาง # รายการเป็นส่วนหนึ่งของลูป} other {การเปลี่ยนเส้นทาง # รายการเป็นส่วนหนึ่งของลูป}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {เลือกแล้ว #} other {เลือกแล้ว #}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2064
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {ข้ามไป # รายการ (มีอยู่แล้ว)} other {ข้ามไป # รายการ (มีอยู่แล้ว)}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {# ผู้ใช้} other {# ผู้ใช้}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:576
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {ฟิลด์} other {ฟิลด์}}"
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1142
+msgid "{0} detected"
+msgstr "ตรวจพบ {0}"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "{0} has been deactivated"
+msgstr "ปิดใช้งาน {0} แล้ว"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "{0} has been removed"
+msgstr "นำ {0} ออกแล้ว"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:203
+msgid "{0} installs"
+msgstr "{0} การติดตั้ง"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "{0} is now active"
+msgstr "ขณะนี้ {0} เปิดใช้งานอยู่"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1809
+msgid "{0} items → {1}"
+msgstr "{0} รายการ → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "{0} items will be imported"
+msgstr "จะนำเข้า {0} รายการ"
+
+#. placeholder {0}: plugin.capabilities.length
+#. placeholder {1}: plugin.capabilities.length !== 1 ? "s" : ""
+#: packages/admin/src/components/PluginManager.tsx:398
+msgid "{0} permission{1}"
+msgstr "{0} สิทธิ์{1}"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:169
+msgid "{0} plugins"
+msgstr "{0} ปลั๊กอิน"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
+msgid "{0} preview"
+msgstr "ดูตัวอย่าง {0}"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:574
+msgid "{0} system + {1} custom {2}"
+msgstr "ระบบ {0} + กำหนดเอง {1} {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:316
+msgid "{0} updated"
+msgstr "อัปเดต {0} แล้ว"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "{0} updated to v{1}"
+msgstr "อัปเดต {0} เป็น v{1} แล้ว"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:782
+#: packages/admin/src/components/MediaPickerModal.tsx:864
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:168
+msgid "{0}/160 characters"
+msgstr "{0}/160 อักขระ"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:255
+msgid "{base} to: {0}"
+msgstr "{base} เป็น: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# การเปลี่ยนแปลงจากรุ่นแก้ไขถัดไป} other {# การเปลี่ยนแปลงจากรุ่นแก้ไขถัดไป}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1908
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# ไฟล์} other {# ไฟล์}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2157
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# รายการ} other {# รายการ}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1979
+msgid "{current} of {total}"
+msgstr "{current} จาก {total}"
+
+#: packages/admin/src/components/ContentList.tsx:506
+msgid "{filteredCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{filteredCount, plural, one {# รายการที่ตรงกับ \"{searchQuery}\"} other {# รายการที่ตรงกับ \"{searchQuery}\"}}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:517
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} รายการ} other {#{1} รายการ}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — ไม่มีคำแปล"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — ดูคำแปล"
+
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "กำหนดแล้ว {matchedCount} จาก {totalCount}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2267
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "จับคู่ผู้เขียนตามอีเมลแล้ว {matchedCount} จาก {totalCount}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1715
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {จะมีการสร้างคอลเลกชันใหม่ # รายการ} other {จะมีการสร้างคอลเลกชันใหม่ # รายการ}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1724
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {จะมีการเพิ่มฟิลด์ไปยังคอลเลกชันที่มีอยู่ # รายการ} other {จะมีการเพิ่มฟิลด์ไปยังคอลเลกชันที่มีอยู่ # รายการ}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} กำลังขอสิทธิ์เพิ่มเติม:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} ต้องการสิทธิ์ต่อไปนี้:"
+
+#: packages/admin/src/components/ContentList.tsx:512
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# รายการ} other {# รายการ}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {รวม #} other {รวม #}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:146
+#: packages/admin/src/components/MediaLibrary.tsx:182
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {อัปโหลดไฟล์แล้ว} other {อัปโหลดไฟล์แล้ว # ไฟล์}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:151
+#: packages/admin/src/components/MediaLibrary.tsx:187
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {การอัปโหลดล้มเหลว} other {การอัปโหลดล้มเหลวทั้งหมด # รายการ}}"
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr "{totalDrafts, plural, one {ฉบับร่าง # รายการ} other {ฉบับร่าง # รายการ}}"
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr "{totalScheduled, plural, one {กำหนดเวลา # รายการ} other {กำหนดเวลา # รายการ}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {ซ่อนรายการที่ไม่เปลี่ยนแปลง # รายการ} other {ซ่อนรายการที่ไม่เปลี่ยนแปลง # รายการ}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {แสดงรายการที่ไม่เปลี่ยนแปลง # รายการ} other {แสดงรายการที่ไม่เปลี่ยนแปลง # รายการ}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:156
+#: packages/admin/src/components/MediaLibrary.tsx:192
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "อัปโหลดแล้ว {uploaded} รายการ, ล้มเหลว {failed} รายการ"
+
+#: packages/admin/src/components/Redirects.tsx:137
+msgid "/new-page or /articles/[slug]"
+msgstr "/new-page หรือ /articles/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:129
+msgid "/old-page or /blog/[slug]"
+msgstr "/old-page หรือ /blog/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:1929
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• ไฟล์จะถูกดาวน์โหลดจากเว็บไซต์ WordPress ของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1930
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• อัปโหลดไปยังที่จัดเก็บมีเดียของ EmDash ของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1931
+msgid "• URLs in your content are updated automatically"
+msgstr "• URL ในเนื้อหาของคุณจะถูกอัปเดตโดยอัตโนมัติ"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1440
+msgid "← Back"
+msgstr "← กลับ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 ปี"
+
+#: packages/admin/src/components/WordPressImport.tsx:1361
+msgid "1. Log into your WordPress admin"
+msgstr "1. เข้าสู่ระบบ WordPress admin ของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. เข้าสู่ระบบแดชบอร์ด WordPress admin ของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "2. Go to"
+msgstr "2. ไปที่"
+
+#: packages/admin/src/components/WordPressImport.tsx:1362
+msgid "2. Go to Users → Profile"
+msgstr "2. ไปที่ Users → Profile"
+
+#: packages/admin/src/components/WordPressImport.tsx:1363
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. เลื่อนไปที่ \"Application Passwords\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "3. Select \"All content\""
+msgstr "3. เลือก \"All content\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 วัน"
+
+#: packages/admin/src/components/Redirects.tsx:150
+msgid "301 Permanent"
+msgstr "301 ถาวร"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "302 Temporary"
+msgstr "302 ชั่วคราว"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "307 Temporary (Strict)"
+msgstr "307 ชั่วคราว (Strict)"
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "308 Permanent (Strict)"
+msgstr "308 ถาวร (Strict)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "4. Click \"Download Export File\""
+msgstr "4. คลิก \"Download Export File\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. ป้อน \"EmDash\" แล้วคลิก \"Add New\""
+
+#: packages/admin/src/components/Redirects.tsx:368
+msgid "404 Errors"
+msgstr "ข้อผิดพลาด 404"
+
+#: packages/admin/src/components/WordPressImport.tsx:1365
+msgid "5. Copy the generated password"
+msgstr "5. คัดลอกรหัสผ่านที่สร้างขึ้น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1120
+msgid "5. Upload the file here"
+msgstr "5. อัปโหลดไฟล์ที่นี่"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 วัน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 วัน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:418
+msgid "A brief description of this content type"
+msgstr "คำอธิบายสั้น ๆ ของประเภทเนื้อหานี้"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "แบนเนอร์ฮีโร่แบบเต็มความกว้างพร้อมหัวเรื่อง ข้อความ และปุ่ม CTA"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr "คำอธิบายสั้น ๆ ของเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:170
+msgid "Accept & Install"
+msgstr "ยอมรับและติดตั้ง"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Accept & Update"
+msgstr "ยอมรับและอัปเดต"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:206
+msgid "Accept Invite"
+msgstr "ยอมรับคำเชิญ"
+
+#: packages/admin/src/router.tsx:1186
+msgid "Access Denied"
+msgstr "การเข้าถึงถูกปฏิเสธ"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Access your media library"
+msgstr "เข้าถึงไลบรารีมีเดียของคุณ"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "บัญชี"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:121
+msgid "Account already exists"
+msgstr "มีบัญชีอยู่แล้ว"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "มีบัญชีอยู่แล้ว"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "ข้อมูลบัญชี"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:262
+#: packages/admin/src/components/ContentList.tsx:373
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/MediaLibrary.tsx:431
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+msgid "Actions"
+msgstr "การดำเนินการ"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "ใช้งานอยู่"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentEditor.tsx:2045
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TaxonomyManager.tsx:812
+#: packages/admin/src/components/TaxonomySidebar.tsx:439
+msgid "Add"
+msgstr "เพิ่ม"
+
+#. placeholder {0}: field.item_label
+#: packages/admin/src/components/PortableTextEditor.tsx:1489
+msgid "Add {0}"
+msgstr "เพิ่ม {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:238
+msgid "Add {label}"
+msgstr "เพิ่ม {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:204
+msgid "Add a new passkey"
+msgstr "เพิ่ม Passkey ใหม่"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
+msgid "Add an allowed domain"
+msgstr "เพิ่มโดเมนที่อนุญาต"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "เพิ่มฟิลด์ย่อยอย่างน้อยหนึ่งฟิลด์เพื่อกำหนดโครงสร้างของตัวทำซ้ำ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2575
+msgid "Add column after"
+msgstr "เพิ่มคอลัมน์ถัดไป"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2568
+msgid "Add column before"
+msgstr "เพิ่มคอลัมน์ก่อนหน้า"
+
+#: packages/admin/src/components/MenuEditor.tsx:291
+#: packages/admin/src/components/MenuEditor.tsx:406
+msgid "Add Content"
+msgstr "เพิ่มเนื้อหา"
+
+#: packages/admin/src/components/MenuEditor.tsx:303
+#: packages/admin/src/components/MenuEditor.tsx:310
+#: packages/admin/src/components/MenuEditor.tsx:409
+msgid "Add Custom Link"
+msgstr "เพิ่มลิงก์ที่กำหนดเอง"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Add Domain"
+msgstr "เพิ่มโดเมน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:582
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Add Field"
+msgstr "เพิ่มฟิลด์"
+
+#: packages/admin/src/components/WordPressImport.tsx:1820
+msgid "Add fields"
+msgstr "เพิ่มฟิลด์"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:604
+msgid "Add fields to define the structure of your content"
+msgstr "เพิ่มฟิลด์เพื่อกำหนดโครงสร้างของเนื้อหาของคุณ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:607
+msgid "Add First Field"
+msgstr "เพิ่มฟิลด์แรก"
+
+#: packages/admin/src/components/RepeaterField.tsx:169
+msgid "Add First Item"
+msgstr "เพิ่มรายการแรก"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1489
+msgid "Add item"
+msgstr "เพิ่มรายการ"
+
+#: packages/admin/src/components/RepeaterField.tsx:153
+msgid "Add Item"
+msgstr "เพิ่มรายการ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2535
+msgid "Add link"
+msgstr "เพิ่มลิงก์"
+
+#: packages/admin/src/components/MenuEditor.tsx:399
+msgid "Add links to build your navigation menu"
+msgstr "เพิ่มลิงก์เพื่อสร้างเมนูนำทางของคุณ"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "เพิ่มประเภท MIME หรือนามสกุลไฟล์"
+
+#: packages/admin/src/components/ContentList.tsx:186
+msgid "Add New"
+msgstr "เพิ่มใหม่"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:449
+msgid "Add new {0}"
+msgstr "เพิ่ม {0} ใหม่"
+
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Add noindex meta tag"
+msgstr "เพิ่มแท็ก meta noindex"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:225
+msgid "Add Passkey"
+msgstr "เพิ่ม Passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:205
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "เพิ่มปลั๊กอินใน astro.config.mjs ของคุณเพื่อขยายความสามารถของ EmDash"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2598
+msgid "Add row after"
+msgstr "เพิ่มแถวถัดไป"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2591
+msgid "Add row before"
+msgstr "เพิ่มแถวก่อนหน้า"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:476
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "เพิ่มฟิลด์ข้อมูลเมตา SEO (ชื่อ คำอธิบาย รูปภาพ) และรวมไว้ใน sitemap"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "เพิ่มฟิลด์ย่อย"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:237
+msgid "Add tags..."
+msgstr "เพิ่มแท็ก..."
+
+#: packages/admin/src/components/Widgets.tsx:338
+msgid "Add Widget Area"
+msgstr "เพิ่มพื้นที่วิดเจ็ต"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "เพิ่มโปรไฟล์โซเชียลมีเดียของคุณ ข้อมูลเหล่านี้ใช้ได้กับธีมของเว็บไซต์ และสามารถแสดงในส่วนหัว ส่วนท้าย หรือประวัติผู้เขียน"
+
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+msgid "Adding..."
+msgstr "กำลังเพิ่ม..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1592
+msgid "Additional data to import."
+msgstr "ข้อมูลเพิ่มเติมที่จะนำเข้า"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:454
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "ผู้ดูแลระบบ"
+
+#: packages/admin/src/components/Sidebar.tsx:394
+msgid "Admin navigation"
+msgstr "การนำทางของผู้ดูแลระบบ"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "ผู้ดูแลระบบ"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "After send:"
+msgstr "หลังส่ง:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2923
+msgid "Align Center"
+msgstr "จัดกึ่งกลาง"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2916
+msgid "Align Left"
+msgstr "จัดชิดซ้าย"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2930
+msgid "Align Right"
+msgstr "จัดชิดขวา"
+
+#: packages/admin/src/components/ContentList.tsx:213
+msgid "All"
+msgstr "ทั้งหมด"
+
+#: packages/admin/src/routes/bylines.tsx:325
+msgid "All bylines"
+msgstr "ชื่อผู้เขียนทั้งหมด"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "ความสามารถทั้งหมด"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "คอลเลกชันทั้งหมด"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "ความคิดเห็นทั้งหมดต้องได้รับการอนุมัติ"
+
+#: packages/admin/src/components/WordPressImport.tsx:2324
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "เนื้อหาที่นำเข้าทั้งหมดจะไม่ถูกกำหนดผู้เขียน คุณสามารถกำหนดผู้เขียนใหม่ได้ภายหลังจากตัวแก้ไขเนื้อหา"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "ทุกภาษา"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "ทุกบทบาท"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "ทุกแหล่งที่มา"
+
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "All statuses"
+msgstr "ทุกสถานะ"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "All types"
+msgstr "ทุกประเภท"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "อนุญาตให้ผู้ใช้จากโดเมนที่ระบุสมัครใช้งาน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:497
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "อนุญาตให้ผู้เข้าชมแสดงความคิดเห็นบนเนื้อหาของคอลเลกชันนี้"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
+msgid "Allowed Domains"
+msgstr "โดเมนที่อนุญาต"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "ประเภทที่อนุญาต"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "มีบัญชีอยู่แล้ว?"
+
+#: packages/admin/src/components/PluginManager.tsx:630
+msgid "Also delete plugin storage data"
+msgstr "ลบข้อมูลที่จัดเก็บของปลั๊กอินด้วย"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:202
+msgid "Alt text"
+msgstr "ข้อความ Alt"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:202
+msgid "Alt Text"
+msgstr "ข้อความ Alt"
+
+#: packages/admin/src/components/MediaLibrary.tsx:633
+#: packages/admin/src/components/MediaLibrary.tsx:690
+msgid "Alt text set"
+msgstr "ตั้งค่าข้อความ Alt แล้ว"
+
+#: packages/admin/src/components/WordPressImport.tsx:1234
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "หรืออีกทางหนึ่ง คุณสามารถส่งออกจาก WordPress (Tools → Export) และอัปโหลดไฟล์ได้"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:97
+#: packages/admin/src/components/PluginManager.tsx:116
+#: packages/admin/src/components/TaxonomySidebar.tsx:321
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:341
+#: packages/admin/src/router.tsx:356
+#: packages/admin/src/router.tsx:370
+#: packages/admin/src/router.tsx:384
+#: packages/admin/src/router.tsx:736
+#: packages/admin/src/router.tsx:767
+#: packages/admin/src/router.tsx:783
+#: packages/admin/src/router.tsx:799
+#: packages/admin/src/router.tsx:818
+#: packages/admin/src/router.tsx:836
+#: packages/admin/src/router.tsx:854
+#: packages/admin/src/router.tsx:884
+#: packages/admin/src/router.tsx:904
+#: packages/admin/src/router.tsx:1131
+#: packages/admin/src/router.tsx:1147
+#: packages/admin/src/router.tsx:1172
+#: packages/admin/src/router.tsx:1645
+msgid "An error occurred"
+msgstr "เกิดข้อผิดพลาด"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:217
+msgid "An unknown error occurred"
+msgstr "เกิดข้อผิดพลาดที่ไม่ทราบสาเหตุ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1414
+msgid "Analyzing export file..."
+msgstr "กำลังวิเคราะห์ไฟล์ส่งออก..."
+
+#: packages/admin/src/components/WordPressImport.tsx:735
+msgid "Analyzing WordPress site..."
+msgstr "กำลังวิเคราะห์เว็บไซต์ WordPress..."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "อนุญาตมีเดียทุกประเภท (ขึ้นอยู่กับขีดจำกัดส่วนกลาง)"
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "API Tokens"
+
+#: packages/admin/src/components/Widgets.tsx:375
+msgid "Appears on posts and pages"
+msgstr "ปรากฏบนโพสต์และหน้า"
+
+#: packages/admin/src/components/WordPressImport.tsx:1329
+msgid "Application Password"
+msgstr "Application Password"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2990
+msgid "Apply"
+msgstr "ใช้"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:144
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:145
+msgid "Apply language"
+msgstr "ใช้ภาษา"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2475
+#: packages/admin/src/components/PortableTextEditor.tsx:2476
+msgid "Apply link"
+msgstr "ใช้ลิงก์"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "อนุมัติ"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "อนุมัติแล้ว"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "อนุมัติแล้ว"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "ข้อมูล JSON ตามต้องการ"
+
+#: packages/admin/src/components/ContentList.tsx:731
+msgid "archived"
+msgstr "เก็บถาวรแล้ว"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+msgid "Archives"
+msgstr "คลังเก็บถาวร"
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบ \"{0}\"? การดำเนินการนี้จะลบเนื้อหาทั้งหมดในคอลเลกชันนี้ด้วย"
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:660
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบฟิลด์ \"{0}\"?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบเมนูนี้? การดำเนินการนี้จะลบรายการเมนูทั้งหมดด้วย และไม่สามารถยกเลิกได้"
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "ในฐานะผู้ดูแลระบบ คุณสามารถเชิญผู้ใช้คนอื่นได้จากส่วนผู้ใช้"
+
+#: packages/admin/src/components/WordPressImport.tsx:2262
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "กำหนดผู้เขียน WordPress ให้กับผู้ใช้ EmDash โพสต์จะถูกระบุว่าเป็นของผู้ใช้ที่เลือก"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+msgid "Audio"
+msgstr "เสียง"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "ข้อผิดพลาดในการยืนยันตัวตน: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "ข้อผิดพลาดในการยืนยันตัวตน: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:256
+msgid "Authentication failed"
+msgstr "การยืนยันตัวตนล้มเหลว"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:129
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "การยืนยันตัวตนถูกจัดการโดยผู้ให้บริการภายนอก ({0}) การตั้งค่า Passkey ไม่พร้อมใช้งานเมื่อใช้การยืนยันตัวตนจากภายนอก"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "การยืนยันตัวตนถูกยกเลิกหรือหมดเวลา โปรดลองอีกครั้ง"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "ผู้เขียน"
+
+#: packages/admin/src/components/WordPressImport.tsx:2277
+msgid "Author Mapping"
+msgstr "การแม็พผู้เขียน"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "ปฏิเสธการอนุญาตสิทธิ์"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "การอนุญาตสิทธิ์ล้มเหลว"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "อนุญาตสิทธิ์"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "อนุญาตสิทธิ์อุปกรณ์"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "กำลังอนุญาตสิทธิ์..."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:458
+msgid "Authors"
+msgstr "ผู้เขียน"
+
+#: packages/admin/src/components/Redirects.tsx:495
+msgid "auto"
+msgstr "อัตโนมัติ"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Auto (slug change)"
+msgstr "อัตโนมัติ (เปลี่ยน slug)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:541
+msgid "Auto-approve authenticated users"
+msgstr "อนุมัติผู้ใช้ที่ยืนยันตัวตนแล้วโดยอัตโนมัติ"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:406
+msgid "Auto-generated from name (you can edit)"
+msgstr "สร้างอัตโนมัติจากชื่อ (คุณสามารถแก้ไขได้)"
+
+#: packages/admin/src/router.tsx:766
+msgid "Autosave failed"
+msgstr "บันทึกอัตโนมัติล้มเหลว"
+
+#: packages/admin/src/components/ContentEditor.tsx:643
+msgid "Autosave status"
+msgstr "สถานะการบันทึกอัตโนมัติ"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:647
+msgid "Available media"
+msgstr "มีเดียที่ใช้ได้"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "Available Providers"
+msgstr "ผู้ให้บริการที่ใช้ได้"
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Available Widgets"
+msgstr "วิดเจ็ตที่ใช้ได้"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:254
+#: packages/admin/src/components/MenuEditor.tsx:275
+#: packages/admin/src/components/WordPressImport.tsx:1349
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Back"
+msgstr "ย้อนกลับ"
+
+#: packages/admin/src/components/ContentEditor.tsx:612
+msgid "Back to {collectionLabel} list"
+msgstr "กลับไปยังรายการ {collectionLabel}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "กลับไปยังประเภทเนื้อหา"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:139
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "กลับไปเข้าสู่ระบบ"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:116
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:392
+msgid "Back to marketplace"
+msgstr "กลับไปยังมาร์เก็ตเพลส"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:559
+msgid "Back to plugins"
+msgstr "กลับไปยังปลั๊กอิน"
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+#: packages/admin/src/components/SectionEditor.tsx:174
+msgid "Back to sections"
+msgstr "กลับไปยังส่วนต่าง ๆ"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "กลับไปยังการตั้งค่า"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "กลับไปยังธีม"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:219
+msgid "Before send:"
+msgstr "ก่อนส่ง:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:233
+msgid "Bing Verification"
+msgstr "การยืนยัน Bing"
+
+#: packages/admin/src/routes/bylines.tsx:409
+msgid "Bio"
+msgstr "ประวัติย่อ"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "การกระทำของบล็อก - ลากเพื่อจัดเรียงใหม่ คลิกเพื่อเปิดเมนู"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2499
+#: packages/admin/src/components/PortableTextEditor.tsx:2805
+msgid "Bold"
+msgstr "ตัวหนา"
+
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "บูลีน"
+
+#: packages/admin/src/components/SeoPanel.tsx:169
+msgid "Brief summary shown below the title in search results"
+msgstr "สรุปสั้น ๆ ที่แสดงใต้ชื่อในผลการค้นหา"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "เรียกดูและติดตั้งปลั๊กอินที่เผยแพร่ในรีจิสตรีแบบกระจายศูนย์"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "เรียกดูและติดตั้งปลั๊กอินเพื่อขยายความสามารถของเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:966
+#: packages/admin/src/components/WordPressImport.tsx:1433
+msgid "Browse Files"
+msgstr "เรียกดูไฟล์"
+
+#: packages/admin/src/components/PluginManager.tsx:198
+msgid "Browse the"
+msgstr "เรียกดู"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "เรียกดูธีมและดูตัวอย่างด้วยเนื้อหาของคุณเอง"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:101
+#: packages/admin/src/components/PortableTextEditor.tsx:887
+#: packages/admin/src/components/PortableTextEditor.tsx:2873
+msgid "Bullet List"
+msgstr "รายการแบบจุด"
+
+#: packages/admin/src/components/ContentEditor.tsx:996
+#: packages/admin/src/components/Sidebar.tsx:209
+#: packages/admin/src/routes/bylines.tsx:299
+msgid "Bylines"
+msgstr "ชื่อผู้เขียน"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "สามารถสร้างเนื้อหาได้"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "สามารถจัดการเนื้อหาทั้งหมดได้"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "สามารถเผยแพร่เนื้อหาของตนเองได้"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "สามารถดูเนื้อหาได้"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:161
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentEditor.tsx:705
+#: packages/admin/src/components/ContentEditor.tsx:910
+#: packages/admin/src/components/ContentEditor.tsx:962
+#: packages/admin/src/components/ContentEditor.tsx:2148
+#: packages/admin/src/components/ContentEditor.tsx:2201
+#: packages/admin/src/components/ContentList.tsx:619
+#: packages/admin/src/components/ContentList.tsx:690
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:156
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:157
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/editor/ImageNode.tsx:223
+#: packages/admin/src/components/editor/ImageNode.tsx:224
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:648
+#: packages/admin/src/components/MediaDetailPanel.tsx:234
+#: packages/admin/src/components/MediaPickerModal.tsx:729
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:636
+#: packages/admin/src/components/PortableTextEditor.tsx:2974
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:313
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:423
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:325
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:453
+#: packages/admin/src/components/settings/SecuritySettings.tsx:206
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:470
+#: packages/admin/src/components/TaxonomyManager.tsx:684
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/Widgets.tsx:386
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "ยกเลิก (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "ยกเลิกการเปลี่ยนชื่อ"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "ไม่สามารถลบส่วนของธีมได้"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:400
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "ไม่สามารถระบุประเภท MIME จาก URL ได้ ใช้ URL ที่ลงท้ายด้วยนามสกุลรูปภาพที่รองรับ (เช่น .jpg, .png, .webp)"
+
+#: packages/admin/src/components/SeoPanel.tsx:181
+msgid "Canonical URL"
+msgstr "Canonical URL"
+
+#: packages/admin/src/components/PluginManager.tsx:469
+msgid "Capabilities"
+msgstr "ความสามารถ"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "การยินยอมให้ใช้ความสามารถ"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:210
+msgid "Caption"
+msgstr "คำบรรยายภาพ"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "คำบรรยายภาพ / คำบรรยายใต้ภาพ"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "หมวดหมู่"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1621
+msgid "Categories ({0})"
+msgstr "หมวดหมู่ ({0})"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1665
+#: packages/admin/src/components/ContentEditor.tsx:1694
+#: packages/admin/src/components/ContentEditor.tsx:1868
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/SeoImageField.tsx:47
+msgid "Change"
+msgstr "เปลี่ยน"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "เปลี่ยน <0>{0}</0> จาก <1>{1}</1> เป็น <2>{2}</2> หรือไม่ พวกเขาจะไม่สามารถเข้าถึงฟีเจอร์ระดับสูงขึ้นได้"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:262
+msgid "Change Favicon"
+msgstr "เปลี่ยน Favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Change Image"
+msgstr "เปลี่ยนรูปภาพ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:208
+msgid "Change Logo"
+msgstr "เปลี่ยนโลโก้"
+
+#: packages/admin/src/router.tsx:811
+msgid "Changes discarded"
+msgstr "ละทิ้งการเปลี่ยนแปลงแล้ว"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:162
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "อักขระระหว่างชื่อหน้าและชื่อเว็บไซต์ (เช่น \"My Post | My Site\")"
+
+#: packages/admin/src/components/PluginManager.tsx:161
+msgid "Check for updates"
+msgstr "ตรวจหาอัปเดต"
+
+#: packages/admin/src/components/WordPressImport.tsx:937
+msgid "Check Site"
+msgstr "ตรวจสอบเว็บไซต์"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "ตรวจสอบอีเมลของคุณ"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+msgid "Checking {urlInput}..."
+msgstr "กำลังตรวจสอบ {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "กำลังตรวจสอบการยืนยันตัวตน..."
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "เลือกวิธีเข้าสู่ระบบ"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "เลือกภาษาผู้ดูแลระบบที่คุณต้องการ"
+
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "ล้างตัวกรอง"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "คลิกลิงก์ในอีเมลเพื่อตั้งค่าบัญชีของคุณต่อ"
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "คลิกลิงก์ในอีเมลเพื่อเข้าสู่ระบบ"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:437
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+#: packages/admin/src/components/MediaDetailPanel.tsx:133
+#: packages/admin/src/components/MediaPickerModal.tsx:469
+#: packages/admin/src/components/MediaPickerModal.tsx:475
+#: packages/admin/src/components/MediaPickerModal.tsx:479
+#: packages/admin/src/components/MenuEditor.tsx:313
+#: packages/admin/src/components/MenuEditor.tsx:319
+#: packages/admin/src/components/MenuEditor.tsx:323
+#: packages/admin/src/components/MenuEditor.tsx:481
+#: packages/admin/src/components/MenuEditor.tsx:487
+#: packages/admin/src/components/MenuEditor.tsx:491
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1273
+#: packages/admin/src/components/PortableTextEditor.tsx:1279
+#: packages/admin/src/components/PortableTextEditor.tsx:1283
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:371
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:377
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:369
+#: packages/admin/src/components/TaxonomyManager.tsx:375
+#: packages/admin/src/components/TaxonomyManager.tsx:379
+#: packages/admin/src/components/TaxonomyManager.tsx:603
+#: packages/admin/src/components/TaxonomyManager.tsx:609
+#: packages/admin/src/components/TaxonomyManager.tsx:613
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:348
+#: packages/admin/src/components/Widgets.tsx:354
+#: packages/admin/src/components/Widgets.tsx:358
+msgid "Close"
+msgstr "ปิด"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:520
+msgid "Close comments after (days)"
+msgstr "ปิดความคิดเห็นหลังจาก (วัน)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "ปิดแผง"
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:2527
+#: packages/admin/src/components/Redirects.tsx:443
+msgid "Code"
+msgstr "โค้ด"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:93
+#: packages/admin/src/components/PortableTextEditor.tsx:917
+#: packages/admin/src/components/PortableTextEditor.tsx:2894
+msgid "Code Block"
+msgstr "บล็อกโค้ด"
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Collapse"
+msgstr "ย่อ"
+
+#: packages/admin/src/components/PluginManager.tsx:450
+msgid "Collapse details"
+msgstr "ย่อรายละเอียด"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr "colleague@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "คอลเลกชัน"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "คอลเลกชัน:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:654
+msgid "Collections"
+msgstr "คอลเลกชัน"
+
+#: packages/admin/src/components/WordPressImport.tsx:2133
+msgid "Collections created:"
+msgstr "คอลเลกชันที่สร้าง:"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "Comma-separated keywords for search."
+msgstr "คำสำคัญสำหรับการค้นหา คั่นด้วยเครื่องหมายจุลภาค"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "ความคิดเห็น"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "รายละเอียดความคิดเห็น"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:487
+#: packages/admin/src/components/Sidebar.tsx:193
+msgid "Comments"
+msgstr "ความคิดเห็น"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:544
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "ความคิดเห็นจากผู้ใช้ CMS ที่เข้าสู่ระบบแล้วจะได้รับการอนุมัติโดยอัตโนมัติ"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "ทำการสมัครให้เสร็จสิ้น"
+
+#: packages/admin/src/components/Widgets.tsx:851
+msgid "Component"
+msgstr "คอมโพเนนต์"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "กำหนดค่าฟิลด์"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Confirm"
+msgstr "ยืนยัน"
+
+#: packages/admin/src/components/WordPressImport.tsx:627
+msgid "Connect"
+msgstr "เชื่อมต่อ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1346
+msgid "Connect & Analyze"
+msgstr "เชื่อมต่อและวิเคราะห์"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1296
+msgid "Connect to {0}"
+msgstr "เชื่อมต่อกับ {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1212
+msgid "Connect with WordPress"
+msgstr "เชื่อมต่อกับ WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "เชื่อมต่อ {0} แล้ว"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:164
+#: packages/admin/src/components/PortableTextEditor.tsx:2006
+#: packages/admin/src/components/SectionEditor.tsx:194
+#: packages/admin/src/components/Sidebar.tsx:428
+#: packages/admin/src/components/Widgets.tsx:819
+msgid "Content"
+msgstr "เนื้อหา"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "บล็อกเนื้อหา"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2188
+msgid "Content Errors ({0})"
+msgstr "ข้อผิดพลาดของเนื้อหา ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1156
+msgid "Content found:"
+msgstr "พบเนื้อหา:"
+
+#: packages/admin/src/router.tsx:830
+msgid "Content has been scheduled for publishing"
+msgstr "กำหนดเวลาเผยแพร่เนื้อหาแล้ว"
+
+#: packages/admin/src/components/RevisionHistory.tsx:131
+msgid "Content has been updated to the selected revision."
+msgstr "อัปเดตเนื้อหาเป็นรุ่นแก้ไขที่เลือกแล้ว"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "ID เนื้อหา:"
+
+#: packages/admin/src/router.tsx:778
+msgid "Content is now live"
+msgstr "เนื้อหาเผยแพร่แล้ว"
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "content items"
+msgstr "รายการเนื้อหา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "อ่านเนื้อหา"
+
+#: packages/admin/src/router.tsx:794
+msgid "Content removed from public view"
+msgstr "นำเนื้อหาออกจากมุมมองสาธารณะแล้ว"
+
+#: packages/admin/src/router.tsx:848
+msgid "Content reverted to draft"
+msgstr "เปลี่ยนเนื้อหากลับเป็นฉบับร่างแล้ว"
+
+#: packages/admin/src/components/RevisionHistory.tsx:296
+msgid "Content snapshot:"
+msgstr "สแนปช็อตเนื้อหา:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1570
+msgid "Content to Import"
+msgstr "เนื้อหาที่จะนำเข้า"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:213
+msgid "Content Types"
+msgstr "ประเภทเนื้อหา"
+
+#: packages/admin/src/components/WordPressImport.tsx:2116
+msgid "Content was skipped because it already exists"
+msgstr "ข้ามเนื้อหาเนื่องจากมีอยู่แล้ว"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "เขียนเนื้อหา"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "ดำเนินการต่อ"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "ดำเนินการต่อ →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2335
+msgid "Continue Import"
+msgstr "ดำเนินการนำเข้าต่อ"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "ผู้ร่วมเขียน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
+msgid "Copied to clipboard"
+msgstr "คัดลอกไปยังคลิปบอร์ดแล้ว"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "คัดลอก {0} ไปยังคลิปบอร์ด"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "คัดลอกลิงก์คำเชิญ"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "คัดลอก Slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "คัดลอกโทเค็นนี้ตอนนี้ — จะไม่แสดงอีก"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "คัดลอกโทเค็น"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+msgid "Copy URL"
+msgstr "คัดลอก URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "ไม่สามารถคัดลอกโดยอัตโนมัติ โปรดเลือก URL ด้านบนแล้วคัดลอกด้วยตนเอง"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:426
+msgid "Could not load image from URL"
+msgstr "ไม่สามารถโหลดรูปภาพจาก URL ได้"
+
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Couldn't detect WordPress"
+msgstr "ตรวจไม่พบ WordPress"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "ไม่สามารถจับคู่ \"{draft}\" กับประเภท MIME ได้ พิมพ์ MIME โดยตรง"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:820
+msgid "Count"
+msgstr "จำนวน"
+
+#: packages/admin/src/components/ContentEditor.tsx:2172
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:184
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:477
+#: packages/admin/src/components/Widgets.tsx:389
+#: packages/admin/src/routes/bylines.tsx:456
+msgid "Create"
+msgstr "สร้าง"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Create \"{trimmedInput}\""
+msgstr "สร้าง \"{trimmedInput}\""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:888
+msgid "Create a bullet list"
+msgstr "สร้างรายการแบบจุด"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:365
+msgid "Create a new {0}"
+msgstr "สร้าง {0} ใหม่"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:898
+msgid "Create a numbered list"
+msgstr "สร้างรายการแบบลำดับเลข"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:81
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "สร้างบัญชี"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "สร้างบัญชี"
+
+#: packages/admin/src/components/ContentEditor.tsx:2120
+#: packages/admin/src/routes/bylines.tsx:389
+msgid "Create byline"
+msgstr "สร้างชื่อผู้เขียน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "สร้างประเภทเนื้อหา"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "สร้างเมนู"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "สร้างเมนูใหม่"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
+msgid "Create New Token"
+msgstr "สร้างโทเค็นใหม่"
+
+#: packages/admin/src/components/WordPressImport.tsx:1340
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "สร้างใน WordPress: Users → Profile → Application Passwords"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "สร้าง Passkey"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "สร้างโทเค็นการเข้าถึงส่วนบุคคลสำหรับการเข้าถึง API แบบเป็นโปรแกรม"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for {0}"
+msgstr "สร้างการเปลี่ยนเส้นทางสำหรับ {0}"
+
+#: packages/admin/src/components/Redirects.tsx:237
+msgid "Create redirect for this path"
+msgstr "สร้างการเปลี่ยนเส้นทางสำหรับเส้นทางนี้"
+
+#: packages/admin/src/components/Redirects.tsx:435
+msgid "Create redirect rules to manage URL changes."
+msgstr "สร้างกฎการเปลี่ยนเส้นทางเพื่อจัดการการเปลี่ยนแปลง URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "Create Schema & Import"
+msgstr "สร้างสคีมาและนำเข้า"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "สร้างส่วน"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "สร้างส่วนในไลบรารีส่วนเพื่อใช้งานที่นี่"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:596
+#: packages/admin/src/components/TaxonomyManager.tsx:687
+msgid "Create Taxonomy"
+msgstr "สร้างอนุกรมวิธาน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+msgid "Create Token"
+msgstr "สร้างโทเค็น"
+
+#: packages/admin/src/components/Widgets.tsx:345
+msgid "Create Widget Area"
+msgstr "สร้างพื้นที่วิดเจ็ต"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "สร้างบัญชีของคุณ"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "สร้างเมนูนำทางแรกของคุณเพื่อเริ่มต้น"
+
+#: packages/admin/src/components/ContentList.tsx:286
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "สร้างรายการแรกของคุณ"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "สร้างส่วนเนื้อหาที่นำกลับมาใช้ใหม่ได้รายการแรกของคุณเพื่อเริ่มต้น"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:72
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "สร้าง Passkey ของคุณ"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Create, update, and delete content"
+msgstr "สร้าง อัปเดต และลบเนื้อหา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "สร้าง อัปเดต และลบเมนูนำทาง"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "สร้าง อัปเดต และลบเทอมอนุกรมวิธาน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "สร้าง อัปเดต ลบเนื้อหา"
+
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "สร้างแล้ว"
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "สร้าง {0} แล้ว"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:878
+msgid "Created {0} translation"
+msgstr "สร้างคำแปล {0} แล้ว"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "สร้างเมื่อ"
+
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:930
+msgid "Created: {0}"
+msgstr "สร้างเมื่อ: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "Creating collections and fields..."
+msgstr "กำลังสร้างคอลเลกชันและฟิลด์..."
+
+#: packages/admin/src/components/ContentEditor.tsx:2172
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:181
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+#: packages/admin/src/components/TaxonomyManager.tsx:687
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Creating..."
+msgstr "กำลังสร้าง..."
+
+#: packages/admin/src/components/TranslationsPanel.tsx:78
+msgid "current"
+msgstr "ปัจจุบัน"
+
+#: packages/admin/src/components/RevisionHistory.tsx:264
+msgid "Current"
+msgstr "ปัจจุบัน"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "กำหนดเอง"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:614
+msgid "Custom Fields"
+msgstr "ฟิลด์กำหนดเอง"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:243
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "เนื้อหา robots.txt แบบกำหนดเอง เว้นว่างไว้เพื่อใช้ค่าเริ่มต้น"
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Custom Section"
+msgstr "ส่วนกำหนดเอง"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "มืด"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "มืด"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:179
+#: packages/admin/src/components/Sidebar.tsx:417
+msgid "Dashboard"
+msgstr "แดชบอร์ด"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:259
+msgid "Date"
+msgstr "วันที่"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "วันที่และเวลา"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "ตัวเลือกวันที่และเวลา"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:304
+msgid "Date Format"
+msgstr "รูปแบบวันที่"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "เลขทศนิยม"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:523
+msgid "Declared permissions"
+msgstr "สิทธิ์ที่ประกาศไว้"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
+msgid "Default Role"
+msgstr "บทบาทเริ่มต้น"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
+msgid "Default role:"
+msgstr "บทบาทเริ่มต้น:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:180
+msgid "Default social image"
+msgstr "รูปภาพโซเชียลเริ่มต้น"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:171
+msgid "Default Social Image"
+msgstr "รูปภาพโซเชียลเริ่มต้น"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:599
+msgid "Define a new taxonomy for classifying content"
+msgstr "กำหนดอนุกรมวิธานใหม่สำหรับการจัดประเภทเนื้อหา"
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "กำหนดโครงสร้างของเนื้อหาของคุณ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:361
+msgid "Defined in code"
+msgstr "กำหนดไว้ในโค้ด"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:663
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:298
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+#: packages/admin/src/components/MenuEditor.tsx:455
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:552
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+#: packages/admin/src/components/Widgets.tsx:636
+#: packages/admin/src/routes/bylines.tsx:465
+#: packages/admin/src/routes/bylines.tsx:501
+msgid "Delete"
+msgstr "ลบ"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "ลบ \"{0}\" หรือไม่ การดำเนินการนี้ไม่สามารถยกเลิกได้"
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: section.title
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "Delete {0}"
+msgstr "ลบ {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:740
+msgid "Delete {0} field"
+msgstr "ลบฟิลด์ {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "ลบเมนู {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:584
+msgid "Delete {0} widget area"
+msgstr "ลบพื้นที่วิดเจ็ต {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:880
+msgid "Delete {0}?"
+msgstr "ลบ {0} หรือไม่?"
+
+#: packages/admin/src/routes/bylines.tsx:499
+msgid "Delete Byline?"
+msgstr "ลบชื่อผู้เขียนหรือไม่?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2582
+msgid "Delete column"
+msgstr "ลบคอลัมน์"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "ลบความคิดเห็นหรือไม่?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "ลบประเภทเนื้อหาหรือไม่?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "ลบสื่อฝัง"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:657
+msgid "Delete Field?"
+msgstr "ลบฟิลด์หรือไม่?"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:191
+#: packages/admin/src/components/editor/ImageNode.tsx:192
+msgid "Delete image"
+msgstr "ลบรูปภาพ"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:253
+msgid "Delete Media?"
+msgstr "ลบมีเดียหรือไม่?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "ลบเมนู"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "ลบถาวร"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:701
+msgid "Delete Permanently"
+msgstr "ลบถาวร"
+
+#: packages/admin/src/components/ContentList.tsx:681
+msgid "Delete Permanently?"
+msgstr "ลบถาวรหรือไม่?"
+
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Delete redirect"
+msgstr "ลบการเปลี่ยนเส้นทาง"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:510
+msgid "Delete redirect {0}"
+msgstr "ลบการเปลี่ยนเส้นทาง {0}"
+
+#: packages/admin/src/components/Redirects.tsx:550
+msgid "Delete Redirect?"
+msgstr "ลบการเปลี่ยนเส้นทางหรือไม่?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2603
+msgid "Delete row"
+msgstr "ลบแถว"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "ลบส่วนหรือไม่?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2618
+msgid "Delete table"
+msgstr "ลบตาราง"
+
+#: packages/admin/src/components/Widgets.tsx:634
+msgid "Delete Widget Area?"
+msgstr "ลบพื้นที่วิดเจ็ตหรือไม่?"
+
+#: packages/admin/src/components/ContentList.tsx:370
+msgid "Deleted"
+msgstr "ลบแล้ว"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:664
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:553
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/TaxonomyManager.tsx:885
+#: packages/admin/src/components/Widgets.tsx:637
+#: packages/admin/src/routes/bylines.tsx:502
+msgid "Deleting..."
+msgstr "กำลังลบ..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "เดโม"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "ลดบทบาทผู้ใช้"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "ลดบทบาทผู้ใช้หรือไม่?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "กำลังลดบทบาท..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "ปฏิเสธ"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Describe the image..."
+msgstr "อธิบายรูปภาพ..."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:205
+msgid "Describe this image for accessibility"
+msgstr "อธิบายรูปภาพนี้เพื่อการเข้าถึง"
+
+#: packages/admin/src/components/SectionEditor.tsx:262
+msgid "Describe what this section is for..."
+msgstr "อธิบายว่าส่วนนี้มีไว้เพื่ออะไร..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:415
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:373
+msgid "Description"
+msgstr "คำอธิบาย"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:432
+msgid "Description (optional)"
+msgstr "คำอธิบาย (ไม่บังคับ)"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Destination"
+msgstr "ปลายทาง"
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr "เส้นทางปลายทาง"
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "details"
+msgstr "รายละเอียด"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "อนุญาตอุปกรณ์แล้ว"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "รหัสอุปกรณ์"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "ผูกกับอุปกรณ์"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Passkey ที่ผูกกับอุปกรณ์"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "ไม่ได้รับอีเมลหรือไม่?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:176
+msgid "Dimensions:"
+msgstr "ขนาด:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "ปิดใช้งาน"
+
+#: packages/admin/src/components/PluginManager.tsx:444
+msgid "Disable plugin"
+msgstr "ปิดใช้งานปลั๊กอิน"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Disable redirect"
+msgstr "ปิดใช้งานการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "ปิดใช้งานผู้ใช้"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "ปิดใช้งานผู้ใช้หรือไม่?"
+
+#: packages/admin/src/components/PluginManager.tsx:353
+#: packages/admin/src/components/Redirects.tsx:392
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "ปิดใช้งานแล้ว"
+
+#: packages/admin/src/components/PluginManager.tsx:527
+msgid "Disabled:"
+msgstr "ปิดใช้งานแล้ว:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "การปิดใช้งาน <0>{0}</0> จะทำให้ผู้ใช้ไม่สามารถเข้าสู่ระบบได้จนกว่าจะเปิดใช้งานอีกครั้ง เนื้อหาของผู้ใช้จะถูกเก็บรักษาไว้"
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "กำลังปิดใช้งาน..."
+
+#: packages/admin/src/components/ContentEditor.tsx:690
+#: packages/admin/src/components/ContentEditor.tsx:712
+msgid "Discard changes"
+msgstr "ละทิ้งการเปลี่ยนแปลง"
+
+#: packages/admin/src/components/ContentEditor.tsx:696
+msgid "Discard draft changes?"
+msgstr "ละทิ้งการเปลี่ยนแปลงในฉบับร่าง?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
+msgid "Dismiss"
+msgstr "ปิด"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "แสดงเมนูนำทาง"
+
+#: packages/admin/src/components/ContentEditor.tsx:2123
+#: packages/admin/src/components/ContentEditor.tsx:2185
+#: packages/admin/src/routes/bylines.tsx:394
+msgid "Display name"
+msgstr "ชื่อที่แสดง"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "ชื่อที่แสดงสำหรับส่วนติดต่อผู้ดูแลระบบ"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr "ขนาดที่แสดง"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr "แสดงด้านล่างของรูปภาพเป็นคำบรรยายที่มองเห็นได้"
+
+#: packages/admin/src/components/ContentEditor.tsx:666
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "โหมดไร้สิ่งรบกวน (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:927
+msgid "Divider"
+msgstr "เส้นแบ่ง"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+msgid "Documents"
+msgstr "เอกสาร"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
+msgid "Domain"
+msgstr "โดเมน"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
+msgid "Domain added successfully"
+msgstr "เพิ่มโดเมนสำเร็จ"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
+msgid "Domain removed"
+msgstr "นำโดเมนออกแล้ว"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
+msgid "Domain updated"
+msgstr "อัปเดตโดเมนแล้ว"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "ยังไม่มีบัญชี? <0>สมัครใช้งาน</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1964
+msgid "Done"
+msgstr "เสร็จสิ้น"
+
+#: packages/admin/src/components/ContentEditor.tsx:2066
+msgid "Down"
+msgstr "ลง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1962
+msgid "Downloading"
+msgstr "กำลังดาวน์โหลด"
+
+#: packages/admin/src/components/ContentList.tsx:727
+msgid "draft"
+msgstr "ฉบับร่าง"
+
+#: packages/admin/src/components/ContentEditor.tsx:861
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+msgid "Draft"
+msgstr "ฉบับร่าง"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "ฉบับร่าง เผยแพร่แล้ว หรือเก็บถาวร"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:188
+msgid "Drafts"
+msgstr "ฉบับร่าง"
+
+#: packages/admin/src/components/WordPressImport.tsx:961
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "ลากแล้ววางหรือคลิกเพื่อเลือกไฟล์ (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drag here to add"
+msgstr "ลากมาที่นี่เพื่อเพิ่ม"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1665
+msgid "Drag to reorder"
+msgstr "ลากเพื่อจัดเรียงใหม่"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:707
+#: packages/admin/src/components/Widgets.tsx:722
+msgid "Drag to reorder {0}"
+msgstr "ลากเพื่อจัดเรียง {0} ใหม่"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:335
+msgid "Drag to reorder block"
+msgstr "ลากเพื่อจัดเรียงบล็อกใหม่"
+
+#: packages/admin/src/components/Widgets.tsx:624
+msgid "Drag widgets here to add them"
+msgstr "ลากวิดเจ็ตมาที่นี่เพื่อเพิ่ม"
+
+#: packages/admin/src/components/Widgets.tsx:402
+msgid "Drag widgets into an area to add them"
+msgstr "ลากวิดเจ็ตไปยังพื้นที่เพื่อเพิ่ม"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drop to add widget"
+msgstr "วางเพื่อเพิ่มวิดเจ็ต"
+
+#: packages/admin/src/components/WordPressImport.tsx:1427
+msgid "Drop your WordPress export file here"
+msgstr "วางไฟล์ส่งออก WordPress ของคุณที่นี่"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:289
+msgid "Duplicate"
+msgstr "ทำสำเนา"
+
+#: packages/admin/src/components/ContentList.tsx:592
+msgid "Duplicate {title}"
+msgstr "ทำสำเนา {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "เช่น application/zip หรือ .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "e.g. import, blog"
+msgstr "เช่น import, blog"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
+msgid "e.g., CI/CD Pipeline"
+msgstr "เช่น CI/CD Pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "เช่น MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentEditor.tsx:2075
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:450
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/PortableTextEditor.tsx:1270
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TranslationsPanel.tsx:88
+msgid "Edit"
+msgstr "แก้ไข"
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: selected.displayName
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:276
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/routes/bylines.tsx:389
+msgid "Edit {0}"
+msgstr "แก้ไข {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+msgid "Edit {0} field"
+msgstr "แก้ไขฟิลด์ {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:629
+msgid "Edit {collectionLabel}"
+msgstr "แก้ไข {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:584
+msgid "Edit {title}"
+msgstr "แก้ไข {title}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2182
+msgid "Edit byline"
+msgstr "แก้ไขชื่อผู้เขียน"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
+msgid "Edit Domain"
+msgstr "แก้ไขโดเมน"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "แก้ไขฟิลด์"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2535
+msgid "Edit link"
+msgstr "แก้ไขลิงก์"
+
+#: packages/admin/src/components/MenuEditor.tsx:478
+msgid "Edit Menu Item"
+msgstr "แก้ไขรายการเมนู"
+
+#: packages/admin/src/components/MenuEditor.tsx:282
+msgid "Edit menu items"
+msgstr "แก้ไขรายการเมนู"
+
+#: packages/admin/src/components/Redirects.tsx:501
+msgid "Edit redirect"
+msgstr "แก้ไขการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr "แก้ไขการเปลี่ยนเส้นทาง"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "Edit redirect {0}"
+msgstr "แก้ไขการเปลี่ยนเส้นทาง {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "แก้ไข URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "ผู้แก้ไข"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:59
+#: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "อีเมล"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr "อีเมล (ไม่บังคับ)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
+msgid "Email address"
+msgstr "ที่อยู่อีเมล"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "ต้องระบุอีเมล"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:215
+msgid "Email Middleware"
+msgstr "Email Middleware"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:125
+msgid "Email Pipeline"
+msgstr "Email Pipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:199
+msgid "Email provider active"
+msgstr "ผู้ให้บริการอีเมลใช้งานอยู่"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:85
+#: packages/admin/src/components/settings/EmailSettings.tsx:100
+msgid "Email Settings"
+msgstr "ตั้งค่าอีเมล"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "ยืนยันอีเมลแล้ว"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "ยืนยันอีเมลแล้ว!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2019
+msgid "Embed a {0}"
+msgstr "ฝัง {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2022
+msgid "Embeds"
+msgstr "การฝัง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1047
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "ตรวจพบปลั๊กอิน EmDash Exporter! คุณสามารถนำเข้าได้โดยตรง"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "เปิดใช้งาน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Enable comments"
+msgstr "เปิดใช้งานความคิดเห็น"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "เปิดใช้งานการค้นหาแบบเต็มข้อความในคอลเลกชันนี้"
+
+#: packages/admin/src/components/PluginManager.tsx:444
+msgid "Enable plugin"
+msgstr "เปิดใช้งานปลั๊กอิน"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Enable redirect"
+msgstr "เปิดใช้งานการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/Redirects.tsx:168
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "Enabled"
+msgstr "เปิดใช้งาน"
+
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1226
+msgid "Enter {0}..."
+msgstr "ป้อน {0}..."
+
+#: packages/admin/src/components/MenuEditor.tsx:336
+#: packages/admin/src/components/MenuEditor.tsx:506
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "ป้อน URL (https://…) หรือพาธสัมพัทธ์ (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1474
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "ป้อน URL ที่ถูกต้อง (เช่น https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1219
+msgid "Enter credentials manually"
+msgstr "ป้อนข้อมูลรับรองด้วยตนเอง"
+
+#: packages/admin/src/components/ContentEditor.tsx:665
+msgid "Enter distraction-free mode"
+msgstr "เข้าสู่โหมดไร้สิ่งรบกวน"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "ป้อนอีเมล"
+
+#: packages/admin/src/components/ContentEditor.tsx:1248
+msgid "Enter markdown content..."
+msgstr "ป้อนเนื้อหา Markdown..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "ป้อนชื่อ"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "ป้อนรหัสจากเทอร์มินัลของคุณ"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "ป้อน URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "ป้อน handle ของคุณเพื่อเข้าสู่ระบบ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1298
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "ป้อนข้อมูลรับรอง WordPress ของคุณเพื่อนำเข้าเนื้อหาโดยตรง"
+
+#: packages/admin/src/components/WordPressImport.tsx:924
+msgid "Enter your WordPress site URL"
+msgstr "ป้อน URL ของเว็บไซต์ WordPress ของคุณ"
+
+#: packages/admin/src/components/MenuEditor.tsx:101
+#: packages/admin/src/components/MenuEditor.tsx:139
+#: packages/admin/src/components/MenuEditor.tsx:179
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:689
+#: packages/admin/src/router.tsx:1826
+msgid "Error"
+msgstr "ข้อผิดพลาด"
+
+#: packages/admin/src/components/Widgets.tsx:174
+msgid "Error adding widget"
+msgstr "เกิดข้อผิดพลาดในการเพิ่มวิดเจ็ต"
+
+#: packages/admin/src/components/Widgets.tsx:235
+msgid "Error reordering widgets"
+msgstr "เกิดข้อผิดพลาดในการจัดเรียงวิดเจ็ตใหม่"
+
+#: packages/admin/src/components/SectionEditor.tsx:52
+msgid "Error saving section"
+msgstr "เกิดข้อผิดพลาดในการบันทึกส่วน"
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Error updating widget"
+msgstr "เกิดข้อผิดพลาดในการอัปเดตวิดเจ็ต"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:415
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "ทุกรุ่นที่เผยแพร่ของปลั๊กอินนี้ถูกถอนออกหรือไม่สามารถยืนยันได้ โปรดกลับมาตรวจสอบใหม่ภายหลัง หรือติดต่อผู้เผยแพร่"
+
+#: packages/admin/src/components/WordPressImport.tsx:1846
+msgid "Exists"
+msgstr "มีอยู่"
+
+#: packages/admin/src/components/ContentEditor.tsx:623
+msgid "Exit distraction-free mode"
+msgstr "ออกจากโหมดไร้สิ่งรบกวน"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3036
+msgid "Exit Spotlight Mode"
+msgstr "ออกจากโหมด Spotlight"
+
+#: packages/admin/src/components/PluginManager.tsx:456
+msgid "Expand"
+msgstr "ขยาย"
+
+#: packages/admin/src/components/PluginManager.tsx:450
+msgid "Expand details"
+msgstr "ขยายรายละเอียด"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
+msgid "Expires {0}"
+msgstr "หมดอายุ {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
+msgid "Expiry"
+msgstr "วันหมดอายุ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1112
+msgid "Export from WordPress manually"
+msgstr "ส่งออกจาก WordPress ด้วยตนเอง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1236
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "ส่งออกเนื้อหาของคุณจาก WordPress เพื่อนำเข้าทุกอย่างรวมถึงฉบับร่าง"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:144
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "ล้มเหลว"
+
+#: packages/admin/src/components/WordPressImport.tsx:1966
+msgid "Failed"
+msgstr "ล้มเหลว"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:189
+msgid "Failed security audit"
+msgstr "การตรวจสอบความปลอดภัยล้มเหลว"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Failed to add domain"
+msgstr "เพิ่มโดเมนไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:367
+msgid "Failed to analyze WordPress site"
+msgstr "วิเคราะห์เว็บไซต์ WordPress ไม่สำเร็จ"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "สื่อสารกับปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "สร้างผู้ดูแลระบบไม่สำเร็จ"
+
+#: packages/admin/src/components/ContentEditor.tsx:2166
+msgid "Failed to create byline"
+msgstr "สร้างชื่อผู้เขียนไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1553
+msgid "Failed to create some collections"
+msgstr "สร้างบางคอลเลกชันไม่สำเร็จ"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:456
+msgid "Failed to create term"
+msgstr "สร้างเทอมไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:883
+msgid "Failed to create translation"
+msgstr "สร้างคำแปลไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:340
+#: packages/admin/src/router.tsx:369
+#: packages/admin/src/router.tsx:903
+msgid "Failed to delete"
+msgstr "ลบไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "ลบโดเมนที่อนุญาตไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/bylines.ts:117
+msgid "Failed to delete byline"
+msgstr "ลบชื่อผู้เขียนไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "ลบคอลเลกชันไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1146
+msgid "Failed to delete comment"
+msgstr "ลบความคิดเห็นไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/content.ts:217
+msgid "Failed to delete content"
+msgstr "ลบเนื้อหาไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/schema.ts:278
+msgid "Failed to delete field"
+msgstr "ลบฟิลด์ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/media.ts:338
+msgid "Failed to delete from provider"
+msgstr "ลบจากผู้ให้บริการไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/media.ts:215
+msgid "Failed to delete media"
+msgstr "ลบมีเดียไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "ลบเมนูไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "ลบรายการเมนูไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "ลบ Passkey ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "ลบการเปลี่ยนเส้นทางไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "ลบส่วนไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "ลบเทอมไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "ลบวิดเจ็ตไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "ลบพื้นที่วิดเจ็ตไม่สำเร็จ"
+
+#: packages/admin/src/components/PluginManager.tsx:115
+msgid "Failed to disable plugin"
+msgstr "ปิดใช้งานปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "ปิดใช้งานผู้ใช้ไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:817
+msgid "Failed to discard changes"
+msgstr "ละทิ้งการเปลี่ยนแปลงไม่สำเร็จ"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "ปิดข้อความต้อนรับไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:383
+msgid "Failed to duplicate"
+msgstr "ทำสำเนาไม่สำเร็จ"
+
+#: packages/admin/src/components/PluginManager.tsx:96
+msgid "Failed to enable plugin"
+msgstr "เปิดใช้งานปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "เปิดใช้งานผู้ใช้ไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:295
+msgid "Failed to execute import"
+msgstr "ดำเนินการนำเข้าไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "ดึงข้อมูลคอลเลกชันไม่สำเร็จ"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:81
+msgid "Failed to fetch entry terms"
+msgstr "ดึงข้อมูลเทอมของรายการไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/client.ts:208
+msgid "Failed to fetch manifest"
+msgstr "ดึงข้อมูล manifest ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "ดึงข้อมูลปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/content.ts:462
+#: packages/admin/src/lib/api/content.ts:467
+msgid "Failed to fetch revision"
+msgstr "ดึงข้อมูลรุ่นแก้ไขไม่สำเร็จ"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "ดึงข้อมูลสถานะการตั้งค่าไม่สำเร็จ"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:65
+msgid "Failed to fetch terms"
+msgstr "ดึงข้อมูลเทอมไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:667
+#: packages/admin/src/router.tsx:1077
+msgid "Failed to fetch user"
+msgstr "ดึงข้อมูลผู้ใช้ไม่สำเร็จ"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
+msgid "Failed to generate preview"
+msgstr "สร้างตัวอย่างไม่สำเร็จ"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "สร้าง URL ดูตัวอย่างไม่สำเร็จ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "รับตัวเลือกการตรวจสอบสิทธิ์ไม่สำเร็จ"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "รับตัวเลือกการลงทะเบียนไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:386
+msgid "Failed to import from WordPress"
+msgstr "นำเข้าจาก WordPress ไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:319
+#: packages/admin/src/lib/api/import.ts:256
+msgid "Failed to import media"
+msgstr "นำเข้ามีเดียไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:455
+msgid "Failed to install plugin"
+msgstr "ติดตั้งปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:246
+msgid "Failed to load admin"
+msgstr "โหลดหน้าผู้ดูแลระบบไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Failed to load allowed domains"
+msgstr "โหลดโดเมนที่อนุญาตไม่สำเร็จ"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:287
+msgid "Failed to load bylines: {0}"
+msgstr "โหลดชื่อผู้เขียนไม่สำเร็จ: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:89
+msgid "Failed to load email settings"
+msgstr "โหลดการตั้งค่าอีเมลไม่สำเร็จ"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:409
+msgid "Failed to load image"
+msgstr "โหลดรูปภาพไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:144
+msgid "Failed to load passkeys"
+msgstr "โหลด Passkey ไม่สำเร็จ"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:111
+msgid "Failed to load plugin"
+msgstr "โหลดปลั๊กอินไม่สำเร็จ"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:144
+msgid "Failed to load plugins: {0}"
+msgstr "โหลดปลั๊กอินไม่สำเร็จ: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "โหลดปลั๊กอินไม่สำเร็จ อาจไม่สามารถเข้าถึงตัวรวบรวมรีจิสตรีได้"
+
+#: packages/admin/src/components/RevisionHistory.tsx:180
+msgid "Failed to load revisions"
+msgstr "โหลดรุ่นแก้ไขไม่สำเร็จ"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "โหลดการตั้งค่าไม่สำเร็จ"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "โหลดธีมไม่สำเร็จ"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "โหลดผู้ใช้ไม่สำเร็จ: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "โหลดวิดเจ็ตไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:1171
+msgid "Failed to perform bulk action"
+msgstr "ดำเนินการแบบกลุ่มไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/content.ts:260
+msgid "Failed to permanently delete content"
+msgstr "ลบเนื้อหาอย่างถาวรไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:276
+msgid "Failed to prepare import"
+msgstr "เตรียมการนำเข้าไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:782
+msgid "Failed to publish"
+msgstr "เผยแพร่ไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
+msgid "Failed to remove domain"
+msgstr "นำโดเมนออกไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr "นำ Passkey ออกไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr "เปลี่ยนชื่อ Passkey ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/schema.ts:293
+msgid "Failed to reorder fields"
+msgstr "จัดเรียงฟิลด์ใหม่ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "จัดเรียงวิดเจ็ตใหม่ไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:355
+msgid "Failed to restore"
+msgstr "กู้คืนไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/content.ts:249
+msgid "Failed to restore content"
+msgstr "กู้คืนเนื้อหาไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/content.ts:484
+#: packages/admin/src/lib/api/content.ts:489
+msgid "Failed to restore revision"
+msgstr "กู้คืนรุ่นแก้ไขไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "เพิกถอนโทเค็น API ไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:332
+msgid "Failed to rewrite URLs"
+msgstr "เขียน URL ใหม่ไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:735
+#: packages/admin/src/router.tsx:1644
+msgid "Failed to save"
+msgstr "บันทึกไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:58
+#: packages/admin/src/components/settings/SeoSettings.tsx:62
+#: packages/admin/src/components/settings/SocialSettings.tsx:53
+msgid "Failed to save settings"
+msgstr "บันทึกการตั้งค่าไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:835
+msgid "Failed to schedule"
+msgstr "กำหนดเวลาไม่สำเร็จ"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "ส่ง magic link ไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "ส่งลิงก์กู้คืนไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:61
+msgid "Failed to send test email"
+msgstr "ส่งอีเมลทดสอบไม่สำเร็จ"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "ส่งอีเมลยืนยันไม่สำเร็จ"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:100
+msgid "Failed to set entry terms"
+msgstr "กำหนดเทอมของรายการไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:594
+msgid "Failed to uninstall plugin"
+msgstr "ถอนการติดตั้งปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:798
+msgid "Failed to unpublish"
+msgstr "ยกเลิกการเผยแพร่ไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:853
+msgid "Failed to unschedule"
+msgstr "ยกเลิกการกำหนดเวลาไม่สำเร็จ"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:320
+msgid "Failed to update {0}"
+msgstr "อัปเดต {0} ไม่สำเร็จ"
+
+#: packages/admin/src/components/ContentEditor.tsx:2216
+msgid "Failed to update byline"
+msgstr "อัปเดตชื่อผู้เขียนไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+msgid "Failed to update domain"
+msgstr "อัปเดตโดเมนไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:526
+msgid "Failed to update plugin"
+msgstr "อัปเดตปลั๊กอินไม่สำเร็จ"
+
+#: packages/admin/src/router.tsx:1130
+msgid "Failed to update status"
+msgstr "อัปเดตสถานะไม่สำเร็จ"
+
+#: packages/admin/src/lib/api/media.ts:132
+msgid "Failed to upload file"
+msgstr "อัปโหลดไฟล์ไม่สำเร็จ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:250
+msgid "Failed to verify authentication"
+msgstr "ยืนยันการตรวจสอบสิทธิ์ไม่สำเร็จ"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "ยืนยันการลงทะเบียนไม่สำเร็จ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:236
+#: packages/admin/src/components/settings/GeneralSettings.tsx:242
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1022
+msgid "Feature"
+msgstr "คุณสมบัติ"
+
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "คุณสมบัติ"
+
+#: packages/admin/src/components/WordPressImport.tsx:736
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "กำลังดึงเนื้อหาจาก EmDash Exporter API"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "ป้ายกำกับฟิลด์"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "ป้ายกำกับฟิลด์"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Slug ของฟิลด์ไม่สามารถเปลี่ยนได้หลังจากสร้างแล้ว"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:572
+msgid "Fields"
+msgstr "ฟิลด์"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Fields created:"
+msgstr "ฟิลด์ที่สร้าง:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "ไฟล์"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:1994
+msgid "File {0}"
+msgstr "ไฟล์ {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "ไฟล์จากคลังมีเดีย"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:428
+msgid "Filename"
+msgstr "ชื่อไฟล์"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:196
+msgid "Filename cannot be changed after upload"
+msgstr "ชื่อไฟล์ไม่สามารถเปลี่ยนได้หลังจากอัปโหลดแล้ว"
+
+#: packages/admin/src/components/WordPressImport.tsx:2172
+msgid "files imported"
+msgstr "ไฟล์ที่นำเข้า"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "กรองตามความสามารถ"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "กรองตามคอลเลกชัน"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "กรองตามบทบาท"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "กรองตามแหล่งที่มา"
+
+#: packages/admin/src/components/Redirects.tsx:393
+msgid "Filter by status"
+msgstr "กรองตามสถานะ"
+
+#: packages/admin/src/components/Redirects.tsx:399
+msgid "Filter by type"
+msgstr "กรองตามประเภท"
+
+#: packages/admin/src/routes/bylines.tsx:321
+msgid "Filter byline type"
+msgstr "กรองตามประเภทชื่อผู้เขียน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "เฉพาะผู้แสดงความคิดเห็นครั้งแรกเท่านั้น"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "แบบอักษร"
+
+#: packages/admin/src/components/WordPressImport.tsx:1237
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "สำหรับการนำเข้าที่สมบูรณ์รวมถึงฉบับร่างและเนื้อหาทั้งหมด ให้ส่งออกจาก WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1046
+msgid "For the best import experience, install the"
+msgstr "เพื่อประสบการณ์การนำเข้าที่ดีที่สุด ให้ติดตั้ง"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "เข้าถึงได้เต็มรูปแบบ"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "สิทธิ์เข้าถึงระดับผู้ดูแลระบบเต็มรูปแบบ"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "ทั่วไป"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:101
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr "การตั้งค่าทั่วไป"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:624
+msgid "Genres"
+msgstr "แนว"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "เริ่มต้นใช้งาน"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:138
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "ตั้งชื่อให้ Passkey นี้เพื่อช่วยให้คุณระบุได้ในภายหลัง"
+
+#: packages/admin/src/components/WordPressImport.tsx:2224
+#: packages/admin/src/router.tsx:1846
+msgid "Go to Dashboard"
+msgstr "ไปที่แดชบอร์ด"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:227
+msgid "Google Verification"
+msgstr "การยืนยัน Google"
+
+#: packages/admin/src/components/MediaLibrary.tsx:238
+msgid "Grid view"
+msgstr "มุมมองตาราง"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "Group (optional)"
+msgstr "กลุ่ม (ไม่บังคับ)"
+
+#: packages/admin/src/routes/bylines.tsx:432
+msgid "Guest byline"
+msgstr "ชื่อผู้เขียนรับเชิญ"
+
+#: packages/admin/src/routes/bylines.tsx:326
+msgid "Guest only"
+msgstr "เฉพาะผู้มาเยือนเท่านั้น"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:61
+#: packages/admin/src/components/PortableTextEditor.tsx:857
+#: packages/admin/src/components/PortableTextEditor.tsx:2846
+msgid "Heading 1"
+msgstr "หัวข้อ 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:69
+#: packages/admin/src/components/PortableTextEditor.tsx:867
+#: packages/admin/src/components/PortableTextEditor.tsx:2853
+msgid "Heading 2"
+msgstr "หัวข้อ 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:77
+#: packages/admin/src/components/PortableTextEditor.tsx:877
+#: packages/admin/src/components/PortableTextEditor.tsx:2860
+msgid "Heading 3"
+msgstr "หัวข้อ 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr "ความสูง"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "แบนเนอร์ Hero"
+
+#: packages/admin/src/components/SectionEditor.tsx:271
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:191
+msgid "Hide from search engines"
+msgstr "ซ่อนจากเครื่องมือค้นหา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "ซ่อนโทเค็น"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:647
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "แบบลำดับชั้น (เหมือนหมวดหมู่ ที่มีความสัมพันธ์แม่/ลูก)"
+
+#: packages/admin/src/components/Redirects.tsx:216
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "Hits"
+msgstr "การเข้าชม"
+
+#: packages/admin/src/components/MenuEditor.tsx:329
+msgid "Home"
+msgstr "หน้าแรก"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "หน้าแรก"
+
+#: packages/admin/src/components/PluginManager.tsx:384
+msgid "Hooks"
+msgstr "Hooks"
+
+#: packages/admin/src/components/WordPressImport.tsx:1359
+msgid "How to create an Application Password"
+msgstr "วิธีสร้าง Application Password"
+
+#: packages/admin/src/components/MenuEditor.tsx:337
+msgid "https://example.com or /about"
+msgstr "https://example.com หรือ /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:495
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:143
+msgid "Icon blurred due to image audit"
+msgstr "ไอคอนถูกเบลอเนื่องจากการตรวจสอบรูปภาพ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "หากมีบัญชีสำหรับ <0>{email}</0> เราได้ส่งลิงก์เข้าสู่ระบบไปแล้ว"
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/PortableTextEditor.tsx:1988
+msgid "Image"
+msgstr "รูปภาพ"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "รูปภาพจากคลังมีเดีย"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ContentEditor.tsx:1656
+msgid "Image not found"
+msgstr "ไม่พบรูปภาพ"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:179
+#: packages/admin/src/components/editor/ImageNode.tsx:180
+msgid "Image settings"
+msgstr "ตั้งค่ารูปภาพ"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr "ตั้งค่ารูปภาพ"
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr "รูปภาพที่แสดงเมื่อแชร์หน้านี้บนโซเชียลมีเดีย"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:496
+msgid "Image URL"
+msgstr "URL ของรูปภาพ"
+
+#: packages/admin/src/components/WordPressImport.tsx:2176
+msgid "image URLs updated in"
+msgstr "URL ของรูปภาพอัปเดตใน"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+msgid "Images"
+msgstr "รูปภาพ"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:244
+#: packages/admin/src/components/WordPressImport.tsx:664
+msgid "Import"
+msgstr "นำเข้า"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1794
+msgid "Import {0}"
+msgstr "นำเข้า {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1205
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "นำเข้าเนื้อหาทั้งหมดโดยตรง รวมถึงฉบับร่าง custom post type ฟิลด์ ACF และข้อมูล SEO โดยไม่ต้องดาวน์โหลดไฟล์"
+
+#: packages/admin/src/components/WordPressImport.tsx:2222
+msgid "Import Another File"
+msgstr "นำเข้าไฟล์อื่น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1016
+msgid "Import Capabilities"
+msgstr "ความสามารถในการนำเข้า"
+
+#: packages/admin/src/components/WordPressImport.tsx:2110
+msgid "Import Complete"
+msgstr "นำเข้าเสร็จสมบูรณ์"
+
+#: packages/admin/src/components/WordPressImport.tsx:2111
+msgid "Import Completed with Errors"
+msgstr "นำเข้าเสร็จสมบูรณ์โดยมีข้อผิดพลาด"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Import failed"
+msgstr "นำเข้าไม่สำเร็จ"
+
+#: packages/admin/src/components/WordPressImport.tsx:617
+msgid "Import from WordPress"
+msgstr "นำเข้าจาก WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1943
+msgid "Import Media"
+msgstr "นำเข้ามีเดีย"
+
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "Import Media Files"
+msgstr "นำเข้าไฟล์มีเดีย"
+
+#: packages/admin/src/components/WordPressImport.tsx:619
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "นำเข้าโพสต์ หน้า และ custom post type จาก WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1650
+msgid "Import site configuration from WordPress."
+msgstr "นำเข้าการกำหนดค่าเว็บไซต์จาก WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Import via EmDash Exporter"
+msgstr "นำเข้าผ่าน EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "นำเข้าแล้ว"
+
+#: packages/admin/src/components/WordPressImport.tsx:2150
+msgid "Imported by Collection"
+msgstr "นำเข้าตามคอลเลกชัน"
+
+#: packages/admin/src/components/WordPressImport.tsx:820
+msgid "Importing content..."
+msgstr "กำลังนำเข้าเนื้อหา..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1975
+msgid "Importing Media"
+msgstr "กำลังนำเข้ามีเดีย"
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "รวมเนื้อหาตัวอย่าง (แนะนำสำหรับเว็บไซต์ใหม่)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1816
+msgid "Incompatible"
+msgstr "ไม่เข้ากัน"
+
+#. placeholder {0}: formatDate(release.indexedAt)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:325
+msgid "indexed {0}"
+msgstr "จัดทำดัชนีแล้ว {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2833
+msgid "Inline Code"
+msgstr "โค้ดในบรรทัด"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:507
+#: packages/admin/src/components/MediaPickerModal.tsx:732
+#: packages/admin/src/components/PortableTextEditor.tsx:1270
+msgid "Insert"
+msgstr "แทรก"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:908
+msgid "Insert a blockquote"
+msgstr "แทรกข้อความอ้างอิง"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:918
+msgid "Insert a code block"
+msgstr "แทรกบล็อกโค้ด"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:928
+msgid "Insert a horizontal rule"
+msgstr "แทรกเส้นคั่นแนวนอน"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2003
+msgid "Insert a reusable section"
+msgstr "แทรกส่วนที่นำกลับมาใช้ใหม่ได้"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:938
+msgid "Insert a table"
+msgstr "แทรกตาราง"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1989
+msgid "Insert an image"
+msgstr "แทรกรูปภาพ"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:489
+msgid "Insert from URL"
+msgstr "แทรกจาก URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3003
+msgid "Insert Horizontal Rule"
+msgstr "แทรกเส้นคั่นแนวนอน"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2998
+msgid "Insert Image"
+msgstr "แทรกรูปภาพ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2945
+msgid "Insert Link"
+msgstr "แทรกลิงก์"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "แทรกส่วน"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2903
+msgid "Insert Table"
+msgstr "แทรกตาราง"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:150
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:193
+#: packages/admin/src/components/RegistryPluginDetail.tsx:373
+msgid "Install"
+msgstr "ติดตั้ง"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:181
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "ติดตั้งและเปิดใช้งานปลั๊กอินผู้ให้บริการอีเมลเพื่อเปิดใช้งานฟีเจอร์อีเมล เช่น คำเชิญ ลิงก์มหัศจรรย์ และการกู้คืนรหัสผ่าน"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:187
+msgid "Install blocked"
+msgstr "การติดตั้งถูกบล็อก"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:174
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:365
+msgid "Installed"
+msgstr "ติดตั้งแล้ว"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:496
+msgid "Installed from marketplace (v{0})"
+msgstr "ติดตั้งจากมาร์เก็ตเพลส (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:515
+msgid "Installed:"
+msgstr "ติดตั้งแล้ว:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:167
+msgid "Installing..."
+msgstr "กำลังติดตั้ง..."
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "จำนวนเต็ม"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:119
+msgid "Invalid invite link"
+msgstr "ลิงก์คำเชิญไม่ถูกต้อง"
+
+#: packages/admin/src/components/ContentEditor.tsx:1543
+msgid "Invalid JSON"
+msgstr "JSON ไม่ถูกต้อง"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "ลิงก์ไม่ถูกต้อง"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:207
+msgid "Invite Error"
+msgstr "เกิดข้อผิดพลาดในการเชิญ"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:117
+msgid "Invite expired"
+msgstr "คำเชิญหมดอายุ"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "สร้างลิงก์คำเชิญแล้ว"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "เชิญผู้ใช้"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "เชิญสมาชิกทีมคนแรกของคุณ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2506
+#: packages/admin/src/components/PortableTextEditor.tsx:2812
+msgid "Italic"
+msgstr "ตัวเอียง"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1651
+#: packages/admin/src/components/RepeaterField.tsx:234
+msgid "Item {0}"
+msgstr "รายการ {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Item added"
+msgstr "เพิ่มรายการแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:133
+msgid "Item deleted"
+msgstr "ลบรายการแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:158
+msgid "Item updated"
+msgstr "อัปเดตรายการแล้ว"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Jane Doe"
+
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:294
+#: packages/admin/src/components/SectionEditor.tsx:268
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "คำสำคัญ"
+
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:329
+#: packages/admin/src/components/MenuEditor.tsx:498
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:621
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Label"
+msgstr "ป้ายกำกับ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:394
+msgid "Label (Plural)"
+msgstr "ป้ายกำกับ (พหูพจน์)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:386
+msgid "Label (Singular)"
+msgstr "ป้ายกำกับ (เอกพจน์)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:125
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr "ภาษา"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:858
+msgid "Large section heading"
+msgstr "หัวข้อส่วนขนาดใหญ่"
+
+#: packages/admin/src/components/PluginManager.tsx:521
+msgid "Last enabled:"
+msgstr "เปิดใช้งานล่าสุด:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "เข้าสู่ระบบล่าสุด"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "เข้าสู่ระบบล่าสุด"
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "Last seen"
+msgstr "พบครั้งล่าสุด"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "อัปเดตล่าสุด"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr "ใช้งานล่าสุด"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "ใช้งานล่าสุด {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr "เว้นว่างไว้เพื่อใช้ passkey แบบค้นพบได้"
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Leave unassigned"
+msgstr "เว้นว่างไว้โดยไม่กำหนด"
+
+#: packages/admin/src/components/MediaLibrary.tsx:88
+#: packages/admin/src/components/MediaLibrary.tsx:208
+#: packages/admin/src/components/MediaLibrary.tsx:320
+msgid "Library"
+msgstr "ไลบรารี"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "สัญญาอนุญาต"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "สว่าง"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "สว่าง"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "ลิงก์หมดอายุ"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "ลิงก์ไปยังรายการเนื้อหาอื่น"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "บัญชีที่เชื่อมโยง ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:327
+msgid "Linked only"
+msgstr "เชื่อมโยงเท่านั้น"
+
+#: packages/admin/src/routes/bylines.tsx:415
+msgid "Linked user"
+msgstr "ผู้ใช้ที่เชื่อมโยง"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:156
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "ลิงก์"
+
+#: packages/admin/src/components/MediaLibrary.tsx:247
+msgid "List view"
+msgstr "มุมมองรายการ"
+
+#: packages/admin/src/components/ContentEditor.tsx:744
+msgid "Live View"
+msgstr "มุมมองสด"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:381
+msgid "Load more"
+msgstr "โหลดเพิ่มเติม"
+
+#: packages/admin/src/components/ContentList.tsx:354
+#: packages/admin/src/components/ContentList.tsx:411
+#: packages/admin/src/components/MediaLibrary.tsx:478
+#: packages/admin/src/components/MediaPickerModal.tsx:708
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "โหลดเพิ่มเติม"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "กำลังโหลดคอลเลกชัน..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "กำลังโหลดความคิดเห็น..."
+
+#: packages/admin/src/router.tsx:1815
+msgid "Loading configuration..."
+msgstr "กำลังโหลดการกำหนดค่า..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "กำลังโหลดเนื้อหา..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2333
+msgid "Loading editor..."
+msgstr "กำลังโหลดตัวแก้ไข..."
+
+#: packages/admin/src/components/MenuEditor.tsx:255
+msgid "Loading menu..."
+msgstr "กำลังโหลดเมนู..."
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "กำลังโหลดเมนู..."
+
+#: packages/admin/src/components/PluginManager.tsx:135
+msgid "Loading plugins..."
+msgstr "กำลังโหลดปลั๊กอิน..."
+
+#: packages/admin/src/components/Redirects.tsx:430
+msgid "Loading redirects..."
+msgstr "กำลังโหลดการเปลี่ยนเส้นทาง..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "กำลังโหลดส่วนต่างๆ..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:108
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+msgid "Loading settings..."
+msgstr "กำลังโหลดการตั้งค่า..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "กำลังโหลดการตั้งค่า..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:825
+msgid "Loading terms..."
+msgstr "กำลังโหลดเทอม..."
+
+#: packages/admin/src/components/Widgets.tsx:310
+msgid "Loading widgets..."
+msgstr "กำลังโหลดวิดเจ็ต..."
+
+#: packages/admin/src/components/ContentList.tsx:272
+#: packages/admin/src/components/ContentList.tsx:354
+#: packages/admin/src/components/ContentList.tsx:383
+#: packages/admin/src/components/ContentList.tsx:411
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:478
+#: packages/admin/src/components/MediaPickerModal.tsx:708
+#: packages/admin/src/components/PortableTextEditor.tsx:1778
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:176
+#: packages/admin/src/components/settings/SecuritySettings.tsx:113
+#: packages/admin/src/components/TaxonomyManager.tsx:777
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:381
+msgid "Loading..."
+msgstr "กำลังโหลด..."
+
+#: packages/admin/src/components/ContentList.tsx:252
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "ภาษา"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr "ล็อกอัตราส่วนภาพ"
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr "ออกจากระบบ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+#: packages/admin/src/components/settings/GeneralSettings.tsx:188
+msgid "Logo"
+msgstr "โลโก้"
+
+#: packages/admin/src/components/WordPressImport.tsx:1668
+msgid "Logo & favicon"
+msgstr "โลโก้และ favicon"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "ข้อความยาว"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "ใช้ได้เฉพาะตัวอักษรพิมพ์เล็ก ตัวเลข และยัติภังค์เท่านั้น"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:639
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "ใช้ได้เฉพาะตัวอักษรพิมพ์เล็ก ตัวเลข และขีดล่างเท่านั้น โดยขึ้นต้นด้วยตัวอักษร"
+
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Main Sidebar"
+msgstr "แถบด้านข้างหลัก"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Make network requests"
+msgstr "ส่งคำขอเครือข่าย"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests to any host (unrestricted)"
+msgstr "ส่งคำขอเครือข่ายไปยังโฮสต์ใดก็ได้ (ไม่จำกัด)"
+
+#: packages/admin/src/components/Sidebar.tsx:442
+msgid "Manage"
+msgstr "จัดการ"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:796
+msgid "Manage {0} for {1}"
+msgstr "จัดการ {0} สำหรับ {1}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2020
+msgid "Manage bylines in {entryLocale}"
+msgstr "จัดการชื่อผู้เขียนใน {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:326
+msgid "Manage content widgets in your widget areas"
+msgstr "จัดการวิดเจ็ตเนื้อหาในพื้นที่วิดเจ็ตของคุณ"
+
+#: packages/admin/src/components/PluginManager.tsx:174
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "จัดการปลั๊กอินที่ติดตั้งไว้ เปิดใช้งานหรือปิดใช้งานปลั๊กอินเพื่อควบคุมการทำงาน"
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "จัดการเมนูนำทางสำหรับเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/Redirects.tsx:333
+msgid "Manage URL redirects and view 404 errors."
+msgstr "จัดการการเปลี่ยนเส้นทาง URL และดูข้อผิดพลาด 404"
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "จัดการ Passkey และการยืนยันตัวตนของคุณ"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Manual"
+msgstr "กำหนดเอง"
+
+#: packages/admin/src/components/WordPressImport.tsx:2260
+msgid "Map Authors"
+msgstr "จับคู่ผู้เขียน"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2308
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "จับคู่ผู้ใช้ WordPress {0} กับผู้ใช้ EmDash"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "ทำเครื่องหมายเป็นสแปม"
+
+#: packages/admin/src/components/PluginManager.tsx:200
+msgid "marketplace"
+msgstr "marketplace"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:166
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Sidebar.tsx:228
+msgid "Marketplace"
+msgstr "Marketplace"
+
+#: packages/admin/src/components/FieldEditor.tsx:626
+msgid "Max Items"
+msgstr "จำนวนรายการสูงสุด"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "ความยาวสูงสุด"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "ค่าสูงสุด"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1992
+#: packages/admin/src/components/Sidebar.tsx:188
+#: packages/admin/src/components/WordPressImport.tsx:678
+#: packages/admin/src/components/WordPressImport.tsx:1173
+msgid "Media"
+msgstr "มีเดีย"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:130
+msgid "Media Details"
+msgstr "รายละเอียดมีเดีย"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2206
+msgid "Media Errors ({0})"
+msgstr "ข้อผิดพลาดของมีเดีย ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2168
+msgid "Media Import"
+msgstr "นำเข้ามีเดีย"
+
+#: packages/admin/src/components/WordPressImport.tsx:2109
+msgid "Media Import Complete"
+msgstr "นำเข้ามีเดียเสร็จสมบูรณ์"
+
+#: packages/admin/src/components/WordPressImport.tsx:2120
+msgid "Media import was skipped"
+msgstr "ข้ามการนำเข้ามีเดียแล้ว"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:232
+msgid "Media Library"
+msgstr "คลังมีเดีย"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "อ่านมีเดีย"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "เขียนมีเดีย"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:868
+msgid "Medium section heading"
+msgstr "หัวข้อส่วนขนาดกลาง"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:834
+msgid "Menu"
+msgstr "เมนู"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:90
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "สร้างเมนู \"{0}\" ({1}) แล้ว"
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "สร้างเมนู \"{0}\" แล้ว"
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "สร้างเมนูแล้ว"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "ลบเมนูแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Menu item has been added."
+msgstr "เพิ่มรายการเมนูแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:134
+msgid "Menu item has been deleted."
+msgstr "ลบรายการเมนูแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:159
+msgid "Menu item has been updated."
+msgstr "อัปเดตรายการเมนูแล้ว"
+
+#: packages/admin/src/components/MenuEditor.tsx:263
+msgid "Menu not found"
+msgstr "ไม่พบเมนู"
+
+#: packages/admin/src/components/MenuEditor.tsx:174
+msgid "Menu order has been updated."
+msgstr "อัปเดตลำดับเมนูแล้ว"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:198
+msgid "Menus"
+msgstr "เมนู"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1604
+msgid "Menus ({0})"
+msgstr "เมนู ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "จัดการเมนู"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Meta Description"
+msgstr "Meta Description"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:236
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "เนื้อหา Meta tag สำหรับการยืนยัน Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:230
+msgid "Meta tag content for Google Search Console verification"
+msgstr "เนื้อหา Meta tag สำหรับการยืนยัน Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1681
+msgid "Meta titles, descriptions, and social images"
+msgstr "Meta title คำอธิบาย และรูปภาพสำหรับโซเชียล"
+
+#: packages/admin/src/components/FieldEditor.tsx:619
+msgid "Min Items"
+msgstr "รายการขั้นต่ำ"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "ความยาวขั้นต่ำ"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "ค่าต่ำสุด"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:506
+msgid "Moderation"
+msgstr "การกลั่นกรอง"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "สัญญาณการกลั่นกรอง"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "แก้ไขแล้ว"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "แก้ไขสคีมาของคอลเลกชัน"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "ยอดนิยมที่สุด"
+
+#: packages/admin/src/components/ContentList.tsx:613
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "ย้าย \"{title}\" ไปยังถังขยะ? คุณสามารถกู้คืนได้ภายหลัง"
+
+#: packages/admin/src/components/ContentList.tsx:604
+msgid "Move {title} to trash"
+msgstr "ย้าย {title} ไปยังถังขยะ"
+
+#: packages/admin/src/components/MenuEditor.tsx:443
+msgid "Move down"
+msgstr "เลื่อนลง"
+
+#: packages/admin/src/components/ContentEditor.tsx:947
+#: packages/admin/src/components/ContentEditor.tsx:969
+#: packages/admin/src/components/ContentList.tsx:626
+msgid "Move to Trash"
+msgstr "ย้ายไปยังถังขยะ"
+
+#: packages/admin/src/components/ContentEditor.tsx:953
+#: packages/admin/src/components/ContentList.tsx:611
+msgid "Move to Trash?"
+msgstr "ย้ายไปยังถังขยะ?"
+
+#: packages/admin/src/components/MenuEditor.tsx:434
+msgid "Move up"
+msgstr "เลื่อนขึ้น"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "เลือกได้หลายรายการ"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "ข้อความธรรมดาหลายบรรทัด"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "เลือกได้หลายตัวเลือกจากรายการ"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "My Awesome Blog"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:387
+#: packages/admin/src/components/TaxonomyManager.tsx:630
+#: packages/admin/src/components/TaxonomyManager.tsx:819
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:365
+msgid "Name"
+msgstr "ชื่อ"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:556
+msgid "Name and label are required"
+msgstr "ต้องระบุชื่อและป้ายกำกับ"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:562
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "ชื่อต้องขึ้นต้นด้วยตัวอักษร และประกอบด้วยตัวอักษรพิมพ์เล็ก ตัวเลข และขีดล่างเท่านั้น"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "การนำทาง"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "ไม่เลย"
+
+#: packages/admin/src/router.tsx:878
+msgid "new"
+msgstr "ใหม่"
+
+#: packages/admin/src/routes/bylines.tsx:339
+msgid "New"
+msgstr "ใหม่"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:106
+msgid "NEW"
+msgstr "ใหม่"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:427
+msgid "New {0}"
+msgstr "{0} ใหม่"
+
+#: packages/admin/src/components/ContentEditor.tsx:629
+msgid "New {collectionLabel}"
+msgstr "{collectionLabel} ใหม่"
+
+#: packages/admin/src/components/WordPressImport.tsx:1818
+msgid "New collection"
+msgstr "คอลเลกชันใหม่"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "ประเภทเนื้อหาใหม่"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:116
+msgid "New public routes"
+msgstr "เส้นทางสาธารณะใหม่"
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:336
+msgid "New Redirect"
+msgstr "การเปลี่ยนเส้นทางใหม่"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "ส่วนใหม่"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "แท็บใหม่"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:809
+msgid "New Taxonomy"
+msgstr "อนุกรมวิธานใหม่"
+
+#: packages/admin/src/components/MenuEditor.tsx:343
+#: packages/admin/src/components/MenuEditor.tsx:346
+#: packages/admin/src/components/MenuEditor.tsx:514
+#: packages/admin/src/components/MenuEditor.tsx:517
+msgid "New window"
+msgstr "หน้าต่างใหม่"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "ใหม่ที่สุด"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:390
+msgid "News"
+msgstr "ข่าวสาร"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "ถัดไป"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:342
+msgid "Next page"
+msgstr "หน้าถัดไป"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:464
+msgid "Next screenshot"
+msgstr "ภาพหน้าจอถัดไป"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+msgid "No"
+msgstr "ไม่"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:397
+msgid "No {0} available."
+msgstr "ไม่มี{0}ให้ใช้งาน"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:279
+msgid "No {0} yet."
+msgstr "ยังไม่มี{0}"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:828
+msgid "No {0} yet. Create one to get started."
+msgstr "ยังไม่มี{0} สร้างขึ้นมาเพื่อเริ่มต้นใช้งาน"
+
+#: packages/admin/src/components/Redirects.tsx:208
+msgid "No 404 errors recorded yet."
+msgstr "ยังไม่มีการบันทึกข้อผิดพลาด 404"
+
+#: packages/admin/src/components/MediaLibrary.tsx:633
+#: packages/admin/src/components/MediaLibrary.tsx:690
+msgid "No alt text"
+msgstr "ไม่มี alt text"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
+msgid "No API tokens yet. Create one to get started."
+msgstr "ยังไม่มี API token สร้างขึ้นมาเพื่อเริ่มต้นใช้งาน"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "ยังไม่มีความคิดเห็นที่อนุมัติแล้ว"
+
+#: packages/admin/src/components/ContentEditor.tsx:2012
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "ไม่มีชื่อผู้เขียนให้ใช้งานใน {entryLocale} สร้างรูปแบบจากหน้าชื่อผู้เขียนก่อนที่จะระบุเครดิตในรายการนี้"
+
+#: packages/admin/src/routes/bylines.tsx:365
+msgid "No bylines found"
+msgstr "ไม่พบชื่อผู้เขียน"
+
+#: packages/admin/src/components/ContentEditor.tsx:2107
+msgid "No bylines selected."
+msgstr "ยังไม่ได้เลือกชื่อผู้เขียน"
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr "ยังไม่ได้กำหนดค่าคอลเลกชัน"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "ไม่มีความคิดเห็นที่รอการตรวจสอบ"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "ไม่มีความคิดเห็นที่ตรงกับการค้นหาของคุณ"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:80
+msgid "No content"
+msgstr "ไม่มีเนื้อหา"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "ไม่พบเนื้อหา"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "ไม่มีเนื้อหาในคอลเลกชันนี้"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "ยังไม่มีประเภทเนื้อหา"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:603
+msgid "No custom fields yet"
+msgstr "ยังไม่มีฟิลด์ที่กำหนดเอง"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:265
+msgid "No detailed description available."
+msgstr "ไม่มีคำอธิบายโดยละเอียด"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
+msgid "No domains configured. Users must be invited individually."
+msgstr "ยังไม่ได้กำหนดค่าโดเมน ต้องเชิญผู้ใช้ทีละราย"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:178
+msgid "No email provider configured"
+msgstr "ยังไม่ได้กำหนดค่าผู้ให้บริการอีเมล"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "ยังไม่ได้กำหนดค่าผู้ให้บริการอีเมล แชร์ลิงก์นี้ด้วยตนเอง"
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "No EmDash users found"
+msgstr "ไม่พบผู้ใช้ EmDash"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "ไม่มีวันหมดอายุ"
+
+#: packages/admin/src/components/RevisionHistory.tsx:327
+msgid "No fields to compare"
+msgstr "ไม่มีฟิลด์ให้เปรียบเทียบ"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:189
+msgid "No headings in document"
+msgstr "ไม่มีหัวข้อในเอกสาร"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:413
+msgid "No installable releases"
+msgstr "ไม่มีรุ่นที่สามารถติดตั้งได้"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:159
+msgid "No invite token provided"
+msgstr "ไม่ได้ระบุโทเค็นคำเชิญ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1574
+#: packages/admin/src/components/RepeaterField.tsx:160
+msgid "No items yet"
+msgstr "ยังไม่มีรายการ"
+
+#: packages/admin/src/components/FieldEditor.tsx:630
+msgid "No limit"
+msgstr "ไม่จำกัด"
+
+#: packages/admin/src/routes/bylines.tsx:426
+msgid "No linked user"
+msgstr "ไม่มีผู้ใช้ที่เชื่อมโยง"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:134
+msgid "No matches"
+msgstr "ไม่พบรายการที่ตรงกัน"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr "ไม่พบ passkey ที่ตรงกับบัญชีนี้"
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "ไม่มีค่าสูงสุด"
+
+#: packages/admin/src/components/MediaLibrary.tsx:381
+#: packages/admin/src/components/MediaPickerModal.tsx:631
+msgid "No media available from this provider"
+msgstr "ไม่มีมีเดียจากผู้ให้บริการนี้"
+
+#: packages/admin/src/components/MediaLibrary.tsx:375
+#: packages/admin/src/components/MediaPickerModal.tsx:625
+msgid "No media found"
+msgstr "ไม่พบมีเดีย"
+
+#: packages/admin/src/components/MediaLibrary.tsx:364
+msgid "No media yet"
+msgstr "ยังไม่มีมีเดีย"
+
+#: packages/admin/src/components/MenuEditor.tsx:398
+msgid "No menu items yet"
+msgstr "ยังไม่มีรายการเมนู"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "ยังไม่มีเมนู"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "ไม่มีค่าต่ำสุด"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "ไม่มีการกลั่นกรอง (อนุมัติทั้งหมดอัตโนมัติ)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "ยังไม่มี passkey ที่ลงทะเบียน"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "No passkeys registered yet."
+msgstr "ยังไม่มี passkey ที่ลงทะเบียน"
+
+#: packages/admin/src/components/PluginManager.tsx:194
+msgid "No plugins configured"
+msgstr "ยังไม่มีปลั๊กอินที่กำหนดค่า"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "ไม่พบปลั๊กอิน"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "ยังไม่มีปลั๊กอินที่เผยแพร่ไปยัง registry นี้"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "ไม่มีปลั๊กอินที่ตรงกับ \"{debouncedQuery}\""
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "ไม่มีตัวอย่าง"
+
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr "ไม่มีกิจกรรมล่าสุด"
+
+#: packages/admin/src/components/Redirects.tsx:434
+msgid "No redirects yet"
+msgstr "ยังไม่มีการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1132
+msgid "No results"
+msgstr "ไม่มีผลลัพธ์"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "ไม่มีผลลัพธ์สำหรับ \"{debouncedQuery}\" ลองใช้คำค้นหาอื่น"
+
+#: packages/admin/src/components/ContentList.tsx:293
+msgid "No results for \"{searchQuery}\""
+msgstr "ไม่มีผลลัพธ์สำหรับ \"{searchQuery}\""
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "ไม่พบผลลัพธ์"
+
+#: packages/admin/src/components/RevisionHistory.tsx:183
+msgid "No revisions yet"
+msgstr "ยังไม่มีรุ่นแก้ไข"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "ไม่มีส่วนที่ใช้ได้"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "ไม่พบส่วน"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "ยังไม่มีส่วน"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "ไม่มีความคิดเห็นที่เป็นสแปม"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "ไม่พบธีม"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "ไม่พบผู้ใช้ที่ตรงกับตัวกรองของคุณ"
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "ยังไม่มีผู้ใช้"
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "No widget areas yet. Create one to get started."
+msgstr "ยังไม่มีพื้นที่วิดเจ็ต สร้างขึ้นมาเพื่อเริ่มต้นใช้งาน"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:416
+#: packages/admin/src/components/TaxonomyManager.tsx:422
+msgid "None (top level)"
+msgstr "ไม่มี (ระดับบนสุด)"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "ตัวเลข"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:301
+msgid "Number of posts to show per page on list views"
+msgstr "จำนวนโพสต์ที่จะแสดงต่อหน้าในมุมมองรายการ"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:109
+#: packages/admin/src/components/PortableTextEditor.tsx:897
+#: packages/admin/src/components/PortableTextEditor.tsx:2880
+msgid "Numbered List"
+msgstr "รายการแบบมีลำดับเลข"
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr "OG Image"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "บนชื่อโฮสต์ที่กำหนดเองจะไม่ถือว่าปลอดภัย แม้บน loopback"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "อนุญาตเฉพาะรหัสที่คุณรู้จักเท่านั้น"
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "อนุญาตให้สมัครใช้งานได้เฉพาะอีเมลจากโดเมนที่อนุญาตเท่านั้น"
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "ใช้ได้เฉพาะตัวอักษรพิมพ์เล็ก ตัวเลข และเครื่องหมายขีดกลางเท่านั้น"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "ระบบจะยอมรับเฉพาะประเภท MIME ที่ระบุไว้สำหรับฟิลด์นี้เท่านั้น"
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "อุ๊ปส์!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "เปิดในแท็บใหม่"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Open WordPress Profile"
+msgstr "เปิดโปรไฟล์ WordPress"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr "ตัวเลือก 1\nตัวเลือก 2\nตัวเลือก 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr "คำบรรยายที่ไม่บังคับแสดงด้านล่างรูปภาพ"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:213
+msgid "Optional caption for display"
+msgstr "คำบรรยายที่ไม่บังคับสำหรับการแสดงผล"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:435
+msgid "Optional description"
+msgstr "คำอธิบายที่ไม่บังคับ"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr "คำแนะนำเพิ่มเติมเมื่อชี้เมาส์"
+
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "ตัวเลือก (หนึ่งรายการต่อบรรทัด)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:519
+msgid "or choose from library"
+msgstr "หรือเลือกจากไลบรารี"
+
+#: packages/admin/src/components/WordPressImport.tsx:1429
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "หรือคลิกเพื่อเรียกดู รองรับไฟล์ .xml ที่ส่งออกจาก WordPress"
+
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "หรือดำเนินการต่อด้วย"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Or upload an export file"
+msgstr "หรืออัปโหลดไฟล์ส่งออก"
+
+#: packages/admin/src/components/WordPressImport.tsx:949
+msgid "or upload directly"
+msgstr "หรืออัปโหลดโดยตรง"
+
+#: packages/admin/src/components/MenuEditor.tsx:173
+msgid "Order saved"
+msgstr "บันทึกลำดับแล้ว"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr "ต้นฉบับ:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:181
+msgid "Outline"
+msgstr "โครงร่าง"
+
+#: packages/admin/src/components/SeoPanel.tsx:155
+msgid "Overrides the page title in search engine results"
+msgstr "แทนที่ชื่อหน้าในผลการค้นหาของเครื่องมือค้นหา"
+
+#: packages/admin/src/components/ContentEditor.tsx:984
+msgid "Ownership"
+msgstr "ความเป็นเจ้าของ"
+
+#: packages/admin/src/components/PluginManager.tsx:505
+msgid "Package"
+msgstr "แพ็กเกจ"
+
+#: packages/admin/src/router.tsx:1841
+msgid "Page Not Found"
+msgstr "ไม่พบหน้า"
+
+#: packages/admin/src/components/PluginManager.tsx:372
+#: packages/admin/src/components/WordPressImport.tsx:1167
+msgid "Pages"
+msgstr "หน้า"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:53
+msgid "Paragraph"
+msgstr "ย่อหน้า"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:412
+msgid "Parent"
+msgstr "รายการแม่"
+
+#: packages/admin/src/components/Redirects.tsx:483
+#: packages/admin/src/components/Redirects.tsx:489
+msgid "Part of a redirect loop"
+msgstr "เป็นส่วนหนึ่งของวงวนการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "ผ่าน"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr "เพิ่ม Passkey สำเร็จ"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "ชื่อ Passkey"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "ชื่อ Passkey (ไม่บังคับ)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "ลงทะเบียน Passkey สำเร็จ!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr "นำ Passkey ออกแล้ว"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr "เปลี่ยนชื่อ Passkey แล้ว"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passkey"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passkey ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passkey เป็นวิธีเข้าสู่ระบบบัญชีของคุณที่ปลอดภัยและไม่ต้องใช้รหัสผ่าน คุณสามารถลงทะเบียน Passkey ได้หลายรายการสำหรับอุปกรณ์ที่แตกต่างกัน"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passkey เป็นวิธีเข้าสู่ระบบที่ปลอดภัยและไม่ต้องใช้รหัสผ่าน โดยใช้ข้อมูลชีวมิติ, PIN หรือกุญแจความปลอดภัยของอุปกรณ์ของคุณ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "ไม่สามารถใช้ Passkey ที่นี่ได้"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passkey ต้องการ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passkey ต้องใช้ HTTPS หรือ http://localhost (พร้อมพอร์ตของคุณ) ชื่อโฮสต์นี้ไม่ใช่บริบทเบราว์เซอร์ที่ปลอดภัย"
+
+#: packages/admin/src/components/Redirects.tsx:215
+msgid "Path"
+msgstr "เส้นทาง"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "รูปแบบ (Regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:437
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "รูปแบบสำหรับสร้าง URL เช่น /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:433
+msgid "Pattern must include a {0} placeholder"
+msgstr "รูปแบบต้องมีตัวยึดตำแหน่ง {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:750
+msgid "pending"
+msgstr "รอดำเนินการ"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+msgid "Pending"
+msgstr "รอดำเนินการ"
+
+#: packages/admin/src/components/ContentEditor.tsx:859
+msgid "Pending changes"
+msgstr "การเปลี่ยนแปลงที่รอดำเนินการ"
+
+#: packages/admin/src/components/ContentList.tsx:684
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "ลบ \"{title}\" อย่างถาวร? การดำเนินการนี้ไม่สามารถยกเลิกได้"
+
+#: packages/admin/src/components/ContentList.tsx:673
+msgid "Permanently delete {title}"
+msgstr "ลบ {title} อย่างถาวร"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:274
+msgid "Permissions"
+msgstr "สิทธิ์"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "เลือกวิธีใดก็ได้เพื่อสร้างบัญชีผู้ดูแลระบบของคุณ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "ธรรมดา"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:133
+msgid "Please ask your administrator to send a new invite."
+msgstr "โปรดขอให้ผู้ดูแลระบบของคุณส่งคำเชิญใหม่"
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "โปรดป้อนอีเมลที่ถูกต้อง"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "โปรดป้อนที่อยู่อีเมลที่ถูกต้อง"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:386
+msgid "Please enter a valid URL"
+msgstr "โปรดป้อน URL ที่ถูกต้อง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1024
+msgid "Plugin"
+msgstr "ปลั๊กอิน"
+
+#: packages/admin/src/components/PluginManager.tsx:109
+msgid "Plugin disabled"
+msgstr "ปิดใช้งานปลั๊กอินแล้ว"
+
+#: packages/admin/src/components/PluginManager.tsx:90
+msgid "Plugin enabled"
+msgstr "เปิดใช้งานปลั๊กอินแล้ว"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "ข้อผิดพลาดของปลั๊กอิน"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "ข้อผิดพลาดของปลั๊กอิน ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:113
+msgid "Plugin not found"
+msgstr "ไม่พบปลั๊กอิน"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:293
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "ไม่พบปลั๊กอิน อาจระบุ handle ของผู้เผยแพร่หรือ Slug ไม่ถูกต้อง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1048
+msgid "plugin on your WordPress site."
+msgstr "plugin บนเว็บไซต์ WordPress ของคุณ"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "สิทธิ์ของปลั๊กอิน"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "ทะเบียนปลั๊กอิน"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "ปลั๊กอินตอบกลับด้วย {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:304
+msgid "Plugin uninstalled"
+msgstr "ถอนการติดตั้งปลั๊กอินแล้ว"
+
+#: packages/admin/src/lib/api/registry.ts:546
+msgid "Plugin update requires re-consent"
+msgstr "การอัปเดตปลั๊กอินต้องขอความยินยอมใหม่"
+
+#: packages/admin/src/components/PluginManager.tsx:257
+msgid "Plugin updated"
+msgstr "อัปเดตปลั๊กอินแล้ว"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:134
+#: packages/admin/src/components/PluginManager.tsx:143
+#: packages/admin/src/components/PluginManager.tsx:152
+#: packages/admin/src/components/Sidebar.tsx:215
+#: packages/admin/src/components/Sidebar.tsx:466
+msgid "Plugins"
+msgstr "ปลั๊กอิน"
+
+#: packages/admin/src/components/SeoPanel.tsx:182
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "ชี้ให้เครื่องมือค้นหาไปยังเวอร์ชันต้นฉบับของหน้านี้ หากซ้ำกับ URL อื่น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1161
+msgid "Posts"
+msgstr "โพสต์"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:295
+msgid "Posts Per Page"
+msgstr "จำนวนโพสต์ต่อหน้า"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:327
+msgid "Pre-release"
+msgstr "รุ่นก่อนเผยแพร่"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "กำลังเตรียมการลงทะเบียน..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2020
+msgid "Preparing to download files from WordPress..."
+msgstr "กำลังเตรียมดาวน์โหลดไฟล์จาก WordPress..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "กำลังเตรียม..."
+
+#: packages/admin/src/components/ContentEditor.tsx:679
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:427
+msgid "Preview"
+msgstr "ดูตัวอย่าง"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "ดูตัวอย่างเนื้อหาก่อนเผยแพร่"
+
+#: packages/admin/src/components/ContentEditor.tsx:679
+msgid "Preview draft"
+msgstr "ดูตัวอย่างฉบับร่าง"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "ก่อนหน้า"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:330
+msgid "Previous page"
+msgstr "หน้าก่อนหน้า"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:446
+msgid "Previous screenshot"
+msgstr "ภาพหน้าจอก่อนหน้า"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "การนำทางหลัก"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:202
+msgid "Provider:"
+msgstr "ผู้ให้บริการ:"
+
+#: packages/admin/src/components/ContentEditor.tsx:734
+#: packages/admin/src/components/ContentEditor.tsx:840
+msgid "Publish"
+msgstr "เผยแพร่"
+
+#: packages/admin/src/components/ContentEditor.tsx:724
+msgid "Publish changes"
+msgstr "เผยแพร่การเปลี่ยนแปลง"
+
+#: packages/admin/src/components/ContentList.tsx:725
+msgid "published"
+msgstr "เผยแพร่แล้ว"
+
+#: packages/admin/src/components/ContentEditor.tsx:855
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/Dashboard.tsx:187
+#: packages/admin/src/router.tsx:778
+msgid "Published"
+msgstr "เผยแพร่แล้ว"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:327
+msgid "Published {0}"
+msgstr "เผยแพร่แล้ว {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "เผยแพร่เมื่อ"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:319
+msgid "Published by"
+msgstr "เผยแพร่โดย"
+
+#: packages/admin/src/components/ContentEditor.tsx:2115
+msgid "Quick create byline"
+msgstr "สร้างชื่อผู้เขียนแบบด่วน"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:167
+#: packages/admin/src/components/editor/ImageNode.tsx:168
+msgid "Quick edit alt text"
+msgstr "แก้ไขข้อความ alt แบบด่วน"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:85
+#: packages/admin/src/components/PortableTextEditor.tsx:907
+#: packages/admin/src/components/PortableTextEditor.tsx:2887
+msgid "Quote"
+msgstr "คำพูดอ้างอิง"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "อ่านสคีมาของคอลเลกชัน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "อ่านรายการเนื้อหา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "อ่านไฟล์มีเดีย"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "อ่านการตั้งค่าเว็บไซต์"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Read user accounts"
+msgstr "อ่านบัญชีผู้ใช้"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:230
+msgid "Read your content"
+msgstr "อ่านเนื้อหาของคุณ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:292
+msgid "Reading"
+msgstr "การอ่าน"
+
+#: packages/admin/src/components/WordPressImport.tsx:1822
+msgid "Ready"
+msgstr "พร้อม"
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr "กิจกรรมล่าสุด"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "อัปเดตล่าสุด"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:144
+msgid "Recipient email"
+msgstr "อีเมลผู้รับ"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "ส่งลิงก์กู้คืนไปยัง {0} แล้ว"
+
+#: packages/admin/src/components/Redirects.tsx:416
+msgid "Redirect loop detected"
+msgstr "ตรวจพบการวนซ้ำของการเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "กำลังเปลี่ยนเส้นทางไปยังหน้าเข้าสู่ระบบ..."
+
+#: packages/admin/src/components/Redirects.tsx:332
+#: packages/admin/src/components/Redirects.tsx:351
+#: packages/admin/src/components/Sidebar.tsx:199
+msgid "Redirects"
+msgstr "การเปลี่ยนเส้นทาง"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3023
+msgid "Redo"
+msgstr "ทำซ้ำ"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "การอ้างอิง"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:251
+msgid "Referenced favicon unavailable."
+msgstr "ไม่สามารถใช้ favicon ที่อ้างอิงได้"
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "ลงทะเบียน"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:220
+msgid "Register Passkey"
+msgstr "ลงทะเบียน Passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "ผู้ใช้ที่ลงทะเบียนแล้ว"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "การลงทะเบียนล้มเหลว"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "การลงทะเบียนถูกยกเลิกหรือหมดเวลา โปรดลองอีกครั้ง"
+
+#: packages/admin/src/components/Sidebar.tsx:221
+msgid "Registry"
+msgstr "รีจิสทรี"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:429
+msgid "Release is too new to install"
+msgstr "รุ่นนี้ใหม่เกินกว่าจะติดตั้งได้"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentEditor.tsx:2084
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/PortableTextEditor.tsx:2986
+#: packages/admin/src/components/settings/GeneralSettings.tsx:217
+#: packages/admin/src/components/settings/GeneralSettings.tsx:271
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
+#: packages/admin/src/components/settings/SeoSettings.tsx:209
+msgid "Remove"
+msgstr "นำออก"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:222
+msgid "Remove {0}"
+msgstr "นำออก {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "นำออก {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1876
+msgid "Remove {label}"
+msgstr "นำออก {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
+msgid "Remove Domain"
+msgstr "นำโดเมนออก"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
+msgid "Remove Domain?"
+msgstr "นำโดเมนออกหรือไม่"
+
+#: packages/admin/src/components/ContentEditor.tsx:1673
+#: packages/admin/src/components/ContentEditor.tsx:1702
+#: packages/admin/src/components/SeoImageField.tsx:55
+msgid "Remove image"
+msgstr "นำรูปภาพออก"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr "นำรูปภาพออก"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr "นำรูปภาพออกหรือไม่"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1690
+#: packages/admin/src/components/RepeaterField.tsx:270
+msgid "Remove item {0}"
+msgstr "นำรายการ {0} ออก"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2487
+#: packages/admin/src/components/PortableTextEditor.tsx:2488
+msgid "Remove link"
+msgstr "นำลิงก์ออก"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr "นำ passkey ออก"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr "นำ passkey ออกหรือไม่"
+
+#: packages/admin/src/components/FieldEditor.tsx:610
+msgid "Remove sub-field"
+msgstr "นำฟิลด์ย่อยออก"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr "นำรูปภาพนี้ออกจากเอกสารหรือไม่"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
+msgid "Removing..."
+msgstr "กำลังนำออก..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr "เปลี่ยนชื่อ"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr "เปลี่ยนชื่อ {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr "เปลี่ยนชื่อ passkey"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Repeater"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "กลุ่มฟิลด์ที่ทำซ้ำได้"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr "แทนที่รูปภาพ"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "ตอบกลับถึง:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "ที่เก็บข้อมูล"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "ขอลิงก์ใหม่"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:721
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:592
+msgid "Required"
+msgstr "ต้องระบุ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1835
+msgid "Required fields:"
+msgstr "ฟิลด์ที่ต้องระบุ:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "ต้องระบุเพื่อการเข้าถึง อธิบายรูปภาพสำหรับโปรแกรมอ่านหน้าจอ"
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:325
+msgid "Requires EmDash {0}"
+msgstr "ต้องใช้ EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "ส่งอีเมลอีกครั้ง"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "ส่งอีกครั้งใน {resendCooldown} วินาที"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr "รีเซ็ตเป็นค่าดั้งเดิม"
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restore"
+msgstr "กู้คืน"
+
+#: packages/admin/src/components/ContentList.tsx:661
+msgid "Restore {title}"
+msgstr "กู้คืน {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:136
+msgid "Restore failed"
+msgstr "การกู้คืนล้มเหลว"
+
+#: packages/admin/src/components/RevisionHistory.tsx:214
+msgid "Restore Revision?"
+msgstr "กู้คืนรุ่นแก้ไขหรือไม่"
+
+#: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Restore this version"
+msgstr "กู้คืนเวอร์ชันนี้"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:217
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "กู้คืนเวอร์ชันนี้จาก {0} หรือไม่? การดำเนินการนี้จะอัปเดตเนื้อหาปัจจุบันเป็นข้อมูลของรุ่นแก้ไขนี้"
+
+#: packages/admin/src/components/RevisionHistory.tsx:221
+msgid "Restoring..."
+msgstr "กำลังกู้คืน..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:1829
+msgid "Retry"
+msgstr "ลองใหม่"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "บล็อกเนื้อหาที่นำกลับมาใช้ซ้ำได้ ซึ่งคุณสามารถแทรกลงในเนื้อหาใดก็ได้"
+
+#: packages/admin/src/router.tsx:812
+msgid "Reverted to published version"
+msgstr "เปลี่ยนกลับเป็นเวอร์ชันที่เผยแพร่แล้ว"
+
+#: packages/admin/src/components/WordPressImport.tsx:650
+msgid "Review"
+msgstr "ตรวจสอบ"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "ตรวจสอบสิทธิ์ใหม่"
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Revision restored"
+msgstr "กู้คืนรุ่นแก้ไขแล้ว"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:161
+msgid "Revisions"
+msgstr "รุ่นแก้ไข"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
+msgid "Revoke token"
+msgstr "เพิกถอนโทเค็น"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoke?"
+msgstr "เพิกถอนหรือไม่?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Revoking..."
+msgstr "กำลังเพิกถอน..."
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Rich Text"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "เนื้อหา Rich Text"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "ตัวแก้ไข Rich Text"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:312
+msgid "Risk score: {0}/100"
+msgstr "คะแนนความเสี่ยง: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "บทบาท"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "บทบาท {role}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2089
+msgid "Role label"
+msgstr "ป้ายกำกับบทบาท"
+
+#: packages/admin/src/components/MenuEditor.tsx:343
+#: packages/admin/src/components/MenuEditor.tsx:345
+#: packages/admin/src/components/MenuEditor.tsx:514
+#: packages/admin/src/components/MenuEditor.tsx:516
+msgid "Same window"
+msgstr "หน้าต่างเดียวกัน"
+
+#: packages/admin/src/components/ContentEditor.tsx:2222
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/editor/ImageNode.tsx:235
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:525
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:456
+msgid "Save"
+msgstr "บันทึก"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "บันทึก (Enter)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:236
+msgid "Save alt text"
+msgstr "บันทึกข้อความแสดงแทน"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "บันทึกการเปลี่ยนแปลง"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "บันทึกเนื้อหาเป็นฉบับร่างก่อนเผยแพร่"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "บันทึกชื่อ"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+msgid "Save SEO Settings"
+msgstr "บันทึกการตั้งค่า SEO"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Save Settings"
+msgstr "บันทึกการตั้งค่า"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+msgid "Save Social Links"
+msgstr "บันทึกลิงก์โซเชียล"
+
+#: packages/admin/src/components/ContentEditor.tsx:654
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr "บันทึกแล้ว"
+
+#: packages/admin/src/components/ContentEditor.tsx:649
+#: packages/admin/src/components/ContentEditor.tsx:2222
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/FieldEditor.tsx:659
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:525
+#: packages/admin/src/components/Redirects.tsx:180
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+#: packages/admin/src/components/TaxonomyManager.tsx:474
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:456
+msgid "Saving..."
+msgstr "กำลังบันทึก..."
+
+#: packages/admin/src/components/ContentEditor.tsx:899
+msgid "Schedule"
+msgstr "กำหนดเวลา"
+
+#: packages/admin/src/components/ContentEditor.tsx:885
+msgid "Schedule for"
+msgstr "กำหนดเวลาสำหรับ"
+
+#: packages/admin/src/components/ContentEditor.tsx:922
+msgid "Schedule for later"
+msgstr "กำหนดเวลาสำหรับภายหลัง"
+
+#: packages/admin/src/components/ContentList.tsx:729
+msgid "scheduled"
+msgstr "กำหนดเวลา"
+
+#: packages/admin/src/components/ContentEditor.tsx:862
+#: packages/admin/src/router.tsx:829
+msgid "Scheduled"
+msgstr "กำหนดเวลา"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:872
+msgid "Scheduled for: {0}"
+msgstr "กำหนดเวลาสำหรับ: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Schema Changes"
+msgstr "การเปลี่ยนแปลงสคีมา"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Schema preparation failed"
+msgstr "การเตรียมสคีมาล้มเหลว"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "อ่านสคีมา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "เขียนสคีมา"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
+msgid "Scopes"
+msgstr "ขอบเขต"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
+msgid "Scopes: {0}"
+msgstr "ขอบเขต: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:244
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "ภาพหน้าจอ {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:454
+msgid "Screenshot {0} of {1}"
+msgstr "ภาพหน้าจอ {0} จาก {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:247
+msgid "Screenshot blurred due to image audit"
+msgstr "ภาพหน้าจอถูกเบลอเนื่องจากการตรวจสอบรูปภาพ"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:432
+msgid "Screenshot viewer"
+msgstr "ตัวดูภาพหน้าจอ"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:234
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "ภาพหน้าจอ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+msgid "Search"
+msgstr "ค้นหา"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:197
+msgid "Search {0}"
+msgstr "ค้นหา {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:196
+msgid "Search {0}..."
+msgstr "ค้นหา {0}..."
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "ค้นหาตามชื่อหรืออีเมล..."
+
+#: packages/admin/src/routes/bylines.tsx:314
+msgid "Search bylines"
+msgstr "ค้นหาชื่อผู้เขียน"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "ค้นหาความคิดเห็น"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "ค้นหาความคิดเห็น..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "ค้นหาเนื้อหา..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:155
+msgid "Search Engine Optimization"
+msgstr "Search Engine Optimization"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "การทำ SEO และการยืนยัน"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:565
+msgid "Search media"
+msgstr "ค้นหามีเดีย"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "ค้นหาหน้าและเนื้อหา..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "ค้นหาปลั๊กอิน"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "ค้นหาปลั๊กอิน..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "ค้นหาส่วน..."
+
+#: packages/admin/src/components/Redirects.tsx:383
+msgid "Search source or destination..."
+msgstr "ค้นหาต้นทางหรือปลายทาง..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "ค้นหาธีม"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "ค้นหาธีม..."
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "ค้นหาผู้ใช้"
+
+#: packages/admin/src/components/MediaLibrary.tsx:342
+#: packages/admin/src/components/MediaPickerModal.tsx:564
+msgid "Search..."
+msgstr "ค้นหา..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:723
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "ค้นหาได้"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2002
+msgid "Section"
+msgstr "ส่วน"
+
+#: packages/admin/src/components/SectionEditor.tsx:82
+msgid "Section \"{slug}\" could not be found."
+msgstr "ไม่พบส่วน \"{slug}\""
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "สร้างส่วนแล้ว"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "ลบส่วนแล้ว"
+
+#: packages/admin/src/components/SectionEditor.tsx:233
+msgid "Section Details"
+msgstr "รายละเอียดส่วน"
+
+#: packages/admin/src/components/SectionEditor.tsx:78
+msgid "Section Not Found"
+msgstr "ไม่พบส่วน"
+
+#: packages/admin/src/components/SectionEditor.tsx:44
+msgid "Section saved"
+msgstr "บันทึกส่วนแล้ว"
+
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "Section title"
+msgstr "ชื่อส่วน"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:201
+msgid "Sections"
+msgstr "ส่วน"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "secure context"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "รักษาความปลอดภัยบัญชีของคุณ"
+
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "ความปลอดภัย"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:308
+msgid "Security Audit"
+msgstr "การตรวจสอบความปลอดภัย"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "การตรวจสอบความปลอดภัยล้มเหลว"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "การตรวจสอบความปลอดภัยพบข้อกังวล"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "การตรวจสอบความปลอดภัยพบข้อกังวลที่อาจเกิดขึ้นกับปลั๊กอินนี้"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "การตรวจสอบความปลอดภัยระบุว่าปลั๊กอินนี้อาจไม่ปลอดภัย"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "ผ่านการตรวจสอบความปลอดภัย"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:491
+msgid "Security contacts"
+msgstr "ผู้ติดต่อด้านความปลอดภัย"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "เกิดข้อผิดพลาดด้านความปลอดภัย ตรวจสอบให้แน่ใจว่าคุณกำลังใช้การเชื่อมต่อที่ปลอดภัย"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+msgid "Security Settings"
+msgstr "ตั้งค่าความปลอดภัย"
+
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "เลือก"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1730
+#: packages/admin/src/components/ContentEditor.tsx:1888
+#: packages/admin/src/components/ContentEditor.tsx:1904
+msgid "Select {label}"
+msgstr "เลือก {label}"
+
+#: packages/admin/src/components/Widgets.tsx:871
+msgid "Select a component..."
+msgstr "เลือกคอมโพเนนต์..."
+
+#: packages/admin/src/components/Widgets.tsx:839
+msgid "Select a menu..."
+msgstr "เลือกเมนู..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "เลือกทั้งหมด"
+
+#: packages/admin/src/components/ContentEditor.tsx:2032
+msgid "Select byline"
+msgstr "เลือกชื่อผู้เขียน"
+
+#: packages/admin/src/components/ContentEditor.tsx:2029
+msgid "Select byline..."
+msgstr "เลือกชื่อผู้เขียน..."
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "เลือกความคิดเห็นโดย {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "เลือกเนื้อหา"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:268
+msgid "Select Default Social Image"
+msgstr "เลือกรูปภาพโซเชียลเริ่มต้น"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:283
+#: packages/admin/src/components/settings/GeneralSettings.tsx:344
+msgid "Select Favicon"
+msgstr "เลือก Favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1892
+msgid "Select file"
+msgstr "เลือกไฟล์"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:138
+msgid "Select File"
+msgstr "เลือกไฟล์"
+
+#: packages/admin/src/components/ContentEditor.tsx:1718
+msgid "Select image"
+msgstr "เลือกรูปภาพ"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:138
+#: packages/admin/src/components/PortableTextEditor.tsx:2375
+#: packages/admin/src/components/PortableTextEditor.tsx:3048
+#: packages/admin/src/components/settings/SeoSettings.tsx:221
+msgid "Select Image"
+msgstr "เลือกรูปภาพ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:229
+#: packages/admin/src/components/settings/GeneralSettings.tsx:336
+msgid "Select Logo"
+msgstr "เลือกโลโก้"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "เลือกมีเดีย"
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr "เลือกรูปภาพ OG"
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr "เลือกรูปภาพ OG"
+
+#: packages/admin/src/components/WordPressImport.tsx:1571
+msgid "Select which content types to import."
+msgstr "เลือกประเภทเนื้อหาที่จะนำเข้า"
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:1785
+#: packages/admin/src/components/RepeaterField.tsx:361
+msgid "Select..."
+msgstr "เลือก..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:719
+msgid "Selected:"
+msgstr "เลือกแล้ว:"
+
+#: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
+msgid "Self-Signup Domains"
+msgstr "โดเมนสำหรับสมัครใช้งานด้วยตนเอง"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:139
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "ส่งอีเมลทดสอบผ่านไปป์ไลน์ทั้งหมดเพื่อตรวจสอบการตั้งค่าอีเมลของคุณ"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "ส่งอีเมลเชิญไปยังสมาชิกทีมใหม่"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr "ส่งคำเชิญ"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "ส่งลิงก์เข้าสู่ระบบ"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "ส่งลิงก์กู้คืน"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Send Test"
+msgstr "ส่งการทดสอบ"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:136
+msgid "Send Test Email"
+msgstr "ส่งอีเมลทดสอบ"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "กำลังส่ง..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1043
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "SEO Settings"
+msgstr "ตั้งค่า SEO"
+
+#: packages/admin/src/components/WordPressImport.tsx:1679
+msgid "SEO settings (Yoast)"
+msgstr "การตั้งค่า SEO (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:57
+msgid "SEO settings saved"
+msgstr "บันทึกการตั้งค่า SEO แล้ว"
+
+#: packages/admin/src/components/SeoPanel.tsx:154
+msgid "SEO Title"
+msgstr "ชื่อ SEO"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr "กำหนดขนาดการแสดงผลที่กำหนดเองสำหรับอินสแตนซ์รูปภาพนี้"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:170
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:174
+msgid "Set language"
+msgstr "ตั้งค่าภาษา"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "Set language (current: {label})"
+msgstr "ตั้งค่าภาษา (ปัจจุบัน: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:531
+msgid "Set to 0 to never close comments automatically."
+msgstr "ตั้งค่าเป็น 0 เพื่อไม่ปิดความคิดเห็นโดยอัตโนมัติ"
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "ตั้งค่าเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "กำลังตั้งค่า..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentTypeEditor.tsx:383
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:433
+#: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:245
+#: packages/admin/src/components/WordPressImport.tsx:1647
+msgid "Settings"
+msgstr "ตั้งค่า"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "จัดการการตั้งค่า"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "อ่านการตั้งค่า"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:53
+msgid "Settings saved successfully"
+msgstr "บันทึกการตั้งค่าสำเร็จ"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "การตั้งค่าล้มเหลว"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "แชร์ลิงก์นี้กับผู้ใช้ที่ได้รับเชิญ"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "ข้อความสั้น"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "แสดงโทเค็น"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr "แสดงเมื่อชี้เมาส์เหนือรูปภาพ"
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "เข้าสู่ระบบ"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "เข้าสู่ระบบ"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "เข้าสู่ระบบแทน"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "เข้าสู่ระบบเว็บไซต์ของคุณ"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "เข้าสู่ระบบด้วย {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "เข้าสู่ระบบด้วยอีเมล"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "เข้าสู่ระบบด้วยลิงก์อีเมล"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "เข้าสู่ระบบด้วย Passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "เข้าสู่ระบบในชื่อ {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "เลือกได้หนึ่งตัวเลือกจากรายการ"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "ช่องป้อนข้อความบรรทัดเดียว"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "เว็บไซต์"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr "เอกลักษณ์เว็บไซต์"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "เอกลักษณ์เว็บไซต์ โลโก้ favicon และการตั้งค่าการอ่าน"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+msgid "Site Settings"
+msgstr "ตั้งค่าเว็บไซต์"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "ชื่อเว็บไซต์"
+
+#: packages/admin/src/components/WordPressImport.tsx:1659
+msgid "Site title & tagline"
+msgstr "ชื่อเว็บไซต์และคำโปรย"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "ต้องระบุชื่อเว็บไซต์"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr "URL เว็บไซต์"
+
+#: packages/admin/src/components/MediaLibrary.tsx:430
+msgid "Size"
+msgstr "ขนาด"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:170
+msgid "Size:"
+msgstr "ขนาด:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1940
+msgid "Skip Media Import"
+msgstr "ข้ามการนำเข้ามีเดีย"
+
+#: packages/admin/src/components/WordPressImport.tsx:1965
+msgid "Skipped"
+msgstr "ข้ามแล้ว"
+
+#: packages/admin/src/components/ContentEditor.tsx:843
+#: packages/admin/src/components/ContentEditor.tsx:2131
+#: packages/admin/src/components/ContentEditor.tsx:2193
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:404
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:244
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:396
+#: packages/admin/src/routes/bylines.tsx:399
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "คัดลอก Slug ไปยังคลิปบอร์ดแล้ว"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:878
+msgid "Small section heading"
+msgstr "หัวข้อส่วนขนาดเล็ก"
+
+#: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:78
+#: packages/admin/src/components/settings/SocialSettings.tsx:103
+msgid "Social Links"
+msgstr "ลิงก์โซเชียล"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:48
+msgid "Social links saved"
+msgstr "บันทึกลิงก์โซเชียลแล้ว"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "ลิงก์โปรไฟล์โซเชียลมีเดีย"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:126
+msgid "Social Profiles"
+msgstr "โปรไฟล์โซเชียล"
+
+#: packages/admin/src/components/WordPressImport.tsx:1696
+msgid "Some content types cannot be imported"
+msgstr "เนื้อหาบางประเภทไม่สามารถนำเข้าได้"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:122
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "เกิดข้อผิดพลาดบางอย่าง"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "จัดเรียงปลั๊กอิน"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "จัดเรียงธีม"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:215
+#: packages/admin/src/components/PluginManager.tsx:493
+#: packages/admin/src/components/Redirects.tsx:440
+#: packages/admin/src/components/SectionEditor.tsx:279
+msgid "Source"
+msgstr "แหล่งที่มา"
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr "พาธแหล่งที่มา"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "สแปม"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "สแปม"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3036
+msgid "Spotlight Mode"
+msgstr "โหมดสปอตไลต์"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "สเปรดชีต"
+
+#: packages/admin/src/components/WordPressImport.tsx:1758
+msgid "Start Import"
+msgstr "เริ่มการนำเข้า"
+
+#: packages/admin/src/components/ContentEditor.tsx:849
+#: packages/admin/src/components/ContentList.tsx:245
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:445
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "สถานะ"
+
+#: packages/admin/src/components/Redirects.tsx:146
+msgid "Status code"
+msgstr "รหัสสถานะ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2520
+#: packages/admin/src/components/PortableTextEditor.tsx:2826
+msgid "Strikethrough"
+msgstr "ขีดทับ"
+
+#: packages/admin/src/components/WordPressImport.tsx:1591
+msgid "Structure"
+msgstr "โครงสร้าง"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "ฟิลด์ย่อย"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "ผู้ติดตาม"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "ซิงค์แล้ว"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Passkey ที่ซิงค์แล้ว"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:768
+msgid "System"
+msgstr "ระบบ"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "ระบบ ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:590
+msgid "System Fields"
+msgstr "ฟิลด์ของระบบ"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:937
+msgid "Table"
+msgstr "ตาราง"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "คำโปรย"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "แท็ก"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1633
+msgid "Tags ({0})"
+msgstr "แท็ก ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:340
+#: packages/admin/src/components/MenuEditor.tsx:511
+msgid "Target"
+msgstr "เป้าหมาย"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "ภาษาเป้าหมาย"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:495
+msgid "Taxonomies"
+msgstr "อนุกรมวิธาน"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "จัดการอนุกรมวิธาน"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:896
+msgid "Taxonomy created"
+msgstr "สร้างอนุกรมวิธานแล้ว"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:783
+msgid "Taxonomy not found:"
+msgstr "ไม่พบอนุกรมวิธาน:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "อนุกรมวิธาน: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "เทมเพลต:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:360
+#: packages/admin/src/components/TaxonomyManager.tsx:812
+msgid "Term"
+msgstr "เทอม"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:757
+msgid "Term \"{0}\" created in {1}."
+msgstr "สร้างเทอม \"{0}\" ใน {1} แล้ว"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:739
+msgid "Term deleted"
+msgstr "ลบเทอมแล้ว"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2796
+msgid "Text formatting"
+msgstr "การจัดรูปแบบข้อความ"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "อุปกรณ์จะไม่ได้รับสิทธิ์เข้าถึง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1698
+msgid "The existing collection has fields with incompatible types."
+msgstr "คอลเลกชันที่มีอยู่มีฟิลด์ที่มีประเภทไม่เข้ากัน"
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "ตารางต่อไปนี้มีเนื้อหาแต่ยังไม่ได้ลงทะเบียนเป็นคอลเลกชัน ลงทะเบียนเพื่อจัดการเนื้อหานี้ในส่วนผู้ดูแลระบบ"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr "ผู้ใช้ที่ได้รับเชิญจะมีบทบาทนี้เมื่อลงทะเบียนเสร็จสมบูรณ์"
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "ลิงก์จะหมดอายุใน 15 นาที"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "มาร์เก็ตเพลสว่างเปล่า กลับมาตรวจสอบในภายหลังสำหรับปลั๊กอินใหม่"
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "ลบเมนูแล้ว"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr "ชื่อเว็บไซต์ของคุณ ใช้ในส่วนหัวและข้อมูลเมตา"
+
+#: packages/admin/src/router.tsx:1843
+msgid "The page you're looking for doesn't exist."
+msgstr "ไม่พบหน้าที่คุณกำลังค้นหา"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "URL สาธารณะของเว็บไซต์ของคุณ (ใช้สำหรับลิงก์ canonical และไซต์แมป)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:189
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "รูปภาพที่อ้างอิงไม่พร้อมใช้งานอีกต่อไป เลือกรูปใหม่หรือนำการอ้างอิงออก"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:197
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "โลโก้ที่อ้างอิงไม่พร้อมใช้งานอีกต่อไป เลือกใหม่หรือนำการอ้างอิงออก"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "มาร์เก็ตเพลสธีมว่างเปล่า กลับมาตรวจสอบในภายหลัง"
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "ธีม"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:292
+msgid "Theme ID: {0}"
+msgstr "ID ธีม: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "ไม่พบธีม"
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Theme Section"
+msgstr "ส่วนของธีม"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "ไม่สามารถลบส่วนที่มาจากธีมได้ แก้ไขส่วนนี้เพื่อสร้างสำเนาที่กำหนดเอง แล้วจึงลบสำเนานั้น"
+
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr "ธีม: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:237
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "ธีม"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:372
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "คอลเลกชันนี้กำหนดไว้ในโค้ด การตั้งค่าบางอย่างไม่สามารถเปลี่ยนแปลงได้ที่นี่ แก้ไขไฟล์ live.config.ts ของคุณเพื่อปรับเปลี่ยนสคีมา"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:405
+msgid "This field does not accept {sniffedMime} files."
+msgstr "ฟิลด์นี้ไม่รองรับไฟล์ {sniffedMime}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1734
+#: packages/admin/src/components/ContentEditor.tsx:1907
+msgid "This field is required"
+msgstr "ฟิลด์นี้ต้องระบุ"
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "This is a custom section."
+msgstr "นี่เป็นส่วนที่กำหนดเอง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "This is a WordPress site."
+msgstr "นี่เป็นเว็บไซต์ WordPress"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "ลิงก์นี้หมดอายุใน 7 วันและใช้ได้เพียงครั้งเดียวเท่านั้น"
+
+#: packages/admin/src/components/WordPressImport.tsx:821
+msgid "This may take a while for large exports."
+msgstr "การดำเนินการนี้อาจใช้เวลาสักครู่สำหรับการส่งออกขนาดใหญ่"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Passkey นี้ลงทะเบียนบนอุปกรณ์นี้แล้ว"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:277
+msgid "This plugin requires no special permissions."
+msgstr "ปลั๊กอินนี้ไม่ต้องการสิทธิ์พิเศษใด ๆ"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:398
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "ผู้เผยแพร่นี้อ้างชื่อที่ไม่สามารถพิสูจน์ความเป็นเจ้าของได้ — อาจกำลังแอบอ้างเป็นบุคคลอื่น การติดตั้งถูกปิดใช้งาน หากคุณรู้จักผู้เผยแพร่และไว้วางใจพวกเขา ให้ขอให้พวกเขาแก้ไขการตั้งค่าตัวตนก่อนลองอีกครั้ง"
+
+#: packages/admin/src/components/Redirects.tsx:551
+msgid "This redirect rule will be permanently removed."
+msgstr "กฎการเปลี่ยนเส้นทางนี้จะถูกนำออกอย่างถาวร"
+
+#: packages/admin/src/routes/bylines.tsx:500
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "การดำเนินการนี้จะนำโปรไฟล์ชื่อผู้เขียนออก ลิงก์ชื่อผู้เขียนในเนื้อหาจะถูกนำออกและตัวชี้รายการนำจะถูกล้าง"
+
+#: packages/admin/src/components/SectionEditor.tsx:283
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "ส่วนนี้มาจากธีม การแก้ไขจะสร้างสำเนาที่กำหนดเองซึ่งจะแทนที่เวอร์ชันของธีม"
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This section was imported from another system."
+msgstr "ส่วนนี้นำเข้ามาจากระบบอื่น"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:119
+msgid "This update exposes the following routes without authentication:"
+msgstr "การอัปเดตนี้เปิดเผยเส้นทางต่อไปนี้โดยไม่มีการตรวจสอบสิทธิ์:"
+
+#: packages/admin/src/components/Widgets.tsx:635
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "การดำเนินการนี้จะลบพื้นที่วิดเจ็ตและวิดเจ็ตทั้งหมดในนั้น การดำเนินการนี้ไม่สามารถยกเลิกได้"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "การดำเนินการนี้จะให้สิทธิ์เข้าถึง CLI ด้วยสิทธิ์ของคุณ"
+
+#: packages/admin/src/components/ContentEditor.tsx:956
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "การดำเนินการนี้จะย้ายรายการไปยังถังขยะ คุณสามารถกู้คืนได้ในภายหลังจากถังขยะ"
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "การดำเนินการนี้จะลบ \"{0}\" อย่างถาวรและนำออกจากเนื้อหาทั้งหมด"
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "การดำเนินการนี้จะลบ \"{0}\" อย่างถาวร ไม่สามารถยกเลิกการดำเนินการนี้ได้"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "การดำเนินการนี้จะลบความคิดเห็นนี้อย่างถาวร ไม่สามารถยกเลิกการดำเนินการนี้ได้"
+
+#: packages/admin/src/components/PluginManager.tsx:625
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "การดำเนินการนี้จะนำปลั๊กอินและบันเดิลของปลั๊กอินออกจากเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/ContentEditor.tsx:699
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "การดำเนินการนี้จะย้อนกลับไปยังเวอร์ชันที่เผยแพร่แล้ว การเปลี่ยนแปลงในฉบับร่างของคุณจะสูญหาย"
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "ความคิด บทแนะนำ และอื่น ๆ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:310
+msgid "Timezone"
+msgstr "เขตเวลา"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "เขตเวลาสำหรับการแสดงวันที่ (เช่น America/New_York)"
+
+#: packages/admin/src/components/ContentList.tsx:239
+#: packages/admin/src/components/ContentList.tsx:367
+#: packages/admin/src/components/SectionEditor.tsx:236
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:811
+msgid "Title"
+msgstr "ชื่อ"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr "ชื่อ (Tooltip)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:159
+msgid "Title Separator"
+msgstr "ตัวคั่นชื่อ"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "เพื่อปิด"
+
+#: packages/admin/src/components/PluginManager.tsx:202
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "เพื่อติดตั้งปลั๊กอิน หรือเพิ่มลงใน astro.config.mjs ของคุณ"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "เพื่อเลือก"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2612
+msgid "Toggle header row"
+msgstr "สลับแถวส่วนหัว"
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr "สลับธีม (ปัจจุบัน: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "สร้างโทเค็นแล้ว: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
+msgid "Token Name"
+msgstr "ชื่อโทเค็น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "Tools → Export"
+msgstr "Tools → Export"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "ติดตามประวัติเนื้อหา"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translate"
+msgstr "แปล"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "แปล \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "แปล {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translating..."
+msgstr "กำลังแปล..."
+
+#: packages/admin/src/components/MenuEditor.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:756
+#: packages/admin/src/router.tsx:877
+msgid "Translation created"
+msgstr "สร้างคำแปลแล้ว"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:56
+msgid "Translations"
+msgstr "คำแปล"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "ถังขยะ"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:219
+msgid "Trash"
+msgstr "ถังขยะ"
+
+#: packages/admin/src/components/ContentList.tsx:390
+msgid "Trash is empty"
+msgstr "ถังขยะว่างเปล่า"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "ถังขยะว่างเปล่า"
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "สวิตช์จริง/เท็จ"
+
+#: packages/admin/src/components/MediaLibrary.tsx:378
+#: packages/admin/src/components/MediaPickerModal.tsx:628
+msgid "Try a different search term"
+msgstr "ลองใช้คำค้นหาอื่น"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "ลองปรับการค้นหาของคุณ"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "ลองปรับการค้นหาหรือตัวกรองของคุณ"
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "ลองอีกครั้ง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1421
+msgid "Try Again"
+msgstr "ลองอีกครั้ง"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "ลองรหัสอื่น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1125
+#: packages/admin/src/components/WordPressImport.tsx:1247
+msgid "Try Another URL"
+msgstr "ลอง URL อื่น"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "ลองด้วยข้อมูลของฉัน"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:279
+msgid "Turn into"
+msgstr "เปลี่ยนเป็น"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:132
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:429
+msgid "Type"
+msgstr "ประเภท"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1854
+msgid "Type mismatch ({0})"
+msgstr "ประเภทไม่ตรงกัน ({0})"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "ไม่สามารถเชื่อมต่อกับมาร์เก็ตเพลซได้"
+
+#: packages/admin/src/components/ContentEditor.tsx:2236
+#: packages/admin/src/components/ContentEditor.tsx:2251
+msgid "Unassigned"
+msgstr "ยังไม่ได้กำหนด"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2513
+#: packages/admin/src/components/PortableTextEditor.tsx:2819
+msgid "Underline"
+msgstr "ขีดเส้นใต้"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3016
+msgid "Undo"
+msgstr "เลิกทำ"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:181
+#: packages/admin/src/components/PluginManager.tsx:543
+#: packages/admin/src/components/PluginManager.tsx:639
+msgid "Uninstall"
+msgstr "ถอนการติดตั้ง"
+
+#: packages/admin/src/components/PluginManager.tsx:623
+msgid "Uninstall {pluginName}?"
+msgstr "ถอนการติดตั้ง {pluginName} หรือไม่?"
+
+#: packages/admin/src/components/PluginManager.tsx:618
+msgid "Uninstall confirmation"
+msgstr "การยืนยันการถอนการติดตั้ง"
+
+#: packages/admin/src/components/PluginManager.tsx:639
+msgid "Uninstalling..."
+msgstr "กำลังถอนการติดตั้ง..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:722
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "ไม่ซ้ำ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "ตัวระบุที่ไม่ซ้ำ (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "ไม่ทราบ"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "บทบาทที่ไม่รู้จัก"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr "ปลดล็อกอัตราส่วนภาพ"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Passkey ที่ไม่มีชื่อ"
+
+#: packages/admin/src/components/ContentEditor.tsx:728
+msgid "Unpublish"
+msgstr "ยกเลิกการเผยแพร่"
+
+#: packages/admin/src/router.tsx:794
+msgid "Unpublished"
+msgstr "ยกเลิกการเผยแพร่แล้ว"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "พบตารางเนื้อหาที่ยังไม่ได้ลงทะเบียน"
+
+#: packages/admin/src/components/ContentEditor.tsx:874
+msgid "Unschedule"
+msgstr "ยกเลิกการกำหนดเวลา"
+
+#: packages/admin/src/router.tsx:847
+msgid "Unscheduled"
+msgstr "ยกเลิกการกำหนดเวลาแล้ว"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "ประเภทองค์ประกอบวิดเจ็ตที่ไม่รองรับ: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr "ไม่มีชื่อ"
+
+#: packages/admin/src/components/ContentEditor.tsx:1810
+msgid "Untitled file"
+msgstr "ไฟล์ไม่มีชื่อ"
+
+#: packages/admin/src/components/Widgets.tsx:466
+#: packages/admin/src/components/Widgets.tsx:729
+msgid "Untitled Widget"
+msgstr "วิดเจ็ตไม่มีชื่อ"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "ผู้เผยแพร่ที่ยังไม่ได้รับการยืนยัน"
+
+#: packages/admin/src/components/ContentEditor.tsx:2063
+msgid "Up"
+msgstr "ขึ้น"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+msgid "Update"
+msgstr "อัปเดต"
+
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Update Field"
+msgstr "อัปเดตฟิลด์"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
+msgid "Update settings for {0}"
+msgstr "อัปเดตการตั้งค่าสำหรับ {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "อัปเดตการตั้งค่าเว็บไซต์"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:364
+msgid "Update the {0} details"
+msgstr "อัปเดตรายละเอียดของ {0}"
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr "อัปเดตกฎการเปลี่ยนเส้นทางนี้"
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:413
+msgid "Update to v{0}"
+msgstr "อัปเดตเป็น v{0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "อัปเดตเมื่อ"
+
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:931
+msgid "Updated: {0}"
+msgstr "อัปเดตแล้ว: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:844
+msgid "Updating content URLs..."
+msgstr "กำลังอัปเดต URL ของเนื้อหา..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:166
+#: packages/admin/src/components/PluginManager.tsx:413
+msgid "Updating..."
+msgstr "กำลังอัปเดต..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:586
+msgid "Upload"
+msgstr "อัปโหลด"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:140
+msgid "Upload a file to get started"
+msgstr "อัปโหลดไฟล์เพื่อเริ่มต้น"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Upload an export file"
+msgstr "อัปโหลดไฟล์ส่งออก"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:141
+msgid "Upload an image to get started"
+msgstr "อัปโหลดรูปภาพเพื่อเริ่มต้น"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "อัปโหลดและลบมีเดีย"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Upload and manage media"
+msgstr "อัปโหลดและจัดการมีเดีย"
+
+#: packages/admin/src/components/WordPressImport.tsx:1123
+#: packages/admin/src/components/WordPressImport.tsx:1244
+msgid "Upload Export File"
+msgstr "อัปโหลดไฟล์ส่งออก"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:606
+msgid "Upload failed: {uploadError}"
+msgstr "อัปโหลดล้มเหลว: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:598
+msgid "Upload file"
+msgstr "อัปโหลดไฟล์"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:142
+msgid "Upload File"
+msgstr "อัปโหลดไฟล์"
+
+#: packages/admin/src/components/MediaLibrary.tsx:329
+msgid "Upload files"
+msgstr "อัปโหลดไฟล์"
+
+#: packages/admin/src/components/MediaLibrary.tsx:369
+msgid "Upload Files"
+msgstr "อัปโหลดไฟล์"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:142
+msgid "Upload Image"
+msgstr "อัปโหลดรูปภาพ"
+
+#: packages/admin/src/components/MediaLibrary.tsx:366
+msgid "Upload images, videos, and documents to get started."
+msgstr "อัปโหลดรูปภาพ วิดีโอ และเอกสารเพื่อเริ่มต้น"
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr "อัปโหลดมีเดีย"
+
+#: packages/admin/src/components/MediaLibrary.tsx:380
+msgid "Upload media to get started"
+msgstr "อัปโหลดมีเดียเพื่อเริ่มต้น"
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:320
+msgid "Upload to {0}"
+msgstr "อัปโหลดไปยัง {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:960
+msgid "Upload WordPress export file"
+msgstr "อัปโหลดไฟล์ส่งออก WordPress"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:184
+msgid "Uploaded:"
+msgstr "อัปโหลดแล้ว:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1963
+msgid "Uploading"
+msgstr "กำลังอัปโหลด"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:295
+msgid "Uploading {0}/{1}..."
+msgstr "กำลังอัปโหลด {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:296
+#: packages/admin/src/components/MediaPickerModal.tsx:586
+msgid "Uploading..."
+msgstr "กำลังอัปโหลด..."
+
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:331
+#: packages/admin/src/components/MenuEditor.tsx:501
+#: packages/admin/src/components/PortableTextEditor.tsx:2952
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:425
+msgid "URL Pattern"
+msgstr "รูปแบบ URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "ตัวระบุที่เหมาะกับ URL"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "ตัวระบุที่เหมาะกับ URL (เช่น \"primary\", \"footer\")"
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "ใช้ [param] หรือ [...rest] ในเส้นทางเพื่อจับคู่รูปแบบ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "ใช้การยืนยันตัวตนด้วยข้อมูลชีวมาตรของอุปกรณ์ คีย์รักษาความปลอดภัย หรือ PIN เพื่อเข้าสู่ระบบ"
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "ใช้ Passkey ที่ลงทะเบียนไว้เพื่อเข้าสู่ระบบอย่างปลอดภัย"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:173
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "ใช้เป็นรูปภาพ Open Graph สำรองเมื่อหน้าไม่มีรูปภาพ ขนาดที่แนะนำ: 1200×630"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:642
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "ใช้เป็นตัวระบุ ใช้ได้เฉพาะตัวอักษรพิมพ์เล็ก ตัวเลข และขีดล่างเท่านั้น"
+
+#: packages/admin/src/components/ContentEditor.tsx:1325
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "ใช้เป็นภาพหลักของโพสต์นี้ในหน้ารายการและที่ส่วนบนของโพสต์"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Used by screen readers and when image fails to load"
+msgstr "ใช้โดยโปรแกรมอ่านหน้าจอและเมื่อรูปภาพโหลดไม่สำเร็จ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:410
+msgid "Used in URLs and API endpoints"
+msgstr "ใช้ใน URL และ API endpoint"
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "ใช้เพื่อระบุส่วนนี้ ใช้ได้เฉพาะตัวอักษรพิมพ์เล็ก ตัวเลข และยัติภังค์เท่านั้น"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "ผู้ใช้"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "การเข้าถึงของผู้ใช้ถูกจัดการโดยผู้ให้บริการภายนอก ({0}) การตั้งค่าโดเมนสำหรับการสมัครด้วยตนเองไม่พร้อมใช้งานเมื่อใช้การยืนยันตัวตนภายนอก"
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "รายละเอียดผู้ใช้"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "ไม่พบผู้ใช้"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:214
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "ผู้ใช้"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
+msgid "Users from"
+msgstr "ผู้ใช้จาก"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "ผู้ใช้ที่มีที่อยู่อีเมลจากโดเมนเหล่านี้สามารถสมัครใช้งานได้โดยไม่ต้องมีคำเชิญ และจะได้รับมอบหมายบทบาทที่ระบุไว้โดยอัตโนมัติ"
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:357
+msgid "v{0} available"
+msgstr "มี v{0} ให้ใช้งาน"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "การตรวจสอบความถูกต้อง"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:314
+msgid "Verified publisher"
+msgstr "ผู้เผยแพร่ที่ได้รับการยืนยัน"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:194
+msgid "Verifying your invite..."
+msgstr "กำลังยืนยันคำเชิญของคุณ..."
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "กำลังยืนยันลิงก์ของคุณ..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "กำลังยืนยัน..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:321
+#: packages/admin/src/components/RegistryPluginDetail.tsx:334
+msgid "Version"
+msgstr "เวอร์ชัน"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:325
+msgid "Version {0}"
+msgstr "เวอร์ชัน {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "ดูสถานะผู้ให้บริการอีเมลและส่งอีเมลทดสอบ"
+
+#: packages/admin/src/components/PluginManager.tsx:425
+msgid "View in Marketplace"
+msgstr "ดูใน Marketplace"
+
+#: packages/admin/src/components/MediaLibrary.tsx:233
+msgid "View mode"
+msgstr "โหมดการแสดงผล"
+
+#: packages/admin/src/components/ContentList.tsx:577
+msgid "View published {title}"
+msgstr "ดู {title} ที่เผยแพร่แล้ว"
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr "ดูเว็บไซต์"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:449
+msgid "View source"
+msgstr "ดูซอร์ส"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:681
+msgid "View the {license} license on spdx.org"
+msgstr "ดูสัญญาอนุญาต {license} บน spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:422
+msgid "Visitors hitting these paths will see an error."
+msgstr "ผู้เข้าชมที่เข้าถึงเส้นทางเหล่านี้จะพบข้อผิดพลาด"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "กำลังรอ Passkey..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "เตือน"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "เราไม่สามารถเชื่อมต่อกับเว็บไซต์ WordPress ที่ {0} ได้ อาจเป็นเพราะเว็บไซต์ไม่ใช่ WordPress, REST API ถูกปิดใช้งาน หรือไม่สามารถเข้าถึงเว็บไซต์ได้"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:396
+msgid "We couldn't verify this publisher's identity"
+msgstr "เราไม่สามารถยืนยันตัวตนของผู้เผยแพร่รายนี้ได้"
+
+#: packages/admin/src/components/WordPressImport.tsx:926
+msgid "We'll check what import options are available for your site."
+msgstr "เราจะตรวจสอบว่ามีตัวเลือกการนำเข้าใดบ้างที่พร้อมใช้งานสำหรับเว็บไซต์ของคุณ"
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "เราจะส่งลิงก์ให้คุณเพื่อเข้าสู่ระบบโดยไม่ต้องใช้รหัสผ่าน"
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "เราได้ส่งลิงก์ยืนยันไปยัง"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "ที่อยู่เว็บ"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn ไม่รองรับในเบราว์เซอร์นี้"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:226
+#: packages/admin/src/components/RegistryPluginDetail.tsx:474
+msgid "Website"
+msgstr "เว็บไซต์"
+
+#: packages/admin/src/routes/bylines.tsx:404
+msgid "Website URL"
+msgstr "URL ของเว็บไซต์"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "ยินดีต้อนรับสู่ EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "ยินดีต้อนรับสู่ EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1927
+msgid "What happens when you import:"
+msgstr "สิ่งที่จะเกิดขึ้นเมื่อคุณนำเข้า:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1710
+msgid "What will happen when you import"
+msgstr "สิ่งที่จะเกิดขึ้นเมื่อคุณนำเข้า"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "เวลาที่สร้างรายการ"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "เวลาที่แก้ไขรายการครั้งล่าสุด"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "เวลาที่เผยแพร่รายการ"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Which content types can use this taxonomy"
+msgstr "ประเภทเนื้อหาใดบ้างที่ใช้อนุกรมวิธานนี้ได้"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "จำนวนเต็ม"
+
+#: packages/admin/src/components/Widgets.tsx:722
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "widget"
+msgstr "วิดเจ็ต"
+
+#: packages/admin/src/components/Widgets.tsx:170
+msgid "Widget added"
+msgstr "เพิ่มวิดเจ็ตแล้ว"
+
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Widget area created"
+msgstr "สร้างพื้นที่วิดเจ็ตแล้ว"
+
+#: packages/admin/src/components/Widgets.tsx:565
+msgid "Widget area deleted"
+msgstr "ลบพื้นที่วิดเจ็ตแล้ว"
+
+#: packages/admin/src/components/Widgets.tsx:685
+msgid "Widget deleted"
+msgstr "ลบวิดเจ็ตแล้ว"
+
+#: packages/admin/src/components/Widgets.tsx:814
+msgid "Widget title"
+msgstr "ชื่อวิดเจ็ต"
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Widget updated"
+msgstr "อัปเดตวิดเจ็ตแล้ว"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:378
+#: packages/admin/src/components/Sidebar.tsx:200
+#: packages/admin/src/components/Widgets.tsx:325
+msgid "Widgets"
+msgstr "วิดเจ็ต"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr "ความกว้าง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1850
+msgid "Will create"
+msgstr "จะสร้าง"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "จะไม่สามารถสมัครใช้งานได้อีกต่อไปหากไม่มีคำเชิญ ผู้ใช้ที่มีอยู่เดิมจะไม่ได้รับผลกระทบ"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:184
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "หากไม่มีผู้ให้บริการอีเมล ต้องแชร์ลิงก์คำเชิญด้วยตนเอง"
+
+#: packages/admin/src/components/WordPressImport.tsx:1315
+msgid "WordPress Username"
+msgstr "ชื่อผู้ใช้ WordPress"
+
+#: packages/admin/src/components/Widgets.tsx:824
+msgid "Write widget content..."
+msgstr "เขียนเนื้อหาวิดเจ็ต..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1023
+msgid "WXR File"
+msgstr "ไฟล์ WXR"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+msgid "Yes"
+msgstr "ใช่"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "คุณสามารถปิดหน้านี้และกลับไปยังเทอร์มินัลของคุณได้"
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "คุณสามารถสร้างและแก้ไขเนื้อหาของคุณเองได้"
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "คุณสามารถจัดการเนื้อหา มีเดีย เมนู และอนุกรมวิธานได้"
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "คุณสามารถดูและมีส่วนร่วมกับเว็บไซต์ได้"
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "คุณไม่สามารถเปลี่ยนบทบาทของตนเองได้"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "คุณมีสิทธิ์เข้าถึงเต็มรูปแบบในการจัดการเว็บไซต์นี้ รวมถึงผู้ใช้ การตั้งค่า และเนื้อหาทั้งหมด"
+
+#: packages/admin/src/router.tsx:1187
+msgid "You need Editor permissions to moderate comments."
+msgstr "คุณต้องมีสิทธิ์ผู้แก้ไขเพื่อกลั่นกรองความคิดเห็น"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "คุณจะไม่สามารถใช้ \"{0}\" เพื่อเข้าสู่ระบบได้อีกต่อไป การกระทำนี้ไม่สามารถยกเลิกได้"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "คุณจะไม่สามารถใช้ passkey นี้เพื่อเข้าสู่ระบบได้อีกต่อไป การกระทำนี้ไม่สามารถยกเลิกได้"
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "คุณจะเข้าร่วมในฐานะ <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "คุณจะได้รับการแจ้งให้ใช้การยืนยันตัวตนด้วยข้อมูลชีวมาตรของอุปกรณ์ คีย์รักษาความปลอดภัย หรือ PIN"
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "คุณจะถูกเปลี่ยนเส้นทางไปยัง WordPress เพื่ออนุญาตการเชื่อมต่อ"
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "คุณจะสมัครใช้งานในฐานะ"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "คุณเข้าสู่ระบบผ่าน Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:50
+msgid "You've been invited!"
+msgstr "คุณได้รับคำเชิญ!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr "you@company.com"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "you@example.com"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "สร้างบัญชีของคุณสำเร็จแล้ว"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "เบราว์เซอร์ของคุณไม่รองรับ passkey โปรดใช้เบราว์เซอร์รุ่นใหม่ เช่น Chrome, Safari, Firefox หรือ Edge"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "อุปกรณ์ของคุณไม่รองรับคุณสมบัติความปลอดภัยที่จำเป็น"
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "อีเมลของคุณ"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Your Facebook page or profile username"
+msgstr "ชื่อผู้ใช้เพจหรือโปรไฟล์ Facebook ของคุณ"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:141
+msgid "Your GitHub username"
+msgstr "ชื่อผู้ใช้ GitHub ของคุณ"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:153
+msgid "Your Instagram username"
+msgstr "ชื่อผู้ใช้ Instagram ของคุณ"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:159
+msgid "Your LinkedIn profile username"
+msgstr "ชื่อผู้ใช้โปรไฟล์ LinkedIn ของคุณ"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "ชื่อของคุณ"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "ชื่อของคุณ (ไม่บังคับ)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "บทบาทของคุณ"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:431
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "เว็บไซต์ของคุณกำหนดให้รุ่นต้องมีอายุอย่างน้อย {0} ก่อนจึงจะติดตั้งได้ รุ่นนี้จะติดตั้งได้ในภายหลัง"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:135
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "ชื่อบัญชี Twitter/X ของคุณ (เช่น @username)"
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1898
+msgid "Your WordPress export contains {0} media files."
+msgstr "การส่งออก WordPress ของคุณมีไฟล์มีเดีย {0} ไฟล์"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:165
+msgid "Your YouTube channel ID or handle"
+msgstr "ID หรือชื่อช่อง YouTube ของคุณ"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:162
+msgid "YouTube"
+msgstr "YouTube"


### PR DESCRIPTION
## What does this PR do?

Adds **Thai (ไทย)** as a selectable locale for the admin UI, with a complete translation of all 1,606 catalog strings.

- Registers `th` (label `ไทย`, LTR) in `packages/admin/src/locales/locales.ts` and enables it.
- Adds `packages/admin/src/locales/th/messages.po` — a full translation built with a consistent CMS glossary: brand/technical terms (EmDash, API, OAuth, Webhook, Slug, Markdown, JSON, CSRF, …) stay in Latin script; domain/action terms are translated; formal-neutral register with no sentence-final politeness particles (ครับ/ค่ะ). ICU plurals use Thai's single plural form; all placeholders/tag markers preserved.

No component changes were needed — the admin language switcher and direction handling are data-driven from `SUPPORTED_LOCALES` / `getLocaleLabel` / `getLocaleDir`.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (locale catalog tests — `th` catalog loads)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — N/A; this is a data-only locale addition and the existing `locales.test.ts` already asserts every enabled catalog loads.
- [x] User-visible strings are wrapped for translation — this **is** a translation PR; `messages.po` is the deliverable.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — `patch` for `@emdash-cms/admin`.
- [ ] New features link to an approved Discussion — N/A.

## AI-generated code disclosure

- [x] This PR includes AI-generated content — model/tool: **Claude Opus 4.8**

The translation was produced and consistency-reviewed by AI (glossary adherence, terminology consistency, placeholder/ICU integrity, register), then verified with a full browser sweep of the admin in Thai. It has **not** yet been reviewed by a native Thai speaker — a follow-up native pass is welcome. A few technical/SEO labels (e.g. `Meta Description`, `Canonical URL`, `OG Image`, `Repeater`, `Rich Text`) are intentionally kept in English per the glossary policy.

## Screenshots / test output

- Locale unit tests pass (`th` catalog loads with 1,606 messages).
- Full browser sweep (dashboard, content list + editor, media, comments, menus, redirects, widgets, sections, taxonomies, bylines, content types, users, plugins, WordPress import, settings) renders correctly in Thai — `<html lang="th" dir="ltr">`, proper Thai typography, no clipping or layout breakage. The language switcher correctly shows `ไทย` selected.
