### PR TITLE
plugin-cli: import the probe artifact via a file URL so builds work on Windows

### DIFF
--- a/.changeset/fix-plugin-cli-windows-probe-path.md
+++ b/.changeset/fix-plugin-cli-windows-probe-path.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-cli": patch
+---
+
+Fixes plugin builds on Windows by importing the probe artifact through a file URL.

--- a/packages/plugin-cli/src/build/pipeline.ts
+++ b/packages/plugin-cli/src/build/pipeline.ts
@@ -36,6 +36,7 @@
 
 import { copyFile, mkdir, readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type { ResolvedPlugin } from "../bundle/types.js";
 import { fileExists } from "../bundle/utils.js";
@@ -301,7 +302,7 @@ export async function probeAndAssemble(ctx: ProbeAndAssembleContext): Promise<Re
 		);
 	}
 
-	const pluginModule: unknown = await import(probeOutputPath);
+	const pluginModule: unknown = await import(pathToFileURL(probeOutputPath).href);
 	if (!isObjectRecord(pluginModule)) {
 		throw new BuildPipelineError(
 			"INVALID_PLUGIN_FORMAT",

--- a/packages/plugin-cli/tests/bundle.test.ts
+++ b/packages/plugin-cli/tests/bundle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, rmdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,6 +6,11 @@ import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { BundleError, bundlePlugin, type PluginManifest } from "../src/api.js";
+import {
+	probeAndAssemble,
+	type ProbeAndAssembleContext,
+	type ResolvedSources,
+} from "../src/build/pipeline.js";
 
 const FIXTURE = fileURLToPath(new URL("./fixtures/minimal-plugin", import.meta.url));
 const BAD_FIXTURE = fileURLToPath(new URL("./fixtures/bad-plugin", import.meta.url));
@@ -181,3 +186,80 @@ describe("bundlePlugin", () => {
 		expect(b.manifest.id).toBe("fixture-minimal");
 	});
 });
+
+describe("probeAndAssemble", () => {
+	it("imports drive-letter probe artifact paths through file URLs", async () => {
+		const tmpDir = await createDriveLetterTmpDir();
+		try {
+			const entries = makeResolvedSources(tmpDir);
+			const build: ProbeAndAssembleContext["build"] = async (options) => {
+				if (typeof options?.outDir !== "string") {
+					throw new Error("Expected probe build to receive an outDir");
+				}
+				await mkdir(options.outDir, { recursive: true });
+				await writeFile(
+					join(options.outDir, "plugin.mjs"),
+					"export default { hooks: {}, routes: {} };\n",
+				);
+				return [];
+			};
+
+			const result = await probeAndAssemble({ entries, tmpDir, build });
+
+			expect(result.id).toBe("fixture-minimal");
+			expect(result.hooks).toEqual({});
+			expect(result.routes).toEqual({});
+		} finally {
+			await removeDriveLetterTmpDir(tmpDir);
+		}
+	});
+});
+
+async function createDriveLetterTmpDir(): Promise<string> {
+	if (process.platform === "win32") {
+		return mkdtemp(join(tmpdir(), "emdash-probe-"));
+	}
+
+	const driveRoot = "Z:";
+	const base = join(driveRoot, `emdash-probe-${process.pid}-${Date.now()}`);
+	await mkdir(base, { recursive: true });
+	return mkdtemp(join(base, "tmp-"));
+}
+
+async function removeDriveLetterTmpDir(tmpDir: string): Promise<void> {
+	if (process.platform === "win32") {
+		await rm(tmpDir, { recursive: true, force: true });
+		return;
+	}
+
+	await rm(join(tmpDir, ".."), { recursive: true, force: true });
+	await rmdir("Z:").catch(() => {});
+}
+
+function makeResolvedSources(tmpDir: string): ResolvedSources {
+	return {
+		pluginDir: tmpDir,
+		pluginEntry: join(tmpDir, "src", "plugin.ts"),
+		manifest: {
+			slug: "fixture-minimal",
+			version: "1.2.3",
+			publisher: "did:plc:fixture",
+			license: "MIT",
+			authors: [{ name: "Fixture Author" }],
+			securityContacts: [{ email: "security@example.com" }],
+			name: undefined,
+			description: undefined,
+			keywords: undefined,
+			repo: undefined,
+			requires: undefined,
+			artifacts: undefined,
+			capabilities: ["content:read"],
+			allowedHosts: [],
+			storage: {},
+			admin: { pages: [], widgets: [] },
+		},
+		manifestPath: join(tmpDir, "emdash-plugin.jsonc"),
+		packageName: "fixture-minimal",
+		hasPackageJson: true,
+	};
+}


### PR DESCRIPTION
## What does this PR do?

`emdash-plugin build` failed on Windows while probing the built plugin: the pipeline dynamically `import()`s the probe output by its absolute filesystem path, and on Windows an absolute path like `C:\...` is rejected as an ESM specifier (it parses as a URL with a `c:` scheme).

Import the probe artifact through a `file://` URL via `pathToFileURL(probeOutputPath).href`, which is the supported way to dynamically import an absolute path and is a no-op difference on POSIX.

Closes #1236

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (plugin-cli)
- [x] `pnpm lint` passes (changed files)
- [x] `pnpm test` passes (plugin-cli bundle suite: 365 passing)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings: N/A
- [x] I have added a changeset (`@emdash-cms/plugin-cli: patch`)
- [x] New features link to an approved Discussion: N/A (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.5 (Codex CLI)

## Screenshots / test output

```
packages/plugin-cli bundle suite
Test Files  20 passed (20)
     Tests  365 passed (365)
```
