### PR TITLE
TaxonomySidebar: show existing taxonomy terms in the tag picker

### DIFF
--- a/.changeset/fix-admin-tag-picker-suggestions.md
+++ b/.changeset/fix-admin-tag-picker-suggestions.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the flat taxonomy tag picker so focusing an empty input shows available existing terms for the collection.

--- a/packages/admin/src/components/TaxonomySidebar.tsx
+++ b/packages/admin/src/components/TaxonomySidebar.tsx
@@ -43,6 +43,8 @@ interface TaxonomySidebarProps {
 	onChange?: (taxonomyName: string, termIds: string[]) => void;
 }
 
+const EMPTY_TERMS: TaxonomyTerm[] = [];
+
 /**
  * Fetch taxonomy definitions
  */
@@ -163,16 +165,16 @@ function TagInput({
 }) {
 	const { t } = useLingui();
 	const [input, setInput] = React.useState("");
+	const [isOpen, setIsOpen] = React.useState(false);
 
 	const selectedTerms = terms.filter((term) => selectedIds.has(term.id));
 
 	const trimmedInput = input.trim();
 
 	const suggestions = React.useMemo(() => {
-		if (!trimmedInput) return [];
-		return terms
-			.filter((term) => !selectedIds.has(term.id) && termMatches(term, trimmedInput))
-			.slice(0, 5);
+		const availableTerms = terms.filter((term) => !selectedIds.has(term.id));
+		if (!trimmedInput) return availableTerms.slice(0, 5);
+		return availableTerms.filter((term) => termMatches(term, trimmedInput)).slice(0, 5);
 	}, [trimmedInput, terms, selectedIds]);
 
 	const hasExactMatch = React.useMemo(() => {
@@ -185,12 +187,20 @@ function TagInput({
 	const handleSelect = (term: TaxonomyTerm) => {
 		onAdd(term.id);
 		setInput("");
+		setIsOpen(false);
 	};
 
 	const handleCreate = () => {
 		if (!trimmedInput || isCreating) return;
 		onCreate(trimmedInput);
 		setInput("");
+		setIsOpen(false);
+	};
+
+	const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+		const nextFocused = e.relatedTarget;
+		if (nextFocused instanceof Node && e.currentTarget.contains(nextFocused)) return;
+		setIsOpen(false);
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -229,10 +239,14 @@ function TagInput({
 			)}
 
 			{/* Input with autocomplete */}
-			<div className="relative">
+			<div className="relative" onBlur={handleBlur}>
 				<Input
 					value={input}
-					onChange={(e) => setInput(e.target.value)}
+					onChange={(e) => {
+						setInput(e.target.value);
+						setIsOpen(true);
+					}}
+					onFocus={() => setIsOpen(true)}
 					onKeyDown={handleKeyDown}
 					placeholder={t`Add tags...`}
 					aria-label={t`Add ${label}`}
@@ -240,12 +254,13 @@ function TagInput({
 				/>
 
 				{/* Suggestions dropdown */}
-				{(suggestions.length > 0 || showCreateOption) && (
+				{isOpen && (suggestions.length > 0 || showCreateOption) && (
 					<div className="absolute top-full start-0 end-0 mt-1 bg-kumo-overlay border rounded-md shadow-lg z-10">
 						{suggestions.map((term) => (
 							<button
 								key={term.id}
 								type="button"
+								onMouseDown={(e) => e.preventDefault()}
 								onClick={() => handleSelect(term)}
 								className="w-full text-start px-3 py-2 text-sm hover:bg-kumo-tint"
 							>
@@ -255,6 +270,7 @@ function TagInput({
 						{showCreateOption && (
 							<button
 								type="button"
+								onMouseDown={(e) => e.preventDefault()}
 								onClick={handleCreate}
 								disabled={isCreating}
 								className="w-full text-start px-3 py-2 text-sm hover:bg-kumo-tint text-kumo-accent flex items-center gap-1 border-t"
@@ -290,12 +306,12 @@ function TaxonomySection({
 	const [newCategoryLabel, setNewCategoryLabel] = React.useState("");
 	const [showCategoryInput, setShowCategoryInput] = React.useState(false);
 
-	const { data: terms = [] } = useQuery({
+	const { data: terms = EMPTY_TERMS } = useQuery({
 		queryKey: ["taxonomy-terms", taxonomy.name],
 		queryFn: () => fetchTerms(taxonomy.name),
 	});
 
-	const { data: entryTerms = [] } = useQuery({
+	const { data: entryTerms = EMPTY_TERMS } = useQuery({
 		queryKey: ["entry-terms", collection, entryId, taxonomy.name],
 		queryFn: () => {
 			if (!entryId) return [];

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -1,0 +1,197 @@
+import { Toasty } from "@cloudflare/kumo";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { TaxonomySidebar } from "../../src/components/TaxonomySidebar";
+import { render } from "../utils/render.tsx";
+
+vi.mock("../../src/lib/api/client.js", async () => {
+	const actual = await vi.importActual("../../src/lib/api/client.js");
+	return {
+		...actual,
+		apiFetch: vi.fn(),
+	};
+});
+
+import { apiFetch } from "../../src/lib/api/client.js";
+
+interface TestTaxonomy {
+	id: string;
+	name: string;
+	label: string;
+	labelSingular?: string;
+	hierarchical: boolean;
+	collections: string[];
+}
+
+interface TestTerm {
+	id: string;
+	name: string;
+	slug: string;
+	label: string;
+	parentId?: string | null;
+	children: TestTerm[];
+}
+
+const tagsTaxonomy: TestTaxonomy = {
+	id: "tax_tags",
+	name: "tags",
+	label: "Tags",
+	labelSingular: "Tag",
+	hierarchical: false,
+	collections: ["products"],
+};
+
+const categoriesTaxonomy: TestTaxonomy = {
+	id: "tax_categories",
+	name: "categories",
+	label: "Categories",
+	labelSingular: "Category",
+	hierarchical: true,
+	collections: ["products"],
+};
+
+const alphaTerm = makeTerm("term_alpha", "Alpha");
+const betaTerm = makeTerm("term_beta", "Beta");
+
+function makeTerm(id: string, label: string): TestTerm {
+	return {
+		id,
+		name: label.toLowerCase(),
+		slug: label.toLowerCase(),
+		label,
+		parentId: null,
+		children: [],
+	};
+}
+
+function dataResponse(data: unknown) {
+	return Promise.resolve(
+		new Response(JSON.stringify({ data }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		}),
+	);
+}
+
+function mockApiFetch({
+	taxonomies = [tagsTaxonomy],
+	terms = [alphaTerm, betaTerm],
+	entryTerms = [],
+}: {
+	taxonomies?: TestTaxonomy[];
+	terms?: TestTerm[];
+	entryTerms?: TestTerm[];
+} = {}) {
+	vi.mocked(apiFetch).mockImplementation((url: string | URL | Request, init?: RequestInit) => {
+		const urlString = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+		const method = init?.method ?? "GET";
+
+		if (method === "GET" && urlString === "/_emdash/api/taxonomies") {
+			return dataResponse({ taxonomies });
+		}
+
+		if (method === "GET" && urlString === "/_emdash/api/taxonomies/tags/terms") {
+			return dataResponse({ terms });
+		}
+
+		if (method === "GET" && urlString === "/_emdash/api/taxonomies/categories/terms") {
+			return dataResponse({ terms });
+		}
+
+		if (
+			method === "GET" &&
+			urlString === "/_emdash/api/content/products/entry_1/terms/tags"
+		) {
+			return dataResponse({ terms: entryTerms });
+		}
+
+		return dataResponse({});
+	});
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	const queryClient = React.useMemo(
+		() =>
+			new QueryClient({
+				defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			}),
+		[],
+	);
+
+	return (
+		<QueryClientProvider client={queryClient}>
+			<Toasty>{children}</Toasty>
+		</QueryClientProvider>
+	);
+}
+
+describe("TaxonomySidebar", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockApiFetch();
+	});
+
+	it("shows existing flat taxonomy terms when the tag picker receives focus", async () => {
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByLabelText("Add Tags")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /^Alpha$/ }).query()).toBeNull();
+
+		await screen.getByLabelText("Add Tags").click();
+
+		await expect.element(screen.getByRole("button", { name: /^Alpha$/ })).toBeInTheDocument();
+		await expect.element(screen.getByRole("button", { name: /^Beta$/ })).toBeInTheDocument();
+	});
+
+	it("filters flat taxonomy terms while preserving the create option for new input", async () => {
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		const input = screen.getByLabelText("Add Tags");
+		await input.fill("Alp");
+
+		await expect.element(screen.getByRole("button", { name: /^Alpha$/ })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /^Beta$/ }).query()).toBeNull();
+		await expect.element(screen.getByText('Create "Alp"')).toBeInTheDocument();
+	});
+
+	it("does not suggest terms already assigned to the entry", async () => {
+		mockApiFetch({ entryTerms: [alphaTerm] });
+
+		const screen = await render(<TaxonomySidebar collection="products" entryId="entry_1" />, {
+			wrapper: Wrapper,
+		});
+
+		await expect.element(screen.getByLabelText("Remove Alpha")).toBeInTheDocument();
+		await screen.getByLabelText("Add Tags").click();
+
+		expect(screen.getByRole("button", { name: /^Alpha$/ }).query()).toBeNull();
+		await expect.element(screen.getByRole("button", { name: /^Beta$/ })).toBeInTheDocument();
+	});
+
+	it("keeps the create prompt available when no flat taxonomy terms exist", async () => {
+		mockApiFetch({ terms: [] });
+
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		const input = screen.getByLabelText("Add Tags");
+		await input.click();
+
+		expect(screen.getByText('Create "Gamma"').query()).toBeNull();
+
+		await input.fill("Gamma");
+
+		await expect.element(screen.getByText('Create "Gamma"')).toBeInTheDocument();
+	});
+
+	it("continues to render hierarchical taxonomies as a checkbox tree", async () => {
+		mockApiFetch({ taxonomies: [categoriesTaxonomy], terms: [alphaTerm] });
+
+		const screen = await render(<TaxonomySidebar collection="products" />, { wrapper: Wrapper });
+
+		await expect.element(screen.getByText("Categories")).toBeInTheDocument();
+		await expect.element(screen.getByText("Alpha")).toBeInTheDocument();
+		expect(screen.getByLabelText("Add Categories").query()).toBeNull();
+	});
+});

--- a/packages/admin/tests/components/TaxonomySidebar.test.tsx
+++ b/packages/admin/tests/components/TaxonomySidebar.test.tsx
@@ -100,10 +100,7 @@ function mockApiFetch({
 			return dataResponse({ terms });
 		}
 
-		if (
-			method === "GET" &&
-			urlString === "/_emdash/api/content/products/entry_1/terms/tags"
-		) {
+		if (method === "GET" && urlString === "/_emdash/api/content/products/entry_1/terms/tags") {
 			return dataResponse({ terms: entryTerms });
 		}
 


### PR DESCRIPTION
## What does this PR do?

The taxonomy tag picker only rendered its suggestion list when the user had typed something, so existing terms were never shown on focus — a reporter saw "no existing terms" and could only create new ones.

Now the picker shows the available terms on focus (not just while typing), tracks an explicit open/close state driven by focus and blur, and uses `onMouseDown preventDefault` on the suggestion buttons so a click registers before blur closes the list. A stable empty-array default avoids re-render churn from new `[]` references on every render.

Closes #1199

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (admin)
- [x] `pnpm lint` passes (oxlint, changed files)
- [x] `pnpm test` passes (TaxonomySidebar suite: 5 passing)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings: existing `t\`...\`` wrappers preserved; no new untranslated strings
- [x] I have added a changeset (`@emdash-cms/admin: patch`)
- [x] New features link to an approved Discussion: N/A (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.5 (Codex CLI)

## Screenshots / test output

```
packages/admin TaxonomySidebar.test.tsx
Tests  5 passed (5)
```
