### PR TITLE
fix(admin): drop removed kumo Sidebar.GroupContent API (#1240)

### DIFF
--- a/.changeset/fix-admin-kumo-sidebar.md
+++ b/.changeset/fix-admin-kumo-sidebar.md
@@ -1,0 +1,10 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fix admin crash on authenticated load with @cloudflare/kumo 2.4.x (#1240). The
+sidebar was using `Sidebar.GroupContent` and group-level `collapsible`/
+`defaultOpen` props, which were removed in kumo 2.4.0. The four nav sections
+(Content, Manage, Admin, Plugins) now render as plain `Sidebar.Group` blocks.
+The workspace catalog range for `@cloudflare/kumo` is bumped from `^2.3.0` to
+`^2.4.0` to match.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -422,51 +422,43 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 
 					<KumoSidebar.Separator />
 
-					{/* Content — collections + media (collapsible) */}
+					{/* Content — collections + media */}
 					{visibleContent.length > 1 && (
-						<KumoSidebar.Group collapsible defaultOpen>
+						<KumoSidebar.Group>
 							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Content`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.GroupContent>
-								<KumoSidebar.Menu>
-									{renderNavItems(visibleContent.filter((i) => i.to !== "/"))}
-								</KumoSidebar.Menu>
-							</KumoSidebar.GroupContent>
+							<KumoSidebar.Menu>
+								{renderNavItems(visibleContent.filter((i) => i.to !== "/"))}
+							</KumoSidebar.Menu>
 						</KumoSidebar.Group>
 					)}
 
 					<KumoSidebar.Separator />
 
-					{/* Manage — comments, menus, taxonomies, etc. (collapsible) */}
+					{/* Manage — comments, menus, taxonomies, etc. */}
 					{visibleManage.length > 0 && (
-						<KumoSidebar.Group collapsible defaultOpen>
+						<KumoSidebar.Group>
 							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Manage`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.GroupContent>
-								<KumoSidebar.Menu>{renderNavItems(visibleManage)}</KumoSidebar.Menu>
-							</KumoSidebar.GroupContent>
+							<KumoSidebar.Menu>{renderNavItems(visibleManage)}</KumoSidebar.Menu>
 						</KumoSidebar.Group>
 					)}
 
 					<KumoSidebar.Separator />
 
-					{/* Admin — content types, users, plugins, import (collapsible) */}
+					{/* Admin — content types, users, plugins, import */}
 					{visibleAdmin.length > 0 && (
-						<KumoSidebar.Group collapsible defaultOpen>
+						<KumoSidebar.Group>
 							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Admin`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.GroupContent>
-								<KumoSidebar.Menu>{renderNavItems(visibleAdmin)}</KumoSidebar.Menu>
-							</KumoSidebar.GroupContent>
+							<KumoSidebar.Menu>{renderNavItems(visibleAdmin)}</KumoSidebar.Menu>
 						</KumoSidebar.Group>
 					)}
 
-					{/* Plugin pages (collapsible) */}
+					{/* Plugin pages */}
 					{visiblePlugins.length > 0 && (
 						<>
 							<KumoSidebar.Separator />
-							<KumoSidebar.Group collapsible defaultOpen>
+							<KumoSidebar.Group>
 								<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Plugins`}</KumoSidebar.GroupLabel>
-								<KumoSidebar.GroupContent>
-									<KumoSidebar.Menu>{renderNavItems(visiblePlugins)}</KumoSidebar.Menu>
-								</KumoSidebar.GroupContent>
+								<KumoSidebar.Menu>{renderNavItems(visiblePlugins)}</KumoSidebar.Menu>
 							</KumoSidebar.Group>
 						</>
 					)}

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -329,15 +329,6 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 				border-top: 1px solid rgba(255,255,255,0.08);
 			}
 
-			/* Keep all nav icons visible when sidebar collapses to icon mode */
-			.emdash-sidebar[data-state="collapsed"] [data-sidebar="group-content"] {
-				grid-template-rows: 1fr !important;
-			}
-			/* Mobile drawer: kumo's Sheet has no data-state attribute, so group-content
-			   stays at grid-rows-[0fr] (hidden). Force it open in the mobile sidebar. */
-			.emdash-sidebar[data-mobile="true"] [data-sidebar="group-content"] {
-				grid-template-rows: 1fr !important;
-			}
 			/* Collapsed separators — thin centered line */
 			.emdash-sidebar[data-state="collapsed"] [data-sidebar="separator"] {
 				margin: 0.375rem 0.625rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: ^0.9.1
       version: 0.9.1
     '@cloudflare/kumo':
-      specifier: ^2.3.0
-      version: 2.3.0
+      specifier: ^2.4.0
+      version: 2.4.1
     '@cloudflare/vite-plugin':
       specifier: ^1.36.3
       version: 1.36.3
@@ -928,7 +928,7 @@ importers:
         version: 1.3.0
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1235,7 +1235,7 @@ importers:
         version: 1.2.10
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -1247,7 +1247,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: 'catalog:'
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1302,7 +1302,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@emdash-cms/blocks':
         specifier: workspace:*
         version: link:..
@@ -1794,7 +1794,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1897,7 +1897,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1934,7 +1934,7 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
+        version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3250,8 +3250,8 @@ packages:
   '@cloudflare/containers@0.3.5':
     resolution: {integrity: sha512-P6jYEDkw1Q9qWRr9iFBxe1fozI5HfGMY6XrNg/jROPGZykcYrrzOluUqXv+q4N8gIoRXPCqJJ1FGALbTqnYTkg==}
 
-  '@cloudflare/kumo@2.3.0':
-    resolution: {integrity: sha512-Nw3JzTIj3KDyl/d2+vXwSGXiu+E/NgL08Cqn/lxJkyc7tTEwBY3UgTFWNE9RHakCPo161LgZRysZuHy2YmOIPg==}
+  '@cloudflare/kumo@2.4.1':
+    resolution: {integrity: sha512-G4/pOPh/j6XAL8YI9OvP135R4XtxZRnARsBTOSQ3l48VZZwg73VZOdD2IPcUWmQaMAp37B38P3qGeIvepjvtBw==}
     hasBin: true
     peerDependencies:
       '@phosphor-icons/react': ^2.1.10
@@ -3260,6 +3260,8 @@ packages:
       react-dom: ^18.0.0 || ^19.0.0
       zod: ^4.0.0
     peerDependenciesMeta:
+      echarts:
+        optional: true
       zod:
         optional: true
 
@@ -13248,14 +13250,13 @@ snapshots:
 
   '@cloudflare/containers@0.3.5': {}
 
-  '@cloudflare/kumo@2.3.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)':
+  '@cloudflare/kumo@2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)':
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@shikijs/langs': 4.0.2
       '@shikijs/themes': 4.0.2
       clsx: 2.1.1
-      echarts: 6.0.0
       motion: 12.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-day-picker: 9.14.0(react@19.2.4)
@@ -13263,6 +13264,7 @@ snapshots:
       shiki: 4.0.2
       tailwind-merge: 3.4.0
     optionalDependencies:
+      echarts: 6.0.0
       zod: 4.4.1
     transitivePeerDependencies:
       - '@date-fns/tz'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,7 +89,7 @@ catalog:
   "@atcute/xrpc-server-cloudflare": ^2.0.0
   "@atproto/crypto": ^0.4.5
   "@atproto/repo": ^0.9.1
-  "@cloudflare/kumo": ^2.3.0
+  "@cloudflare/kumo": ^2.4.0
   "@cloudflare/vite-plugin": ^1.36.3
   "@cloudflare/vitest-pool-workers": ^0.16.3
   "@cloudflare/workers-types": ^4.20260305.1


### PR DESCRIPTION
## What does this PR do?

Fixes the admin SPA crashing on authenticated load after the `@cloudflare/kumo` 2.4.0 upgrade. Kumo 2.4 removed `Sidebar.GroupContent` and the group-level `collapsible` / `defaultOpen` props from `Sidebar.Group`, but `packages/admin/src/components/Sidebar.tsx` still used them, so the sidebar threw as soon as it rendered.

The four nav sections (Content, Manage, Admin, Plugins) now render as plain `Sidebar.Group` blocks with `Sidebar.Menu` children directly, matching the 2.4 API. The workspace catalog range for `@cloudflare/kumo` is bumped `^2.3.0` -> `^2.4.0` (lockfile resolves to 2.4.1) so the types and runtime agree.

This was reproduced and fixed by the investigation bot from the `bot:repro` flow on #1240, then opened as this PR.

Closes #1240

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a; the crash is a render-time API mismatch verified in the browser, no unit-testable surface
- [x] User-visible strings in the admin UI are wrapped for translation — unchanged; the existing `t\`...\`` group labels are preserved
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/admin` patch)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: EmDash investigation bot (Flue, Claude Opus)

## Notes

Reviewer follow-up (emdashbot): the inline `<style>` block in `Sidebar.tsx` still has two rules targeting `[data-sidebar="group-content"]` (collapsed + mobile-drawer states), which is now dead since `Sidebar.GroupContent` is gone. Worth removing as a small cleanup.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://bot-fix-1240-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `bot/fix-1240`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
