### PR TITLE
fix(ci): use full branch name in bot preview install URL

### DIFF
--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -491,9 +491,12 @@ jobs:
 
           rm -f "$GIT_ASKPASS"
 
-          # Build the install command from the branch name. pkg.pr.new
-          # already publishes preview releases on every push to this repo.
-          INSTALL_CMD="npm i https://pkg.pr.new/emdash@${FIX_BRANCH##*/}"
+          # Build the install command from the branch name. The
+          # preview-releases.yml workflow publishes a pkg.pr.new release on
+          # every push to bot/fix-*. pkg.pr.new keys branch resolution by the
+          # *full* branch name, so use "$FIX_BRANCH" verbatim -- stripping the
+          # "bot/" prefix (e.g. "fix-123") produces a URL that 404s.
+          INSTALL_CMD="npm i https://pkg.pr.new/emdash@${FIX_BRANCH}"
 
           # ISO-8601 timestamp embedded in the comment as a hidden
           # HTML marker. reporter-reply.yml uses this to verify that a

--- a/.github/workflows/preview-releases.yml
+++ b/.github/workflows/preview-releases.yml
@@ -4,8 +4,9 @@ on:
   push:
     # `bot/fix-*` branches are pushed by .github/workflows/investigate.yml
     # before the bot asks the reporter to verify a candidate fix. The
-    # ask comment includes an `npm i https://pkg.pr.new/emdash@fix-<n>`
-    # install URL that only resolves once pkg.pr.new has actually
+    # ask comment includes an `npm i https://pkg.pr.new/emdash@bot/fix-<n>`
+    # install URL (the full branch name -- pkg.pr.new resolves branches by
+    # their full ref) that only resolves once pkg.pr.new has actually
     # published a preview release on the branch -- hence the explicit
     # branch pattern here.
     branches: [main, "bot/fix-*"]


### PR DESCRIPTION
## What does this PR do?

The investigation bot's ask comment includes an `npm i https://pkg.pr.new/emdash@...` line so the reporter can try a candidate fix. It was building that URL by stripping the `bot/` prefix off the fix branch (`${FIX_BRANCH##*/}` -> `fix-1240`), but pkg.pr.new resolves branches by their **full** ref. So the published preview lives at `emdash@bot/fix-1240` (and the commit SHA), while the URL the bot posted, `emdash@fix-1240`, 404s.

Verified against the live #1240 preview:

```
emdash@fix-1240      -> 404
emdash@bot/fix-1240  -> 200
emdash@<commit-sha>  -> 200
```

Fix: use `${FIX_BRANCH}` verbatim in the install command. Also corrected the now-inaccurate doc comment in `preview-releases.yml`.

Note: the preview release itself was publishing fine all along, via the separate `preview-releases.yml` workflow on push to `bot/fix-*`. Only the install URL in the comment was wrong.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes (CI-only change, no source touched)
- [ ] `pnpm lint` passes (CI-only change)
- [ ] `pnpm test` passes (CI-only change)
- [x] `pnpm format` has been run (no formatted files changed)
- [ ] I have added a changeset (no published package changed)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-bot-preview-install-url-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/bot-preview-install-url`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
