### PR TITLE
chore: enable Dependabot npm updates with pnpm cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # npm ecosystem covers pnpm, including workspace catalogs (GA Feb 2025).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # pnpm enforces minimumReleaseAge (1440min / 1 day) at install time, so a
+    # PR for a too-fresh version would fail `pnpm install` in CI. Hold updates
+    # back past that gate (with margin) so Dependabot never proposes a version
+    # pnpm will refuse. See pnpm-workspace.yaml.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

Adds the `npm` ecosystem to Dependabot (currently only `github-actions` is configured) and wires in a `cooldown` so automated updates stay compatible with our pnpm supply-chain hardening.

`pnpm-workspace.yaml` sets `minimumReleaseAge: 1440` (1 day), enforced at install time. Without a matching cooldown, Dependabot could open a PR for a version published moments ago, and CI's `pnpm install` would hit the cooldown gate and fail (the same failure mode the existing `minimumReleaseAgeExclude` entries work around). The `cooldown` block holds updates back past that gate, with margin (3 days default, 7 for majors), so Dependabot never proposes a version pnpm will refuse.

Dependabot's `npm` ecosystem covers pnpm including workspace catalogs (GA Feb 2025), so the bulk of our deps in the `catalog:` block get updated correctly.

Updates are grouped (dev / production) to reduce PR noise.

Note: the stricter install-time gates (`strictDepBuilds`/`allowBuilds`, `trustPolicy: no-downgrade`, `blockExoticSubdeps`) remain deliberate manual review checkpoints. They surface on the Dependabot PR and fail CI until a human reviews and updates the allowlist/exclude, which is the intended workflow.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes (n/a, config-only)
- [ ] `pnpm lint` passes (n/a, config-only)
- [ ] `pnpm test` passes (n/a, config-only)
- [ ] `pnpm format` has been run (n/a, config-only)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)