### PR TITLE
chore: keep major Dependabot updates out of grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,15 @@ updates:
     cooldown:
       default-days: 3
       semver-major-days: 7
+    # Group only minor/patch bumps. Majors carry breaking changes and
+    # peer-dep incompatibilities (e.g. @vitejs/plugin-react@6 importing
+    # vite/internal, which rolldown-vite doesn't export), so they break out
+    # into individual PRs for separate review instead of poisoning the batch.
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types: ["minor", "patch"]
       production-dependencies:
         dependency-type: "production"
+        update-types: ["minor", "patch"]
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

Restricts the Dependabot `dev-dependencies` and `production-dependencies` groups to `minor` and `patch` bumps. Major updates now break out into their own individual PRs instead of being batched in.

The first grouped PR (#1262) failed all build-dependent checks because Dependabot lumped a major `@vitejs/plugin-react` bump (4 -> 6) in with ~18 safe minor/patch updates. `@vitejs/plugin-react@6` imports `vite/internal`, a subpath our pinned Vite 8 (rolldown-vite) doesn't export, so `vite build` died and took the whole batch down with it.

Isolating majors keeps the safe minor/patch updates flowing as a single low-noise PR, while breaking changes land individually where they can be reviewed (or closed) on their own. We can pick up the Vite-ecosystem majors when Astro bumps its Vite peer.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://chore-dependabot-separate-majors-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `chore/dependabot-separate-majors`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
