### PR TITLE
fix: correct package name in core-list-nesting-fix changeset

### DIFF
--- a/.changeset/core-list-nesting-fix.md
+++ b/.changeset/core-list-nesting-fix.md
@@ -1,5 +1,5 @@
 ---
-"@emdash-cms/core": patch
+"emdash": patch
 ---
 
 Fixes `portableTextToProsemirror` flattening nested lists whose subtree mixes `listItem` types. The outer run-grouping broke on the first nested type switch (e.g. an `orderedList` child under a `bulletList` parent), so an input like `[bullet L1, number L2, bullet L1]` was emitted as three separate top-level lists instead of one bullet list with a numbered sub-list under the first item. Internal `convertList`/`convertListItem` recursion was already correct — only the outer grouping needed to be widened to include `level > 1` blocks regardless of `listItem` type.


### PR DESCRIPTION
## What does this PR do?

The `core-list-nesting-fix` changeset declared a bump for `@emdash-cms/core`, which is not a workspace package, the core package is published as `emdash`. `changeset version` errors on the unknown package name (`Found changeset core-list-nesting-fix for package @emdash-cms/core which is not in the workspace`), which is failing the Release workflow on `main`.

Corrects the package name to `emdash` so the release can version normally.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)