### PR TITLE
fix(admin): restore dark sidebar chrome in light mode for Kumo 2.4

### DIFF
--- a/.changeset/sidebar-light-mode-fix.md
+++ b/.changeset/sidebar-light-mode-fix.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fix admin sidebar rendering white text on a light background in light mode. Kumo 2.4 moved the sidebar surface to an inner container painted with `bg-(--sidebar-bg)`, where `--sidebar-bg` is resolved from the wrapper's default (light) `--color-kumo-base`. The sidebar's dark-chrome override only set `--color-kumo-base`, which no longer reaches that surface, so the dark background was lost while the white text remained. The override now sets `--sidebar-bg` directly.

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -290,6 +290,9 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 			/* Classic dark chrome — override kumo tokens within the sidebar */
 			.emdash-sidebar {
 				--color-kumo-base: #1d2327;
+				/* Kumo 2.4 paints the surface via bg-(--sidebar-bg) on an inner
+				   container, resolved from the wrapper's light --color-kumo-base. */
+				--sidebar-bg: #1d2327;
 				--color-kumo-tint: rgba(255,255,255,0.1);
 				--color-kumo-line: rgba(255,255,255,0.08);
 				--color-kumo-brand: #2271b1;


### PR DESCRIPTION
## What does this PR do?

Fixes the admin sidebar rendering white text on a light background in light mode (regression in 0.16, surfaced by the Kumo 2.3 -> 2.4 bump in #1255).

Kumo 2.4 moved the sidebar surface to an inner `[data-sidebar="content-container"]` element painted with `bg-(--sidebar-bg)`, where `--sidebar-bg` is declared on the outer wrapper as `var(--color-kumo-base)` and resolved there in the default (light) context. Our dark-chrome override only set `--color-kumo-base` on `.emdash-sidebar`, which sits below where the variable was resolved, so the dark background never reached the visible surface. The white text override still inherited, giving white-on-light. Dark mode looked fine because the wrapper's base was already dark.

The fix sets `--sidebar-bg: #1d2327` directly on `.emdash-sidebar`; it inherits down to the content container and overrides the wrapper's resolved value.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm format` has been run
- [x] I have added a changeset (patch, `@emdash-cms/admin`)

A CSS custom-property cascade isn't meaningfully testable in jsdom, so this is verified manually in the browser rather than with a unit test.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Light mode, after fix: sidebar renders dark `#1d2327` chrome with legible text. Computed background of `[data-sidebar="content-container"]` is `rgb(29, 35, 39)` with `data-mode="light"`.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-admin-sidebar-light-mode-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/admin-sidebar-light-mode`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
