### PR TITLE
fix(core): surface sandboxed plugins in the admin plugin management API

### DIFF
--- a/.changeset/admin-list-sandboxed-plugins.md
+++ b/.changeset/admin-list-sandboxed-plugins.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes statically-sandboxed plugins (registered via `sandboxed: []` in `astro.config.mjs`) being absent from the admin Plugins screen. They are now listed alongside trusted and marketplace plugins, and can be fetched, enabled, and disabled through the same plugin management API.

--- a/packages/core/src/api/handlers/plugins.ts
+++ b/packages/core/src/api/handlers/plugins.ts
@@ -5,6 +5,7 @@
 import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
+import type { SandboxedPluginEntry } from "../../emdash-runtime.js";
 import { PluginStateRepository, type PluginState, type PluginStatus } from "../../plugins/state.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import type { ApiResult } from "../types.js";
@@ -17,6 +18,8 @@ export interface PluginInfo {
 	enabled: boolean;
 	status: PluginStatus;
 	source?: "config" | "marketplace" | "registry";
+	/** True for statically-sandboxed plugins (registered via `sandboxed: []`) */
+	sandboxed?: boolean;
 	marketplaceVersion?: string;
 	/** Publisher DID, for registry-source plugins */
 	registryPublisherDid?: string;
@@ -85,11 +88,42 @@ function buildPluginInfo(
 }
 
 /**
+ * Build plugin info for a statically-sandboxed plugin entry
+ */
+function buildSandboxedPluginInfo(
+	entry: SandboxedPluginEntry,
+	state: PluginState | null,
+): PluginInfo {
+	const status = state?.status ?? "active";
+	const enabled = status === "active";
+
+	return {
+		id: entry.id,
+		name: state?.displayName || entry.id,
+		version: entry.version,
+		package: undefined, // v2 doesn't have package field
+		enabled,
+		status,
+		source: "config",
+		sandboxed: true,
+		capabilities: entry.capabilities,
+		hasAdminPages: (entry.adminPages?.length ?? 0) > 0,
+		hasDashboardWidgets: (entry.adminWidgets?.length ?? 0) > 0,
+		hasHooks: false,
+		installedAt: state?.installedAt?.toISOString(),
+		activatedAt: state?.activatedAt?.toISOString() ?? undefined,
+		deactivatedAt: state?.deactivatedAt?.toISOString() ?? undefined,
+		description: state?.description ?? undefined,
+	};
+}
+
+/**
  * List all configured plugins with their state
  */
 export async function handlePluginList(
 	db: Kysely<Database>,
 	configuredPlugins: ResolvedPlugin[],
+	sandboxedPluginEntries: SandboxedPluginEntry[],
 	marketplaceUrl?: string,
 ): Promise<ApiResult<PluginListResponse>> {
 	try {
@@ -103,6 +137,14 @@ export async function handlePluginList(
 			const state = stateMap.get(plugin.id) ?? null;
 			return buildPluginInfo(plugin, state, marketplaceUrl);
 		});
+
+		// Include statically-sandboxed plugins (registered via `sandboxed: []`
+		// in astro.config.mjs).
+		for (const entry of sandboxedPluginEntries) {
+			if (configuredIds.has(entry.id)) continue;
+			configuredIds.add(entry.id);
+			items.push(buildSandboxedPluginInfo(entry, stateMap.get(entry.id) ?? null));
+		}
 
 		// Include runtime-installed plugins (marketplace or registry) that
 		// aren't in the configured plugins list.
@@ -156,27 +198,37 @@ export async function handlePluginList(
 export async function handlePluginGet(
 	db: Kysely<Database>,
 	configuredPlugins: ResolvedPlugin[],
+	sandboxedPluginEntries: SandboxedPluginEntry[],
 	pluginId: string,
 	marketplaceUrl?: string,
 ): Promise<ApiResult<PluginResponse>> {
 	try {
+		const stateRepo = new PluginStateRepository(db);
 		const plugin = configuredPlugins.find((p) => p.id === pluginId);
-		if (!plugin) {
+
+		if (plugin) {
+			const state = await stateRepo.get(pluginId);
 			return {
-				success: false,
-				error: {
-					code: "NOT_FOUND",
-					message: `Plugin not found: ${pluginId}`,
-				},
+				success: true,
+				data: { item: buildPluginInfo(plugin, state, marketplaceUrl) },
 			};
 		}
 
-		const stateRepo = new PluginStateRepository(db);
-		const state = await stateRepo.get(pluginId);
+		const sandboxed = sandboxedPluginEntries.find((e) => e.id === pluginId);
+		if (sandboxed) {
+			const state = await stateRepo.get(pluginId);
+			return {
+				success: true,
+				data: { item: buildSandboxedPluginInfo(sandboxed, state) },
+			};
+		}
 
 		return {
-			success: true,
-			data: { item: buildPluginInfo(plugin, state, marketplaceUrl) },
+			success: false,
+			error: {
+				code: "NOT_FOUND",
+				message: `Plugin not found: ${pluginId}`,
+			},
 		};
 	} catch {
 		return {
@@ -227,6 +279,7 @@ function buildStateOnlyPluginInfo(
 export async function handlePluginEnable(
 	db: Kysely<Database>,
 	configuredPlugins: ResolvedPlugin[],
+	sandboxedPluginEntries: SandboxedPluginEntry[],
 	pluginId: string,
 ): Promise<ApiResult<PluginResponse>> {
 	try {
@@ -237,6 +290,13 @@ export async function handlePluginEnable(
 		if (plugin) {
 			const state = await stateRepo.enable(pluginId, plugin.version);
 			return { success: true, data: { item: buildPluginInfo(plugin, state) } };
+		}
+
+		// Statically-sandboxed plugin: addressable via its build-time entry.
+		const sandboxed = sandboxedPluginEntries.find((e) => e.id === pluginId);
+		if (sandboxed) {
+			const state = await stateRepo.enable(pluginId, sandboxed.version);
+			return { success: true, data: { item: buildSandboxedPluginInfo(sandboxed, state) } };
 		}
 
 		// Runtime-installed plugin (marketplace or registry): only
@@ -268,6 +328,7 @@ export async function handlePluginEnable(
 export async function handlePluginDisable(
 	db: Kysely<Database>,
 	configuredPlugins: ResolvedPlugin[],
+	sandboxedPluginEntries: SandboxedPluginEntry[],
 	pluginId: string,
 ): Promise<ApiResult<PluginResponse>> {
 	try {
@@ -277,6 +338,12 @@ export async function handlePluginDisable(
 		if (plugin) {
 			const state = await stateRepo.disable(pluginId, plugin.version);
 			return { success: true, data: { item: buildPluginInfo(plugin, state) } };
+		}
+
+		const sandboxed = sandboxedPluginEntries.find((e) => e.id === pluginId);
+		if (sandboxed) {
+			const state = await stateRepo.disable(pluginId, sandboxed.version);
+			return { success: true, data: { item: buildSandboxedPluginInfo(sandboxed, state) } };
 		}
 
 		const existing = await stateRepo.get(pluginId);

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -522,6 +522,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					hooks: runtime.hooks,
 					email: runtime.email,
 					configuredPlugins: runtime.configuredPlugins,
+					sandboxedPluginEntries: runtime.sandboxedPluginEntries,
 
 					// Configuration (for checking database type, auth mode, etc.)
 					config,

--- a/packages/core/src/astro/routes/api/admin/plugins/[id]/disable.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/[id]/disable.ts
@@ -28,7 +28,12 @@ export const POST: APIRoute = async ({ params, locals }) => {
 		return apiError("INVALID_REQUEST", "Plugin ID required", 400);
 	}
 
-	const result = await handlePluginDisable(emdash.db, emdash.configuredPlugins, id);
+	const result = await handlePluginDisable(
+		emdash.db,
+		emdash.configuredPlugins,
+		emdash.sandboxedPluginEntries,
+		id,
+	);
 
 	if (!result.success) return unwrapResult(result);
 

--- a/packages/core/src/astro/routes/api/admin/plugins/[id]/enable.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/[id]/enable.ts
@@ -28,7 +28,12 @@ export const POST: APIRoute = async ({ params, locals }) => {
 		return apiError("INVALID_REQUEST", "Plugin ID required", 400);
 	}
 
-	const result = await handlePluginEnable(emdash.db, emdash.configuredPlugins, id);
+	const result = await handlePluginEnable(
+		emdash.db,
+		emdash.configuredPlugins,
+		emdash.sandboxedPluginEntries,
+		id,
+	);
 
 	if (!result.success) return unwrapResult(result);
 

--- a/packages/core/src/astro/routes/api/admin/plugins/[id]/index.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/[id]/index.ts
@@ -30,6 +30,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
 	const result = await handlePluginGet(
 		emdash.db,
 		emdash.configuredPlugins,
+		emdash.sandboxedPluginEntries,
 		id,
 		emdash.config.marketplace,
 	);

--- a/packages/core/src/astro/routes/api/admin/plugins/index.ts
+++ b/packages/core/src/astro/routes/api/admin/plugins/index.ts
@@ -25,6 +25,7 @@ export const GET: APIRoute = async ({ locals }) => {
 	const result = await handlePluginList(
 		emdash.db,
 		emdash.configuredPlugins,
+		emdash.sandboxedPluginEntries,
 		emdash.config.marketplace,
 	);
 

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -425,6 +425,10 @@ export interface EmDashHandlers {
 	// Configured plugins (for plugin management)
 	configuredPlugins: import("../plugins/types.js").ResolvedPlugin[];
 
+	// Statically-sandboxed plugin entries (registered via `sandboxed: []`),
+	// surfaced through the admin plugin management API alongside configured plugins.
+	sandboxedPluginEntries: import("../emdash-runtime.js").SandboxedPluginEntry[];
+
 	// Configuration (for checking database type, auth mode, etc.)
 	config: import("./integration/runtime.js").EmDashConfig;
 

--- a/packages/core/tests/integration/api/plugins.test.ts
+++ b/packages/core/tests/integration/api/plugins.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Plugin admin list handler: a statically-sandboxed entry surfaces flagged
+ * sandboxed, and a configured plugin shadows a sandboxed entry with the same id.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handlePluginList } from "../../../src/api/handlers/plugins.js";
+import type { Database } from "../../../src/database/types.js";
+import type { SandboxedPluginEntry } from "../../../src/emdash-runtime.js";
+import type { ResolvedPlugin } from "../../../src/plugins/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+function createTestPlugin(overrides: Partial<ResolvedPlugin> = {}): ResolvedPlugin {
+	return {
+		id: "trusted-plugin",
+		version: "1.0.0",
+		capabilities: [],
+		allowedHosts: [],
+		storage: {},
+		admin: { pages: [], widgets: [], fieldWidgets: {} },
+		hooks: {},
+		routes: {},
+		settings: undefined,
+		...overrides,
+	} as ResolvedPlugin;
+}
+
+function createSandboxedEntry(overrides: Partial<SandboxedPluginEntry> = {}): SandboxedPluginEntry {
+	return {
+		id: "sandboxed-plugin",
+		version: "2.1.0",
+		options: {},
+		code: "",
+		capabilities: ["read:content"],
+		allowedHosts: [],
+		storage: {},
+		adminPages: [{ path: "settings" }],
+		adminWidgets: [{ id: "status" }],
+		...overrides,
+	};
+}
+
+describe("plugin admin handlers: sandboxed plugins", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("surfaces a sandboxed entry, and a configured plugin shadows one with the same id", async () => {
+		const result = await handlePluginList(
+			db,
+			[createTestPlugin({ id: "shared-id", version: "1.0.0" })],
+			[createSandboxedEntry({ id: "sandboxed-only" }), createSandboxedEntry({ id: "shared-id" })],
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		// A sandboxed-only entry surfaces, flagged.
+		const surfaced = result.data.items.filter((p) => p.id === "sandboxed-only");
+		expect(surfaced).toHaveLength(1);
+		expect(surfaced[0]).toMatchObject({ source: "config", sandboxed: true });
+
+		// A configured plugin with the same id wins; the sandboxed entry is not listed twice.
+		const shared = result.data.items.filter((p) => p.id === "shared-id");
+		expect(shared).toHaveLength(1);
+		expect(shared[0]?.version).toBe("1.0.0");
+		expect(shared[0]?.sandboxed).toBeUndefined();
+	});
+});

--- a/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
+++ b/packages/core/tests/integration/astro/admin-plugins-sandboxed.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Statically-sandboxed plugins through the real admin plugin routes and a real
+ * EmDashRuntime: the list route surfaces them, and the enable/disable routes
+ * toggle them without error.
+ */
+
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { EmDashConfig } from "../../../src/astro/integration/runtime.js";
+import { POST as disablePlugin } from "../../../src/astro/routes/api/admin/plugins/[id]/disable.js";
+import { POST as enablePlugin } from "../../../src/astro/routes/api/admin/plugins/[id]/enable.js";
+import { GET as listPlugins } from "../../../src/astro/routes/api/admin/plugins/index.js";
+import type { Database } from "../../../src/database/types.js";
+import { EmDashRuntime, type SandboxedPluginEntry } from "../../../src/emdash-runtime.js";
+import { createHookPipeline } from "../../../src/plugins/hooks.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+function buildRuntime(db: Kysely<Database>, entries: SandboxedPluginEntry[]): EmDashRuntime {
+	const config: EmDashConfig = {};
+	const pipelineFactoryOptions = { db } as const;
+	const hooks = createHookPipeline([], pipelineFactoryOptions);
+	const pipelineRef = { current: hooks };
+	const runtimeDeps = {
+		config,
+		plugins: [],
+		// eslint-disable-next-line typescript/no-explicit-any -- match RuntimeDependencies signature
+		createDialect: (() => {
+			throw new Error("createDialect not used in this test");
+		}) as any,
+		createStorage: null,
+		sandboxEnabled: false,
+		sandboxedPluginEntries: entries,
+		createSandboxRunner: null,
+	};
+
+	return new EmDashRuntime({
+		db,
+		storage: null,
+		configuredPlugins: [],
+		sandboxedPlugins: new Map(),
+		sandboxedPluginEntries: entries,
+		hooks,
+		enabledPlugins: new Set(),
+		pluginStates: new Map(),
+		config,
+		mediaProviders: new Map(),
+		mediaProviderEntries: [],
+		cronExecutor: null,
+		cronScheduler: null,
+		emailPipeline: null,
+		allPipelinePlugins: [],
+		pipelineFactoryOptions,
+		runtimeDeps,
+		pipelineRef,
+	});
+}
+
+// Role.ADMIN is 50 in @emdash-cms/auth; plugins:read / plugins:manage require it.
+const admin = { id: "admin-1", role: 50 };
+
+// Mirror the subset of the middleware's `locals.emdash` facade that the plugin
+// routes read. The facade once dropped `sandboxedPluginEntries` (not compile-checked
+// here), which a raw-runtime fixture would hide, so this drives the real field through.
+function facade(runtime: EmDashRuntime) {
+	return {
+		db: runtime.db,
+		configuredPlugins: runtime.configuredPlugins,
+		sandboxedPluginEntries: runtime.sandboxedPluginEntries,
+		config: runtime.config,
+		setPluginStatus: runtime.setPluginStatus.bind(runtime),
+	};
+}
+
+function ctx(runtime: EmDashRuntime, params: Record<string, string> = {}): APIContext {
+	return {
+		locals: { emdash: facade(runtime), user: admin },
+		params,
+		request: new Request("http://test.local/_emdash/api/admin/plugins"),
+	} as unknown as APIContext;
+}
+
+function sandboxedEntry(overrides: Partial<SandboxedPluginEntry> = {}): SandboxedPluginEntry {
+	return {
+		id: "webhook-notifier",
+		version: "0.1.0",
+		options: {},
+		code: "",
+		capabilities: ["network:fetch"],
+		allowedHosts: ["*"],
+		storage: {},
+		adminPages: [],
+		adminWidgets: [],
+		...overrides,
+	};
+}
+
+async function listIds(runtime: EmDashRuntime) {
+	const res = await listPlugins(ctx(runtime));
+	expect(res.status).toBe(200);
+	const body = (await res.json()) as {
+		data: { items: Array<{ id: string; source?: string; sandboxed?: boolean; enabled: boolean }> };
+	};
+	return body.data;
+}
+
+describe("admin plugin routes: statically-sandboxed plugins (real runtime)", () => {
+	let db: Kysely<Database>;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		runtime = buildRuntime(db, [sandboxedEntry()]);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("the list route surfaces a sandboxed plugin from the runtime", async () => {
+		const body = await listIds(runtime);
+		const plugin = body.items.find((p) => p.id === "webhook-notifier");
+		expect(plugin).toMatchObject({ source: "config", sandboxed: true, enabled: true });
+	});
+
+	it("the enable and disable routes toggle a sandboxed plugin end to end", async () => {
+		const off = await disablePlugin(ctx(runtime, { id: "webhook-notifier" }));
+		expect(off.status).toBe(200);
+		let body = await listIds(runtime);
+		expect(body.items.find((p) => p.id === "webhook-notifier")?.enabled).toBe(false);
+
+		const on = await enablePlugin(ctx(runtime, { id: "webhook-notifier" }));
+		expect(on.status).toBe(200);
+		body = await listIds(runtime);
+		expect(body.items.find((p) => p.id === "webhook-notifier")?.enabled).toBe(true);
+	});
+});

--- a/packages/core/tests/utils/mcp-runtime.ts
+++ b/packages/core/tests/utils/mcp-runtime.ts
@@ -202,6 +202,7 @@ export function handlersFromRuntime(runtime: EmDashRuntime): EmDashHandlers {
 		hooks: runtime.hooks,
 		email: runtime.email,
 		configuredPlugins: runtime.configuredPlugins,
+		sandboxedPluginEntries: runtime.sandboxedPluginEntries,
 		config: runtime.config,
 		getManifest: runtime.getManifest.bind(runtime),
 		invalidateUrlPatternCache,


### PR DESCRIPTION
## What does this PR do?

Plugins registered statically via `sandboxed: []` in `astro.config.mjs` did not appear on the admin Plugins screen (`/_emdash/admin/plugins`). Trusted `plugins: []` entries and marketplace installs showed up, but sandboxed plugins were invisible there even though their hooks, cron schedules, and sandbox isolation all kept working.

The four admin plugin handlers in `packages/core/src/api/handlers/plugins.ts` (`handlePluginList`, `handlePluginGet`, `handlePluginEnable`, `handlePluginDisable`) only read `configuredPlugins` and never the runtime's `sandboxedPluginEntries`, so the `sandboxed: []` array fell through the gap between the configured list and the marketplace state rows.

The fix passes `sandboxedPluginEntries` to all four handlers and adds a `buildSandboxedPluginInfo` helper. The routes read it from `locals.emdash`, so the middleware now exposes `sandboxedPluginEntries` there and the `EmDashHandlers` type declares it (required, so it can not be dropped). Sandboxed plugins now list with `source: "config"` and a new `sandboxed: true` flag, and can be fetched, enabled, and disabled the same way trusted `plugins: []` entries are. The runtime already gates sandboxed hook execution on `isPluginEnabled`, and the enable/disable routes propagate state through `emdash.setPluginStatus`, so toggling worked at the runtime level but could not be reached from the admin API. A list-only change would have shown a toggle that returns `NOT_FOUND`, so all four handlers move together.

A few notes for reviewers:

- The sandboxed enable/disable branch mirrors the trusted-config branch exactly (`stateRepo.enable`/`disable` with no `source` override). An id that already has a leftover marketplace state row behaves the same on both config paths, so I left that case as-is rather than special-casing the sandboxed path.
- The `sandboxed` flag is added to the core API response, matching the runtime manifest which already marks these entries. I did not add an admin UI badge; the admin `PluginInfo` type has lagged core additions before, and the flag is available for a follow-up if a badge is wanted.
- `handlePluginGet` still returns `NOT_FOUND` for marketplace and registry plugins. That is pre-existing and outside the scope here.

A route-level test drives a real `EmDashRuntime` through the actual admin routes: the list route surfaces the sandboxed plugin and the enable/disable routes toggle it, and the same test returns 404 against the current code. A handler test covers a sandboxed entry surfacing in the list and the case where a configured plugin shadows one with the same id, where the configured entry wins and the row is listed once.

Closes #773

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). Do not include `messages.po` changes except in translation PRs.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: Claude Opus 4.8

## Screenshots / test output

```
$ pnpm --filter emdash exec vitest run tests/integration/api/plugins.test.ts tests/integration/astro/admin-plugins-sandboxed.test.ts
 Test Files  2 passed (2)
      Tests  3 passed (3)
```
