### PR TITLE
fix: surface per-entry SEO metadata on entry.data.seo

### DIFF
--- a/.changeset/fix-seo-loader-hydration.md
+++ b/.changeset/fix-seo-loader-hydration.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix SEO fields (noindex toggle, canonical URL) not affecting rendered pages. The content loader now surfaces per-entry SEO metadata on `entry.data.seo`, so `getSeoMeta()` reflects values set in the admin SEO panel. SEO is folded into the existing entry query via a LEFT JOIN, adding no extra database round-trips.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -25,12 +25,27 @@ import { isMissingColumnError, isMissingTableError } from "./utils/db-errors.js"
 const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
- * SEO columns joined in from `_emdash_seo` on the single-entry path. Kept out
- * of the generic field mapping (see SYSTEM_COLUMNS) and surfaced as a nested
- * `data.seo` object instead. SEO lives in a side table, so a LEFT JOIN folds
- * it into the entry load at zero extra query cost.
+ * SEO columns joined in from `_emdash_seo` on the single-entry path, mapped to
+ * aliased result keys. SEO lives in a side table, so a LEFT JOIN folds it into
+ * the entry load at zero extra query cost; the result is surfaced as a nested
+ * `data.seo` object (see extractSeo) rather than flat fields.
+ *
+ * The `_emdash_` prefix on the aliases guarantees they can never collide with
+ * a content field. Field slugs must match `/^[a-z][a-z0-9_]*$/`, so a user can
+ * legitimately define a `seo_title` field; selecting the joined column under
+ * its bare name would shadow that field in the result set and drop the user's
+ * value. The prefix (illegal as a leading slug char) sidesteps this entirely.
  */
-const SEO_COLUMNS = ["seo_title", "seo_description", "seo_image", "seo_canonical", "seo_no_index"];
+const SEO_COLUMN_ALIASES: Record<string, string> = {
+	seo_title: "_emdash_seo_title",
+	seo_description: "_emdash_seo_description",
+	seo_image: "_emdash_seo_image",
+	seo_canonical: "_emdash_seo_canonical",
+	seo_no_index: "_emdash_seo_no_index",
+};
+
+/** Aliased SEO result keys — excluded from generic field mapping. */
+const SEO_ALIAS_COLUMNS = Object.values(SEO_COLUMN_ALIASES);
 
 /**
  * System columns excluded from entry.data
@@ -52,9 +67,11 @@ const SYSTEM_COLUMNS = new Set([
 	"draft_revision_id",
 	"locale",
 	"translation_group",
-	// SEO columns joined from _emdash_seo on the single-entry path. Surfaced
-	// as a nested data.seo object (see extractSeo), never as flat fields.
-	...SEO_COLUMNS,
+	// Aliased SEO columns joined from _emdash_seo on the single-entry path.
+	// Surfaced as a nested data.seo object (see extractSeo), never as flat
+	// fields. The aliases are _emdash_-prefixed so they can't shadow a user
+	// field named e.g. `seo_title`.
+	...SEO_ALIAS_COLUMNS,
 ]);
 
 /** Resolved SEO shape attached to `entry.data.seo`. Mirrors `ContentSeo`. */
@@ -75,13 +92,18 @@ interface EntrySeo {
  * `getSeoMeta()` falls back to its defaults exactly as before.
  */
 function extractSeo(row: Record<string, unknown>): EntrySeo | null {
-	if (row.seo_no_index === null || row.seo_no_index === undefined) return null;
+	const noIndex = row[SEO_COLUMN_ALIASES.seo_no_index];
+	if (noIndex === null || noIndex === undefined) return null;
+	const title = row[SEO_COLUMN_ALIASES.seo_title];
+	const description = row[SEO_COLUMN_ALIASES.seo_description];
+	const image = row[SEO_COLUMN_ALIASES.seo_image];
+	const canonical = row[SEO_COLUMN_ALIASES.seo_canonical];
 	return {
-		title: typeof row.seo_title === "string" ? row.seo_title : null,
-		description: typeof row.seo_description === "string" ? row.seo_description : null,
-		image: typeof row.seo_image === "string" ? row.seo_image : null,
-		canonical: typeof row.seo_canonical === "string" ? row.seo_canonical : null,
-		noIndex: row.seo_no_index === 1,
+		title: typeof title === "string" ? title : null,
+		description: typeof description === "string" ? description : null,
+		image: typeof image === "string" ? image : null,
+		canonical: typeof canonical === "string" ? canonical : null,
+		noIndex: noIndex === 1,
 	};
 }
 
@@ -853,9 +875,14 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				// extractSeo() and excluded from the generic field mapping. SEO is
 				// 1:1 with content (PK on collection+content_id), so the join never
 				// multiplies rows.
+				const seoSelect = sql.join(
+					Object.entries(SEO_COLUMN_ALIASES).map(
+						([col, alias]) => sql`${sql.ref(`s.${col}`)} AS ${sql.ref(alias)}`,
+					),
+				);
 				const result = locale
 					? await sql<Record<string, unknown>>`
-							SELECT c.*, ${sql.join(SEO_COLUMNS.map((col) => sql.ref(`s.${col}`)))}
+							SELECT c.*, ${seoSelect}
 							FROM ${sql.ref(tableName)} AS c
 							LEFT JOIN ${sql.ref("_emdash_seo")} AS s
 								ON s.collection = ${type} AND s.content_id = c.id
@@ -864,7 +891,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 							LIMIT 1
 						`.execute(db)
 					: await sql<Record<string, unknown>>`
-							SELECT c.*, ${sql.join(SEO_COLUMNS.map((col) => sql.ref(`s.${col}`)))}
+							SELECT c.*, ${seoSelect}
 							FROM ${sql.ref(tableName)} AS c
 							LEFT JOIN ${sql.ref("_emdash_seo")} AS s
 								ON s.collection = ${type} AND s.content_id = c.id

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -25,8 +25,13 @@ import { isMissingColumnError, isMissingTableError } from "./utils/db-errors.js"
 const FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
- * System columns that are not part of the content data
+ * SEO columns joined in from `_emdash_seo` on the single-entry path. Kept out
+ * of the generic field mapping (see SYSTEM_COLUMNS) and surfaced as a nested
+ * `data.seo` object instead. SEO lives in a side table, so a LEFT JOIN folds
+ * it into the entry load at zero extra query cost.
  */
+const SEO_COLUMNS = ["seo_title", "seo_description", "seo_image", "seo_canonical", "seo_no_index"];
+
 /**
  * System columns excluded from entry.data
  * Note: slug is intentionally NOT excluded - it's useful as data.slug in templates
@@ -47,7 +52,38 @@ const SYSTEM_COLUMNS = new Set([
 	"draft_revision_id",
 	"locale",
 	"translation_group",
+	// SEO columns joined from _emdash_seo on the single-entry path. Surfaced
+	// as a nested data.seo object (see extractSeo), never as flat fields.
+	...SEO_COLUMNS,
 ]);
+
+/** Resolved SEO shape attached to `entry.data.seo`. Mirrors `ContentSeo`. */
+interface EntrySeo {
+	title: string | null;
+	description: string | null;
+	image: string | null;
+	canonical: string | null;
+	noIndex: boolean;
+}
+
+/**
+ * Build a `data.seo` object from the joined `_emdash_seo` columns on a row.
+ *
+ * Returns `null` when no SEO row exists (LEFT JOIN miss → `seo_no_index` is
+ * NULL, since the column is `NOT NULL DEFAULT 0` whenever a row is present).
+ * Returning null keeps the `seo` key off entries that have none, so
+ * `getSeoMeta()` falls back to its defaults exactly as before.
+ */
+function extractSeo(row: Record<string, unknown>): EntrySeo | null {
+	if (row.seo_no_index === null || row.seo_no_index === undefined) return null;
+	return {
+		title: typeof row.seo_title === "string" ? row.seo_title : null,
+		description: typeof row.seo_description === "string" ? row.seo_description : null,
+		image: typeof row.seo_image === "string" ? row.seo_image : null,
+		canonical: typeof row.seo_canonical === "string" ? row.seo_canonical : null,
+		noIndex: row.seo_no_index === 1,
+	};
+}
 
 /**
  * Get the table name for a collection type
@@ -809,18 +845,31 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 
 				// Use raw SQL for dynamic table name, match by slug or id
 				// When locale is specified, prefer locale-scoped slug match,
-				// but IDs are globally unique so always check id without locale scope
+				// but IDs are globally unique so always check id without locale scope.
+				//
+				// LEFT JOIN _emdash_seo folds per-entry SEO (canonical, noindex,
+				// etc.) into this single query at zero extra round-trip cost. The
+				// joined columns are surfaced as a nested data.seo object via
+				// extractSeo() and excluded from the generic field mapping. SEO is
+				// 1:1 with content (PK on collection+content_id), so the join never
+				// multiplies rows.
 				const result = locale
 					? await sql<Record<string, unknown>>`
-							SELECT * FROM ${sql.ref(tableName)}
-							WHERE deleted_at IS NULL
-							AND ((slug = ${id} AND locale = ${locale}) OR id = ${id})
+							SELECT c.*, ${sql.join(SEO_COLUMNS.map((col) => sql.ref(`s.${col}`)))}
+							FROM ${sql.ref(tableName)} AS c
+							LEFT JOIN ${sql.ref("_emdash_seo")} AS s
+								ON s.collection = ${type} AND s.content_id = c.id
+							WHERE c.deleted_at IS NULL
+							AND ((c.slug = ${id} AND c.locale = ${locale}) OR c.id = ${id})
 							LIMIT 1
 						`.execute(db)
 					: await sql<Record<string, unknown>>`
-							SELECT * FROM ${sql.ref(tableName)}
-							WHERE deleted_at IS NULL
-							AND (slug = ${id} OR id = ${id})
+							SELECT c.*, ${sql.join(SEO_COLUMNS.map((col) => sql.ref(`s.${col}`)))}
+							FROM ${sql.ref(tableName)} AS c
+							LEFT JOIN ${sql.ref("_emdash_seo")} AS s
+								ON s.collection = ${type} AND s.content_id = c.id
+							WHERE c.deleted_at IS NULL
+							AND (c.slug = ${id} OR c.id = ${id})
 							LIMIT 1
 						`.execute(db);
 
@@ -872,11 +921,20 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 							revLocale !== "" &&
 							(revLocale !== i18nConfig.defaultLocale || i18nConfig.prefixDefaultLocale);
 						const revId = shouldPrefixRev ? `${revLocale}/${revSlug}` : revSlug;
+						// SEO is not revisioned — it comes from the content row's
+						// joined _emdash_seo columns, not the revision snapshot.
+						const revEntryData: Record<string, unknown> = {
+							...systemData,
+							slug,
+							...mapRevisionData(parsed),
+						};
+						const revSeo = extractSeo(row);
+						if (revSeo) revEntryData.seo = revSeo;
 						return {
 							id: revId,
 							slug,
 							status: rowStr(row, "status", "draft"),
-							data: { ...systemData, slug, ...mapRevisionData(parsed) },
+							data: revEntryData,
 							cacheHint: {
 								tags: [rowStr(row, "id")],
 								lastModified: row.updated_at ? new Date(rowStr(row, "updated_at")) : undefined,
@@ -885,11 +943,14 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 					}
 				}
 
+				const entryData = mapRowToData(row);
+				const entrySeo = extractSeo(row);
+				if (entrySeo) entryData.seo = entrySeo;
 				return {
 					id: entryId,
 					slug: rowStr(row, "slug"),
 					status: rowStr(row, "status", "draft"),
-					data: mapRowToData(row),
+					data: entryData,
 					cacheHint: {
 						tags: [rowStr(row, "id")],
 						lastModified: row.updated_at ? new Date(rowStr(row, "updated_at")) : undefined,

--- a/packages/core/tests/unit/loader-seo.test.ts
+++ b/packages/core/tests/unit/loader-seo.test.ts
@@ -1,0 +1,109 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+
+import { handleContentCreate } from "../../src/api/index.js";
+import { SeoRepository } from "../../src/database/repositories/seo.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../utils/test-db.js";
+
+/**
+ * Regression test for #1270: SEO fields (noindex toggle, canonical URL) set in
+ * the admin had no effect on rendered pages because the content loader never
+ * surfaced the `_emdash_seo` row. The loader now LEFT JOINs that table and
+ * attaches the result to `entry.data.seo`, which `getSeoMeta()` reads.
+ *
+ * Run on both dialects — the LEFT JOIN SQL is dialect-sensitive.
+ */
+describeEachDialect("Loader SEO hydration (#1270)", (dialect) => {
+	let ctx: DialectTestContext;
+	let seoRepo: SeoRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		seoRepo = new SeoRepository(ctx.db);
+		// Enable SEO on the `post` collection (page stays without SEO).
+		await ctx.db
+			.updateTable("_emdash_collections")
+			.set({ has_seo: 1 })
+			.where("slug", "=", "post")
+			.execute();
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	async function createPublishedPost(title: string) {
+		const result = await handleContentCreate(ctx.db, "post", {
+			data: { title },
+			status: "published",
+		});
+		if (!result.success) throw new Error("Failed to create post");
+		return result.data!.item;
+	}
+
+	function load(idOrSlug: string) {
+		const loader = emdashLoader();
+		return runWithContext({ db: ctx.db }, () =>
+			loader.loadEntry!({ filter: { type: "post", id: idOrSlug } }),
+		);
+	}
+
+	it("attaches noindex + canonical from _emdash_seo to entry.data.seo", async () => {
+		const post = await createPublishedPost("Hidden Post");
+		await seoRepo.upsert("post", post.id, {
+			noIndex: true,
+			canonical: "https://example.com/canonical",
+			title: "SEO Title",
+		});
+
+		const result = await load(post.slug!);
+		const data = (result as { data: Record<string, unknown> }).data;
+		const seo = data.seo as Record<string, unknown>;
+
+		expect(seo).toBeDefined();
+		expect(seo.noIndex).toBe(true);
+		expect(seo.canonical).toBe("https://example.com/canonical");
+		expect(seo.title).toBe("SEO Title");
+	});
+
+	it("does not attach data.seo when no SEO row exists", async () => {
+		const post = await createPublishedPost("Plain Post");
+
+		const result = await load(post.slug!);
+		const data = (result as { data: Record<string, unknown> }).data;
+
+		expect(data.seo).toBeUndefined();
+	});
+
+	it("reflects noIndex=false as a present-but-false seo object once a row exists", async () => {
+		const post = await createPublishedPost("Indexed Post");
+		// A row exists (e.g. only a canonical was set), noIndex defaults false.
+		await seoRepo.upsert("post", post.id, { canonical: "https://example.com/x" });
+
+		const result = await load(post.slug!);
+		const data = (result as { data: Record<string, unknown> }).data;
+		const seo = data.seo as Record<string, unknown>;
+
+		expect(seo).toBeDefined();
+		expect(seo.noIndex).toBe(false);
+		expect(seo.canonical).toBe("https://example.com/x");
+	});
+
+	it("does not leak raw seo_* columns as flat data fields", async () => {
+		const post = await createPublishedPost("No Leak");
+		await seoRepo.upsert("post", post.id, { noIndex: true });
+
+		const result = await load(post.slug!);
+		const data = (result as { data: Record<string, unknown> }).data;
+
+		expect(data.seo_no_index).toBeUndefined();
+		expect(data.seo_title).toBeUndefined();
+		expect(data.seo_canonical).toBeUndefined();
+	});
+});

--- a/packages/core/tests/unit/loader-seo.test.ts
+++ b/packages/core/tests/unit/loader-seo.test.ts
@@ -105,5 +105,33 @@ describeEachDialect("Loader SEO hydration (#1270)", (dialect) => {
 		expect(data.seo_no_index).toBeUndefined();
 		expect(data.seo_title).toBeUndefined();
 		expect(data.seo_canonical).toBeUndefined();
+		// Aliased join columns must not leak either.
+		expect(data._emdash_seo_no_index).toBeUndefined();
+		expect(data._emdash_seo_title).toBeUndefined();
+	});
+
+	it("does not shadow a user field named seo_title with the joined SEO column", async () => {
+		// A collection is free to define a `seo_title` field (it's a valid,
+		// non-reserved slug). The join must not clobber it.
+		const { SchemaRegistry } = await import("../../src/schema/registry.js");
+		const registry = new SchemaRegistry(ctx.db);
+		await registry.createField("post", { slug: "seo_title", label: "SEO Title", type: "string" });
+
+		const result = await handleContentCreate(ctx.db, "post", {
+			data: { title: "Has SEO Field", seo_title: "user-defined value" },
+			status: "published",
+		});
+		if (!result.success) throw new Error("create failed");
+		const post = result.data!.item;
+		await seoRepo.upsert("post", post.id, { title: "panel value", noIndex: true });
+
+		const loaded = await load(post.slug!);
+		const data = (loaded as { data: Record<string, unknown> }).data;
+
+		// The user's field value survives.
+		expect(data.seo_title).toBe("user-defined value");
+		// The SEO panel value lands on the nested object, distinct from the field.
+		expect((data.seo as Record<string, unknown>).title).toBe("panel value");
+		expect((data.seo as Record<string, unknown>).noIndex).toBe(true);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Fixes SEO fields (the **Hide from search engines** noindex toggle and **canonical URL**) having no effect on rendered pages.

SEO is stored in a side table (`_emdash_seo`) and the admin API hydrates it correctly, but the front-end query path never did: the content loader builds `entry.data` only from the content table's own columns, so `getSeoMeta(post, ...)` always read an absent `data.seo` and fell back to defaults (`noIndex: false`, canonical derived from path). Toggling anything in the SEO panel produced no change in the output.

`loadEntry` now `LEFT JOIN`s `_emdash_seo` and surfaces the result as a nested `entry.data.seo` object. Because SEO is 1:1 with content (PK on `collection + content_id`), it folds into the existing entry query with **zero extra database round-trips** — verified against the query-count snapshot (unchanged).

Only the single-entry path is hydrated, not collection lists: templates call `getSeoMeta` on the single rendered entry, while list pages render bylines/tags rather than per-item canonical/robots.

Closes #1270

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable). N/A
- [x] I have added a changeset (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

New `tests/unit/loader-seo.test.ts` runs on both SQLite and Postgres (the JOIN is dialect-sensitive):

- attaches noindex + canonical to `entry.data.seo`
- no `data.seo` when no SEO row exists
- `noIndex:false` surfaced once a row exists (e.g. canonical-only)
- raw `seo_*` columns are not leaked as flat data fields

Full core suite: 3594 passing against Postgres (3557 SQLite). `pnpm query-counts` matches the baseline exactly.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-seo-loader-hydration-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/seo-loader-hydration`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
