### PR TITLE
fix(ci): archive triage board cards when issues close

### DIFF
--- a/.github/workflows/triage-project-sync.yml
+++ b/.github/workflows/triage-project-sync.yml
@@ -7,6 +7,12 @@
 # workflows just move labels as they always have; this never writes back to
 # them.
 #
+# It also keeps board membership in sync with the issue's open/closed state:
+# closing an issue ARCHIVES its card (it leaves the active board views but
+# stays recoverable in the project's archive, since triage is done once the
+# issue is closed); reopening unarchives and re-syncs it if it still carries
+# triage labels.
+#
 # Auth: mints an emdashbot App installation token (same APP_ID / APP_PRIVATE_KEY
 # secrets the other bot workflows use). The App needs organization "Projects:
 # Read and write" for the project mutations.
@@ -15,7 +21,7 @@ name: Triage project sync
 
 on:
   issues:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, closed, reopened]
   workflow_dispatch: # one-shot backfill of issues already carrying triage labels
 
 concurrency:
@@ -109,6 +115,85 @@ jobs:
             const fieldId = project.field.id;
             const optionId = (name) => project.field.options.find((o) => o.name === name)?.id;
 
+            // Archive an issue's card on THIS board, if present. An issue can
+            // belong to several projects; match on the project NODE ID, not the
+            // number -- Projects v2 numbers are per-owner, so a foreign project
+            // could also be #3 and a number match would target the wrong item.
+            // Archiving is reversible (unlike delete) and hides the card from
+            // active board views. Idempotent -- returns false when the issue
+            // has no card here, and re-archiving an archived item is a no-op.
+            const archiveCard = async (number) => {
+              const data = await github.graphql(
+                `query($owner:String!, $repo:String!, $number:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    issue(number:$number) {
+                      projectItems(first:100) { nodes { id project { id } } }
+                    }
+                  }
+                }`,
+                { owner, repo, number },
+              );
+              const nodes = data.repository?.issue?.projectItems?.nodes || [];
+              const item = nodes.find((n) => n.project?.id === project.id);
+              if (!item) {
+                // first:100 isn't paginated; warn if we hit the cap so a silent
+                // miss on an issue attached to 100+ projects is at least visible.
+                if (nodes.length === 100) {
+                  core.warning(`#${number}: on 100+ projects; could not confirm board membership`);
+                }
+                return false;
+              }
+              await github.graphql(
+                `mutation($project:ID!, $item:ID!) {
+                  archiveProjectV2Item(input:{ projectId:$project, itemId:$item }) { item { id } }
+                }`,
+                { project: project.id, item: item.id },
+              );
+              return true;
+            };
+
+            // Add the issue to the board (idempotent) and set its Triage State.
+            const upsertState = async (iss) => {
+              const stateName = pickState(labelNames(iss));
+              if (!stateName) {
+                core.info(`#${iss.number}: no triage label; skipping`);
+                return;
+              }
+              const optId = optionId(stateName);
+              if (!optId) {
+                core.warning(`#${iss.number}: no board option named "${stateName}"`);
+                return;
+              }
+              // Idempotent: returns the existing item if the issue is already added.
+              const added = await github.graphql(
+                `mutation($project:ID!, $content:ID!) {
+                  addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } }
+                }`,
+                { project: project.id, content: iss.node_id },
+              );
+              const itemId = added.addProjectV2ItemById.item.id;
+              // addProjectV2ItemById returns an EXISTING item as-is -- including
+              // when it was archived on close -- so unarchive to bring a
+              // reopened issue's card back onto the active board. No-op for
+              // items that are already active.
+              await github.graphql(
+                `mutation($project:ID!, $item:ID!) {
+                  unarchiveProjectV2Item(input:{ projectId:$project, itemId:$item }) { item { id } }
+                }`,
+                { project: project.id, item: itemId },
+              );
+              await github.graphql(
+                `mutation($project:ID!, $item:ID!, $field:ID!, $opt:String!) {
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId:$project, itemId:$item, fieldId:$field,
+                    value:{ singleSelectOptionId:$opt }
+                  }) { projectV2Item { id } }
+                }`,
+                { project: project.id, item: itemId, field: fieldId, opt: optId },
+              );
+              core.info(`#${iss.number} -> ${stateName}`);
+            };
+
             // Build the work list.
             let issues = [];
             if (context.eventName === "workflow_dispatch") {
@@ -129,33 +214,31 @@ jobs:
               issues = [iss];
             }
 
+            // Per-issue try/catch so the bulk backfill reconciles every issue
+            // even if one fails (e.g. a transient GraphQL error). Single-issue
+            // event runs still fail loudly via setFailed below, since the next
+            // event would otherwise be the only chance to recover.
+            let failures = 0;
             for (const iss of issues) {
-              const stateName = pickState(labelNames(iss));
-              if (!stateName) {
-                core.info(`#${iss.number}: no triage label; skipping`);
-                continue;
+              try {
+                // Closed issues never belong on the board: triage is finished
+                // once the issue is closed (however it was closed). Handling it
+                // here -- rather than only on the `closed` event -- means label
+                // changes on an already-closed issue, and the dispatch backfill,
+                // also reconcile, so the board self-heals to "open triaged
+                // issues only". Reopening hits the else-branch with state "open"
+                // and is re-added below if it still carries triage labels.
+                if ((iss.state || "").toLowerCase() === "closed") {
+                  const archived = await archiveCard(iss.number);
+                  core.info(`#${iss.number}: closed; ${archived ? "archived" : "not on board"}`);
+                  continue;
+                }
+                await upsertState(iss);
+              } catch (e) {
+                failures++;
+                core.warning(`#${iss.number}: sync failed: ${e.message}`);
               }
-              const optId = optionId(stateName);
-              if (!optId) {
-                core.warning(`#${iss.number}: no board option named "${stateName}"`);
-                continue;
-              }
-              // Idempotent: returns the existing item if the issue is already added.
-              const added = await github.graphql(
-                `mutation($project:ID!, $content:ID!) {
-                  addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } }
-                }`,
-                { project: project.id, content: iss.node_id },
-              );
-              const itemId = added.addProjectV2ItemById.item.id;
-              await github.graphql(
-                `mutation($project:ID!, $item:ID!, $field:ID!, $opt:String!) {
-                  updateProjectV2ItemFieldValue(input:{
-                    projectId:$project, itemId:$item, fieldId:$field,
-                    value:{ singleSelectOptionId:$opt }
-                  }) { projectV2Item { id } }
-                }`,
-                { project: project.id, item: itemId, field: fieldId, opt: optId },
-              );
-              core.info(`#${iss.number} -> ${stateName}`);
+            }
+            if (failures > 0 && context.eventName !== "workflow_dispatch") {
+              core.setFailed(`${failures} issue(s) failed to sync`);
             }


### PR DESCRIPTION
## What does this PR do?

The `triage-project-sync` workflow mirrors an issue's triage state onto the Auto-Triage Projects v2 board, but it only ever **added/updated** cards on label changes, so closed issues stayed on the board forever. This makes board membership track open/closed state. No linked issue (maintainer-initiated CI fix).

**How:**

- Adds `closed` and `reopened` to the `issues` trigger.
- The add-vs-remove decision is keyed on the issue's open/closed state in the main loop: closing **archives** the card (reversible, leaves active board views but stays in the project archive); reopening **unarchives + re-syncs** from labels.
- `addProjectV2ItemById` returns an existing item as-is, so the upsert path now calls `unarchiveProjectV2Item` explicitly, ensuring a reopened card returns to the active board.
- Handling state in the loop (not only on the `closed` event) means label edits on already-closed issues and the manual `workflow_dispatch` backfill reconcile too, so the board self-heals to "open triaged issues only".
- Card lookup matches on the project **node id**, not the per-owner project number (a foreign project that also happens to be #3 can't be targeted).
- The backfill loop is per-issue `try/catch` so one failure doesn't abort the batch; single-issue event runs still fail loudly via `setFailed`.

Archive (over hard delete) was chosen deliberately: it's reversible and preserves any card state, which matters given a recent destructive Projects v2 incident.

**Safety:** adversarial review pass; HIGH finding (project-number vs node-id match) and several MEDIUM findings (null guard, page-cap warning, resilient backfill loop) addressed. github-script JS syntax-checked, `zizmor` clean. Existing `organization-projects: write` token scope already covers archive/unarchive.

After merge, a one-shot `workflow_dispatch` run will archive the closed issues currently on the board.

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm lint` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- N/A: workflow YAML only -->
- [ ] `pnpm format` has been run <!-- N/A: workflow YAML only -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- N/A: CI workflow change -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- N/A -->
- [x] I have added a changeset (if this PR changes a published package) <!-- N/A: no published package changed -->
- [ ] New features link to an approved Discussion <!-- N/A: CI tooling -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (via opencode). Adversarial review pass run with the same model family.

## Screenshots / test output

`zizmor --persona=regular` reports no findings. YAML validated; embedded github-script syntax-checked with `node --check` (async-wrapped).

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-triage-sync-remove-on-close-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/triage-sync-remove-on-close`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
