### PR TITLE
fix(ci): pipe slurped gh api output to jq in reporter-reply

### DIFF
--- a/.github/workflows/reporter-reply.yml
+++ b/.github/workflows/reporter-reply.yml
@@ -131,7 +131,7 @@ jobs:
           # has a strictly greater id.
           LATEST_ASK_ID="$(
             gh api "/repos/emdash-cms/emdash/issues/${ISSUE_NUMBER}/comments" --paginate --slurp \
-              --jq '
+              | jq '
                 [ .[]
                   | .[]
                   | select(.user.login == "emdashbot[bot]")
@@ -473,7 +473,7 @@ jobs:
           #      bare integer.
           COUNT="$(
             gh api "/repos/emdash-cms/emdash/issues/${ISSUE_NUMBER}/comments" --paginate --slurp \
-              --jq '
+              | jq '
                 [ .[]
                   | .[]
                   | select(.user.login == "emdashbot[bot]")


### PR DESCRIPTION
## What does this PR do?

Fixes the `Reporter Reply` workflow, which is currently failing on `main` at the "Re-verify live state" step:

```
the --slurp option is not supported with --jq or --template
```

(example failure: run on issue #1272). The current `gh` CLI on `ubuntu-latest` no longer allows `--slurp` together with `--jq`. Two queries used that combination: the live-check `LATEST_ASK_ID` lookup and the negative-path retry `COUNT`. Both now keep `--paginate --slurp` (needed to flatten pages into a single array the jq filters iterate) and pipe the result to a standalone `jq`. The filter logic is unchanged.

This was pre-existing code; the recently merged #1286 made `live-check` run for non-reporter comments too, which surfaced it (it would also break the reporter path).

**Verified:** both jq filters produce identical results when piped (latest bot-ask id, retry-count max ignoring forged non-bot markers), including the empty-input `// 0` fallback.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm lint` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- N/A: workflow YAML only -->
- [ ] `pnpm format` has been run <!-- N/A: workflow YAML only -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- N/A: CI workflow change -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- N/A -->
- [x] I have added a changeset (if this PR changes a published package) <!-- N/A: no published package changed -->
- [ ] New features link to an approved Discussion <!-- N/A: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (via opencode).

## Screenshots / test output

`zizmor --persona=regular` reports no findings. YAML validated. jq filters tested locally against slurped sample payloads.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-reporter-reply-slurp-jq-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/reporter-reply-slurp-jq`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
