### PR TITLE
fix(ci): re-trigger investigation via repository_dispatch

### DIFF
--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -5,8 +5,14 @@ name: Investigate
 # fix branch). The orchestrator (this workflow) performs all GitHub writes
 # based on the agent's structured JSON output.
 #
-# Also accepts workflow_dispatch so the reporter-reply workflow can re-trigger
-# investigation when the reporter says the first attempt missed something.
+# Also accepts re-triggers from the reporter-reply workflow when the reporter
+# (or a maintainer) says the first attempt missed something:
+#   * workflow_dispatch -- for manual re-runs from the Actions UI.
+#   * repository_dispatch (type `reporter-retry`) -- used by reporter-reply.yml,
+#     because firing it needs only the contents:write the emdashbot App already
+#     has, whereas workflow_dispatch from the App would need actions:write.
+# Both carry { issueNumber, retryContext }; repository_dispatch in
+# client_payload, workflow_dispatch in inputs.
 
 on:
   issues:
@@ -21,6 +27,8 @@ on:
         description: "Reporter feedback from previous attempt"
         required: false
         type: string
+  repository_dispatch:
+    types: [reporter-retry]
 
 # Default-deny at workflow level. The job below opens up only what it needs.
 permissions:
@@ -34,13 +42,14 @@ jobs:
     # a PR (issues.labeled fires for PRs too).
     if: >-
       github.event_name == 'workflow_dispatch'
+      || github.event_name == 'repository_dispatch'
       || (github.event.label.name == 'bot:repro' && github.event.issue.pull_request == null)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # Serialize per-issue. Don't cancel in-flight runs -- partial state is
     # worse than a queue, since the agent may have already pushed branches.
     concurrency:
-      group: investigate-${{ github.event.issue.number || inputs.issueNumber }}
+      group: investigate-${{ github.event.issue.number || inputs.issueNumber || github.event.client_payload.issueNumber }}
       cancel-in-progress: false
     # Sandbox token (GITHUB_TOKEN) is intentionally read-only. All writes use
     # the minted app token from the step below.
@@ -75,11 +84,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EVENT_NAME: ${{ github.event_name }}
           LABEL_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          DISPATCH_ISSUE_NUMBER: ${{ inputs.issueNumber }}
+          # Re-trigger issue number / feedback come from inputs (workflow_dispatch)
+          # or client_payload (repository_dispatch); only one is ever set.
+          DISPATCH_ISSUE_NUMBER: ${{ inputs.issueNumber || github.event.client_payload.issueNumber }}
           LABEL_ISSUE_TITLE: ${{ github.event.issue.title }}
           LABEL_ISSUE_BODY: ${{ github.event.issue.body }}
           LABEL_ISSUE_REPORTER: ${{ github.event.issue.user.login }}
-          RETRY_CONTEXT: ${{ inputs.retryContext }}
+          RETRY_CONTEXT: ${{ inputs.retryContext || github.event.client_payload.retryContext }}
         run: |
           set -euo pipefail
           # The issue body and retry context are attacker-controllable
@@ -89,9 +100,24 @@ jobs:
           # and let the attacker forge subsequent outputs. Avoid
           # putting them in step outputs at all -- write to /tmp files
           # that later steps read directly.
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "repository_dispatch" ]]; then
             NUM="$DISPATCH_ISSUE_NUMBER"
+            # The dispatched number is attacker-influenceable (a forged
+            # repository_dispatch could carry a path-traversal value) and is
+            # about to be interpolated into an API path -- validate BEFORE the
+            # call, ahead of the shared check below. Issue numbers are positive
+            # integers with no leading zero (also keeps --argjson happy later).
+            if ! [[ "$NUM" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::invalid issue number: $NUM"
+              exit 1
+            fi
             gh api "/repos/emdash-cms/emdash/issues/${NUM}" > /tmp/issue.json
+            # The issues API returns PRs too; only the labeled path was
+            # PR-guarded. Reject a PR number dispatched by mistake or forgery.
+            if jq -e '.pull_request' /tmp/issue.json >/dev/null 2>&1; then
+              echo "::error::#${NUM} is a pull request, not an issue"
+              exit 1
+            fi
             TITLE="$(jq -r '.title // ""' /tmp/issue.json | tr -d '\r\n')"
             REPORTER="$(jq -r '.user.login // ""' /tmp/issue.json | tr -d '\r\n')"
             jq -r '.body // ""' /tmp/issue.json > /tmp/ctx-body.txt
@@ -107,7 +133,7 @@ jobs:
           # outputs. Issue numbers are integers; logins match a tight
           # regex. Anything weird produces a hard fail rather than a
           # silent injection.
-          if ! [[ "$NUM" =~ ^[0-9]+$ ]]; then
+          if ! [[ "$NUM" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::invalid issue number: $NUM"
             exit 1
           fi

--- a/.github/workflows/reporter-reply.yml
+++ b/.github/workflows/reporter-reply.yml
@@ -448,12 +448,11 @@ jobs:
           # maintainer (authorized in live-check, check 4). Login charset
           # is safe.
           COMMENTER: ${{ github.event.comment.user.login }}
-          # Pull workflow context values into env so the shell never sees
-          # raw `${{ ... }}` expansions -- zizmor flags these as template
-          # injection even though `github.repository` and `github.ref_name`
-          # are trustworthy on a non-fork issue_comment trigger. Defensive.
+          # Pull workflow context into env so the shell never sees raw
+          # `${{ ... }}` expansions -- zizmor flags these as template injection
+          # even though `github.repository` is trustworthy on a non-fork
+          # issue_comment trigger. Defensive.
           REPO_FULL: ${{ github.repository }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -506,17 +505,26 @@ jobs:
             exit 0
           fi
 
-          # Dispatch first, then transition the label. Order matters
-          # for recovery: if dispatch fails, the label stays put
-          # (so a maintainer can re-trigger by removing + re-adding
-          # `bot:repro` manually) rather than getting stuck in a
-          # `triage/reproducing` state with no investigation running.
+          # Re-trigger investigation via a repository_dispatch event (type
+          # `reporter-retry`) rather than `gh workflow run` (workflow_dispatch):
+          # firing repository_dispatch needs only contents:write, which the app
+          # token has, whereas workflow_dispatch needs actions:write, which the
+          # emdashbot App is not granted. investigate.yml reads issueNumber /
+          # retryContext from client_payload. The body is built with jq so the
+          # attacker-controlled REPLY_BODY is JSON-escaped, never interpolated
+          # into a command. repository_dispatch always runs on the default
+          # branch, so no ref is needed.
+          #
+          # Dispatch first, then transition the label. Order matters for
+          # recovery: if dispatch fails, the label stays put (so a maintainer
+          # can re-trigger by removing + re-adding `bot:repro` manually) rather
+          # than getting stuck in `triage/reproducing` with nothing running.
           set +e
-          gh workflow run investigate.yml \
-            --repo "$REPO_FULL" \
-            --ref "$REF_NAME" \
-            -f issueNumber="${ISSUE_NUMBER}" \
-            -f retryContext="${REPLY_BODY}"
+          jq -nc \
+            --arg n "$ISSUE_NUMBER" \
+            --arg r "$REPLY_BODY" \
+            '{event_type: "reporter-retry", client_payload: {issueNumber: $n, retryContext: $r}}' \
+            | gh api --method POST "/repos/${REPO_FULL}/dispatches" --input -
           DISPATCH_EXIT=$?
           set -e
 
@@ -525,7 +533,7 @@ jobs:
             # decide what to do. Leave the label on triage/awaiting-reporter
             # so the maintainer's manual `bot:repro` re-application
             # works as expected.
-            echo "::warning::workflow_dispatch failed (exit ${DISPATCH_EXIT}); leaving label on triage/awaiting-reporter"
+            echo "::warning::repository_dispatch failed (exit ${DISPATCH_EXIT}); leaving label on triage/awaiting-reporter"
             {
               echo "<!-- bot-retry-count: ${NEXT} -->"
               echo "I tried to re-run the investigation but the dispatch failed. A maintainer can re-trigger by removing the \`triage/awaiting-reporter\` label and re-adding \`bot:repro\`."


### PR DESCRIPTION
## What does this PR do?

The reporter-reply negative/retry path re-triggered `investigate.yml` with `gh workflow run` (workflow_dispatch), which **fails in production**: the emdashbot App token has `contents`/`issues`/`pull-requests` write but **not `actions:write`** (required for workflow_dispatch). The handler caught the failure and fell back to asking a maintainer to re-trigger manually, so automatic retries never ran. Surfaced by a `@emdashbot reject` on #1269 ([run](https://github.com/emdash-cms/emdash/actions/runs/26833864556/job/79122330272): `workflow_dispatch failed (exit 1)`).

**Fix:** switch to `repository_dispatch` (event type `reporter-retry`), which needs only `contents:write` that the App already has — chosen over granting the App `actions:write` to keep it least-privilege.

- `reporter-reply.yml`: builds the payload with `jq` (so the attacker-controlled retry text is JSON-escaped, never interpolated into a command) and POSTs to `/repos/{repo}/dispatches`. Removed the now-unused `REF_NAME`.
- `investigate.yml`: adds a `repository_dispatch: types: [reporter-retry]` trigger; the job `if:` allows the new event; `issueNumber`/`retryContext` resolve from `client_payload`, falling back to the existing `workflow_dispatch` inputs; the ctx branch handles both dispatch types.

**Hardening from adversarial review:**
- Validate the dispatched issue number (`^[1-9][0-9]*$`) **before** it's interpolated into the issues API path (previously validated only after the `gh api` call; the lower-privilege trigger made that ordering worth fixing).
- Reject PR numbers on the dispatch path — the issues API returns PRs too, and only the labeled path was PR-guarded.

Both files must land together: `repository_dispatch` runs the default-branch workflow definition.

**Safety:** adversarial review pass, no Critical/High. Injection closed end to end (jq `--arg` on send; env var + `printf` + `jq --rawfile` on receive). repository_dispatch requires `contents:write`, so external commenters can't fire it; the only reachable path is the already-authorized reporter-reply flow, bound to `github.event.issue.number`. `zizmor` clean; YAML validated; PR-guard and regex tested.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm lint` passes <!-- N/A: workflow YAML only -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- N/A: workflow YAML only -->
- [ ] `pnpm format` has been run <!-- N/A: workflow YAML only -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- N/A: CI workflow change -->
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- N/A -->
- [x] I have added a changeset (if this PR changes a published package) <!-- N/A: no published package changed -->
- [ ] New features link to an approved Discussion <!-- N/A: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (via opencode). Adversarial review pass run with the same model family.

## Screenshots / test output

`zizmor --persona=regular` reports no findings on both files. YAML validated. PR-guard (`jq -e '.pull_request'`) and issue-number regex tested locally.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-reporter-retry-dispatch-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/reporter-retry-dispatch`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
