### PR TITLE
Fix locale-scoped content updates

### DIFF
--- a/.changeset/fix-content-update-locale.md
+++ b/.changeset/fix-content-update-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes locale-aware content updates so REST, CLI, client, and MCP callers can safely update content by slug when multiple locales share the same slug.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -695,6 +695,7 @@ export async function handleContentUpdate(
 		status?: string;
 		authorId?: string | null;
 		bylines?: ContentBylineInput[];
+		locale?: string;
 		_rev?: string;
 		seo?: ContentSeoInput;
 		publishedAt?: string | null;
@@ -722,7 +723,7 @@ export async function handleContentUpdate(
 		const repo = new ContentRepository(db);
 
 		// Resolve slug → ID if needed
-		const resolvedId = (await resolveId(repo, collection, id)) ?? id;
+		const resolvedId = (await resolveId(repo, collection, id, body.locale)) ?? id;
 
 		// Wrap content + SEO writes in a transaction for atomicity.
 		// The _rev check is inside the transaction so the read-then-write

--- a/packages/core/src/api/openapi/document.ts
+++ b/packages/core/src/api/openapi/document.ts
@@ -257,6 +257,9 @@ const contentPaths = {
 					collection: z.string().meta({ description: "Collection slug" }),
 					id: z.string().meta({ description: "Content ID or slug" }),
 				}),
+				query: z.object({
+					locale: z.string().optional().meta({ description: "Locale filter" }),
+				}),
 			},
 			requestBody: {
 				content: { [JSON_CONTENT]: { schema: contentUpdateBody } },

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -68,7 +68,15 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 	const id = params.id!;
-	const locale = new URL(request.url).searchParams.get("locale") || undefined;
+			requestParams: {
+				path: z.object({
+					collection: z.string().meta({ description: "Collection slug" }),
+					id: z.string().meta({ description: "Content ID or slug" }),
+				}),
+				query: z.object({
+					locale: z.string().optional().meta({ description: "Locale filter" }),
+				}),
+			},
 	const body = await parseBody(request, contentUpdateBody);
 	if (isParseError(body)) return body;
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -68,6 +68,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 	const id = params.id!;
+	const locale = new URL(request.url).searchParams.get("locale") || undefined;
 	const body = await parseBody(request, contentUpdateBody);
 	if (isParseError(body)) return body;
 
@@ -76,7 +77,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	}
 
 	// Fetch item to check ownership
-	const existing = await emdash.handleContentGet(collection, id);
+	const existing = await emdash.handleContentGet(collection, id, locale);
 	if (!existing.success) {
 		return apiError(
 			existing.error?.code ?? "UNKNOWN_ERROR",
@@ -120,6 +121,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	// Pass _rev through for optimistic concurrency validation
 	const result = await emdash.handleContentUpdate(collection, resolvedId, {
 		...updateBody,
+		locale,
 		_rev: body._rev,
 	});
 

--- a/packages/core/src/astro/routes/api/content/[collection]/[id].ts
+++ b/packages/core/src/astro/routes/api/content/[collection]/[id].ts
@@ -68,15 +68,7 @@ export const PUT: APIRoute = async ({ params, request, locals, cache }) => {
 	const { emdash, user } = locals;
 	const collection = params.collection!;
 	const id = params.id!;
-			requestParams: {
-				path: z.object({
-					collection: z.string().meta({ description: "Collection slug" }),
-					id: z.string().meta({ description: "Content ID or slug" }),
-				}),
-				query: z.object({
-					locale: z.string().optional().meta({ description: "Locale filter" }),
-				}),
-			},
+	const locale = new URL(request.url).searchParams.get("locale") || undefined;
 	const body = await parseBody(request, contentUpdateBody);
 	if (isParseError(body)) return body;
 

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -274,6 +274,7 @@ export interface EmDashHandlers {
 			status?: string;
 			authorId?: string | null;
 			bylines?: Array<{ bylineId: string; roleLabel?: string | null }>;
+			locale?: string;
 			seo?: {
 				title?: string | null;
 				description?: string | null;

--- a/packages/core/src/cli/commands/content.ts
+++ b/packages/core/src/cli/commands/content.ts
@@ -233,6 +233,7 @@ const updateCommand = defineCommand({
 			description: "Revision token from get (prevents overwriting unseen changes)",
 			required: true,
 		},
+		locale: { type: "string", description: "Locale for slug resolution" },
 		draft: {
 			type: "boolean",
 			description: "Keep as draft instead of auto-publishing",
@@ -247,17 +248,18 @@ const updateCommand = defineCommand({
 			const updated = await client.update(args.collection, args.id, {
 				data,
 				_rev: args.rev,
+				locale: args.locale,
 			});
 
 			// Auto-publish unless --draft is set.
 			// Only publish if the update created a draft revision (i.e. the
 			// collection supports revisions and data went to a draft).
 			if (!args.draft && updated.draftRevisionId) {
-				await client.publish(args.collection, args.id);
+				await client.publish(args.collection, updated.id);
 			}
 
 			// Re-fetch to return the current state
-			const item = await client.get(args.collection, args.id);
+			const item = await client.get(args.collection, updated.id);
 			output(item, args);
 		} catch (error) {
 			consola.error(error instanceof Error ? error.message : "Unknown error");

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -521,6 +521,7 @@ export class EmDashClient {
 			slug?: string;
 			status?: string;
 			_rev?: string;
+			locale?: string;
 		},
 	): Promise<ContentItem> {
 		// Convert markdown strings to PT
@@ -536,9 +537,11 @@ export class EmDashClient {
 			status: input.status,
 			...(input._rev ? { _rev: input._rev } : {}),
 		};
+		const params = new URLSearchParams();
+		if (input.locale) params.set("locale", input.locale);
 		const result = await this.request<{ item: ContentItem; _rev?: string }>(
 			"PUT",
-			`/content/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`,
+			`/content/${encodeURIComponent(collection)}/${encodeURIComponent(id)}${params.toString() ? `?${params}` : ""}`,
 			body,
 		);
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2272,6 +2272,7 @@ export class EmDashRuntime {
 				noIndex?: boolean;
 			};
 			publishedAt?: string | null;
+			locale?: string;
 			/** Skip revision creation (used by autosave) */
 			skipRevision?: boolean;
 			_rev?: string;
@@ -2280,7 +2281,7 @@ export class EmDashRuntime {
 		// Resolve slug → ID if needed (before any lookups)
 		const { ContentRepository } = await import("./database/repositories/content.js");
 		const repo = new ContentRepository(this.db);
-		const resolvedItem = await repo.findByIdOrSlug(collection, id);
+		const resolvedItem = await repo.findByIdOrSlug(collection, id, body.locale);
 		const resolvedId = resolvedItem?.id ?? id;
 
 		// Validate _rev early — before draft revision writes which modify updated_at.

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -632,6 +632,12 @@ export function createMcpServer(): McpServer {
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug"),
 				id: z.string().describe("Content item ID or slug"),
+				locale: z
+					.string()
+					.optional()
+					.describe(
+						"Locale to scope slug lookup (e.g. 'fr'). Only affects slug resolution; IDs are globally unique.",
+					),
 				data: z
 					.record(z.string(), z.unknown())
 					.optional()
@@ -677,7 +683,7 @@ export function createMcpServer(): McpServer {
 			const { emdash, userId, userRole } = getExtra(extra);
 
 			// Fetch item to check ownership
-			const existing = await emdash.handleContentGet(args.collection, args.id);
+			const existing = await emdash.handleContentGet(args.collection, args.id, args.locale);
 			if (!existing.success) {
 				return unwrap(existing);
 			}
@@ -713,6 +719,7 @@ export function createMcpServer(): McpServer {
 						data: args.data,
 						slug: args.slug,
 						authorId: userId,
+						locale: args.locale,
 						seo: args.seo,
 						bylines: args.bylines,
 						publishedAt: args.publishedAt,
@@ -736,6 +743,7 @@ export function createMcpServer(): McpServer {
 						data: args.data,
 						slug: args.slug,
 						authorId: userId,
+						locale: args.locale,
 						seo: args.seo,
 						bylines: args.bylines,
 						publishedAt: args.publishedAt,
@@ -751,6 +759,7 @@ export function createMcpServer(): McpServer {
 					data: args.data,
 					slug: args.slug,
 					authorId: userId,
+					locale: args.locale,
 					seo: args.seo,
 					bylines: args.bylines,
 					publishedAt: args.publishedAt,

--- a/packages/core/tests/integration/cli/cli.test.ts
+++ b/packages/core/tests/integration/cli/cli.test.ts
@@ -172,6 +172,76 @@ describe("CLI Integration", () => {
 			await cli("content", "delete", "posts", created.id);
 		});
 
+		it("updates content by slug scoped to locale", async () => {
+			const slug = "cli-shared-locale";
+			const en = await cliJson<{ id: string; data: { title: string } }>(
+				"content",
+				"create",
+				"posts",
+				"--data",
+				JSON.stringify({ title: "CLI EN" }),
+				"--slug",
+				slug,
+				"--locale",
+				"en",
+			);
+			const fr = await cliJson<{ id: string; data: { title: string } }>(
+				"content",
+				"create",
+				"posts",
+				"--data",
+				JSON.stringify({ title: "CLI FR" }),
+				"--slug",
+				slug,
+				"--locale",
+				"fr",
+			);
+
+			const currentFr = await cliJson<{ _rev: string }>(
+				"content",
+				"get",
+				"posts",
+				slug,
+				"--locale",
+				"fr",
+			);
+			await cliJson<{ id: string; locale: string; data: { title: string } }>(
+				"content",
+				"update",
+				"posts",
+				slug,
+				"--locale",
+				"fr",
+				"--rev",
+				currentFr._rev,
+				"--data",
+				JSON.stringify({ title: "CLI FR Updated" }),
+			);
+
+			const fetchedEn = await cliJson<{ data: { title: string } }>(
+				"content",
+				"get",
+				"posts",
+				slug,
+				"--locale",
+				"en",
+			);
+			const fetchedFr = await cliJson<{ locale: string; data: { title: string } }>(
+				"content",
+				"get",
+				"posts",
+				slug,
+				"--locale",
+				"fr",
+			);
+			expect(fetchedEn.data.title).toBe("CLI EN");
+			expect(fetchedFr.locale).toBe("fr");
+			expect(fetchedFr.data.title).toBe("CLI FR Updated");
+
+			await cli("content", "delete", "posts", en.id);
+			await cli("content", "delete", "posts", fr.id);
+		});
+
 		it("publishes and unpublishes content", async () => {
 			const item = await cliJson<{ id: string }>(
 				"content",

--- a/packages/core/tests/integration/mcp/content-misc.test.ts
+++ b/packages/core/tests/integration/mcp/content-misc.test.ts
@@ -265,6 +265,51 @@ describe("content_translations + locale", () => {
 		expect(frTitle).toBe("FR");
 	});
 
+	it("content_update with locale param resolves slug per-locale", async () => {
+		const slug = "shared-update";
+		await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "EN" }, slug, locale: "en" },
+		});
+		await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "FR" }, slug, locale: "fr" },
+		});
+
+		const currentFr = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id: slug, locale: "fr" },
+		});
+		const rev = extractJson<{ _rev: string }>(currentFr)._rev;
+
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id: slug,
+				locale: "fr",
+				data: { title: "FR Updated" },
+				_rev: rev,
+			},
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		const en = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id: slug, locale: "en" },
+		});
+		const fr = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id: slug, locale: "fr" },
+		});
+		const enItem = extractJson<{ item: { data: { title?: unknown } } }>(en).item;
+		const frItem = extractJson<{ item: { data: { title?: unknown }; locale: string } }>(fr).item;
+
+		expect(enItem.data.title).toBe("EN");
+		expect(frItem.locale).toBe("fr");
+		expect(frItem.data.title).toBe("FR Updated");
+	});
+
 	it("rejects translationOf pointing to a non-existent item", async () => {
 		const result = await harness.client.callTool({
 			name: "content_create",

--- a/packages/core/tests/unit/api/content-handlers.test.ts
+++ b/packages/core/tests/unit/api/content-handlers.test.ts
@@ -217,6 +217,43 @@ describe("Content Handlers — auto-slug generation", () => {
 		});
 	});
 
+	describe("handleContentUpdate — locale-aware slug resolution", () => {
+		it("updates the row matching body.locale when the identifier is a shared slug", async () => {
+			const slug = "shared-locale-update";
+			const en = await handleContentCreate(db, "post", {
+				data: { title: "English" },
+				slug,
+				locale: "en",
+			});
+			const fr = await handleContentCreate(db, "post", {
+				data: { title: "French" },
+				slug,
+				locale: "fr",
+			});
+			expect(en.success).toBe(true);
+			expect(fr.success).toBe(true);
+
+			const currentFr = await handleContentGet(db, "post", slug, "fr");
+			expect(currentFr.success).toBe(true);
+
+			const updated = await handleContentUpdate(db, "post", slug, {
+				data: { title: "French Updated" },
+				locale: "fr",
+				_rev: currentFr.data!._rev,
+			});
+
+			expect(updated.success).toBe(true);
+			expect(updated.data?.item.id).toBe(fr.data?.item.id);
+			expect(updated.data?.item.locale).toBe("fr");
+			expect(updated.data?.item.data.title).toBe("French Updated");
+
+			const fetchedEn = await handleContentGet(db, "post", slug, "en");
+			const fetchedFr = await handleContentGet(db, "post", slug, "fr");
+			expect(fetchedEn.data?.item.data.title).toBe("English");
+			expect(fetchedFr.data?.item.data.title).toBe("French Updated");
+		});
+	});
+
 	describe("byline hydration and assignment", () => {
 		it("should assign and return bylines on create", async () => {
 			const bylineRepo = new BylineRepository(db);

--- a/packages/core/tests/unit/api/content-route-permissions.test.ts
+++ b/packages/core/tests/unit/api/content-route-permissions.test.ts
@@ -275,5 +275,43 @@ describe("content route — publishedAt / createdAt permission gate", () => {
 			expect(response.status).toBe(200);
 			expect(handleContentUpdate).toHaveBeenCalled();
 		});
+
+		it("passes locale query through slug ownership lookup and update", async () => {
+			const handleContentGet = vi.fn().mockResolvedValue({
+				success: true,
+				data: { item: { id: "fr-id", authorId: "user-1" }, _rev: "rev1" },
+			});
+			const handleContentUpdate = vi.fn().mockResolvedValue({
+				success: true,
+				data: { item: { id: "fr-id" }, _rev: "rev2" },
+			});
+
+			const request = new Request("http://localhost/_emdash/api/content/post/shared?locale=fr", {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: { title: "FR" } }),
+			});
+
+			const response = await updateContent({
+				params: { collection: "post", id: "shared" },
+				request,
+				locals: {
+					emdash: { handleContentUpdate, handleContentGet },
+					user: makeUser(Role.AUTHOR),
+				},
+				cache: makeCache(),
+			} as Parameters<typeof updateContent>[0]);
+
+			expect(response.status).toBe(200);
+			expect(handleContentGet).toHaveBeenCalledWith("post", "shared", "fr");
+			expect(handleContentUpdate).toHaveBeenCalledWith(
+				"post",
+				"fr-id",
+				expect.objectContaining({
+					data: { title: "FR" },
+					locale: "fr",
+				}),
+			);
+		});
 	});
 });

--- a/packages/core/tests/unit/api/openapi.test.ts
+++ b/packages/core/tests/unit/api/openapi.test.ts
@@ -154,6 +154,18 @@ describe("OpenAPI document generation", () => {
 		expect(itemPath).toHaveProperty("delete");
 	});
 
+	it("documents locale query parameter on content item update", () => {
+		const doc = generateOpenApiDocument();
+		const itemPath = doc.paths?.["/_emdash/api/content/{collection}/{id}"];
+		const updateOp = itemPath?.put as {
+			parameters?: Array<{ name?: string; in?: string }>;
+		};
+
+		expect(updateOp.parameters).toEqual(
+			expect.arrayContaining([expect.objectContaining({ name: "locale", in: "query" })]),
+		);
+	});
+
 	it("generates unique operation IDs for all operations", () => {
 		const doc = generateOpenApiDocument();
 		const operationIds: string[] = [];

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -189,6 +189,46 @@ describe("EmDashClient", () => {
 			expect(updated.data.title).toBe("Updated");
 			expect(updated._rev).toBe("bmV3cmV2");
 		});
+
+		it("update() appends locale for slug resolution", async () => {
+			const backend = createMockBackend([
+				{
+					method: "GET",
+					path: "/schema/collections/posts",
+					handler: () =>
+						jsonResponse({
+							item: {
+								slug: "posts",
+								label: "Posts",
+								fields: [{ slug: "title", type: "string", label: "Title" }],
+							},
+						}),
+				},
+				{
+					method: "PUT",
+					path: "/content/posts/shared?locale=fr",
+					handler: () =>
+						jsonResponse({
+							item: { id: "fr-id", locale: "fr", data: { title: "French Updated" } },
+							_rev: "bmV3cmV2",
+						}),
+				},
+			]);
+
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			const updated = await client.update("posts", "shared", {
+				data: { title: "French Updated" },
+				locale: "fr",
+			});
+
+			expect(updated.id).toBe("fr-id");
+			expect(updated.locale).toBe("fr");
+		});
 	});
 
 	describe("create()", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes locale-scoped content updates when callers update by slug and multiple locales share that slug.

This wires `locale` through REST `PUT /content/:collection/:id?locale=...`, the core handler/runtime slug resolution, the JS client, CLI `content update`, and MCP `content_update`. The CLI also uses the returned concrete `item.id` for follow-up publish/refetch calls so it does not reuse an ambiguous slug after a locale-scoped update.

Closes #1243

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs - a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code - model/tool: Codex (GPT-5-5 xHigh)

## Screenshots / test output

Non-visual bug fix.

Checks run:

- `pnpm build`
- `pnpm lint:quick`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter emdash test tests/unit/api/content-handlers.test.ts tests/unit/api/content-route-permissions.test.ts tests/unit/client/client.test.ts tests/unit/mcp/authorization.test.ts tests/integration/mcp/content-misc.test.ts`
- `pnpm --filter emdash test:integration tests/integration/cli/cli.test.ts`
- `pnpm format`
- `git diff --check`