### PR TITLE
fix(admin): resolve plugin admin pages opened at the plugin root

### DIFF
--- a/.changeset/fix-plugin-page-root-resolution.md
+++ b/.changeset/fix-plugin-page-root-resolution.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes plugin admin pages showing a Plugin Error when opened from the Plugin Manager. The Settings gear opens a plugin at its root (`/plugins/<id>/`), but a plugin that registers its page at `/settings` rather than `/` had no page there, so the admin fell through to a 404. Plugin page resolution now resolves the plugin root to the first registered page and treats `/settings` and `/settings/` as the same path, so a single registration works from the Plugin Manager gear and the sidebar regardless of trailing slash.

--- a/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
+++ b/docs/src/content/docs/plugins/creating-native-plugins/react-admin.mdx
@@ -224,7 +224,7 @@ export const widgets = {
 ```
 
 <Aside type="caution">
-	Page paths in `pages` must match the `path` values in `admin.pages`. Widget keys must match the `id` values in `admin.widgets`.
+	Page paths in `pages` should match the `path` values in `admin.pages`. A trailing slash is treated as equivalent, so `/settings` and `/settings/` resolve to the same page. Opening a plugin at its root resolves to the first registered page. Widget keys must match the `id` values in `admin.widgets`.
 </Aside>
 
 ## Using admin components

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -23,7 +23,7 @@ import * as React from "react";
 
 import { fetchCommentCounts } from "../lib/api/comments";
 import { useCurrentUser } from "../lib/api/current-user";
-import { usePluginAdmins } from "../lib/plugin-context";
+import { resolvePluginPagePath, usePluginAdmins } from "../lib/plugin-context";
 import { cn } from "../lib/utils";
 import { BrandIcon } from "./Logo.js";
 
@@ -252,7 +252,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 			const pluginPages = pluginAdmins[pluginId]?.pages;
 			const isBlocksMode = config.adminMode === "blocks";
 			for (const page of config.adminPages) {
-				if (!isBlocksMode && !pluginPages?.[page.path]) continue;
+				if (!isBlocksMode && !resolvePluginPagePath(pluginPages, page.path)) continue;
 				const label =
 					page.label ||
 					pluginId

--- a/packages/admin/src/lib/plugin-context.tsx
+++ b/packages/admin/src/lib/plugin-context.tsx
@@ -48,12 +48,33 @@ export function usePluginWidget(pluginId: string, widgetId: string): React.Compo
 	return admins[pluginId]?.widgets?.[widgetId] ?? null;
 }
 
+function togglePagePathTrailingSlash(path: string): string {
+	if (path === "/") return path;
+	return path.endsWith("/") ? path.slice(0, -1) : `${path}/`;
+}
+
 /**
- * Get a plugin page component by plugin ID and path
+ * Resolve a plugin page component by path, treating a trailing slash as equivalent and falling back to the first registered page at the root
+ */
+export function resolvePluginPagePath(
+	pages: Record<string, React.ComponentType> | undefined,
+	path: string,
+): React.ComponentType | null {
+	if (!pages) return null;
+	const match = pages[path] ?? pages[togglePagePathTrailingSlash(path)];
+	if (match) return match;
+	// The Plugin Manager gear opens a plugin at "/plugins/<id>/", so the root
+	// falls back to the first registered page when no page is keyed at "/".
+	if (path === "/") return Object.values(pages)[0] ?? null;
+	return null;
+}
+
+/**
+ * Get a plugin page component by plugin ID and path, with trailing-slash and root-fallback resolution
  */
 export function usePluginPage(pluginId: string, path: string): React.ComponentType | null {
 	const admins = useContext(PluginAdminContext);
-	return admins[pluginId]?.pages?.[path] ?? null;
+	return resolvePluginPagePath(admins[pluginId]?.pages, path);
 }
 
 /**

--- a/packages/admin/tests/lib/plugin-context.test.ts
+++ b/packages/admin/tests/lib/plugin-context.test.ts
@@ -1,0 +1,50 @@
+import type * as React from "react";
+import { describe, it, expect } from "vitest";
+
+import { resolvePluginPagePath } from "../../src/lib/plugin-context";
+
+const SettingsPage: React.ComponentType = () => null;
+const SettingsPageWithSlash: React.ComponentType = () => null;
+const RootPage: React.ComponentType = () => null;
+const AdvancedPage: React.ComponentType = () => null;
+
+describe("resolvePluginPagePath", () => {
+	it("resolves an exact page path", () => {
+		expect(resolvePluginPagePath({ "/settings": SettingsPage }, "/settings")).toBe(SettingsPage);
+	});
+
+	it("resolves a trailing-slash path to the page registered without one", () => {
+		expect(resolvePluginPagePath({ "/settings": SettingsPage }, "/settings/")).toBe(SettingsPage);
+	});
+
+	it("resolves a path without a trailing slash to the page registered with one", () => {
+		expect(resolvePluginPagePath({ "/settings/": SettingsPage }, "/settings")).toBe(SettingsPage);
+	});
+
+	it("prefers an exact match when both slash variants are registered", () => {
+		const pages = { "/settings": SettingsPage, "/settings/": SettingsPageWithSlash };
+		expect(resolvePluginPagePath(pages, "/settings")).toBe(SettingsPage);
+		expect(resolvePluginPagePath(pages, "/settings/")).toBe(SettingsPageWithSlash);
+	});
+
+	it("resolves the root path to a page registered at the root", () => {
+		expect(resolvePluginPagePath({ "/": RootPage }, "/")).toBe(RootPage);
+	});
+
+	it("falls back to the first registered page at the root when no root page exists", () => {
+		expect(resolvePluginPagePath({ "/settings": SettingsPage }, "/")).toBe(SettingsPage);
+	});
+
+	it("falls back to the first of several pages at the root", () => {
+		const pages = { "/settings": SettingsPage, "/advanced": AdvancedPage };
+		expect(resolvePluginPagePath(pages, "/")).toBe(SettingsPage);
+	});
+
+	it("does not fall back for an unregistered non-root path", () => {
+		expect(resolvePluginPagePath({ "/settings": SettingsPage }, "/missing")).toBeNull();
+	});
+
+	it("returns null when the plugin has no pages", () => {
+		expect(resolvePluginPagePath(undefined, "/settings")).toBeNull();
+	});
+});

--- a/skills/creating-plugins/references/admin-ui.md
+++ b/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,


### PR DESCRIPTION
## What does this PR do?

Closes #281.

Opening a plugin from the Plugin Manager showed a Plugin Error. The Settings gear links to the plugin root (`/plugins/<id>/`, an empty route splat), but a plugin that registers its admin page at `/settings` has no page at the root, so `usePluginPage` returned null and the admin fell through to the Block Kit route, which 404s for a React plugin. The lookup also compared paths by exact key, so `/settings` and `/settings/` were treated as different.

**Fix:**

- `resolvePluginPagePath` now resolves the plugin root to the first registered page, so opening a plugin lands on its admin page instead of a 404. It also matches a trailing-slash variant, so `/settings` and `/settings/` resolve to the same registration.
- `usePluginPage` (page rendering) and the sidebar nav-visibility check share this resolver.
- Update the plugin docs and skill reference, which said page paths must match exactly.

**Testing:** verified in a running admin (`demos/plugins-demo`, which wires the `api-test` plugin registered only at `/test`). Before, the Plugin Manager gear opened `/plugins/api-test` and rendered "Plugin Error: Plugin route not found (404)"; after, it renders the plugin's page. `resolvePluginPagePath` has unit coverage for the exact, trailing-slash (both directions), both-registered, root-fallback, and unregistered cases. `@emdash-cms/admin` typecheck, `oxlint`, and `oxfmt` pass.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No `messages.po` changes are included.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code (model: Claude Opus 4.8)
