### PR TITLE
fix(registry-client): bundle semver so workerd doesn't hit `require is not defined` (#1292)

### DIFF
--- a/.changeset/fix-registry-client-workerd-semver.md
+++ b/.changeset/fix-registry-client-workerd-semver.md
@@ -1,0 +1,8 @@
+---
+"@emdash-cms/registry-client": patch
+"emdash": patch
+---
+
+Fix `require is not defined` crash on every EmDash API route under `astro dev` on Cloudflare Workers (#1292).
+
+`@emdash-cms/registry-client` listed `semver` (CommonJS) in `dependencies`, which the build externalizes -- so consumers loaded a nested CJS copy. Vite's SSR module runner (workerd) evaluates modules with no `require` binding, so semver's internal `require()` threw and took down any route whose import graph reached registry-client (schema, plugins, env compatibility checks). semver is now bundled into the ESM output, so nothing CommonJS reaches the worker.

--- a/packages/registry-client/package.json
+++ b/packages/registry-client/package.json
@@ -41,14 +41,14 @@
 		"@atcute/atproto": "catalog:",
 		"@atcute/client": "catalog:",
 		"@atcute/lexicons": "catalog:",
-		"@emdash-cms/registry-lexicons": "workspace:*",
-		"semver": "catalog:"
+		"@emdash-cms/registry-lexicons": "workspace:*"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "catalog:",
 		"@types/node": "catalog:",
 		"@types/semver": "catalog:",
 		"publint": "catalog:",
+		"semver": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/packages/registry-client/src/env/index.ts
+++ b/packages/registry-client/src/env/index.ts
@@ -15,7 +15,9 @@
  * (browser compat warning), all sharing one implementation.
  */
 
-import { satisfies, valid, validRange } from "semver";
+import satisfies from "semver/functions/satisfies.js";
+import valid from "semver/functions/valid.js";
+import validRange from "semver/ranges/valid.js";
 
 export interface HostEnv {
 	/** Map of `env:*` key to the host's current version of that environment. */

--- a/packages/registry-client/tsdown.config.ts
+++ b/packages/registry-client/tsdown.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
 	clean: true,
 	platform: "node",
 	target: "node22",
+	// semver (a devDependency) is bundled on purpose so its CJS `require` never
+	// reaches workerd (#1292). Disable tsdown's bundled-dependency advisory,
+	// which CI escalates to an error.
+	inlineOnly: false,
 	external: [
 		"@atcute/atproto",
 		"@atcute/client",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2017,9 +2017,6 @@ importers:
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../registry-lexicons
-      semver:
-        specifier: 'catalog:'
-        version: 7.7.4
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -2033,6 +2030,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.17
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.4
       tsdown:
         specifier: 'catalog:'
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.16.4)(publint@0.3.17)(typescript@6.0.3)


### PR DESCRIPTION
Fixes #1292.

## The bug

After upgrading to `emdash@0.16.1`, every EmDash API route 500s with `require is not defined` under `astro dev` on Cloudflare Workers. The failure happens during route module import, before any handler runs.

## Root cause

`@emdash-cms/registry-client` is externalized by core's build, so a consumer's site loads registry-client's own `dist/`. Its `env/` module imported `semver` — a CommonJS package — and tsdown externalizes anything in `dependencies`, so the built `dist/env/index.js` shipped a bare `import { satisfies, valid, validRange } from "semver"`, resolving to a nested CJS copy.

Under `astro dev` on Cloudflare, Vite's SSR module runner (workerd) evaluates each module with **no `require` binding**. semver's internal `require("./internal/re")` therefore throws `require is not defined`, taking down every route whose import graph reaches registry-client (schema, plugins, env compatibility checks). A production `astro build` (Rollup CJS handling) wasn't affected, which is why this was dev-only.

Credit to @dzacarias for tracing the leaf module to the nested CJS `semver` in the issue thread.

## The fix

tsdown externalizes `dependencies` but **bundles `devDependencies`**. Moving `semver` to `devDependencies` forces it into registry-client's ESM output, so nothing CommonJS reaches the worker:

- **`package.json`** — `semver` moved to `devDependencies`.
- **`tsdown.config.ts`** — `inlineOnly: false`, since bundling a dependency trips tsdown's advisory, which CI escalates to a build error (core's config does the same).
- **`src/env/index.ts`** — the three functions are imported from their submodule entry points (`semver/functions/satisfies.js`, etc.) so the bundled chunk tree-shakes: 10.3KB → 7.3KB gzip.

## Verification

- Built `dist` confirmed free of `from "semver"`, bare `require(`, and `createRequire`; `CI=true pnpm build` across emdash + registry packages passes.
- registry-client (70) and plugin-cli (391) tests pass; `pnpm typecheck` clean, lint 0, `publint` + `attw` green.

## Testing gap (follow-up)

This class — "fine on Node, dead on workerd" — is invisible to the current test matrix: every CI job runs on Node (vitest) or the Astro **node** adapter (e2e), and `demo-cloudflare` is typecheck-only. Nothing boots the Cloudflare runtime, which is the only place this breaks. A proper workerd smoke test (boot the Cloudflare template under `astro dev`, hit an API route) is the real guard and will come in a separate PR.

The changeset bumps `@emdash-cms/registry-client` (patch) and `emdash` (patch) so the fix ships to consumers — `emdash`'s `workspace:*` range rewrites to the fixed registry-client at publish.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-registry-client-bundle-semver-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/registry-client-bundle-semver`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
