### PR TITLE
docs(agents): copy the PR template into the body when opening via gh/CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ During work:
 
 Before opening a PR: tests pass, lint clean, formatted, changeset added if a published package changed. See [CONTRIBUTING.md § Changesets](CONTRIBUTING.md#changesets).
 
+When opening a PR with `gh`/the API, copy `.github/PULL_REQUEST_TEMPLATE.md` into the body and fill every section -- the GitHub UI injects it automatically but the CLI does not, and PRs missing it are auto-closed. Check the AI-generated code disclosure box and name the model. Tick checklist items only for what you actually verified; for test-only/docs/CI PRs, note why changeset/i18n/Discussion items are n/a.
+
 ## Architecture
 
 EmDash is an Astro-native CMS on Cloudflare (D1 + R2 + Workers) or Node + SQLite.


### PR DESCRIPTION
## What does this PR do?

Adds one instruction to `AGENTS.md` (the agent-facing instructions, symlinked as `.claude/CLAUDE.md`): when opening a PR via `gh`/the API, copy `.github/PULL_REQUEST_TEMPLATE.md` into the body and fill it out.

CONTRIBUTING.md already mandates the template and notes PRs without it are auto-closed — but that's human-facing, and humans never hit the gap because the GitHub UI injects the template automatically. Agents opening PRs from the CLI get a blank body and skip it (I did, on two PRs this week). The rule belongs in the agent instructions, so it's in front of the actor who actually needs it.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

> Notes: docs-only change to `AGENTS.md` — no code, no tests, no published package, no admin strings, not a feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

N/A — single-line documentation change.