### PR TITLE
test(e2e): correct the Cloudflare skip-comment characterizations

### DIFF
--- a/e2e/tests/i18n.spec.ts
+++ b/e2e/tests/i18n.spec.ts
@@ -176,16 +176,18 @@ test.describe("i18n", () => {
 		});
 
 		test("shows Edit link for existing translations", async ({ admin }) => {
-			// FIXME(cloudflare): on the Cloudflare/workerd target the EN "Edit"
-			// link does not appear in the translations sidebar on the freshly
-			// created FR translation page (the EN sibling isn't read back in time),
-			// even though the translation itself is created and navigable (the
-			// other i18n specs pass). Same write-then-read signature as the skipped
-			// invite-flow test — suspected D1 Sessions read-after-write under
-			// miniflare dev. Flagged for maintainers; skipped so the CF lane stays green.
+			// FIXME(cloudflare): flaky on the Cloudflare/workerd target — the EN
+			// "Edit" link doesn't appear in the translations sidebar within the
+			// helper's timeout on the freshly created FR translation page. The
+			// backend is NOT at fault: hitting the translations API directly on
+			// D1 returns both siblings correctly (EN's translation_group is
+			// self-referential, FR's points to EN). It's a front-end render-timing
+			// issue specific to the slower workerd dev runtime — the sibling
+			// `clickEditTranslation` test (208) passes because `.click()` waits
+			// longer than this `isVisible` check. Skipped so the CF lane stays green.
 			test.skip(
 				process.env.EMDASH_E2E_TARGET === "cloudflare",
-				"CF: translation sibling not read back on the new translation page (under investigation)",
+				"CF: translations sidebar Edit link renders too slowly (front-end timing; backend verified OK)",
 			);
 			// Create a post and its FR translation
 			await admin.goToNewContent("posts");

--- a/e2e/tests/invite-flow.spec.ts
+++ b/e2e/tests/invite-flow.spec.ts
@@ -236,12 +236,16 @@ test.describe("Full invite flow with passkey registration", () => {
 		// not visible in the users list after the passkey-invite registration
 		// above — reproducible in isolation, passes on Node. The registration
 		// ceremony completes (redirects to admin, no errors) but the user row
-		// isn't read back. Suspected D1 Sessions read-after-write under miniflare
-		// dev rather than a production bug, but unconfirmed. Tracked for the
-		// EmDash maintainers to investigate; skipped here so the CF lane stays green.
+		// isn't read back. NOT a consistency artifact: miniflare D1 is a local
+		// SQLite file (strongly consistent), so if the read misses a committed
+		// write it's a real code bug — likely a SQLite-vs-D1-dialect difference in
+		// the invite-registration write or the user-list read. Needs a
+		// browser-driven repro (passkey-gated) to confirm backend vs front-end.
+		// Flagged for maintainers as possibly a real Cloudflare bug; skipped so
+		// the CF lane stays green.
 		test.skip(
 			process.env.EMDASH_E2E_TARGET === "cloudflare",
-			"CF: invited user not read back after passkey-invite registration (under investigation)",
+			"CF: invited user not read back after passkey-invite registration (possible real bug, under investigation)",
 		);
 		await admin.devBypassAuth();
 		await admin.goto("/users");


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1322. Corrects the `FIXME(cloudflare)` comments on the two CF-skipped tests after investigating them — the merged PR pinned both on "suspected D1 Sessions read-after-write," which is wrong (miniflare D1 is a strongly-consistent local SQLite file, so a read-after-write *lag* is impossible).

Both tests stay skipped, now with accurate characterizations:

- **`i18n › shows Edit link for existing translations`** — **backend verified correct on D1** (the translations API returns both siblings). The flake is a dev-runtime artifact: the workerd dev runner's Vite optimizer re-bundles mid-test and stalls the translations-sidebar fetch, so the "Edit" link occasionally renders past the helper's timeout. *I explored a fix* — a browser-based admin-chunk warm-up in `global-setup` — and it made the test reliable locally (~2.4s), but on CI's slower 2-core runner the render still exceeded a reasonable timeout, and the resource-heavy warm-up destabilized other shards. So it's reverted; the test stays skipped with the accurate comment. Not a product bug (production has no Vite optimizer).
- **`invite-flow › invited user appears in the users list`** — passkey-gated write path I couldn't reach to verify. Re-characterized: if the read genuinely misses the write on strongly-consistent local D1, it's a **real code bug** (likely a SQLite-vs-D1-dialect difference), not a dev artifact. Flagged for maintainers; needs a browser-driven repro.

No behavior change — comments + skip-reason strings only.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

> Notes: test-only comment/string corrections — no code change, no published package, no admin strings, not a feature.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

N/A — comment + skip-reason corrections only.