### PR TITLE
fix(cli): make export-seed i18n-aware via data-driven locale detection

### DIFF
--- a/.changeset/fix-export-seed-cli-i18n.md
+++ b/.changeset/fix-export-seed-cli-i18n.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix `emdash export-seed` collapsing locale variants into duplicate seed ids on i18n projects. The CLI never initializes the runtime i18n config, so `isI18nEnabled()` was always `false` and the exporter stripped the `:locale` suffix from taxonomy, menu, and content seed ids — merging every locale variant into one bare id and producing duplicates that `validateSeed` rejected. The exporter now derives locale-awareness from the data (a project is multi-locale when its i18n-aware tables hold more than one distinct locale), so multi-locale exports keep their per-locale suffixes and `translationOf` links while genuinely single-locale projects still export bare ids.

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -9,6 +9,7 @@ import { resolve } from "node:path";
 import { defineCommand } from "citty";
 import consola from "consola";
 import type { Kysely } from "kysely";
+import { sql } from "kysely";
 
 import { createDatabase } from "../../database/connection.js";
 import { runMigrations } from "../../database/migrations/runner.js";
@@ -17,6 +18,7 @@ import { MediaRepository } from "../../database/repositories/media.js";
 import { OptionsRepository } from "../../database/repositories/options.js";
 import { TaxonomyRepository } from "../../database/repositories/taxonomy.js";
 import type { Database } from "../../database/types.js";
+import { validateIdentifier } from "../../database/validate.js";
 import { isI18nEnabled } from "../../i18n/config.js";
 import { SchemaRegistry } from "../../schema/registry.js";
 import type { FieldType } from "../../schema/types.js";
@@ -118,11 +120,17 @@ export async function exportSeed(db: Kysely<Database>, withContent?: string): Pr
 	// 2. Export collections and fields
 	seed.collections = await exportCollections(db);
 
+	// Decide locale-awareness from the data. The runtime sets the i18n config via
+	// middleware, but the CLI never does, so `isI18nEnabled()` is always false
+	// under `emdash export-seed` (#1330). Detecting multiple locales in the data
+	// keeps the export locale-aware without the runtime flag.
+	const i18nEnabled = await detectI18nEnabled(db, seed.collections);
+
 	// 3. Export taxonomy definitions and terms
-	seed.taxonomies = await exportTaxonomies(db);
+	seed.taxonomies = await exportTaxonomies(db, i18nEnabled);
 
 	// 4. Export menus
-	seed.menus = await exportMenus(db);
+	seed.menus = await exportMenus(db, i18nEnabled);
 
 	// 5. Export widget areas
 	seed.widgetAreas = await exportWidgetAreas(db);
@@ -137,10 +145,51 @@ export async function exportSeed(db: Kysely<Database>, withContent?: string): Pr
 						.map((s) => s.trim())
 						.filter(Boolean);
 
-		seed.content = await exportContent(db, seed.collections || [], collections);
+		seed.content = await exportContent(db, seed.collections || [], collections, i18nEnabled);
 	}
 
 	return seed;
+}
+
+/**
+ * Determine whether the export should emit locale-suffixed seed ids.
+ *
+ * The runtime initializes the i18n config in middleware, but the CLI never does,
+ * so `isI18nEnabled()` is always false under `emdash export-seed` (#1330). When
+ * the flag is unset, fall back to the data: a project is multi-locale when its
+ * i18n-aware tables hold rows in more than one distinct locale. `locale` is
+ * NOT NULL (defaulting to the site's default locale), so a per-row presence
+ * check is not enough — only the *count* of distinct locales distinguishes a
+ * genuinely single-locale project from a multi-locale one. This keeps
+ * single-locale exports on bare ids and gives multi-locale exports the
+ * per-locale suffix they need to avoid duplicate seed ids.
+ */
+async function detectI18nEnabled(
+	db: Kysely<Database>,
+	collections: SeedCollection[],
+): Promise<boolean> {
+	if (isI18nEnabled()) return true;
+
+	const locales = new Set<string>();
+	const collectDistinctLocales = async (tableRef: ReturnType<typeof sql.ref>): Promise<boolean> => {
+		const result = await sql<{ locale: string | null }>`
+			SELECT DISTINCT locale FROM ${tableRef}
+		`.execute(db);
+		for (const row of result.rows) {
+			if (row.locale) locales.add(row.locale);
+		}
+		return locales.size > 1;
+	};
+
+	if (await collectDistinctLocales(sql.ref("_emdash_taxonomy_defs"))) return true;
+	if (await collectDistinctLocales(sql.ref("_emdash_menus"))) return true;
+
+	for (const collection of collections) {
+		validateIdentifier(collection.slug, "collection slug");
+		if (await collectDistinctLocales(sql.ref(`ec_${collection.slug}`))) return true;
+	}
+
+	return false;
 }
 
 /**
@@ -212,9 +261,10 @@ async function exportCollections(db: Kysely<Database>): Promise<SeedCollection[]
 /**
  * Export taxonomy definitions and terms
  */
-async function exportTaxonomies(db: Kysely<Database>): Promise<SeedTaxonomy[]> {
-	const i18nEnabled = isI18nEnabled();
-
+async function exportTaxonomies(
+	db: Kysely<Database>,
+	i18nEnabled: boolean,
+): Promise<SeedTaxonomy[]> {
 	// Mirrors the content export pattern: one entry per (name, locale), stable
 	// seed-local id, translations linked via `translationOf` to the anchor's id.
 	const defs = await db
@@ -306,9 +356,7 @@ async function exportTaxonomies(db: Kysely<Database>): Promise<SeedTaxonomy[]> {
 /**
  * Export menus with their items
  */
-async function exportMenus(db: Kysely<Database>): Promise<SeedMenu[]> {
-	const i18nEnabled = isI18nEnabled();
-
+async function exportMenus(db: Kysely<Database>, i18nEnabled: boolean): Promise<SeedMenu[]> {
 	const menus = await db
 		.selectFrom("_emdash_menus")
 		.selectAll()
@@ -546,6 +594,7 @@ async function exportContent(
 	db: Kysely<Database>,
 	collections: SeedCollection[],
 	includeCollections: string[] | null,
+	i18nEnabled: boolean,
 ): Promise<Record<string, SeedContentEntry[]>> {
 	const content: Record<string, SeedContentEntry[]> = {};
 	const contentRepo = new ContentRepository(db);
@@ -578,8 +627,6 @@ async function exportContent(
 	} catch {
 		// Media table might not exist or be empty
 	}
-
-	const i18nEnabled = isI18nEnabled();
 
 	for (const collection of collections) {
 		// Skip if not in include list

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -34,6 +34,7 @@ import type {
 	SeedWidget,
 	SeedContentEntry,
 } from "../../seed/types.js";
+import { isMissingTableError } from "../../utils/db-errors.js";
 import { slugify } from "../../utils/slugify.js";
 
 const SETTINGS_PREFIX = "site:";
@@ -186,7 +187,13 @@ async function detectI18nEnabled(
 
 	for (const collection of collections) {
 		validateIdentifier(collection.slug, "collection slug");
-		if (await collectDistinctLocales(sql.ref(`ec_${collection.slug}`))) return true;
+		// On D1, deleteCollection is non-atomic, so a collection row can outlive
+		// its ec_* table. Skip missing tables rather than crashing the export.
+		try {
+			if (await collectDistinctLocales(sql.ref(`ec_${collection.slug}`))) return true;
+		} catch (error) {
+			if (!isMissingTableError(error)) throw error;
+		}
 	}
 
 	return false;

--- a/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from "kysely";
+import { sql } from "kysely";
 import { ulid } from "ulidx";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -241,6 +242,20 @@ describe("exportSeed: CLI (no runtime i18n config) stays locale-aware (#1330)", 
 		const result = validateSeed(seed);
 		expect(result.errors).toEqual([]);
 		expect(result.valid).toBe(true);
+	});
+
+	it("does not crash when a collection row outlives its dropped ec_* table", async () => {
+		// On D1, deleteCollection is non-atomic, so a `_emdash_collections` row can
+		// survive without its `ec_*` table. The locale probe must skip the missing
+		// table rather than hard-crashing the export with "no such table".
+		db = await setupTestDatabaseWithCollections();
+
+		await sql`DROP TABLE ec_post`.execute(db);
+
+		const seed = await exportSeed(db);
+
+		// The collection metadata still exports; only the missing content table is skipped.
+		expect(seed.collections?.some((c) => c.slug === "post")).toBe(true);
 	});
 
 	it("keeps bare ids for genuinely single-locale projects", async () => {

--- a/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
@@ -1,0 +1,263 @@
+import type { Kysely } from "kysely";
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportSeed } from "../../../src/cli/commands/export-seed.js";
+import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { validateSeed } from "../../../src/seed/validate.js";
+import {
+	setupTestDatabase,
+	setupTestDatabaseWithCollections,
+	teardownTestDatabase,
+} from "../../utils/test-db.js";
+
+/**
+ * Regression for #1330: `emdash export-seed` runs in the CLI, which never calls
+ * `setI18nConfig()`, so `isI18nEnabled()` is always false. Multi-locale projects
+ * then export every locale variant with the locale suffix stripped, producing
+ * byte-identical duplicate seed ids that `validateSeed` rejects.
+ *
+ * These tests run with i18n config UNSET (null) — exactly the CLI environment —
+ * and assert that the export stays locale-aware by reading the per-row data.
+ */
+
+async function insertTaxonomyDef(
+	db: Kysely<Database>,
+	args: { id: string; name: string; label: string; locale: string; group: string },
+) {
+	await db
+		.insertInto("_emdash_taxonomy_defs")
+		.values({
+			id: args.id,
+			name: args.name,
+			label: args.label,
+			hierarchical: 0,
+			collections: JSON.stringify(["post"]),
+			created_at: new Date().toISOString(),
+			locale: args.locale,
+			translation_group: args.group,
+		})
+		.execute();
+}
+
+async function insertTerm(
+	db: Kysely<Database>,
+	args: { id: string; name: string; slug: string; label: string; locale: string; group: string },
+) {
+	await db
+		.insertInto("taxonomies")
+		.values({
+			id: args.id,
+			name: args.name,
+			slug: args.slug,
+			label: args.label,
+			parent_id: null,
+			data: null,
+			locale: args.locale,
+			translation_group: args.group,
+		})
+		.execute();
+}
+
+async function insertMenu(
+	db: Kysely<Database>,
+	args: { id: string; name: string; label: string; locale: string; group: string },
+) {
+	const now = new Date().toISOString();
+	await db
+		.insertInto("_emdash_menus")
+		.values({
+			id: args.id,
+			name: args.name,
+			label: args.label,
+			created_at: now,
+			updated_at: now,
+			locale: args.locale,
+			translation_group: args.group,
+		})
+		.execute();
+}
+
+describe("exportSeed: CLI (no runtime i18n config) stays locale-aware (#1330)", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(() => {
+		// Mirror the CLI: the i18n config is never initialized.
+		setI18nConfig(null);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		setI18nConfig(null);
+	});
+
+	it("suffixes taxonomy def + term ids per locale instead of colliding", async () => {
+		db = await setupTestDatabase();
+
+		const enGroup = ulid();
+		const enDefId = ulid();
+		const arDefId = ulid();
+		await insertTaxonomyDef(db, {
+			id: enDefId,
+			name: "genre",
+			label: "Categories",
+			locale: "en",
+			group: enGroup,
+		});
+		await insertTaxonomyDef(db, {
+			id: arDefId,
+			name: "genre",
+			label: "التصنيفات",
+			locale: "ar",
+			group: enGroup,
+		});
+
+		const enTermGroup = ulid();
+		await insertTerm(db, {
+			id: ulid(),
+			name: "genre",
+			slug: "news",
+			label: "News",
+			locale: "en",
+			group: enTermGroup,
+		});
+		await insertTerm(db, {
+			id: ulid(),
+			name: "genre",
+			slug: "news",
+			label: "أخبار",
+			locale: "ar",
+			group: enTermGroup,
+		});
+
+		const seed = await exportSeed(db);
+
+		const cats = seed.taxonomies?.filter((t) => t.name === "genre") ?? [];
+		expect(cats).toHaveLength(2);
+
+		// Ids must be unique across locale variants.
+		const ids = cats.map((t) => t.id);
+		expect(new Set(ids).size).toBe(2);
+		expect(new Set(ids)).toEqual(new Set(["tax:genre:en", "tax:genre:ar"]));
+
+		// One def anchors the group, the other references it.
+		const anchor = cats.find((t) => !t.translationOf);
+		const translation = cats.find((t) => t.translationOf);
+		expect(anchor?.locale).toBeDefined();
+		expect(translation?.translationOf).toBe(anchor?.id);
+
+		// Term ids likewise carry the locale suffix and stay unique.
+		const termIds = cats.flatMap((t) => (t.terms ?? []).map((term) => term.id));
+		expect(termIds).toEqual(expect.arrayContaining(["term:genre:news:en", "term:genre:news:ar"]));
+		expect(new Set(termIds).size).toBe(termIds.length);
+
+		// The whole exported seed must validate (no duplicate-id rejection).
+		const result = validateSeed(seed);
+		expect(result.errors).toEqual([]);
+		expect(result.valid).toBe(true);
+	});
+
+	it("suffixes menu ids per locale instead of colliding", async () => {
+		db = await setupTestDatabase();
+
+		const group = ulid();
+		await insertMenu(db, {
+			id: ulid(),
+			name: "primary",
+			label: "Primary",
+			locale: "en",
+			group,
+		});
+		await insertMenu(db, {
+			id: ulid(),
+			name: "primary",
+			label: "الرئيسية",
+			locale: "ar",
+			group,
+		});
+
+		const seed = await exportSeed(db);
+
+		const menus = seed.menus?.filter((m) => m.name === "primary") ?? [];
+		expect(menus).toHaveLength(2);
+		const ids = menus.map((m) => m.id);
+		expect(new Set(ids)).toEqual(new Set(["menu:primary:en", "menu:primary:ar"]));
+
+		const anchor = menus.find((m) => !m.translationOf);
+		const translation = menus.find((m) => m.translationOf);
+		expect(translation?.translationOf).toBe(anchor?.id);
+
+		const result = validateSeed(seed);
+		expect(result.errors).toEqual([]);
+		expect(result.valid).toBe(true);
+	});
+
+	it("suffixes content entry ids per locale instead of colliding", async () => {
+		db = await setupTestDatabaseWithCollections();
+
+		const now = new Date().toISOString();
+		const group = ulid();
+		await db
+			.insertInto("ec_post")
+			.values({
+				id: ulid(),
+				slug: "hello",
+				status: "published",
+				created_at: now,
+				updated_at: now,
+				version: 1,
+				locale: "en",
+				translation_group: group,
+				title: "Hello",
+			} as never)
+			.execute();
+		await db
+			.insertInto("ec_post")
+			.values({
+				id: ulid(),
+				slug: "hello",
+				status: "published",
+				created_at: now,
+				updated_at: now,
+				version: 1,
+				locale: "ar",
+				translation_group: group,
+				title: "مرحبا",
+			} as never)
+			.execute();
+
+		const seed = await exportSeed(db, "post");
+
+		const posts = seed.content?.post ?? [];
+		expect(posts).toHaveLength(2);
+		const ids = posts.map((p) => p.id);
+		expect(new Set(ids)).toEqual(new Set(["post:hello:en", "post:hello:ar"]));
+
+		const anchor = posts.find((p) => !p.translationOf);
+		const translation = posts.find((p) => p.translationOf);
+		expect(translation?.translationOf).toBe(anchor?.id);
+
+		const result = validateSeed(seed);
+		expect(result.errors).toEqual([]);
+		expect(result.valid).toBe(true);
+	});
+
+	it("keeps bare ids for genuinely single-locale projects", async () => {
+		db = await setupTestDatabase();
+
+		await insertTaxonomyDef(db, {
+			id: ulid(),
+			name: "genre",
+			label: "Categories",
+			locale: "en",
+			group: ulid(),
+		});
+
+		const seed = await exportSeed(db);
+		const cat = seed.taxonomies?.find((t) => t.name === "genre");
+		expect(cat?.id).toBe("tax:genre");
+		expect(cat?.locale).toBeUndefined();
+		expect(cat?.translationOf).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`emdash export-seed` runs in the CLI, which never calls `setI18nConfig()`, so `isI18nEnabled()` is always `false` there. For any i18n-enabled project the exporter stripped the `:locale` suffix from taxonomy / menu / content seed ids, collapsing every locale variant into a single bare id. When ≥2 locale variants exist this produced byte-identical duplicate ids, which `validateSeed` then rejected — making the exported seed un-appliable by every consumer (`emdash seed`, runtime auto-seed, setup route).

The fix derives locale-awareness from the **data** rather than the runtime-only flag. A new `detectI18nEnabled()` helper still honors `isI18nEnabled()` when it's set (runtime), then falls back to counting **distinct locales** across the i18n-aware tables (`_emdash_taxonomy_defs`, `_emdash_menus`, each `ec_*`). A project is multi-locale only when more than one distinct locale exists.

Note: the issue suggested gating on `def.locale ? … : …`, but that doesn't work — `locale` is `NOT NULL DEFAULT <defaultLocale>` and so is never null, which would suffix every single-locale project and break the existing bare-id contract. The distinct-locale count is what actually separates the two cases. Single-locale projects keep **bare ids** (backwards-compatible); multi-locale projects keep their per-locale suffixes and `translationOf` links.

The flag is computed once and threaded through `exportTaxonomies` / `exportMenus` / `exportContent`, replacing the three runtime-only `isI18nEnabled()` calls.

Closes #1330

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`packages/core` clean; pre-existing unrelated failure in `packages/plugin-cli` `oauth.ts` re: `registry-lexicons` exports)
- [x] `pnpm lint` passes (only 8 pre-existing diagnostics in unrelated demo/template `astro.config.mjs` files)
- [x] `pnpm test` passes (targeted: full `tests/unit/seed`, `tests/unit/cli`, `tests/integration/seed` — 275 tests green)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes — new `tests/unit/seed/export-seed-cli-i18n.test.ts` reproduces the bug (TDD: written failing first) with i18n config unset, covering taxonomies, menus, content, and the single-locale bare-id case
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings touched
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash: patch`)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
 RUN  v4.1.5 /home/malloo/projects/emdash/packages/core
 ✓ tests/unit/seed/export-seed-cli-i18n.test.ts (4 tests)
   ✓ suffixes taxonomy def + term ids per locale instead of colliding
   ✓ suffixes menu ids per locale instead of colliding
   ✓ suffixes content entry ids per locale instead of colliding
   ✓ keeps bare ids for genuinely single-locale projects

 Test Files  16 passed (16)
      Tests  275 passed (275)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)