### PR TITLE
fix(core): pre-bundle auth/MCP/admin deps to stop CF dev optimize cascade

### DIFF
--- a/.changeset/fix-cf-dev-optimize-cascade.md
+++ b/.changeset/fix-cf-dev-optimize-cascade.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Pre-bundle EmDash's auth, MCP, and admin-shell dependencies so `astro dev` on Cloudflare no longer triggers a re-optimize + full-reload cascade on the first authenticated/admin/MCP request.
+
+These deps (`@oslojs/crypto/{hmac,subtle,rsa}`, `arctic`, the MCP server entrypoints, `@lingui/react`, `@cloudflare/kumo/primitives`, `astro/assets/services/noop`) are only imported on routes the initial Vite scan never reaches, so the workerd runtime discovered them one at a time. Each discovery invalidated the optimize cache mid-flight, producing `The file does not exist at ".../deps_ssr/chunk-*.js"` errors and repeated full reloads on cold start. Adding them to the Cloudflare SSR `optimizeDeps.include` list front-loads them into a single startup optimize pass.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -395,10 +395,25 @@ export function createViteConfig(
 							"emdash > @emdash-cms/auth > @oslojs/crypto/ecdsa",
 							"emdash > @emdash-cms/auth > @oslojs/crypto/sha2",
 							"emdash > @emdash-cms/auth > @oslojs/webauthn",
+							// Auth deps imported only on auth/login/callback routes, so
+							// the initial page scan misses them. Pre-bundle to avoid a
+							// re-optimize + reload cascade on first authenticated request.
+							"emdash > @oslojs/crypto/hmac",
+							"emdash > @oslojs/crypto/subtle",
+							"emdash > @oslojs/crypto/rsa",
+							"emdash > arctic",
 							// MCP SDK — server/index.js statically imports ajv (CJS-only).
 							// Pre-bundling converts CJS to ESM so workerd can load it.
 							"emdash > @modelcontextprotocol/sdk > ajv",
 							"emdash > @modelcontextprotocol/sdk > ajv-formats",
+							// MCP server entrypoints — only imported on the MCP route, so
+							// also missed by the initial scan.
+							"emdash > @modelcontextprotocol/sdk/server/mcp.js",
+							"emdash > @modelcontextprotocol/sdk/server/webStandardStreamableHttp.js",
+							// Admin shell SSR deps, reached only when the admin route is
+							// first rendered.
+							"emdash > @emdash-cms/admin > @lingui/react",
+							"emdash > @emdash-cms/admin > @cloudflare/kumo/primitives",
 							// React (commonly used, may be hoisted)
 							"react",
 							"react/jsx-dev-runtime",
@@ -415,6 +430,7 @@ export function createViteConfig(
 							"astro/content/runtime",
 							"astro/assets/utils/inferRemoteSize.js",
 							"astro/assets/fonts/runtime.js",
+							"astro/assets/services/noop",
 							"@astrojs/cloudflare/image-service",
 						],
 					},


### PR DESCRIPTION
## What does this PR do?

On `astro dev` with the Cloudflare adapter, the first request to an auth, admin, or MCP route triggered a re-optimize + full-reload cascade: repeated `[vite] new dependencies optimized` / `program reload` lines and intermittent crashes like:

```
The file does not exist at ".../node_modules/.vite/deps_ssr/chunk-XXXX.js" which is in the optimize deps directory.
```

Root cause: Vite's initial esbuild scan only crawls from page entries. EmDash's middleware is injected via a virtual module and resolved at request time, so the scan never reaches the auth/MCP/admin-shell import graph. The workerd runtime then discovers those deps one at a time on first request, and each discovery invalidates the optimize cache mid-flight (the previous hashed chunk is gone), producing the error and a full reload.

EmDash already mitigates this with a curated `ssr.optimizeDeps.include` list in `vite-config.ts` (the `cloudflare` branch), but it only covered transitive deps reachable from the page scan. This PR adds the entrypoints that are only reached on auth/MCP/admin routes:

- `@oslojs/crypto/{hmac,subtle,rsa}`, `arctic` (auth / OAuth)
- `@modelcontextprotocol/sdk/server/{mcp.js,webStandardStreamableHttp.js}` (MCP)
- `@emdash-cms/admin > {@lingui/react,@cloudflare/kumo/primitives}` (admin shell SSR)
- `astro/assets/services/noop`

They now pre-bundle in the single startup optimize pass. Node sites are unaffected (this branch only runs when the adapter is `@astrojs/cloudflare`).

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`lint:json` -> 0 diagnostics)
- [ ] `pnpm test` passes — n/a, no automated harness covers dev-server dep-optimization; verified manually (below)
- [ ] `pnpm format` — change is hand-aligned to the existing tab-indented array; `git diff --check` clean
- [ ] I have added/updated tests for my changes — n/a (dev-only Vite config behavior)
- [x] User-visible strings wrapped for translation — n/a, no UI strings; no `messages.po` changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (OpenCode)

## Screenshots / test output

Verified against `demos/cloudflare` on a cold cache (`rm -rf node_modules/.vite`), hitting `/`, `/_emdash/admin`, then `/` again:

| Metric (post-ready)            | Before | After |
| ------------------------------ | -----: | ----: |
| `new dependencies optimized` passes | 6 | 0 |
| `program reload` events        |      6 |     0 |
| `file does not exist` errors   |      2 |     0 |

After the fix, all added entries appear in `deps_ssr/_metadata.json` (pre-bundled at startup) and routes serve 200/302 with no reloads.