### PR TITLE
i18n(nb): add Norwegian Bokmål translation

### DIFF
--- a/.changeset/norwegian-bokmal-admin-locale.md
+++ b/.changeset/norwegian-bokmal-admin-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds Norwegian Bokmål (nb) locale to the admin UI.

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -42,6 +42,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "id", label: "Bahasa Indonesia", enabled: true }, // Indonesian
 	{ code: "ja", label: "日本語", enabled: true }, // Japanese
 	{ code: "ko", label: "한국어", enabled: false }, // Korean
+	{ code: "nb", label: "Norsk bokmål", enabled: true }, // Norwegian Bokmål
 	{ code: "pl", label: "Polski", enabled: true }, // Polish
 	{ code: "pt-BR", label: "Português (Brasil)", enabled: true }, // Portuguese (Brazil)
 	{ code: "es-419", label: "Español (Latinoamérica)", enabled: true }, // Spanish (Latin America)

--- a/packages/admin/src/locales/nb/messages.po
+++ b/packages/admin/src/locales/nb/messages.po
@@ -1,0 +1,7680 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-04 12:28+0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: packages/admin/src/routes/bylines.tsx:433
+msgid " - Guest"
+msgstr " - Gjest"
+
+#: packages/admin/src/routes/bylines.tsx:433
+msgid " - Linked"
+msgstr " - Lenket"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:76
+msgid " (default)"
+msgstr " (standard)"
+
+#: packages/admin/src/components/MenuEditor.tsx:435
+msgid " (opens in new window)"
+msgstr " (åpnes i nytt vindu)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:792
+#: packages/admin/src/components/MediaPickerModal.tsx:874
+msgid " (selected)"
+msgstr " (valgt)"
+
+#: packages/admin/src/routes/bylines.tsx:689
+msgid "-- Select --"
+msgstr "-- Velg --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", eller åpne admin på"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": bruk"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:732
+msgid "(from {0})"
+msgstr "(fra {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:518
+msgid "(pre-release)"
+msgstr "(forhåndsutgivelse)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(synkronisert)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:521
+msgid "(too new)"
+msgstr "(for ny)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(med din dev-port)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:147
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# oppføring)} other {(# oppføringer)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# samling} other {# samlinger}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1182
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# kommentar oppdatert} other {# kommentarer oppdatert}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# kommentar} other {# kommentarer}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2080
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# innholdsfeil} other {# innholdsfeil}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2056
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# innholdsoppføring importert} other {# innholdsoppføringer importert}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# oppføring} other {# oppføringer}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2085
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# mediefeil} other {# mediefeil}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# mediefil importert} other {# mediefiler importert}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr "{0, plural, one {# mediefil} other {# mediefiler}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1739
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# meny vil bli importert} other {# menyer vil bli importert}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:399
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# tillatelse} other {# tillatelser}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2292
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# innlegg} other {# innlegg}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# omdirigering er del av en løkke.} other {# omdirigeringer er del av en løkke.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# valgt} other {# valgt}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2064
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# hoppet over (finnes allerede)} other {# hoppet over (finnes allerede)}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {# bruker} other {# brukere}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:576
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {felt} other {felt}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:621
+msgid "{0} {1} required — you have {2}."
+msgstr "{0} {1} påkrevd — du har {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:410
+msgid "{0} banner"
+msgstr "{0}-banner"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1142
+msgid "{0} detected"
+msgstr "{0} oppdaget"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:111
+msgid "{0} has been deactivated"
+msgstr "{0} er deaktivert"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:306
+msgid "{0} has been removed"
+msgstr "{0} er fjernet"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:422
+msgid "{0} icon"
+msgstr "{0}-ikon"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:202
+msgid "{0} installs"
+msgstr "{0} installasjoner"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:92
+msgid "{0} is now active"
+msgstr "{0} er nå aktiv"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1809
+msgid "{0} items → {1}"
+msgstr "{0} oppføringer → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "{0} items will be imported"
+msgstr "{0} oppføringer vil bli importert"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "{0} plugins"
+msgstr "{0} utvidelser"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
+msgid "{0} preview"
+msgstr "{0}-forhåndsvisning"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:574
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} system + {1} egendefinert {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:345
+msgid "{0} updated"
+msgstr "{0} oppdatert"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "{0} updated to v{1}"
+msgstr "{0} oppdatert til v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:792
+#: packages/admin/src/components/MediaPickerModal.tsx:874
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:168
+msgid "{0}/160 characters"
+msgstr "{0}/160 tegn"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:255
+msgid "{base} to: {0}"
+msgstr "{base} til: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# endring fra neste revisjon} other {# endringer fra neste revisjon}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1908
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# fil} other {# filer}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2157
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# oppføring} other {# oppføringer}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1979
+msgid "{current} of {total}"
+msgstr "{current} av {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:557
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} oppføring} other {#{1} oppføringer}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — ingen oversettelse"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — vis oversettelse"
+
+#: packages/admin/src/components/ContentList.tsx:546
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# oppføring samsvarer med \"{searchQuery}\"} other {# oppføringer samsvarer med \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} av {totalCount} tilordnet"
+
+#: packages/admin/src/components/WordPressImport.tsx:2267
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} av {totalCount} forfattere samsvarer på e-post"
+
+#: packages/admin/src/components/WordPressImport.tsx:1715
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# ny samling vil bli opprettet} other {# nye samlinger vil bli opprettet}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1724
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Felt vil bli lagt til i # eksisterende samling} other {Felt vil bli lagt til i # eksisterende samlinger}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} ber om flere tillatelser:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} krever følgende tillatelser:"
+
+#: packages/admin/src/components/ContentList.tsx:552
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# oppføring} other {# oppføringer}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# totalt} other {# totalt}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:178
+#: packages/admin/src/components/MediaLibrary.tsx:214
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {Fil lastet opp} other {# filer lastet opp}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:183
+#: packages/admin/src/components/MediaLibrary.tsx:219
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Opplasting mislyktes} other {Alle # opplastinger mislyktes}}"
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr "{totalDrafts, plural, one {# kladd} other {# kladder}}"
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr "{totalScheduled, plural, one {# planlagt} other {# planlagt}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Skjul # uendret} other {Skjul # uendret}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Vis # uendret} other {Vis # uendret}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:188
+#: packages/admin/src/components/MediaLibrary.tsx:224
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} lastet opp, {failed} mislyktes"
+
+#: packages/admin/src/components/Redirects.tsx:137
+msgid "/new-page or /articles/[slug]"
+msgstr "/new-page or /articles/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:129
+msgid "/old-page or /blog/[slug]"
+msgstr "/old-page or /blog/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:1929
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Filer lastes ned fra WordPress-nettstedet ditt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1930
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Lastet opp til EmDash-medielageret ditt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1931
+msgid "• URLs in your content are updated automatically"
+msgstr "• URL-er i innholdet ditt oppdateres automatisk"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1440
+msgid "← Back"
+msgstr "← Tilbake"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 år"
+
+#: packages/admin/src/components/WordPressImport.tsx:1361
+msgid "1. Log into your WordPress admin"
+msgstr "1. Logg inn på WordPress-administrasjonen"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Logg inn på WordPress-administrasjonspanelet"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "2. Go to"
+msgstr "2. Gå til"
+
+#: packages/admin/src/components/WordPressImport.tsx:1362
+msgid "2. Go to Users → Profile"
+msgstr "2. Gå til Brukere → Profil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1363
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Bla ned til \"Application Passwords\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "3. Select \"All content\""
+msgstr "3. Velg \"All content\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 dager"
+
+#: packages/admin/src/components/Redirects.tsx:150
+msgid "301 Permanent"
+msgstr "301 Permanent"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "302 Temporary"
+msgstr "302 Midlertidig"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "307 Temporary (Strict)"
+msgstr "307 Midlertidig (streng)"
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanent (streng)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "4. Click \"Download Export File\""
+msgstr "4. Klikk \"Download Export File\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Skriv inn \"EmDash\" og klikk \"Add New\""
+
+#: packages/admin/src/components/Redirects.tsx:368
+msgid "404 Errors"
+msgstr "404-feil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1365
+msgid "5. Copy the generated password"
+msgstr "5. Kopier det genererte passordet"
+
+#: packages/admin/src/components/WordPressImport.tsx:1120
+msgid "5. Upload the file here"
+msgstr "5. Last opp filen her"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 dager"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 dager"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:418
+msgid "A brief description of this content type"
+msgstr "En kort beskrivelse av denne innholdstypen"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "Et fullbredde hero-banner med overskrift, tekst og CTA-knapp"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr "En kort beskrivelse av nettstedet ditt"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:170
+msgid "Accept & Install"
+msgstr "Godta og installer"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Accept & Update"
+msgstr "Godta og oppdater"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:206
+msgid "Accept Invite"
+msgstr "Godta invitasjon"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Tilgang nektet"
+
+#: packages/admin/src/router.tsx:1202
+msgid "Access Denied"
+msgstr "Tilgang nektet"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Access your media library"
+msgstr "Få tilgang til mediebiblioteket ditt"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Konto"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:121
+msgid "Account already exists"
+msgstr "Kontoen finnes allerede"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "Kontoen finnes"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Kontoinformasjon"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:290
+#: packages/admin/src/components/ContentList.tsx:408
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/MediaLibrary.tsx:486
+#: packages/admin/src/components/TaxonomyManager.tsx:823
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Handlinger"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Aktiv"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentEditor.tsx:2091
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/TaxonomySidebar.tsx:476
+msgid "Add"
+msgstr "Legg til"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Add {0}"
+msgstr "Legg til {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Add {label}"
+msgstr "Legg til {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:204
+msgid "Add a new passkey"
+msgstr "Legg til en ny passnøkkel"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
+msgid "Add an allowed domain"
+msgstr "Legg til et tillatt domene"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Legg til minst ett underfelt for å definere repeterstrukturen."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2617
+msgid "Add column after"
+msgstr "Legg til kolonne etter"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2610
+msgid "Add column before"
+msgstr "Legg til kolonne før"
+
+#: packages/admin/src/components/MenuEditor.tsx:299
+#: packages/admin/src/components/MenuEditor.tsx:414
+msgid "Add Content"
+msgstr "Legg til innhold"
+
+#: packages/admin/src/components/MenuEditor.tsx:311
+#: packages/admin/src/components/MenuEditor.tsx:318
+#: packages/admin/src/components/MenuEditor.tsx:417
+msgid "Add Custom Link"
+msgstr "Legg til egendefinert lenke"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Add Domain"
+msgstr "Legg til domene"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:582
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Add Field"
+msgstr "Legg til felt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1820
+msgid "Add fields"
+msgstr "Legg til felt"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Legg til felt som «Stillingstittel» eller «Pronomen» for å berike hver byline."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:604
+msgid "Add fields to define the structure of your content"
+msgstr "Legg til felt for å definere strukturen på innholdet ditt"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:607
+msgid "Add First Field"
+msgstr "Legg til første felt"
+
+#: packages/admin/src/components/RepeaterField.tsx:169
+msgid "Add First Item"
+msgstr "Legg til første element"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+msgid "Add item"
+msgstr "Legg til element"
+
+#: packages/admin/src/components/RepeaterField.tsx:153
+msgid "Add Item"
+msgstr "Legg til element"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2577
+msgid "Add link"
+msgstr "Legg til lenke"
+
+#: packages/admin/src/components/MenuEditor.tsx:407
+msgid "Add links to build your navigation menu"
+msgstr "Legg til lenker for å bygge navigasjonsmenyen din"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Legg til MIME-type eller filendelse"
+
+#: packages/admin/src/components/ContentList.tsx:214
+msgid "Add New"
+msgstr "Legg til ny"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:486
+msgid "Add new {0}"
+msgstr "Legg til ny {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Add noindex meta tag"
+msgstr "Legg til noindex-metatagg"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:225
+msgid "Add Passkey"
+msgstr "Legg til passnøkkel"
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Legg til utvidelser i astro.config.mjs for å utvide funksjonaliteten i EmDash."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2640
+msgid "Add row after"
+msgstr "Legg til rad etter"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2633
+msgid "Add row before"
+msgstr "Legg til rad før"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:476
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Legg til SEO-metadatafelt (tittel, beskrivelse, bilde) og ta med i nettstedskartet"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Legg til underfelt"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:262
+msgid "Add tags..."
+msgstr "Legg til stikkord …"
+
+#: packages/admin/src/components/Widgets.tsx:338
+msgid "Add Widget Area"
+msgstr "Legg til widgetområde"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Legg til profilene dine på sosiale medier. Disse er tilgjengelige for temaet på nettstedet ditt og kan vises i topptekster, bunntekster eller forfatterbiografier."
+
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+msgid "Adding..."
+msgstr "Legger til …"
+
+#: packages/admin/src/components/WordPressImport.tsx:1592
+msgid "Additional data to import."
+msgstr "Ytterligere data som skal importeres."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:599
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Administrasjon"
+
+#: packages/admin/src/components/Sidebar.tsx:543
+msgid "Admin navigation"
+msgstr "Administrasjonsnavigasjon"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Administrator"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "After send:"
+msgstr "Etter sending:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2965
+msgid "Align Center"
+msgstr "Midtstill"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2958
+msgid "Align Left"
+msgstr "Venstrejuster"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2972
+msgid "Align Right"
+msgstr "Høyrejuster"
+
+#: packages/admin/src/components/ContentList.tsx:241
+msgid "All"
+msgstr "Alle"
+
+#: packages/admin/src/routes/bylines.tsx:399
+msgid "All bylines"
+msgstr "Alle bylines"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "Alle tillatelser"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "Alle samlinger"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "Alle kommentarer krever godkjenning"
+
+#: packages/admin/src/components/WordPressImport.tsx:2324
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "Alt importert innhold blir uten tilordning. Du kan tilordne forfattere på nytt senere fra innholdsredigeringen."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "Alle språk"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "Alle roller"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "Alle kilder"
+
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "All statuses"
+msgstr "Alle statuser"
+
+#: packages/admin/src/components/MediaLibrary.tsx:393
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "All types"
+msgstr "Alle typer"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "Tillat brukere fra bestemte domener å registrere seg"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:497
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Tillat besøkende å legge igjen kommentarer på innholdet i denne samlingen"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
+msgid "Allowed Domains"
+msgstr "Tillatte domener"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Tillatte typer"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "Har du allerede en konto?"
+
+#: packages/admin/src/components/PluginManager.tsx:634
+msgid "Also delete plugin storage data"
+msgstr "Slett også lagrede data for utvidelsen"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:202
+msgid "Alt text"
+msgstr "Alt-tekst"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:202
+msgid "Alt Text"
+msgstr "Alt-tekst"
+
+#: packages/admin/src/components/MediaLibrary.tsx:688
+#: packages/admin/src/components/MediaLibrary.tsx:745
+msgid "Alt text set"
+msgstr "Alt-tekst angitt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1234
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Alternativt kan du eksportere fra WordPress (Verktøy → Eksporter) og laste opp filen."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:98
+#: packages/admin/src/components/PluginManager.tsx:117
+#: packages/admin/src/components/TaxonomySidebar.tsx:350
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:347
+#: packages/admin/src/router.tsx:362
+#: packages/admin/src/router.tsx:376
+#: packages/admin/src/router.tsx:390
+#: packages/admin/src/router.tsx:743
+#: packages/admin/src/router.tsx:774
+#: packages/admin/src/router.tsx:790
+#: packages/admin/src/router.tsx:806
+#: packages/admin/src/router.tsx:825
+#: packages/admin/src/router.tsx:843
+#: packages/admin/src/router.tsx:861
+#: packages/admin/src/router.tsx:891
+#: packages/admin/src/router.tsx:911
+#: packages/admin/src/router.tsx:1147
+#: packages/admin/src/router.tsx:1163
+#: packages/admin/src/router.tsx:1188
+#: packages/admin/src/router.tsx:1670
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "Det oppstod en feil"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "Det oppstod en uventet feil."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:217
+msgid "An unknown error occurred"
+msgstr "Det oppstod en ukjent feil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1414
+msgid "Analyzing export file..."
+msgstr "Analyserer eksportfil …"
+
+#: packages/admin/src/components/WordPressImport.tsx:735
+msgid "Analyzing WordPress site..."
+msgstr "Analyserer WordPress-nettsted …"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "Alle medietyper tillatt (med forbehold om globale grenser)."
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "API-tokener"
+
+#: packages/admin/src/components/Widgets.tsx:375
+msgid "Appears on posts and pages"
+msgstr "Vises på innlegg og sider"
+
+#: packages/admin/src/components/WordPressImport.tsx:1329
+msgid "Application Password"
+msgstr "Programpassord"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3032
+msgid "Apply"
+msgstr "Bruk"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:144
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:145
+msgid "Apply language"
+msgstr "Bruk språk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2517
+#: packages/admin/src/components/PortableTextEditor.tsx:2518
+msgid "Apply link"
+msgstr "Bruk lenke"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "Godkjenn"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "godkjent"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "Godkjent"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Vilkårlige JSON-data"
+
+#: packages/admin/src/components/ContentList.tsx:771
+msgid "archived"
+msgstr "arkivert"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+msgid "Archives"
+msgstr "Arkiv"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Er du sikker på at du vil slette «{0}»? Ingen lagrede verdier refererer til dette feltet."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Er du sikker på at du vil slette «{0}»? Dette sletter også alt innhold i denne samlingen."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:660
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Er du sikker på at du vil slette feltet «{0}»?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Er du sikker på at du vil slette denne menyen? Dette sletter også alle menyelementer. Denne handlingen kan ikke angres."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "Som administrator kan du invitere andre brukere fra Brukere-delen."
+
+#: packages/admin/src/components/WordPressImport.tsx:2262
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Tilordne WordPress-forfattere til EmDash-brukere. Innlegg blir tilskrevet den valgte brukeren."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:396
+msgid "Audio"
+msgstr "Lyd"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Autentiseringsfeil: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "Autentiseringsfeil: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:256
+msgid "Authentication failed"
+msgstr "Autentisering mislyktes"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:129
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "Autentisering håndteres av en ekstern leverandør ({0}). Innstillinger for passnøkkel er ikke tilgjengelige når du bruker ekstern autentisering."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Autentiseringen ble avbrutt eller tidsavbrutt. Prøv på nytt."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Forfatter"
+
+#: packages/admin/src/components/WordPressImport.tsx:2277
+msgid "Author Mapping"
+msgstr "Forfattertilordning"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Autorisasjon nektet"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Autorisasjon mislyktes"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Autoriser"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Autoriser enhet"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Autoriserer …"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:670
+msgid "Authors"
+msgstr "Forfattere"
+
+#: packages/admin/src/components/Redirects.tsx:495
+msgid "auto"
+msgstr "auto"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Auto (slug change)"
+msgstr "Auto (slug-endring)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:541
+msgid "Auto-approve authenticated users"
+msgstr "Godkjenn autentiserte brukere automatisk"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "Auto-generated from name (you can edit)"
+msgstr "Generert automatisk fra navn (du kan redigere)"
+
+#: packages/admin/src/router.tsx:773
+msgid "Autosave failed"
+msgstr "Autolagring mislyktes"
+
+#: packages/admin/src/components/ContentEditor.tsx:645
+msgid "Autosave status"
+msgstr "Status for autolagring"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:657
+msgid "Available media"
+msgstr "Tilgjengelige medier"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "Available Providers"
+msgstr "Tilgjengelige leverandører"
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Available Widgets"
+msgstr "Tilgjengelige widgeter"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/WordPressImport.tsx:1349
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Back"
+msgstr "Tilbake"
+
+#: packages/admin/src/components/ContentEditor.tsx:614
+msgid "Back to {collectionLabel} list"
+msgstr "Tilbake til {collectionLabel}-listen"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Tilbake til innholdstyper"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:139
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "Tilbake til innlogging"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:115
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:391
+msgid "Back to marketplace"
+msgstr "Tilbake til markedsplassen"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:803
+msgid "Back to plugins"
+msgstr "Tilbake til utvidelser"
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+#: packages/admin/src/components/SectionEditor.tsx:174
+msgid "Back to sections"
+msgstr "Tilbake til seksjoner"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Tilbake til innstillinger"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Tilbake til temaer"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:219
+msgid "Before send:"
+msgstr "Før sending:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:233
+msgid "Bing Verification"
+msgstr "Bing-verifisering"
+
+#: packages/admin/src/routes/bylines.tsx:483
+msgid "Bio"
+msgstr "Biografi"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Blokkhandlinger – dra for å endre rekkefølge, klikk for meny"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2541
+#: packages/admin/src/components/PortableTextEditor.tsx:2847
+msgid "Bold"
+msgstr "Fet"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Boolsk"
+
+#: packages/admin/src/components/SeoPanel.tsx:169
+msgid "Brief summary shown below the title in search results"
+msgstr "Kort sammendrag som vises under tittelen i søkeresultater"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Bla gjennom og installer utvidelser publisert til det desentraliserte registeret."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Bla gjennom og installer utvidelser for å utvide nettstedet ditt."
+
+#: packages/admin/src/components/WordPressImport.tsx:966
+#: packages/admin/src/components/WordPressImport.tsx:1433
+msgid "Browse Files"
+msgstr "Bla gjennom filer"
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "Browse the"
+msgstr "Bla gjennom"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Bla gjennom temaer og forhåndsvis dem med ditt eget innhold."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:913
+#: packages/admin/src/components/PortableTextEditor.tsx:2915
+msgid "Bullet List"
+msgstr "Punktliste"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:370
+msgid "Byline schema"
+msgstr "Byline-skjema"
+
+#: packages/admin/src/components/ContentEditor.tsx:998
+#: packages/admin/src/components/Sidebar.tsx:363
+#: packages/admin/src/routes/bylines.tsx:362
+msgid "Bylines"
+msgstr "Bylines"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Kan opprette innhold"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Kan administrere alt innhold"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Kan publisere eget innhold"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Kan vise innhold"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:161
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentEditor.tsx:707
+#: packages/admin/src/components/ContentEditor.tsx:912
+#: packages/admin/src/components/ContentEditor.tsx:964
+#: packages/admin/src/components/ContentEditor.tsx:2205
+#: packages/admin/src/components/ContentEditor.tsx:2258
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:156
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:157
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/editor/ImageNode.tsx:223
+#: packages/admin/src/components/editor/ImageNode.tsx:224
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:648
+#: packages/admin/src/components/MediaDetailPanel.tsx:234
+#: packages/admin/src/components/MediaPickerModal.tsx:739
+#: packages/admin/src/components/MenuEditor.tsx:359
+#: packages/admin/src/components/MenuEditor.tsx:530
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:640
+#: packages/admin/src/components/PortableTextEditor.tsx:3016
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:313
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:423
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:325
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:453
+#: packages/admin/src/components/settings/SecuritySettings.tsx:206
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:472
+#: packages/admin/src/components/TaxonomyManager.tsx:686
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/Widgets.tsx:386
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Avbryt (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Avbryt endring av navn"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "Kan ikke slette temaseksjoner"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:408
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "Kan ikke fastslå MIME-type fra URL. Bruk en URL som slutter på en gjenkjent bildeendelse (f.eks. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:181
+msgid "Canonical URL"
+msgstr "Kanonisk URL"
+
+#: packages/admin/src/components/PluginManager.tsx:473
+msgid "Capabilities"
+msgstr "Egenskaper"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "Samtykke til egenskaper"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:210
+msgid "Caption"
+msgstr "Bildetekst"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Bildetekster / undertekster"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "Kategorier"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1621
+msgid "Categories ({0})"
+msgstr "Kategorier ({0})"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1672
+#: packages/admin/src/components/ContentEditor.tsx:1701
+#: packages/admin/src/components/ContentEditor.tsx:1875
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/SeoImageField.tsx:47
+msgid "Change"
+msgstr "Endre"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Endre <0>{0}</0> fra <1>{1}</1> til <2>{2}</2>? De vil miste tilgang til funksjoner på høyere nivå."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:262
+msgid "Change Favicon"
+msgstr "Endre favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Change Image"
+msgstr "Endre bilde"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:208
+msgid "Change Logo"
+msgstr "Endre logo"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:791
+msgid "Changelog"
+msgstr "Endringslogg"
+
+#: packages/admin/src/router.tsx:818
+msgid "Changes discarded"
+msgstr "Endringene ble forkastet"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:162
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Tegn mellom sidetittel og nettstedsnavn (f.eks. «Mitt innlegg | Mitt nettsted»)"
+
+#: packages/admin/src/components/PluginManager.tsx:162
+msgid "Check for updates"
+msgstr "Se etter oppdateringer"
+
+#: packages/admin/src/components/WordPressImport.tsx:937
+msgid "Check Site"
+msgstr "Sjekk nettsted"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "Sjekk e-posten din"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+msgid "Checking {urlInput}..."
+msgstr "Sjekker {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Sjekker autentisering..."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "Sjekker hvor mange lagrede verdier som refererer til «{0}»…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Velg hvordan du vil logge inn"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "Velg ditt foretrukne administrasjonsspråk"
+
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Tøm filtre"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Klikk på lenken i e-posten for å fortsette å sette opp kontoen din."
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "Klikk på lenken i e-posten for å logge inn."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:436
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+#: packages/admin/src/components/MediaDetailPanel.tsx:133
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:483
+#: packages/admin/src/components/MediaPickerModal.tsx:487
+#: packages/admin/src/components/MenuEditor.tsx:321
+#: packages/admin/src/components/MenuEditor.tsx:327
+#: packages/admin/src/components/MenuEditor.tsx:331
+#: packages/admin/src/components/MenuEditor.tsx:489
+#: packages/admin/src/components/MenuEditor.tsx:495
+#: packages/admin/src/components/MenuEditor.tsx:499
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1314
+#: packages/admin/src/components/PortableTextEditor.tsx:1320
+#: packages/admin/src/components/PortableTextEditor.tsx:1324
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:371
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:377
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:371
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:605
+#: packages/admin/src/components/TaxonomyManager.tsx:611
+#: packages/admin/src/components/TaxonomyManager.tsx:615
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:348
+#: packages/admin/src/components/Widgets.tsx:354
+#: packages/admin/src/components/Widgets.tsx:358
+msgid "Close"
+msgstr "Lukk"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:520
+msgid "Close comments after (days)"
+msgstr "Lukk kommentarer etter (dager)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Lukk panel"
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:2569
+#: packages/admin/src/components/Redirects.tsx:443
+msgid "Code"
+msgstr "Kode"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:943
+#: packages/admin/src/components/PortableTextEditor.tsx:2936
+msgid "Code Block"
+msgstr "Kodeblokk"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Collapse"
+msgstr "Slå sammen"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Collapse details"
+msgstr "Skjul detaljer"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr "kollega@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Samling"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Samling:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Collections"
+msgstr "Samlinger"
+
+#: packages/admin/src/components/WordPressImport.tsx:2133
+msgid "Collections created:"
+msgstr "Samlinger opprettet:"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "Comma-separated keywords for search."
+msgstr "Kommaseparerte nøkkelord for søk."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "Kommentar"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Kommentardetaljer"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:487
+#: packages/admin/src/components/Sidebar.tsx:347
+msgid "Comments"
+msgstr "Kommentarer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:544
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "Kommentarer fra innloggede CMS-brukere godkjennes automatisk"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "Fullfør registrering"
+
+#: packages/admin/src/components/Widgets.tsx:851
+msgid "Component"
+msgstr "Komponent"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Konfigurer felt"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Confirm"
+msgstr "Bekreft"
+
+#: packages/admin/src/components/WordPressImport.tsx:627
+msgid "Connect"
+msgstr "Koble til"
+
+#: packages/admin/src/components/WordPressImport.tsx:1346
+msgid "Connect & Analyze"
+msgstr "Koble til og analyser"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1296
+msgid "Connect to {0}"
+msgstr "Koble til {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1212
+msgid "Connect with WordPress"
+msgstr "Koble til med WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "Koblet til {0}"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:164
+#: packages/admin/src/components/PortableTextEditor.tsx:2047
+#: packages/admin/src/components/SectionEditor.tsx:194
+#: packages/admin/src/components/Sidebar.tsx:577
+#: packages/admin/src/components/Widgets.tsx:819
+msgid "Content"
+msgstr "Innhold"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "Innholdsblokk"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2188
+msgid "Content Errors ({0})"
+msgstr "Innholdsfeil ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1156
+msgid "Content found:"
+msgstr "Innhold funnet:"
+
+#: packages/admin/src/router.tsx:837
+msgid "Content has been scheduled for publishing"
+msgstr "Innholdet er planlagt for publisering"
+
+#: packages/admin/src/components/RevisionHistory.tsx:131
+msgid "Content has been updated to the selected revision."
+msgstr "Innholdet er oppdatert til den valgte revisjonen."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "Innholds-ID:"
+
+#: packages/admin/src/router.tsx:785
+msgid "Content is now live"
+msgstr "Innholdet er nå publisert"
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "content items"
+msgstr "innholdselementer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "Les innhold"
+
+#: packages/admin/src/router.tsx:801
+msgid "Content removed from public view"
+msgstr "Innholdet er fjernet fra offentlig visning"
+
+#: packages/admin/src/router.tsx:855
+msgid "Content reverted to draft"
+msgstr "Innholdet er tilbakestilt til kladd"
+
+#: packages/admin/src/components/RevisionHistory.tsx:296
+msgid "Content snapshot:"
+msgstr "Innholdsøyeblikksbilde:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1570
+msgid "Content to Import"
+msgstr "Innhold som skal importeres"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:367
+msgid "Content Types"
+msgstr "Innholdstyper"
+
+#: packages/admin/src/components/WordPressImport.tsx:2116
+msgid "Content was skipped because it already exists"
+msgstr "Innholdet ble hoppet over fordi det allerede finnes"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "Skriv innhold"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "Fortsett"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Fortsett →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2335
+msgid "Continue Import"
+msgstr "Fortsett import"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Bidragsyter"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
+msgid "Copied to clipboard"
+msgstr "Kopiert til utklippstavlen"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Kopier {0} til utklippstavlen"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Kopier invitasjonslenke"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Kopier slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "Kopier denne tokenen nå — den vises ikke igjen."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "Kopier token"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+msgid "Copy URL"
+msgstr "Kopier URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Kunne ikke kopiere automatisk. Merk URL-en ovenfor og kopier manuelt."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:434
+msgid "Could not load image from URL"
+msgstr "Kunne ikke laste bilde fra URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Couldn't detect WordPress"
+msgstr "Kunne ikke oppdage WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "Kunne ikke laste byline-felt."
+
+#: packages/admin/src/routes/bylines.tsx:530
+msgid "Couldn't load custom fields."
+msgstr "Kunne ikke laste egendefinerte felt."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "Kunne ikke knytte «{draft}» til en MIME-type. Skriv inn MIME-typen direkte."
+
+#: packages/admin/src/components/ContentEditor.tsx:2097
+msgid "Couldn't search bylines. Please try again."
+msgstr "Kunne ikke søke i bylines. Prøv på nytt."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "Kunne ikke bekrefte hvor mange verdier som refererer til «{0}». Sletting vil fortsatt fjerne alle lagrede verdier for dette feltet — men antallet ovenfor kunne ikke kontrolleres."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:822
+msgid "Count"
+msgstr "Antall"
+
+#: packages/admin/src/components/ContentEditor.tsx:2229
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:184
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:479
+#: packages/admin/src/components/Widgets.tsx:389
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Create"
+msgstr "Opprett"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Create \"{trimmedInput}\""
+msgstr "Opprett «{trimmedInput}»"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:914
+msgid "Create a bullet list"
+msgstr "Opprett en punktliste"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:367
+msgid "Create a new {0}"
+msgstr "Opprett en ny {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:924
+msgid "Create a numbered list"
+msgstr "Opprett en nummerert liste"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:81
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "Opprett konto"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "Opprett en konto"
+
+#: packages/admin/src/components/ContentEditor.tsx:2177
+#: packages/admin/src/routes/bylines.tsx:463
+msgid "Create byline"
+msgstr "Opprett byline"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Opprett innholdstype"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Opprett felt"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "Opprett meny"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "Opprett ny meny"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
+msgid "Create New Token"
+msgstr "Opprett ny token"
+
+#: packages/admin/src/components/WordPressImport.tsx:1340
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Opprett en i WordPress: Brukere → Profil → Programpassord"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Opprett passnøkkel"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Opprett personlige tilgangstokener for programmatisk API-tilgang"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for {0}"
+msgstr "Opprett omdirigering for {0}"
+
+#: packages/admin/src/components/Redirects.tsx:237
+msgid "Create redirect for this path"
+msgstr "Opprett omdirigering for denne stien"
+
+#: packages/admin/src/components/Redirects.tsx:435
+msgid "Create redirect rules to manage URL changes."
+msgstr "Opprett omdirigeringsregler for å håndtere URL-endringer."
+
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "Create Schema & Import"
+msgstr "Opprett skjema og importer"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Opprett seksjon"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Opprett seksjoner i seksjonsbiblioteket for å bruke dem her"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:598
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+msgid "Create Taxonomy"
+msgstr "Opprett taksonomi"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+msgid "Create Token"
+msgstr "Opprett token"
+
+#: packages/admin/src/components/Widgets.tsx:345
+msgid "Create Widget Area"
+msgstr "Opprett widgetområde"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Opprett kontoen din"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "Opprett din første navigasjonsmeny for å komme i gang"
+
+#: packages/admin/src/components/ContentList.tsx:318
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Opprett din første"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Opprett din første gjenbrukbare innholdsseksjon for å komme i gang."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:72
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "Opprett passnøkkelen din"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Create, update, and delete content"
+msgstr "Opprett, oppdater og slett innhold"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "Opprett, oppdater og slett navigasjonsmenyer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Opprett, oppdater og slett taksonomitermer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "Opprett, oppdater, slett innhold"
+
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Opprettet"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "Opprettet \"{0}\"."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "Opprettet {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:885
+msgid "Created {0} translation"
+msgstr "Opprettet {0}-oversettelse"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Opprettet"
+
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:932
+msgid "Created: {0}"
+msgstr "Opprettet: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "Creating collections and fields..."
+msgstr "Oppretter samlinger og felter …"
+
+#: packages/admin/src/components/ContentEditor.tsx:2229
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:181
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Creating..."
+msgstr "Oppretter …"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:78
+msgid "current"
+msgstr "gjeldende"
+
+#: packages/admin/src/components/RevisionHistory.tsx:264
+msgid "Current"
+msgstr "Gjeldende"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Egendefinert"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:614
+msgid "Custom Fields"
+msgstr "Egendefinerte felter"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:243
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Egendefinert innhold i robots.txt. La stå tomt for å bruke standarden."
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Custom Section"
+msgstr "Egendefinert seksjon"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "mørk"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Mørk"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:333
+#: packages/admin/src/components/Sidebar.tsx:566
+msgid "Dashboard"
+msgstr "Dashbord"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:287
+msgid "Date"
+msgstr "Dato"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Dato og klokkeslett"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Velger for dato og klokkeslett"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:304
+msgid "Date Format"
+msgstr "Datoformat"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Desimaltall"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:735
+msgid "Declared permissions"
+msgstr "Deklarerte tillatelser"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
+msgid "Default Role"
+msgstr "Standardrolle"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
+msgid "Default role:"
+msgstr "Standardrolle:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:180
+msgid "Default social image"
+msgstr "Standard sosialt bilde"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:171
+msgid "Default Social Image"
+msgstr "Standard sosialt bilde"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:601
+msgid "Define a new taxonomy for classifying content"
+msgstr "Definer en ny taksonomi for å klassifisere innhold"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Definer egendefinerte felter som lagres på hver byline – stillingstittel, pronomen, sosiale brukernavn og mer."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Definer strukturen for innholdet ditt"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:361
+msgid "Defined in code"
+msgstr "Definert i kode"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:663
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+#: packages/admin/src/components/MenuEditor.tsx:463
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:552
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/TaxonomyManager.tsx:886
+#: packages/admin/src/components/Widgets.tsx:636
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:571
+#: packages/admin/src/routes/bylines.tsx:607
+msgid "Delete"
+msgstr "Slett"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Slette \"{0}\"? Dette kan ikke angres."
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:737
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Slett {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:740
+msgid "Delete {0} field"
+msgstr "Slett feltet {0}"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "Slett menyen {0}"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:584
+msgid "Delete {0} widget area"
+msgstr "Slett widgetområdet {0}"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "Delete {0}?"
+msgstr "Slette {0}?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Slette byline-felt?"
+
+#: packages/admin/src/routes/bylines.tsx:605
+msgid "Delete Byline?"
+msgstr "Slette byline?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2624
+msgid "Delete column"
+msgstr "Slett kolonne"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "Slette kommentar?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Slette innholdstype?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Slett innbygging"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:657
+msgid "Delete Field?"
+msgstr "Slette felt?"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Slett HTML-blokk"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:191
+#: packages/admin/src/components/editor/ImageNode.tsx:192
+msgid "Delete image"
+msgstr "Slett bilde"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:253
+msgid "Delete Media?"
+msgstr "Slette medier?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "Slett meny"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "Slett permanent"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:741
+msgid "Delete Permanently"
+msgstr "Slett permanent"
+
+#: packages/admin/src/components/ContentList.tsx:721
+msgid "Delete Permanently?"
+msgstr "Slette permanent?"
+
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Delete redirect"
+msgstr "Slett omdirigering"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:510
+msgid "Delete redirect {0}"
+msgstr "Slett omdirigering {0}"
+
+#: packages/admin/src/components/Redirects.tsx:550
+msgid "Delete Redirect?"
+msgstr "Slette omdirigering?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2645
+msgid "Delete row"
+msgstr "Slett rad"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Slette seksjon?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2660
+msgid "Delete table"
+msgstr "Slett tabell"
+
+#: packages/admin/src/components/Widgets.tsx:634
+msgid "Delete Widget Area?"
+msgstr "Slette widgetområde?"
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "Deleted"
+msgstr "Slettet"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "Sletting av \"{0}\" fjerner også {1, plural, one {# lagret verdi} other {# lagrede verdier}} på tvers av alle bylines. Dette kan ikke angres."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:664
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:553
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/TaxonomyManager.tsx:887
+#: packages/admin/src/components/Widgets.tsx:637
+#: packages/admin/src/routes/bylines.tsx:608
+msgid "Deleting..."
+msgstr "Sletter …"
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "Sletter …"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Demo"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Nedgrader bruker"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Nedgradere bruker?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "Nedgraderer …"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Avslå"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Describe the image..."
+msgstr "Beskriv bildet …"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:205
+msgid "Describe this image for accessibility"
+msgstr "Beskriv dette bildet for tilgjengelighet"
+
+#: packages/admin/src/components/SectionEditor.tsx:262
+msgid "Describe what this section is for..."
+msgstr "Beskriv hva denne seksjonen er til for …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:415
+#: packages/admin/src/components/RegistryPluginDetail.tsx:788
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:373
+msgid "Description"
+msgstr "Beskrivelse"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+msgid "Description (optional)"
+msgstr "Beskrivelse (valgfri)"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Destination"
+msgstr "Mål"
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr "Målsti"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "details"
+msgstr "detaljer"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Enhet autorisert"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Enhetskode"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Enhetsbundet"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Enhetsbundet passnøkkel"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "Mottok du ikke e-posten?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:176
+msgid "Dimensions:"
+msgstr "Dimensjoner:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Deaktiver"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Disable plugin"
+msgstr "Deaktiver utvidelse"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Disable redirect"
+msgstr "Deaktiver omdirigering"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Deaktiver bruker"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Deaktivere bruker?"
+
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Redirects.tsx:392
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: packages/admin/src/components/PluginManager.tsx:531
+msgid "Disabled:"
+msgstr "Deaktivert:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Deaktivering av <0>{0}</0> hindrer dem i å logge inn til de aktiveres på nytt. Innholdet deres beholdes."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "Deaktiverer …"
+
+#: packages/admin/src/components/ContentEditor.tsx:692
+#: packages/admin/src/components/ContentEditor.tsx:714
+msgid "Discard changes"
+msgstr "Forkast endringer"
+
+#: packages/admin/src/components/ContentEditor.tsx:698
+msgid "Discard draft changes?"
+msgstr "Forkaste kladdendringer?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
+msgid "Dismiss"
+msgstr "Lukk"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "Vis en navigasjonsmeny"
+
+#: packages/admin/src/components/ContentEditor.tsx:2180
+#: packages/admin/src/components/ContentEditor.tsx:2242
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Display name"
+msgstr "Visningsnavn"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "Visningsnavn for administratorgrensesnittet"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr "Visningsstørrelse"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr "Vises under bildet som en synlig bildetekst."
+
+#: packages/admin/src/components/ContentEditor.tsx:668
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Distraksjonsfri modus (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:968
+msgid "Divider"
+msgstr "Skillelinje"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:397
+msgid "Documents"
+msgstr "Dokumenter"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
+msgid "Domain"
+msgstr "Domene"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
+msgid "Domain added successfully"
+msgstr "Domenet ble lagt til"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
+msgid "Domain removed"
+msgstr "Domenet ble fjernet"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
+msgid "Domain updated"
+msgstr "Domenet ble oppdatert"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Har du ikke en konto? <0>Registrer deg</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1964
+msgid "Done"
+msgstr "Ferdig"
+
+#: packages/admin/src/components/ContentEditor.tsx:2123
+msgid "Down"
+msgstr "Ned"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:477
+msgid "Download SBOM"
+msgstr "Last ned SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:1962
+msgid "Downloading"
+msgstr "Laster ned"
+
+#: packages/admin/src/components/ContentList.tsx:767
+msgid "draft"
+msgstr "kladd"
+
+#: packages/admin/src/components/ContentEditor.tsx:863
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+msgid "Draft"
+msgstr "Kladd"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "kladd, publisert eller arkivert"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:188
+msgid "Drafts"
+msgstr "Kladder"
+
+#: packages/admin/src/components/WordPressImport.tsx:961
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Dra og slipp eller klikk for å bla gjennom (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drag here to add"
+msgstr "Dra hit for å legge til"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1706
+msgid "Drag to reorder"
+msgstr "Dra for å endre rekkefølge"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:707
+#: packages/admin/src/components/Widgets.tsx:722
+msgid "Drag to reorder {0}"
+msgstr "Dra for å endre rekkefølge på {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Dra for å endre rekkefølge på blokk"
+
+#: packages/admin/src/components/Widgets.tsx:624
+msgid "Drag widgets here to add them"
+msgstr "Dra moduler hit for å legge dem til"
+
+#: packages/admin/src/components/Widgets.tsx:402
+msgid "Drag widgets into an area to add them"
+msgstr "Dra moduler inn i et område for å legge dem til"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drop to add widget"
+msgstr "Slipp for å legge til modul"
+
+#: packages/admin/src/components/WordPressImport.tsx:1427
+msgid "Drop your WordPress export file here"
+msgstr "Slipp WordPress-eksportfilen din her"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Dupliser"
+
+#: packages/admin/src/components/ContentList.tsx:632
+msgid "Duplicate {title}"
+msgstr "Dupliser {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "f.eks. application/zip eller .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "e.g. import, blog"
+msgstr "f.eks. import, blogg"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
+msgid "e.g., CI/CD Pipeline"
+msgstr "f.eks. CI/CD-pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "f.eks. MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentEditor.tsx:2132
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:458
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:88
+msgid "Edit"
+msgstr "Rediger"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:1311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:276
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:463
+msgid "Edit {0}"
+msgstr "Rediger {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+msgid "Edit {0} field"
+msgstr "Rediger feltet {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:631
+msgid "Edit {collectionLabel}"
+msgstr "Rediger {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:624
+msgid "Edit {title}"
+msgstr "Rediger {title}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2239
+msgid "Edit byline"
+msgstr "Rediger byline"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Rediger byline-felt"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
+msgid "Edit Domain"
+msgstr "Rediger domene"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Rediger felt"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2577
+msgid "Edit link"
+msgstr "Rediger lenke"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Edit Menu Item"
+msgstr "Rediger menyelement"
+
+#: packages/admin/src/components/MenuEditor.tsx:290
+msgid "Edit menu items"
+msgstr "Rediger menyelementer"
+
+#: packages/admin/src/components/Redirects.tsx:501
+msgid "Edit redirect"
+msgstr "Rediger omdirigering"
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr "Rediger omdirigering"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "Edit redirect {0}"
+msgstr "Rediger omdirigering {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Rediger URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Redaktør"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr "Redaktør\nReporter\nFotograf"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:59
+#: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "E-post"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr "E-post (valgfri)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
+msgid "Email address"
+msgstr "E-postadresse"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "E-post er påkrevd"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:215
+msgid "Email Middleware"
+msgstr "E-post-mellomvare"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:125
+msgid "Email Pipeline"
+msgstr "E-post-pipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:199
+msgid "Email provider active"
+msgstr "E-postleverandør aktiv"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:85
+#: packages/admin/src/components/settings/EmailSettings.tsx:100
+msgid "Email Settings"
+msgstr "E-postinnstillinger"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "E-post bekreftet"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "E-post bekreftet!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2060
+msgid "Embed a {0}"
+msgstr "Bygg inn et {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2063
+msgid "Embeds"
+msgstr "Innbygginger"
+
+#: packages/admin/src/components/WordPressImport.tsx:1047
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "EmDash Exporter-utvidelsen ble oppdaget! Du kan importere direkte."
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Aktiver"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Enable comments"
+msgstr "Aktiver kommentarer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Aktiver fulltekstsøk på denne samlingen"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Enable plugin"
+msgstr "Aktiver utvidelse"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Enable redirect"
+msgstr "Aktiver omdirigering"
+
+#: packages/admin/src/components/Redirects.tsx:168
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "Enabled"
+msgstr "Aktivert"
+
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1233
+msgid "Enter {0}..."
+msgstr "Skriv inn {0}..."
+
+#: packages/admin/src/components/MenuEditor.tsx:344
+#: packages/admin/src/components/MenuEditor.tsx:514
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Skriv inn en URL (https://…) eller en relativ sti (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1481
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Skriv inn en gyldig URL (f.eks. https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1219
+msgid "Enter credentials manually"
+msgstr "Skriv inn legitimasjon manuelt"
+
+#: packages/admin/src/components/ContentEditor.tsx:667
+msgid "Enter distraction-free mode"
+msgstr "Gå inn i distraksjonsfri modus"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Skriv inn e-post"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Skriv inn HTML..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1255
+msgid "Enter markdown content..."
+msgstr "Skriv inn markdown-innhold..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Skriv inn navn"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Skriv inn koden fra terminalen din"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Skriv inn URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "Skriv inn brukernavnet ditt for å logge inn."
+
+#: packages/admin/src/components/WordPressImport.tsx:1298
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Skriv inn WordPress-legitimasjonen din for å importere innhold direkte."
+
+#: packages/admin/src/components/WordPressImport.tsx:924
+msgid "Enter your WordPress site URL"
+msgstr "Skriv inn URL-en til WordPress-nettstedet ditt"
+
+#: packages/admin/src/components/MenuEditor.tsx:101
+#: packages/admin/src/components/MenuEditor.tsx:139
+#: packages/admin/src/components/MenuEditor.tsx:179
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:689
+#: packages/admin/src/router.tsx:1852
+msgid "Error"
+msgstr "Feil"
+
+#: packages/admin/src/components/Widgets.tsx:174
+msgid "Error adding widget"
+msgstr "Feil ved tillegging av modul"
+
+#: packages/admin/src/components/Widgets.tsx:235
+msgid "Error reordering widgets"
+msgstr "Feil ved endring av modulrekkefølge"
+
+#: packages/admin/src/components/SectionEditor.tsx:52
+msgid "Error saving section"
+msgstr "Feil ved lagring av seksjon"
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Error updating widget"
+msgstr "Feil ved oppdatering av modul"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:581
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Alle publiserte utgivelser av denne utvidelsen er trukket tilbake eller kunne ikke verifiseres. Sjekk igjen senere, eller kontakt utgiveren."
+
+#: packages/admin/src/components/WordPressImport.tsx:1846
+msgid "Exists"
+msgstr "Finnes"
+
+#: packages/admin/src/components/ContentEditor.tsx:625
+msgid "Exit distraction-free mode"
+msgstr "Avslutt distraksjonsfri modus"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3078
+msgid "Exit Spotlight Mode"
+msgstr "Avslutt søkelysmodus"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Expand"
+msgstr "Utvid"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Expand details"
+msgstr "Vis detaljer"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
+msgid "Expires {0}"
+msgstr "Utløper {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
+msgid "Expiry"
+msgstr "Utløp"
+
+#: packages/admin/src/components/WordPressImport.tsx:1112
+msgid "Export from WordPress manually"
+msgstr "Eksporter fra WordPress manuelt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1236
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Eksporter innholdet ditt fra WordPress for å importere alt, inkludert kladder."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:144
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Mislykket"
+
+#: packages/admin/src/components/WordPressImport.tsx:1966
+msgid "Failed"
+msgstr "Mislyktes"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:188
+msgid "Failed security audit"
+msgstr "Sikkerhetsrevisjon mislyktes"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Failed to add domain"
+msgstr "Kunne ikke legge til domene"
+
+#: packages/admin/src/components/WordPressImport.tsx:367
+msgid "Failed to analyze WordPress site"
+msgstr "Kunne ikke analysere WordPress-nettstedet"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "Kunne ikke kommunisere med utvidelsen"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "Kunne ikke opprette administrator"
+
+#: packages/admin/src/components/ContentEditor.tsx:2223
+msgid "Failed to create byline"
+msgstr "Kunne ikke opprette byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "Kunne ikke opprette byline-felt"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "Kunne ikke opprette felt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1553
+msgid "Failed to create some collections"
+msgstr "Kunne ikke opprette noen samlinger"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:493
+msgid "Failed to create term"
+msgstr "Kunne ikke opprette term"
+
+#: packages/admin/src/router.tsx:890
+msgid "Failed to create translation"
+msgstr "Kunne ikke opprette oversettelse"
+
+#: packages/admin/src/router.tsx:346
+#: packages/admin/src/router.tsx:375
+#: packages/admin/src/router.tsx:910
+msgid "Failed to delete"
+msgstr "Kunne ikke slette"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "Kunne ikke slette tillatt domene"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "Kunne ikke slette byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "Kunne ikke slette byline-felt"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "Kunne ikke slette samling"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1162
+msgid "Failed to delete comment"
+msgstr "Kunne ikke slette kommentar"
+
+#: packages/admin/src/lib/api/content.ts:220
+msgid "Failed to delete content"
+msgstr "Kunne ikke slette innhold"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "Kunne ikke slette felt"
+
+#: packages/admin/src/lib/api/media.ts:357
+msgid "Failed to delete from provider"
+msgstr "Kunne ikke slette fra leverandør"
+
+#: packages/admin/src/lib/api/media.ts:234
+msgid "Failed to delete media"
+msgstr "Kunne ikke slette medier"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "Kunne ikke slette meny"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "Kunne ikke slette menyelement"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "Kunne ikke slette passnøkkel"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "Kunne ikke slette omdirigering"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "Kunne ikke slette seksjon"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "Kunne ikke slette term"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "Kunne ikke slette modul"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "Kunne ikke slette modulområde"
+
+#: packages/admin/src/components/PluginManager.tsx:116
+msgid "Failed to disable plugin"
+msgstr "Kunne ikke deaktivere utvidelse"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "Kunne ikke deaktivere bruker"
+
+#: packages/admin/src/router.tsx:824
+msgid "Failed to discard changes"
+msgstr "Kunne ikke forkaste endringer"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "Kunne ikke lukke velkomstmelding"
+
+#: packages/admin/src/router.tsx:389
+msgid "Failed to duplicate"
+msgstr "Kunne ikke duplisere"
+
+#: packages/admin/src/components/PluginManager.tsx:97
+msgid "Failed to enable plugin"
+msgstr "Kunne ikke aktivere utvidelse"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "Kunne ikke aktivere bruker"
+
+#: packages/admin/src/components/WordPressImport.tsx:295
+msgid "Failed to execute import"
+msgstr "Kunne ikke kjøre import"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "Kunne ikke hente samling"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:90
+msgid "Failed to fetch entry terms"
+msgstr "Kunne ikke hente termer for oppføring"
+
+#: packages/admin/src/lib/api/client.ts:210
+msgid "Failed to fetch manifest"
+msgstr "Kunne ikke hente manifest"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "Kunne ikke hente utvidelse"
+
+#: packages/admin/src/lib/api/content.ts:465
+#: packages/admin/src/lib/api/content.ts:470
+msgid "Failed to fetch revision"
+msgstr "Kunne ikke hente revisjon"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "Kunne ikke hente oppsettstatus"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:71
+msgid "Failed to fetch terms"
+msgstr "Kunne ikke hente termer"
+
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:674
+#: packages/admin/src/router.tsx:1093
+msgid "Failed to fetch user"
+msgstr "Kunne ikke hente bruker"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
+msgid "Failed to generate preview"
+msgstr "Kunne ikke generere forhåndsvisning"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "Kunne ikke generere URL for forhåndsvisning"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "Kunne ikke hente autentiseringsalternativer"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "Kunne ikke hente registreringsalternativer"
+
+#: packages/admin/src/components/WordPressImport.tsx:386
+msgid "Failed to import from WordPress"
+msgstr "Kunne ikke importere fra WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:319
+#: packages/admin/src/lib/api/import.ts:256
+msgid "Failed to import media"
+msgstr "Kunne ikke importere medier"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:692
+msgid "Failed to install plugin"
+msgstr "Kunne ikke installere utvidelse"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "Kunne ikke liste byline-felt"
+
+#: packages/admin/src/router.tsx:247
+msgid "Failed to load admin"
+msgstr "Kunne ikke laste inn admin"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Failed to load allowed domains"
+msgstr "Kunne ikke laste inn tillatte domener"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:352
+msgid "Failed to load bylines: {0}"
+msgstr "Kunne ikke laste inn bylines: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:89
+msgid "Failed to load email settings"
+msgstr "Kunne ikke laste inn e-postinnstillinger"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:417
+msgid "Failed to load image"
+msgstr "Kunne ikke laste inn bilde"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:144
+msgid "Failed to load passkeys"
+msgstr "Kunne ikke laste inn passnøkler"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:110
+msgid "Failed to load plugin"
+msgstr "Kunne ikke laste inn utvidelse"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:145
+msgid "Failed to load plugins: {0}"
+msgstr "Kunne ikke laste inn utvidelser: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "Kunne ikke laste inn utvidelser. Registeraggregatoren er kanskje utilgjengelig."
+
+#: packages/admin/src/components/RevisionHistory.tsx:180
+msgid "Failed to load revisions"
+msgstr "Kunne ikke laste inn revisjoner"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "Kunne ikke laste inn oppsett"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "Kunne ikke laste inn tema"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "Kunne ikke laste inn brukere: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "Kunne ikke laste inn modul"
+
+#: packages/admin/src/router.tsx:1187
+msgid "Failed to perform bulk action"
+msgstr "Kunne ikke utføre masseoperasjon"
+
+#: packages/admin/src/lib/api/content.ts:263
+msgid "Failed to permanently delete content"
+msgstr "Kunne ikke slette innhold permanent"
+
+#: packages/admin/src/components/WordPressImport.tsx:276
+msgid "Failed to prepare import"
+msgstr "Kunne ikke forberede import"
+
+#: packages/admin/src/router.tsx:789
+msgid "Failed to publish"
+msgstr "Kunne ikke publisere"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "Kunne ikke lese bruk av byline-felt"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
+msgid "Failed to remove domain"
+msgstr "Kunne ikke fjerne domene"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr "Kunne ikke fjerne passnøkkel"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr "Kunne ikke gi nytt navn til passnøkkel"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "Kunne ikke endre rekkefølge på byline-felt"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "Kunne ikke endre rekkefølge på felt"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "Kunne ikke endre rekkefølge på moduler"
+
+#: packages/admin/src/router.tsx:361
+msgid "Failed to restore"
+msgstr "Kunne ikke gjenopprette"
+
+#: packages/admin/src/lib/api/content.ts:252
+msgid "Failed to restore content"
+msgstr "Kunne ikke gjenopprette innhold"
+
+#: packages/admin/src/lib/api/content.ts:487
+#: packages/admin/src/lib/api/content.ts:492
+msgid "Failed to restore revision"
+msgstr "Kunne ikke gjenopprette revisjon"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "Kunne ikke tilbakekalle API-token"
+
+#: packages/admin/src/components/WordPressImport.tsx:332
+msgid "Failed to rewrite URLs"
+msgstr "Kunne ikke skrive om URL-er"
+
+#: packages/admin/src/router.tsx:742
+#: packages/admin/src/router.tsx:1669
+msgid "Failed to save"
+msgstr "Kunne ikke lagre"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "Kunne ikke lagre felt"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:58
+#: packages/admin/src/components/settings/SeoSettings.tsx:62
+#: packages/admin/src/components/settings/SocialSettings.tsx:53
+msgid "Failed to save settings"
+msgstr "Kunne ikke lagre innstillinger"
+
+#: packages/admin/src/router.tsx:842
+msgid "Failed to schedule"
+msgstr "Kunne ikke planlegge"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "Kunne ikke sende magisk lenke"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "Kunne ikke sende gjenopprettingslenke"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:61
+msgid "Failed to send test email"
+msgstr "Kunne ikke sende test-e-post"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "Kunne ikke sende bekreftelses-e-post"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:113
+msgid "Failed to set entry terms"
+msgstr "Kunne ikke angi termer for oppføring"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:831
+msgid "Failed to uninstall plugin"
+msgstr "Kunne ikke avinstallere utvidelse"
+
+#: packages/admin/src/router.tsx:805
+msgid "Failed to unpublish"
+msgstr "Kunne ikke avpublisere"
+
+#: packages/admin/src/router.tsx:860
+msgid "Failed to unschedule"
+msgstr "Kunne ikke oppheve planlegging"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:349
+msgid "Failed to update {0}"
+msgstr "Kunne ikke oppdatere {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2273
+msgid "Failed to update byline"
+msgstr "Kunne ikke oppdatere byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "Kunne ikke oppdatere byline-felt"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+msgid "Failed to update domain"
+msgstr "Kunne ikke oppdatere domene"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:763
+msgid "Failed to update plugin"
+msgstr "Kunne ikke oppdatere utvidelse"
+
+#: packages/admin/src/router.tsx:1146
+msgid "Failed to update status"
+msgstr "Kunne ikke oppdatere status"
+
+#: packages/admin/src/lib/api/media.ts:151
+msgid "Failed to upload file"
+msgstr "Kunne ikke laste opp fil"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:250
+msgid "Failed to verify authentication"
+msgstr "Kunne ikke bekrefte autentisering"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "Kunne ikke bekrefte registrering"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:790
+msgid "FAQ"
+msgstr "Ofte stilte spørsmål"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:236
+#: packages/admin/src/components/settings/GeneralSettings.tsx:242
+msgid "Favicon"
+msgstr "Favorittikon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1022
+msgid "Feature"
+msgstr "Funksjon"
+
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Funksjoner"
+
+#: packages/admin/src/components/WordPressImport.tsx:736
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Henter innhold fra EmDash Exporter-API-et."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "Felt opprettet"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "Felt slettet"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Feltetikett"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Feltetikett"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Felt-slugs kan ikke endres etter opprettelse"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "Felttype kan ikke endres etter opprettelse."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "Felt oppdatert"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:572
+msgid "Fields"
+msgstr "Felter"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Fields created:"
+msgstr "Felter opprettet:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "Fil"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:1994
+msgid "File {0}"
+msgstr "Fil {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "Fil fra mediebibliotek"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:483
+msgid "Filename"
+msgstr "Filnavn"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:196
+msgid "Filename cannot be changed after upload"
+msgstr "Filnavn kan ikke endres etter opplasting"
+
+#: packages/admin/src/components/WordPressImport.tsx:2172
+msgid "files imported"
+msgstr "filer importert"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Filtrer etter kapabilitet"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "Filtrer etter samling"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Filtrer etter rolle"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Filtrer etter kilde"
+
+#: packages/admin/src/components/Redirects.tsx:393
+msgid "Filter by status"
+msgstr "Filtrer etter status"
+
+#: packages/admin/src/components/MediaLibrary.tsx:399
+#: packages/admin/src/components/Redirects.tsx:399
+msgid "Filter by type"
+msgstr "Filtrer etter type"
+
+#: packages/admin/src/routes/bylines.tsx:395
+msgid "Filter byline type"
+msgstr "Filtrer byline-type"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "Kun førstegangskommentatorer"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Skrifter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1237
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "For en fullstendig import inkludert kladder og alt innhold, eksporter fra WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1046
+msgid "For the best import experience, install the"
+msgstr "For den beste importopplevelsen, installer"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Full tilgang"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "Full admintilgang"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "Generelt"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:101
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr "Generelle innstillinger"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "Genres"
+msgstr "Sjangere"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Kom i gang"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:138
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Gi denne passnøkkelen et navn slik at du kjenner den igjen senere."
+
+#: packages/admin/src/components/WordPressImport.tsx:2224
+#: packages/admin/src/router.tsx:1872
+msgid "Go to Dashboard"
+msgstr "Gå til dashbordet"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:227
+msgid "Google Verification"
+msgstr "Google-verifisering"
+
+#: packages/admin/src/components/MediaLibrary.tsx:270
+msgid "Grid view"
+msgstr "Rutenettvisning"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "Group (optional)"
+msgstr "Gruppe (valgfri)"
+
+#: packages/admin/src/routes/bylines.tsx:538
+msgid "Guest byline"
+msgstr "Gjestebyline"
+
+#: packages/admin/src/routes/bylines.tsx:400
+msgid "Guest only"
+msgstr "Kun gjest"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/PortableTextEditor.tsx:883
+#: packages/admin/src/components/PortableTextEditor.tsx:2888
+msgid "Heading 1"
+msgstr "Overskrift 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/PortableTextEditor.tsx:893
+#: packages/admin/src/components/PortableTextEditor.tsx:2895
+msgid "Heading 2"
+msgstr "Overskrift 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/PortableTextEditor.tsx:903
+#: packages/admin/src/components/PortableTextEditor.tsx:2902
+msgid "Heading 3"
+msgstr "Overskrift 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr "Høyde"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Hero-banner"
+
+#: packages/admin/src/components/SectionEditor.tsx:271
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:191
+msgid "Hide from search engines"
+msgstr "Skjul for søkemotorer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "Skjul token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:649
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Hierarkisk (som kategorier, med foreldre/barn-relasjoner)"
+
+#: packages/admin/src/components/Redirects.tsx:216
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "Hits"
+msgstr "Treff"
+
+#: packages/admin/src/components/MenuEditor.tsx:337
+msgid "Home"
+msgstr "Hjem"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Hjemmeside"
+
+#: packages/admin/src/components/PluginManager.tsx:385
+msgid "Hooks"
+msgstr "Hooks"
+
+#: packages/admin/src/components/WordPressImport.tsx:1359
+msgid "How to create an Application Password"
+msgstr "Slik oppretter du et applikasjonspassord"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:953
+msgid "HTML"
+msgstr "HTML"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "HTML-kilde"
+
+#: packages/admin/src/components/MenuEditor.tsx:345
+msgid "https://example.com or /about"
+msgstr "https://example.com eller /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:503
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:142
+msgid "Icon blurred due to image audit"
+msgstr "Ikonet er uskarpt på grunn av bildekontroll"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "Hvis det finnes en konto for <0>{email}</0>, har vi sendt en innloggingslenke."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/PortableTextEditor.tsx:2029
+msgid "Image"
+msgstr "Bilde"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Bilde fra mediebibliotek"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ContentEditor.tsx:1663
+msgid "Image not found"
+msgstr "Fant ikke bildet"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:179
+#: packages/admin/src/components/editor/ImageNode.tsx:180
+msgid "Image settings"
+msgstr "Bildeinnstillinger"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr "Bildeinnstillinger"
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr "Bilde som vises når denne siden deles på sosiale medier"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Image URL"
+msgstr "Bilde-URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:2176
+msgid "image URLs updated in"
+msgstr "bilde-URL-er oppdatert i"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/MediaLibrary.tsx:394
+msgid "Images"
+msgstr "Bilder"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:398
+#: packages/admin/src/components/WordPressImport.tsx:664
+msgid "Import"
+msgstr "Importer"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1794
+msgid "Import {0}"
+msgstr "Importer {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1205
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Importer alt innhold direkte, inkludert kladder, egendefinerte innleggstyper, ACF-felter og SEO-data. Ingen filnedlasting nødvendig."
+
+#: packages/admin/src/components/WordPressImport.tsx:2222
+msgid "Import Another File"
+msgstr "Importer en annen fil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1016
+msgid "Import Capabilities"
+msgstr "Importmuligheter"
+
+#: packages/admin/src/components/WordPressImport.tsx:2110
+msgid "Import Complete"
+msgstr "Import fullført"
+
+#: packages/admin/src/components/WordPressImport.tsx:2111
+msgid "Import Completed with Errors"
+msgstr "Import fullført med feil"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Import failed"
+msgstr "Import mislyktes"
+
+#: packages/admin/src/components/WordPressImport.tsx:617
+msgid "Import from WordPress"
+msgstr "Importer fra WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1943
+msgid "Import Media"
+msgstr "Importer medier"
+
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "Import Media Files"
+msgstr "Importer mediefiler"
+
+#: packages/admin/src/components/WordPressImport.tsx:619
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Importer innlegg, sider og egendefinerte innleggstyper fra WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1650
+msgid "Import site configuration from WordPress."
+msgstr "Importer nettstedskonfigurasjon fra WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Import via EmDash Exporter"
+msgstr "Importer via EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Importert"
+
+#: packages/admin/src/components/WordPressImport.tsx:2150
+msgid "Imported by Collection"
+msgstr "Importert etter samling"
+
+#: packages/admin/src/components/WordPressImport.tsx:820
+msgid "Importing content..."
+msgstr "Importerer innhold …"
+
+#: packages/admin/src/components/WordPressImport.tsx:1975
+msgid "Importing Media"
+msgstr "Importerer medier"
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Inkluder eksempelinnhold (anbefalt for nye nettsteder)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1816
+msgid "Incompatible"
+msgstr "Inkompatibel"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:491
+msgid "Indexed"
+msgstr "Indeksert"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2875
+msgid "Inline Code"
+msgstr "Inline-kode"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:515
+#: packages/admin/src/components/MediaPickerModal.tsx:742
+msgid "Insert"
+msgstr "Sett inn"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1311
+msgid "Insert {0}"
+msgstr "Sett inn {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:934
+msgid "Insert a blockquote"
+msgstr "Sett inn et sitat"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:944
+msgid "Insert a code block"
+msgstr "Sett inn en kodeblokk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:969
+msgid "Insert a horizontal rule"
+msgstr "Sett inn en horisontal linje"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2044
+msgid "Insert a reusable section"
+msgstr "Sett inn en gjenbrukbar seksjon"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:979
+msgid "Insert a table"
+msgstr "Sett inn en tabell"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2030
+msgid "Insert an image"
+msgstr "Sett inn et bilde"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:497
+msgid "Insert from URL"
+msgstr "Sett inn fra URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3045
+msgid "Insert Horizontal Rule"
+msgstr "Sett inn horisontal linje"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3040
+msgid "Insert Image"
+msgstr "Sett inn bilde"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2987
+msgid "Insert Link"
+msgstr "Sett inn lenke"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:954
+msgid "Insert raw HTML"
+msgstr "Sett inn rå HTML"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Sett inn seksjon"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2945
+msgid "Insert Table"
+msgstr "Sett inn tabell"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:150
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:192
+#: packages/admin/src/components/RegistryPluginDetail.tsx:539
+msgid "Install"
+msgstr "Installer"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:181
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Installer og aktiver en utvidelse for e-postleverandør for å aktivere e-postfunksjoner som invitasjoner, magiske lenker og passordgjenoppretting."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:186
+msgid "Install blocked"
+msgstr "Installasjon blokkert"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:789
+msgid "Installation"
+msgstr "Installasjon"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:173
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:531
+msgid "Installed"
+msgstr "Installert"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Installed from marketplace (v{0})"
+msgstr "Installert fra markedsplass (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Installed:"
+msgstr "Installert:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:167
+msgid "Installing..."
+msgstr "Installerer …"
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Heltall"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:119
+msgid "Invalid invite link"
+msgstr "Ugyldig invitasjonslenke"
+
+#: packages/admin/src/components/ContentEditor.tsx:1550
+msgid "Invalid JSON"
+msgstr "Ugyldig JSON"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "Ugyldig lenke"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:207
+msgid "Invite Error"
+msgstr "Invitasjonsfeil"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:117
+msgid "Invite expired"
+msgstr "Invitasjon utløpt"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Invitasjonslenke opprettet"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Inviter bruker"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Inviter ditt første teammedlem"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2548
+#: packages/admin/src/components/PortableTextEditor.tsx:2854
+msgid "Italic"
+msgstr "Kursiv"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1692
+#: packages/admin/src/components/RepeaterField.tsx:234
+msgid "Item {0}"
+msgstr "Element {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Item added"
+msgstr "Element lagt til"
+
+#: packages/admin/src/components/MenuEditor.tsx:133
+msgid "Item deleted"
+msgstr "Element slettet"
+
+#: packages/admin/src/components/MenuEditor.tsx:158
+msgid "Item updated"
+msgstr "Element oppdatert"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Kari Nordmann"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Stillingstittel"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr "job_title"
+
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/ContentEditor.tsx:2102
+msgid "Keep typing to narrow down more bylines."
+msgstr "Fortsett å skrive for å begrense bylinene ytterligere."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:293
+#: packages/admin/src/components/SectionEditor.tsx:268
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Nøkkelord"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:337
+#: packages/admin/src/components/MenuEditor.tsx:506
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+#: packages/admin/src/components/Widgets.tsx:371
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Etikett"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:394
+msgid "Label (Plural)"
+msgstr "Etikett (flertall)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:386
+msgid "Label (Singular)"
+msgstr "Etikett (entall)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:125
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr "Språk"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:884
+msgid "Large section heading"
+msgstr "Stor seksjonsoverskrift"
+
+#: packages/admin/src/components/PluginManager.tsx:525
+msgid "Last enabled:"
+msgstr "Sist aktivert:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Sist innlogget"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Sist innlogget"
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "Last seen"
+msgstr "Sist sett"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Sist oppdatert"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr "Sist brukt"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Sist brukt {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr "La stå tomt for å bruke en søkbar passnøkkel."
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Leave unassigned"
+msgstr "La stå utildelt"
+
+#: packages/admin/src/components/MediaLibrary.tsx:120
+#: packages/admin/src/components/MediaLibrary.tsx:240
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "Library"
+msgstr "Bibliotek"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Lisens"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "lys"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Lys"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "Lenken er utløpt"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Lenke til et annet innholdselement"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Tilknyttede kontoer ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:401
+msgid "Linked only"
+msgstr "Kun tilknyttet"
+
+#: packages/admin/src/routes/bylines.tsx:489
+msgid "Linked user"
+msgstr "Tilknyttet bruker"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:156
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Lenker"
+
+#: packages/admin/src/components/MediaLibrary.tsx:279
+msgid "List view"
+msgstr "Listevisning"
+
+#: packages/admin/src/components/ContentEditor.tsx:746
+msgid "Live View"
+msgstr "Live-visning"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:455
+msgid "Load more"
+msgstr "Last inn mer"
+
+#: packages/admin/src/components/ContentList.tsx:389
+#: packages/admin/src/components/ContentList.tsx:446
+#: packages/admin/src/components/MediaLibrary.tsx:533
+#: packages/admin/src/components/MediaPickerModal.tsx:718
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Last inn mer"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "Laster bylinjefelt…"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "Laster samlinger..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "Laster kommentarer..."
+
+#: packages/admin/src/router.tsx:1841
+msgid "Loading configuration..."
+msgstr "Laster konfigurasjon..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "Laster innhold..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2375
+msgid "Loading editor..."
+msgstr "Laster redigering..."
+
+#: packages/admin/src/components/MenuEditor.tsx:263
+msgid "Loading menu..."
+msgstr "Laster meny..."
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "Laster menyer..."
+
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Loading plugins..."
+msgstr "Laster utvidelser..."
+
+#: packages/admin/src/components/Redirects.tsx:430
+msgid "Loading redirects..."
+msgstr "Laster videresendinger..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "Laster seksjoner..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:108
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+msgid "Loading settings..."
+msgstr "Laster innstillinger..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "Laster oppsett..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:827
+msgid "Loading terms..."
+msgstr "Laster termer..."
+
+#: packages/admin/src/components/Widgets.tsx:310
+msgid "Loading widgets..."
+msgstr "Laster moduler..."
+
+#: packages/admin/src/components/ContentList.tsx:300
+#: packages/admin/src/components/ContentList.tsx:389
+#: packages/admin/src/components/ContentList.tsx:418
+#: packages/admin/src/components/ContentList.tsx:446
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:533
+#: packages/admin/src/components/MediaPickerModal.tsx:718
+#: packages/admin/src/components/PortableTextEditor.tsx:1819
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:176
+#: packages/admin/src/components/settings/SecuritySettings.tsx:113
+#: packages/admin/src/components/TaxonomyManager.tsx:779
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:455
+msgid "Loading..."
+msgstr "Laster..."
+
+#: packages/admin/src/components/ContentList.tsx:280
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Språk"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr "Lås sideforhold"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Låst fordi dette feltet har lagrede verdier. Slett verdiene (eller feltet) for å endre dette."
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr "Logg ut"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+#: packages/admin/src/components/settings/GeneralSettings.tsx:188
+msgid "Logo"
+msgstr "Logo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1668
+msgid "Logo & favicon"
+msgstr "Logo og favikon"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Lang tekst"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Lang tekst"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Kun små bokstaver, tall og bindestreker"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:641
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Kun små bokstaver, tall og understreker, og må starte med en bokstav"
+
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Main Sidebar"
+msgstr "Hovedsidefelt"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Make network requests"
+msgstr "Send nettverksforespørsler"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Send nettverksforespørsler til alle verter (ubegrenset)"
+
+#: packages/admin/src/components/Sidebar.tsx:589
+msgid "Manage"
+msgstr "Administrer"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:798
+msgid "Manage {0} for {1}"
+msgstr "Administrer {0} for {1}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2065
+msgid "Manage bylines in {entryLocale}"
+msgstr "Administrer bylinjer i {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:326
+msgid "Manage content widgets in your widget areas"
+msgstr "Administrer innholdsmoduler i modulområdene dine"
+
+#: packages/admin/src/components/PluginManager.tsx:175
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Administrer installerte utvidelser. Aktiver eller deaktiver utvidelser for å styre funksjonaliteten deres."
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "Administrer navigasjonsmenyer for nettstedet ditt"
+
+#: packages/admin/src/components/Redirects.tsx:333
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Administrer URL-videresendinger og se 404-feil."
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "Administrer passnøklene og autentiseringen din"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Manual"
+msgstr "Manuelt"
+
+#: packages/admin/src/components/WordPressImport.tsx:2260
+msgid "Map Authors"
+msgstr "Tilordne forfattere"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2308
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Tilordne WordPress-bruker {0} til EmDash-bruker"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "Merk som spam"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "marketplace"
+msgstr "markedsplass"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:167
+#: packages/admin/src/components/PluginManager.tsx:355
+#: packages/admin/src/components/Sidebar.tsx:382
+msgid "Marketplace"
+msgstr "Markedsplass"
+
+#: packages/admin/src/components/FieldEditor.tsx:626
+msgid "Max Items"
+msgstr "Maks antall"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Maks lengde"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Maksverdi"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2033
+#: packages/admin/src/components/Sidebar.tsx:342
+#: packages/admin/src/components/WordPressImport.tsx:678
+#: packages/admin/src/components/WordPressImport.tsx:1173
+msgid "Media"
+msgstr "Medier"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:130
+msgid "Media Details"
+msgstr "Mediedetaljer"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2206
+msgid "Media Errors ({0})"
+msgstr "Mediefeil ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2168
+msgid "Media Import"
+msgstr "Medieimport"
+
+#: packages/admin/src/components/WordPressImport.tsx:2109
+msgid "Media Import Complete"
+msgstr "Medieimport fullført"
+
+#: packages/admin/src/components/WordPressImport.tsx:2120
+msgid "Media import was skipped"
+msgstr "Medieimport ble hoppet over"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:264
+msgid "Media Library"
+msgstr "Mediebibliotek"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "Lese medier"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "Skrive medier"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:894
+msgid "Medium section heading"
+msgstr "Mellomstor seksjonsoverskrift"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:834
+msgid "Menu"
+msgstr "Meny"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:90
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "Menyen «{0}» ({1}) er opprettet."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "Menyen «{0}» er opprettet."
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "Meny opprettet"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "Meny slettet"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Menu item has been added."
+msgstr "Menyelementet er lagt til."
+
+#: packages/admin/src/components/MenuEditor.tsx:134
+msgid "Menu item has been deleted."
+msgstr "Menyelementet er slettet."
+
+#: packages/admin/src/components/MenuEditor.tsx:159
+msgid "Menu item has been updated."
+msgstr "Menyelementet er oppdatert."
+
+#: packages/admin/src/components/MenuEditor.tsx:271
+msgid "Menu not found"
+msgstr "Fant ikke menyen"
+
+#: packages/admin/src/components/MenuEditor.tsx:174
+msgid "Menu order has been updated."
+msgstr "Menyrekkefølgen er oppdatert."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:352
+msgid "Menus"
+msgstr "Menyer"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1604
+msgid "Menus ({0})"
+msgstr "Menyer ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "Administrer menyer"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Meta Description"
+msgstr "Metabeskrivelse"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:236
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Metatagg-innhold for verifisering med Bing Webmaster Tools"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:230
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Metatagg-innhold for verifisering med Google Search Console"
+
+#: packages/admin/src/components/WordPressImport.tsx:1681
+msgid "Meta titles, descriptions, and social images"
+msgstr "Metatitler, beskrivelser og sosiale bilder"
+
+#: packages/admin/src/components/FieldEditor.tsx:619
+msgid "Min Items"
+msgstr "Min. antall"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Min. lengde"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Minverdi"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:506
+msgid "Moderation"
+msgstr "Moderering"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Modereringssignaler"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Endret"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "Endre samlingsskjemaer"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Mest populære"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Flytt «{0}» ned"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Flytt «{0}» opp"
+
+#: packages/admin/src/components/ContentList.tsx:653
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Vil du flytte «{title}» til papirkurven? Du kan gjenopprette det senere."
+
+#: packages/admin/src/components/ContentList.tsx:644
+msgid "Move {title} to trash"
+msgstr "Flytt {title} til papirkurven"
+
+#: packages/admin/src/components/MenuEditor.tsx:451
+msgid "Move down"
+msgstr "Flytt ned"
+
+#: packages/admin/src/components/ContentEditor.tsx:949
+#: packages/admin/src/components/ContentEditor.tsx:971
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Move to Trash"
+msgstr "Flytt til papirkurven"
+
+#: packages/admin/src/components/ContentEditor.tsx:955
+#: packages/admin/src/components/ContentList.tsx:651
+msgid "Move to Trash?"
+msgstr "Flytte til papirkurven?"
+
+#: packages/admin/src/components/MenuEditor.tsx:442
+msgid "Move up"
+msgstr "Flytt opp"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Flervalg"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Flerlinjes ren tekst"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Flere valg fra alternativer"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "Bloggen min"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:389
+#: packages/admin/src/components/TaxonomyManager.tsx:632
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:365
+msgid "Name"
+msgstr "Navn"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:558
+msgid "Name and label are required"
+msgstr "Navn og etikett er påkrevd"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Navnet må starte med en bokstav og kan kun inneholde små bokstaver, tall og understreker"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Navigasjon"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Aldri"
+
+#: packages/admin/src/router.tsx:885
+msgid "new"
+msgstr "ny"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "New"
+msgstr "Ny"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:106
+msgid "NEW"
+msgstr "NY"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:464
+msgid "New {0}"
+msgstr "Ny {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:631
+msgid "New {collectionLabel}"
+msgstr "Ny {collectionLabel}"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "Nytt bylinjefelt"
+
+#: packages/admin/src/components/WordPressImport.tsx:1818
+msgid "New collection"
+msgstr "Ny samling"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "Ny innholdstype"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "Nytt felt"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:116
+msgid "New public routes"
+msgstr "Nye offentlige ruter"
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:336
+msgid "New Redirect"
+msgstr "Ny omdirigering"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "Ny seksjon"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "ny fane"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:811
+msgid "New Taxonomy"
+msgstr "Ny taksonomi"
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:525
+msgid "New window"
+msgstr "Nytt vindu"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Nyeste"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:392
+msgid "News"
+msgstr "Nyheter"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Neste"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:377
+msgid "Next page"
+msgstr "Neste side"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:463
+msgid "Next screenshot"
+msgstr "Neste skjermbilde"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "Nei"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "Nei (delt på tvers av oversettelser)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:434
+msgid "No {0} available."
+msgstr "Ingen {0} tilgjengelig."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:311
+msgid "No {0} yet."
+msgstr "Ingen {0} ennå."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:830
+msgid "No {0} yet. Create one to get started."
+msgstr "Ingen {0} ennå. Opprett en for å komme i gang."
+
+#: packages/admin/src/components/Redirects.tsx:208
+msgid "No 404 errors recorded yet."
+msgstr "Ingen 404-feil registrert ennå."
+
+#: packages/admin/src/components/MediaLibrary.tsx:688
+#: packages/admin/src/components/MediaLibrary.tsx:745
+msgid "No alt text"
+msgstr "Ingen alt-tekst"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
+msgid "No API tokens yet. Create one to get started."
+msgstr "Ingen API-tokener ennå. Opprett en for å komme i gang."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "Ingen godkjente kommentarer ennå."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "Ingen byline-felt ennå."
+
+#: packages/admin/src/components/ContentEditor.tsx:2057
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "Ingen bylines tilgjengelig på {entryLocale}. Opprett en variant fra Bylines-siden før du krediterer en på denne oppføringen."
+
+#: packages/admin/src/routes/bylines.tsx:439
+msgid "No bylines found"
+msgstr "Fant ingen bylines"
+
+#: packages/admin/src/components/ContentEditor.tsx:2164
+msgid "No bylines selected."
+msgstr "Ingen bylines valgt."
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr "Ingen samlinger konfigurert"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "Ingen kommentarer venter på moderering."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "Ingen kommentarer samsvarer med søket ditt."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:80
+msgid "No content"
+msgstr "Ingen innhold"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "Fant ingen innhold"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "Ingen innhold i denne samlingen"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "Ingen innholdstyper ennå."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:603
+msgid "No custom fields yet"
+msgstr "Ingen egendefinerte felt ennå"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:264
+msgid "No detailed description available."
+msgstr "Ingen detaljert beskrivelse tilgjengelig."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
+msgid "No domains configured. Users must be invited individually."
+msgstr "Ingen domener konfigurert. Brukere må inviteres enkeltvis."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:178
+msgid "No email provider configured"
+msgstr "Ingen e-postleverandør konfigurert"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "Ingen e-postleverandør konfigurert. Del denne lenken manuelt."
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "No EmDash users found"
+msgstr "Fant ingen EmDash-brukere"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "Ingen utløp"
+
+#: packages/admin/src/components/RevisionHistory.tsx:327
+msgid "No fields to compare"
+msgstr "Ingen felt å sammenligne"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:189
+msgid "No headings in document"
+msgstr "Ingen overskrifter i dokumentet"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:579
+msgid "No installable releases"
+msgstr "Ingen installerbare utgivelser"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:159
+msgid "No invite token provided"
+msgstr "Ingen invitasjonstoken oppgitt"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1615
+#: packages/admin/src/components/RepeaterField.tsx:160
+msgid "No items yet"
+msgstr "Ingen elementer ennå"
+
+#: packages/admin/src/components/FieldEditor.tsx:630
+msgid "No limit"
+msgstr "Ingen grense"
+
+#: packages/admin/src/routes/bylines.tsx:500
+msgid "No linked user"
+msgstr "Ingen tilknyttet bruker"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:134
+msgid "No matches"
+msgstr "Ingen treff"
+
+#: packages/admin/src/components/ContentEditor.tsx:2099
+msgid "No matching bylines."
+msgstr "Ingen samsvarende bylines."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr "Fant ingen samsvarende passkey for denne kontoen."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "Ingen maksimum"
+
+#: packages/admin/src/components/MediaLibrary.tsx:436
+#: packages/admin/src/components/MediaPickerModal.tsx:641
+msgid "No media available from this provider"
+msgstr "Ingen medier tilgjengelig fra denne leverandøren"
+
+#: packages/admin/src/components/MediaLibrary.tsx:430
+#: packages/admin/src/components/MediaPickerModal.tsx:635
+msgid "No media found"
+msgstr "Fant ingen medier"
+
+#: packages/admin/src/components/MediaLibrary.tsx:419
+msgid "No media yet"
+msgstr "Ingen medier ennå"
+
+#: packages/admin/src/components/MenuEditor.tsx:406
+msgid "No menu items yet"
+msgstr "Ingen menyelementer ennå"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "Ingen menyer ennå"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "Ingen minimum"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "Ingen moderering (godkjenn alle automatisk)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "Ingen passkeys registrert"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "No passkeys registered yet."
+msgstr "Ingen passkeys registrert ennå."
+
+#: packages/admin/src/components/PluginManager.tsx:195
+msgid "No plugins configured"
+msgstr "Ingen utvidelser konfigurert"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "Fant ingen utvidelser"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "Ingen utvidelser er publisert til dette registeret ennå."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "Ingen utvidelser samsvarer med \"{debouncedQuery}\"."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "Ingen forhåndsvisning"
+
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr "Ingen nylig aktivitet"
+
+#: packages/admin/src/components/Redirects.tsx:434
+msgid "No redirects yet"
+msgstr "Ingen omdirigeringer ennå"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1173
+msgid "No results"
+msgstr "Ingen resultater"
+
+#: packages/admin/src/components/ContentList.tsx:308
+#: packages/admin/src/components/ContentList.tsx:327
+msgid "No results for \"{activeSearch}\""
+msgstr "Ingen resultater for \"{activeSearch}\""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "Ingen resultater for \"{debouncedQuery}\". Prøv et annet søkeord."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "Fant ingen resultater"
+
+#: packages/admin/src/components/RevisionHistory.tsx:183
+msgid "No revisions yet"
+msgstr "Ingen revisjoner ennå"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "Ingen seksjoner tilgjengelig"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "Fant ingen seksjoner"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "Ingen seksjoner ennå"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "Ingen useriøse kommentarer."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "Fant ingen temaer"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "Fant ingen brukere som samsvarer med filtrene dine."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "Ingen brukere ennå."
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "No widget areas yet. Create one to get started."
+msgstr "Ingen widgetområder ennå. Opprett ett for å komme i gang."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:418
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "None (top level)"
+msgstr "Ingen (øverste nivå)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:614
+msgid "Not compatible with this environment"
+msgstr "Ikke kompatibel med dette miljøet"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Tall"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:301
+msgid "Number of posts to show per page on list views"
+msgstr "Antall innlegg som vises per side i listevisninger"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:923
+#: packages/admin/src/components/PortableTextEditor.tsx:2922
+msgid "Numbered List"
+msgstr "Nummerert liste"
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr "OG-bilde"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "på et egendefinert vertsnavn behandles ikke som sikkert, selv på loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Autoriser bare koder du kjenner igjen."
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Bare e-postadresser fra tillatte domener kan registrere seg."
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Kun små bokstaver, tall og bindestreker"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Bare de oppførte MIME-typene godtas for dette feltet."
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "Oi sann!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Åpne i ny fane"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Open WordPress Profile"
+msgstr "Åpne WordPress-profil"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr "Alternativ 1\nAlternativ 2\nAlternativ 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr "Valgfri bildetekst som vises under bildet"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:213
+msgid "Optional caption for display"
+msgstr "Valgfri bildetekst for visning"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+msgid "Optional description"
+msgstr "Valgfri beskrivelse"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr "Valgfritt verktøytips ved peking"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Alternativer (ett per linje)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:527
+msgid "or choose from library"
+msgstr "eller velg fra biblioteket"
+
+#: packages/admin/src/components/WordPressImport.tsx:1429
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Eller klikk for å bla gjennom. Godtar .xml-filer eksportert fra WordPress."
+
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "Eller fortsett med"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Or upload an export file"
+msgstr "Eller last opp en eksportfil"
+
+#: packages/admin/src/components/WordPressImport.tsx:949
+msgid "or upload directly"
+msgstr "eller last opp direkte"
+
+#: packages/admin/src/components/MenuEditor.tsx:173
+msgid "Order saved"
+msgstr "Rekkefølge lagret"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr "Original:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:181
+msgid "Outline"
+msgstr "Disposisjon"
+
+#: packages/admin/src/components/SeoPanel.tsx:155
+msgid "Overrides the page title in search engine results"
+msgstr "Overstyrer sidetittelen i søkemotorresultater"
+
+#: packages/admin/src/components/ContentEditor.tsx:986
+msgid "Ownership"
+msgstr "Eierskap"
+
+#: packages/admin/src/components/PluginManager.tsx:509
+msgid "Package"
+msgstr "Pakke"
+
+#: packages/admin/src/router.tsx:1867
+msgid "Page Not Found"
+msgstr "Fant ikke siden"
+
+#: packages/admin/src/components/PluginManager.tsx:373
+#: packages/admin/src/components/WordPressImport.tsx:1167
+msgid "Pages"
+msgstr "Sider"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Avsnitt"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+msgid "Parent"
+msgstr "Overordnet"
+
+#: packages/admin/src/components/Redirects.tsx:483
+#: packages/admin/src/components/Redirects.tsx:489
+msgid "Part of a redirect loop"
+msgstr "Del av en omdirigeringssløyfe"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Bestått"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr "Passkey lagt til"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Navn på passkey"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Navn på passkey (valgfritt)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey registrert!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr "Passnøkkel fjernet"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr "Passnøkkel fikk nytt navn"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passnøkler"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passnøkler ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passnøkler er en sikker, passordløs måte å logge inn på kontoen din. Du kan registrere flere passnøkler for ulike enheter."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passnøkler er en sikker, passordløs måte å logge inn ved hjelp av enhetens biometri, PIN-kode eller sikkerhetsnøkkel."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passnøkler er ikke tilgjengelige her"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passnøkler krever en"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passnøkler krever HTTPS eller http://localhost (med porten din); dette vertsnavnet er ikke en sikker nettleserkontekst."
+
+#: packages/admin/src/components/Redirects.tsx:215
+msgid "Path"
+msgstr "Sti"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Mønster (regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:437
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Mønster for å generere URL-er, f.eks. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:433
+msgid "Pattern must include a {0} placeholder"
+msgstr "Mønsteret må inneholde en {0}-plassholder"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "pending"
+msgstr "venter"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+msgid "Pending"
+msgstr "Venter"
+
+#: packages/admin/src/components/ContentEditor.tsx:861
+msgid "Pending changes"
+msgstr "Ventende endringer"
+
+#: packages/admin/src/components/ContentList.tsx:724
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Slette «{title}» permanent? Dette kan ikke angres."
+
+#: packages/admin/src/components/ContentList.tsx:713
+msgid "Permanently delete {title}"
+msgstr "Slett {title} permanent"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:273
+msgid "Permissions"
+msgstr "Tillatelser"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Velg en metode for å opprette administratorkontoen din."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Vanlig"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:133
+msgid "Please ask your administrator to send a new invite."
+msgstr "Be administratoren din om å sende en ny invitasjon."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Skriv inn en gyldig e-postadresse"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "Skriv inn en gyldig e-postadresse"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:394
+msgid "Please enter a valid URL"
+msgstr "Skriv inn en gyldig URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1024
+msgid "Plugin"
+msgstr "Utvidelse"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:747
+msgid "Plugin details"
+msgstr "Detaljer om utvidelse"
+
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "Plugin disabled"
+msgstr "Utvidelse deaktivert"
+
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "Plugin enabled"
+msgstr "Utvidelse aktivert"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Feil i utvidelse"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Feil i utvidelse ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:112
+msgid "Plugin not found"
+msgstr "Utvidelse ikke funnet"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:396
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "Utvidelse ikke funnet. Utgiverhåndtaket eller slug kan være feil."
+
+#: packages/admin/src/components/WordPressImport.tsx:1048
+msgid "plugin on your WordPress site."
+msgstr "-utvidelsen på WordPress-nettstedet ditt."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "Tillatelser for utvidelse"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "Utvidelsesregister"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "Utvidelsen svarte med {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "Plugin uninstalled"
+msgstr "Utvidelse avinstallert"
+
+#: packages/admin/src/lib/api/registry.ts:783
+msgid "Plugin update requires re-consent"
+msgstr "Oppdatering av utvidelse krever nytt samtykke"
+
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "Plugin updated"
+msgstr "Utvidelse oppdatert"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:153
+#: packages/admin/src/components/Sidebar.tsx:369
+#: packages/admin/src/components/Sidebar.tsx:609
+msgid "Plugins"
+msgstr "Utvidelser"
+
+#: packages/admin/src/components/SeoPanel.tsx:182
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Peker søkemotorer til den opprinnelige versjonen av denne siden, dersom den er duplisert fra en annen URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1161
+msgid "Posts"
+msgstr "Innlegg"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:295
+msgid "Posts Per Page"
+msgstr "Innlegg per side"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:463
+msgid "Pre-release"
+msgstr "Forhåndsutgivelse"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Forbereder registrering …"
+
+#: packages/admin/src/components/WordPressImport.tsx:2020
+msgid "Preparing to download files from WordPress..."
+msgstr "Forbereder nedlasting av filer fra WordPress …"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "Forbereder …"
+
+#: packages/admin/src/components/ContentEditor.tsx:681
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:482
+msgid "Preview"
+msgstr "Forhåndsvisning"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Forhåndsvis innhold før publisering"
+
+#: packages/admin/src/components/ContentEditor.tsx:681
+msgid "Preview draft"
+msgstr "Forhåndsvis kladd"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Forrige"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:365
+msgid "Previous page"
+msgstr "Forrige side"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:445
+msgid "Previous screenshot"
+msgstr "Forrige skjermbilde"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "Hovednavigasjon"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:202
+msgid "Provider:"
+msgstr "Leverandør:"
+
+#: packages/admin/src/components/ContentEditor.tsx:736
+#: packages/admin/src/components/ContentEditor.tsx:842
+msgid "Publish"
+msgstr "Publiser"
+
+#: packages/admin/src/components/ContentEditor.tsx:726
+msgid "Publish changes"
+msgstr "Publiser endringer"
+
+#: packages/admin/src/components/ContentList.tsx:765
+msgid "published"
+msgstr "publisert"
+
+#: packages/admin/src/components/ContentEditor.tsx:857
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/Dashboard.tsx:187
+#: packages/admin/src/router.tsx:785
+msgid "Published"
+msgstr "Publisert"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:326
+msgid "Published {0}"
+msgstr "Publisert {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Publisert"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:457
+msgid "Published by"
+msgstr "Publisert av"
+
+#: packages/admin/src/components/ContentEditor.tsx:2172
+msgid "Quick create byline"
+msgstr "Opprett byline raskt"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:167
+#: packages/admin/src/components/editor/ImageNode.tsx:168
+msgid "Quick edit alt text"
+msgstr "Rediger alt-tekst raskt"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:933
+#: packages/admin/src/components/PortableTextEditor.tsx:2929
+msgid "Quote"
+msgstr "Sitat"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "Les samlingsskjemaer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "Les innholdsoppføringer"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "Les mediefiler"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "Les nettstedsinnstillinger"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Read user accounts"
+msgstr "Les brukerkontoer"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:230
+msgid "Read your content"
+msgstr "Les innholdet ditt"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:292
+msgid "Reading"
+msgstr "Lesing"
+
+#: packages/admin/src/components/WordPressImport.tsx:1822
+msgid "Ready"
+msgstr "Klar"
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr "Nylig aktivitet"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Nylig oppdatert"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:144
+msgid "Recipient email"
+msgstr "Mottakerens e-post"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "Gjenopprettingslenke sendt til {0}"
+
+#: packages/admin/src/components/Redirects.tsx:416
+msgid "Redirect loop detected"
+msgstr "Omdirigeringssløyfe oppdaget"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Omdirigerer til innlogging …"
+
+#: packages/admin/src/components/Redirects.tsx:332
+#: packages/admin/src/components/Redirects.tsx:351
+#: packages/admin/src/components/Sidebar.tsx:353
+msgid "Redirects"
+msgstr "Omdirigeringer"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3065
+msgid "Redo"
+msgstr "Gjør om"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Referanse"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:251
+msgid "Referenced favicon unavailable."
+msgstr "Det refererte favikonet er utilgjengelig."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Registrer"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:220
+msgid "Register Passkey"
+msgstr "Registrer passnøkkel"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Registrert bruker"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Registrering mislyktes"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "Registreringen ble avbrutt eller fikk tidsavbrudd. Prøv på nytt."
+
+#: packages/admin/src/components/Sidebar.tsx:375
+msgid "Registry"
+msgstr "Register"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:595
+msgid "Release is too new to install"
+msgstr "Utgivelsen er for ny til å installeres"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentEditor.tsx:2141
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/PortableTextEditor.tsx:3028
+#: packages/admin/src/components/settings/GeneralSettings.tsx:217
+#: packages/admin/src/components/settings/GeneralSettings.tsx:271
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
+#: packages/admin/src/components/settings/SeoSettings.tsx:209
+msgid "Remove"
+msgstr "Fjern"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:243
+msgid "Remove {0}"
+msgstr "Fjern {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Fjern {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1883
+msgid "Remove {label}"
+msgstr "Fjern {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
+msgid "Remove Domain"
+msgstr "Fjern domene"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
+msgid "Remove Domain?"
+msgstr "Fjerne domene?"
+
+#: packages/admin/src/components/ContentEditor.tsx:1680
+#: packages/admin/src/components/ContentEditor.tsx:1709
+#: packages/admin/src/components/SeoImageField.tsx:55
+msgid "Remove image"
+msgstr "Fjern bilde"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr "Fjern bilde"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr "Fjerne bilde?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1731
+#: packages/admin/src/components/RepeaterField.tsx:270
+msgid "Remove item {0}"
+msgstr "Fjern element {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2529
+#: packages/admin/src/components/PortableTextEditor.tsx:2530
+msgid "Remove link"
+msgstr "Fjern lenke"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr "Fjern passnøkkel"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr "Fjerne passnøkkel?"
+
+#: packages/admin/src/components/FieldEditor.tsx:610
+msgid "Remove sub-field"
+msgstr "Fjern underfelt"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr "Fjerne dette bildet fra dokumentet?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
+msgid "Removing..."
+msgstr "Fjerner …"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr "Gi nytt navn"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr "Gi {0} nytt navn"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr "Gi passnøkkel nytt navn"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Repeater"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Gjentakende gruppe med felt"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr "Erstatt bilde"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Svar til:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Kodelager"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "Be om en ny lenke"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:721
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:592
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Påkrevd"
+
+#: packages/admin/src/components/WordPressImport.tsx:1835
+msgid "Required fields:"
+msgstr "Påkrevde felt:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Påkrevd for tilgjengelighet. Beskriver bildet for skjermlesere."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:324
+msgid "Requires EmDash {0}"
+msgstr "Krever EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "Send e-post på nytt"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "Send på nytt om {resendCooldown} s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr "Tilbakestill til original"
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restore"
+msgstr "Gjenopprett"
+
+#: packages/admin/src/components/ContentList.tsx:701
+msgid "Restore {title}"
+msgstr "Gjenopprett {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:136
+msgid "Restore failed"
+msgstr "Gjenoppretting mislyktes"
+
+#: packages/admin/src/components/RevisionHistory.tsx:214
+msgid "Restore Revision?"
+msgstr "Gjenopprette revisjon?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Restore this version"
+msgstr "Gjenopprett denne versjonen"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:217
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Gjenopprette denne versjonen fra {0}? Dette oppdaterer det gjeldende innholdet til dataene i denne revisjonen."
+
+#: packages/admin/src/components/RevisionHistory.tsx:221
+msgid "Restoring..."
+msgstr "Gjenoppretter …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:1855
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Prøv igjen"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Gjenbrukbare innholdsblokker du kan sette inn i hvilket som helst innhold"
+
+#: packages/admin/src/router.tsx:819
+msgid "Reverted to published version"
+msgstr "Tilbakestilt til publisert versjon"
+
+#: packages/admin/src/components/WordPressImport.tsx:650
+msgid "Review"
+msgstr "Gjennomgå"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "Gjennomgå nye tillatelser"
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Revision restored"
+msgstr "Revisjon gjenopprettet"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:161
+msgid "Revisions"
+msgstr "Revisjoner"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
+msgid "Revoke token"
+msgstr "Tilbakekall token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoke?"
+msgstr "Tilbakekalle?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Revoking..."
+msgstr "Tilbakekaller …"
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Rik tekst"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "Innhold med rik tekst"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Redigeringsverktøy for rik tekst"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:311
+msgid "Risk score: {0}/100"
+msgstr "Risikoscore: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Rolle"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Rolle {role}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2146
+msgid "Role label"
+msgstr "Rolleetikett"
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:353
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:524
+msgid "Same window"
+msgstr "Samme vindu"
+
+#: packages/admin/src/components/ContentEditor.tsx:2279
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/editor/ImageNode.tsx:235
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Save"
+msgstr "Lagre"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Lagre (Enter)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:236
+msgid "Save alt text"
+msgstr "Lagre alt-tekst"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Lagre endringer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Lagre endringer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Lagre innhold som kladd før publisering"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Lagre navn"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+msgid "Save SEO Settings"
+msgstr "Lagre SEO-innstillinger"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Save Settings"
+msgstr "Lagre innstillinger"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+msgid "Save Social Links"
+msgstr "Lagre sosiale lenker"
+
+#: packages/admin/src/components/ContentEditor.tsx:656
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr "Lagret"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "Lagret \"{0}\"."
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+#: packages/admin/src/components/ContentEditor.tsx:2279
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/FieldEditor.tsx:659
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:180
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Saving..."
+msgstr "Lagrer …"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "Lagrer …"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:467
+msgid "SBOM"
+msgstr "SBOM"
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:465
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:901
+msgid "Schedule"
+msgstr "Planlegg"
+
+#: packages/admin/src/components/ContentEditor.tsx:887
+msgid "Schedule for"
+msgstr "Planlegg til"
+
+#: packages/admin/src/components/ContentEditor.tsx:924
+msgid "Schedule for later"
+msgstr "Planlegg for senere"
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "scheduled"
+msgstr "planlagt"
+
+#: packages/admin/src/components/ContentEditor.tsx:864
+#: packages/admin/src/router.tsx:836
+msgid "Scheduled"
+msgstr "Planlagt"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:874
+msgid "Scheduled for: {0}"
+msgstr "Planlagt til: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Schema Changes"
+msgstr "Skjemaendringer"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Schema preparation failed"
+msgstr "Klargjøring av skjema mislyktes"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "Lese skjema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "Skrive skjema"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
+msgid "Scopes"
+msgstr "Omfang"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
+msgid "Scopes: {0}"
+msgstr "Omfang: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:243
+#: packages/admin/src/components/RegistryPluginDetail.tsx:640
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Skjermbilde {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:453
+msgid "Screenshot {0} of {1}"
+msgstr "Skjermbilde {0} av {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:246
+msgid "Screenshot blurred due to image audit"
+msgstr "Skjermbildet er gjort uskarpt på grunn av bildevurdering"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:431
+msgid "Screenshot viewer"
+msgstr "Skjermbildevisning"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:233
+#: packages/admin/src/components/RegistryPluginDetail.tsx:634
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Skjermbilder"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+msgid "Search"
+msgstr "Søk"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:225
+msgid "Search {0}"
+msgstr "Søk i {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:224
+msgid "Search {0}..."
+msgstr "Søk i {0} …"
+
+#: packages/admin/src/components/MediaLibrary.tsx:376
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "Search by filename..."
+msgstr "Søk etter filnavn …"
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Søk etter navn eller e-post …"
+
+#: packages/admin/src/components/ContentEditor.tsx:2074
+#: packages/admin/src/routes/bylines.tsx:388
+msgid "Search bylines"
+msgstr "Søk i bylines"
+
+#: packages/admin/src/components/ContentEditor.tsx:2073
+msgid "Search bylines to add..."
+msgstr "Søk i bylines for å legge til …"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "Søk i kommentarer"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "Søk i kommentarer …"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Søk i innhold …"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:155
+msgid "Search Engine Optimization"
+msgstr "Søkemotoroptimalisering"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "Søkemotoroptimalisering og verifisering"
+
+#: packages/admin/src/components/MediaLibrary.tsx:377
+#: packages/admin/src/components/MediaPickerModal.tsx:574
+msgid "Search media"
+msgstr "Søk i medier"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Søk i sider og innhold …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "Søk i utvidelser"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "Søk i utvidelser …"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Søk i seksjoner …"
+
+#: packages/admin/src/components/Redirects.tsx:383
+msgid "Search source or destination..."
+msgstr "Søk i kilde eller destinasjon …"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Søk i temaer"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Søk i temaer …"
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Søk i brukere"
+
+#: packages/admin/src/components/MediaLibrary.tsx:376
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "Search..."
+msgstr "Søk …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:723
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Søkbar"
+
+#: packages/admin/src/components/ContentEditor.tsx:2077
+msgid "Searching..."
+msgstr "Søker …"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2043
+msgid "Section"
+msgstr "Seksjon"
+
+#: packages/admin/src/components/SectionEditor.tsx:82
+msgid "Section \"{slug}\" could not be found."
+msgstr "Seksjonen \"{slug}\" ble ikke funnet."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "Seksjon opprettet"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "Seksjon slettet"
+
+#: packages/admin/src/components/SectionEditor.tsx:233
+msgid "Section Details"
+msgstr "Seksjonsdetaljer"
+
+#: packages/admin/src/components/SectionEditor.tsx:78
+msgid "Section Not Found"
+msgstr "Seksjon ikke funnet"
+
+#: packages/admin/src/components/SectionEditor.tsx:44
+msgid "Section saved"
+msgstr "Seksjon lagret"
+
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "Section title"
+msgstr "Seksjonstittel"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:355
+msgid "Sections"
+msgstr "Seksjoner"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "sikker kontekst"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Sikre kontoen din"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:792
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "Sikkerhet"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:307
+msgid "Security Audit"
+msgstr "Sikkerhetsvurdering"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Sikkerhetsvurdering mislyktes"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "Sikkerhetsvurderingen flagget bekymringer"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "Sikkerhetsvurderingen flagget mulige bekymringer ved denne utvidelsen."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "Sikkerhetsvurderingen flagget denne utvidelsen som potensielt utrygg."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "Sikkerhetsvurderingen ble bestått"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:703
+msgid "Security contacts"
+msgstr "Sikkerhetskontakter"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Sikkerhetsfeil. Sørg for at du er på en sikker tilkobling."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+msgid "Security Settings"
+msgstr "Sikkerhetsinnstillinger"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Velg"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1737
+#: packages/admin/src/components/ContentEditor.tsx:1895
+#: packages/admin/src/components/ContentEditor.tsx:1911
+msgid "Select {label}"
+msgstr "Velg {label}"
+
+#: packages/admin/src/components/Widgets.tsx:871
+msgid "Select a component..."
+msgstr "Velg en komponent …"
+
+#: packages/admin/src/components/Widgets.tsx:839
+msgid "Select a menu..."
+msgstr "Velg en meny …"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "Velg alle"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "Velg kommentar fra {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Velg innhold"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:268
+msgid "Select Default Social Image"
+msgstr "Velg standard sosialt bilde"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:283
+#: packages/admin/src/components/settings/GeneralSettings.tsx:344
+msgid "Select Favicon"
+msgstr "Velg favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1899
+msgid "Select file"
+msgstr "Velg fil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:140
+msgid "Select File"
+msgstr "Velg fil"
+
+#: packages/admin/src/components/ContentEditor.tsx:1725
+msgid "Select image"
+msgstr "Velg bilde"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:140
+#: packages/admin/src/components/PortableTextEditor.tsx:2417
+#: packages/admin/src/components/PortableTextEditor.tsx:3090
+#: packages/admin/src/components/settings/SeoSettings.tsx:221
+msgid "Select Image"
+msgstr "Velg bilde"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:229
+#: packages/admin/src/components/settings/GeneralSettings.tsx:336
+msgid "Select Logo"
+msgstr "Velg logo"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Velg medier"
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr "Velg OG-bilde"
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr "Velg OG-bilde"
+
+#: packages/admin/src/components/WordPressImport.tsx:1571
+msgid "Select which content types to import."
+msgstr "Velg hvilke innholdstyper som skal importeres."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:1826
+#: packages/admin/src/components/RepeaterField.tsx:361
+msgid "Select..."
+msgstr "Velg …"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:729
+msgid "Selected:"
+msgstr "Valgt:"
+
+#: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
+msgid "Self-Signup Domains"
+msgstr "Domener for selvregistrering"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:139
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Send en test-e-post gjennom hele kjeden for å verifisere e-postoppsettet ditt."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Send en invitasjonsepost til et nytt teammedlem."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr "Send invitasjon"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "Send magisk lenke"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Send gjenopprettingslenke"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Send Test"
+msgstr "Send test"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:136
+msgid "Send Test Email"
+msgstr "Send test-e-post"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "Sender …"
+
+#: packages/admin/src/components/ContentEditor.tsx:1050
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "SEO Settings"
+msgstr "SEO-innstillinger"
+
+#: packages/admin/src/components/WordPressImport.tsx:1679
+msgid "SEO settings (Yoast)"
+msgstr "SEO-innstillinger (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:57
+msgid "SEO settings saved"
+msgstr "SEO-innstillinger lagret"
+
+#: packages/admin/src/components/SeoPanel.tsx:154
+msgid "SEO Title"
+msgstr "SEO-tittel"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr "Angi en egendefinert visningsstørrelse for denne bildeinstansen."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:170
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:174
+msgid "Set language"
+msgstr "Angi språk"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "Set language (current: {label})"
+msgstr "Angi språk (nåværende: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:531
+msgid "Set to 0 to never close comments automatically."
+msgstr "Sett til 0 for å aldri lukke kommentarer automatisk."
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Sett opp nettstedet ditt"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "Setter opp …"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentTypeEditor.tsx:383
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:437
+#: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:399
+#: packages/admin/src/components/WordPressImport.tsx:1647
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "Administrer innstillinger"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "Les innstillinger"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:53
+msgid "Settings saved successfully"
+msgstr "Innstillingene ble lagret"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Oppsettet mislyktes"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Del denne lenken med den inviterte brukeren"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Deles på tvers av alle oversettelser av samme byline."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Kort tekst"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Kort tekst"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "Vis token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr "Vises når du holder musepekeren over bildet."
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "Logg inn"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Logg inn"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Logg inn i stedet"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "Logg inn på nettstedet ditt"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Logg inn med {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "Logg inn med e-post"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "Logg inn med e-postlenke"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "Logg inn med passnøkkel"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Logget inn som {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Enkeltvalg fra alternativer"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Enlinjes tekstfelt"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Nettsted"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr "Nettstedsidentitet"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Nettstedsidentitet, logo, favicon og lesepreferanser"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+msgid "Site Settings"
+msgstr "Nettstedsinnstillinger"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Nettstedstittel"
+
+#: packages/admin/src/components/WordPressImport.tsx:1659
+msgid "Site title & tagline"
+msgstr "Nettstedstittel og slagord"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "Nettstedstittel er påkrevd"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr "Nettsteds-URL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:485
+msgid "Size"
+msgstr "Størrelse"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:170
+msgid "Size:"
+msgstr "Størrelse:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1940
+msgid "Skip Media Import"
+msgstr "Hopp over medieimport"
+
+#: packages/admin/src/components/WordPressImport.tsx:1965
+msgid "Skipped"
+msgstr "Hoppet over"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentEditor.tsx:845
+#: packages/admin/src/components/ContentEditor.tsx:2188
+#: packages/admin/src/components/ContentEditor.tsx:2250
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:404
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:244
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:398
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:473
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "Slug kopiert til utklippstavlen"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Sluger kan ikke endres etter at feltet er opprettet."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:904
+msgid "Small section heading"
+msgstr "Liten seksjonsoverskrift"
+
+#: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:78
+#: packages/admin/src/components/settings/SocialSettings.tsx:103
+msgid "Social Links"
+msgstr "Sosiale lenker"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:48
+msgid "Social links saved"
+msgstr "Sosiale lenker lagret"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "Lenker til profiler på sosiale medier"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:126
+msgid "Social Profiles"
+msgstr "Sosiale profiler"
+
+#: packages/admin/src/components/WordPressImport.tsx:1696
+msgid "Some content types cannot be imported"
+msgstr "Enkelte innholdstyper kan ikke importeres"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:122
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "Noe gikk galt"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Sorter utvidelser"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Sorter temaer"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:214
+#: packages/admin/src/components/PluginManager.tsx:497
+#: packages/admin/src/components/Redirects.tsx:440
+#: packages/admin/src/components/SectionEditor.tsx:279
+msgid "Source"
+msgstr "Kilde"
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr "Kildesti"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "søppelpost"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "Søppelpost"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3078
+msgid "Spotlight Mode"
+msgstr "Rampelysmodus"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Regneark"
+
+#: packages/admin/src/components/WordPressImport.tsx:1758
+msgid "Start Import"
+msgstr "Start import"
+
+#: packages/admin/src/components/ContentEditor.tsx:851
+#: packages/admin/src/components/ContentList.tsx:273
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:445
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Status"
+
+#: packages/admin/src/components/Redirects.tsx:146
+msgid "Status code"
+msgstr "Statuskode"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "Lagres per språk – hver oversettelse av en byline får sin egen verdi."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2562
+#: packages/admin/src/components/PortableTextEditor.tsx:2868
+msgid "Strikethrough"
+msgstr "Gjennomstreking"
+
+#: packages/admin/src/components/WordPressImport.tsx:1591
+msgid "Structure"
+msgstr "Struktur"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Underfelt"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Abonnent"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Synkronisert"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Synkronisert passnøkkel"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:768
+msgid "System"
+msgstr "System"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "System ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:590
+msgid "System Fields"
+msgstr "Systemfelt"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:978
+msgid "Table"
+msgstr "Tabell"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Slagord"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "Stikkord"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1633
+msgid "Tags ({0})"
+msgstr "Stikkord ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:348
+#: packages/admin/src/components/MenuEditor.tsx:519
+msgid "Target"
+msgstr "Mål"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "Målspråk"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:537
+msgid "Taxonomies"
+msgstr "Taksonomier"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "Administrer taksonomier"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:898
+msgid "Taxonomy created"
+msgstr "Taksonomi opprettet"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:785
+msgid "Taxonomy not found:"
+msgstr "Taksonomi ikke funnet:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Taksonomi: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Mal:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Term"
+msgstr "Term"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:759
+msgid "Term \"{0}\" created in {1}."
+msgstr "Termen \"{0}\" ble opprettet i {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:741
+msgid "Term deleted"
+msgstr "Term slettet"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2838
+msgid "Text formatting"
+msgstr "Tekstformatering"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "Enheten vil ikke få tilgang."
+
+#: packages/admin/src/components/WordPressImport.tsx:1698
+msgid "The existing collection has fields with incompatible types."
+msgstr "Den eksisterende samlingen har felter med inkompatible typer."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "Følgende tabeller inneholder innhold, men er ikke registrert som samlinger. Registrer dem for å administrere dette innholdet i admin."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr "Den inviterte brukeren vil ha denne rollen når registreringen er fullført."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "Lenken utløper om 15 minutter."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "Markedsplassen er tom. Kom tilbake senere for nye utvidelser."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "Menyen er slettet."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr "Navnet på nettstedet ditt, brukt i toppteksten og metadataene"
+
+#: packages/admin/src/router.tsx:1869
+msgid "The page you're looking for doesn't exist."
+msgstr "Siden du leter etter, finnes ikke."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "Den offentlige URL-en til nettstedet ditt (brukes for kanoniske lenker og nettstedskart)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:189
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "Det refererte bildet er ikke lenger tilgjengelig. Velg et nytt, eller fjern referansen."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:197
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "Den refererte logoen er ikke lenger tilgjengelig. Velg en ny eller fjern referansen."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "Temamarkedet er tomt. Kom tilbake senere."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Tema"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:292
+msgid "Theme ID: {0}"
+msgstr "Tema-ID: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "Fant ikke temaet"
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Theme Section"
+msgstr "Temaseksjon"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Seksjoner fra temaet kan ikke slettes. Rediger seksjonen for å lage en egendefinert kopi, og slett deretter den."
+
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr "Tema: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:391
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Temaer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:372
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "Denne samlingen er definert i kode. Enkelte innstillinger kan ikke endres her. Rediger live.config.ts-filen for å endre skjemaet."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:413
+msgid "This field does not accept {sniffedMime} files."
+msgstr "Dette feltet godtar ikke {sniffedMime}-filer."
+
+#: packages/admin/src/components/ContentEditor.tsx:1741
+#: packages/admin/src/components/ContentEditor.tsx:1914
+msgid "This field is required"
+msgstr "Dette feltet er påkrevd"
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "This is a custom section."
+msgstr "Dette er en egendefinert seksjon."
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "This is a WordPress site."
+msgstr "Dette er et WordPress-nettsted."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "Denne lenken utløper om 7 dager og kan bare brukes én gang."
+
+#: packages/admin/src/components/WordPressImport.tsx:821
+msgid "This may take a while for large exports."
+msgstr "Dette kan ta en stund for store eksporter."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "Denne tilgangsnøkkelen er allerede registrert på denne enheten."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:276
+msgid "This plugin requires no special permissions."
+msgstr "Denne utvidelsen krever ingen spesielle tillatelser."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:564
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "Denne utgiveren hevder å ha et navn de ikke kunne bevise at de eier — muligens et forsøk på å utgi seg for å være noen andre. Installasjon er deaktivert. Hvis du kjenner utgiveren og stoler på dem, be dem rette opp identitetsoppsettet før du prøver på nytt."
+
+#: packages/admin/src/components/Redirects.tsx:551
+msgid "This redirect rule will be permanently removed."
+msgstr "Denne omdirigeringsregelen vil bli fjernet permanent."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:616
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "Denne versjonen krever et nyere miljø enn nettstedet ditt kjører på nå. Oppgrader før du installerer."
+
+#: packages/admin/src/routes/bylines.tsx:606
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "Dette fjerner forfatterprofilen. Lenker til forfattersignaturer i innhold fjernes, og hovedpekere tømmes."
+
+#: packages/admin/src/components/SectionEditor.tsx:283
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "Denne seksjonen kommer fra temaet. Redigering oppretter en egendefinert kopi som overstyrer temaversjonen."
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This section was imported from another system."
+msgstr "Denne seksjonen ble importert fra et annet system."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:119
+msgid "This update exposes the following routes without authentication:"
+msgstr "Denne oppdateringen eksponerer følgende ruter uten autentisering:"
+
+#: packages/admin/src/components/Widgets.tsx:635
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "Dette sletter widgetområdet og alle widgetene i det. Denne handlingen kan ikke angres."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "Dette gir CLI-tilgang med dine tillatelser."
+
+#: packages/admin/src/components/ContentEditor.tsx:958
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "Dette flytter elementet til papirkurven. Du kan gjenopprette det senere fra papirkurven."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "Dette sletter \"{0}\" permanent og fjerner det fra alt innhold."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "Dette sletter \"{0}\" permanent. Denne handlingen kan ikke angres."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "Dette sletter denne kommentaren permanent. Denne handlingen kan ikke angres."
+
+#: packages/admin/src/components/PluginManager.tsx:629
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "Dette fjerner utvidelsen og pakken dens fra nettstedet ditt."
+
+#: packages/admin/src/components/ContentEditor.tsx:701
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "Dette tilbakestiller til den publiserte versjonen. Kladdeendringene dine går tapt."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Tanker, veiledninger og mer"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:310
+msgid "Timezone"
+msgstr "Tidssone"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Tidssone for visning av datoer (f.eks. America/New_York)"
+
+#: packages/admin/src/components/ContentList.tsx:267
+#: packages/admin/src/components/ContentList.tsx:402
+#: packages/admin/src/components/SectionEditor.tsx:236
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:811
+msgid "Title"
+msgstr "Tittel"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr "Tittel (verktøytips)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:159
+msgid "Title Separator"
+msgstr "Tittelskilletegn"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "for å lukke"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "for å installere utvidelser, eller legg dem til i astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "for å velge"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2654
+msgid "Toggle header row"
+msgstr "Slå overskriftsrad av/på"
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr "Bytt tema (gjeldende: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "Token opprettet: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
+msgid "Token Name"
+msgstr "Tokennavn"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "Tools → Export"
+msgstr "Verktøy → Eksport"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Spor innholdshistorikk"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Oversettbar"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translate"
+msgstr "Oversett"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "Oversett \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "Oversett {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translating..."
+msgstr "Oversetter …"
+
+#: packages/admin/src/components/MenuEditor.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:758
+#: packages/admin/src/router.tsx:884
+msgid "Translation created"
+msgstr "Oversettelse opprettet"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:56
+msgid "Translations"
+msgstr "Oversettelser"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "papirkurv"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:247
+msgid "Trash"
+msgstr "Papirkurv"
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Trash is empty"
+msgstr "Papirkurven er tom"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "Papirkurven er tom."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "Av/på-bryter (sann/usann)"
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/MediaPickerModal.tsx:638
+msgid "Try a different search term"
+msgstr "Prøv et annet søkeord"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Prøv å justere søket"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Prøv å justere søket eller filtrene."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Prøv igjen"
+
+#: packages/admin/src/components/WordPressImport.tsx:1421
+msgid "Try Again"
+msgstr "Prøv igjen"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Prøv en annen kode"
+
+#: packages/admin/src/components/WordPressImport.tsx:1125
+#: packages/admin/src/components/WordPressImport.tsx:1247
+msgid "Try Another URL"
+msgstr "Prøv en annen URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Prøv med mine data"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Gjør om til"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:132
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:484
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Type"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1854
+msgid "Type mismatch ({0})"
+msgstr "Typen stemmer ikke ({0})"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "Får ikke kontakt med markedet"
+
+#: packages/admin/src/components/ContentEditor.tsx:2293
+#: packages/admin/src/components/ContentEditor.tsx:2308
+msgid "Unassigned"
+msgstr "Ikke tildelt"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2555
+#: packages/admin/src/components/PortableTextEditor.tsx:2861
+msgid "Underline"
+msgstr "Understreking"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3058
+msgid "Undo"
+msgstr "Angre"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:180
+#: packages/admin/src/components/PluginManager.tsx:547
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstall"
+msgstr "Avinstaller"
+
+#: packages/admin/src/components/PluginManager.tsx:627
+msgid "Uninstall {pluginName}?"
+msgstr "Avinstallere {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:622
+msgid "Uninstall confirmation"
+msgstr "Bekreft avinstallering"
+
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstalling..."
+msgstr "Avinstallerer …"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:722
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Unik"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Unik identifikator (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Ukjent rolle"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr "Lås opp sideforhold"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Tilgangsnøkkel uten navn"
+
+#: packages/admin/src/components/ContentEditor.tsx:730
+msgid "Unpublish"
+msgstr "Avpubliser"
+
+#: packages/admin/src/router.tsx:801
+msgid "Unpublished"
+msgstr "Avpublisert"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "Fant uregistrerte innholdstabeller"
+
+#: packages/admin/src/components/ContentEditor.tsx:876
+msgid "Unschedule"
+msgstr "Fjern planlegging"
+
+#: packages/admin/src/router.tsx:854
+msgid "Unscheduled"
+msgstr "Ikke planlagt"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Widgetelementtype som ikke støttes: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr "Uten tittel"
+
+#: packages/admin/src/components/ContentEditor.tsx:1817
+msgid "Untitled file"
+msgstr "Fil uten navn"
+
+#: packages/admin/src/components/Widgets.tsx:466
+#: packages/admin/src/components/Widgets.tsx:729
+msgid "Untitled Widget"
+msgstr "Widget uten navn"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Ikke-verifisert utgiver"
+
+#: packages/admin/src/components/ContentEditor.tsx:2120
+msgid "Up"
+msgstr "Opp"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:478
+msgid "Update"
+msgstr "Oppdater"
+
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Update Field"
+msgstr "Oppdater felt"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
+msgid "Update settings for {0}"
+msgstr "Oppdater innstillinger for {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "Oppdater nettstedinnstillinger"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:366
+msgid "Update the {0} details"
+msgstr "Oppdater detaljene for {0}"
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr "Oppdater denne omdirigeringsregelen."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Update to v{0}"
+msgstr "Oppdater til v{0}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:486
+msgid "Updated"
+msgstr "Oppdatert"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Oppdatert den"
+
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:933
+msgid "Updated: {0}"
+msgstr "Oppdatert: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:844
+msgid "Updating content URLs..."
+msgstr "Oppdaterer innholds-URL-er …"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:166
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Updating..."
+msgstr "Oppdaterer …"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:596
+msgid "Upload"
+msgstr "Last opp"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:142
+msgid "Upload a file to get started"
+msgstr "Last opp en fil for å komme i gang"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Upload an export file"
+msgstr "Last opp en eksportfil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:143
+msgid "Upload an image to get started"
+msgstr "Last opp et bilde for å komme i gang"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "Last opp og slett medier"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Upload and manage media"
+msgstr "Last opp og administrer medier"
+
+#: packages/admin/src/components/WordPressImport.tsx:1123
+#: packages/admin/src/components/WordPressImport.tsx:1244
+msgid "Upload Export File"
+msgstr "Last opp eksportfil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:616
+msgid "Upload failed: {uploadError}"
+msgstr "Opplasting mislyktes: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:608
+msgid "Upload file"
+msgstr "Last opp fil"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Upload File"
+msgstr "Last opp fil"
+
+#: packages/admin/src/components/MediaLibrary.tsx:361
+msgid "Upload files"
+msgstr "Last opp filer"
+
+#: packages/admin/src/components/MediaLibrary.tsx:424
+msgid "Upload Files"
+msgstr "Last opp filer"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Upload Image"
+msgstr "Last opp bilde"
+
+#: packages/admin/src/components/MediaLibrary.tsx:421
+msgid "Upload images, videos, and documents to get started."
+msgstr "Last opp bilder, videoer og dokumenter for å komme i gang."
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr "Last opp medier"
+
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Upload media to get started"
+msgstr "Last opp medier for å komme i gang"
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "Upload to {0}"
+msgstr "Last opp til {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:960
+msgid "Upload WordPress export file"
+msgstr "Last opp WordPress-eksportfil"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:184
+msgid "Uploaded:"
+msgstr "Lastet opp:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1963
+msgid "Uploading"
+msgstr "Laster opp"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:327
+msgid "Uploading {0}/{1}..."
+msgstr "Laster opp {0}/{1} …"
+
+#: packages/admin/src/components/MediaLibrary.tsx:328
+#: packages/admin/src/components/MediaPickerModal.tsx:596
+msgid "Uploading..."
+msgstr "Laster opp …"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:339
+#: packages/admin/src/components/MenuEditor.tsx:509
+#: packages/admin/src/components/PortableTextEditor.tsx:2994
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:425
+msgid "URL Pattern"
+msgstr "URL-mønster"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "URL-vennlig identifikator"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "URL-vennlig identifikator (f.eks. \"primary\", \"footer\")"
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Bruk [param] eller [...rest] i stier for mønstertilpasning."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Bruk enhetens biometriske autentisering, sikkerhetsnøkkel eller PIN-kode for å logge inn."
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "Bruk den registrerte passnøkkelen din for å logge inn sikkert."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:173
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "Brukes som reserve-Open Graph-bilde når en side mangler bilde. Anbefalt størrelse: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:644
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Brukes som identifikator. Kun små bokstaver, tall og understreker."
+
+#: packages/admin/src/components/ContentEditor.tsx:1332
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "Brukes som hovedbildet for dette innlegget på listesider og øverst i innlegget"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Used by screen readers and when image fails to load"
+msgstr "Brukes av skjermlesere og når bildet ikke kan lastes inn"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:410
+msgid "Used in URLs and API endpoints"
+msgstr "Brukes i URL-er og API-endepunkter"
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Brukes til å identifisere denne seksjonen. Kun små bokstaver, tall og bindestreker."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "Bruker"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "Brukertilgang administreres av en ekstern leverandør ({0}). Innstillinger for selvregistreringsdomene er ikke tilgjengelige ved bruk av ekstern autentisering."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "Brukerdetaljer"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "Fant ikke brukeren"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:368
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Brukere"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
+msgid "Users from"
+msgstr "Brukere fra"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Brukere med e-postadresser fra disse domenene kan registrere seg uten en invitasjon. De tildeles automatisk den angitte rollen."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:358
+msgid "v{0} available"
+msgstr "v{0} tilgjengelig"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Validering"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:447
+msgid "Verified publisher"
+msgstr "Verifisert utgiver"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:446
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Verifisert utgiver, bekreftet av merkeren {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:437
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Verifisert utgiver. En merker ({verifiedLabeller}) har bekreftet identiteten til denne utgiveren."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:438
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Verifisert utgiver. En merker har bekreftet identiteten til denne utgiveren."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:194
+msgid "Verifying your invite..."
+msgstr "Verifiserer invitasjonen din …"
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "Verifiserer lenken din …"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Verifiserer …"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:320
+#: packages/admin/src/components/RegistryPluginDetail.tsx:500
+msgid "Version"
+msgstr "Versjon"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:462
+msgid "Version {0}"
+msgstr "Versjon {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:395
+msgid "Video"
+msgstr "Video"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "Se status for e-postleverandør og send test-e-poster"
+
+#: packages/admin/src/components/PluginManager.tsx:429
+msgid "View in Marketplace"
+msgstr "Vis i Marketplace"
+
+#: packages/admin/src/components/MediaLibrary.tsx:265
+msgid "View mode"
+msgstr "Visningsmodus"
+
+#: packages/admin/src/components/ContentList.tsx:617
+msgid "View published {title}"
+msgstr "Vis publisert {title}"
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr "Vis nettsted"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:661
+msgid "View source"
+msgstr "Vis kilde"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:936
+msgid "View the {license} license on spdx.org"
+msgstr "Vis {license}-lisensen på spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:422
+msgid "Visitors hitting these paths will see an error."
+msgstr "Besøkende som åpner disse stiene, vil se en feil."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "Venter på passnøkkel …"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Advarsel"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "Vi kunne ikke koble til et WordPress-nettsted på {0}. Det kan bety at nettstedet ikke er WordPress, at REST-API-et er deaktivert, eller at nettstedet ikke er tilgjengelig."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:562
+msgid "We couldn't verify this publisher's identity"
+msgstr "Vi kunne ikke verifisere identiteten til denne utgiveren"
+
+#: packages/admin/src/components/WordPressImport.tsx:926
+msgid "We'll check what import options are available for your site."
+msgstr "Vi sjekker hvilke importalternativer som er tilgjengelige for nettstedet ditt."
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "Vi sender deg en lenke for å logge inn uten passord."
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "Vi har sendt en verifiseringslenke til"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Nettadresse"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn støttes ikke i denne nettleseren"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/RegistryPluginDetail.tsx:686
+msgid "Website"
+msgstr "Nettsted"
+
+#: packages/admin/src/routes/bylines.tsx:478
+msgid "Website URL"
+msgstr "Nettsted-URL"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Velkommen til EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Velkommen til EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1927
+msgid "What happens when you import:"
+msgstr "Hva skjer når du importerer:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1710
+msgid "What will happen when you import"
+msgstr "Hva som skjer når du importerer"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "Da oppføringen ble opprettet"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "Da oppføringen sist ble endret"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "Da oppføringen ble publisert"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:658
+msgid "Which content types can use this taxonomy"
+msgstr "Hvilke innholdstyper som kan bruke denne taksonomien"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Heltall"
+
+#: packages/admin/src/components/Widgets.tsx:722
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "widget"
+msgstr "widget"
+
+#: packages/admin/src/components/Widgets.tsx:170
+msgid "Widget added"
+msgstr "Widget lagt til"
+
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Widget area created"
+msgstr "Widgetområde opprettet"
+
+#: packages/admin/src/components/Widgets.tsx:565
+msgid "Widget area deleted"
+msgstr "Widgetområde slettet"
+
+#: packages/admin/src/components/Widgets.tsx:685
+msgid "Widget deleted"
+msgstr "Widget slettet"
+
+#: packages/admin/src/components/Widgets.tsx:814
+msgid "Widget title"
+msgstr "Widgettittel"
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Widget updated"
+msgstr "Widget oppdatert"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:379
+#: packages/admin/src/components/Sidebar.tsx:354
+#: packages/admin/src/components/Widgets.tsx:325
+msgid "Widgets"
+msgstr "Widgeter"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr "Bredde"
+
+#: packages/admin/src/components/WordPressImport.tsx:1850
+msgid "Will create"
+msgstr "Vil opprette"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "vil ikke lenger kunne registrere seg uten en invitasjon. Eksisterende brukere påvirkes ikke."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:184
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Uten en e-postleverandør må invitasjonslenker deles manuelt."
+
+#: packages/admin/src/components/WordPressImport.tsx:1315
+msgid "WordPress Username"
+msgstr "WordPress-brukernavn"
+
+#: packages/admin/src/components/Widgets.tsx:824
+msgid "Write widget content..."
+msgstr "Skriv widgetinnhold …"
+
+#: packages/admin/src/components/WordPressImport.tsx:1023
+msgid "WXR File"
+msgstr "WXR-fil"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Ja"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "Du kan lukke denne siden og gå tilbake til terminalen din."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "Du kan opprette og redigere ditt eget innhold."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "Du kan administrere innhold, medier, menyer og taksonomier."
+
+#: packages/admin/src/routes/bylines.tsx:532
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "Du kan fortsatt redigere de faste feltene over. Lagring berører ikke lagrede verdier for tilpassede felt."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "Du kan se og bidra til nettstedet."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "Du kan ikke endre din egen rolle"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "Du har full tilgang til å administrere dette nettstedet, inkludert brukere, innstillinger og alt innhold."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "Du trenger administratortillatelser for å administrere byline-skjema."
+
+#: packages/admin/src/router.tsx:1203
+msgid "You need Editor permissions to moderate comments."
+msgstr "Du trenger redaktørtillatelser for å moderere kommentarer."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "Du vil ikke lenger kunne bruke \"{0}\" til å logge inn. Denne handlingen kan ikke angres."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "Du vil ikke lenger kunne bruke denne passnøkkelen til å logge inn. Denne handlingen kan ikke angres."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "Du blir med som <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "Du blir bedt om å bruke enhetens biometriske autentisering, sikkerhetsnøkkel eller PIN-kode."
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "Du blir videresendt til WordPress for å godkjenne tilkoblingen."
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "Du registrerer deg som"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "Du er logget inn via Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:50
+msgid "You've been invited!"
+msgstr "Du er invitert!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr "du@firma.no"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "du@eksempel.no"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Kontoen din er opprettet."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Nettleseren din støtter ikke passnøkler. Bruk en moderne nettleser som Chrome, Safari, Firefox eller Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Enheten din støtter ikke de påkrevde sikkerhetsfunksjonene."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "E-posten din"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Your Facebook page or profile username"
+msgstr "Brukernavnet til Facebook-siden eller -profilen din"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:141
+msgid "Your GitHub username"
+msgstr "GitHub-brukernavnet ditt"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:153
+msgid "Your Instagram username"
+msgstr "Instagram-brukernavnet ditt"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:159
+msgid "Your LinkedIn profile username"
+msgstr "Brukernavnet til LinkedIn-profilen din"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "Navnet ditt"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "Navnet ditt (valgfritt)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Rollen din"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:597
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "Nettstedet ditt krever at utgivelser er minst {0} gamle før de kan installeres. Denne utgivelsen blir installerbar senere."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:135
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Twitter/X-brukernavnet ditt (f.eks. @username)"
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1898
+msgid "Your WordPress export contains {0} media files."
+msgstr "WordPress-eksporten din inneholder {0} mediefiler."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:165
+msgid "Your YouTube channel ID or handle"
+msgstr "Din YouTube-kanal-ID eller -alias"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:162
+msgid "YouTube"
+msgstr "YouTube"


### PR DESCRIPTION
## What does this PR do?

Adds **Norwegian Bokmål (nb)** as a selectable locale for the admin UI, with a complete translation of all **1,682** catalog strings. Mirrors the structure of #1245 (Thai) and #754 (Polish).

- Registers `nb` (label `Norsk bokmål`, LTR) in `packages/admin/src/locales/locales.ts` and enables it.
- Adds `packages/admin/src/locales/nb/messages.po` — a full translation with a consistent CMS glossary (post→innlegg, collection→samling, plugin→utvidelse, settings→innstillinger, draft→kladd; imperative for action buttons: Lagre, Slett, Publiser, Avbryt). Brand/technical tokens (EmDash, API, OAuth, Webhook, Slug, MIME, WordPress UI labels, route paths) left as-is. Bokmål shares English's `one`/`other` plural categories, so ICU plural/select structures map 1:1; all placeholders and escapes are preserved.
- `.changeset/norwegian-bokmal-admin-locale.md` — `patch` bump for `@emdash-cms/admin`.

No component changes were needed — the language switcher and direction handling are data-driven from `SUPPORTED_LOCALES` / `getLocaleLabel` / `getLocaleDir`.

## Type of change

- [x] Translation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- not run locally; data-only locale catalog (one line in locales.ts + the .po) -->
- [ ] `pnpm lint` passes <!-- not run locally; data-only locale catalog -->
- [ ] `pnpm test` passes <!-- locales.test.ts asserts the enabled nb catalog loads — relying on CI -->
- [ ] `pnpm format` has been run <!-- not run locally, but the Format CI check passes on this branch -->
- [ ] I have added/updated tests for my changes (if applicable) — N/A; data-only locale addition; the existing `locales.test.ts` already asserts every enabled catalog loads
- [x] User-visible strings are wrapped for translation (if applicable) — N/A; this is a translation PR, so `messages.po` is expected here
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — N/A (translation)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8**. The translation was generated, then adversarially reviewed for placeholder/ICU integrity and terminology consistency, and validated with the FormatJS ICU parser (`@formatjs/icu-messageformat-parser`): **0 parse errors, 0 argument-set mismatches** across all 1,682 strings. A native-speaker phrasing pass is welcome.

## Screenshots / test output

FormatJS ICU validation: `checked: 1682 · ICU parse errors: 0 · argument-set mismatches: 0`.