### PR TITLE
docs: document the experimental plugin registry

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -89,76 +89,101 @@ export default defineConfig({
 					items: [
 						{ label: "Plugin Overview", slug: "plugins/overview" },
 						{ label: "Installing Plugins", slug: "plugins/installing" },
+						{ label: "Plugin Registry", slug: "plugins/registry" },
 						{ label: "Upgrading Plugins", slug: "plugins/upgrading-sites" },
-						{ label: "Field Kit", slug: "plugins/field-kit" },
 					],
 				},
 				{
-					label: "Creating Sandboxed Plugins",
+					label: "Migration",
+					items: [
+						{
+							label: "Migrate from WordPress",
+							slug: "migration/from-wordpress",
+						},
+						{ label: "Content Import", slug: "migration/content-import" },
+						{
+							label: "Porting WordPress Plugins",
+							slug: "migration/porting-plugins",
+						},
+					],
+				},
+				{
+					label: "Plugin Development",
 					items: [
 						{
 							label: "Choosing a Plugin Format",
 							slug: "plugins/creating-plugins/choosing-a-format",
 						},
 						{
-							label: "Your First Plugin",
-							slug: "plugins/creating-plugins/your-first-plugin",
+							label: "Sandboxed Plugins",
+							collapsed: true,
+							items: [
+								{
+									label: "Your First Plugin",
+									slug: "plugins/creating-plugins/your-first-plugin",
+								},
+								{
+									label: "The Manifest",
+									slug: "plugins/creating-plugins/manifest",
+								},
+								{
+									label: "The Plugin CLI",
+									slug: "plugins/creating-plugins/cli",
+								},
+								{ label: "Hooks", slug: "plugins/creating-plugins/hooks" },
+								{ label: "API Routes", slug: "plugins/creating-plugins/api-routes" },
+								{ label: "Storage", slug: "plugins/creating-plugins/storage" },
+								{ label: "Settings", slug: "plugins/creating-plugins/settings" },
+								{ label: "Block Kit", slug: "plugins/creating-plugins/block-kit" },
+								{
+									label: "Capabilities & Security",
+									slug: "plugins/creating-plugins/capabilities",
+								},
+								{
+									label: "Bundling & Publishing",
+									slug: "plugins/creating-plugins/publishing",
+								},
+								{
+									label: "Migrating to the CLI",
+									slug: "plugins/creating-plugins/migrating-to-the-cli",
+								},
+							],
 						},
 						{
-							label: "The Manifest",
-							slug: "plugins/creating-plugins/manifest",
+							label: "Native Plugins",
+							collapsed: true,
+							items: [
+								{
+									label: "Your First Native Plugin",
+									slug: "plugins/creating-native-plugins/your-first-native-plugin",
+								},
+								{
+									label: "React Admin Pages & Widgets",
+									slug: "plugins/creating-native-plugins/react-admin",
+								},
+								{
+									label: "Portable Text Components",
+									slug: "plugins/creating-native-plugins/portable-text-components",
+								},
+								{
+									label: "Page Fragments",
+									slug: "plugins/creating-native-plugins/page-fragments",
+								},
+								{
+									label: "Distributing Native Plugins",
+									slug: "plugins/creating-native-plugins/distributing",
+								},
+							],
 						},
 						{
-							label: "The Plugin CLI",
-							slug: "plugins/creating-plugins/cli",
+							label: "Querying the Registry",
+							slug: "plugins/registry-client",
 						},
-						{ label: "Hooks", slug: "plugins/creating-plugins/hooks" },
-						{ label: "API Routes", slug: "plugins/creating-plugins/api-routes" },
-						{ label: "Storage", slug: "plugins/creating-plugins/storage" },
-						{ label: "Settings", slug: "plugins/creating-plugins/settings" },
-						{ label: "Block Kit", slug: "plugins/creating-plugins/block-kit" },
-						{
-							label: "Capabilities & Security",
-							slug: "plugins/creating-plugins/capabilities",
-						},
-						{
-							label: "Bundling & Publishing",
-							slug: "plugins/creating-plugins/publishing",
-						},
-						{
-							label: "Migrating to the CLI",
-							slug: "plugins/creating-plugins/migrating-to-the-cli",
-						},
-					],
-				},
-				{
-					label: "Creating Native Plugins",
-					items: [
-						{
-							label: "Your First Native Plugin",
-							slug: "plugins/creating-native-plugins/your-first-native-plugin",
-						},
-						{
-							label: "React Admin Pages & Widgets",
-							slug: "plugins/creating-native-plugins/react-admin",
-						},
-						{
-							label: "Portable Text Components",
-							slug: "plugins/creating-native-plugins/portable-text-components",
-						},
-						{
-							label: "Page Fragments",
-							slug: "plugins/creating-native-plugins/page-fragments",
-						},
-						{
-							label: "Distributing Native Plugins",
-							slug: "plugins/creating-native-plugins/distributing",
-						},
+						{ label: "Field Kit", slug: "plugins/field-kit" },
 					],
 				},
 				{
 					label: "Contributing",
-					collapsed: true,
 					items: [
 						{ label: "Contributor Guide", slug: "contributing" },
 						{
@@ -189,20 +214,6 @@ export default defineConfig({
 					],
 				},
 				{
-					label: "Migration",
-					items: [
-						{
-							label: "Migrate from WordPress",
-							slug: "migration/from-wordpress",
-						},
-						{ label: "Content Import", slug: "migration/content-import" },
-						{
-							label: "Porting WordPress Plugins",
-							slug: "migration/porting-plugins",
-						},
-					],
-				},
-				{
 					label: "Deployment",
 					items: [
 						{ label: "Deploy to Cloudflare", slug: "deployment/cloudflare" },
@@ -213,7 +224,6 @@ export default defineConfig({
 				},
 				{
 					label: "Concepts",
-					collapsed: true,
 					items: [
 						{ label: "Architecture", slug: "concepts/architecture" },
 						{ label: "Collections", slug: "concepts/collections" },

--- a/docs/src/content/docs/plugins/installing.mdx
+++ b/docs/src/content/docs/plugins/installing.mdx
@@ -11,6 +11,10 @@ EmDash plugins can be installed in two ways: from the marketplace via the admin 
 
 The admin dashboard includes a marketplace browser where you can search, install, and manage plugins.
 
+<Aside type="tip">
+  EmDash also has an experimental, federated alternative to the central marketplace. See [The plugin registry](/plugins/registry/).
+</Aside>
+
 ### Prerequisites
 
 To install marketplace plugins, your site needs:

--- a/docs/src/content/docs/plugins/registry-client.mdx
+++ b/docs/src/content/docs/plugins/registry-client.mdx
@@ -1,0 +1,108 @@
+---
+title: Querying the registry
+description: Build a plugin directory, search page, or release feed against the registry's public discovery API with @emdash-cms/registry-client.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+This is an advanced topic for building your own software against the [plugin registry](/plugins/registry/). If you only want to install plugins on an EmDash site, you do not need any of this — enable the registry in your config and use the admin dashboard.
+
+The registry's discovery side is a public, read-only API. The `@emdash-cms/registry-client` package wraps it, so you can build a plugin directory, a search page, or a release feed outside of EmDash. The client runs anywhere `fetch` is available — Node, Workers, the browser, or an Astro site.
+
+<Aside type="caution" title="Experimental">
+	The client targets an experimental API whose shapes may change without notice.
+	Pin `@emdash-cms/registry-client` to an exact version.
+</Aside>
+
+## Install
+
+The `discovery` subpath carries no authentication or OAuth dependencies. Install the client and pin it to an exact version:
+
+```sh
+npm install @emdash-cms/registry-client@0.3.1
+```
+
+## List and resolve packages
+
+The following Astro page lists every plugin in a registry:
+
+```astro title="src/pages/plugins/index.astro"
+---
+import { DiscoveryClient } from "@emdash-cms/registry-client/discovery";
+
+const discovery = new DiscoveryClient({
+  aggregatorUrl: "https://registry.emdashcms.com",
+});
+
+const { packages } = await discovery.searchPackages({ q: "", limit: 50 });
+---
+
+<ul>
+  {
+    packages.map((pkg) => (
+      <li>
+        <a href={`/plugins/${pkg.handle}/${pkg.slug}`}>
+          {pkg.profile?.name ?? pkg.slug}
+        </a>
+        <span>v{pkg.latestVersion}</span>
+        <p>{pkg.profile?.description}</p>
+      </li>
+    ))
+  }
+</ul>
+```
+
+A package detail page resolves a plugin by its handle and slug, then fetches the latest release:
+
+```typescript title="src/lib/plugin.ts"
+import { DiscoveryClient } from "@emdash-cms/registry-client/discovery";
+
+const discovery = new DiscoveryClient({
+  aggregatorUrl: "https://registry.emdashcms.com",
+});
+
+export async function getPlugin(handle: string, slug: string) {
+  const pkg = await discovery.resolvePackage({ handle, slug });
+  const latest = await discovery.getLatestRelease({
+    did: pkg.did,
+    package: pkg.slug,
+  });
+  return { pkg, latest };
+}
+```
+
+## Discovery methods
+
+The client exposes one method per aggregator query:
+
+- **`searchPackages({ q, capability?, limit?, cursor? })`** — free-text search, optionally filtered to packages declaring a given access category. Returns `{ packages, cursor? }`.
+- **`resolvePackage({ handle, slug })`** — resolve a package from a handle and slug.
+- **`getPackage({ did, slug })`** — fetch a package by its DID and slug.
+- **`listReleases({ did, package, limit?, cursor? })`** — every release for a package, newest version first.
+- **`getLatestRelease({ did, package })`** — the highest non-yanked release version.
+
+## Handling untrusted records
+
+The aggregator is an untrusted index that relays records it did not author, so the client validates each one at the boundary. Two rules follow from that:
+
+- **The `profile` and `release` fields can be `null`.** When a relayed record fails validation, the client surfaces it as `null` rather than failing the whole call, so one malformed record does not blank a search page. Always null-check before reading `pkg.profile?.name` or `release.release?.artifact`.
+- **Validate URL schemes yourself before rendering.** Validation checks structure, not URL safety — a `uri` field can carry a `javascript:` scheme. Apply your own `http`/`https` allow-list before putting any registry-supplied URL into an `href` or `src`.
+
+A non-2xx response throws `ClientResponseError` (re-exported from the package), carrying `.error`, `.description`, `.status`, and `.headers`.
+
+## Filtering by host compatibility
+
+A release can declare environment requirements (an EmDash or Astro version range) in its `requires` block. The `@emdash-cms/registry-client/env` subpath evaluates them, so a directory can flag releases that will not run on a given host:
+
+```typescript title="src/lib/compat.ts"
+import { checkEnvCompatibility, hostEnvFromVersions } from "@emdash-cms/registry-client/env";
+
+const host = hostEnvFromVersions("0.17.0", "5.6.0");
+const mismatches = checkEnvCompatibility(release.requires, host);
+// mismatches is [] when the release runs on this host.
+```
+
+## What to read next
+
+- [The plugin registry](/plugins/registry/) — enable and use the registry on an EmDash site
+- [Bundling and publishing](/plugins/creating-plugins/publishing/) — publish a plugin to the registry

--- a/docs/src/content/docs/plugins/registry-client.mdx
+++ b/docs/src/content/docs/plugins/registry-client.mdx
@@ -41,10 +41,10 @@ const { packages } = await discovery.searchPackages({ q: "", limit: 50 });
   {
     packages.map((pkg) => (
       <li>
-        <a href={`/plugins/${pkg.handle}/${pkg.slug}`}>
+        <a href={`/plugins/${pkg.did}/${pkg.slug}`}>
           {pkg.profile?.name ?? pkg.slug}
         </a>
-        <span>v{pkg.latestVersion}</span>
+        {pkg.latestVersion && <span>v{pkg.latestVersion}</span>}
         <p>{pkg.profile?.description}</p>
       </li>
     ))
@@ -52,7 +52,9 @@ const { packages } = await discovery.searchPackages({ q: "", limit: 50 });
 </ul>
 ```
 
-A package detail page resolves a plugin by its handle and slug, then fetches the latest release:
+The link uses `pkg.did`, which is always present. The publisher `handle` is best-effort and can be absent, so don't build URLs from it.
+
+A package detail page fetches a plugin by its DID and slug, then fetches the latest release:
 
 ```typescript title="src/lib/plugin.ts"
 import { DiscoveryClient } from "@emdash-cms/registry-client/discovery";
@@ -61,8 +63,8 @@ const discovery = new DiscoveryClient({
   aggregatorUrl: "https://registry.emdashcms.com",
 });
 
-export async function getPlugin(handle: string, slug: string) {
-  const pkg = await discovery.resolvePackage({ handle, slug });
+export async function getPlugin(did: string, slug: string) {
+  const pkg = await discovery.getPackage({ did, slug });
   const latest = await discovery.getLatestRelease({
     did: pkg.did,
     package: pkg.slug,
@@ -85,7 +87,7 @@ The client exposes one method per aggregator query:
 
 The aggregator is an untrusted index that relays records it did not author, so the client validates each one at the boundary. Two rules follow from that:
 
-- **The `profile` and `release` fields can be `null`.** When a relayed record fails validation, the client surfaces it as `null` rather than failing the whole call, so one malformed record does not blank a search page. Always null-check before reading `pkg.profile?.name` or `release.release?.artifact`.
+- **The `profile` and `release` fields can be `null`.** When a relayed record fails validation, the client surfaces it as `null` rather than failing the whole call, so one malformed record does not blank a search page. Always null-check before reading `pkg.profile?.name` or `latest.release?.artifacts.package`.
 - **Validate URL schemes yourself before rendering.** Validation checks structure, not URL safety — a `uri` field can carry a `javascript:` scheme. Apply your own `http`/`https` allow-list before putting any registry-supplied URL into an `href` or `src`.
 
 A non-2xx response throws `ClientResponseError` (re-exported from the package), carrying `.error`, `.description`, `.status`, and `.headers`.
@@ -96,10 +98,15 @@ A release can declare environment requirements (an EmDash or Astro version range
 
 ```typescript title="src/lib/compat.ts"
 import { checkEnvCompatibility, hostEnvFromVersions } from "@emdash-cms/registry-client/env";
+import type { ValidatedReleaseView } from "@emdash-cms/registry-client/discovery";
 
 const host = hostEnvFromVersions("0.17.0", "5.6.0");
-const mismatches = checkEnvCompatibility(release.requires, host);
-// mismatches is [] when the release runs on this host.
+
+// Pass a getLatestRelease() result. The returned array is empty when the
+// release runs on this host.
+export function envMismatches(latest: ValidatedReleaseView) {
+  return checkEnvCompatibility(latest.release?.requires, host);
+}
 ```
 
 ## What to read next

--- a/docs/src/content/docs/plugins/registry.mdx
+++ b/docs/src/content/docs/plugins/registry.mdx
@@ -1,0 +1,110 @@
+---
+title: The plugin registry
+description: Install plugins from the experimental, federated EmDash plugin registry, and query it from your own site.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+The plugin registry is the decentralized successor to the central [marketplace](/plugins/installing/#from-the-marketplace). No single authority owns it or decides which plugins are listed, and the index that makes plugins discoverable — the **aggregator** — is something anyone can run. When you point your site at a registry, the admin dashboard browses and installs plugins from there instead of from the marketplace.
+
+It is built on the [AT Protocol](https://atproto.com/), the network behind [Bluesky](https://bsky.app).
+
+<Aside type="caution" title="Experimental">
+	The registry is experimental and under active development. It is intended to
+	replace the marketplace, but its behaviour and data shapes may change before
+	then — pin EmDash to an exact version while you depend on it, and check the
+	changelog before upgrading. The reference aggregator runs at
+	`registry.emdashcms.com`.
+</Aside>
+
+## Registry vs. marketplace
+
+Both the [marketplace](/plugins/installing/#from-the-marketplace) and the registry let an administrator browse, install, update, and remove sandboxed plugins from the admin dashboard. The install experience — capability consent, checksum verification, the sandbox runner — is the same. They differ in who controls the catalog and who you trust.
+
+| | Marketplace | Registry |
+| --- | --- | --- |
+| **Control** | One company owns and operates it | No central owner; anyone can run an aggregator |
+| **Discovery** | Served by the marketplace service | Served by an aggregator that indexes the network |
+| **Moderation** | The operator vets listings and can remove them | Labellers issue takedown and verification labels you choose to accept |
+| **Who you trust** | The marketplace operator | The aggregator you point at, plus any labellers you accept |
+
+You configure one or the other for a given site. When `experimental.registry` is set, the admin's browse and install flows use the registry.
+
+## Enable the registry
+
+The registry requires a `sandboxRunner`, because registry plugins always run sandboxed. See [Installing Plugins](/plugins/installing/#prerequisites) for the runner setup.
+
+The following configuration points a site at the reference aggregator:
+
+```typescript title="astro.config.mjs"
+import { defineConfig } from "astro/config";
+import emdash from "emdash/astro";
+
+export default defineConfig({
+  integrations: [
+    emdash({
+      sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+      experimental: {
+        registry: "https://registry.emdashcms.com",
+      },
+    }),
+  ],
+});
+```
+
+The bare URL string is shorthand. Use the object form when you need a labeller or a release-age policy:
+
+```typescript title="astro.config.mjs"
+emdash({
+  sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+  experimental: {
+    registry: {
+      aggregatorUrl: "https://registry.emdashcms.com",
+      acceptLabelers: "did:plc:emdashverification",
+      policy: {
+        minimumReleaseAge: "48h",
+        minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
+      },
+    },
+  },
+})
+```
+
+The aggregator URL must be HTTPS in production (`http://localhost` is allowed in development).
+
+### Configuration options
+
+- **`acceptLabelers`** — a comma-separated list of labeller DIDs forwarded to the aggregator. Labellers apply takedown and verification labels; the aggregator filters and annotates results according to the ones you accept. When unset, the aggregator applies its operator default set.
+- **`policy.minimumReleaseAge`** — hold back releases newer than this age when choosing the version to install or update to, widening the window for a takedown to land before a compromised release reaches your site. Accepts a duration string (`"24h"`, `"7d"`) or a number of seconds.
+- **`policy.minimumReleaseAgeExclude`** — DIDs exempt from the holdback, for publishers whose release tempo you have explicitly accepted (such as your own first-party plugins). Each entry is a bare publisher DID, or a `<did>/<slug>` pair to exempt a single package. Only DIDs are accepted, not handles.
+
+## Browse and install
+
+<Steps>
+1. Open the admin panel and navigate to **Plugins > Registry**.
+2. Browse or search. Each result shows the publisher's verified handle, the latest version, and any labels.
+3. Open a plugin to see its README, screenshots, declared access, and release history.
+4. Click **Install** and review the capability consent dialog.
+5. Confirm.
+</Steps>
+
+Installation verifies the downloaded bytes against the release checksum, confirms the bundle's plugin id and version match the release, and confirms its declared capabilities match what you approved. Updates and uninstalling work as they do for [marketplace plugins](/plugins/installing/#updates).
+
+### Trust model
+
+The registry is decentralized, so trust is explicit. Before activating a plugin, EmDash independently verifies that the artifact bytes hash to the release checksum, that the bundle addresses the plugin id and version it claims, and that its capabilities match the consent dialog.
+
+<Aside type="caution">
+	Point `aggregatorUrl` only at an aggregator you operate or trust with the same
+	authority as a central plugin source. `policy.minimumReleaseAge` and
+	`acceptLabelers` widen the takedown window but assume the labeller system is
+	operating.
+</Aside>
+
+## What to read next
+
+- [Installing Plugins](/plugins/installing/) — the marketplace and config-based install flows
+- [Bundling and publishing](/plugins/creating-plugins/publishing/) — publish your own plugin to the registry
+- [Querying the registry](/plugins/registry-client/) — build a plugin directory or search page against the registry's discovery API
+- [Capabilities and security](/plugins/creating-plugins/capabilities/) — the sandbox trust contract
+- [RFC 0001](https://github.com/emdash-cms/emdash/pull/694) — the protocol design, for contributors and aggregator operators

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -351,6 +351,45 @@ emdash({
 
 Uploads that exceed the configured limit are rejected with a `413 Payload Too Large` response on the direct upload path, or a `400 Validation Error` on the signed-URL path.
 
+### `experimental`
+
+**Optional.** Opt-in features whose behaviour or wire format may change, or be removed, in a minor release. Each field is independently enabled.
+
+<Aside type="caution">
+	Experimental options are unstable. Pin EmDash to an exact version when you depend on one, and check the changelog before upgrading.
+</Aside>
+
+#### `experimental.registry`
+
+**Optional.** Point the admin dashboard's plugin browse and install flows at a federated [plugin registry](/plugins/registry/) instead of the central marketplace. Requires `sandboxRunner`, because registry plugins run sandboxed.
+
+Pass a bare aggregator URL string, or an object when you need a labeller or a release-age policy. The following example uses the object form:
+
+```js title="astro.config.mjs"
+emdash({
+	sandboxRunner: "@emdash-cms/sandbox-cloudflare",
+	experimental: {
+		registry: {
+			aggregatorUrl: "https://registry.emdashcms.com",
+			acceptLabelers: "did:plc:emdashverification",
+			policy: {
+				minimumReleaseAge: "48h",
+				minimumReleaseAgeExclude: ["did:plc:yourfirstpartydid"],
+			},
+		},
+	},
+});
+```
+
+| Option                            | Type                   | Description                                                                                   |
+| --------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------- |
+| `aggregatorUrl`                   | `string`               | Aggregator origin where the registry's XRPC endpoints are mounted. HTTPS in production.        |
+| `acceptLabelers`                  | `string`               | Comma-separated labeller DIDs forwarded to the aggregator for takedown and verification labels. |
+| `policy.minimumReleaseAge`        | `string \| number`     | Hold back releases newer than this age. Duration string (`"48h"`, `"7d"`) or seconds.          |
+| `policy.minimumReleaseAgeExclude` | `string[]`             | DIDs (or `<did>/<slug>` pairs) exempt from the holdback.                                        |
+
+See [The plugin registry](/plugins/registry/) for the full workflow, trust model, and how to query the registry from your own site.
+
 ## Database adapters
 
 Import the adapters from `emdash/db`:


### PR DESCRIPTION
## What does this PR do?

Documents the experimental decentralized plugin registry and reorganizes the plugin docs into a "using" section and a "developing" section.

Related: the registry work tracked under #1026 and RFC 0001 (#694). Not closing an issue — docs only.

- **New "Plugin Registry" page** (`plugins/registry`): what the registry is (a decentralized successor to the central marketplace), how it compares to the marketplace, how to enable it (`experimental.registry`), the browse/install flow, and the trust model. Framed as experimental but intended to replace the marketplace.
- **New "Querying the Registry" page** (`plugins/registry-client`): an advanced guide to the discovery client (`@emdash-cms/registry-client`) for building a plugin directory or search page outside EmDash. Kept separate from the operator page because it is a developer/integration topic.
- **Configuration reference**: adds the `experimental.registry` option (`aggregatorUrl`, `acceptLabelers`, `policy.minimumReleaseAge`, `policy.minimumReleaseAgeExclude`).
- **Installing Plugins**: a tip linking to the registry from the marketplace section.
- **Sidebar restructure**: a lean operator-facing **Plugins** group, and a new nested **Plugin Development** group (Sandboxed / Native subgroups, plus the registry client and Field Kit). Migration moved ahead of dev; the two type subgroups collapse by default; Contributing and Concepts expanded.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, docs-only; the docs site builds cleanly (`astro build`).
- [ ] `pnpm lint` passes — n/a, docs-only.
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, no tests for docs content.
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, docs.
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI changes.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, no published package changed (docs site only).
- [ ] New features link to an approved Discussion — n/a, documentation of existing/experimental functionality.

All documented options were verified against the exported types in `packages/core/src/registry/` and the `DiscoveryClient` surface in `packages/registry-client`. The registry is flagged experimental throughout; the aggregator host (`registry.emdashcms.com`) matches the config type docstrings — worth a final confirm before this is treated as canonical.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

`astro build` succeeds; both new pages (`/plugins/registry/`, `/plugins/registry-client/`) and the modified pages render, and the nested sidebar validates.
