### PR TITLE
Fix date format example in reading settings

### DIFF
--- a/.changeset/fix-admin-date-format-example.md
+++ b/.changeset/fix-admin-date-format-example.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the reading settings date format example so it follows the configured format string.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -71,6 +71,7 @@
     "@tiptap/y-tiptap": "catalog:",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "dompurify": "^3.3.2",
     "marked": "^17.0.3",
     "react-hotkeys-hook": "^5.2.4",

--- a/packages/admin/src/components/settings/GeneralSettings.tsx
+++ b/packages/admin/src/components/settings/GeneralSettings.tsx
@@ -12,6 +12,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
 
 import { fetchSettings, updateSettings, type SiteSettings, type MediaItem } from "../../lib/api";
+import { DEFAULT_DATE_FORMAT, formatDateFormatExample } from "../../lib/date-format-example";
 import { EditorHeader } from "../EditorHeader";
 import { MediaPickerModal } from "../MediaPickerModal";
 import { BackToSettingsLink } from "./BackToSettingsLink.js";
@@ -68,6 +69,9 @@ export function GeneralSettings() {
 	const handleChange = (key: keyof SiteSettings, value: unknown) => {
 		setFormData((prev) => ({ ...prev, [key]: value }));
 	};
+
+	const dateFormat = formData.dateFormat || DEFAULT_DATE_FORMAT;
+	const dateFormatExample = formatDateFormatExample(dateFormat);
 
 	const handleLogoSelect = (media: MediaItem) => {
 		setFormData((prev) => ({
@@ -302,9 +306,13 @@ export function GeneralSettings() {
 						/>
 						<Input
 							label={t`Date Format`}
-							value={formData.dateFormat || "MMMM d, yyyy"}
+							value={dateFormat}
 							onChange={(e) => handleChange("dateFormat", e.target.value)}
-							description={`Example: ${formData.dateFormat || "MMMM d, yyyy"} → January 23, 2026`}
+							description={
+								dateFormatExample
+									? t`Example: ${dateFormat} → ${dateFormatExample}`
+									: t`Example: ${dateFormat} → Invalid date format`
+							}
 						/>
 						<Input
 							label={t`Timezone`}

--- a/packages/admin/src/lib/date-format-example.ts
+++ b/packages/admin/src/lib/date-format-example.ts
@@ -1,0 +1,13 @@
+import { format } from "date-fns";
+
+const DATE_FORMAT_EXAMPLE_DATE = new Date(2026, 0, 23, 12);
+
+export const DEFAULT_DATE_FORMAT = "MMMM d, yyyy";
+
+export function formatDateFormatExample(dateFormat: string): string | null {
+	try {
+		return format(DATE_FORMAT_EXAMPLE_DATE, dateFormat || DEFAULT_DATE_FORMAT);
+	} catch {
+		return null;
+	}
+}

--- a/packages/admin/tests/date-format-example.test.ts
+++ b/packages/admin/tests/date-format-example.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_DATE_FORMAT, formatDateFormatExample } from "../src/lib/date-format-example";
+
+describe("formatDateFormatExample", () => {
+	it("formats the default date format example", () => {
+		expect(formatDateFormatExample(DEFAULT_DATE_FORMAT)).toBe("January 23, 2026");
+	});
+
+	it("formats ISO-style date format examples", () => {
+		expect(formatDateFormatExample("yyyy-MM-dd")).toBe("2026-01-23");
+	});
+
+	it("returns null for invalid date formats", () => {
+		expect(formatDateFormatExample("yyyy-MM-dd nope")).toBeNull();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,6 +1177,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dompurify:
         specifier: ^3.3.2
         version: 3.3.2


### PR DESCRIPTION
## What does this PR do?

Fixes the Reading settings date format example in the admin UI so it is rendered from the configured date format string instead of always showing the hard-coded `January 23, 2026` example.

For example, `yyyy-MM-dd` now previews as `2026-01-23`.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

Validated with:

```bash
pnpm --filter @emdash-cms/admin typecheck
pnpm --filter @emdash-cms/admin exec vitest run tests/date-format-example.test.ts
pnpm changeset status --since=origin/main
pnpm exec prettier --check packages/admin/src/components/settings/GeneralSettings.tsx packages/admin/src/lib/date-format-example.ts packages/admin/tests/date-format-example.test.ts .changeset/fix-admin-date-format-example.md
```

I did not run the full repository lint or full test suite; this PR is scoped to the admin date format preview helper and its targeted test.
