### PR TITLE
fix: isolate Postgres tests per worker and scope schema introspection

### DIFF
--- a/.changeset/fix-pg-schema-scoping.md
+++ b/.changeset/fix-pg-schema-scoping.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Scope Postgres table/column introspection to the connection's active schema instead of hardcoding `public`. `tableExists` and `listTablesLike` (`database/dialect-helpers.ts`) and two idempotency checks in the `019_i18n` migration queried `information_schema` with `table_schema = 'public'`, so a Postgres deployment using a non-public schema (per-tenant or shared-cluster setups) would see tables from the wrong schema or none at all, causing collection/schema operations to misbehave and the i18n migration to skip its column additions. These now use `current_schema()`, matching the already-correct `indexExists`/`columnExists` helpers and migration `038`.

--- a/packages/core/src/database/dialect-helpers.ts
+++ b/packages/core/src/database/dialect-helpers.ts
@@ -74,10 +74,12 @@ export function currentTimestampValue(db: Kysely<any>): RawBuilder<string> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export async function tableExists(db: Kysely<any>, tableName: string): Promise<boolean> {
 	if (isPostgres(db)) {
+		// Scope to the active schema (matches indexExists/columnExists below).
+		// Hardcoding 'public' breaks non-public-schema Postgres deployments.
 		const result = await sql<{ exists: boolean }>`
 			SELECT EXISTS(
 				SELECT 1 FROM information_schema.tables
-				WHERE table_schema = 'public' AND table_name = ${tableName}
+				WHERE table_schema = current_schema() AND table_name = ${tableName}
 			) as exists
 		`.execute(db);
 		return result.rows[0]?.exists === true;
@@ -146,9 +148,13 @@ export async function columnExists(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any Kysely instance
 export async function listTablesLike(db: Kysely<any>, pattern: string): Promise<string[]> {
 	if (isPostgres(db)) {
+		// Scope to the connection's active schema rather than hardcoding
+		// 'public'. A Postgres deployment using a non-public schema (per-tenant
+		// or shared-cluster setups), or per-test schemas, otherwise sees tables
+		// from the wrong schema — or none at all. Mirrors migration 038.
 		const result = await sql<{ table_name: string }>`
 			SELECT table_name FROM information_schema.tables
-			WHERE table_schema = 'public' AND table_name LIKE ${pattern}
+			WHERE table_schema = current_schema() AND table_name LIKE ${pattern}
 		`.execute(db);
 		return result.rows.map((r) => r.table_name);
 	}

--- a/packages/core/src/database/migrations/019_i18n.ts
+++ b/packages/core/src/database/migrations/019_i18n.ts
@@ -142,7 +142,7 @@ async function upPostgres(db: Kysely<unknown>): Promise<void> {
 		const hasLocale = await sql<{ exists: boolean }>`
 			SELECT EXISTS(
 				SELECT 1 FROM information_schema.columns
-				WHERE table_schema = 'public' AND table_name = ${t} AND column_name = 'locale'
+				WHERE table_schema = current_schema() AND table_name = ${t} AND column_name = 'locale'
 			) as exists
 		`.execute(db);
 		if (hasLocale.rows[0]?.exists === true) continue;
@@ -189,7 +189,7 @@ async function upPostgres(db: Kysely<unknown>): Promise<void> {
 	const hasTranslatable = await sql<{ exists: boolean }>`
 		SELECT EXISTS(
 			SELECT 1 FROM information_schema.columns
-			WHERE table_schema = 'public' AND table_name = '_emdash_fields' AND column_name = 'translatable'
+			WHERE table_schema = current_schema() AND table_name = '_emdash_fields' AND column_name = 'translatable'
 		) as exists
 	`.execute(db);
 	if (hasTranslatable.rows[0]?.exists !== true) {

--- a/packages/core/tests/integration/database/list-tables-like.test.ts
+++ b/packages/core/tests/integration/database/list-tables-like.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { listTablesLike } from "../../../src/database/dialect-helpers.js";
+import {
+	type DialectTestContext,
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+} from "../../utils/test-db.js";
+
+// Regression: `listTablesLike` (and the migration column-existence checks)
+// must scope to the connection's active schema, not a hardcoded `public`.
+// On a Postgres deployment using a non-public schema — including the
+// per-test schemas this harness creates — hardcoding `public` returns tables
+// from the wrong schema, or none at all. The Postgres variant of this test
+// fails against the old `WHERE table_schema = 'public'` query.
+describeEachDialect("listTablesLike schema scoping", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("finds content tables in the active schema", async () => {
+		const tables = await listTablesLike(ctx.db, "ec_%");
+		expect(tables.toSorted()).toEqual(["ec_page", "ec_post"]);
+	});
+
+	it("returns an empty list when nothing matches the pattern", async () => {
+		const tables = await listTablesLike(ctx.db, "nonexistent_%");
+		expect(tables).toEqual([]);
+	});
+});

--- a/packages/core/tests/utils/test-db.ts
+++ b/packages/core/tests/utils/test-db.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import Database from "better-sqlite3";
 import { Kysely, PostgresDialect, SqliteDialect } from "kysely";
 import { Pool } from "pg";
@@ -105,30 +107,128 @@ export async function teardownTestDatabase(db: Kysely<DatabaseSchema>): Promise<
 // PostgreSQL helpers
 // ---------------------------------------------------------------------------
 
+// --- Per-worker database isolation -----------------------------------------
+//
+// Vitest runs test files in parallel worker processes that all share one
+// Postgres server. The original harness isolated each test in its own *schema*
+// inside one shared database. That breaks down under parallelism: Kysely's
+// migrator introspects the catalog database-wide (`pg_namespace`, `pg_class`)
+// with no schema filter, so a migration in one worker sees — and races against
+// — the sibling schemas other workers are concurrently creating and dropping.
+// The result is intermittent `schema/relation/column "test_…" does not exist`
+// failures during setup (issue #1333).
+//
+// Postgres catalogs are *per database*, so giving each worker its own database
+// fully isolates introspection. Within a worker, schemas are still created and
+// dropped per test, but sequentially (Vitest runs one file at a time per
+// worker and awaits hooks in order), so there is no concurrent catalog churn.
+
+/** Validate an identifier we must interpolate into DDL (no bind params allowed). */
+function assertSafeIdentifier(id: string): void {
+	if (!/^[a-z][a-z0-9_]*$/.test(id) || id.length > 63) {
+		throw new Error(`Unsafe SQL identifier: ${id}`);
+	}
+}
+
 /**
- * Shared pool for Postgres tests. One pool per test process, many schemas.
- * Created lazily on first call to createTestPostgresDatabase().
+ * Name of the Postgres database dedicated to the current Vitest worker.
+ * `VITEST_POOL_ID` is the stable worker-slot id (reused across files within a
+ * worker); we fall back to the pid so the harness still works outside Vitest.
+ */
+function workerDatabaseName(): string {
+	const raw = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? String(process.pid);
+	const slug = raw.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+	const name = `emdash_test_w_${slug}`;
+	assertSafeIdentifier(name);
+	return name;
+}
+
+/** Swap the database in a connection string for the per-worker database. */
+function withDatabase(connectionString: string, database: string): string {
+	const url = new URL(connectionString);
+	url.pathname = `/${database}`;
+	return url.toString();
+}
+
+/**
+ * Ensure the per-worker database exists and resolve its connection string.
+ * Memoised per process so the create-database round-trip happens once.
+ */
+let workerConnPromise: Promise<string> | null = null;
+function getWorkerConnectionString(): Promise<string> {
+	if (!workerConnPromise) {
+		workerConnPromise = (async () => {
+			const dbName = workerDatabaseName();
+			// Connect to the maintenance database from the original connection
+			// string to issue CREATE DATABASE (which cannot run while connected
+			// to its target, nor inside a transaction).
+			const admin = new Pool({ connectionString: PG_CONNECTION_STRING, max: 1 });
+			try {
+				const { rows } = await admin.query<{ exists: number }>(
+					"SELECT 1 AS exists FROM pg_database WHERE datname = $1",
+					[dbName],
+				);
+				if (rows.length === 0) {
+					// Concurrent CREATE DATABASE calls (different worker names) can
+					// still collide on the template1 lock; retry a few times.
+					await createDatabaseWithRetry(admin, dbName);
+				}
+			} finally {
+				await admin.end();
+			}
+			return withDatabase(PG_CONNECTION_STRING, dbName);
+		})();
+	}
+	return workerConnPromise;
+}
+
+async function createDatabaseWithRetry(admin: Pool, dbName: string): Promise<void> {
+	for (let attempt = 0; attempt < 10; attempt++) {
+		try {
+			await admin.query(`CREATE DATABASE ${dbName}`);
+			return;
+		} catch (error) {
+			const msg = String(error instanceof Error ? error.message : error);
+			// 42P04 = duplicate_database (another check-then-create raced us).
+			if (/already exists|duplicate_database/i.test(msg)) return;
+			// "source database … is being accessed by other users" — template1
+			// is locked by another concurrent CREATE DATABASE; back off and retry.
+			if (attempt < 9 && /being accessed by other users/i.test(msg)) {
+				await new Promise((resolve) => setTimeout(resolve, 50 + attempt * 50));
+				continue;
+			}
+			throw error;
+		}
+	}
+}
+
+/**
+ * Shared pool for the current worker's Postgres database. One pool per test
+ * process, used for schema create/drop. Created lazily.
  */
 let sharedPool: Pool | null = null;
 
-function getSharedPool(): Pool {
+async function getSharedPool(): Promise<Pool> {
 	if (!sharedPool) {
-		sharedPool = new Pool({
-			connectionString: PG_CONNECTION_STRING,
-			max: 10,
-		});
+		const connectionString = await getWorkerConnectionString();
+		sharedPool = new Pool({ connectionString, max: 10 });
 	}
 	return sharedPool;
 }
 
 /**
  * Generate a unique schema name for test isolation.
- * Format: test_<timestamp>_<random> — short, valid SQL identifier.
+ *
+ * Unique within the worker database via a monotonic counter (clock resolution
+ * independent) plus crypto entropy, so two contexts in the same process can
+ * never collide on a name. PostgreSQL identifiers are capped at 63 bytes; this
+ * stays well under.
  */
+let schemaCounter = 0;
 function uniqueSchemaName(): string {
-	const ts = Date.now().toString(36);
-	const rand = Math.random().toString(36).slice(2, 8);
-	return `test_${ts}_${rand}`;
+	const seq = (schemaCounter++).toString(36);
+	const rand = randomUUID().replace(/-/g, "").slice(0, 12);
+	return `test_${seq}_${rand}`;
 }
 
 export interface PgTestContext {
@@ -139,13 +239,15 @@ export interface PgTestContext {
 /**
  * Create an isolated Postgres database for a single test.
  *
- * Each call creates a unique schema and returns a Kysely instance
- * whose search_path is set to that schema. Tables are fully isolated.
+ * Each call creates a unique schema inside the worker's database and returns a
+ * Kysely instance whose search_path is set to that schema. Tables are fully
+ * isolated.
  *
  * Call `teardownTestPostgresDatabase()` in afterEach to drop the schema.
  */
 export async function createTestPostgresDatabase(): Promise<PgTestContext> {
-	const pool = getSharedPool();
+	const connectionString = await getWorkerConnectionString();
+	const pool = await getSharedPool();
 	const schemaName = uniqueSchemaName();
 
 	// Create the isolated schema using a raw connection
@@ -160,7 +262,7 @@ export async function createTestPostgresDatabase(): Promise<PgTestContext> {
 	// Test schema comes first so CREATE TABLE goes there.
 	// public is included for Postgres system functions and extensions.
 	const testPool = new Pool({
-		connectionString: PG_CONNECTION_STRING,
+		connectionString,
 		max: 5,
 		options: `-c search_path=${schemaName},public`,
 	});
@@ -231,7 +333,7 @@ export async function teardownTestPostgresDatabase(ctx: PgTestContext): Promise<
 	await ctx.db.destroy();
 
 	// Drop the schema using the shared pool
-	const pool = getSharedPool();
+	const pool = await getSharedPool();
 	const client = await pool.connect();
 	try {
 		await client.query(`DROP SCHEMA IF EXISTS ${ctx.schemaName} CASCADE`);


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky Postgres integration failures, plus a related production bug for non-public-schema Postgres deployments.

**Root cause (the flake).** Vitest runs test files in parallel worker processes that all shared one Postgres database, isolating each test by *schema*. Kysely's migrator introspects the catalog database-wide (`pg_namespace`, `pg_class`) with **no schema filter**, so a migration in one worker saw — and raced against — the sibling schemas other workers were concurrently creating and dropping. That surfaced as intermittent `schema/relation/column "test_…" does not exist` during setup. It was never a `search_path` issue (verified correct via instrumentation); it's the global catalog introspection colliding with concurrent create/drop of sibling schemas.

**Fix (test harness).** Postgres catalogs are per-database, so each Vitest worker now gets its own database (`emdash_test_w_<VITEST_POOL_ID>`). Introspection then only sees that worker's schemas, which are created/dropped sequentially within the worker — no concurrent catalog churn. Per-test schema isolation is unchanged inside the worker DB. Measured **0 failures over 25 full integration runs** vs **~30% (3/10) on the baseline**.

**Fix (product bug).** `tableExists` and `listTablesLike` (`database/dialect-helpers.ts`) and two idempotency checks in the `019_i18n` migration queried `information_schema` with hardcoded `table_schema = 'public'`. Any Postgres deployment using a non-public schema (per-tenant or shared-cluster setups) would see the wrong schema's tables, or none — breaking collection/schema operations and causing the i18n migration to skip its column additions. These now use `current_schema()`, matching the already-correct `indexExists`/`columnExists` helpers and migration `038`. A new regression test (`list-tables-like.test.ts`) is verified to fail on the old query and pass on the fix.

Closes #1333 

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — full SQLite suite (3663) and full Postgres suite (3719) green
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch, for the `current_schema()` fixes; the harness change is test-only)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Flake validation (db-per-worker), against real Postgres:

```
baseline (original code):       3 / 10 runs failed (~30%)
db-per-worker (this PR):        0 / 25 runs failed
```

Full suites with `EMDASH_TEST_PG` set: `242 files, 3719 tests passed`.
