### PR TITLE
ci: skip changeset validation when no changesets are present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,14 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm changeset status --since=origin/main
+      - name: Validate changesets
+        run: |
+          shopt -s extglob
+          if compgen -G ".changeset/!(README).md" > /dev/null; then
+            pnpm changeset status --since=origin/main
+          else
+            echo "No changesets present; skipping validation."
+          fi
 
   test:
     name: Tests


### PR DESCRIPTION
## What does this PR do?

The `changeset-validate` CI job ran `pnpm changeset status --since=origin/main` unconditionally, which exits non-zero when a PR contains no changesets. This blocked PRs that legitimately don't need one (docs-only, test-only, CI/chore), even though our own contributor guidance says those are valid n/a cases.

The step now checks for changeset files first (any `.changeset/*.md` other than `README.md`) and only runs `changeset status` when at least one is present. When none exist, it logs a skip message and passes. Validation of malformed/invalid changesets is unchanged when changesets do exist.

Uses bash `extglob` negation (`.changeset/!(README).md`) with `compgen -G` as the presence check.

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- n/a: CI workflow only, no source changes -->
- [ ] `pnpm lint` passes <!-- n/a: CI workflow only, no source changes -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: CI workflow only -->
- [ ] `pnpm format` has been run <!-- n/a: YAML workflow file -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a: not unit-testable workflow logic; verified glob behavior locally in bash -->
- [ ] User-visible strings in the admin UI are wrapped for translation <!-- n/a: no UI strings -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a: no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Verified locally in bash that `compgen -G ".changeset/!(README).md"` returns success only when a non-README changeset exists:

- Only `.changeset/README.md` present -> skip branch taken
- A real changeset file present -> `changeset status` runs