### PR TITLE
fix(core): transform EmDash/adapter/plugin packages inline in CF dev

### DIFF
--- a/.changeset/fix-cf-dev-inline-plugins.md
+++ b/.changeset/fix-cf-dev-inline-plugins.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Stop the `astro dev` dependency-optimize reload cascade on Cloudflare for npm-installed sites. EmDash core, the Cloudflare adapter (`@emdash-cms/cloudflare`), and configured plugins are now transformed inline by Vite in dev instead of being pre-bundled one subpath at a time.
+
+Plugins and the adapter expose many subpath exports (`emdash/middleware`, `@emdash-cms/cloudflare/db/d1`, `<plugin>/astro`, ...) and plugins often ship TypeScript source. On a registry install the dev dep-optimizer discovered these lazily on the first request to each route, invalidating the optimize cache mid-flight (`The file does not exist at ".../deps_ssr/chunk-*.js"`) and forcing repeated full reloads on cold start. Plugin package names are derived from their descriptors, so third-party plugins are covered automatically. Workspace/monorepo setups were unaffected, which is why this only reproduced in standalone projects.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -296,6 +296,41 @@ function isCloudflareAdapter(astroConfig: AstroConfig): boolean {
 	return astroConfig.adapter?.name === "@astrojs/cloudflare";
 }
 
+/** Matches relative/absolute path specifiers (`./x`, `../x`, `/x`, `.`). */
+const RELATIVE_OR_ABSOLUTE_SPECIFIER = /^[./]/;
+
+/**
+ * Extracts the bare npm package name from a module specifier, or `undefined`
+ * for non-package specifiers (relative/absolute paths, `virtual:`, `node:`, etc).
+ * `@emdash-cms/plugin-forms/astro` -> `@emdash-cms/plugin-forms`; `./local.ts` -> undefined.
+ */
+function packageNameFromSpecifier(spec: string): string | undefined {
+	if (!spec || RELATIVE_OR_ABSOLUTE_SPECIFIER.test(spec) || spec.includes(":")) return undefined;
+	const parts = spec.split("/");
+	if (spec.startsWith("@")) return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : undefined;
+	return parts[0] || undefined;
+}
+
+/**
+ * Collects the npm package names of configured plugins from their descriptors.
+ * Used to mark plugin packages for inline transform in dev (see `inlinePackages`
+ * in {@link createViteConfig}). Plugins commonly ship TypeScript source and
+ * multiple subpath exports (`/astro`, `/admin`), which the dev dep-optimizer
+ * otherwise discovers and pre-bundles one subpath at a time on first request,
+ * triggering a re-optimize + full-reload cascade.
+ */
+function collectPluginPackages(descriptors: PluginDescriptor[]): string[] {
+	const packages = new Set<string>();
+	for (const descriptor of descriptors) {
+		for (const spec of [descriptor.entrypoint, descriptor.adminEntry, descriptor.componentsEntry]) {
+			if (!spec) continue;
+			const pkg = packageNameFromSpecifier(spec);
+			if (pkg) packages.add(pkg);
+		}
+	}
+	return [...packages];
+}
+
 /**
  * Creates the Vite config update for EmDash.
  */
@@ -310,6 +345,21 @@ export function createViteConfig(
 
 	const adminSourcePath = isDev ? resolveAdminSource(projectRoot) : undefined;
 	const useSource = adminSourcePath !== undefined;
+
+	// Packages to transform inline (dev only) rather than pre-bundle: EmDash
+	// core, the Cloudflare adapter, and configured plugins. These either ship
+	// source or expose many subpath exports reached lazily across routes
+	// (`emdash/middleware`, `@emdash-cms/cloudflare/db/d1`, `<plugin>/astro`...).
+	// Letting the dep-optimizer discover them one at a time on first request
+	// invalidates the optimize cache mid-flight ("file does not exist at
+	// .../deps_ssr/chunk-*.js") and forces repeated full reloads on cold start.
+	// Excluding them from optimizeDeps makes Vite transform them as part of the
+	// module graph; they remain `noExternal` so workerd still gets ESM. Their
+	// CJS/heavy transitive deps stay pre-bundled via `optimizeDeps.include`.
+	const inlinePackages =
+		cloudflare && isDev
+			? [...new Set(["emdash", "@emdash-cms/cloudflare", ...collectPluginPackages(options.pluginDescriptors)])]
+			: [];
 
 	return {
 		// Astro SSR routes resolve version.ts from source (not tsdown dist),
@@ -360,7 +410,7 @@ export function createViteConfig(
 		// ssr.external conflicts with @cloudflare/vite-plugin's resolve.external validation.
 		ssr: cloudflare
 			? {
-					noExternal: ["emdash", "@emdash-cms/admin"],
+					noExternal: [...new Set(["emdash", "@emdash-cms/admin", ...inlinePackages])],
 					// Pre-bundle EmDash's runtime deps for workerd. Without this,
 					// Vite discovers them one-by-one on first request, causing workerd
 					// to enter "worker cancelled" state on cold cache.
@@ -371,7 +421,10 @@ export function createViteConfig(
 						// during pre-bundling and can't resolve them. Vite's exclude
 						// uses prefix matching (id.startsWith(m + "/")), so
 						// "virtual:emdash" matches all "virtual:emdash/*" imports.
-						exclude: ["virtual:emdash"],
+						// `inlinePackages` (EmDash core, the CF adapter, plugins) are
+						// excluded so their subpaths transform inline instead of
+						// cascading through lazy pre-bundling.
+						exclude: ["virtual:emdash", ...inlinePackages],
 						include: [
 							// EmDash direct deps
 							"emdash > @portabletext/toolkit",
@@ -423,6 +476,7 @@ export function createViteConfig(
 							// Top-level deps (use astro > path for pnpm compat)
 							"astro > zod/v4",
 							"astro > zod/v4/core",
+							"astro/zod",
 							"@emdash-cms/cloudflare > kysely-d1",
 							// Astro internal deps not covered by @astrojs/cloudflare adapter
 							"astro/virtual-modules/middleware.js",

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -358,7 +358,13 @@ export function createViteConfig(
 	// CJS/heavy transitive deps stay pre-bundled via `optimizeDeps.include`.
 	const inlinePackages =
 		cloudflare && isDev
-			? [...new Set(["emdash", "@emdash-cms/cloudflare", ...collectPluginPackages(options.pluginDescriptors)])]
+			? [
+					...new Set([
+						"emdash",
+						"@emdash-cms/cloudflare",
+						...collectPluginPackages(options.pluginDescriptors),
+					]),
+				]
 			: [];
 
 	return {


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1336. That PR pre-bundled auth/MCP/admin deps, but a **registry (npm) install** still cascaded on first request:

```
12:21:44 [vite] ✨ new dependencies optimized: emdash/middleware, emdash/middleware/redirect, ...
12:21:45 [vite] ✨ new dependencies optimized: @emdash-cms/cloudflare/db/d1
12:21:46 [vite] An error happened during full reload
The file does not exist at ".../node_modules/.vite/deps_ssr/chunk-23YHL7U2.js" ...
12:21:47 [vite] ✨ new dependencies optimized: @emdash-cms/plugin-forms
```

Root cause: EmDash core, the Cloudflare adapter, and plugins expose many subpath exports (`emdash/middleware`, `@emdash-cms/cloudflare/db/d1`, `<plugin>/astro`, ...) and plugins commonly ship TypeScript source. On a registry install the dev dep-optimizer discovers these lazily, one subpath per route, each discovery invalidating the optimize cache mid-flight and forcing a full reload. **Enumerating every subpath in `optimizeDeps.include` is a losing game** (and can't cover arbitrary third-party plugins).

Fix: add `emdash`, `@emdash-cms/cloudflare`, and the configured plugin packages to `ssr.optimizeDeps.exclude` (and `noExternal`, dev only) so Vite transforms them as part of the module graph instead of pre-bundling each subpath. Plugin package names are derived from their descriptors (`entrypoint`/`adminEntry`/`componentsEntry`), so third-party plugins are covered automatically. Their CJS/heavy transitive deps stay pre-bundled via the existing `include` list. Also added `astro/zod` to `include` (the last straggler).

This only reproduced on standalone projects — **workspace/monorepo installs masked it** because linked packages are already transformed inline, which is why #1336's `demos/cloudflare` verification looked clean. I reproduced and verified this one against a real npm-installed site.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`lint:json` -> 0 diagnostics)
- [ ] `pnpm test` passes — n/a, no automated harness covers dev-server dep-optimization; verified manually (below)
- [ ] `pnpm format` — change is tab-aligned to surrounding code; `git diff --check` clean
- [ ] I have added/updated tests — n/a (dev-only Vite config behavior)
- [x] User-visible strings wrapped for translation — n/a, no UI strings; no `messages.po` changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (OpenCode)

## Screenshots / test output

Verified against a real npm-installed site (`emdash@0.17.2` + `@emdash-cms/cloudflare` + `@emdash-cms/plugin-forms`) by swapping in the built dist, cold cache (`rm -rf node_modules/.vite`), hitting `/`, `/_emdash/admin`, `/`:

| Metric (post-ready)            | Before | After |
| ------------------------------ | -----: | ----: |
| `new dependencies optimized` passes | 6+ | 0 |
| `program reload` events        |   6+ |     0 |
| `file does not exist` errors   |    2 |     0 |

The `collectPluginPackages` derivation correctly picked up `@emdash-cms/plugin-forms`; the forms + webhook-notifier plugins still loaded, routes serve 200/302.