### PR TITLE
Revert "fix(core): transform EmDash/adapter/plugin packages inline in CF dev (#1359)"

### DIFF
--- a/.changeset/fix-cf-dev-inline-plugins.md
+++ b/.changeset/fix-cf-dev-inline-plugins.md
@@ -1,7 +1,0 @@
----
-"emdash": patch
----
-
-Stop the `astro dev` dependency-optimize reload cascade on Cloudflare for npm-installed sites. EmDash core, the Cloudflare adapter (`@emdash-cms/cloudflare`), and configured plugins are now transformed inline by Vite in dev instead of being pre-bundled one subpath at a time.
-
-Plugins and the adapter expose many subpath exports (`emdash/middleware`, `@emdash-cms/cloudflare/db/d1`, `<plugin>/astro`, ...) and plugins often ship TypeScript source. On a registry install the dev dep-optimizer discovered these lazily on the first request to each route, invalidating the optimize cache mid-flight (`The file does not exist at ".../deps_ssr/chunk-*.js"`) and forcing repeated full reloads on cold start. Plugin package names are derived from their descriptors, so third-party plugins are covered automatically. Workspace/monorepo setups were unaffected, which is why this only reproduced in standalone projects.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -296,41 +296,6 @@ function isCloudflareAdapter(astroConfig: AstroConfig): boolean {
 	return astroConfig.adapter?.name === "@astrojs/cloudflare";
 }
 
-/** Matches relative/absolute path specifiers (`./x`, `../x`, `/x`, `.`). */
-const RELATIVE_OR_ABSOLUTE_SPECIFIER = /^[./]/;
-
-/**
- * Extracts the bare npm package name from a module specifier, or `undefined`
- * for non-package specifiers (relative/absolute paths, `virtual:`, `node:`, etc).
- * `@emdash-cms/plugin-forms/astro` -> `@emdash-cms/plugin-forms`; `./local.ts` -> undefined.
- */
-function packageNameFromSpecifier(spec: string): string | undefined {
-	if (!spec || RELATIVE_OR_ABSOLUTE_SPECIFIER.test(spec) || spec.includes(":")) return undefined;
-	const parts = spec.split("/");
-	if (spec.startsWith("@")) return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : undefined;
-	return parts[0] || undefined;
-}
-
-/**
- * Collects the npm package names of configured plugins from their descriptors.
- * Used to mark plugin packages for inline transform in dev (see `inlinePackages`
- * in {@link createViteConfig}). Plugins commonly ship TypeScript source and
- * multiple subpath exports (`/astro`, `/admin`), which the dev dep-optimizer
- * otherwise discovers and pre-bundles one subpath at a time on first request,
- * triggering a re-optimize + full-reload cascade.
- */
-function collectPluginPackages(descriptors: PluginDescriptor[]): string[] {
-	const packages = new Set<string>();
-	for (const descriptor of descriptors) {
-		for (const spec of [descriptor.entrypoint, descriptor.adminEntry, descriptor.componentsEntry]) {
-			if (!spec) continue;
-			const pkg = packageNameFromSpecifier(spec);
-			if (pkg) packages.add(pkg);
-		}
-	}
-	return [...packages];
-}
-
 /**
  * Creates the Vite config update for EmDash.
  */
@@ -345,27 +310,6 @@ export function createViteConfig(
 
 	const adminSourcePath = isDev ? resolveAdminSource(projectRoot) : undefined;
 	const useSource = adminSourcePath !== undefined;
-
-	// Packages to transform inline (dev only) rather than pre-bundle: EmDash
-	// core, the Cloudflare adapter, and configured plugins. These either ship
-	// source or expose many subpath exports reached lazily across routes
-	// (`emdash/middleware`, `@emdash-cms/cloudflare/db/d1`, `<plugin>/astro`...).
-	// Letting the dep-optimizer discover them one at a time on first request
-	// invalidates the optimize cache mid-flight ("file does not exist at
-	// .../deps_ssr/chunk-*.js") and forces repeated full reloads on cold start.
-	// Excluding them from optimizeDeps makes Vite transform them as part of the
-	// module graph; they remain `noExternal` so workerd still gets ESM. Their
-	// CJS/heavy transitive deps stay pre-bundled via `optimizeDeps.include`.
-	const inlinePackages =
-		cloudflare && isDev
-			? [
-					...new Set([
-						"emdash",
-						"@emdash-cms/cloudflare",
-						...collectPluginPackages(options.pluginDescriptors),
-					]),
-				]
-			: [];
 
 	return {
 		// Astro SSR routes resolve version.ts from source (not tsdown dist),
@@ -416,7 +360,7 @@ export function createViteConfig(
 		// ssr.external conflicts with @cloudflare/vite-plugin's resolve.external validation.
 		ssr: cloudflare
 			? {
-					noExternal: [...new Set(["emdash", "@emdash-cms/admin", ...inlinePackages])],
+					noExternal: ["emdash", "@emdash-cms/admin"],
 					// Pre-bundle EmDash's runtime deps for workerd. Without this,
 					// Vite discovers them one-by-one on first request, causing workerd
 					// to enter "worker cancelled" state on cold cache.
@@ -427,10 +371,7 @@ export function createViteConfig(
 						// during pre-bundling and can't resolve them. Vite's exclude
 						// uses prefix matching (id.startsWith(m + "/")), so
 						// "virtual:emdash" matches all "virtual:emdash/*" imports.
-						// `inlinePackages` (EmDash core, the CF adapter, plugins) are
-						// excluded so their subpaths transform inline instead of
-						// cascading through lazy pre-bundling.
-						exclude: ["virtual:emdash", ...inlinePackages],
+						exclude: ["virtual:emdash"],
 						include: [
 							// EmDash direct deps
 							"emdash > @portabletext/toolkit",
@@ -482,7 +423,6 @@ export function createViteConfig(
 							// Top-level deps (use astro > path for pnpm compat)
 							"astro > zod/v4",
 							"astro > zod/v4/core",
-							"astro/zod",
 							"@emdash-cms/cloudflare > kysely-d1",
 							// Astro internal deps not covered by @astrojs/cloudflare adapter
 							"astro/virtual-modules/middleware.js",


### PR DESCRIPTION
## What does this PR do?

Reverts #1359 (commit c9d07241), which broke the **E2E Cloudflare** lane on `main` and the release PR (#1360).

`main` was green at `4fb27752` and went red on `c9d07241` (the #1359 merge). The **E2E Cloudflare (1/8)** shard fails deterministically (confirmed across two runs) on three tests, while the only Node-lane failure (an `invite-flow` flake) recovered on re-run:

- `api-tokens.spec.ts:22` / `:137` — `strict mode violation: locator('text=dev-bypass-token') resolved to 2 elements`
- `accessibility.spec.ts:28` — Login Page `h1` `"Sign in"` not found (15s timeout)

### Why #1359 caused it

#1359 added `emdash`, `@emdash-cms/cloudflare`, and configured plugin packages to `ssr.optimizeDeps.exclude` + `noExternal` (dev only), so Vite transforms them inline instead of pre-bundling. Under the workerd dev runtime used by the CF e2e fixture this regresses the admin/login route (slow cold compile and/or SSR error): the login `h1` never appears within 15s, and global-setup's `dev-bypass?token=1` (guarded by `waitForOk` with a 10s per-attempt timeout) times out client-side after the server has already created the token, retries, and creates a **second** `dev-bypass-token` — hence the duplicate.

The fix itself is still wanted (it resolves the dependency-optimize reload cascade on registry installs, the original report). It needs to be redone with verification against the CF e2e fixture (`EMDASH_E2E_TARGET=cloudflare`), which I did not run for #1359 — my manual verification used route requests, not the e2e suite. Reverting unblocks the release; I'll reopen a corrected PR.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (pure revert to a previously-green commit)
- [x] `pnpm lint` passes
- [ ] `pnpm test` — relying on CI; this restores the previously-green tree
- [ ] `pnpm format` — n/a, revert only
- [ ] Tests — n/a (revert)
- [x] User-visible strings — n/a
- [x] Changeset — n/a; the revert removes #1359's unreleased changeset, so the feature simply won't ship in this release
- [ ] Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (OpenCode)