### PR TITLE
perf(core): lazily load sandboxed plugins

### DIFF
--- a/.changeset/lazy-sandboxed-plugins.md
+++ b/.changeset/lazy-sandboxed-plugins.md
@@ -1,0 +1,11 @@
+---
+"emdash": patch
+---
+
+Lazily load sandboxed plugins so they no longer block the first request of a cold isolate.
+
+Previously, every build-time sandboxed plugin was provisioned on the Worker Loader during runtime init, so the first request of each cold isolate — including anonymous reads — waited on plugins it never exercised. A write-only plugin (declaring only `content:afterSave`/`afterDelete`, for example) could add over a second to content reads that never trigger it.
+
+Plugins are now registered (cheap, synchronous) at init and loaded on first use of an extension point they actually declare. At build time the integration reads each plugin's `dist/manifest.json` and emits its declared hooks/routes; hook and route dispatch load only the plugins relevant to the current event, preserving config order. Plugins without a manifest are treated as "unknown" and loaded eagerly to stay correct. Route authorization is seeded from declared routes, so a route can be authorized without provisioning the isolate. A public render loads no plugin that doesn't declare `page:metadata`.
+
+No public API or configuration change — purely an internal performance improvement. Marketplace/registry plugins remain eagerly loaded for now.

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 import type { AuthProviderDescriptor } from "../../auth/types.js";
 import type { MediaProviderDescriptor } from "../../media/types.js";
@@ -504,6 +504,53 @@ function resolveModulePathFromProject(specifier: string, projectRoot: string): s
 }
 
 /**
+ * Read declared hook + route names from a sandboxed plugin's built
+ * `manifest.json`, located alongside its entry file.
+ *
+ * Manifest `hooks` entries are either bare hook-name strings or
+ * `{ name, priority?, timeout? }` objects; `routes` are either strings or
+ * `{ name }` objects. Both are normalized to a flat list of names. Returns
+ * empty arrays when the manifest is missing or unreadable — the runtime treats
+ * that as "unknown" and falls back to loading the plugin, so an older plugin
+ * build without this metadata still works (just without the lazy-load win).
+ */
+/** Extract a hook/route name from a manifest entry (string or `{ name }`). */
+function manifestEntryName(entry: unknown): string | null {
+	if (typeof entry === "string") return entry;
+	if (typeof entry === "object" && entry !== null) {
+		const name = (entry as { name?: unknown }).name;
+		if (typeof name === "string") return name;
+	}
+	return null;
+}
+
+function readSandboxedPluginManifestMeta(entryFilePath: string): {
+	hooks?: string[];
+	routes?: string[];
+} {
+	try {
+		const manifestPath = resolve(dirname(entryFilePath), "manifest.json");
+		const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
+		if (typeof parsed !== "object" || parsed === null) return {};
+		const manifest = parsed as { hooks?: unknown; routes?: unknown };
+
+		const names = (value: unknown): string[] =>
+			Array.isArray(value)
+				? value.map(manifestEntryName).filter((n): n is string => n !== null)
+				: [];
+
+		// A present manifest is authoritative: an absent `hooks` key means the
+		// plugin declares none (→ never loaded for a hook). A *missing* manifest
+		// (the catch below) returns undefined → treated as "unknown" so the
+		// plugin still loads to stay correct.
+		return { hooks: names(manifest.hooks), routes: names(manifest.routes) };
+	} catch {
+		// No manifest, or unparseable — leave undefined ("unknown").
+		return {};
+	}
+}
+
+/**
  * Generates the sandboxed plugins module.
  * Resolves plugin entrypoints to files, reads them, and embeds the code.
  *
@@ -540,6 +587,12 @@ export const sandboxedPlugins = [];
 
 		const code = readFileSync(filePath, "utf-8");
 
+		// Read declared hooks/routes from the plugin's built manifest (a sibling
+		// of the entry file). These let the runtime lazily load the plugin only
+		// when a hook it declares fires or a route it owns is hit — a content
+		// read that touches none of its extension points never provisions it.
+		const { hooks, routes } = readSandboxedPluginManifestMeta(filePath);
+
 		// Create the plugin entry with embedded code and sandbox config
 		pluginEntries.push(`{
     id: ${JSON.stringify(descriptor.id)},
@@ -551,6 +604,8 @@ export const sandboxedPlugins = [];
     adminPages: ${JSON.stringify(descriptor.adminPages ?? [])},
     adminWidgets: ${JSON.stringify(descriptor.adminWidgets ?? [])},
     adminEntry: ${JSON.stringify(descriptor.adminEntry)},
+    hooks: ${JSON.stringify(hooks)},
+    routes: ${JSON.stringify(routes)},
     // Code read from: ${filePath}
     code: ${JSON.stringify(code)},
   }`);

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -214,6 +214,19 @@ export interface SandboxedPluginEntry {
 	 * Weaker than an existing admin DB selection — config order wins when no selection exists.
 	 */
 	preferred?: string[];
+	/**
+	 * Hook names the plugin declares (from its built `manifest.json`). Used to
+	 * decide, without loading the plugin, whether a given hook dispatch needs
+	 * it. Absent/empty means "unknown" — the runtime then falls back to loading
+	 * the plugin to preserve correctness (legacy behaviour for plugins built
+	 * before manifests carried hook metadata).
+	 */
+	hooks?: string[];
+	/**
+	 * Route names the plugin declares (from its built `manifest.json`). Lets
+	 * route auth resolve without loading the plugin.
+	 */
+	routes?: string[];
 }
 
 /**
@@ -334,11 +347,38 @@ const marketplaceManifestCache = new Map<
 		id: string;
 		version: string;
 		admin?: { pages?: PluginAdminPage[]; widgets?: PluginDashboardWidget[] };
+		/** Declared hook names — lets dispatch decide whether to load the plugin. */
+		hooks?: string[];
+		/** Declared route names. */
+		routes?: string[];
 	}
 >();
 /** Route metadata for sandboxed plugins: pluginId -> routeName -> RouteMeta */
 const sandboxedRouteMetaCache = new Map<string, Map<string, RouteMeta>>();
 let sandboxRunner: SandboxRunner | null = null;
+/**
+ * In-flight on-demand loads, keyed by `${id}:${version}`. Dedupes concurrent
+ * first-use loads of the same sandboxed plugin so two simultaneous dispatches
+ * don't both provision it (mirrors the dbInitPromise pattern).
+ */
+const sandboxedLoadPromises = new Map<string, Promise<SandboxedPluginInstance | null>>();
+
+/**
+ * Reset the per-isolate sandboxed-plugin module state.
+ *
+ * @internal Test-only. These caches are module-level so they persist across
+ * requests within a worker isolate (the intended production behavior); tests
+ * that construct multiple runtimes need to clear them for isolation.
+ */
+export function __resetSandboxStateForTests(): void {
+	sandboxedPluginCache.clear();
+	marketplacePluginKeys.clear();
+	registryPluginKeys.clear();
+	marketplaceManifestCache.clear();
+	sandboxedRouteMetaCache.clear();
+	sandboxedLoadPromises.clear();
+	sandboxRunner = null;
+}
 
 /**
  * EmDashRuntime - singleton per worker
@@ -659,18 +699,21 @@ export class EmDashRuntime {
 				this.sandboxedPlugins.set(key, loaded);
 				keySet.add(key);
 
-				// Cache manifest admin config for getManifest()
+				// Cache manifest admin config + declared hooks/routes for
+				// getManifest() and lazy hook/route dispatch.
+				const normalizedRoutes = bundle.manifest.routes.map(normalizeManifestRoute);
 				marketplaceManifestCache.set(pluginId, {
 					id: bundle.manifest.id,
 					version: bundle.manifest.version,
 					admin: bundle.manifest.admin,
+					hooks: bundle.manifest.hooks.map((h) => (typeof h === "string" ? h : h.name)),
+					routes: normalizedRoutes.map((r) => r.name),
 				});
 
 				// Cache route metadata from manifest for auth decisions
-				if (bundle.manifest.routes.length > 0) {
+				if (normalizedRoutes.length > 0) {
 					const routeMetaMap = new Map<string, RouteMeta>();
-					for (const entry of bundle.manifest.routes) {
-						const normalized = normalizeManifestRoute(entry);
+					for (const normalized of normalizedRoutes) {
 						routeMetaMap.set(normalized.name, { public: normalized.public === true });
 					}
 					sandboxedRouteMetaCache.set(pluginId, routeMetaMap);
@@ -1045,10 +1088,13 @@ export class EmDashRuntime {
 		};
 		const pipeline = createHookPipeline(enabledPluginList, pipelineFactoryOptions);
 
-		// Load sandboxed plugins (build-time, sandbox runner path)
-		const sandboxedPlugins = await phase("rt.sandbox", "Sandboxed plugins", () =>
-			EmDashRuntime.loadSandboxedPlugins(deps, db, storage),
-		);
+		// Register build-time sandboxed plugins WITHOUT loading them. Each is
+		// provisioned on first use (hook fire / route hit / page-metadata
+		// contribution), so cold reads aren't blocked on the Worker Loader.
+		// Registration is cheap and synchronous; the loaded-instance cache
+		// starts empty and fills lazily.
+		EmDashRuntime.registerSandboxedPlugins(deps, db, storage);
+		const sandboxedPlugins = sandboxedPluginCache;
 
 		// Cold-start: load marketplace-installed plugins from site R2 via
 		// the sandbox runner. In bypass mode this was already handled above.
@@ -1443,75 +1489,110 @@ export class EmDashRuntime {
 	/**
 	 * Load sandboxed plugins using SandboxRunner
 	 */
-	private static async loadSandboxedPlugins(
+	/**
+	 * Lazily construct the per-isolate sandbox runner (cheap — it only reads
+	 * bindings; it does not provision any isolate). Returns null when sandboxing
+	 * is disabled or no factory is configured.
+	 */
+	private static ensureSandboxRunner(
 		deps: RuntimeDependencies,
 		db: Kysely<Database>,
 		mediaStorage?: Storage | null,
-	): Promise<Map<string, SandboxedPluginInstance>> {
-		// Return cached plugins if already loaded
-		if (sandboxedPluginCache.size > 0) {
-			return sandboxedPluginCache;
-		}
+	): SandboxRunner | null {
+		if (sandboxRunner) return sandboxRunner;
+		if (!deps.sandboxEnabled || !deps.createSandboxRunner) return null;
+		sandboxRunner = deps.createSandboxRunner({
+			db,
+			mediaStorage: mediaStorage
+				? {
+						upload: (opts) =>
+							mediaStorage.upload({
+								key: opts.key,
+								body: opts.body,
+								contentType: opts.contentType,
+							}),
+						delete: (key) => mediaStorage.delete(key),
+					}
+				: undefined,
+		});
+		return sandboxRunner;
+	}
 
-		// Check if sandboxing is enabled
-		if (!deps.sandboxEnabled) {
-			return sandboxedPluginCache;
-		}
+	/**
+	 * Register build-time sandboxed plugins WITHOUT provisioning them.
+	 *
+	 * Each plugin is loaded on demand the first time one of its extension
+	 * points is actually exercised (a hook it declares fires, a route it owns
+	 * is hit, or it contributes page metadata) — see
+	 * {@link ensureSandboxedPluginLoaded}. A content read that touches none of
+	 * a plugin's extension points never provisions it, so cold reads aren't
+	 * blocked on the Worker Loader.
+	 *
+	 * Registration is cheap and synchronous: it constructs the runner (to warn
+	 * early if the platform can't run sandboxes) and seeds route-auth metadata
+	 * from each plugin's declared routes so route authorization resolves
+	 * without loading the isolate.
+	 */
+	private static registerSandboxedPlugins(
+		deps: RuntimeDependencies,
+		db: Kysely<Database>,
+		mediaStorage?: Storage | null,
+	): void {
+		if (!deps.sandboxEnabled || deps.sandboxBypassed) return;
+		if (deps.sandboxedPluginEntries.length === 0) return;
 
-		// Create sandbox runner if not exists
-		if (!sandboxRunner && deps.createSandboxRunner) {
-			sandboxRunner = deps.createSandboxRunner({
-				db,
-				mediaStorage: mediaStorage
-					? {
-							upload: (opts) =>
-								mediaStorage.upload({
-									key: opts.key,
-									body: opts.body,
-									contentType: opts.contentType,
-								}),
-							delete: (key) => mediaStorage.delete(key),
-						}
-					: undefined,
-			});
-		}
-
-		if (!sandboxRunner) {
-			return sandboxedPluginCache;
-		}
-
-		// Check if the runner is actually available (has required bindings).
-		// Warn regardless of whether there are plugins to load, so operators
-		// see the issue even if no marketplace plugins are installed yet.
-		if (!sandboxRunner.isAvailable()) {
+		const runner = EmDashRuntime.ensureSandboxRunner(deps, db, mediaStorage);
+		if (!runner) return;
+		if (!runner.isAvailable()) {
 			console.warn(
 				"EmDash: Plugin sandbox is configured but not available on this platform. " +
 					"Sandboxed plugins will not be loaded. " +
 					"If using @emdash-cms/sandbox-workerd/sandbox, ensure workerd is installed.",
 			);
-			return sandboxedPluginCache;
+			return;
 		}
 
-		if (deps.sandboxedPluginEntries.length === 0) {
-			return sandboxedPluginCache;
-		}
-
-		// sandbox: false escape hatch is handled separately (before pipeline
-		// creation) via loadBypassedPlugins. If we somehow reach here with the
-		// flag set, just return — the plugins are already in the trusted pipeline.
-		if (deps.sandboxBypassed) {
-			return sandboxedPluginCache;
-		}
-
-		// Load each sandboxed plugin via sandbox runner
+		// Seed route-auth metadata from declared routes so getPluginRouteMeta()
+		// can authorize a sandboxed route without provisioning the isolate.
+		// (Build-time sandboxed routes are private, matching prior behavior.)
 		for (const entry of deps.sandboxedPluginEntries) {
-			const pluginKey = `${entry.id}:${entry.version}`;
-			if (sandboxedPluginCache.has(pluginKey)) {
-				continue;
-			}
+			if (!entry.routes || entry.routes.length === 0) continue;
+			if (sandboxedRouteMetaCache.has(entry.id)) continue;
+			const routeMeta = new Map<string, RouteMeta>();
+			for (const name of entry.routes) routeMeta.set(name, { public: false });
+			sandboxedRouteMetaCache.set(entry.id, routeMeta);
+		}
+	}
 
+	/**
+	 * Provision a sandboxed plugin on first use and memoize it for the isolate.
+	 *
+	 * Returns the already-loaded instance when present (covers eagerly-loaded
+	 * marketplace/registry plugins and previously lazy-loaded build plugins).
+	 * Otherwise loads the matching build-time entry via the sandbox runner,
+	 * deduping concurrent first-loads. Returns null when the plugin isn't a
+	 * loadable build entry, the runner is unavailable, the load fails, or the
+	 * plugin was disabled while loading.
+	 */
+	async ensureSandboxedPluginLoaded(pluginId: string): Promise<SandboxedPluginInstance | null> {
+		const existing = this.findSandboxedPlugin(pluginId);
+		if (existing) return existing;
+		if (!this.isPluginEnabled(pluginId)) return null;
+
+		// Only build-time entries are lazily loadable here; marketplace/registry
+		// plugins are provisioned at cold start.
+		const entry = this.sandboxedPluginEntries.find((e) => e.id === pluginId);
+		if (!entry) return null;
+
+		const key = `${entry.id}:${entry.version}`;
+		const inflight = sandboxedLoadPromises.get(key);
+		if (inflight) return inflight;
+
+		const loadPromise = (async (): Promise<SandboxedPluginInstance | null> => {
 			try {
-				// Build manifest from entry's declared config
+				const runner = EmDashRuntime.ensureSandboxRunner(this.runtimeDeps, this._db, this.storage);
+				if (!runner || !runner.isAvailable()) return null;
+
 				const manifest: PluginManifest = {
 					id: entry.id,
 					version: entry.version,
@@ -1523,17 +1604,71 @@ export class EmDashRuntime {
 					admin: {},
 				};
 
-				const plugin = await sandboxRunner.load(manifest, entry.code);
-				sandboxedPluginCache.set(pluginKey, plugin);
+				const loaded = await runner.load(manifest, entry.code);
+
+				// State can change while awaiting the load; don't cache a plugin
+				// that was disabled in the meantime.
+				if (!this.isPluginEnabled(pluginId)) {
+					await loaded.terminate().catch(() => {});
+					return null;
+				}
+
+				// Write both the module cache (per-isolate) and the instance map
+				// (`findSandboxedPlugin` reads the latter); in production they are
+				// the same Map, but keep them in sync defensively — mirrors the
+				// marketplace/registry sync path.
+				sandboxedPluginCache.set(key, loaded);
+				this.sandboxedPlugins.set(key, loaded);
 				console.log(
-					`EmDash: Loaded sandboxed plugin ${pluginKey} with capabilities: [${manifest.capabilities.join(", ")}]`,
+					`EmDash: Loaded sandboxed plugin ${key} with capabilities: [${manifest.capabilities.join(", ")}]`,
 				);
+				return loaded;
 			} catch (error) {
 				console.error(`EmDash: Failed to load sandboxed plugin ${entry.id}:`, error);
+				return null;
+			} finally {
+				sandboxedLoadPromises.delete(key);
 			}
-		}
+		})();
 
-		return sandboxedPluginCache;
+		sandboxedLoadPromises.set(key, loadPromise);
+		return loadPromise;
+	}
+
+	/**
+	 * All sandboxed plugins that *could* run in this isolate, with their
+	 * declared hook names — build-time entries first (config order), then
+	 * runtime-installed (marketplace, then registry). Iterated by hook/route
+	 * dispatch to decide which plugins to load on demand, without provisioning
+	 * any. Insertion order preserves the previous dispatch order.
+	 */
+	private *sandboxedCandidates(): Generator<{
+		id: string;
+		version: string;
+		hooks?: string[];
+	}> {
+		for (const entry of this.sandboxedPluginEntries) {
+			yield { id: entry.id, version: entry.version, hooks: entry.hooks };
+		}
+		for (const manifest of marketplaceManifestCache.values()) {
+			yield { id: manifest.id, version: manifest.version, hooks: manifest.hooks };
+		}
+	}
+
+	/**
+	 * Whether a candidate declares the given hook. Unknown declared-hook
+	 * metadata (`undefined`, e.g. a plugin built before manifests carried hook
+	 * lists) is treated as "might declare it" → load to stay correct.
+	 */
+	private static candidateDeclaresHook(hooks: string[] | undefined, event: string): boolean {
+		return hooks === undefined || hooks.includes(event);
+	}
+
+	/** Whether a plugin id is a registered sandboxed plugin (loaded or not). */
+	private isSandboxedPluginRegistered(pluginId: string): boolean {
+		if (this.sandboxedPluginEntries.some((e) => e.id === pluginId)) return true;
+		if (marketplaceManifestCache.has(pluginId)) return true;
+		return this.findSandboxedPlugin(pluginId) !== undefined;
 	}
 
 	/**
@@ -1559,25 +1694,12 @@ export class EmDashRuntime {
 	): Promise<void> {
 		// Ensure sandbox runner exists with media storage wired up.
 		// (storage here is the media Storage adapter from the runtime.)
-		if (!sandboxRunner && deps.createSandboxRunner) {
-			sandboxRunner = deps.createSandboxRunner({
-				db,
-				mediaStorage: {
-					upload: (opts) =>
-						storage.upload({
-							key: opts.key,
-							body: opts.body,
-							contentType: opts.contentType,
-						}),
-					delete: (key) => storage.delete(key),
-				},
-			});
-		}
+		const runner = EmDashRuntime.ensureSandboxRunner(deps, db, storage);
 		// In sandbox bypass mode, marketplace plugins are loaded in-process
 		// BEFORE pipeline creation by EmDashRuntime.create(). Skip here.
 		if (deps.sandboxBypassed) return;
 
-		if (!sandboxRunner || !sandboxRunner.isAvailable()) {
+		if (!runner || !runner.isAvailable()) {
 			return;
 		}
 
@@ -1609,22 +1731,29 @@ export class EmDashRuntime {
 						continue;
 					}
 
-					const loaded = await sandboxRunner.load(bundle.manifest, bundle.backendCode);
+					const loaded = await runner.load(bundle.manifest, bundle.backendCode);
 					cache.set(pluginKey, loaded);
 					keySet.add(pluginKey);
 
-					// Cache manifest admin config for getManifest()
+					// Normalize declared route names (preserving public flags for
+					// route auth) and hook names (for lazy dispatch decisions).
+					const normalizedRoutes = bundle.manifest.routes.map(normalizeManifestRoute);
+					const hookNames = bundle.manifest.hooks.map((h) => (typeof h === "string" ? h : h.name));
+
+					// Cache manifest admin config + declared hooks/routes for
+					// getManifest() and the lazy hook/route dispatch candidate list.
 					marketplaceManifestCache.set(plugin.pluginId, {
 						id: bundle.manifest.id,
 						version: bundle.manifest.version,
 						admin: bundle.manifest.admin,
+						hooks: hookNames,
+						routes: normalizedRoutes.map((r) => r.name),
 					});
 
 					// Cache route metadata from manifest for auth decisions
-					if (bundle.manifest.routes.length > 0) {
+					if (normalizedRoutes.length > 0) {
 						const routeMeta = new Map<string, RouteMeta>();
-						for (const entry of bundle.manifest.routes) {
-							const normalized = normalizeManifestRoute(entry);
+						for (const normalized of normalizedRoutes) {
 							routeMeta.set(normalized.name, { public: normalized.public === true });
 						}
 						sandboxedRouteMetaCache.set(plugin.pluginId, routeMeta);
@@ -2772,9 +2901,12 @@ export class EmDashRuntime {
 			}
 		}
 
-		// Fallback: if the plugin exists in the sandbox cache, allow the route.
-		// The sandbox runner will return an error if the route doesn't actually exist.
-		if (this.findSandboxedPlugin(pluginId)) {
+		// Fallback: if the plugin is a registered sandboxed plugin, allow the
+		// route (private). Checked against registered metadata, not the loaded
+		// instance, so route auth resolves without provisioning the isolate —
+		// the actual load happens in handlePluginApiRoute. The sandbox runner
+		// returns an error if the route doesn't actually exist.
+		if (this.isSandboxedPluginRegistered(pluginId)) {
 			return { public: false };
 		}
 
@@ -2812,8 +2944,9 @@ export class EmDashRuntime {
 			return routeRegistry.invoke(pluginId, routeKey, { request, body });
 		}
 
-		// Check sandboxed (marketplace) plugins second
-		const sandboxedPlugin = this.findSandboxedPlugin(pluginId);
+		// Check sandboxed plugins second — provision on demand (build-time
+		// plugins are loaded lazily; marketplace/registry are already loaded).
+		const sandboxedPlugin = await this.ensureSandboxedPluginLoaded(pluginId);
 		if (sandboxedPlugin) {
 			return this.handleSandboxedRoute(sandboxedPlugin, path, request);
 		}
@@ -2885,9 +3018,12 @@ export class EmDashRuntime {
 	): Promise<Record<string, unknown>> {
 		let result = content;
 
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [id] = pluginKey.split(":");
-			if (!id || !this.isPluginEnabled(id)) continue;
+		// Sequential to preserve the mutation chain order across plugins.
+		for (const cand of this.sandboxedCandidates()) {
+			if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:beforeSave")) continue;
+			if (!this.isPluginEnabled(cand.id)) continue;
+			const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+			if (!plugin) continue;
 
 			try {
 				const hookResult = await plugin.invokeHook("content:beforeSave", {
@@ -2904,7 +3040,7 @@ export class EmDashRuntime {
 					result = record;
 				}
 			} catch (error) {
-				console.error(`EmDash: Sandboxed plugin ${id} beforeSave hook error:`, error);
+				console.error(`EmDash: Sandboxed plugin ${cand.id} beforeSave hook error:`, error);
 			}
 		}
 
@@ -2912,9 +3048,11 @@ export class EmDashRuntime {
 	}
 
 	private async runSandboxedBeforeDelete(id: string, collection: string): Promise<boolean> {
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [pluginId] = pluginKey.split(":");
-			if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
+		for (const cand of this.sandboxedCandidates()) {
+			if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:beforeDelete")) continue;
+			if (!this.isPluginEnabled(cand.id)) continue;
+			const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+			if (!plugin) continue;
 
 			try {
 				const result = await plugin.invokeHook("content:beforeDelete", {
@@ -2925,7 +3063,7 @@ export class EmDashRuntime {
 					return false;
 				}
 			} catch (error) {
-				console.error(`EmDash: Sandboxed plugin ${pluginId} beforeDelete hook error:`, error);
+				console.error(`EmDash: Sandboxed plugin ${cand.id} beforeDelete hook error:`, error);
 			}
 		}
 
@@ -2947,18 +3085,20 @@ export class EmDashRuntime {
 				}
 			}
 
-			// Sandboxed plugins
+			// Sandboxed plugins — load (on demand) and invoke only those that
+			// declare the hook.
 			const tasks: Promise<void>[] = [];
-			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-				const [id] = pluginKey.split(":");
-				if (!id || !this.isPluginEnabled(id)) continue;
-
+			for (const cand of this.sandboxedCandidates()) {
+				if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:afterSave")) continue;
+				if (!this.isPluginEnabled(cand.id)) continue;
 				tasks.push(
 					(async () => {
 						try {
+							const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+							if (!plugin) return;
 							await plugin.invokeHook("content:afterSave", { content, collection, isNew });
 						} catch (err) {
-							console.error(`EmDash: Sandboxed plugin ${id} afterSave error:`, err);
+							console.error(`EmDash: Sandboxed plugin ${cand.id} afterSave error:`, err);
 						}
 					})(),
 				);
@@ -2976,15 +3116,18 @@ export class EmDashRuntime {
 		}
 
 		// Sandboxed plugins
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [pluginId] = pluginKey.split(":");
-			if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
-
-			plugin
-				.invokeHook("content:afterDelete", { id, collection, permanent })
-				.catch((err) =>
-					console.error(`EmDash: Sandboxed plugin ${pluginId} afterDelete error:`, err),
-				);
+		for (const cand of this.sandboxedCandidates()) {
+			if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:afterDelete")) continue;
+			if (!this.isPluginEnabled(cand.id)) continue;
+			void (async () => {
+				try {
+					const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+					if (!plugin) return;
+					await plugin.invokeHook("content:afterDelete", { id, collection, permanent });
+				} catch (err) {
+					console.error(`EmDash: Sandboxed plugin ${cand.id} afterDelete error:`, err);
+				}
+			})();
 		}
 	}
 
@@ -3001,16 +3144,17 @@ export class EmDashRuntime {
 
 			// Sandboxed plugins
 			const tasks: Promise<void>[] = [];
-			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-				const [pluginId] = pluginKey.split(":");
-				if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
-
+			for (const cand of this.sandboxedCandidates()) {
+				if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:afterPublish")) continue;
+				if (!this.isPluginEnabled(cand.id)) continue;
 				tasks.push(
 					(async () => {
 						try {
+							const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+							if (!plugin) return;
 							await plugin.invokeHook("content:afterPublish", { content, collection });
 						} catch (err) {
-							console.error(`EmDash: Sandboxed plugin ${pluginId} afterPublish error:`, err);
+							console.error(`EmDash: Sandboxed plugin ${cand.id} afterPublish error:`, err);
 						}
 					})(),
 				);
@@ -3028,15 +3172,18 @@ export class EmDashRuntime {
 		}
 
 		// Sandboxed plugins
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [pluginId] = pluginKey.split(":");
-			if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
-
-			plugin
-				.invokeHook("content:afterUnpublish", { content, collection })
-				.catch((err) =>
-					console.error(`EmDash: Sandboxed plugin ${pluginId} afterUnpublish error:`, err),
-				);
+		for (const cand of this.sandboxedCandidates()) {
+			if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "content:afterUnpublish")) continue;
+			if (!this.isPluginEnabled(cand.id)) continue;
+			void (async () => {
+				try {
+					const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+					if (!plugin) return;
+					await plugin.invokeHook("content:afterUnpublish", { content, collection });
+				} catch (err) {
+					console.error(`EmDash: Sandboxed plugin ${cand.id} afterUnpublish error:`, err);
+				}
+			})();
 		}
 	}
 
@@ -3124,10 +3271,15 @@ export class EmDashRuntime {
 			}
 		}
 
-		// Sandboxed plugins — metadata only, never fragments
-		for (const [pluginKey, plugin] of this.sandboxedPlugins) {
-			const [id] = pluginKey.split(":");
-			if (!id || !this.isPluginEnabled(id)) continue;
+		// Sandboxed plugins — metadata only, never fragments. Only plugins that
+		// declare `page:metadata` are loaded; a plugin that contributes nothing
+		// to page metadata (e.g. a write-only webhook plugin) is never
+		// provisioned on a public render — keeping cold reads fast.
+		for (const cand of this.sandboxedCandidates()) {
+			if (!EmDashRuntime.candidateDeclaresHook(cand.hooks, "page:metadata")) continue;
+			if (!this.isPluginEnabled(cand.id)) continue;
+			const plugin = await this.ensureSandboxedPluginLoaded(cand.id);
+			if (!plugin) continue;
 
 			try {
 				const result = await plugin.invokeHook("page:metadata", { page });
@@ -3140,7 +3292,7 @@ export class EmDashRuntime {
 					}
 				}
 			} catch (error) {
-				console.error(`EmDash: Sandboxed plugin ${id} page:metadata error:`, error);
+				console.error(`EmDash: Sandboxed plugin ${cand.id} page:metadata error:`, error);
 			}
 		}
 

--- a/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
+++ b/packages/core/tests/unit/astro/virtual-modules-sandbox.test.ts
@@ -110,4 +110,40 @@ describe("generateSandboxedPluginsModule", () => {
 			),
 		).toThrow(/my-broken-plugin/);
 	});
+
+	it("emits declared hooks and routes from the sibling manifest.json", async () => {
+		await setupFakeProject("dist/sandbox-entry.mjs", "export default {};");
+		await writeFile(
+			join(tmpDir, "node_modules", "@test", "plugin", "dist", "manifest.json"),
+			JSON.stringify({
+				id: "test-plugin",
+				version: "1.0.0",
+				// Mix of object form (with priority) and bare-string form.
+				hooks: [{ name: "content:afterSave", priority: 210 }, "media:afterUpload"],
+				routes: ["status", { name: "settings" }],
+			}),
+		);
+
+		const result = generateSandboxedPluginsModule(
+			[descriptor({ entrypoint: "@test/plugin/sandbox" })],
+			tmpDir,
+		);
+
+		expect(result).toContain('hooks: ["content:afterSave","media:afterUpload"]');
+		expect(result).toContain('routes: ["status","settings"]');
+	});
+
+	it("emits undefined hooks/routes when no manifest.json is present (unknown)", async () => {
+		await setupFakeProject("dist/sandbox-entry.mjs", "export default {};");
+
+		const result = generateSandboxedPluginsModule(
+			[descriptor({ entrypoint: "@test/plugin/sandbox" })],
+			tmpDir,
+		);
+
+		// Unknown metadata → undefined, so the runtime loads the plugin to stay
+		// correct rather than skipping it as "declares no hooks".
+		expect(result).toContain("hooks: undefined");
+		expect(result).toContain("routes: undefined");
+	});
 });

--- a/packages/core/tests/unit/plugins/sandbox-lazy-load.test.ts
+++ b/packages/core/tests/unit/plugins/sandbox-lazy-load.test.ts
@@ -1,0 +1,186 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EmDashConfig } from "../../../src/astro/integration/runtime.js";
+import type { Database } from "../../../src/database/types.js";
+import {
+	EmDashRuntime,
+	__resetSandboxStateForTests,
+	type SandboxedPluginEntry,
+} from "../../../src/emdash-runtime.js";
+import { createHookPipeline } from "../../../src/plugins/hooks.js";
+import type { SandboxedPluginInstance, SandboxRunner } from "../../../src/plugins/sandbox/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/** A fake loaded plugin instance with a spy on invokeHook. */
+function fakeInstance(key: string): SandboxedPluginInstance {
+	return {
+		id: key,
+		invokeHook: vi.fn(() => Promise.resolve(undefined)),
+		invokeRoute: vi.fn(() => Promise.resolve(undefined)),
+		terminate: vi.fn(() => Promise.resolve()),
+	};
+}
+
+/** A fake sandbox runner whose `load` is a spy returning fake instances. */
+function fakeRunner(): SandboxRunner & { load: ReturnType<typeof vi.fn> } {
+	const load = vi.fn((manifest: { id: string; version: string }) =>
+		Promise.resolve(fakeInstance(`${manifest.id}:${manifest.version}`)),
+	);
+	return {
+		isAvailable: () => true,
+		isHealthy: () => true,
+		load,
+		setEmailSend: () => {},
+		terminateAll: () => Promise.resolve(),
+	} as unknown as SandboxRunner & { load: ReturnType<typeof vi.fn> };
+}
+
+function buildEntry(overrides: Partial<SandboxedPluginEntry>): SandboxedPluginEntry {
+	return {
+		id: "wh",
+		version: "1.0.0",
+		options: {},
+		code: "export default {};",
+		capabilities: [],
+		allowedHosts: [],
+		storage: {},
+		...overrides,
+	};
+}
+
+function buildRuntime(
+	db: Kysely<Database>,
+	entries: SandboxedPluginEntry[],
+	runner: SandboxRunner,
+): EmDashRuntime {
+	const config: EmDashConfig = {};
+	const pipelineFactoryOptions = { db } as const;
+	const hooks = createHookPipeline([], pipelineFactoryOptions);
+	const runtimeDeps = {
+		config,
+		plugins: [],
+		// eslint-disable-next-line typescript/no-explicit-any -- match RuntimeDependencies signature
+		createDialect: (() => {
+			throw new Error("createDialect not used in this test");
+		}) as any,
+		createStorage: null,
+		sandboxEnabled: true,
+		sandboxedPluginEntries: entries,
+		createSandboxRunner: () => runner,
+	};
+
+	return new EmDashRuntime({
+		db,
+		storage: null,
+		configuredPlugins: [],
+		sandboxedPlugins: new Map(),
+		sandboxedPluginEntries: entries,
+		hooks,
+		enabledPlugins: new Set(entries.map((e) => e.id)),
+		// Empty states map → isPluginEnabled treats every plugin as enabled
+		// (status undefined). Individual tests override to "disabled" as needed.
+		pluginStates: new Map(),
+		config,
+		mediaProviders: new Map(),
+		mediaProviderEntries: [],
+		cronExecutor: null,
+		cronScheduler: null,
+		emailPipeline: null,
+		allPipelinePlugins: [],
+		pipelineFactoryOptions,
+		// eslint-disable-next-line typescript/no-explicit-any -- partial deps sufficient for these tests
+		runtimeDeps: runtimeDeps as any,
+		pipelineRef: { current: hooks },
+	});
+}
+
+const PAGE = {
+	url: new URL("https://example.com/posts/hello"),
+	pathname: "/posts/hello",
+	collection: "posts",
+	// eslint-disable-next-line typescript/no-explicit-any -- minimal page context for the metadata collector
+} as any;
+
+describe("sandboxed plugin lazy loading", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		__resetSandboxStateForTests();
+	});
+
+	afterEach(async () => {
+		__resetSandboxStateForTests();
+		await teardownTestDatabase(db);
+	});
+
+	it("does not load a write-only plugin on a public render (read path)", async () => {
+		const runner = fakeRunner();
+		// Declares only content:afterSave — nothing a public render exercises.
+		const runtime = buildRuntime(
+			db,
+			[buildEntry({ hooks: ["content:afterSave"], routes: [] })],
+			runner,
+		);
+
+		await runtime.collectPageContributions(PAGE);
+
+		expect(runner.load).not.toHaveBeenCalled();
+	});
+
+	it("loads a plugin that declares page:metadata on render, and invokes it", async () => {
+		const runner = fakeRunner();
+		const runtime = buildRuntime(
+			db,
+			[buildEntry({ hooks: ["page:metadata"], routes: [] })],
+			runner,
+		);
+
+		await runtime.collectPageContributions(PAGE);
+
+		expect(runner.load).toHaveBeenCalledTimes(1);
+		const instance = await runner.load.mock.results[0]!.value;
+		expect(instance.invokeHook).toHaveBeenCalledWith("page:metadata", { page: PAGE });
+	});
+
+	it("loads a plugin with unknown (undefined) declared hooks, to stay correct", async () => {
+		const runner = fakeRunner();
+		// hooks omitted → "unknown" (e.g. built before manifests carried hooks).
+		const runtime = buildRuntime(db, [buildEntry({ routes: [] })], runner);
+
+		await runtime.collectPageContributions(PAGE);
+
+		expect(runner.load).toHaveBeenCalledTimes(1);
+	});
+
+	it("ensureSandboxedPluginLoaded loads once and dedupes concurrent calls", async () => {
+		const runner = fakeRunner();
+		const runtime = buildRuntime(db, [buildEntry({ hooks: ["content:afterSave"] })], runner);
+
+		const [a, b] = await Promise.all([
+			runtime.ensureSandboxedPluginLoaded("wh"),
+			runtime.ensureSandboxedPluginLoaded("wh"),
+		]);
+
+		expect(runner.load).toHaveBeenCalledTimes(1);
+		expect(a).toBe(b);
+
+		// A subsequent call returns the memoized instance without reloading.
+		const c = await runtime.ensureSandboxedPluginLoaded("wh");
+		expect(runner.load).toHaveBeenCalledTimes(1);
+		expect(c).toBe(a);
+	});
+
+	it("returns null and does not load when the plugin is disabled", async () => {
+		const runner = fakeRunner();
+		const runtime = buildRuntime(db, [buildEntry({ hooks: ["content:afterSave"] })], runner);
+		// Disable it.
+		// eslint-disable-next-line typescript/no-explicit-any -- reach into private state for the test
+		(runtime as any).pluginStates.set("wh", "disabled");
+
+		const result = await runtime.ensureSandboxedPluginLoaded("wh");
+		expect(result).toBeNull();
+		expect(runner.load).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Lazily loads sandboxed plugins so they no longer block the first request of a cold isolate.

Previously, every build-time sandboxed plugin was provisioned on the Worker Loader during runtime init, so the first request of each cold isolate — **including anonymous reads** — waited on plugins it never exercised. A write-only plugin (declaring only `content:afterSave`/`afterDelete`, for example) could add over a second to content reads that never trigger it.

Plugins are now **registered** (cheap, synchronous) at init and **loaded on first use** of an extension point they actually declare:

- **Build-time:** the integration reads each plugin's `dist/manifest.json` and emits its declared hooks/routes onto the entry (`SandboxedPluginEntry` gains `hooks?`/`routes?`). Plugins without a manifest are treated as "unknown" and loaded eagerly to stay correct.
- **`create()`** registers build-time entries instead of loading them, and seeds route-auth metadata from declared routes so a route can be authorized without provisioning the isolate.
- **`ensureSandboxedPluginLoaded()`** loads a plugin on first use, memoizes per isolate, dedupes concurrent first-loads, and re-checks enabled state after load.
- **Hook/route dispatch** iterates only candidates whose declared metadata includes the event and loads only those, preserving config order. A public render loads no plugin that doesn't declare `page:metadata`.

Marketplace/registry plugins remain eagerly loaded for now (deferring them needs an R2 manifest-only fetch — follow-up). No public API or configuration change.

Closes #<!-- pending -->

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — sandbox-lazy-load + virtual-modules-sandbox suites (13 passed)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion. _n/a — performance improvement, no API change._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

```
sandbox-lazy-load.test.ts / virtual-modules-sandbox.test.ts — 13 passed
pnpm lint — 0 diagnostics; pnpm typecheck — clean
```
