### PR TITLE
i18n(id): complete byline schema admin translations

### DIFF
--- a/.changeset/fair-cows-applaud.md
+++ b/.changeset/fair-cows-applaud.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates the Indonesian admin catalog for the byline schema and custom-field management UI with formal, complete translations.

--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -37,7 +37,7 @@ msgstr " (terpilih)"
 
 #: packages/admin/src/routes/bylines.tsx:689
 msgid "-- Select --"
-msgstr ""
+msgstr "-- Pilih --"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:310
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
@@ -496,7 +496,7 @@ msgstr "Terima Undangan"
 
 #: packages/admin/src/routes/byline-schema.tsx:174
 msgid "Access denied"
-msgstr ""
+msgstr "Akses ditolak"
 
 #: packages/admin/src/router.tsx:1202
 msgid "Access Denied"
@@ -605,7 +605,7 @@ msgstr "Tambah field"
 
 #: packages/admin/src/routes/byline-schema.tsx:293
 msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
-msgstr ""
+msgstr "Tambahkan bidang seperti \"Jabatan\" atau \"Kata ganti\" untuk melengkapi setiap byline."
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:604
 msgid "Add fields to define the structure of your content"
@@ -847,7 +847,7 @@ msgstr "Terjadi kesalahan"
 
 #: packages/admin/src/routes/byline-schema.tsx:272
 msgid "An unexpected error occurred."
-msgstr ""
+msgstr "Terjadi kesalahan yang tidak terduga."
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:217
 msgid "An unknown error occurred"
@@ -921,7 +921,7 @@ msgstr "Arsip"
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:375
 msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
-msgstr ""
+msgstr "Apakah Anda yakin ingin menghapus \"{0}\"? Tidak ada nilai tersimpan yang merujuk ke bidang ini."
 
 #. placeholder {0}: deleteTarget.label
 #: packages/admin/src/components/ContentTypeList.tsx:145
@@ -1151,7 +1151,7 @@ msgstr "Daftar Poin"
 #: packages/admin/src/routes/byline-schema.tsx:218
 #: packages/admin/src/routes/bylines.tsx:370
 msgid "Byline schema"
-msgstr ""
+msgstr "Skema byline"
 
 #: packages/admin/src/components/ContentEditor.tsx:998
 #: packages/admin/src/components/Sidebar.tsx:363
@@ -1330,7 +1330,7 @@ msgstr "Memeriksa autentikasi..."
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr ""
+msgstr "Memeriksa berapa banyak nilai tersimpan yang merujuk ke \"{0}\"..."
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
@@ -1663,11 +1663,11 @@ msgstr "Tidak dapat mendeteksi WordPress"
 
 #: packages/admin/src/routes/byline-schema.tsx:268
 msgid "Couldn't load byline fields."
-msgstr ""
+msgstr "Tidak dapat memuat bidang byline."
 
 #: packages/admin/src/routes/bylines.tsx:530
 msgid "Couldn't load custom fields."
-msgstr ""
+msgstr "Tidak dapat memuat bidang kustom."
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:88
 msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
@@ -1680,7 +1680,7 @@ msgstr "Tidak dapat mencari byline. Silakan coba lagi."
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr ""
+msgstr "Tidak dapat memverifikasi berapa banyak nilai yang merujuk ke \"{0}\". Penghapusan tetap akan menghapus semua nilai tersimpan untuk bidang ini, tetapi jumlah di atas tidak dapat diperiksa."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:822
 msgid "Count"
@@ -1733,7 +1733,7 @@ msgstr "Buat Tipe Konten"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Create field"
-msgstr ""
+msgstr "Buat bidang"
 
 #: packages/admin/src/components/MenuList.tsx:126
 #: packages/admin/src/components/MenuList.tsx:189
@@ -1847,7 +1847,7 @@ msgstr "Dibuat"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr ""
+msgstr "\"{0}\" dibuat."
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
@@ -1973,7 +1973,7 @@ msgstr "Tentukan taksonomi baru untuk mengklasifikasikan konten"
 
 #: packages/admin/src/routes/byline-schema.tsx:220
 msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
-msgstr ""
+msgstr "Tentukan bidang kustom yang disimpan pada setiap byline - jabatan, kata ganti, akun media sosial, dan lainnya."
 
 #: packages/admin/src/components/ContentTypeList.tsx:41
 msgid "Define the structure of your content"
@@ -2044,7 +2044,7 @@ msgstr "Hapus {0}?"
 
 #: packages/admin/src/routes/byline-schema.tsx:358
 msgid "Delete byline field?"
-msgstr ""
+msgstr "Hapus bidang byline?"
 
 #: packages/admin/src/routes/bylines.tsx:605
 msgid "Delete Byline?"
@@ -2137,7 +2137,7 @@ msgstr "Dihapus"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr ""
+msgstr "Menghapus \"{0}\" juga akan menghapus {1, plural, one {# nilai tersimpan} other {# nilai tersimpan}} di semua byline. Tindakan ini tidak dapat dibatalkan."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
 #: packages/admin/src/components/ContentTypeEditor.tsx:664
@@ -2155,7 +2155,7 @@ msgstr "Menghapus..."
 
 #: packages/admin/src/routes/byline-schema.tsx:379
 msgid "Deleting…"
-msgstr ""
+msgstr "Menghapus..."
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
 #: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
@@ -2491,7 +2491,7 @@ msgstr "Sunting byline"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "Edit byline field"
-msgstr ""
+msgstr "Edit bidang byline"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
 msgid "Edit Domain"
@@ -2795,11 +2795,11 @@ msgstr "Gagal membuat kredit penulis"
 
 #: packages/admin/src/lib/api/byline-fields.ts:120
 msgid "Failed to create byline field"
-msgstr ""
+msgstr "Gagal membuat bidang byline"
 
 #: packages/admin/src/routes/byline-schema.tsx:102
 msgid "Failed to create field"
-msgstr ""
+msgstr "Gagal membuat bidang"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
@@ -2829,7 +2829,7 @@ msgstr "Gagal menghapus byline"
 
 #: packages/admin/src/lib/api/byline-fields.ts:143
 msgid "Failed to delete byline field"
-msgstr ""
+msgstr "Gagal menghapus bidang byline"
 
 #: packages/admin/src/lib/api/schema.ts:222
 msgid "Failed to delete collection"
@@ -2991,7 +2991,7 @@ msgstr "Gagal memasang plugin"
 
 #: packages/admin/src/lib/api/byline-fields.ts:98
 msgid "Failed to list byline fields"
-msgstr ""
+msgstr "Gagal memuat daftar bidang byline"
 
 #: packages/admin/src/router.tsx:247
 msgid "Failed to load admin"
@@ -3070,7 +3070,7 @@ msgstr "Gagal menerbitkan"
 
 #: packages/admin/src/lib/api/byline-fields.ts:106
 msgid "Failed to read byline field usage"
-msgstr ""
+msgstr "Gagal membaca penggunaan bidang byline"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
 msgid "Failed to remove domain"
@@ -3087,7 +3087,7 @@ msgstr "Gagal mengganti nama passkey"
 
 #: packages/admin/src/lib/api/byline-fields.ts:156
 msgid "Failed to reorder byline fields"
-msgstr ""
+msgstr "Gagal mengurutkan ulang bidang byline"
 
 #: packages/admin/src/lib/api/schema.ts:293
 #: packages/admin/src/routes/byline-schema.tsx:152
@@ -3126,7 +3126,7 @@ msgstr "Gagal menyimpan"
 
 #: packages/admin/src/routes/byline-schema.tsx:122
 msgid "Failed to save field"
-msgstr ""
+msgstr "Gagal menyimpan bidang"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:58
 #: packages/admin/src/components/settings/SeoSettings.tsx:62
@@ -3183,7 +3183,7 @@ msgstr "Gagal memperbarui kredit penulis"
 
 #: packages/admin/src/lib/api/byline-fields.ts:135
 msgid "Failed to update byline field"
-msgstr ""
+msgstr "Gagal memperbarui bidang byline"
 
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
 msgid "Failed to update domain"
@@ -3233,11 +3233,11 @@ msgstr "Mengambil konten dari API Eksportir EmDash."
 
 #: packages/admin/src/routes/byline-schema.tsx:95
 msgid "Field created"
-msgstr ""
+msgstr "Bidang dibuat"
 
 #: packages/admin/src/routes/byline-schema.tsx:133
 msgid "Field deleted"
-msgstr ""
+msgstr "Bidang dihapus"
 
 #: packages/admin/src/components/FieldEditor.tsx:567
 msgid "Field label"
@@ -3253,11 +3253,11 @@ msgstr "Slug field tidak dapat diubah setelah dibuat"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:268
 msgid "Field type cannot be changed after creation."
-msgstr ""
+msgstr "Tipe bidang tidak dapat diubah setelah dibuat."
 
 #: packages/admin/src/routes/byline-schema.tsx:115
 msgid "Field updated"
-msgstr ""
+msgstr "Bidang diperbarui"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:572
 msgid "Fields"
@@ -3793,11 +3793,11 @@ msgstr "Jane Doe"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
-msgstr ""
+msgstr "Jabatan"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:246
 msgid "job_title"
-msgstr ""
+msgstr "jabatan"
 
 #: packages/admin/src/components/FieldEditor.tsx:222
 msgid "JSON"
@@ -3956,7 +3956,7 @@ msgstr "Muat Lebih"
 
 #: packages/admin/src/routes/byline-schema.tsx:257
 msgid "Loading byline fields…"
-msgstr ""
+msgstr "Memuat bidang byline..."
 
 #: packages/admin/src/components/ContentTypeList.tsx:114
 msgid "Loading collections..."
@@ -4053,7 +4053,7 @@ msgstr "Kunci rasio aspek"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:291
 msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
-msgstr ""
+msgstr "Dikunci karena bidang ini memiliki nilai tersimpan. Hapus nilainya (atau bidangnya) untuk mengubahnya."
 
 #: packages/admin/src/components/Header.tsx:101
 msgid "Log out"
@@ -4070,7 +4070,7 @@ msgstr "Logo & favicon"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
-msgstr ""
+msgstr "Teks panjang"
 
 #: packages/admin/src/components/FieldEditor.tsx:156
 #: packages/admin/src/components/FieldEditor.tsx:580
@@ -4328,12 +4328,12 @@ msgstr "Terpopuler"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "Pindahkan \"{0}\" ke bawah"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "Pindahkan \"{0}\" ke atas"
 
 #: packages/admin/src/components/ContentList.tsx:653
 msgid "Move \"{title}\" to trash? You can restore it later."
@@ -4430,7 +4430,7 @@ msgstr "{collectionLabel} Baru"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:209
 msgid "New byline field"
-msgstr ""
+msgstr "Bidang byline baru"
 
 #: packages/admin/src/components/WordPressImport.tsx:1818
 msgid "New collection"
@@ -4443,7 +4443,7 @@ msgstr "Tipe Konten Baru"
 
 #: packages/admin/src/routes/byline-schema.tsx:224
 msgid "New field"
-msgstr ""
+msgstr "Bidang baru"
 
 #: packages/admin/src/components/CapabilityConsentDialog.tsx:116
 msgid "New public routes"
@@ -4502,7 +4502,7 @@ msgstr "Tidak"
 
 #: packages/admin/src/routes/byline-schema.tsx:420
 msgid "No (shared across translations)"
-msgstr ""
+msgstr "Tidak (dibagikan di semua terjemahan)"
 
 #. placeholder {0}: taxonomy.label.toLowerCase()
 #: packages/admin/src/components/TaxonomySidebar.tsx:434
@@ -4538,7 +4538,7 @@ msgstr "Belum ada komentar disetujui."
 
 #: packages/admin/src/routes/byline-schema.tsx:291
 msgid "No byline fields yet."
-msgstr ""
+msgstr "Belum ada bidang byline."
 
 #: packages/admin/src/components/ContentEditor.tsx:2057
 msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
@@ -5660,7 +5660,7 @@ msgstr "Simpan teks alternatif"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Save changes"
-msgstr ""
+msgstr "Simpan perubahan"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:560
 #: packages/admin/src/components/users/UserDetail.tsx:311
@@ -5698,7 +5698,7 @@ msgstr "Tersimpan"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "\"{0}\" disimpan."
 
 #: packages/admin/src/components/ContentEditor.tsx:651
 #: packages/admin/src/components/ContentEditor.tsx:2279
@@ -5723,7 +5723,7 @@ msgstr "Menyimpan..."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:318
 msgid "Saving…"
-msgstr ""
+msgstr "Menyimpan..."
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:467
 msgid "SBOM"
@@ -6227,11 +6227,11 @@ msgstr "Bagikan tautan ini dengan pengguna yang diundang"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:294
 msgid "Shared across all translations of the same byline."
-msgstr ""
+msgstr "Dibagikan di semua terjemahan untuk byline yang sama."
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:52
 msgid "Short text"
-msgstr ""
+msgstr "Teks pendek"
 
 #: packages/admin/src/components/FieldEditor.tsx:150
 #: packages/admin/src/components/FieldEditor.tsx:579
@@ -6369,7 +6369,7 @@ msgstr "Slug disalin ke papan klip"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:251
 msgid "Slugs cannot be changed after the field is created."
-msgstr ""
+msgstr "Slug tidak dapat diubah setelah bidang dibuat."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:904
 msgid "Small section heading"
@@ -6460,7 +6460,7 @@ msgstr "Kode status"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:293
 msgid "Stored per locale — each translation of a byline gets its own value."
-msgstr ""
+msgstr "Disimpan per lokal - setiap terjemahan byline memiliki nilainya sendiri."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2562
 #: packages/admin/src/components/PortableTextEditor.tsx:2868
@@ -6827,7 +6827,7 @@ msgstr "Lacak riwayat konten"
 #: packages/admin/src/components/BylineFieldEditor.tsx:287
 #: packages/admin/src/routes/byline-schema.tsx:243
 msgid "Translatable"
-msgstr ""
+msgstr "Dapat diterjemahkan"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:83
 #: packages/admin/src/components/TaxonomyManager.tsx:194
@@ -7548,7 +7548,7 @@ msgstr "Anda dapat mengelola konten, media, menu, dan taksonomi."
 
 #: packages/admin/src/routes/bylines.tsx:532
 msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
-msgstr ""
+msgstr "Anda masih dapat mengedit bidang tetap di atas. Penyimpanan tidak akan mengubah nilai bidang kustom yang sudah tersimpan."
 
 #: packages/admin/src/components/WelcomeModal.tsx:44
 msgid "You can view and contribute to the site."
@@ -7564,7 +7564,7 @@ msgstr "Anda memiliki akses penuh untuk mengelola situs ini, termasuk pengguna, 
 
 #: packages/admin/src/routes/byline-schema.tsx:175
 msgid "You need admin permissions to manage byline schema."
-msgstr ""
+msgstr "Anda memerlukan izin admin untuk mengelola skema byline."
 
 #: packages/admin/src/router.tsx:1203
 msgid "You need Editor permissions to moderate comments."


### PR DESCRIPTION
## What does this PR do?

Completes the current batch of missing Indonesian (`id`) admin translations for the byline schema and custom-field management UI, using formal Indonesian wording that matches the existing catalog style.

Closes #1383

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode + GPT-5.4

## Screenshots / test output

Verification run locally:

- `pnpm install`
- `pnpm format`
- `pnpm --filter @emdash-cms/registry-client build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `rg -U '^msgid ".+"\\nmsgstr ""$' packages/admin/src/locales/id/messages.po`
- `git diff --check`

Additional notes:

- `pnpm test` passed with existing Vitest deprecation warnings in `packages/admin`, but no test failures.
- `@emdash-cms/registry-client` needed a local build in this workspace before the full verification run so the `./env` subpath export existed for dependent packages during typecheck/test.
