### PR TITLE
[codex] Skip core SEO routes when site routes exist

### DIFF
--- a/.changeset/seo-route-overrides.md
+++ b/.changeset/seo-route-overrides.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Skips default robots.txt and sitemap.xml route injection when the host site defines its own root routes.

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -315,7 +315,7 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 				});
 
 				// Inject all core routes
-				injectCoreRoutes(injectRoute);
+				injectCoreRoutes(injectRoute, { srcDir: astroConfig.srcDir });
 
 				// Inject routes from pluggable auth providers (authProviders config)
 				if (resolvedConfig.authProviders?.length) {

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -46,7 +46,18 @@ interface InjectCoreRoutesOptions {
 	srcDir?: URL;
 }
 
-const ROUTE_OVERRIDE_EXTENSIONS = [".astro", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts"];
+const ROUTE_OVERRIDE_EXTENSIONS = [
+	".astro",
+	".js",
+	".ts",
+	".jsx",
+	".tsx",
+	".mjs",
+	".mts",
+	".md",
+	".mdx",
+	".html",
+];
 
 /**
  * Detect whether the host site defines its own root-level public route file.

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -4,6 +4,7 @@
  * Defines and injects all EmDash routes into the Astro application.
  */
 
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -41,10 +42,31 @@ function resolveRoute(route: string): string {
 /** Route injection function type */
 type InjectRoute = (route: { pattern: string; entrypoint: string }) => void;
 
+interface InjectCoreRoutesOptions {
+	srcDir?: URL;
+}
+
+const ROUTE_OVERRIDE_EXTENSIONS = [".astro", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".mts"];
+
+/**
+ * Detect whether the host site defines its own root-level public route file.
+ */
+export function hasUserDefinedPublicRoute(srcDir: URL, basename: string): boolean {
+	const srcDirPath = fileURLToPath(srcDir);
+	return ROUTE_OVERRIDE_EXTENSIONS.some(
+		(extension) =>
+			existsSync(resolve(srcDirPath, "pages", `${basename}${extension}`)) ||
+			existsSync(resolve(srcDirPath, "pages", basename, `index${extension}`)),
+	);
+}
+
 /**
  * Injects all core EmDash routes.
  */
-export function injectCoreRoutes(injectRoute: InjectRoute): void {
+export function injectCoreRoutes(
+	injectRoute: InjectRoute,
+	options: InjectCoreRoutesOptions = {},
+): void {
 	// Inject admin shell route
 	injectRoute({
 		pattern: "/_emdash/admin/[...path]",
@@ -746,20 +768,24 @@ export function injectCoreRoutes(injectRoute: InjectRoute): void {
 	});
 
 	// SEO routes (public, at site root)
-	injectRoute({
-		pattern: "/sitemap.xml",
-		entrypoint: resolveRoute("sitemap.xml.ts"),
-	});
+	if (!options.srcDir || !hasUserDefinedPublicRoute(options.srcDir, "sitemap.xml")) {
+		injectRoute({
+			pattern: "/sitemap.xml",
+			entrypoint: resolveRoute("sitemap.xml.ts"),
+		});
+	}
 
 	injectRoute({
 		pattern: "/sitemap-[collection].xml",
 		entrypoint: resolveRoute("sitemap-[collection].xml.ts"),
 	});
 
-	injectRoute({
-		pattern: "/robots.txt",
-		entrypoint: resolveRoute("robots.txt.ts"),
-	});
+	if (!options.srcDir || !hasUserDefinedPublicRoute(options.srcDir, "robots.txt")) {
+		injectRoute({
+			pattern: "/robots.txt",
+			entrypoint: resolveRoute("robots.txt.ts"),
+		});
+	}
 
 	// Setup wizard API routes
 	injectRoute({

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -1,6 +1,14 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
 import { describe, expect, it, vi } from "vitest";
 
-import { injectCoreRoutes } from "../../../src/astro/integration/routes.js";
+import {
+	hasUserDefinedPublicRoute,
+	injectCoreRoutes,
+} from "../../../src/astro/integration/routes.js";
 import { GET as getMediaFile } from "../../../src/astro/routes/api/media/file/[...key].js";
 
 function mockMediaContext(key: string | undefined) {
@@ -24,6 +32,27 @@ function mockMediaContext(key: string | undefined) {
 }
 
 describe("core media route injection", () => {
+	async function withTempSrcDir(files: Record<string, string>, fn: (srcDir: URL) => void) {
+		const root = await mkdtemp(join(tmpdir(), "emdash-routes-"));
+		try {
+			const srcDir = join(root, "src");
+			for (const [filePath, contents] of Object.entries(files)) {
+				const fullPath = join(srcDir, filePath);
+				await mkdir(dirname(fullPath), { recursive: true });
+				await writeFile(fullPath, contents);
+			}
+			fn(pathToFileURL(srcDir));
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+
+	function collectRoutePatterns(srcDir?: URL): string[] {
+		const routes: Array<{ pattern: string; entrypoint: string }> = [];
+		injectCoreRoutes((route) => routes.push(route), { srcDir });
+		return routes.map((route) => route.pattern);
+	}
+
 	it("uses a catch-all media file route so storage keys can contain slashes", () => {
 		const routes: Array<{ pattern: string; entrypoint: string }> = [];
 		injectCoreRoutes((route) => {
@@ -41,6 +70,46 @@ describe("core media route injection", () => {
 				// output placeholders can't mangle dynamic-route filenames.
 				entrypoint: expect.stringContaining("api/media/file/_...key_"),
 			}),
+		);
+	});
+
+	it("injects default root SEO routes when the site does not define them", () => {
+		const routes = collectRoutePatterns();
+
+		expect(routes).toContain("/robots.txt");
+		expect(routes).toContain("/sitemap.xml");
+		expect(routes).toContain("/sitemap-[collection].xml");
+	});
+
+	it("skips root SEO routes that are defined by the site", async () => {
+		await withTempSrcDir(
+			{
+				"pages/robots.txt.ts": "export const GET = () => new Response('');",
+				"pages/sitemap.xml.ts": "export const GET = () => new Response('');",
+			},
+			(srcDir) => {
+				const routes = collectRoutePatterns(srcDir);
+
+				expect(routes).not.toContain("/robots.txt");
+				expect(routes).not.toContain("/sitemap.xml");
+				expect(routes).toContain("/sitemap-[collection].xml");
+			},
+		);
+	});
+
+	it("detects index route files for root public route overrides", async () => {
+		await withTempSrcDir(
+			{
+				"pages/robots.txt/index.ts": "export const GET = () => new Response('');",
+			},
+			(srcDir) => {
+				const routes = collectRoutePatterns(srcDir);
+
+				expect(hasUserDefinedPublicRoute(srcDir, "robots.txt")).toBe(true);
+				expect(hasUserDefinedPublicRoute(srcDir, "sitemap.xml")).toBe(false);
+				expect(routes).not.toContain("/robots.txt");
+				expect(routes).toContain("/sitemap.xml");
+			},
 		);
 	});
 });

--- a/packages/core/tests/unit/astro/routes.test.ts
+++ b/packages/core/tests/unit/astro/routes.test.ts
@@ -112,6 +112,23 @@ describe("core media route injection", () => {
 			},
 		);
 	});
+
+	it("detects markdown and html route files for root public route overrides", async () => {
+		await withTempSrcDir(
+			{
+				"pages/robots.txt.md": "# Robots",
+				"pages/sitemap.xml/index.html": "<html></html>",
+			},
+			(srcDir) => {
+				const routes = collectRoutePatterns(srcDir);
+
+				expect(hasUserDefinedPublicRoute(srcDir, "robots.txt")).toBe(true);
+				expect(hasUserDefinedPublicRoute(srcDir, "sitemap.xml")).toBe(true);
+				expect(routes).not.toContain("/robots.txt");
+				expect(routes).not.toContain("/sitemap.xml");
+			},
+		);
+	});
 });
 
 describe("media file catch-all route", () => {


### PR DESCRIPTION
## What does this PR do?

Skips EmDash's default root `robots.txt` and `sitemap.xml` route injection when the host Astro site already defines its own matching root route under `src/pages`.

This avoids duplicate static route warnings today and prevents future Astro versions from turning those duplicate root routes into hard errors. Per-collection EmDash sitemaps (`/sitemap-[collection].xml`) continue to be injected.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex GPT-5

## Screenshots / test output

Validation run locally:

```text
pnpm --silent lint:json | jq '.diagnostics | length'
# 0

pnpm lint
# passes

pnpm typecheck
# passes

pnpm --dir packages/core exec vitest run tests/unit/astro/routes.test.ts
# Test Files  1 passed (1)
# Tests  6 passed (6)

pnpm --dir packages/core typecheck
# passes

git diff --check
# passes
```

Before root `pnpm typecheck`, local package artifacts were rebuilt after refreshing `node_modules`:

```text
pnpm --filter @emdash-cms/blocks build
pnpm --filter emdash build
```
