### PR TITLE
[codex] Allow public search suggestions

### DIFF
--- a/.changeset/public-search-suggestions.md
+++ b/.changeset/public-search-suggestions.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes public LiveSearch autocomplete requests being blocked by auth middleware.

--- a/packages/core/src/astro/middleware/auth.ts
+++ b/packages/core/src/astro/middleware/auth.ts
@@ -119,6 +119,7 @@ const PUBLIC_API_EXACT = new Set([
 	// so unauthenticated callers only see published content. Admin endpoints
 	// (/enable, /rebuild, /stats) remain private because they're not in this set.
 	"/_emdash/api/search",
+	"/_emdash/api/search/suggest",
 ]);
 
 // Build merged public routes at module load from auth provider descriptors.

--- a/packages/core/tests/integration/search/suggest.test.ts
+++ b/packages/core/tests/integration/search/suggest.test.ts
@@ -47,6 +47,23 @@ describe("getSuggestions (Integration)", () => {
 		});
 	});
 
+	it("does not return draft content", async () => {
+		await repo.create(
+			createPostFixture({
+				slug: "designing-secret-things",
+				status: "draft",
+				data: { title: "Designing secret things" },
+			}),
+		);
+
+		const suggestions = await getSuggestions(db, "des", {
+			collections: ["post"],
+		});
+
+		expect(suggestions).toHaveLength(1);
+		expect(suggestions[0]?.title).toBe("Designing things");
+	});
+
 	it("returns empty array for a non-matching query", async () => {
 		const suggestions = await getSuggestions(db, "zzz", {
 			collections: ["post"],

--- a/packages/core/tests/unit/middleware/oauth-csrf.test.ts
+++ b/packages/core/tests/unit/middleware/oauth-csrf.test.ts
@@ -37,6 +37,7 @@ async function runAuthMiddleware(opts: {
 	extraHeaders?: Record<string, string>;
 }): Promise<{ response: Response; next: ReturnType<typeof vi.fn> }> {
 	const url = new URL(opts.pathname, "https://site.example.com");
+	const method = opts.method ?? "POST";
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 		...opts.extraHeaders,
@@ -53,9 +54,9 @@ async function runAuthMiddleware(opts: {
 		{
 			url,
 			request: new Request(url, {
-				method: opts.method ?? "POST",
+				method,
 				headers,
-				body: "{}",
+				body: method === "GET" || method === "HEAD" ? undefined : "{}",
 			}),
 			locals: {
 				emdash: { db: {}, config: {} },
@@ -69,6 +70,31 @@ async function runAuthMiddleware(opts: {
 
 	return { response, next };
 }
+
+describe("Public search API routes", () => {
+	it.each(["/_emdash/api/search", "/_emdash/api/search/suggest"])(
+		"allows anonymous GET to %s",
+		async (pathname) => {
+			const { response, next } = await runAuthMiddleware({
+				pathname,
+				method: "GET",
+			});
+
+			expect(next).toHaveBeenCalledOnce();
+			expect(response.status).toBe(200);
+		},
+	);
+
+	it("keeps search management endpoints private", async () => {
+		const { response, next } = await runAuthMiddleware({
+			pathname: "/_emdash/api/search/rebuild",
+			method: "GET",
+		});
+
+		expect(next).not.toHaveBeenCalled();
+		expect(response.status).toBe(401);
+	});
+});
 
 /**
  * OAuth protocol endpoints (RFC 6749, 7591, 8628) are designed to be called


### PR DESCRIPTION
## What does this PR do?

Allows anonymous GET requests to `/_emdash/api/search/suggest` so the built-in `LiveSearch` autocomplete mode works on public sites.

The route is added as an exact public API match alongside `/_emdash/api/search`; search management endpoints such as `/_emdash/api/search/rebuild` remain authenticated. The suggestion query still only returns published content, with a regression test covering draft exclusion.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex / GPT-5

## Screenshots / test output

- `pnpm --silent lint:json | jq '.diagnostics | length'` -> `0`
- `pnpm --silent lint:quick`
- `pnpm --dir packages/core exec vitest run tests/unit/middleware/oauth-csrf.test.ts tests/integration/search/suggest.test.ts` -> 20 tests passed
- `pnpm --dir packages/core typecheck`
- `pnpm --filter emdash build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `git diff --check`