### PR TITLE
fix(cli): treat `--with-content=all` as include-all sentinel

### DIFF
--- a/.changeset/fix-export-seed-with-content-all.md
+++ b/.changeset/fix-export-seed-with-content-all.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash export-seed --with-content=all` so it exports content from every collection, matching the documented behaviour. Previously the literal string `"all"` was treated as a collection name and matched none, producing an empty `content` block. The bare flag and `--with-content=true` were the only sentinels honoured.

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -148,13 +148,16 @@ export async function exportSeed(db: Kysely<Database>, withContent?: string): Pr
 
 	// 7. Export content (if requested)
 	if (withContent !== undefined) {
-		const collections =
-			withContent === "" || withContent === "true"
-				? null // all collections
-				: withContent
-						.split(",")
-						.map((s) => s.trim())
-						.filter(Boolean);
+		// Treat "all" as a synonym for the bare flag and "true". The args help
+		// text documents `all` as a valid value, but without this the literal
+		// string is read as a collection name and matches no collection (#1329).
+		const includeAll = withContent === "" || withContent === "true" || withContent === "all";
+		const collections = includeAll
+			? null // all collections
+			: withContent
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean);
 
 		seed.content = await exportContent(
 			db,

--- a/packages/core/tests/unit/seed/export-seed-with-content-all.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-with-content-all.test.ts
@@ -1,0 +1,88 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportSeed } from "../../../src/cli/commands/export-seed.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * Regression for #1329: `emdash export-seed --with-content all` exported
+ * nothing because the literal string "all" was treated as a collection name.
+ * Only the bare flag and `--with-content=true` were honoured as the
+ * "include every collection" sentinel, contradicting the args help text:
+ *
+ *     "with-content": {
+ *       description: "Include content (all or comma-separated collection names)",
+ *     }
+ */
+describe("exportSeed: --with-content sentinel handling", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		setI18nConfig(null);
+		db = await setupTestDatabase();
+
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createCollection({ slug: "pages", label: "Pages" });
+		await registry.createField("pages", { slug: "title", label: "Title", type: "string" });
+
+		const contentRepo = new ContentRepository(db);
+		await contentRepo.create({
+			type: "posts",
+			slug: "hello-post",
+			status: "published",
+			data: { title: "Hello Post" },
+		});
+		await contentRepo.create({
+			type: "pages",
+			slug: "hello-page",
+			status: "published",
+			data: { title: "Hello Page" },
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		setI18nConfig(null);
+	});
+
+	it("treats `all` as a synonym for include-every-collection", async () => {
+		const seed = await exportSeed(db, "all");
+
+		expect(seed.content).toBeDefined();
+		expect(Object.keys(seed.content ?? {}).toSorted()).toEqual(["pages", "posts"]);
+		expect(seed.content?.posts?.[0]?.slug).toBe("hello-post");
+		expect(seed.content?.pages?.[0]?.slug).toBe("hello-page");
+	});
+
+	it("matches the bare flag's behaviour (empty string)", async () => {
+		const seedAll = await exportSeed(db, "all");
+		const seedBare = await exportSeed(db, "");
+
+		expect(Object.keys(seedAll.content ?? {}).toSorted()).toEqual(
+			Object.keys(seedBare.content ?? {}).toSorted(),
+		);
+	});
+
+	it("matches the explicit `true` sentinel's behaviour", async () => {
+		const seedAll = await exportSeed(db, "all");
+		const seedTrue = await exportSeed(db, "true");
+
+		expect(Object.keys(seedAll.content ?? {}).toSorted()).toEqual(
+			Object.keys(seedTrue.content ?? {}).toSorted(),
+		);
+	});
+
+	it("still treats a comma-separated list as a collection-name filter", async () => {
+		const seed = await exportSeed(db, "posts");
+
+		expect(seed.content).toBeDefined();
+		expect(Object.keys(seed.content ?? {})).toEqual(["posts"]);
+		expect(seed.content?.posts?.[0]?.slug).toBe("hello-post");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Treats `--with-content=all` as a synonym for the existing include-every-collection sentinel in `emdash export-seed`, so the CLI matches its own help text.

The args definition in `packages/core/src/cli/commands/export-seed.ts` documents `all` as a valid value:

```ts
"with-content": {
  description: "Include content (all or comma-separated collection names)",
}
```

…but `exportSeed()` only treated `""` and `"true"` as the "include every collection" sentinel. The literal string `"all"` was passed through to the collection-name filter, matched no collection (no collection is named `all`), and produced an empty `content` block. Passing an explicit collection name (e.g. `--with-content posts`) or omitting the value still worked — only the documented `all` shortcut was broken.

The fix adds `"all"` to the same sentinel check. Behaviour for every other input is unchanged. A regression test covers all four shapes (`all`, `""`, `"true"`, `"posts"`).

Closes #1329

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (verified via `tsgo --noEmit` on `packages/core` after building workspace deps)
- [x] `pnpm lint` passes (oxlint clean on changed files)
- [x] `pnpm test` passes (targeted: 4/4 new tests + 117/117 in `tests/unit/seed/`)
- [x] `pnpm format` has been run (oxfmt clean on changed files)
- [x] I have added/updated tests for my changes
- [x] User-visible strings in the admin UI are wrapped for translation — n/a (CLI-only change, no admin strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch)
- [ ] New features link to an approved Discussion — n/a (bug fix, not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.7

## Screenshots / test output

Local verification on Node 22.22.3, pnpm 11.1.3 (matches `package.json#packageManager`):

**Regression test (with fix applied):**

```
RUN  v4.1.5 packages/core
 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  6.18s
```

**Same test against the upstream code (fix reverted) — confirms the test catches the bug:**

```
 FAIL  tests/unit/seed/export-seed-with-content-all.test.ts > matches the explicit `true` sentinel's behaviour
AssertionError: expected [] to deeply equal [ 'pages', 'posts' ]

- Expected
+ Received
- [
-   "pages",
-   "posts",
- ]
+ []

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

(The 1 passing case is the negative test that asserts `--with-content=posts` still works as a collection-name filter — that path was not affected by the bug.)

**Full seed test suite (regression check):**

```
RUN  v4.1.5 packages/core
 Test Files  8 passed (8)
      Tests  117 passed (117)
   Duration  17.86s
```
