### PR TITLE
fix(core): reclaim abandoned init locks to prevent isolate-poisoning deadlock

### DIFF
--- a/.changeset/init-lock-reclaim.md
+++ b/.changeset/init-lock-reclaim.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fix isolate-poisoning deadlock in runtime and database initialization. If the request that owned a cold-isolate init was cancelled mid-await (e.g. the client disconnected during migrations), the release in its `finally` never ran, leaving the init guard stuck forever — every subsequent request in that isolate hung until the platform killed it at the wall limit (observed as 524s after 100s) and the isolate was poisoned until eviction. Initialization is now guarded by a reclaimable lock: waiters poll (never awaiting a cross-request promise), a stale owner is reclaimed after a deadline, and waiters give up with an error rather than hanging indefinitely.
+Fixed a bug where a visitor disconnecting at the wrong moment during a cold start could leave that server instance permanently broken: every subsequent request to it would hang until the platform timed it out (a 524 error on Cloudflare, after 100 seconds), and the instance stayed broken until it was recycled. Sites no longer get stuck — startup now recovers automatically, and in the worst case a request fails fast with an error instead of hanging.

--- a/.changeset/init-lock-reclaim.md
+++ b/.changeset/init-lock-reclaim.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix isolate-poisoning deadlock in runtime and database initialization. If the request that owned a cold-isolate init was cancelled mid-await (e.g. the client disconnected during migrations), the release in its `finally` never ran, leaving the init guard stuck forever — every subsequent request in that isolate hung until the platform killed it at the wall limit (observed as 524s after 100s) and the isolate was poisoned until eviction. Initialization is now guarded by a reclaimable lock: waiters poll (never awaiting a cross-request promise), a stale owner is reclaimed after a deadline, and waiters give up with an error rather than hanging indefinitely.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -68,32 +68,6 @@ import type { EmDashHandlers } from "./types.js";
 const RUNTIME_INIT_DEADLINE_MS = DB_INIT_DEADLINE_MS + 15_000;
 
 /**
- * The runtime singleton and its init lock live on globalThis behind a
- * Symbol — same reasoning as SETUP_VERIFIED_KEY below: the bundler can
- * duplicate this module across SSR chunks, and a duplicated instance/lock
- * would mean multiple runtimes (each with its own cron scheduler) per
- * isolate, initializing and reclaiming independently.
- */
-const RUNTIME_HOLDER_KEY = Symbol.for("emdash:runtime-holder");
-interface RuntimeHolder {
-	instance: EmDashRuntime | null;
-	lock: InitLock;
-}
-
-function getRuntimeHolder(): RuntimeHolder {
-	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
-	let holder = setupFlagStore[RUNTIME_HOLDER_KEY] as RuntimeHolder | undefined;
-	if (!holder) {
-		holder = { instance: null, lock: createInitLock() };
-		setupFlagStore[RUNTIME_HOLDER_KEY] = holder;
-	}
-	return holder;
-}
-
-/** Whether i18n config has been initialized from the virtual module */
-let i18nInitialized = false;
-
-/**
  * Whether we've verified the database has been set up.
  * On a fresh deployment the first request may hit a public page, bypassing
  * runtime init. Without this check, template helpers like getSiteSettings()
@@ -118,6 +92,32 @@ function isSetupVerified(): boolean {
 function markSetupVerified(): void {
 	setupFlagStore[SETUP_VERIFIED_KEY] = true;
 }
+
+/**
+ * The runtime singleton and its init lock live on globalThis behind a
+ * Symbol — same reasoning as SETUP_VERIFIED_KEY above: the bundler can
+ * duplicate this module across SSR chunks, and a duplicated instance/lock
+ * would mean multiple runtimes (each with its own cron scheduler) per
+ * isolate, initializing and reclaiming independently.
+ */
+const RUNTIME_HOLDER_KEY = Symbol.for("emdash:runtime-holder");
+interface RuntimeHolder {
+	instance: EmDashRuntime | null;
+	lock: InitLock;
+}
+
+function getRuntimeHolder(): RuntimeHolder {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
+	let holder = setupFlagStore[RUNTIME_HOLDER_KEY] as RuntimeHolder | undefined;
+	if (!holder) {
+		holder = { instance: null, lock: createInitLock() };
+		setupFlagStore[RUNTIME_HOLDER_KEY] = holder;
+	}
+	return holder;
+}
+
+/** Whether i18n config has been initialized from the virtual module */
+let i18nInitialized = false;
 
 /**
  * Get EmDash configuration from virtual module

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -51,14 +51,16 @@ import {
 	runWithContext,
 } from "../request-context.js";
 import { isMissingTableError } from "../utils/db-errors.js";
+import { createInitLock, initWithLock } from "../utils/init-lock.js";
 import type { EmDashConfig } from "./integration/runtime.js";
 import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js";
 import type { EmDashHandlers } from "./types.js";
 
 // Cached runtime instance (persists across requests within worker)
 let runtimeInstance: EmDashRuntime | null = null;
-// Whether initialization is in progress (prevents concurrent init attempts)
-let runtimeInitializing = false;
+// Guards concurrent init attempts; reclaimable so a request cancelled
+// mid-init can't poison the isolate (see utils/init-lock.ts)
+const runtimeInitLock = createInitLock();
 
 /** Whether i18n config has been initialized from the virtual module */
 let i18nInitialized = false;
@@ -176,29 +178,22 @@ async function getRuntime(
 	config: EmDashConfig,
 	initTimings?: Array<{ name: string; dur: number; desc?: string }>,
 ): Promise<EmDashRuntime> {
-	// Return cached instance if available
-	if (runtimeInstance) {
-		return runtimeInstance;
-	}
-
-	// If another request is already initializing, wait and retry.
-	// We don't share the promise across requests because workerd flags
-	// cross-request promise resolution (causes warnings + potential hangs).
-	if (runtimeInitializing) {
-		// Poll until the initializing request finishes
-		await new Promise((resolve) => setTimeout(resolve, 50));
-		return getRuntime(config, initTimings);
-	}
-
-	runtimeInitializing = true;
-	try {
-		const deps = buildDependencies(config);
-		const runtime = await EmDashRuntime.create(deps, initTimings);
-		runtimeInstance = runtime;
-		return runtime;
-	} finally {
-		runtimeInitializing = false;
-	}
+	// Waiters poll rather than awaiting the initializing request's promise —
+	// workerd flags cross-request promise resolution (warnings + potential
+	// hangs). If the initializing request is cancelled mid-create (client
+	// disconnect tears down its continuation, skipping any `finally`), the
+	// lock is reclaimed after a deadline instead of hanging every subsequent
+	// request in the isolate until eviction.
+	return initWithLock(
+		runtimeInitLock,
+		() => runtimeInstance,
+		async () => {
+			const deps = buildDependencies(config);
+			const runtime = await EmDashRuntime.create(deps, initTimings);
+			runtimeInstance = runtime;
+			return runtime;
+		},
+	);
 }
 
 /**

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -27,12 +27,14 @@ import { sandboxedPlugins as virtualSandboxedPlugins } from "virtual:emdash/sand
 // @ts-ignore - virtual module
 import { createStorage as virtualCreateStorage } from "virtual:emdash/storage";
 
+import { after } from "../after.js";
 import {
 	createRecorder,
 	flushRecorder,
 	isInstrumentationEnabled,
 } from "../database/instrumentation.js";
 import {
+	DB_INIT_DEADLINE_MS,
 	EmDashRuntime,
 	type RuntimeDependencies,
 	type SandboxedPluginEntry,
@@ -51,16 +53,42 @@ import {
 	runWithContext,
 } from "../request-context.js";
 import { isMissingTableError } from "../utils/db-errors.js";
-import { createInitLock, initWithLock } from "../utils/init-lock.js";
+import { createInitLock, type InitLock, initWithLock } from "../utils/init-lock.js";
 import type { EmDashConfig } from "./integration/runtime.js";
 import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js";
 import type { EmDashHandlers } from "./types.js";
 
-// Cached runtime instance (persists across requests within worker)
-let runtimeInstance: EmDashRuntime | null = null;
-// Guards concurrent init attempts; reclaimable so a request cancelled
-// mid-init can't poison the isolate (see utils/init-lock.ts)
-const runtimeInitLock = createInitLock();
+/**
+ * Runtime init lock reclaim deadline. Must be strictly larger than the db
+ * init deadline: this lock wraps EmDashRuntime.create() → getDatabase() →
+ * the db init lock, and equal deadlines would let this outer lock reclaim
+ * (spawning a second cron scheduler and sandbox runner) while the inner db
+ * init is legitimately still working through a contended migration.
+ */
+const RUNTIME_INIT_DEADLINE_MS = DB_INIT_DEADLINE_MS + 15_000;
+
+/**
+ * The runtime singleton and its init lock live on globalThis behind a
+ * Symbol — same reasoning as SETUP_VERIFIED_KEY below: the bundler can
+ * duplicate this module across SSR chunks, and a duplicated instance/lock
+ * would mean multiple runtimes (each with its own cron scheduler) per
+ * isolate, initializing and reclaiming independently.
+ */
+const RUNTIME_HOLDER_KEY = Symbol.for("emdash:runtime-holder");
+interface RuntimeHolder {
+	instance: EmDashRuntime | null;
+	lock: InitLock;
+}
+
+function getRuntimeHolder(): RuntimeHolder {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
+	let holder = setupFlagStore[RUNTIME_HOLDER_KEY] as RuntimeHolder | undefined;
+	if (!holder) {
+		holder = { instance: null, lock: createInitLock() };
+		setupFlagStore[RUNTIME_HOLDER_KEY] = holder;
+	}
+	return holder;
+}
 
 /** Whether i18n config has been initialized from the virtual module */
 let i18nInitialized = false;
@@ -182,16 +210,22 @@ async function getRuntime(
 	// workerd flags cross-request promise resolution (warnings + potential
 	// hangs). If the initializing request is cancelled mid-create (client
 	// disconnect tears down its continuation, skipping any `finally`), the
-	// lock is reclaimed after a deadline instead of hanging every subsequent
-	// request in the isolate until eviction.
+	// anchored init keeps running under waitUntil and populates the cache;
+	// failing that, the stale lock is reclaimed after a deadline instead of
+	// hanging every subsequent request in the isolate until eviction.
+	const holder = getRuntimeHolder();
 	return initWithLock(
-		runtimeInitLock,
-		() => runtimeInstance,
+		holder.lock,
+		() => holder.instance,
 		async () => {
 			const deps = buildDependencies(config);
 			const runtime = await EmDashRuntime.create(deps, initTimings);
-			runtimeInstance = runtime;
+			holder.instance = runtime;
 			return runtime;
+		},
+		{
+			deadlineMs: RUNTIME_INIT_DEADLINE_MS,
+			anchor: (promise) => after(() => promise),
 		},
 	);
 }

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -217,10 +217,22 @@ async function getRuntime(
 	return initWithLock(
 		holder.lock,
 		() => holder.instance,
-		async () => {
+		async (isCurrentClaim) => {
 			const deps = buildDependencies(config);
 			const runtime = await EmDashRuntime.create(deps, initTimings);
-			holder.instance = runtime;
+			if (isCurrentClaim()) {
+				holder.instance = runtime;
+			} else {
+				// This init was reclaimed mid-flight (it ran past the deadline
+				// and a waiter started its own). Don't overwrite the
+				// reclaimer's published runtime, and stop this one's cron
+				// scheduler so it doesn't keep firing unreferenced. The
+				// runtime is still returned — it's fully functional for the
+				// request that built it.
+				runtime.stopCron().catch((error: unknown) => {
+					console.error("[emdash] failed to stop superseded runtime's cron:", error);
+				});
+			}
 			return runtime;
 		},
 		{

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -178,8 +178,13 @@ const MIGRATION_RACE_PATTERN = new RegExp(
 	"i",
 );
 
-/** How long to wait for a concurrent migrator to finish before giving up. */
-const MIGRATION_RACE_WAIT_MS = 10_000;
+/**
+ * How long to wait for a concurrent migrator to finish before giving up.
+ * Exported because the db init lock's reclaim deadline must comfortably
+ * exceed it (see DB_INIT_DEADLINE_MS in emdash-runtime.ts) — a healthy
+ * init can legitimately block this long inside waitForConcurrentMigrator.
+ */
+export const MIGRATION_RACE_WAIT_MS = 10_000;
 /** Polling interval while waiting for a concurrent migrator. */
 const MIGRATION_RACE_POLL_MS = 100;
 

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -22,7 +22,7 @@ import { getAuthMode } from "./auth/mode.js";
 import { getTrustedProxyHeaders } from "./auth/trusted-proxy.js";
 import { isSqlite } from "./database/dialect-helpers.js";
 import { kyselyLogOption } from "./database/instrumentation.js";
-import { runMigrations } from "./database/migrations/runner.js";
+import { MIGRATION_RACE_WAIT_MS, runMigrations } from "./database/migrations/runner.js";
 import { RevisionRepository } from "./database/repositories/revision.js";
 import type { ContentItem as ContentItemInternal } from "./database/repositories/types.js";
 import { validateIdentifier } from "./database/validate.js";
@@ -41,7 +41,7 @@ import type {
 } from "./plugins/types.js";
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
-import { createInitLock, initWithLock } from "./utils/init-lock.js";
+import { createInitLock, type InitLock, initWithLock } from "./utils/init-lock.js";
 import { COMMIT, VERSION } from "./version.js";
 
 const LEADING_SLASH_PATTERN = /^\//;
@@ -311,11 +311,38 @@ function contentItemToRecord(item: ContentItemInternal): Record<string, unknown>
 	return { ...item };
 }
 
-// Module-level caches (persist across requests within worker)
-const dbCache = new Map<string, Kysely<Database>>();
-// Guards concurrent db init; reclaimable so a request cancelled mid-init
-// (migrations on cold D1) can't poison the isolate (see utils/init-lock.ts)
-const dbInitLock = createInitLock();
+/**
+ * Db init lock reclaim deadline. Derived from the migration race wait so
+ * they can't drift apart: a healthy init can legitimately block for the
+ * full MIGRATION_RACE_WAIT_MS inside waitForConcurrentMigrator, plus cold
+ * connect and migrator work, before it should be presumed dead. The outer
+ * runtime init lock (middleware.ts) must use a strictly larger deadline —
+ * it wraps create() → getDatabase() → this lock, and equal deadlines would
+ * let the outer reclaim while the inner is legitimately still working.
+ */
+export const DB_INIT_DEADLINE_MS = MIGRATION_RACE_WAIT_MS + 20_000;
+
+/**
+ * Db cache + its init lock live on globalThis behind a Symbol: the bundler
+ * can duplicate this module across SSR chunks (same reasoning as
+ * request-cache.ts), and a duplicated cache/lock would mean concurrent
+ * independent db inits — and duplicate migrators — per isolate.
+ */
+const DB_HOLDER_KEY = Symbol.for("emdash:db-cache");
+interface DbHolder {
+	cache: Map<string, Kysely<Database>>;
+	lock: InitLock;
+}
+const globalSymbolStore = globalThis as Record<symbol, unknown>;
+function getDbHolder(): DbHolder {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
+	let holder = globalSymbolStore[DB_HOLDER_KEY] as DbHolder | undefined;
+	if (!holder) {
+		holder = { cache: new Map<string, Kysely<Database>>(), lock: createInitLock() };
+		globalSymbolStore[DB_HOLDER_KEY] = holder;
+	}
+	return holder;
+}
 const storageCache = new Map<string, Storage>();
 const sandboxedPluginCache = new Map<string, SandboxedPluginInstance>();
 /**
@@ -1277,11 +1304,14 @@ export class EmDashRuntime {
 		// promise: if the request that owns the init is cancelled mid-await
 		// (e.g. client disconnect during cold migrations), a shared promise
 		// never settles — and the owner's `finally` that would clear it never
-		// runs — deadlocking every later request in the isolate. The lock is
-		// reclaimed after a deadline instead.
+		// runs — deadlocking every later request in the isolate. Prevention:
+		// the in-flight init is anchored via after()/waitUntil so a cancelled
+		// owner's init still completes and populates the cache. Net: a stale
+		// lock is reclaimed after a deadline.
+		const holder = getDbHolder();
 		return initWithLock(
-			dbInitLock,
-			() => dbCache.get(cacheKey),
+			holder.lock,
+			() => holder.cache.get(cacheKey),
 			async () => {
 				const dialect = deps.createDialect(dbConfig.config);
 				const db = new Kysely<Database>({ dialect, log: kyselyLogOption() });
@@ -1336,8 +1366,12 @@ export class EmDashRuntime {
 					// Tables may not exist yet. Non-fatal.
 				}
 
-				dbCache.set(cacheKey, db);
+				holder.cache.set(cacheKey, db);
 				return db;
+			},
+			{
+				deadlineMs: DB_INIT_DEADLINE_MS,
+				anchor: (promise) => after(() => promise),
 			},
 		);
 	}

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -41,6 +41,7 @@ import type {
 } from "./plugins/types.js";
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
+import { createInitLock, initWithLock } from "./utils/init-lock.js";
 import { COMMIT, VERSION } from "./version.js";
 
 const LEADING_SLASH_PATTERN = /^\//;
@@ -312,7 +313,9 @@ function contentItemToRecord(item: ContentItemInternal): Record<string, unknown>
 
 // Module-level caches (persist across requests within worker)
 const dbCache = new Map<string, Kysely<Database>>();
-let dbInitPromise: Promise<Kysely<Database>> | null = null;
+// Guards concurrent db init; reclaimable so a request cancelled mid-init
+// (migrations on cold D1) can't poison the isolate (see utils/init-lock.ts)
+const dbInitLock = createInitLock();
 const storageCache = new Map<string, Storage>();
 const sandboxedPluginCache = new Map<string, SandboxedPluginInstance>();
 /**
@@ -1270,83 +1273,73 @@ export class EmDashRuntime {
 
 		const cacheKey = dbConfig.entrypoint;
 
-		// Return cached instance if available
-		const cached = dbCache.get(cacheKey);
-		if (cached) {
-			return cached;
-		}
+		// Waiters poll the cache rather than sharing the initializing request's
+		// promise: if the request that owns the init is cancelled mid-await
+		// (e.g. client disconnect during cold migrations), a shared promise
+		// never settles — and the owner's `finally` that would clear it never
+		// runs — deadlocking every later request in the isolate. The lock is
+		// reclaimed after a deadline instead.
+		return initWithLock(
+			dbInitLock,
+			() => dbCache.get(cacheKey),
+			async () => {
+				const dialect = deps.createDialect(dbConfig.config);
+				const db = new Kysely<Database>({ dialect, log: kyselyLogOption() });
 
-		// Use initialization lock to prevent race conditions.
-		// Sharing this promise across requests is safe because the Kysely instance
-		// doesn't hold a request-scoped resource — the DO dialect uses a getStub()
-		// factory that creates a fresh stub per query execution.
-		if (dbInitPromise) {
-			return dbInitPromise;
-		}
+				await runMigrations(db);
 
-		dbInitPromise = (async () => {
-			const dialect = deps.createDialect(dbConfig.config);
-			const db = new Kysely<Database>({ dialect, log: kyselyLogOption() });
+				// Note: legacy installs may carry a stray `emdash:manifest_cache`
+				// row in the options table from versions that persisted a JSON
+				// manifest. The runtime no longer reads or writes it. We do not
+				// proactively delete it: the row is a few hundred bytes of dead
+				// weight and is never on the read path, whereas a one-shot
+				// cleanup-flag check costs an extra `options.get()` on every
+				// isolate cold boot forever. Cheaper to leave it.
 
-			await runMigrations(db);
+				// Auto-seed schema if no collections exist and setup hasn't run.
+				// This covers first-load on sites that skip the setup wizard.
+				// Dev-bypass and the wizard apply seeds explicitly.
+				try {
+					const [collectionCount, setupOption] = await Promise.all([
+						db
+							.selectFrom("_emdash_collections")
+							.select((eb) => eb.fn.countAll<number>().as("count"))
+							.executeTakeFirstOrThrow(),
+						db
+							.selectFrom("options")
+							.select("value")
+							.where("name", "=", "emdash:setup_complete")
+							.executeTakeFirst(),
+					]);
 
-			// Note: legacy installs may carry a stray `emdash:manifest_cache`
-			// row in the options table from versions that persisted a JSON
-			// manifest. The runtime no longer reads or writes it. We do not
-			// proactively delete it: the row is a few hundred bytes of dead
-			// weight and is never on the read path, whereas a one-shot
-			// cleanup-flag check costs an extra `options.get()` on every
-			// isolate cold boot forever. Cheaper to leave it.
+					const setupDone = (() => {
+						try {
+							return setupOption && JSON.parse(setupOption.value) === true;
+						} catch {
+							return false;
+						}
+					})();
 
-			// Auto-seed schema if no collections exist and setup hasn't run.
-			// This covers first-load on sites that skip the setup wizard.
-			// Dev-bypass and the wizard apply seeds explicitly.
-			try {
-				const [collectionCount, setupOption] = await Promise.all([
-					db
-						.selectFrom("_emdash_collections")
-						.select((eb) => eb.fn.countAll<number>().as("count"))
-						.executeTakeFirstOrThrow(),
-					db
-						.selectFrom("options")
-						.select("value")
-						.where("name", "=", "emdash:setup_complete")
-						.executeTakeFirst(),
-				]);
+					if (collectionCount.count === 0 && !setupDone) {
+						const { applySeed } = await import("./seed/apply.js");
+						const { loadSeed } = await import("./seed/load.js");
+						const { validateSeed } = await import("./seed/validate.js");
 
-				const setupDone = (() => {
-					try {
-						return setupOption && JSON.parse(setupOption.value) === true;
-					} catch {
-						return false;
+						const seed = await loadSeed();
+						const validation = validateSeed(seed);
+						if (validation.valid) {
+							await applySeed(db, seed, { onConflict: "skip" });
+							console.log("Auto-seeded default collections");
+						}
 					}
-				})();
-
-				if (collectionCount.count === 0 && !setupDone) {
-					const { applySeed } = await import("./seed/apply.js");
-					const { loadSeed } = await import("./seed/load.js");
-					const { validateSeed } = await import("./seed/validate.js");
-
-					const seed = await loadSeed();
-					const validation = validateSeed(seed);
-					if (validation.valid) {
-						await applySeed(db, seed, { onConflict: "skip" });
-						console.log("Auto-seeded default collections");
-					}
+				} catch {
+					// Tables may not exist yet. Non-fatal.
 				}
-			} catch {
-				// Tables may not exist yet. Non-fatal.
-			}
 
-			dbCache.set(cacheKey, db);
-			return db;
-		})();
-
-		try {
-			return await dbInitPromise;
-		} finally {
-			dbInitPromise = null;
-		}
+				dbCache.set(cacheKey, db);
+				return db;
+			},
+		);
 	}
 
 	/**

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -1312,7 +1312,7 @@ export class EmDashRuntime {
 		return initWithLock(
 			holder.lock,
 			() => holder.cache.get(cacheKey),
-			async () => {
+			async (isCurrentClaim) => {
 				const dialect = deps.createDialect(dbConfig.config);
 				const db = new Kysely<Database>({ dialect, log: kyselyLogOption() });
 
@@ -1366,7 +1366,13 @@ export class EmDashRuntime {
 					// Tables may not exist yet. Non-fatal.
 				}
 
-				holder.cache.set(cacheKey, db);
+				// Publish only while still the current owner: a reclaimed slow
+				// init must not flip the cached Kysely identity back after the
+				// reclaimer has published its own. The unpublished instance is
+				// still returned and fully valid for the request that built it.
+				if (isCurrentClaim()) {
+					holder.cache.set(cacheKey, db);
+				}
 				return db;
 			},
 			{

--- a/packages/core/src/utils/init-lock.ts
+++ b/packages/core/src/utils/init-lock.ts
@@ -76,11 +76,18 @@ function sleep(ms: number): Promise<void> {
  * lock. `init` is responsible for storing the value so that `getCached`
  * returns it on subsequent calls — waiters re-check `getCached` after the
  * owner finishes rather than sharing the owner's promise.
+ *
+ * `init` receives an `isCurrentClaim` predicate and must gate its cache
+ * publication on it: a slow init that was reclaimed past the deadline
+ * must not overwrite the value published by the reclaimer (for the
+ * runtime singleton that would orphan the reclaimer's active cron
+ * scheduler). A losing init should also tear down any side resources it
+ * started, since its result will never be published.
  */
 export async function initWithLock<T>(
 	lock: InitLock,
 	getCached: () => T | null | undefined,
-	init: () => Promise<T>,
+	init: (isCurrentClaim: () => boolean) => Promise<T>,
 	options?: InitLockOptions,
 ): Promise<T> {
 	const deadlineMs = options?.deadlineMs ?? DEFAULT_DEADLINE_MS;
@@ -105,9 +112,10 @@ export async function initWithLock<T>(
 			const claim = lock.generation;
 			lock.ownerStartedAt = Date.now();
 			try {
-				// Promise.resolve().then(init) so a synchronous throw from
+				// Promise.resolve().then(...) so a synchronous throw from
 				// init still becomes a rejection after the anchor attaches.
-				const initPromise = Promise.resolve().then(init);
+				const isCurrentClaim = () => lock.generation === claim;
+				const initPromise = Promise.resolve().then(() => init(isCurrentClaim));
 				options?.anchor?.(
 					initPromise.then(
 						() => undefined,

--- a/packages/core/src/utils/init-lock.ts
+++ b/packages/core/src/utils/init-lock.ts
@@ -1,0 +1,94 @@
+/**
+ * Reclaimable initialization lock for isolate-lifetime singletons.
+ *
+ * Guards "first request initializes, everyone else waits" sections
+ * (runtime creation, database init) against a workerd failure mode: if the
+ * request that owns the initialization is cancelled mid-await (client
+ * disconnect, context teardown), its continuation — including any `finally`
+ * that would release the lock — never runs. A plain boolean or shared
+ * promise then stays stuck forever and every subsequent request in the
+ * isolate hangs until the platform kills it (observed as 524s at the
+ * 100-second wall limit, with the isolate poisoned until eviction).
+ *
+ * This lock instead records *when* the owner started. Waiters poll — we
+ * deliberately never await a promise created by another request, which
+ * workerd flags — and if the owner has held the lock past `deadlineMs`,
+ * the next waiter assumes the owner is dead, reclaims the lock, and runs
+ * the initialization itself. Waiters also give up after `maxWaitMs` so a
+ * request degrades to an error response rather than hanging.
+ */
+
+export interface InitLock {
+	/** Epoch ms when the current owner claimed the lock, or null when free. */
+	ownerStartedAt: number | null;
+}
+
+export function createInitLock(): InitLock {
+	return { ownerStartedAt: null };
+}
+
+export interface InitLockOptions {
+	/**
+	 * Reclaim the lock if the owner has held it longer than this. Must be
+	 * comfortably above the slowest legitimate init (cold migrations on a
+	 * contended D1) — a too-short deadline risks two concurrent inits, a
+	 * too-long one delays recovery of a poisoned isolate.
+	 */
+	deadlineMs?: number;
+	/** Waiter poll interval. */
+	pollMs?: number;
+	/** Give up waiting after this long and throw instead of hanging. */
+	maxWaitMs?: number;
+}
+
+const DEFAULT_DEADLINE_MS = 15_000;
+const DEFAULT_POLL_MS = 50;
+const DEFAULT_MAX_WAIT_MS = 30_000;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Return the cached value if present, otherwise initialize it under the
+ * lock. `init` is responsible for storing the value so that `getCached`
+ * returns it on subsequent calls — waiters re-check `getCached` after the
+ * owner finishes rather than sharing the owner's promise.
+ */
+export async function initWithLock<T>(
+	lock: InitLock,
+	getCached: () => T | null | undefined,
+	init: () => Promise<T>,
+	options?: InitLockOptions,
+): Promise<T> {
+	const deadlineMs = options?.deadlineMs ?? DEFAULT_DEADLINE_MS;
+	const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
+	const maxWaitMs = options?.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+	const waitStart = Date.now();
+
+	for (;;) {
+		const cached = getCached();
+		if (cached !== null && cached !== undefined) {
+			return cached;
+		}
+
+		const ownerStartedAt = lock.ownerStartedAt;
+		if (ownerStartedAt === null || Date.now() - ownerStartedAt > deadlineMs) {
+			// Free, or the owner has been gone past the deadline — claim it.
+			// Synchronous between awaits, so two waiters can't both claim.
+			lock.ownerStartedAt = Date.now();
+			try {
+				return await init();
+			} finally {
+				// If this request dies mid-init this never runs; the next
+				// waiter reclaims after deadlineMs instead.
+				lock.ownerStartedAt = null;
+			}
+		}
+
+		if (Date.now() - waitStart > maxWaitMs) {
+			throw new Error(`initWithLock: timed out after ${maxWaitMs}ms waiting for initialization`);
+		}
+		await sleep(pollMs);
+	}
+}

--- a/packages/core/src/utils/init-lock.ts
+++ b/packages/core/src/utils/init-lock.ts
@@ -21,10 +21,17 @@
 export interface InitLock {
 	/** Epoch ms when the current owner claimed the lock, or null when free. */
 	ownerStartedAt: number | null;
+	/**
+	 * Monotonic claim counter identifying the current owner. Release is
+	 * gated on it: a slow owner that finishes after a waiter has reclaimed
+	 * the lock must not clear the reclaimer's claim — that would let yet
+	 * another caller claim the lock and start a third concurrent init.
+	 */
+	generation: number;
 }
 
 export function createInitLock(): InitLock {
-	return { ownerStartedAt: null };
+	return { ownerStartedAt: null, generation: 0 };
 }
 
 export interface InitLockOptions {
@@ -94,9 +101,13 @@ export async function initWithLock<T>(
 		if (ownerStartedAt === null || Date.now() - ownerStartedAt > deadlineMs) {
 			// Free, or the owner has been gone past the deadline — claim it.
 			// Synchronous between awaits, so two waiters can't both claim.
+			lock.generation += 1;
+			const claim = lock.generation;
 			lock.ownerStartedAt = Date.now();
 			try {
-				const initPromise = init();
+				// Promise.resolve().then(init) so a synchronous throw from
+				// init still becomes a rejection after the anchor attaches.
+				const initPromise = Promise.resolve().then(init);
 				options?.anchor?.(
 					initPromise.then(
 						() => undefined,
@@ -106,8 +117,13 @@ export async function initWithLock<T>(
 				return await initPromise;
 			} finally {
 				// If this request dies mid-init unanchored this never runs;
-				// the next waiter reclaims after deadlineMs instead.
-				lock.ownerStartedAt = null;
+				// the next waiter reclaims after deadlineMs instead. Release
+				// only while still the current owner: a reclaimer may have
+				// taken the lock while this (slow) init was running, and
+				// clearing its claim would admit a third concurrent init.
+				if (lock.generation === claim) {
+					lock.ownerStartedAt = null;
+				}
 			}
 		}
 

--- a/packages/core/src/utils/init-lock.ts
+++ b/packages/core/src/utils/init-lock.ts
@@ -31,19 +31,34 @@ export interface InitLockOptions {
 	/**
 	 * Reclaim the lock if the owner has held it longer than this. Must be
 	 * comfortably above the slowest legitimate init (cold migrations on a
-	 * contended D1) — a too-short deadline risks two concurrent inits, a
-	 * too-long one delays recovery of a poisoned isolate.
+	 * contended D1, including the concurrent-migrator wait) — a too-short
+	 * deadline risks two concurrent inits, a too-long one delays recovery
+	 * of a poisoned isolate. Nested locks must compose: an outer lock's
+	 * deadline must exceed the deadline of any lock its init acquires.
 	 */
 	deadlineMs?: number;
 	/** Waiter poll interval. */
 	pollMs?: number;
-	/** Give up waiting after this long and throw instead of hanging. */
+	/**
+	 * Give up waiting after this long and throw instead of hanging.
+	 * Defaults to `deadlineMs` plus headroom so a waiter always survives
+	 * long enough to reclaim a dead owner before giving up.
+	 */
 	maxWaitMs?: number;
+	/**
+	 * Called with the in-flight init promise (errors pre-swallowed) so the
+	 * caller can hand it to the host's lifetime extender (waitUntil via
+	 * `after()`). If the owning request is cancelled mid-init, the anchored
+	 * promise keeps the context alive: init completes, populates the cache,
+	 * and the `finally` below releases the lock — preventing the poisoning
+	 * instead of merely recovering from it via reclaim.
+	 */
+	anchor?: (promise: Promise<void>) => void;
 }
 
 const DEFAULT_DEADLINE_MS = 15_000;
 const DEFAULT_POLL_MS = 50;
-const DEFAULT_MAX_WAIT_MS = 30_000;
+const MAX_WAIT_HEADROOM_MS = 15_000;
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -63,7 +78,10 @@ export async function initWithLock<T>(
 ): Promise<T> {
 	const deadlineMs = options?.deadlineMs ?? DEFAULT_DEADLINE_MS;
 	const pollMs = options?.pollMs ?? DEFAULT_POLL_MS;
-	const maxWaitMs = options?.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+	const maxWaitMs = options?.maxWaitMs ?? deadlineMs + MAX_WAIT_HEADROOM_MS;
+	// Date.now() is deliberate and only works because every loop iteration
+	// awaits: in workerd the clock only advances across I/O, so a sync spin
+	// would never observe the deadline. Don't "optimize" away the sleep.
 	const waitStart = Date.now();
 
 	for (;;) {
@@ -78,10 +96,17 @@ export async function initWithLock<T>(
 			// Synchronous between awaits, so two waiters can't both claim.
 			lock.ownerStartedAt = Date.now();
 			try {
-				return await init();
+				const initPromise = init();
+				options?.anchor?.(
+					initPromise.then(
+						() => undefined,
+						() => undefined,
+					),
+				);
+				return await initPromise;
 			} finally {
-				// If this request dies mid-init this never runs; the next
-				// waiter reclaims after deadlineMs instead.
+				// If this request dies mid-init unanchored this never runs;
+				// the next waiter reclaims after deadlineMs instead.
 				lock.ownerStartedAt = null;
 			}
 		}

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -120,6 +120,7 @@ vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: tr
 vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
 
 vi.mock("../../../src/emdash-runtime.js", () => ({
+	DB_INIT_DEADLINE_MS: 30_000,
 	EmDashRuntime: {
 		create: async () => MOCK_RUNTIME,
 	},
@@ -143,10 +144,12 @@ import onRequest from "../../../src/astro/middleware.js";
 import { getDb } from "../../../src/loader.js";
 import { getRequestContext } from "../../../src/request-context.js";
 
-/** Reset the globalThis-backed "setup verified" singleton between tests. */
+/** Reset the globalThis-backed singletons between tests. */
 const SETUP_VERIFIED_KEY = Symbol.for("emdash:setup-verified");
+const RUNTIME_HOLDER_KEY = Symbol.for("emdash:runtime-holder");
 function resetSetupVerified() {
 	delete (globalThis as Record<symbol, unknown>)[SETUP_VERIFIED_KEY];
+	delete (globalThis as Record<symbol, unknown>)[RUNTIME_HOLDER_KEY];
 }
 
 /** A getDb stub whose migrations-probe query throws `error`. */

--- a/packages/core/tests/unit/utils/init-lock.test.ts
+++ b/packages/core/tests/unit/utils/init-lock.test.ts
@@ -133,6 +133,78 @@ describe("initWithLock", () => {
 		).rejects.toThrow(/timed out/i);
 	});
 
+	it("reclaims from a live-but-slow owner without running init more than twice", async () => {
+		// The dangerous path for deadline tuning: the owner is healthy but
+		// slower than deadlineMs (e.g. contended migrations). A waiter
+		// reclaims and runs a second init; both must resolve, init must run
+		// at most twice, and the cache must converge.
+		const lock = createInitLock();
+		let cache: string | null = null;
+		let initCalls = 0;
+
+		const owner = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				await sleep(250);
+				cache = "slow-owner";
+				return "slow-owner";
+			},
+			{ deadlineMs: 100, pollMs: 10, maxWaitMs: 2000 },
+		);
+		await sleep(10);
+		const waiter = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				cache = "reclaimer";
+				return "reclaimer";
+			},
+			{ deadlineMs: 100, pollMs: 10, maxWaitMs: 2000 },
+		);
+
+		expect(await owner).toBe("slow-owner");
+		expect(await waiter).toBe("reclaimer");
+		expect(initCalls).toBe(2);
+
+		// Cache has converged: later callers are served from it, no third init.
+		const third = await initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				return "third";
+			},
+			{ deadlineMs: 100, pollMs: 10 },
+		);
+		expect(third).toBe(cache);
+		expect(initCalls).toBe(2);
+	});
+
+	it("anchors the in-flight init promise and swallows its rejection", async () => {
+		const lock = createInitLock();
+		const anchored: Promise<void>[] = [];
+
+		await expect(
+			initWithLock(
+				lock,
+				() => null,
+				() => Promise.reject(new Error("boom")),
+				{
+					pollMs: 10,
+					anchor: (promise) => anchored.push(promise),
+				},
+			),
+		).rejects.toThrow("boom");
+
+		expect(anchored).toHaveLength(1);
+		// The anchored copy must never reject (it goes to waitUntil, where a
+		// rejection would surface as an unhandled error in the host).
+		await expect(anchored[0]).resolves.toBeUndefined();
+	});
+
 	it("lets a waiter pick up a value cached by the owner mid-wait", async () => {
 		const lock = createInitLock();
 		let cache: string | null = null;

--- a/packages/core/tests/unit/utils/init-lock.test.ts
+++ b/packages/core/tests/unit/utils/init-lock.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import { createInitLock, initWithLock } from "../../../src/utils/init-lock.js";
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** A promise that never settles — simulates an init whose owning request
+ * context was torn down mid-await (workerd cancels the continuation, so
+ * neither `then` nor `finally` ever runs). */
+function neverSettles<T>(): Promise<T> {
+	return new Promise<T>(() => {});
+}
+
+describe("initWithLock", () => {
+	it("returns the cached value without calling init", async () => {
+		const lock = createInitLock();
+		let initCalls = 0;
+		const result = await initWithLock(
+			lock,
+			() => "cached",
+			async () => {
+				initCalls++;
+				return "fresh";
+			},
+		);
+		expect(result).toBe("cached");
+		expect(initCalls).toBe(0);
+	});
+
+	it("runs init once and shares the result with concurrent waiters", async () => {
+		const lock = createInitLock();
+		let cache: string | null = null;
+		let initCalls = 0;
+		const init = async () => {
+			initCalls++;
+			await sleep(50);
+			cache = "value";
+			return "value";
+		};
+		const opts = { pollMs: 10 };
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () => initWithLock(lock, () => cache, init, opts)),
+		);
+		expect(results).toEqual(["value", "value", "value", "value", "value"]);
+		expect(initCalls).toBe(1);
+	});
+
+	it("reclaims the lock after the deadline when the owner is abandoned", async () => {
+		const lock = createInitLock();
+		let cache: string | null = null;
+
+		// First caller claims the lock, then its continuation dies: init never
+		// settles, so the post-await cleanup never runs and the lock looks
+		// held forever. This is the poisoned-isolate scenario from production.
+		void initWithLock(
+			lock,
+			() => cache,
+			() => neverSettles<string>(),
+			{
+				deadlineMs: 100,
+				pollMs: 10,
+			},
+		);
+		expect(lock.ownerStartedAt).not.toBeNull();
+
+		await sleep(120);
+
+		// A later request must reclaim the stale lock and initialize.
+		const result = await initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				cache = "recovered";
+				return "recovered";
+			},
+			{ deadlineMs: 100, pollMs: 10, maxWaitMs: 1000 },
+		);
+		expect(result).toBe("recovered");
+	});
+
+	it("releases the lock when init throws so the next caller can retry", async () => {
+		const lock = createInitLock();
+		let cache: string | null = null;
+
+		await expect(
+			initWithLock(
+				lock,
+				() => cache,
+				() => Promise.reject(new Error("boom")),
+				{ pollMs: 10 },
+			),
+		).rejects.toThrow("boom");
+		expect(lock.ownerStartedAt).toBeNull();
+
+		const result = await initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				cache = "ok";
+				return "ok";
+			},
+			{ pollMs: 10 },
+		);
+		expect(result).toBe("ok");
+	});
+
+	it("gives up after maxWaitMs instead of waiting forever", async () => {
+		const lock = createInitLock();
+
+		void initWithLock(
+			lock,
+			() => null,
+			() => neverSettles<string>(),
+			{
+				deadlineMs: 60_000,
+				pollMs: 10,
+			},
+		);
+
+		await expect(
+			initWithLock(
+				lock,
+				() => null,
+				async () => "late",
+				{
+					deadlineMs: 60_000,
+					pollMs: 10,
+					maxWaitMs: 100,
+				},
+			),
+		).rejects.toThrow(/timed out/i);
+	});
+
+	it("lets a waiter pick up a value cached by the owner mid-wait", async () => {
+		const lock = createInitLock();
+		let cache: string | null = null;
+
+		const owner = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				await sleep(40);
+				cache = "owner-value";
+				return "owner-value";
+			},
+			{ pollMs: 10 },
+		);
+		await sleep(5);
+		const waiter = initWithLock(
+			lock,
+			() => cache,
+			async () => "waiter-value",
+			{ pollMs: 10, maxWaitMs: 1000 },
+		);
+		expect(await owner).toBe("owner-value");
+		expect(await waiter).toBe("owner-value");
+	});
+});

--- a/packages/core/tests/unit/utils/init-lock.test.ts
+++ b/packages/core/tests/unit/utils/init-lock.test.ts
@@ -170,6 +170,12 @@ describe("initWithLock", () => {
 		expect(initCalls).toBe(2);
 
 		// Cache has converged: later callers are served from it, no third init.
+		// Note which value converged: these test inits write the cache
+		// UNGATED, so the slow owner's late write wins (last-writer-wins) and
+		// `cache` is "slow-owner" here, not the reclaimer's value. Real
+		// callers gate publication on the isCurrentClaim predicate (see the
+		// "gates publication" test below), which makes the reclaimer win.
+		expect(cache).toBe("slow-owner");
 		const third = await initWithLock(
 			lock,
 			() => cache,
@@ -181,6 +187,42 @@ describe("initWithLock", () => {
 		);
 		expect(third).toBe(cache);
 		expect(initCalls).toBe(2);
+	});
+
+	it("gates publication so a reclaimed slow owner cannot overwrite the reclaimer's value", async () => {
+		// Real callers publish through the isCurrentClaim predicate: when a
+		// slow owner finishes after being reclaimed, its publication is
+		// suppressed and the reclaimer's published value survives.
+		const lock = createInitLock();
+		let cache: string | null = null;
+		const claimChecks: boolean[] = [];
+
+		const makeInit = (value: string, delayMs: number) => async (isCurrentClaim: () => boolean) => {
+			await sleep(delayMs);
+			const current = isCurrentClaim();
+			claimChecks.push(current);
+			if (current) cache = value;
+			return value;
+		};
+
+		const owner = initWithLock(lock, () => cache, makeInit("slow-owner", 250), {
+			deadlineMs: 100,
+			pollMs: 10,
+			maxWaitMs: 2000,
+		});
+		await sleep(10);
+		const reclaimer = initWithLock(lock, () => cache, makeInit("reclaimer", 50), {
+			deadlineMs: 100,
+			pollMs: 10,
+			maxWaitMs: 2000,
+		});
+
+		// Each init still returns its own value to its own caller...
+		expect(await owner).toBe("slow-owner");
+		expect(await reclaimer).toBe("reclaimer");
+		// ...but only the reclaimer (the current claim) published.
+		expect(cache).toBe("reclaimer");
+		expect(claimChecks).toEqual([true, false]);
 	});
 
 	it("does not let a finished stale owner release the reclaimer's lock", async () => {

--- a/packages/core/tests/unit/utils/init-lock.test.ts
+++ b/packages/core/tests/unit/utils/init-lock.test.ts
@@ -183,6 +183,63 @@ describe("initWithLock", () => {
 		expect(initCalls).toBe(2);
 	});
 
+	it("does not let a finished stale owner release the reclaimer's lock", async () => {
+		// The clobber race: owner A is slow and eventually FAILS (so it never
+		// populates the cache), waiter B reclaims at the deadline, then A's
+		// cleanup runs while B is still mid-init. A must not release B's
+		// claim — if it does, a third caller C arriving in that window
+		// claims the lock and starts a third concurrent init.
+		const lock = createInitLock();
+		let cache: string | null = null;
+		let initCalls = 0;
+		const opts = { deadlineMs: 300, pollMs: 20, maxWaitMs: 3000 };
+
+		// A: claims at t=0, rejects at t≈400 (after B reclaimed at t≈300+).
+		const ownerA = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				await sleep(400);
+				throw new Error("slow failure");
+			},
+			opts,
+		).catch((error: unknown) => error);
+
+		// B: arrives early, reclaims at t≈300-340, succeeds at t≈520-540.
+		await sleep(20);
+		const reclaimerB = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				await sleep(200);
+				cache = "reclaimer";
+				return "reclaimer";
+			},
+			opts,
+		);
+
+		// C: arrives at t≈440 — after A's cleanup ran, while B is mid-init.
+		// C must wait for B's result, not start a third init.
+		await sleep(420);
+		const lateC = initWithLock(
+			lock,
+			() => cache,
+			async () => {
+				initCalls++;
+				cache = "late";
+				return "late";
+			},
+			opts,
+		);
+
+		expect(await reclaimerB).toBe("reclaimer");
+		expect(await lateC).toBe("reclaimer");
+		expect(await ownerA).toBeInstanceOf(Error);
+		expect(initCalls).toBe(2);
+	});
+
 	it("anchors the in-flight init promise and swallows its rejection", async () => {
 		const lock = createInitLock();
 		const anchored: Promise<void>[] = [];


### PR DESCRIPTION
## What does this PR do?

Fixes an isolate-poisoning deadlock in runtime and database initialization on workerd.

**Mechanism:** `getRuntime()` (middleware) and `getDatabase()` (runtime) guard cold-isolate initialization with single-owner state — a `runtimeInitializing` boolean and a shared `dbInitPromise` respectively. If the request that owns the init is cancelled mid-`await` (client disconnects during cold migrations on contended D1), workerd tears down its continuation and the `finally` that releases the guard **never runs**. The guard is stuck forever: every subsequent request in that isolate spins in the wait path (or awaits a never-settling promise) until the platform kills it at the wall limit — observed in production as 524s at exactly ~100s, with `cf-cache-status: BYPASS`, zero bytes, and no Server-Timing. The isolate stays poisoned until eviction, and the CDN cache's request coalescing amplifies each poisoned fill to every concurrent visitor of that URL.

External reproduction during diagnosis: probes that aborted in-flight cold requests drove the hang rate on a test deployment from ~17% to 44% of uncached requests — each abort during a cold init manufactured another poisoned isolate. This is self-reinforcing in production: slow cold init → user abandons → poisoned isolate → more 524s.

**Fix:** both sites now use a reclaimable init lock (`packages/core/src/utils/init-lock.ts`):

- Waiters poll instead of awaiting a cross-request promise (which workerd flags and which can never settle if the owner dies).
- The owner records a claim timestamp; a waiter that finds the lock held past a 15s deadline assumes the owner is dead, reclaims the lock, and runs init itself — the isolate self-heals.
- Waiters give up with an error after 30s, so the worst case degrades to an error response instead of a 100-second hang.

TDD: the test simulating the abandoned owner (init never settles, cleanup never runs) was written first and fails against the old boolean/shared-promise shape.

Closes #1274

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`packages/core`; the repo-wide run fails on a pre-existing unbuilt-workspace error in `registry-client`, unrelated to this change)
- [x] `pnpm lint` passes (zero new diagnostics vs. the pre-existing baseline)
- [x] `pnpm test` passes — core unit (174 files / 2,639 tests) and integration (70 files / 1,039 tests) suites
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _n/a — bug fix._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

```
 Test Files  174 passed (174)        # tests/unit
      Tests  2639 passed (2639)

 Test Files  70 passed (70)          # tests/integration
      Tests  1039 passed (1039)
```

New suite: `packages/core/tests/unit/utils/init-lock.test.ts` (6 tests) — cached short-circuit, single init shared by concurrent waiters, **stale-owner reclaim after deadline (the production deadlock)**, lock release on init failure, bounded max wait, waiter picks up owner's cached value.

Production fingerprint this fixes (test deployment, cache-busted requests): 524 at ~100,0xx ms, `cf-cache-status: BYPASS`, 0 bytes, no Server-Timing; bimodal isolates (healthy ones serve ~300–500ms misses throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-init-lock-poisoned-isolate-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/init-lock-poisoned-isolate`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
