### PR TITLE
perf(core): emit stream-end metrics to expose post-header query cost

### DIFF
--- a/.changeset/perf-stream-end-metrics.md
+++ b/.changeset/perf-stream-end-metrics.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Emit stream-end metrics when query instrumentation is enabled. Server-Timing db.\* counters are snapshotted when headers are sent, but Astro streams the body afterwards and components issue further DB queries that the headers can't report. With `EMDASH_QUERY_LOG=1`, the middleware now pipes the response body through an identity transform and emits a final `[emdash-stream-end]` NDJSON snapshot (db count/total, cache hits/misses, total elapsed) when the body finishes streaming, so the full request cost is observable. Zero overhead when instrumentation is disabled.

--- a/.changeset/perf-stream-end-metrics.md
+++ b/.changeset/perf-stream-end-metrics.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Emit stream-end metrics when query instrumentation is enabled. Server-Timing db.\* counters are snapshotted when headers are sent, but Astro streams the body afterwards and components issue further DB queries that the headers can't report. With `EMDASH_QUERY_LOG=1`, the middleware now pipes the response body through an identity transform and emits a final `[emdash-stream-end]` NDJSON snapshot (db count/total, cache hits/misses, total elapsed) when the body finishes streaming, so the full request cost is observable. Zero overhead when instrumentation is disabled.
+Query instrumentation (`EMDASH_QUERY_LOG=1`) now captures the whole request, not just the part before the response headers are sent. Queries issued by components while the page is still streaming were previously invisible to the Server-Timing numbers; a final `[emdash-stream-end]` log line now reports the complete query count, database time, and cache hits for each request, so you can see where a slow page really spends its time. No effect when instrumentation is off.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -52,6 +52,7 @@ import {
 } from "../request-context.js";
 import { isMissingTableError } from "../utils/db-errors.js";
 import type { EmDashConfig } from "./integration/runtime.js";
+import { wrapBodyForStreamMetrics } from "./middleware/stream-end-metrics.js";
 import { createPublicPluginApiRouteHandler } from "./public-plugin-api-routes.js";
 import type { EmDashHandlers } from "./types.js";
 
@@ -429,7 +430,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					timings.push({ name: "render", dur: performance.now() - t0, desc: "Page render" });
 					timings.push({ name: "mw", dur: performance.now() - mwStart, desc: "Total middleware" });
 					pushMetricsTimings(timings, metrics);
-					return finalizeResponse(response, timings);
+					// Server-Timing only sees pre-stream queries; the stream-end
+					// wrapper (instrumentation-gated, no-op otherwise) emits the
+					// final counters once the body finishes streaming.
+					return wrapBodyForStreamMetrics(finalizeResponse(response, timings));
 				};
 				if (anonScoped) {
 					const parent = getRequestContext();
@@ -596,7 +600,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				timings.push({ name: "render", dur: performance.now() - t0, desc: "Page render" });
 				timings.push({ name: "mw", dur: performance.now() - mwStart, desc: "Total middleware" });
 				pushMetricsTimings(timings, metrics);
-				return finalizeResponse(response, timings);
+				// Server-Timing only sees pre-stream queries; the stream-end
+				// wrapper (instrumentation-gated, no-op otherwise) emits the
+				// final counters once the body finishes streaming.
+				return wrapBodyForStreamMetrics(finalizeResponse(response, timings));
 			};
 
 			if (scoped) {

--- a/packages/core/src/astro/middleware/stream-end-metrics.ts
+++ b/packages/core/src/astro/middleware/stream-end-metrics.ts
@@ -1,0 +1,96 @@
+/**
+ * Stream-end metrics
+ *
+ * Server-Timing db.* counters are snapshotted when middleware's next()
+ * returns — but at that point only the response *headers* are final.
+ * Astro streams the body afterwards, and components rendered during
+ * streaming issue further DB queries that the headers can never report.
+ *
+ * This module wraps the response body in an identity TransformStream and
+ * snapshots the request metrics in flush(), i.e. when the body actually
+ * finishes streaming. The metrics object lives on the request context
+ * (AsyncLocalStorage) and is mutated in-place by the Kysely log hook, so
+ * a reference captured before wrapping observes every post-header query.
+ * The snapshot is emitted as prefixed NDJSON on stdout (same transport as
+ * [emdash-query-log] — console.log works in both Node and workerd).
+ *
+ * Gated on isInstrumentationEnabled() (EMDASH_QUERY_LOG=1): zero overhead
+ * in normal production traffic.
+ */
+
+import { isInstrumentationEnabled } from "../../database/instrumentation.js";
+import { getRequestContext } from "../../request-context.js";
+
+export const STREAM_END_PREFIX = "[emdash-stream-end]";
+
+/**
+ * Astro attaches AstroCookies to outgoing responses via a well-known global
+ * symbol. Constructing a new Response drops non-header metadata, so the
+ * symbol must be forwarded explicitly or `cookies.set()` calls are silently
+ * dropped. Same pattern as finalizeResponse in ../middleware.ts.
+ */
+const ASTRO_COOKIES_SYMBOL = Symbol.for("astro.cookies");
+
+/** Shape of the NDJSON snapshot emitted when the body finishes streaming. */
+export interface StreamEndSnapshot {
+	route?: string;
+	method?: string;
+	phase?: string;
+	/** Total elapsed ms from middleware entry to end of body streaming. */
+	totalMs: number;
+	dbCount: number;
+	dbTotalMs: number;
+	dbFirstOffset: number | null;
+	dbLastOffset: number | null;
+	cacheHits: number;
+	cacheMisses: number;
+}
+
+/**
+ * Wrap a response body so the FINAL request metrics are emitted when the
+ * body finishes streaming. Returns the response unchanged when
+ * instrumentation is disabled, the body is null, or no request metrics
+ * are attached (e.g. outside the middleware's ALS context).
+ */
+export function wrapBodyForStreamMetrics(response: Response): Response {
+	if (!isInstrumentationEnabled()) return response;
+	if (!response.body) return response;
+
+	// Capture the context's metrics object BEFORE wrapping: flush() runs
+	// after the middleware's ALS frame may have exited, but the object
+	// reference stays live and is mutated in-place by the Kysely log hook.
+	const ctx = getRequestContext();
+	const metrics = ctx?.metrics;
+	if (!metrics) return response;
+	const recorder = ctx?.queryRecorder;
+
+	const transform = new TransformStream<Uint8Array, Uint8Array>({
+		flush() {
+			const snapshot: StreamEndSnapshot = {
+				route: recorder?.route,
+				method: recorder?.method,
+				phase: recorder?.phase,
+				totalMs: performance.now() - metrics.start,
+				dbCount: metrics.dbCount,
+				dbTotalMs: metrics.dbTotalMs,
+				dbFirstOffset: metrics.dbFirstOffset,
+				dbLastOffset: metrics.dbLastOffset,
+				cacheHits: metrics.cacheHits,
+				cacheMisses: metrics.cacheMisses,
+			};
+			console.log(`${STREAM_END_PREFIX} ${JSON.stringify(snapshot)}`);
+		},
+	});
+
+	const wrapped = new Response(response.body.pipeThrough(transform), response);
+	const astroCookies = Reflect.get(response, ASTRO_COOKIES_SYMBOL);
+	if (astroCookies !== undefined) {
+		Reflect.set(wrapped, ASTRO_COOKIES_SYMBOL, astroCookies);
+	}
+	// The identity transform preserves byte counts today, but a stale
+	// Content-Length on a re-constructed streaming Response risks
+	// truncation if anything upstream changes; the header is recomputed
+	// (or chunked encoding used) by the server layer anyway.
+	wrapped.headers.delete("Content-Length");
+	return wrapped;
+}

--- a/packages/core/tests/unit/astro/stream-end-metrics.test.ts
+++ b/packages/core/tests/unit/astro/stream-end-metrics.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	STREAM_END_PREFIX,
+	wrapBodyForStreamMetrics,
+} from "../../../src/astro/middleware/stream-end-metrics.js";
+import { QUERY_LOG_ENV, createRecorder } from "../../../src/database/instrumentation.js";
+import {
+	createRequestMetrics,
+	runWithContext,
+	type RequestMetrics,
+} from "../../../src/request-context.js";
+
+const ASTRO_COOKIES_SYMBOL = Symbol.for("astro.cookies");
+
+/** Wrap inside an ALS frame carrying `metrics`, the way middleware does. */
+function wrapInContext(
+	response: Response,
+	metrics: RequestMetrics,
+	extra: { queryRecorder?: ReturnType<typeof createRecorder> } = {},
+): Response {
+	return runWithContext({ editMode: false, metrics, ...extra }, () =>
+		wrapBodyForStreamMetrics(response),
+	);
+}
+
+/** Collect every console.log line that carries the stream-end prefix. */
+function captureStreamEndLines(): { lines: string[]; spy: ReturnType<typeof vi.spyOn> } {
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+		const line = args.map(String).join(" ");
+		if (line.startsWith(STREAM_END_PREFIX)) lines.push(line);
+	});
+	return { lines, spy };
+}
+
+function parseSnapshot(line: string): Record<string, unknown> {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- test helper parsing our own NDJSON
+	return JSON.parse(line.slice(STREAM_END_PREFIX.length + 1)) as Record<string, unknown>;
+}
+
+describe("wrapBodyForStreamMetrics", () => {
+	beforeEach(() => {
+		vi.stubEnv(QUERY_LOG_ENV, "1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it("returns the response unchanged when instrumentation is disabled", () => {
+		vi.stubEnv(QUERY_LOG_ENV, "");
+		const metrics = createRequestMetrics(performance.now());
+		const response = new Response("hello");
+		const wrapped = wrapInContext(response, metrics);
+		expect(wrapped).toBe(response);
+	});
+
+	it("returns a null-body response unchanged", () => {
+		const metrics = createRequestMetrics(performance.now());
+		const response = new Response(null, { status: 204 });
+		const wrapped = wrapInContext(response, metrics);
+		expect(wrapped).toBe(response);
+	});
+
+	it("returns the response unchanged when no request metrics are attached", () => {
+		const response = new Response("hello");
+		// No ALS frame at all — e.g. a code path outside middleware.
+		const wrapped = wrapBodyForStreamMetrics(response);
+		expect(wrapped).toBe(response);
+	});
+
+	it("passes body bytes through unchanged", async () => {
+		const { lines } = captureStreamEndLines();
+		const metrics = createRequestMetrics(performance.now());
+		const body = "<html><body>chunked content éè—</body></html>";
+		const response = new Response(body, {
+			status: 201,
+			headers: { "Content-Type": "text/html", "X-Custom": "kept" },
+		});
+
+		const wrapped = wrapInContext(response, metrics);
+		expect(wrapped).not.toBe(response);
+		expect(wrapped.status).toBe(201);
+		expect(wrapped.headers.get("Content-Type")).toBe("text/html");
+		expect(wrapped.headers.get("X-Custom")).toBe("kept");
+		await expect(wrapped.text()).resolves.toBe(body);
+		expect(lines).toHaveLength(1);
+	});
+
+	it("snapshots metrics at stream end, including queries recorded after headers", async () => {
+		const { lines } = captureStreamEndLines();
+		const metrics = createRequestMetrics(performance.now());
+		// State at "headers sent" time: one query.
+		metrics.dbCount = 1;
+		metrics.dbTotalMs = 3;
+		metrics.dbFirstOffset = 1;
+		metrics.dbLastOffset = 4;
+
+		const wrapped = wrapInContext(new Response("streamed page"), metrics);
+
+		// Simulate the Kysely log hook firing during body streaming: the
+		// metrics object is mutated in-place after the response was wrapped.
+		metrics.dbCount = 7;
+		metrics.dbTotalMs = 120.5;
+		metrics.dbLastOffset = 250;
+		metrics.cacheHits = 3;
+		metrics.cacheMisses = 2;
+
+		expect(lines).toHaveLength(0); // nothing emitted before the body drains
+		await wrapped.text();
+		expect(lines).toHaveLength(1);
+
+		const snapshot = parseSnapshot(lines[0]!);
+		expect(snapshot).toMatchObject({
+			dbCount: 7,
+			dbTotalMs: 120.5,
+			dbFirstOffset: 1,
+			dbLastOffset: 250,
+			cacheHits: 3,
+			cacheMisses: 2,
+		});
+		expect(typeof snapshot.totalMs).toBe("number");
+		expect(snapshot.totalMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("includes route, method, and phase from the query recorder", async () => {
+		const { lines } = captureStreamEndLines();
+		const metrics = createRequestMetrics(performance.now());
+		const queryRecorder = createRecorder("/posts", "GET", "cold");
+
+		const wrapped = wrapInContext(new Response("page"), metrics, { queryRecorder });
+		await wrapped.text();
+
+		expect(lines).toHaveLength(1);
+		expect(parseSnapshot(lines[0]!)).toMatchObject({
+			route: "/posts",
+			method: "GET",
+			phase: "cold",
+		});
+	});
+
+	it("forwards the Astro cookies symbol and drops Content-Length", () => {
+		const metrics = createRequestMetrics(performance.now());
+		const cookiesMarker = { _marker: "astro-cookies" };
+		const response = new Response("hello", {
+			headers: { "Content-Length": "5" },
+		});
+		Reflect.set(response, ASTRO_COOKIES_SYMBOL, cookiesMarker);
+
+		const wrapped = wrapInContext(response, metrics);
+		expect(wrapped).not.toBe(response);
+		expect(Reflect.get(wrapped, ASTRO_COOKIES_SYMBOL)).toBe(cookiesMarker);
+		expect(wrapped.headers.has("Content-Length")).toBe(false);
+	});
+});

--- a/scripts/query-counts.mjs
+++ b/scripts/query-counts.mjs
@@ -78,6 +78,10 @@ const ROUTES = [
 const TRACKED_PHASES = new Set(["cold", "warm"]);
 const VALID_TARGETS = new Set(["sqlite", "d1"]);
 const QUERY_LOG_PREFIX = "[emdash-query-log] ";
+// Emitted by stream-end-metrics.ts when the response body finishes
+// streaming — captures the FULL request cost, including queries issued
+// during body streaming that Server-Timing headers can't see.
+const STREAM_END_PREFIX = "[emdash-stream-end] ";
 
 /**
  * Resolve once a TCP connection to (host, port) succeeds, or reject on
@@ -221,6 +225,8 @@ async function seedD1ViaDevBypass(events) {
 			}
 			return;
 		}
+		// Stream-end snapshots from seeding aren't measurements; swallow them.
+		if (line.includes(STREAM_END_PREFIX)) return;
 		process.stdout.write(line + "\n");
 	});
 	const exited = new Promise((res) => child.once("exit", res));
@@ -254,7 +260,7 @@ async function seedD1ViaDevBypass(events) {
  * `ready` resolves on a successful TCP connection — no HTTP probing,
  * so a fresh workerd isolate stays cold until our first tagged request.
  */
-function startServer({ collectedEvents }) {
+function startServer({ collectedEvents, streamEndSnapshots = [] }) {
 	let cmd;
 	let args;
 	if (target === "sqlite") {
@@ -290,6 +296,18 @@ function startServer({ collectedEvents }) {
 				collectedEvents.push(JSON.parse(payload));
 			} catch {
 				process.stderr.write(`bad query-log line: ${payload}\n`);
+			}
+			return;
+		}
+		const seIdx = line.indexOf(STREAM_END_PREFIX);
+		if (seIdx !== -1) {
+			const before = line.slice(0, seIdx);
+			if (before.trim().length > 0) process.stdout.write(before + "\n");
+			const payload = line.slice(seIdx + STREAM_END_PREFIX.length);
+			try {
+				streamEndSnapshots.push(JSON.parse(payload));
+			} catch {
+				process.stderr.write(`bad stream-end line: ${payload}\n`);
 			}
 			return;
 		}
@@ -388,14 +406,14 @@ function diffSnapshot(actual) {
 // SQLite: seed the file DB via CLI, build, then run one long-lived node
 // entry. Warmup hit absorbs runtime init queries (filtered as "default"
 // phase). Tagged cold = first visit to route (runtime warm); warm = second.
-async function runSqlite(events) {
+async function runSqlite(events, streamEndSnapshots) {
 	if (!skipSeed) {
 		resetSqliteState();
 		seedSqliteCli();
 	}
 	if (skipBuild) assertExistingBuildMatchesTarget();
 	else buildFixture();
-	const server = startServer({ collectedEvents: events });
+	const server = startServer({ collectedEvents: events, streamEndSnapshots });
 	try {
 		await server.ready;
 		await warmup();
@@ -415,7 +433,7 @@ async function runSqlite(events) {
 // Seed must precede build: `astro dev` leaves `.wrangler/deploy/`
 // without the build-time `config.json` that `astro preview` requires,
 // so building afterwards is what makes the subsequent previews work.
-async function runD1(events) {
+async function runD1(events, streamEndSnapshots) {
 	if (!skipSeed) {
 		resetD1State();
 		// seeding uses its own event sink; we don't want to commingle
@@ -428,7 +446,7 @@ async function runD1(events) {
 
 	for (const [m, p] of ROUTES) {
 		process.stdout.write(`--- fresh isolate for ${m} ${p} ---\n`);
-		const server = startServer({ collectedEvents: events });
+		const server = startServer({ collectedEvents: events, streamEndSnapshots });
 		try {
 			await server.ready;
 			await hit(m, p, "cold");
@@ -439,10 +457,37 @@ async function runD1(events) {
 	}
 }
 
+/**
+ * Print the per-route stream-end snapshots (full request cost measured
+ * when the body finished streaming). Informational only — not part of
+ * the snapshot files, since timings are machine-dependent. The value is
+ * `dbCount` here vs. the header-time count: the difference is queries
+ * issued during body streaming, invisible to Server-Timing.
+ */
+function reportStreamEnd(snapshots) {
+	const tracked = snapshots
+		.filter((s) => TRACKED_PHASES.has(s.phase))
+		.toSorted((a, b) =>
+			`${a.method} ${a.route} ${a.phase}`.localeCompare(`${b.method} ${b.route} ${b.phase}`),
+		);
+	if (tracked.length === 0) return;
+	process.stdout.write("\nStream-end metrics (full request, incl. post-header queries):\n");
+	for (const s of tracked) {
+		const dbMs = typeof s.dbTotalMs === "number" ? s.dbTotalMs.toFixed(1) : "?";
+		const totalMs = typeof s.totalMs === "number" ? s.totalMs.toFixed(1) : "?";
+		process.stdout.write(
+			`  ${s.method} ${s.route} (${s.phase}): db.count=${s.dbCount} db.total=${dbMs}ms total=${totalMs}ms cache=${s.cacheHits}/${s.cacheHits + s.cacheMisses}\n`,
+		);
+	}
+}
+
 async function main() {
 	const events = [];
-	if (target === "sqlite") await runSqlite(events);
-	else await runD1(events);
+	const streamEndSnapshots = [];
+	if (target === "sqlite") await runSqlite(events, streamEndSnapshots);
+	else await runD1(events, streamEndSnapshots);
+
+	reportStreamEnd(streamEndSnapshots);
 
 	const counts = aggregate(events);
 	if (update) {


### PR DESCRIPTION
## What does this PR do?

Server-Timing `db.*` counters are snapshotted when middleware's `next()` returns — but only the response *headers* are final at that point. Astro streams the body afterwards, and components rendered during streaming issue further DB queries the headers can never report. Production measurement on real deployments showed **85–320ms of invisible post-header query time** (chunk-level timing: headers at 470ms, then a 324ms zero-byte stall, then the whole 26KB body in 17ms).

This adds a stream-end metrics wrapper: the response body is piped through an identity `TransformStream`, and on `flush()` (when the body actually finishes) the FINAL request metrics are emitted as one NDJSON line (`[emdash-stream-end] {...}`), same transport as `[emdash-query-log]`. The metrics object lives on the ALS request context and is mutated in-place by the Kysely log hook, so a reference captured before wrapping observes every post-header query.

- Gated on `isInstrumentationEnabled()` (`EMDASH_QUERY_LOG=1`) — zero overhead in normal production traffic.
- Forwards the `astro.cookies` symbol to the re-constructed Response (same pattern as `finalizeResponse`) and drops `Content-Length`.
- `scripts/query-counts.mjs` parses the new prefix and prints a per-route stream-end report. Snapshots are reported in output only, not written into the snapshot JSON files (timings are machine-dependent and would make CI comparison flaky); snapshot files are untouched.

Closes #<!-- none — instrumentation gap found during the #1274 latency investigation -->

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — 7 new tests + full core unit suite (174 files / 2,640 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _n/a — debug instrumentation behind the existing EMDASH_QUERY_LOG flag, not a user-facing feature._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New tests cover: identity byte pass-through, snapshot emitted only at stream end and reflecting metrics mutated after wrapping (simulated post-header queries), cookies symbol forwarding + Content-Length removal, null-body/no-context/disabled no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://perf-stream-end-metrics-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `perf/stream-end-metrics`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
