### PR TITLE
perf(core): parallelize cold-boot init phases and batch exclusive-hook reads

### DIFF
--- a/.changeset/lazy-pugs-brake.md
+++ b/.changeset/lazy-pugs-brake.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-perf(core): reduce sequential DB round trips during cold-isolate runtime init. Plugin-state and site-info reads now run concurrently, marketplace- and registry-installed plugin loads run concurrently when both are enabled, and exclusive hook resolution batches its per-hook option reads into a single query.
+Faster cold starts. The first request a fresh server instance handles — after a deploy, or when traffic picks up again after a quiet spell — now runs its startup steps concurrently instead of one at a time, shaving database and storage round trips off that first page load. Especially noticeable on Cloudflare, where new instances spin up frequently.

--- a/.changeset/lazy-pugs-brake.md
+++ b/.changeset/lazy-pugs-brake.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+perf(core): reduce sequential DB round trips during cold-isolate runtime init. Plugin-state and site-info reads now run concurrently, marketplace- and registry-installed plugin loads run concurrently when both are enabled, and exclusive hook resolution batches its per-hook option reads into a single query.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -887,19 +887,45 @@ export class EmDashRuntime {
 		// Initialize storage (sync)
 		const storage = EmDashRuntime.getStorage(deps);
 
-		// Fetch plugin states from database
+		// Fetch plugin states and site info concurrently — independent reads
+		// against different tables (_plugin_state vs options), so they share
+		// one round-trip window instead of paying two sequential ones. Each
+		// phase() wrapper still records that phase's own duration, and each
+		// body keeps its own non-fatal catch.
 		let pluginStates: Map<string, string> = new Map();
-		await phase("rt.plugins", "Plugin states", async () => {
-			try {
-				const states = await db
-					.selectFrom("_plugin_state")
-					.select(["plugin_id", "status"])
-					.execute();
-				pluginStates = new Map(states.map((s) => [s.plugin_id, s.status]));
-			} catch {
-				// Plugin state table may not exist yet
-			}
-		});
+		let siteInfo: { siteName?: string; siteUrl?: string; locale?: string } | undefined;
+		await Promise.all([
+			// Fetch plugin states from database
+			phase("rt.plugins", "Plugin states", async () => {
+				try {
+					const states = await db
+						.selectFrom("_plugin_state")
+						.select(["plugin_id", "status"])
+						.execute();
+					pluginStates = new Map(states.map((s) => [s.plugin_id, s.status]));
+				} catch {
+					// Plugin state table may not exist yet
+				}
+			}),
+			// Load site info for plugin context extensions (1 batch query instead of 3)
+			phase("rt.site", "Site info options", async () => {
+				try {
+					const optionsRepo = new OptionsRepository(db);
+					const siteOpts = await optionsRepo.getMany<string>([
+						"emdash:site_title",
+						"emdash:site_url",
+						"emdash:locale",
+					]);
+					siteInfo = {
+						siteName: siteOpts.get("emdash:site_title") ?? undefined,
+						siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
+						locale: siteOpts.get("emdash:locale") ?? undefined,
+					};
+				} catch {
+					// Options table may not exist yet (pre-setup)
+				}
+			}),
+		]);
 
 		// Build set of enabled plugins
 		const enabledPlugins = new Set<string>();
@@ -909,26 +935,6 @@ export class EmDashRuntime {
 				enabledPlugins.add(plugin.id);
 			}
 		}
-
-		// Load site info for plugin context extensions (1 batch query instead of 3)
-		let siteInfo: { siteName?: string; siteUrl?: string; locale?: string } | undefined;
-		await phase("rt.site", "Site info options", async () => {
-			try {
-				const optionsRepo = new OptionsRepository(db);
-				const siteOpts = await optionsRepo.getMany<string>([
-					"emdash:site_title",
-					"emdash:site_url",
-					"emdash:locale",
-				]);
-				siteInfo = {
-					siteName: siteOpts.get("emdash:site_title") ?? undefined,
-					siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
-					locale: siteOpts.get("emdash:locale") ?? undefined,
-				};
-			} catch {
-				// Options table may not exist yet (pre-setup)
-			}
-		});
 
 		// Build the full list of pipeline-eligible plugins: all configured
 		// plugins (regardless of current enabled status) plus built-in plugins.
@@ -1050,31 +1056,42 @@ export class EmDashRuntime {
 			EmDashRuntime.loadSandboxedPlugins(deps, db, storage),
 		);
 
-		// Cold-start: load marketplace-installed plugins from site R2 via
-		// the sandbox runner. In bypass mode this was already handled above.
+		// Cold-start: load marketplace- and registry-installed plugins from
+		// site R2 via the sandbox runner. The two tiers only depend on the
+		// sandbox phase above, not on each other, so when both are enabled
+		// they run concurrently instead of paying two sequential loads.
+		// In bypass mode marketplace plugins were already handled above.
+		const installedTierPhases: Promise<void>[] = [];
 		if (deps.config.marketplace && storage && !deps.sandboxBypassed) {
-			await phase("rt.market", "Marketplace plugins", () =>
-				EmDashRuntime.loadInstalledSandboxedPlugins(
-					"marketplace",
-					db,
-					storage,
-					deps,
-					sandboxedPlugins,
+			installedTierPhases.push(
+				phase("rt.market", "Marketplace plugins", () =>
+					EmDashRuntime.loadInstalledSandboxedPlugins(
+						"marketplace",
+						db,
+						storage,
+						deps,
+						sandboxedPlugins,
+					),
 				),
 			);
 		}
 
 		// Cold-start: load registry-installed plugins from site R2
 		if (deps.config.experimental?.registry && storage) {
-			await phase("rt.registry", "Registry plugins", () =>
-				EmDashRuntime.loadInstalledSandboxedPlugins(
-					"registry",
-					db,
-					storage,
-					deps,
-					sandboxedPlugins,
+			installedTierPhases.push(
+				phase("rt.registry", "Registry plugins", () =>
+					EmDashRuntime.loadInstalledSandboxedPlugins(
+						"registry",
+						db,
+						storage,
+						deps,
+						sandboxedPlugins,
+					),
 				),
 			);
+		}
+		if (installedTierPhases.length > 0) {
+			await Promise.all(installedTierPhases);
 		}
 
 		// Initialize media providers
@@ -1778,6 +1795,7 @@ export class EmDashRuntime {
 			pipeline,
 			isActive: () => true,
 			getOption: (key) => optionsRepo.get<string>(key),
+			getOptions: (keys) => optionsRepo.getMany<string>(keys),
 			setOption: (key, value) => optionsRepo.set(key, value),
 			deleteOption: async (key) => {
 				await optionsRepo.delete(key);

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -1303,7 +1303,7 @@ export interface ExclusiveHookResolutionOptions {
 	 * instead of one getOption() call per hook. Keys absent from the
 	 * returned map are treated as unset.
 	 */
-	getOptions?: (keys: string[]) => Promise<Map<string, string | null>>;
+	getOptions?: (keys: string[]) => Promise<ReadonlyMap<string, string>>;
 	/** Write an option value to persistent storage. */
 	setOption: (key: string, value: string) => Promise<void>;
 	/** Delete an option from persistent storage. */
@@ -1336,7 +1336,7 @@ export async function resolveExclusiveHooks(opts: ExclusiveHookResolutionOptions
 
 	// Batch-read current selections in one round trip when the caller
 	// provides a batch reader (1 query instead of N sequential gets).
-	let batchedSelections: Map<string, string | null> | undefined;
+	let batchedSelections: ReadonlyMap<string, string> | undefined;
 	if (getOptions) {
 		try {
 			batchedSelections = await getOptions(

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -1297,6 +1297,13 @@ export interface ExclusiveHookResolutionOptions {
 	isActive: (pluginId: string) => boolean;
 	/** Read an option value from persistent storage. */
 	getOption: (key: string) => Promise<string | null>;
+	/**
+	 * Batch-read option values for many keys in a single round trip.
+	 * When provided, resolution reads all current selections through this
+	 * instead of one getOption() call per hook. Keys absent from the
+	 * returned map are treated as unset.
+	 */
+	getOptions?: (keys: string[]) => Promise<Map<string, string | null>>;
 	/** Write an option value to persistent storage. */
 	setOption: (key: string, value: string) => Promise<void>;
 	/** Delete an option from persistent storage. */
@@ -1322,8 +1329,26 @@ const EXCLUSIVE_HOOK_KEY_PREFIX = "emdash:exclusive_hook:";
  * 5. If multiple providers and no hint → leave unselected (admin must choose).
  */
 export async function resolveExclusiveHooks(opts: ExclusiveHookResolutionOptions): Promise<void> {
-	const { pipeline, isActive, getOption, setOption, deleteOption, preferredHints } = opts;
+	const { pipeline, isActive, getOption, getOptions, setOption, deleteOption, preferredHints } =
+		opts;
 	const exclusiveHookNames = pipeline.getRegisteredExclusiveHooks();
+	if (exclusiveHookNames.length === 0) return;
+
+	// Batch-read current selections in one round trip when the caller
+	// provides a batch reader (1 query instead of N sequential gets).
+	let batchedSelections: Map<string, string | null> | undefined;
+	if (getOptions) {
+		try {
+			batchedSelections = await getOptions(
+				exclusiveHookNames.map((hookName) => `${EXCLUSIVE_HOOK_KEY_PREFIX}${hookName}`),
+			);
+		} catch {
+			// Options table may not be ready. Matches the per-key tolerance
+			// below: every hook's read would fail, so resolution is skipped
+			// entirely without touching any selection.
+			return;
+		}
+	}
 
 	for (const hookName of exclusiveHookNames) {
 		const providers = pipeline.getExclusiveHookProviders(hookName);
@@ -1333,11 +1358,15 @@ export async function resolveExclusiveHooks(opts: ExclusiveHookResolutionOptions
 
 		const key = `${EXCLUSIVE_HOOK_KEY_PREFIX}${hookName}`;
 		let currentSelection: string | null = null;
-		try {
-			currentSelection = await getOption(key);
-		} catch {
-			// Options table may not be ready
-			continue;
+		if (batchedSelections) {
+			currentSelection = batchedSelections.get(key) ?? null;
+		} else {
+			try {
+				currentSelection = await getOption(key);
+			} catch {
+				// Options table may not be ready
+				continue;
+			}
 		}
 
 		// If selection exists and the plugin is still active → keep it

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -544,6 +544,7 @@ export class PluginManager {
 			pipeline: this.hookPipeline!,
 			isActive: (pluginId) => this.isActive(pluginId),
 			getOption: (key) => optionsRepo.get<string>(key),
+			getOptions: (keys) => optionsRepo.getMany<string>(keys),
 			setOption: (key, value) => optionsRepo.set(key, value),
 			deleteOption: async (key) => {
 				await optionsRepo.delete(key);

--- a/packages/core/tests/integration/runtime/create.test.ts
+++ b/packages/core/tests/integration/runtime/create.test.ts
@@ -1,0 +1,113 @@
+/**
+ * EmDashRuntime.create() — cold-boot initialization
+ *
+ * Exercises the full static create() path end-to-end against a real
+ * in-memory SQLite database: migrations, the parallelized plugin-state +
+ * site-info reads, pipeline creation, batched exclusive hook resolution,
+ * and cron init. Asserts that the per-phase timing instrumentation still
+ * records every phase individually after parallelization.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+import { SqliteDialect } from "kysely";
+import { describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_COMMENT_MODERATOR_PLUGIN_ID } from "../../../src/comments/moderator.js";
+import { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
+import { definePlugin } from "../../../src/plugins/define-plugin.js";
+import type { ContentBeforeSaveHandler } from "../../../src/plugins/types.js";
+
+function createDeps(): RuntimeDependencies {
+	return {
+		config: {
+			database: {
+				// Unique entrypoint per test so the module-level dbCache in
+				// emdash-runtime.ts never serves a stale instance across tests.
+				entrypoint: `test-runtime-create-${randomUUID()}`,
+				config: {},
+				type: "sqlite",
+			},
+		},
+		plugins: [
+			definePlugin({
+				id: "test-exclusive-provider",
+				version: "1.0.0",
+				capabilities: ["content:write", "content:read"],
+				hooks: {
+					"content:beforeSave": {
+						exclusive: true,
+						handler: vi.fn() as unknown as ContentBeforeSaveHandler,
+					},
+				},
+			}),
+		],
+		createDialect: () => new SqliteDialect({ database: new Database(":memory:") }),
+		createStorage: null,
+		sandboxEnabled: false,
+		sandboxedPluginEntries: [],
+		createSandboxRunner: null,
+	};
+}
+
+describe("EmDashRuntime.create — cold boot", () => {
+	it("initializes end-to-end and records each phase's own timing", async () => {
+		const timings: Array<{ name: string; dur: number; desc?: string }> = [];
+		const runtime = await EmDashRuntime.create(createDeps(), timings);
+
+		try {
+			// Every phase records its own entry exactly once — including the
+			// parallelized rt.plugins / rt.site pair.
+			const names = timings.map((t) => t.name);
+			for (const expected of [
+				"rt.db",
+				"rt.plugins",
+				"rt.site",
+				"rt.sandbox",
+				"rt.hooks",
+				"rt.cron",
+			]) {
+				expect(names.filter((n) => n === expected)).toHaveLength(1);
+			}
+			// rt.market / rt.registry are not configured — no phantom phases.
+			expect(names).not.toContain("rt.market");
+			expect(names).not.toContain("rt.registry");
+			for (const t of timings) {
+				expect(t.dur).toBeGreaterThanOrEqual(0);
+				expect(Number.isFinite(t.dur)).toBe(true);
+			}
+
+			// Exclusive hooks resolved: sole providers auto-selected, both in
+			// memory and persisted to the options table.
+			expect(runtime.hooks.getExclusiveSelection("content:beforeSave")).toBe(
+				"test-exclusive-provider",
+			);
+			expect(runtime.hooks.getExclusiveSelection("comment:moderate")).toBe(
+				DEFAULT_COMMENT_MODERATOR_PLUGIN_ID,
+			);
+
+			const row = await runtime.db
+				.selectFrom("options")
+				.select("value")
+				.where("name", "=", "emdash:exclusive_hook:content:beforeSave")
+				.executeTakeFirst();
+			expect(row).toBeDefined();
+			expect(JSON.parse(row!.value)).toBe("test-exclusive-provider");
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+
+	it("creates a runtime without a timings array (backwards compatible)", async () => {
+		const runtime = await EmDashRuntime.create(createDeps());
+		try {
+			expect(runtime.hooks.getExclusiveSelection("content:beforeSave")).toBe(
+				"test-exclusive-provider",
+			);
+		} finally {
+			await runtime.stopCron();
+		}
+	});
+});

--- a/packages/core/tests/unit/plugins/exclusive-hooks.test.ts
+++ b/packages/core/tests/unit/plugins/exclusive-hooks.test.ts
@@ -11,6 +11,7 @@
 
 import Database from "better-sqlite3";
 import { Kysely, SqliteDialect } from "kysely";
+import type { KyselyPlugin } from "kysely";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { extractManifest } from "../../../src/cli/commands/bundle-utils.js";
@@ -25,7 +26,10 @@ import type {
 	PluginDefinition,
 	ContentBeforeSaveHandler,
 	ContentAfterSaveHandler,
+	ContentBeforeDeleteHandler,
 } from "../../../src/plugins/types.js";
+import { describeEachDialect, setupForDialect, teardownForDialect } from "../../utils/test-db.js";
+import type { DialectTestContext } from "../../utils/test-db.js";
 
 // ---------------------------------------------------------------------------
 // Helpers — ResolvedPlugin (for HookPipeline tests)
@@ -817,5 +821,227 @@ describe("PluginManager — resolveExclusiveHooks", () => {
 		expect(info[0]!.providers).toHaveLength(1);
 		expect(info[0]!.providers[0]!.pluginId).toBe("provider-a");
 		expect(info[0]!.selectedPluginId).toBe("provider-a");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveExclusiveHooks — batched option reads
+// ---------------------------------------------------------------------------
+
+describe("resolveExclusiveHooks — batched option reads", () => {
+	/**
+	 * Three plugins / three exclusive hooks covering every resolution branch:
+	 * - content:beforeSave: providers a+b active, valid stored selection (kept)
+	 * - content:afterSave: provider c stale (inactive), a remains (auto-select)
+	 * - content:beforeDelete: providers a+b active, no selection (unselected)
+	 */
+	function createScenarioPipeline(): HookPipeline {
+		const pluginA = createTestPlugin({
+			id: "provider-a",
+			hooks: {
+				"content:beforeSave": createTestHook("provider-a", vi.fn(), { exclusive: true }),
+				"content:afterSave": createTestHook("provider-a", vi.fn(), { exclusive: true }),
+				"content:beforeDelete": createTestHook("provider-a", vi.fn(), { exclusive: true }),
+			},
+		});
+		const pluginB = createTestPlugin({
+			id: "provider-b",
+			hooks: {
+				"content:beforeSave": createTestHook("provider-b", vi.fn(), { exclusive: true }),
+				"content:beforeDelete": createTestHook("provider-b", vi.fn(), { exclusive: true }),
+			},
+		});
+		const pluginC = createTestPlugin({
+			id: "provider-c",
+			hooks: {
+				"content:afterSave": createTestHook("provider-c", vi.fn(), { exclusive: true }),
+			},
+		});
+		return new HookPipeline([pluginA, pluginB, pluginC]);
+	}
+
+	function createScenarioStore(): Map<string, string> {
+		return new Map([
+			["emdash:exclusive_hook:content:beforeSave", "provider-a"],
+			["emdash:exclusive_hook:content:afterSave", "provider-c"],
+		]);
+	}
+
+	function createStoreCallbacks(store: Map<string, string>) {
+		return {
+			getOption: vi.fn(async (key: string): Promise<string | null> => store.get(key) ?? null),
+			getOptions: vi.fn(async (keys: string[]): Promise<Map<string, string | null>> => {
+				const result = new Map<string, string | null>();
+				for (const key of keys) {
+					const value = store.get(key);
+					if (value !== undefined) result.set(key, value);
+				}
+				return result;
+			}),
+			setOption: vi.fn(async (key: string, value: string) => {
+				store.set(key, value);
+			}),
+			deleteOption: vi.fn(async (key: string) => {
+				store.delete(key);
+			}),
+		};
+	}
+
+	const isActive = (id: string) => id !== "provider-c";
+
+	it("reads all selections with one getOptions call and no per-hook gets", async () => {
+		const pipeline = createScenarioPipeline();
+		const store = createScenarioStore();
+		const callbacks = createStoreCallbacks(store);
+
+		await resolveExclusiveHooks({ pipeline, isActive, ...callbacks });
+
+		expect(callbacks.getOptions).toHaveBeenCalledTimes(1);
+		expect(callbacks.getOptions.mock.calls[0]![0]).toEqual(
+			expect.arrayContaining([
+				"emdash:exclusive_hook:content:beforeSave",
+				"emdash:exclusive_hook:content:afterSave",
+				"emdash:exclusive_hook:content:beforeDelete",
+			]),
+		);
+		expect(callbacks.getOption).not.toHaveBeenCalled();
+	});
+
+	it("resolves identically to the per-key path", async () => {
+		// Batched path
+		const batchedPipeline = createScenarioPipeline();
+		const batchedStore = createScenarioStore();
+		await resolveExclusiveHooks({
+			pipeline: batchedPipeline,
+			isActive,
+			...createStoreCallbacks(batchedStore),
+		});
+
+		// Per-key path (no getOptions)
+		const perKeyPipeline = createScenarioPipeline();
+		const perKeyStore = createScenarioStore();
+		const { getOptions: _unused, ...perKeyCallbacks } = createStoreCallbacks(perKeyStore);
+		await resolveExclusiveHooks({
+			pipeline: perKeyPipeline,
+			isActive,
+			...perKeyCallbacks,
+		});
+
+		for (const hookName of ["content:beforeSave", "content:afterSave", "content:beforeDelete"]) {
+			expect(batchedPipeline.getExclusiveSelection(hookName)).toBe(
+				perKeyPipeline.getExclusiveSelection(hookName),
+			);
+		}
+		expect(batchedStore).toEqual(perKeyStore);
+
+		// Sanity-check the actual outcomes, not just parity
+		expect(batchedPipeline.getExclusiveSelection("content:beforeSave")).toBe("provider-a");
+		expect(batchedPipeline.getExclusiveSelection("content:afterSave")).toBe("provider-a");
+		expect(batchedPipeline.getExclusiveSelection("content:beforeDelete")).toBeUndefined();
+	});
+
+	it("skips resolution when the batch read fails (options table not ready)", async () => {
+		const pipeline = createScenarioPipeline();
+		const callbacks = createStoreCallbacks(createScenarioStore());
+		callbacks.getOptions.mockRejectedValue(new Error("no such table: options"));
+
+		await expect(
+			resolveExclusiveHooks({ pipeline, isActive, ...callbacks }),
+		).resolves.toBeUndefined();
+
+		// Matches the per-key tolerance: nothing written, nothing selected
+		expect(callbacks.setOption).not.toHaveBeenCalled();
+		expect(callbacks.deleteOption).not.toHaveBeenCalled();
+		expect(pipeline.getExclusiveSelection("content:beforeSave")).toBeUndefined();
+		expect(pipeline.getExclusiveSelection("content:afterSave")).toBeUndefined();
+		expect(pipeline.getExclusiveSelection("content:beforeDelete")).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PluginManager — batched resolution against a real database
+// ---------------------------------------------------------------------------
+
+/**
+ * Kysely plugin that counts compiled SELECT statements — one per executed
+ * select round trip. Used to assert the batched resolution issues a single
+ * options read regardless of how many exclusive hooks are registered.
+ */
+function createSelectCountingPlugin(): { plugin: KyselyPlugin; counter: { count: number } } {
+	const counter = { count: 0 };
+	const plugin: KyselyPlugin = {
+		transformQuery(args) {
+			if (args.node.kind === "SelectQueryNode") counter.count += 1;
+			return args.node;
+		},
+		transformResult(args) {
+			return Promise.resolve(args.result);
+		},
+	};
+	return { plugin, counter };
+}
+
+describeEachDialect("PluginManager — batched exclusive hook resolution", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("resolves all exclusive hooks with a single options select", async () => {
+		const { plugin: countingPlugin, counter } = createSelectCountingPlugin();
+		const db = ctx.db.withPlugin(countingPlugin);
+
+		const manager = new PluginManager({ db });
+		manager.register(
+			createTestDefinition({
+				id: "provider-save",
+				hooks: {
+					"content:beforeSave": {
+						handler: vi.fn() as unknown as ContentBeforeSaveHandler,
+						exclusive: true,
+					},
+				},
+			}),
+		);
+		manager.register(
+			createTestDefinition({
+				id: "provider-after",
+				hooks: {
+					"content:afterSave": {
+						handler: vi.fn() as unknown as ContentAfterSaveHandler,
+						exclusive: true,
+					},
+				},
+			}),
+		);
+		manager.register(
+			createTestDefinition({
+				id: "provider-delete",
+				hooks: {
+					"content:beforeDelete": {
+						handler: vi.fn() as unknown as ContentBeforeDeleteHandler,
+						exclusive: true,
+					},
+				},
+			}),
+		);
+		await manager.activate("provider-save");
+		await manager.activate("provider-after");
+		await manager.activate("provider-delete");
+
+		// All three sole providers were auto-selected during activation;
+		// a fresh resolution keeps them with exactly one batched read.
+		counter.count = 0;
+		await manager.resolveExclusiveHooks();
+		expect(counter.count).toBe(1);
+
+		expect(await manager.getExclusiveHookSelection("content:beforeSave")).toBe("provider-save");
+		expect(await manager.getExclusiveHookSelection("content:afterSave")).toBe("provider-after");
+		expect(await manager.getExclusiveHookSelection("content:beforeDelete")).toBe("provider-delete");
 	});
 });

--- a/packages/core/tests/unit/plugins/exclusive-hooks.test.ts
+++ b/packages/core/tests/unit/plugins/exclusive-hooks.test.ts
@@ -870,8 +870,8 @@ describe("resolveExclusiveHooks — batched option reads", () => {
 	function createStoreCallbacks(store: Map<string, string>) {
 		return {
 			getOption: vi.fn(async (key: string): Promise<string | null> => store.get(key) ?? null),
-			getOptions: vi.fn(async (keys: string[]): Promise<Map<string, string | null>> => {
-				const result = new Map<string, string | null>();
+			getOptions: vi.fn(async (keys: string[]): Promise<ReadonlyMap<string, string>> => {
+				const result = new Map<string, string>();
 				for (const key of keys) {
 					const value = store.get(key);
 					if (value !== undefined) result.set(key, value);


### PR DESCRIPTION
## What does this PR do?

Cold-isolate runtime init (`EmDashRuntime.create()`) runs its phases strictly sequentially, so every phase is a full DB/R2 round trip added to TTFB on the first request an isolate serves. Three changes, all preserving each phase's timing instrumentation and non-fatal error semantics:

1. **`rt.plugins` ∥ `rt.site`** — the `_plugin_state` SELECT and the site-info `getMany()` are independent reads against different tables; they now share one round-trip window under `Promise.all`. The `enabledPlugins` derivation (which consumes plugin states) moved after the join.
2. **`rt.market` ∥ `rt.registry`** — both tiers of installed sandboxed plugins only depend on the sandbox phase, not on each other; when both are enabled they now load concurrently (each is R2 listing + bundle fetches, the slowest part of cold boot on marketplace sites).
3. **Batched exclusive-hook reads** — `resolveExclusiveHooks` did one `getOption()` round trip per registered exclusive hook, sequentially. It now collects all `emdash:exclusive_hook:*` keys and reads them via `OptionsRepository.getMany()` in a single query (new optional `getOptions` on `ExclusiveHookResolutionOptions`; per-key path kept as fallback for callers that don't provide it). Writes are untouched. A batch-read failure (options table not ready) skips resolution entirely — the identical net effect to every per-key read failing.

Per-phase `phase()` timings are preserved by keeping each phase as its own `phase()` call and joining the promises, so Server-Timing still reports each phase's own duration (now overlapping in wall time).

Closes #<!-- none — follow-up to the cold-start latency investigation on #1274 -->

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — unit 173 files / 2,637 tests; integration 71 files / 1,041 tests
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _n/a — performance improvement, no new user-facing surface._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New tests: batched exclusive-hook resolution parity across all three branches (kept / stale-cleared + auto-select / multi-provider-unselected) with exactly 1 SELECT asserted via a query-counting Kysely plugin (dialect-agnostic via `describeEachDialect`), batch-failure tolerance (no writes, no selections), and an end-to-end `EmDashRuntime.create()` integration test against real SQLite asserting each `rt.*` phase appears exactly once with a finite duration and hook selections persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://perf-cold-boot-parallel-init-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `perf/cold-boot-parallel-init`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
