### PR TITLE
perf(core): fix query waterfalls — getTerm parallelism, hydrated terms reuse, menu pattern caching

### DIFF
--- a/.changeset/lucky-pots-repair.md
+++ b/.changeset/lucky-pots-repair.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Removes three query waterfalls on content-site renders:
+
+- `getTerm()` now runs its usage-count and children queries concurrently, saving a round trip on every tag/category archive page.
+- `getMenu()` request-caches the collection `url_pattern` lookup, so pages rendering several menus (header, footer, ...) only pay for it once per request.
+- Generated collection types (`emdash-env.d.ts`) now include the `terms` field that `getEmDashEntry`/`getEmDashCollection` already hydrate, so templates can read `entry.data.terms?.tag` instead of issuing a redundant `getEntryTerms()` query. The bundled templates and demos have been updated to do so.

--- a/.changeset/lucky-pots-repair.md
+++ b/.changeset/lucky-pots-repair.md
@@ -2,8 +2,8 @@
 "emdash": patch
 ---
 
-Removes three query waterfalls on content-site renders:
+Pages render with fewer database round trips:
 
-- `getTerm()` now runs its usage-count and children queries concurrently, saving a round trip on every tag/category archive page.
-- `getMenu()` request-caches the collection `url_pattern` lookup, so pages rendering several menus (header, footer, ...) only pay for it once per request.
-- Generated collection types (`emdash-env.d.ts`) now include the `terms` field that `getEmDashEntry`/`getEmDashCollection` already hydrate, so templates can read `entry.data.terms?.tag` instead of issuing a redundant `getEntryTerms()` query. The bundled templates and demos have been updated to do so.
+- Tag and category archive pages load faster — `getTerm()` fetches its details in parallel instead of one query at a time.
+- Pages with several menus (header, footer, …) no longer repeat the same lookup for each menu.
+- Entries fetched with `getEmDashEntry`/`getEmDashCollection` already include their taxonomy terms — you can now read `entry.data.terms?.tag` directly (it's typed in your generated `emdash-env.d.ts`) instead of making a separate `getEntryTerms()` call. The bundled templates have been updated to do this.

--- a/demos/cloudflare/emdash-env.d.ts
+++ b/demos/cloudflare/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/demos/cloudflare/src/pages/posts/[slug].astro
+++ b/demos/cloudflare/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/demos/playground/emdash-env.d.ts
+++ b/demos/playground/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/demos/playground/src/pages/posts/[slug].astro
+++ b/demos/playground/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/demos/postgres/emdash-env.d.ts
+++ b/demos/postgres/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/demos/postgres/src/pages/posts/[slug].astro
+++ b/demos/postgres/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/demos/preview/emdash-env.d.ts
+++ b/demos/preview/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/demos/preview/src/pages/posts/[slug].astro
+++ b/demos/preview/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/demos/simple/emdash-env.d.ts
+++ b/demos/simple/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/demos/simple/src/pages/posts/[slug].astro
+++ b/demos/simple/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/fixtures/perf-site/emdash-env.d.ts
+++ b/fixtures/perf-site/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/fixtures/perf-site/src/pages/posts/[slug].astro
+++ b/fixtures/perf-site/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -136,15 +136,10 @@ async function buildMenuTree(
 		}
 	}
 
-	const urlPatterns = new Map<string, string | null>();
-	if (collectionSlugs.size > 0) {
-		const rows = await db
-			.selectFrom("_emdash_collections")
-			.select(["slug", "url_pattern"])
-			.where("slug", "in", [...collectionSlugs])
-			.execute();
-		for (const row of rows) urlPatterns.set(row.slug, row.url_pattern);
-	}
+	const urlPatterns =
+		collectionSlugs.size > 0
+			? await getCollectionUrlPatterns(db, collectionSlugs)
+			: new Map<string, string | null>();
 
 	const resolvedItems = await Promise.all(
 		items.map((item) => resolveMenuItem(item, db, urlPatterns, locale)),
@@ -171,6 +166,29 @@ async function buildMenuTree(
 	}
 
 	return rootItems;
+}
+
+/**
+ * Look up the `url_pattern` for a set of collection slugs, request-cached so
+ * a page rendering several menus (header, footer, ...) only pays for the
+ * lookup once per distinct slug set. Callers must treat the returned map as
+ * read-only — it is shared across cache hits within the request.
+ */
+function getCollectionUrlPatterns(
+	db: Kysely<Database>,
+	collectionSlugs: Set<string>,
+): Promise<Map<string, string | null>> {
+	const key = `menu-collection-patterns:${[...collectionSlugs].toSorted().join(",")}`;
+	return requestCached(key, async () => {
+		const rows = await db
+			.selectFrom("_emdash_collections")
+			.select(["slug", "url_pattern"])
+			.where("slug", "in", [...collectionSlugs])
+			.execute();
+		const urlPatterns = new Map<string, string | null>();
+		for (const row of rows) urlPatterns.set(row.slug, row.url_pattern);
+		return urlPatterns;
+	});
 }
 
 /**

--- a/packages/core/src/schema/zod-generator.ts
+++ b/packages/core/src/schema/zod-generator.ts
@@ -288,6 +288,9 @@ export function generateTypeScript(collection: CollectionWithFields): string {
 	lines.push(`  publishedAt: Date | null;`);
 	// Bylines are eagerly loaded by getEmDashCollection/getEmDashEntry
 	lines.push(`  bylines?: ContentBylineCredit[];`);
+	// Taxonomy terms are eagerly loaded by getEmDashCollection/getEmDashEntry,
+	// keyed by taxonomy name (e.g. data.terms?.tag)
+	lines.push(`  terms?: Record<string, TaxonomyTerm[]>;`);
 	lines.push(`}`);
 
 	return lines.join("\n");
@@ -312,8 +315,9 @@ export function generateTypesFile(collections: CollectionWithFields[]): string {
 		c.fields.some((f) => f.type === "portableText"),
 	);
 
-	// Build imports - ContentBylineCredit is always needed for bylines
-	const imports = ["ContentBylineCredit"];
+	// Build imports - ContentBylineCredit and TaxonomyTerm are always needed
+	// for the hydrated bylines/terms fields
+	const imports = ["ContentBylineCredit", "TaxonomyTerm"];
 	if (needsPortableText) {
 		imports.push("PortableTextBlock");
 	}

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -189,13 +189,6 @@ export async function getTerm(
 
 	if (!row) return null;
 
-	const countResult = await db
-		.selectFrom("content_taxonomies")
-		.select((eb) => eb.fn.count<number>("entry_id").as("count"))
-		.where("taxonomy_id", "=", row.translation_group ?? row.id)
-		.executeTakeFirst();
-	const count = countResult?.count ?? 0;
-
 	let childrenQuery = db
 		.selectFrom("taxonomies")
 		.selectAll()
@@ -203,7 +196,18 @@ export async function getTerm(
 		.orderBy("label", "asc");
 	const termLocale = row.locale;
 	if (termLocale) childrenQuery = childrenQuery.where("locale", "=", termLocale);
-	const childRows = await childrenQuery.execute();
+
+	// The usage-count and children queries both depend only on the term row,
+	// so run them concurrently to save a round trip on remote databases.
+	const [countResult, childRows] = await Promise.all([
+		db
+			.selectFrom("content_taxonomies")
+			.select((eb) => eb.fn.count<number>("entry_id").as("count"))
+			.where("taxonomy_id", "=", row.translation_group ?? row.id)
+			.executeTakeFirst(),
+		childrenQuery.execute(),
+	]);
+	const count = countResult?.count ?? 0;
 
 	const children = childRows.map<TaxonomyTerm>((child) => ({
 		id: child.id,

--- a/packages/core/tests/unit/menus/menu-request-cache.test.ts
+++ b/packages/core/tests/unit/menus/menu-request-cache.test.ts
@@ -1,0 +1,121 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import type { Database as DatabaseSchema } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+
+// Mock loader.getDb so the runtime menu functions read from our test db.
+vi.mock("../../../src/loader.js", () => ({
+	getDb: vi.fn(),
+}));
+
+import { getDb } from "../../../src/loader.js";
+import { getMenu } from "../../../src/menus/index.js";
+import { runWithContext } from "../../../src/request-context.js";
+
+/** SQL of every query executed against the test database. */
+let queries: string[] = [];
+
+function collectionPatternQueries(): string[] {
+	return queries.filter((q) => q.includes("_emdash_collections") && q.includes("url_pattern"));
+}
+
+describe("getMenu collection-pattern request cache", () => {
+	let db: Kysely<DatabaseSchema>;
+
+	beforeEach(async () => {
+		queries = [];
+		db = new Kysely<DatabaseSchema>({
+			dialect: new SqliteDialect({ database: new Database(":memory:") }),
+			log(event) {
+				if (event.level === "query") queries.push(event.query.sql);
+			},
+		});
+		await runMigrations(db);
+
+		// A "post" collection with a url_pattern, plus one published entry
+		// that menu items can reference.
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({
+			slug: "post",
+			label: "Posts",
+			labelSingular: "Post",
+		});
+		await db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: "/blog/{slug}" })
+			.where("slug", "=", "post")
+			.execute();
+
+		const entryId = ulid();
+		await db
+			.insertInto("ec_post" as never)
+			.values({
+				id: entryId,
+				slug: "hello",
+				status: "published",
+				locale: "en",
+				translation_group: entryId,
+			} as never)
+			.execute();
+
+		// Two menus that both reference the same collection.
+		for (const name of ["primary", "footer"]) {
+			const menuId = ulid();
+			await db.insertInto("_emdash_menus").values({ id: menuId, name, label: name }).execute();
+			await db
+				.insertInto("_emdash_menu_items")
+				.values({
+					id: ulid(),
+					menu_id: menuId,
+					sort_order: 0,
+					type: "post",
+					reference_collection: "post",
+					reference_id: entryId,
+					label: "Hello",
+				})
+				.execute();
+		}
+
+		vi.mocked(getDb).mockResolvedValue(db);
+	});
+
+	afterEach(async () => {
+		await db.destroy();
+		vi.restoreAllMocks();
+	});
+
+	it("queries collection url_patterns once for multiple menus in one request", async () => {
+		queries = [];
+
+		const [primary, footer] = await runWithContext({ editMode: false }, async () => {
+			const first = await getMenu("primary");
+			const second = await getMenu("footer");
+			return [first, second];
+		});
+
+		expect(primary?.items.map((i) => i.url)).toEqual(["/blog/hello"]);
+		expect(footer?.items.map((i) => i.url)).toEqual(["/blog/hello"]);
+
+		expect(collectionPatternQueries()).toHaveLength(1);
+	});
+
+	it("returns identical results with and without a request context", async () => {
+		const cached = await runWithContext({ editMode: false }, () => getMenu("primary"));
+		const uncached = await getMenu("primary");
+
+		expect(cached).toEqual(uncached);
+	});
+
+	it("does not leak the cached patterns across requests", async () => {
+		await runWithContext({ editMode: false }, () => getMenu("primary"));
+		queries = [];
+
+		await runWithContext({ editMode: false }, () => getMenu("footer"));
+
+		expect(collectionPatternQueries()).toHaveLength(1);
+	});
+});

--- a/packages/core/tests/unit/schema/zod-generator.test.ts
+++ b/packages/core/tests/unit/schema/zod-generator.test.ts
@@ -552,6 +552,9 @@ describe("Zod Generator", () => {
 			expect(ts).toContain("content: PortableTextBlock[];");
 			expect(ts).toContain("featured?: boolean;");
 			expect(ts).toContain('status: "draft" | "published";');
+			// Hydrated by getEmDashCollection/getEmDashEntry
+			expect(ts).toContain("bylines?: ContentBylineCredit[];");
+			expect(ts).toContain("terms?: Record<string, TaxonomyTerm[]>;");
 		});
 	});
 });

--- a/packages/core/tests/unit/taxonomies/get-term.test.ts
+++ b/packages/core/tests/unit/taxonomies/get-term.test.ts
@@ -1,0 +1,176 @@
+import type {
+	KyselyPlugin,
+	PluginTransformQueryArgs,
+	PluginTransformResultArgs,
+	QueryResult,
+	RootOperationNode,
+	UnknownRow,
+} from "kysely";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
+import {
+	describeEachDialect,
+	setupForDialectWithCollections,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+// Mock loader.getDb so the runtime taxonomy functions read from our test db.
+vi.mock("../../../src/loader.js", () => ({
+	getDb: vi.fn(),
+}));
+
+import { getDb } from "../../../src/loader.js";
+import { getTerm } from "../../../src/taxonomies/index.js";
+
+/**
+ * Counts every query executed through the wrapped Kysely instance.
+ * `transformQuery` runs once per execution, so it doubles as a
+ * round-trip counter for asserting query budgets.
+ */
+class QueryCountingPlugin implements KyselyPlugin {
+	count = 0;
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		this.count += 1;
+		return args.node;
+	}
+
+	transformResult(args: PluginTransformResultArgs): Promise<QueryResult<UnknownRow>> {
+		return Promise.resolve(args.result);
+	}
+}
+
+describeEachDialect("getTerm", (dialect) => {
+	let ctx: DialectTestContext;
+	let taxRepo: TaxonomyRepository;
+	let contentRepo: ContentRepository;
+	let counter: QueryCountingPlugin;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		taxRepo = new TaxonomyRepository(ctx.db);
+		contentRepo = new ContentRepository(ctx.db);
+		counter = new QueryCountingPlugin();
+		vi.mocked(getDb).mockResolvedValue(ctx.db.withPlugin(counter));
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+		vi.restoreAllMocks();
+	});
+
+	it("returns the term with usage count and children", async () => {
+		const parent = await taxRepo.create({
+			name: "category",
+			slug: "tech",
+			label: "Technology",
+			data: { description: "All things tech" },
+		});
+		await taxRepo.create({
+			name: "category",
+			slug: "web",
+			label: "Web",
+			parentId: parent.id,
+		});
+		await taxRepo.create({
+			name: "category",
+			slug: "ai",
+			label: "AI",
+			parentId: parent.id,
+		});
+
+		const p1 = await contentRepo.create({
+			type: "post",
+			slug: "p1",
+			data: { title: "P1" },
+		});
+		const p2 = await contentRepo.create({
+			type: "post",
+			slug: "p2",
+			data: { title: "P2" },
+		});
+		await taxRepo.attachToEntry("post", p1.id, parent.id);
+		await taxRepo.attachToEntry("post", p2.id, parent.id);
+
+		const term = await getTerm("category", "tech");
+
+		expect(term).not.toBeNull();
+		expect(term?.id).toBe(parent.id);
+		expect(term?.name).toBe("category");
+		expect(term?.slug).toBe("tech");
+		expect(term?.label).toBe("Technology");
+		expect(term?.description).toBe("All things tech");
+		expect(Number(term?.count)).toBe(2);
+		// Children ordered by label
+		expect(term?.children.map((c) => c.slug)).toEqual(["ai", "web"]);
+		expect(term?.children.every((c) => c.parentId === parent.id)).toBe(true);
+	});
+
+	it("returns null for a non-existent term", async () => {
+		const term = await getTerm("category", "does-not-exist");
+		expect(term).toBeNull();
+	});
+
+	it("only returns children in the term's locale", async () => {
+		const parent = await taxRepo.create({
+			name: "category",
+			slug: "tech",
+			label: "Technology",
+		});
+		await taxRepo.create({
+			name: "category",
+			slug: "web",
+			label: "Web",
+			parentId: parent.id,
+		});
+		// A child row in a different locale must be filtered out.
+		await ctx.db
+			.insertInto("taxonomies")
+			.values({
+				id: "term_fr_child",
+				name: "category",
+				slug: "ouaib",
+				label: "Ouaib",
+				parent_id: parent.id,
+				locale: "fr",
+				translation_group: "term_fr_child",
+			})
+			.execute();
+
+		const term = await getTerm("category", "tech");
+
+		expect(term?.children.map((c) => c.slug)).toEqual(["web"]);
+	});
+
+	it("resolves the term in three queries (term, count, children)", async () => {
+		const parent = await taxRepo.create({
+			name: "category",
+			slug: "tech",
+			label: "Technology",
+		});
+		await taxRepo.create({
+			name: "category",
+			slug: "web",
+			label: "Web",
+			parentId: parent.id,
+		});
+		const post = await contentRepo.create({
+			type: "post",
+			slug: "p1",
+			data: { title: "P1" },
+		});
+		await taxRepo.attachToEntry("post", post.id, parent.id);
+
+		counter.count = 0;
+		const term = await getTerm("category", "tech");
+
+		expect(term).not.toBeNull();
+		expect(Number(term?.count)).toBe(1);
+		expect(term?.children).toHaveLength(1);
+		// 1 term lookup + (count ∥ children) — anything more is a regression.
+		expect(counter.count).toBe(3);
+	});
+});

--- a/templates/blog-cloudflare/emdash-env.d.ts
+++ b/templates/blog-cloudflare/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/templates/blog-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/blog-cloudflare/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/templates/blog/emdash-env.d.ts
+++ b/templates/blog/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { ContentBylineCredit, PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -15,6 +15,7 @@ export interface Page {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -29,6 +30,7 @@ export interface Post {
   updatedAt: Date;
   publishedAt: Date | null;
   bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/templates/blog/src/pages/posts/[slug].astro
+++ b/templates/blog/src/pages/posts/[slug].astro
@@ -2,7 +2,6 @@
 import {
 	getEmDashEntry,
 	getEmDashCollection,
-	getEntryTerms,
 	getTermsForEntries,
 	getSeoMeta,
 	decodeSlug,
@@ -72,18 +71,15 @@ const bylines = post.data.bylines ?? [];
 // Get reading time
 const readingTime = getReadingTime(post.data.content);
 
-// Fetch this post's tags and the related-posts list in parallel — they're
-// independent queries, so running them concurrently halves the round-trip
-// cost on remote databases.
-// Note: post.id is the slug, post.data.id is the database ULID.
-const [tags, { entries: recentPosts }] = await Promise.all([
-	getEntryTerms("posts", post.data.id, "tag"),
-	// Fetch a few extra in case the current post is among them
-	getEmDashCollection("posts", {
-		orderBy: { published_at: "desc" },
-		limit: 4,
-	}),
-]);
+// This post's tags are already hydrated onto the entry by getEmDashEntry —
+// no extra query needed.
+const tags = post.data.terms?.tag ?? [];
+
+// Fetch a few extra recent posts in case the current post is among them.
+const { entries: recentPosts } = await getEmDashCollection("posts", {
+	orderBy: { published_at: "desc" },
+	limit: 4,
+});
 const otherPosts = recentPosts.filter((p) => p.id !== post.id).slice(0, 3);
 
 // Single batched query for related-posts tags, rather than one

--- a/templates/starter-cloudflare/emdash-env.d.ts
+++ b/templates/starter-cloudflare/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -14,6 +14,8 @@ export interface Page {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
+  bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -27,6 +29,8 @@ export interface Post {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
+  bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/templates/starter-cloudflare/src/pages/posts/[slug].astro
+++ b/templates/starter-cloudflare/src/pages/posts/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getEmDashEntry, getEntryTerms, getSeoMeta, decodeSlug, getSiteSettings } from "emdash";
+import { getEmDashEntry, getSeoMeta, decodeSlug, getSiteSettings } from "emdash";
 import { Image, PortableText, WidgetArea } from "emdash/ui";
 import Base from "../../layouts/Base.astro";
 import { resolveStarterSiteIdentity } from "../../utils/site-identity";
@@ -26,9 +26,9 @@ const seo = getSeoMeta(post, {
 	path: `/posts/${slug}`,
 });
 
-// Taxonomy terms for this post (use post.data.id, not post.id)
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-const categories = await getEntryTerms("posts", post.data.id, "category");
+// Taxonomy terms are already hydrated onto the entry by getEmDashEntry.
+const tags = post.data.terms?.tag ?? [];
+const categories = post.data.terms?.category ?? [];
 ---
 
 <Base

--- a/templates/starter/emdash-env.d.ts
+++ b/templates/starter/emdash-env.d.ts
@@ -3,7 +3,7 @@
 
 /// <reference types="emdash/locals" />
 
-import type { PortableTextBlock } from "emdash";
+import type { ContentBylineCredit, TaxonomyTerm, PortableTextBlock } from "emdash";
 
 export interface Page {
   id: string;
@@ -14,6 +14,8 @@ export interface Page {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
+  bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 export interface Post {
@@ -27,6 +29,8 @@ export interface Post {
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
+  bylines?: ContentBylineCredit[];
+  terms?: Record<string, TaxonomyTerm[]>;
 }
 
 declare module "emdash" {

--- a/templates/starter/src/pages/posts/[slug].astro
+++ b/templates/starter/src/pages/posts/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getEmDashEntry, getEntryTerms, getSeoMeta, decodeSlug, getSiteSettings } from "emdash";
+import { getEmDashEntry, getSeoMeta, decodeSlug, getSiteSettings } from "emdash";
 import { Image, PortableText, WidgetArea } from "emdash/ui";
 import Base from "../../layouts/Base.astro";
 import { resolveStarterSiteIdentity } from "../../utils/site-identity";
@@ -26,9 +26,9 @@ const seo = getSeoMeta(post, {
 	path: `/posts/${slug}`,
 });
 
-// Taxonomy terms for this post (use post.data.id, not post.id)
-const tags = await getEntryTerms("posts", post.data.id, "tag");
-const categories = await getEntryTerms("posts", post.data.id, "category");
+// Taxonomy terms are already hydrated onto the entry by getEmDashEntry.
+const tags = post.data.terms?.tag ?? [];
+const categories = post.data.terms?.category ?? [];
 ---
 
 <Base


### PR DESCRIPTION
## What does this PR do?

Three query-waterfall fixes found while investigating uncached-request latency (production pages show 5–7 fully serialized queries at 15–40ms each on D1):

1. **`getTerm()` parallelization** — the usage-count and children queries both depend only on the already-fetched term row but ran sequentially. They now run under `Promise.all`: one round trip saved on every tag/category archive page. Locale filtering on the children query is unchanged (`content_taxonomies` is keyed by translation_group and has no locale column, so the count query has no locale concern).

2. **Reuse hydrated terms in templates** — `getEmDashEntry`/`getEmDashCollection` already hydrate `entry.data.terms` (same join, collection and locale filtering as `getEntryTerms`), but 10 first-party templates/demos re-queried terms per entry anyway. They now read `post.data.terms?.tag ?? []` directly — one query saved per post-detail page (two in the starter, which refetched tag *and* category). Supporting change: the type generator (`zod-generator.ts`) now emits `terms?: Record<string, TaxonomyTerm[]>` alongside the existing `bylines` field (additive), and the touched sites' checked-in `emdash-env.d.ts` files are regenerated. Note: hydrated terms are label-sorted, so tag display order may change where the old per-entry query used a different order.

3. **Menu collection-pattern lookup request-cached** — `buildMenuTree` queried `_emdash_collections.url_pattern` per `getMenu()` call; a page rendering header + footer menus paid it twice. The lookup is now wrapped in `requestCached` keyed by the sorted slug set.

Query-count snapshots will change (decreases only) — intentionally not regenerated here; CI auto-updates them on the PR. Please review that the snapshot diff shows only decreases.

Closes #<!-- none — follow-up to the latency investigation on #1274 -->

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (packages, templates, demos, fixtures)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — unit 175 files / 2,640 tests; integration 70 files / 1,039 tests
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _n/a — performance improvement._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New tests (TDD): `get-term.test.ts` (dialect-agnostic via `describeEachDialect`; behavior lock + exact 3-query budget via a counting Kysely plugin), `menu-request-cache.test.ts` (two getMenu calls → one url_pattern query; failed at 2 queries before the fix), zod-generator `terms` emission. Known pre-existing failure unrelated to this PR: `demos/preview` `astro check` fails on duplicated astro versions in node_modules (identical on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://perf-query-waterfalls-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `perf/query-waterfalls`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
