### PR TITLE
perf(cloudflare): opt-in coalescing of same-turn SELECTs into one D1 batch() round trip

### DIFF
--- a/.changeset/dirty-pugs-attack.md
+++ b/.changeset/dirty-pugs-attack.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": minor
+---
+
+Adds an experimental opt-in `coalesce` option to the `d1()` adapter. When enabled (alongside `session`), SELECT queries issued in the same event-loop turn on the per-request session database are buffered and executed as a single D1 `batch()` call — one HTTP round trip instead of N fully-serialized ones. Writes, CTEs and other statements always execute immediately, and if a batch fails the buffered queries are retried individually so each keeps its own error semantics.

--- a/.changeset/dirty-pugs-attack.md
+++ b/.changeset/dirty-pugs-attack.md
@@ -2,4 +2,12 @@
 "@emdash-cms/cloudflare": minor
 ---
 
-Adds an experimental opt-in `coalesce` option to the `d1()` adapter. When enabled (alongside `session`), SELECT queries issued in the same event-loop turn on the per-request session database are buffered and executed as a single D1 `batch()` call — one HTTP round trip instead of N fully-serialized ones. Writes, CTEs and other statements always execute immediately, and if a batch fails the buffered queries are retried individually so each keeps its own error semantics.
+New experimental `coalesce` option for the `d1()` adapter, for much faster uncached page loads:
+
+```ts
+emdash({
+	database: d1({ binding: "DB", session: "auto", coalesce: true }),
+});
+```
+
+When enabled, read queries that a page issues at the same time are sent to D1 as a single round trip instead of one at a time. A page that runs half a dozen queries — settings, menus, the entry, related posts — pays for one trip to the database instead of six, which can cut uncached render time by more than half. Each query still gets its own results and its own errors, and writes are unaffected. Requires `session` to be enabled; off by default while experimental.

--- a/infra/blog-demo/astro.config.mjs
+++ b/infra/blog-demo/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
 	integrations: [
 		react(),
 		emdash({
-			database: d1({ binding: "DB", session: "auto" }),
+			database: d1({ binding: "DB", session: "auto", coalesce: true }),
 			storage: r2({ binding: "MEDIA" }),
 			plugins: [formsPlugin()],
 			sandboxed: [webhookNotifier],

--- a/infra/cache-demo/astro.config.mjs
+++ b/infra/cache-demo/astro.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig({
 	integrations: [
 		react(),
 		emdash({
-			database: d1({ binding: "DB", session: "auto" }),
+			database: d1({ binding: "DB", session: "auto", coalesce: true }),
 			storage: r2({ binding: "MEDIA" }),
 			plugins: [formsPlugin()],
 			sandboxed: [webhookNotifier],

--- a/packages/cloudflare/src/db/coalescing-d1.ts
+++ b/packages/cloudflare/src/db/coalescing-d1.ts
@@ -35,6 +35,8 @@ interface PendingQuery {
 	statement: D1PreparedStatement;
 	resolve: (result: QueryResult<any>) => void;
 	reject: (error: unknown) => void;
+	/** SQL text, kept for error reporting. */
+	sql: string;
 }
 
 /**
@@ -80,7 +82,7 @@ export class CoalescingD1Connection implements DatabaseConnection {
 		const statement = this.#database.prepare(compiledQuery.sql).bind(...compiledQuery.parameters);
 
 		return new Promise<QueryResult<R>>((resolve, reject) => {
-			this.#buffer.push({ statement, resolve, reject });
+			this.#buffer.push({ statement, resolve, reject, sql: compiledQuery.sql });
 			if (!this.#flushScheduled) {
 				this.#flushScheduled = true;
 				// setTimeout(0) (macrotask), not queueMicrotask: Kysely awaits
@@ -120,16 +122,17 @@ export class CoalescingD1Connection implements DatabaseConnection {
 			// Fall back to executing every buffered statement individually
 			// (they are all SELECTs, safe to re-run) so innocent queries still
 			// resolve and only the genuinely failing one rejects with its own
-			// error. This preserves per-query error semantics.
-			await Promise.all(
-				pending.map(async (p) => {
-					try {
-						p.resolve(mapD1Result(await p.statement.all()));
-					} catch (error) {
-						p.reject(error);
-					}
-				}),
-			);
+			// error. This preserves per-query error semantics. Sequential, in
+			// issue order: this is an error path where determinism matters
+			// more than latency, and it avoids piling concurrent retries onto
+			// a database that just failed.
+			for (const p of pending) {
+				try {
+					p.resolve(mapD1Result(await p.statement.all()));
+				} catch (error) {
+					p.reject(error);
+				}
+			}
 			return;
 		}
 
@@ -144,7 +147,7 @@ export class CoalescingD1Connection implements DatabaseConnection {
 					entry.reject(error);
 				}
 			} else {
-				entry.reject(new Error("D1 batch() returned no result for statement"));
+				entry.reject(new Error(`D1 batch() returned no result for statement ${i}: ${entry.sql}`));
 			}
 		}
 	}

--- a/packages/cloudflare/src/db/coalescing-d1.ts
+++ b/packages/cloudflare/src/db/coalescing-d1.ts
@@ -1,0 +1,224 @@
+/**
+ * Experimental coalescing D1 driver.
+ *
+ * Buffers SELECT queries issued in the same event-loop turn and executes
+ * them as a single D1 `batch()` call (one HTTP round trip) instead of N
+ * fully-serialized round trips. Production pages routinely issue 5-7
+ * serialized queries at 15-40ms each; batching collapses them into one.
+ *
+ * Only used for the per-request session Kysely (see createRequestScopedDb
+ * in d1.ts). The shared singleton must never coalesce: concurrent requests
+ * would share a buffer and one request's queries could be batched into
+ * another request's round trip.
+ */
+
+import {
+	type CompiledQuery,
+	type DatabaseConnection,
+	type Driver,
+	type QueryResult,
+	SqliteAdapter,
+} from "kysely";
+import type { D1DialectConfig } from "kysely-d1";
+
+import { EmDashD1Dialect } from "./d1-dialect.js";
+
+/**
+ * Statements safe to coalesce: plain SELECTs. Deliberately conservative —
+ * `WITH` is excluded because SQLite allows CTEs on writes
+ * (`WITH ... INSERT/UPDATE/DELETE`), and everything else (insert, update,
+ * delete, pragma, explain, ...) takes the direct path.
+ */
+const SELECT_PATTERN = /^select\b/i;
+
+interface PendingQuery {
+	statement: D1PreparedStatement;
+	resolve: (result: QueryResult<any>) => void;
+	reject: (error: unknown) => void;
+}
+
+/**
+ * Map a D1 result to a Kysely QueryResult. Mirrors kysely-d1's mapping
+ * exactly: rows from `results`, numAffectedRows from `meta.changes` as
+ * BigInt when > 0, insertId from `meta.last_row_id`.
+ */
+function mapD1Result<R>(result: D1Result<R>): QueryResult<R> {
+	if (result.error) {
+		throw new Error(result.error);
+	}
+	const numAffectedRows = result.meta.changes > 0 ? BigInt(result.meta.changes) : undefined;
+	return {
+		insertId:
+			result.meta.last_row_id === undefined || result.meta.last_row_id === null
+				? undefined
+				: BigInt(result.meta.last_row_id),
+		rows: result.results ?? [],
+		numAffectedRows,
+	};
+}
+
+export class CoalescingD1Connection implements DatabaseConnection {
+	#database: D1Database;
+	#buffer: PendingQuery[] = [];
+	#flushScheduled = false;
+
+	constructor(database: D1Database) {
+		this.#database = database;
+	}
+
+	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+		if (!SELECT_PATTERN.test(compiledQuery.sql.trim())) {
+			// Non-SELECT: execute immediately on the direct path, identical to
+			// kysely-d1's prepare/bind/all flow.
+			const result = await this.#database
+				.prepare(compiledQuery.sql)
+				.bind(...compiledQuery.parameters)
+				.all<R>();
+			return mapD1Result(result);
+		}
+
+		const statement = this.#database.prepare(compiledQuery.sql).bind(...compiledQuery.parameters);
+
+		return new Promise<QueryResult<R>>((resolve, reject) => {
+			this.#buffer.push({ statement, resolve, reject });
+			if (!this.#flushScheduled) {
+				this.#flushScheduled = true;
+				// setTimeout(0) (macrotask), not queueMicrotask: Kysely awaits
+				// internally between acquiring the connection and executing each
+				// query, so a microtask window would close before sibling queries
+				// issued in the same turn reach the connection.
+				setTimeout(() => {
+					void this.#flush();
+				}, 0);
+			}
+		});
+	}
+
+	async #flush(): Promise<void> {
+		// Clear the flag before awaiting anything so queries arriving while the
+		// batch is in flight schedule a new flush window instead of being lost.
+		this.#flushScheduled = false;
+		const pending = this.#buffer.splice(0, this.#buffer.length);
+		if (pending.length === 0) return;
+
+		const first = pending[0];
+		if (pending.length === 1 && first) {
+			// A lone query gains nothing from batch(); execute it directly.
+			try {
+				first.resolve(mapD1Result(await first.statement.all()));
+			} catch (error) {
+				first.reject(error);
+			}
+			return;
+		}
+
+		let results: D1Result[];
+		try {
+			results = await this.#database.batch(pending.map((p) => p.statement));
+		} catch {
+			// D1 batches are atomic: one bad statement rejects the whole call.
+			// Fall back to executing every buffered statement individually
+			// (they are all SELECTs, safe to re-run) so innocent queries still
+			// resolve and only the genuinely failing one rejects with its own
+			// error. This preserves per-query error semantics.
+			await Promise.all(
+				pending.map(async (p) => {
+					try {
+						p.resolve(mapD1Result(await p.statement.all()));
+					} catch (error) {
+						p.reject(error);
+					}
+				}),
+			);
+			return;
+		}
+
+		for (let i = 0; i < pending.length; i++) {
+			const entry = pending[i];
+			if (!entry) continue;
+			const result = results[i];
+			if (result) {
+				try {
+					entry.resolve(mapD1Result(result));
+				} catch (error) {
+					entry.reject(error);
+				}
+			} else {
+				entry.reject(new Error("D1 batch() returned no result for statement"));
+			}
+		}
+	}
+
+	// eslint-disable-next-line require-yield -- D1 doesn't support streaming (same as kysely-d1)
+	async *streamQuery<R>(): AsyncIterableIterator<QueryResult<R>> {
+		throw new Error("D1 Driver does not support streaming");
+	}
+}
+
+export class CoalescingD1Driver implements Driver {
+	#connection: CoalescingD1Connection;
+
+	constructor(database: D1Database) {
+		// A single shared connection: the whole point is for concurrent queries
+		// in the same request to land in the same buffer.
+		this.#connection = new CoalescingD1Connection(database);
+	}
+
+	async init(): Promise<void> {}
+
+	async acquireConnection(): Promise<DatabaseConnection> {
+		return this.#connection;
+	}
+
+	async beginTransaction(): Promise<void> {
+		throw new Error("Transactions are not supported");
+	}
+
+	async commitTransaction(): Promise<void> {
+		throw new Error("Transactions are not supported");
+	}
+
+	async rollbackTransaction(): Promise<void> {
+		throw new Error("Transactions are not supported");
+	}
+
+	async releaseConnection(): Promise<void> {}
+
+	async destroy(): Promise<void> {}
+}
+
+/**
+ * SqliteAdapter reports `supportsMultipleConnections: false`, which makes
+ * Kysely's RuntimeDriver serialize every query behind a connection mutex
+ * (acquire → execute → release). Under that mutex a second query never
+ * reaches the connection until the first resolves, so nothing would ever
+ * coalesce. Our shared connection is explicitly safe for concurrent
+ * `executeQuery` calls — that is the whole point — so report `true`.
+ * Transactions are rejected by the driver regardless.
+ */
+class CoalescingD1Adapter extends SqliteAdapter {
+	override get supportsMultipleConnections(): boolean {
+		return true;
+	}
+}
+
+/**
+ * D1 dialect that coalesces same-turn SELECTs into a single `batch()` round
+ * trip. Keeps EmDash's D1-compatible introspector.
+ */
+export class CoalescingD1Dialect extends EmDashD1Dialect {
+	#database: D1Database;
+
+	constructor(config: D1DialectConfig) {
+		super(config);
+		this.#database = config.database;
+	}
+
+	override createAdapter(): SqliteAdapter {
+		return new CoalescingD1Adapter();
+	}
+
+	override createDriver(): Driver {
+		return new CoalescingD1Driver(this.#database);
+	}
+}

--- a/packages/cloudflare/src/db/coalescing-d1.ts
+++ b/packages/cloudflare/src/db/coalescing-d1.ts
@@ -43,6 +43,11 @@ interface PendingQuery {
  * Map a D1 result to a Kysely QueryResult. Mirrors kysely-d1's mapping
  * exactly: rows from `results`, numAffectedRows from `meta.changes` as
  * BigInt when > 0, insertId from `meta.last_row_id`.
+ *
+ * No `success` check: the D1Result type declares `success: true`, i.e. a
+ * returned result is always a success — D1 rejects the `.all()`/`.batch()`
+ * promise on failure, which the callers handle (the batch catch-fallback,
+ * and Kysely's own error path on the direct path).
  */
 function mapD1Result<R>(result: D1Result<R>): QueryResult<R> {
 	if (result.error) {
@@ -63,19 +68,51 @@ export class CoalescingD1Connection implements DatabaseConnection {
 	#database: D1Database;
 	#buffer: PendingQuery[] = [];
 	#flushScheduled = false;
+	/**
+	 * Tail of a promise chain that serializes every physical call against the
+	 * shared D1DatabaseSession (direct-path statements and batch flushes
+	 * alike). See #enqueue.
+	 */
+	#opChain: Promise<unknown> = Promise.resolve();
 
 	constructor(database: D1Database) {
 		this.#database = database;
 	}
 
+	/**
+	 * Run `op` after all previously-enqueued session calls have settled, so
+	 * only one physical call is ever in flight against the shared
+	 * D1DatabaseSession at a time.
+	 *
+	 * The plain SqliteAdapter reports `supportsMultipleConnections: false`,
+	 * which makes Kysely serialize every query behind a connection mutex. We
+	 * override that to `true` so same-turn SELECTs can reach the buffer
+	 * together — but that also removes the mutex for writes and direct-path
+	 * statements. D1 sessions are sequentially consistent and advance a
+	 * bookmark per executed query; overlapping calls on one session could
+	 * interleave that bookmark and persist a stale one at commit(), breaking
+	 * read-your-writes. This chain restores the single-in-flight invariant
+	 * for physical calls while still letting SELECTs coalesce into one batch.
+	 *
+	 * A failed op must not break the chain, so the stored tail swallows the
+	 * outcome; the returned promise still rejects for the caller.
+	 */
+	#enqueue<T>(op: () => Promise<T>): Promise<T> {
+		const run = this.#opChain.then(op, op);
+		this.#opChain = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	}
+
 	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
 		if (!SELECT_PATTERN.test(compiledQuery.sql.trim())) {
-			// Non-SELECT: execute immediately on the direct path, identical to
-			// kysely-d1's prepare/bind/all flow.
-			const result = await this.#database
-				.prepare(compiledQuery.sql)
-				.bind(...compiledQuery.parameters)
-				.all<R>();
+			// Non-SELECT: execute on the direct path (kysely-d1's prepare/bind/all
+			// flow), but through the op chain so it can't overlap an in-flight
+			// SELECT batch or another write on the shared session.
+			const statement = this.#database.prepare(compiledQuery.sql).bind(...compiledQuery.parameters);
+			const result = await this.#enqueue(() => statement.all<R>());
 			return mapD1Result(result);
 		}
 
@@ -83,73 +120,85 @@ export class CoalescingD1Connection implements DatabaseConnection {
 
 		return new Promise<QueryResult<R>>((resolve, reject) => {
 			this.#buffer.push({ statement, resolve, reject, sql: compiledQuery.sql });
-			if (!this.#flushScheduled) {
-				this.#flushScheduled = true;
-				// setTimeout(0) (macrotask), not queueMicrotask: Kysely awaits
-				// internally between acquiring the connection and executing each
-				// query, so a microtask window would close before sibling queries
-				// issued in the same turn reach the connection.
-				setTimeout(() => {
-					void this.#flush();
-				}, 0);
-			}
+			this.#scheduleFlush();
 		});
 	}
 
+	/**
+	 * Schedule a flush of buffered SELECTs unless one is already pending.
+	 *
+	 * setTimeout(0) (macrotask), not queueMicrotask: Kysely awaits internally
+	 * between acquiring the connection and executing each query, so a
+	 * microtask window would close before sibling queries issued in the same
+	 * turn reach the connection. Queries that arrive after the buffer is
+	 * drained (flag already cleared) simply schedule the next window; physical
+	 * ordering against any in-flight call is handled by #enqueue.
+	 */
+	#scheduleFlush(): void {
+		if (this.#flushScheduled) return;
+		this.#flushScheduled = true;
+		setTimeout(() => {
+			void this.#flush();
+		}, 0);
+	}
+
 	async #flush(): Promise<void> {
-		// Clear the flag before awaiting anything so queries arriving while the
-		// batch is in flight schedule a new flush window instead of being lost.
+		// Clear the scheduled flag before draining so queries arriving after
+		// this point schedule a fresh window rather than being stranded.
 		this.#flushScheduled = false;
 		const pending = this.#buffer.splice(0, this.#buffer.length);
 		if (pending.length === 0) return;
 
-		const first = pending[0];
-		if (pending.length === 1 && first) {
-			// A lone query gains nothing from batch(); execute it directly.
+		// Serialize the physical batch/all against every other session call.
+		await this.#enqueue(async () => {
+			const first = pending[0];
+			if (pending.length === 1 && first) {
+				// A lone query gains nothing from batch(); execute it directly.
+				try {
+					first.resolve(mapD1Result(await first.statement.all()));
+				} catch (error) {
+					first.reject(error);
+				}
+				return;
+			}
+
+			let results: D1Result[];
 			try {
-				first.resolve(mapD1Result(await first.statement.all()));
-			} catch (error) {
-				first.reject(error);
+				results = await this.#database.batch(pending.map((p) => p.statement));
+			} catch {
+				// D1 batches are atomic: one bad statement rejects the whole call.
+				// Fall back to executing every buffered statement individually
+				// (they are all SELECTs, safe to re-run) so innocent queries still
+				// resolve and only the genuinely failing one rejects with its own
+				// error. This preserves per-query error semantics. Sequential, in
+				// issue order: this is an error path where determinism matters
+				// more than latency, and it avoids piling concurrent retries onto
+				// a database that just failed.
+				for (const p of pending) {
+					try {
+						p.resolve(mapD1Result(await p.statement.all()));
+					} catch (error) {
+						p.reject(error);
+					}
+				}
+				return;
 			}
-			return;
-		}
 
-		let results: D1Result[];
-		try {
-			results = await this.#database.batch(pending.map((p) => p.statement));
-		} catch {
-			// D1 batches are atomic: one bad statement rejects the whole call.
-			// Fall back to executing every buffered statement individually
-			// (they are all SELECTs, safe to re-run) so innocent queries still
-			// resolve and only the genuinely failing one rejects with its own
-			// error. This preserves per-query error semantics. Sequential, in
-			// issue order: this is an error path where determinism matters
-			// more than latency, and it avoids piling concurrent retries onto
-			// a database that just failed.
-			for (const p of pending) {
-				try {
-					p.resolve(mapD1Result(await p.statement.all()));
-				} catch (error) {
-					p.reject(error);
+			for (let i = 0; i < pending.length; i++) {
+				const entry = pending[i];
+				if (!entry) continue;
+				const result = results[i];
+				if (result) {
+					try {
+						entry.resolve(mapD1Result(result));
+					} catch (error) {
+						entry.reject(error);
+					}
+				} else {
+					entry.reject(new Error(`D1 batch() returned no result for statement ${i}: ${entry.sql}`));
 				}
 			}
-			return;
-		}
-
-		for (let i = 0; i < pending.length; i++) {
-			const entry = pending[i];
-			if (!entry) continue;
-			const result = results[i];
-			if (result) {
-				try {
-					entry.resolve(mapD1Result(result));
-				} catch (error) {
-					entry.reject(error);
-				}
-			} else {
-				entry.reject(new Error(`D1 batch() returned no result for statement ${i}: ${entry.sql}`));
-			}
-		}
+		});
 	}
 
 	// eslint-disable-next-line require-yield -- D1 doesn't support streaming (same as kysely-d1)

--- a/packages/cloudflare/src/db/d1-dialect.ts
+++ b/packages/cloudflare/src/db/d1-dialect.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared D1 Kysely dialect with EmDash's D1-compatible introspector.
+ *
+ * Lives in its own module (rather than d1.ts) so the coalescing dialect in
+ * coalescing-d1.ts can extend it without creating a circular import with
+ * d1.ts, and without pulling cloudflare:workers into test environments.
+ */
+
+import type { DatabaseIntrospector, Kysely } from "kysely";
+import { D1Dialect } from "kysely-d1";
+
+import { D1Introspector } from "./d1-introspector.js";
+
+/**
+ * Custom D1 Dialect that uses our D1-compatible introspector
+ *
+ * The default kysely-d1 dialect uses SqliteIntrospector which does a
+ * cross-join with pragma_table_info() that D1 doesn't allow.
+ */
+export class EmDashD1Dialect extends D1Dialect {
+	override createIntrospector(db: Kysely<any>): DatabaseIntrospector {
+		return new D1Introspector(db);
+	}
+}

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -28,6 +28,12 @@ interface D1Config {
 const DEFAULT_BOOKMARK_COOKIE = "__em_d1_bookmark";
 
 /**
+ * One-shot guard so the "coalesce opted in but the binding can't do sessions
+ * at runtime" warning fires once per worker, not on every request.
+ */
+let warnedCoalesceNoRuntimeSession = false;
+
+/**
  * D1 bookmarks are opaque, minted by Cloudflare. We don't validate the shape
  * (a tighter regex risks rejecting a format change and silently degrading
  * read-your-writes), but we do cap length and reject control characters so a
@@ -126,7 +132,20 @@ export interface RequestScopedDb {
 export function createRequestScopedDb(opts: RequestScopedDbOpts): RequestScopedDb | null {
 	if (!isSessionEnabled(opts.config)) return null;
 	const binding = getBinding(opts.config);
-	if (!binding || typeof binding.withSession !== "function") return null;
+	if (!binding || typeof binding.withSession !== "function") {
+		// Sessions are enabled in config, so createDialect's config-time warning
+		// didn't fire — but the live binding can't actually do sessions (older
+		// D1 binding / missing withSession). Coalescing silently falls back to
+		// the singleton, so surface that once rather than leaving the opt-in a
+		// mystery no-op.
+		if (opts.config.coalesce && binding && !warnedCoalesceNoRuntimeSession) {
+			warnedCoalesceNoRuntimeSession = true;
+			console.warn(
+				"[emdash] d1({ coalesce: true }) has no effect: the D1 binding does not support sessions (withSession() is unavailable at runtime). Query coalescing requires D1 sessions.",
+			);
+		}
+		return null;
+	}
 
 	const cookieName = opts.config.bookmarkCookie ?? DEFAULT_BOOKMARK_COOKIE;
 	const configConstraint =

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -10,10 +10,10 @@
 
 import { env } from "cloudflare:workers";
 import { kyselyLogOption } from "emdash/database/instrumentation";
-import { type DatabaseIntrospector, type Dialect, Kysely } from "kysely";
-import { D1Dialect } from "kysely-d1";
+import { type Dialect, Kysely } from "kysely";
 
-import { D1Introspector } from "./d1-introspector.js";
+import { CoalescingD1Dialect } from "./coalescing-d1.js";
+import { EmDashD1Dialect } from "./d1-dialect.js";
 
 /**
  * D1 configuration (runtime type — matches the config-time type in index.ts)
@@ -22,6 +22,7 @@ interface D1Config {
 	binding: string;
 	session?: "disabled" | "auto" | "primary-first";
 	bookmarkCookie?: string;
+	coalesce?: boolean;
 }
 
 const DEFAULT_BOOKMARK_COOKIE = "__em_d1_bookmark";
@@ -43,18 +44,6 @@ function hasControlChars(value: string): boolean {
 		if (code < 0x20 || code === 0x7f) return true;
 	}
 	return false;
-}
-
-/**
- * Custom D1 Dialect that uses our D1-compatible introspector
- *
- * The default kysely-d1 dialect uses SqliteIntrospector which does a
- * cross-join with pragma_table_info() that D1 doesn't allow.
- */
-class EmDashD1Dialect extends D1Dialect {
-	override createIntrospector(db: Kysely<any>): DatabaseIntrospector {
-		return new D1Introspector(db);
-	}
 }
 
 /**
@@ -162,8 +151,17 @@ export function createRequestScopedDb(opts: RequestScopedDbOpts): RequestScopedD
 	// both of which D1DatabaseSession implements.
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- session is structurally compatible with the subset D1Dialect uses
 	const sessionAsDatabase = session as unknown as D1Database;
+	// Coalescing is per-request only by construction: this Kysely (and its
+	// driver buffer) lives for a single request, so there is no cross-request
+	// buffering. The shared singleton from createDialect must never coalesce.
+	const dialect = opts.config.coalesce
+		? new CoalescingD1Dialect({ database: sessionAsDatabase })
+		: new EmDashD1Dialect({ database: sessionAsDatabase });
 	const db = new Kysely<any>({
-		dialect: new EmDashD1Dialect({ database: sessionAsDatabase }),
+		dialect,
+		// Kysely measures around the driver call, so per-query metrics still
+		// count each query. With coalescing, durations reflect the shared batch
+		// window rather than per-statement time — acceptable.
 		log: kyselyLogOption(),
 	});
 

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -71,6 +71,13 @@ export function createDialect(config: D1Config): Dialect {
 				`Check your wrangler.jsonc configuration:\n\n${example}`,
 		);
 	}
+	// Coalescing only applies to the per-request session db; without
+	// sessions it silently does nothing, which would be a confusing no-op.
+	if (config.coalesce && !isSessionEnabled(config)) {
+		console.warn(
+			'[emdash] d1({ coalesce: true }) has no effect without sessions — set session: "auto" (or "primary-first") to enable query coalescing.',
+		);
+	}
 	return new EmDashD1Dialect({ database: db });
 }
 

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -76,20 +76,23 @@ export interface D1Config {
 	 *
 	 * SELECT queries issued in the same event-loop turn are buffered and
 	 * executed as a single D1 `batch()` call (one HTTP round trip) instead
-	 * of N serialized round trips. Writes, CTEs and other statements always
-	 * execute immediately. If the batch fails, queries are retried
-	 * individually so each query keeps its own error semantics.
+	 * of N serialized round trips. Writes, CTEs and other statements are not
+	 * batched — they enqueue immediately on the direct path. If the batch
+	 * fails, queries are retried individually so each query keeps its own
+	 * error semantics. Every physical D1 call (writes and the SELECT batch
+	 * alike) is serialized per request, so the session bookmark always
+	 * advances in execution order.
 	 *
 	 * Only applies to the per-request session database, so `session` must
 	 * also be enabled (`"auto"` or `"primary-first"`); the shared singleton
 	 * never coalesces.
 	 *
 	 * Ordering caveat: buffered reads execute at the next flush window
-	 * (~one macrotask later), while writes execute immediately. A read and
+	 * (~one macrotask later), while a write enqueues immediately. A read and
 	 * a write issued concurrently in the same turn (e.g. under
-	 * `Promise.all`) may therefore execute write-first. Reads that must
-	 * observe pre-write state should be awaited before issuing the write —
-	 * which sequential `await` code already does.
+	 * `Promise.all`) may therefore execute write-first (they never overlap).
+	 * Reads that must observe pre-write state should be awaited before
+	 * issuing the write — which sequential `await` code already does.
 	 *
 	 * @default false
 	 */

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -84,6 +84,13 @@ export interface D1Config {
 	 * also be enabled (`"auto"` or `"primary-first"`); the shared singleton
 	 * never coalesces.
 	 *
+	 * Ordering caveat: buffered reads execute at the next flush window
+	 * (~one macrotask later), while writes execute immediately. A read and
+	 * a write issued concurrently in the same turn (e.g. under
+	 * `Promise.all`) may therefore execute write-first. Reads that must
+	 * observe pre-write state should be awaited before issuing the write —
+	 * which sequential `await` code already does.
+	 *
 	 * @default false
 	 */
 	coalesce?: boolean;

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -70,6 +70,23 @@ export interface D1Config {
 	 * @default "__em_d1_bookmark"
 	 */
 	bookmarkCookie?: string;
+
+	/**
+	 * Experimental: batch concurrent read queries into one D1 round trip.
+	 *
+	 * SELECT queries issued in the same event-loop turn are buffered and
+	 * executed as a single D1 `batch()` call (one HTTP round trip) instead
+	 * of N serialized round trips. Writes, CTEs and other statements always
+	 * execute immediately. If the batch fails, queries are retried
+	 * individually so each query keeps its own error semantics.
+	 *
+	 * Only applies to the per-request session database, so `session` must
+	 * also be enabled (`"auto"` or `"primary-first"`); the shared singleton
+	 * never coalesces.
+	 *
+	 * @default false
+	 */
+	coalesce?: boolean;
 }
 
 /**

--- a/packages/cloudflare/tests/db/coalescing-d1.test.ts
+++ b/packages/cloudflare/tests/db/coalescing-d1.test.ts
@@ -1,0 +1,224 @@
+import { CompiledQuery, Kysely } from "kysely";
+import { describe, expect, it } from "vitest";
+
+import { CoalescingD1Dialect } from "../../src/db/coalescing-d1.js";
+
+interface MockResultConfig {
+	rows?: Record<string, unknown>[];
+	changes?: number;
+	lastRowId?: number;
+	error?: Error;
+}
+
+interface MockStatement {
+	sql: string;
+	params: unknown[];
+	bind: (...params: unknown[]) => MockStatement;
+	all: () => Promise<unknown>;
+}
+
+/**
+ * Hand-rolled mock of the D1Database subset the dialect uses (prepare/batch).
+ * Records every `all()` and `batch()` call (and their order) so tests can
+ * assert exactly which statements were coalesced.
+ */
+function createMockD1(resultsBySql: Record<string, MockResultConfig> = {}) {
+	const operations: string[] = [];
+	const batchCalls: MockStatement[][] = [];
+	const allCalls: MockStatement[] = [];
+
+	function d1Result(stmt: MockStatement) {
+		const config = resultsBySql[stmt.sql] ?? {};
+		if (config.error) throw config.error;
+		return {
+			success: true,
+			results: config.rows ?? [],
+			meta: { changes: config.changes ?? 0, last_row_id: config.lastRowId ?? 0 },
+		};
+	}
+
+	const database = {
+		prepare(sql: string): MockStatement {
+			const stmt: MockStatement = {
+				sql,
+				params: [],
+				bind(...params: unknown[]) {
+					stmt.params = params;
+					return stmt;
+				},
+				async all() {
+					operations.push(`all:${stmt.sql}`);
+					allCalls.push(stmt);
+					return d1Result(stmt);
+				},
+			};
+			return stmt;
+		},
+		// D1 batches are atomic: a single bad statement rejects the whole call,
+		// which the throw inside d1Result reproduces.
+		async batch(statements: MockStatement[]) {
+			operations.push(`batch:${statements.map((s) => s.sql).join("|")}`);
+			batchCalls.push(statements);
+			return statements.map((s) => d1Result(s));
+		},
+	};
+
+	return { database, operations, batchCalls, allCalls };
+}
+
+function createDb(mock: ReturnType<typeof createMockD1>) {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- mock implements the prepare/batch subset the dialect uses
+	const database = mock.database as unknown as D1Database;
+	return new Kysely<any>({ dialect: new CoalescingD1Dialect({ database }) });
+}
+
+describe("CoalescingD1Dialect", () => {
+	it("coalesces SELECTs issued in the same turn into one batch in issue order", async () => {
+		const rowsA = [{ id: 1 }];
+		const rowsB = [{ id: 2 }, { id: 3 }];
+		const mock = createMockD1({
+			"SELECT * FROM a": { rows: rowsA },
+			"select * from b where id = ?": { rows: rowsB },
+		});
+		const db = createDb(mock);
+
+		const [r1, r2] = await Promise.all([
+			db.executeQuery(CompiledQuery.raw("SELECT * FROM a")),
+			db.executeQuery(CompiledQuery.raw("select * from b where id = ?", ["abc"])),
+		]);
+
+		expect(mock.batchCalls).toHaveLength(1);
+		expect(mock.batchCalls[0]?.map((s) => s.sql)).toEqual([
+			"SELECT * FROM a",
+			"select * from b where id = ?",
+		]);
+		// Each caller gets its own rows, and bind params are preserved.
+		expect(r1.rows).toEqual(rowsA);
+		expect(r2.rows).toEqual(rowsB);
+		expect(mock.batchCalls[0]?.[1]?.params).toEqual(["abc"]);
+		// Nothing went through the single-statement path.
+		expect(mock.allCalls).toHaveLength(0);
+	});
+
+	it("does not batch sequentially awaited SELECTs", async () => {
+		const mock = createMockD1({
+			"select 1": { rows: [{ one: 1 }] },
+			"select 2": { rows: [{ two: 2 }] },
+		});
+		const db = createDb(mock);
+
+		const r1 = await db.executeQuery(CompiledQuery.raw("select 1"));
+		const r2 = await db.executeQuery(CompiledQuery.raw("select 2"));
+
+		expect(mock.batchCalls).toHaveLength(0);
+		expect(mock.allCalls.map((s) => s.sql)).toEqual(["select 1", "select 2"]);
+		expect(r1.rows).toEqual([{ one: 1 }]);
+		expect(r2.rows).toEqual([{ two: 2 }]);
+		// Lone SELECTs flow through the buffer but report no affected rows.
+		expect(r1.numAffectedRows).toBeUndefined();
+	});
+
+	it("executes writes and CTEs immediately while same-turn SELECTs still coalesce", async () => {
+		const mock = createMockD1({ "insert into a (name) values (?)": { changes: 1, lastRowId: 7 } });
+		const db = createDb(mock);
+
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select * from a")),
+			db.executeQuery(CompiledQuery.raw("insert into a (name) values (?)", ["x"])),
+			db.executeQuery(CompiledQuery.raw("update a set name = ?", ["y"])),
+			db.executeQuery(CompiledQuery.raw("delete from a where id = ?", [1])),
+			db.executeQuery(CompiledQuery.raw("select * from b")),
+			// WITH is never coalesced: SQLite allows CTEs on writes.
+			db.executeQuery(CompiledQuery.raw("with x as (select 1) delete from a")),
+		]);
+
+		// Non-SELECTs hit the direct path before the macrotask flush fires.
+		expect(mock.operations).toEqual([
+			"all:insert into a (name) values (?)",
+			"all:update a set name = ?",
+			"all:delete from a where id = ?",
+			"all:with x as (select 1) delete from a",
+			"batch:select * from a|select * from b",
+		]);
+	});
+
+	it("falls back to individual execution when the batch rejects", async () => {
+		const failure = new Error("no such column: nope");
+		const mock = createMockD1({
+			"select good1": { rows: [{ ok: 1 }] },
+			"select nope": { error: failure },
+			"select good2": { rows: [{ ok: 2 }] },
+		});
+		const db = createDb(mock);
+
+		const [r1, r2, r3] = await Promise.allSettled([
+			db.executeQuery(CompiledQuery.raw("select good1")),
+			db.executeQuery(CompiledQuery.raw("select nope")),
+			db.executeQuery(CompiledQuery.raw("select good2")),
+		]);
+
+		// One atomic batch was attempted, then every statement re-ran solo.
+		expect(mock.batchCalls).toHaveLength(1);
+		expect(mock.allCalls.map((s) => s.sql)).toEqual([
+			"select good1",
+			"select nope",
+			"select good2",
+		]);
+
+		expect(r1.status).toBe("fulfilled");
+		if (r1.status === "fulfilled") expect(r1.value.rows).toEqual([{ ok: 1 }]);
+		expect(r2.status).toBe("rejected");
+		if (r2.status === "rejected") expect(r2.reason).toBe(failure);
+		expect(r3.status).toBe("fulfilled");
+		if (r3.status === "fulfilled") expect(r3.value.rows).toEqual([{ ok: 2 }]);
+	});
+
+	it("maps rows, numAffectedRows and insertId on the direct path", async () => {
+		const mock = createMockD1({
+			"insert into a (name) values (?)": { changes: 2, lastRowId: 7 },
+			"delete from a where 1 = 0": { changes: 0 },
+		});
+		const db = createDb(mock);
+
+		const inserted = await db.executeQuery(
+			CompiledQuery.raw("insert into a (name) values (?)", ["x"]),
+		);
+		expect(inserted.rows).toEqual([]);
+		expect(inserted.numAffectedRows).toBe(2n);
+		expect(inserted.insertId).toBe(7n);
+		expect(mock.allCalls[0]?.params).toEqual(["x"]);
+
+		// Zero changes maps to undefined, matching kysely-d1.
+		const deleted = await db.executeQuery(CompiledQuery.raw("delete from a where 1 = 0"));
+		expect(deleted.numAffectedRows).toBeUndefined();
+		expect(mock.batchCalls).toHaveLength(0);
+	});
+
+	it("starts a new batch window after a flush", async () => {
+		const mock = createMockD1();
+		const db = createDb(mock);
+
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select 1")),
+			db.executeQuery(CompiledQuery.raw("select 2")),
+		]);
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select 3")),
+			db.executeQuery(CompiledQuery.raw("select 4")),
+		]);
+
+		expect(mock.batchCalls).toHaveLength(2);
+		expect(mock.batchCalls[0]?.map((s) => s.sql)).toEqual(["select 1", "select 2"]);
+		expect(mock.batchCalls[1]?.map((s) => s.sql)).toEqual(["select 3", "select 4"]);
+	});
+
+	it("rejects transactions", async () => {
+		const db = createDb(createMockD1());
+
+		await expect(
+			db.transaction().execute(async () => {
+				// never reached
+			}),
+		).rejects.toThrow("Transactions are not supported");
+	});
+});

--- a/packages/cloudflare/tests/db/coalescing-d1.test.ts
+++ b/packages/cloudflare/tests/db/coalescing-d1.test.ts
@@ -212,6 +212,64 @@ describe("CoalescingD1Dialect", () => {
 		expect(mock.batchCalls[1]?.map((s) => s.sql)).toEqual(["select 3", "select 4"]);
 	});
 
+	it("never overlaps physical session calls: a write and a SELECT batch run serially", async () => {
+		// The driver flips supportsMultipleConnections to true, which removes
+		// Kysely's connection mutex. A same-turn write (direct path) must still
+		// not run concurrently with the buffered-SELECT batch on the shared D1
+		// session — overlapping calls could interleave the session bookmark.
+		// This mock counts how many physical calls are in flight at once; the
+		// pre-serialization code reaches 2 here.
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const ops: string[] = [];
+		const okResult = () => ({ success: true, results: [], meta: { changes: 0, last_row_id: 0 } });
+		async function hold<T>(label: string, value: T): Promise<T> {
+			inFlight++;
+			maxInFlight = Math.max(maxInFlight, inFlight);
+			ops.push(label);
+			// Hold the "connection" across a macrotask so a concurrent call,
+			// if one were issued, would be observed in flight simultaneously.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			inFlight--;
+			return value;
+		}
+		function makeStatement(sql: string): MockStatement {
+			const stmt: MockStatement = {
+				sql,
+				params: [],
+				bind(...params: unknown[]) {
+					stmt.params = params;
+					return stmt;
+				},
+				all: () => hold(`all:${stmt.sql}`, okResult()),
+			};
+			return stmt;
+		}
+		const database = {
+			prepare: (sql: string) => makeStatement(sql),
+			batch: (statements: MockStatement[]) =>
+				hold(
+					`batch:${statements.map((s) => s.sql).join("|")}`,
+					statements.map(() => okResult()),
+				),
+		};
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- mock implements the prepare/batch subset the dialect uses
+		const db = new Kysely<any>({
+			dialect: new CoalescingD1Dialect({ database: database as unknown as D1Database }),
+		});
+
+		await Promise.all([
+			db.executeQuery(CompiledQuery.raw("select * from a")),
+			db.executeQuery(CompiledQuery.raw("select * from b")),
+			db.executeQuery(CompiledQuery.raw("update a set n = ?", ["x"])),
+		]);
+
+		expect(maxInFlight).toBe(1);
+		// The write executes first (direct path, enqueued immediately), then the
+		// coalesced SELECT batch — never overlapping.
+		expect(ops).toEqual(["all:update a set n = ?", "batch:select * from a|select * from b"]);
+	});
+
 	it("rejects transactions", async () => {
 		const db = createDb(createMockD1());
 


### PR DESCRIPTION
## What does this PR do?

Adds an experimental, opt-in coalescing driver for D1: SELECT queries issued in the same event-loop turn are buffered and executed as a **single `D1Database.batch()` call** — one HTTP round trip instead of N. Production pages currently issue 5–7 fully serialized queries at 15–40ms each; with coalescing, queries that are issued concurrently (e.g. `Promise.all` in templates, parallel component renders) collapse into one round trip.

```ts
emdash({
	database: d1({ binding: "DB", session: "auto", coalesce: true }),
});
```

Design constraints (deliberately conservative):
- **SELECT-only.** Writes, `WITH` (SQLite allows CTEs on writes), PRAGMA, EXPLAIN — everything else takes the direct path immediately, with kysely-d1's exact result mapping.
- **Per-request session only.** The coalescing Kysely (and its buffer) is created per request in `createRequestScopedDb`, so cross-request buffering is impossible by construction. The shared singleton never coalesces. `session` must be enabled.
- **Atomic-batch error fallback.** D1 batches are atomic — one bad statement rejects the whole call. On batch failure every buffered statement is re-executed individually (safe: all SELECTs), so innocent queries resolve and only the failing one rejects with its own error. Per-query error semantics preserved.
- Flush window is `setTimeout(0)` (macrotask) — Kysely awaits internally between connection acquisition and execution, so a microtask window closes before sibling queries arrive. A lone query skips `batch()` and executes directly. Queries arriving mid-batch open a fresh window.

**Notable finding while implementing:** kysely's `SqliteAdapter` reports `supportsMultipleConnections: false`, which makes Kysely's `RuntimeDriver` serialize *every* query behind a connection mutex — even `Promise.all`'d queries never run concurrently against D1 today. The coalescing dialect overrides this (its shared connection is concurrent-safe by design; transactions throw regardless). This mutex is plausibly a contributor to the fully-serialized query waterfalls observed in production even where templates already parallelize.

Refactor note: `EmDashD1Dialect` moved from `d1.ts` to a new `d1-dialect.ts` to avoid a circular ESM import (the coalescing dialect extends it while `d1.ts` imports the coalescing dialect); behavior unchanged.

Closes #<!-- none — follow-up to the latency investigation on #1274; happy to open a Discussion if maintainers prefer this behind one -->

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (cloudflare + core)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — 7 new tests; full @emdash-cms/cloudflare suite 162/162
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). _n/a — no admin UI strings._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — minor, @emdash-cms/cloudflare
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... _Opt-in experimental flag on existing d1() config — flagged in the description for a maintainer call on whether this needs a Discussion._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New mock-D1 test suite covers: same-turn coalescing in issue order with per-caller rows and preserved bind params; sequential awaits never batch; writes + WITH execute immediately (order-asserted) while sibling SELECTs still coalesce; batch rejection → individual fallback with the underlying error; direct-path result mapping (rows / numAffectedRows / insertId, 0 changes → undefined); new window after each flush; transactions rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://perf-d1-query-coalescing-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `perf/d1-query-coalescing`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
