### PR TITLE
feat(i18n): add en-GB (British English) locale

### DIFF
--- a/.changeset/en-gb-locale.md
+++ b/.changeset/en-gb-locale.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds an en-GB (British English) locale to the admin UI. British spelling and morphology only - terminology is unchanged. en-GB browsers are auto-selected via the existing Accept-Language resolution.

--- a/e2e/tests/settings-pages.spec.ts
+++ b/e2e/tests/settings-pages.spec.ts
@@ -187,13 +187,13 @@ test.describe("Language Switcher", () => {
 
 		// Switch to German
 		await page.locator('[aria-label="Language"]').click();
-		await page.locator("[role='option']", { hasText: "Deutsch" }).click();
+		await page.getByRole("option", { name: "Deutsch", exact: true }).click();
 
 		await expect(page.locator("h1")).toContainText("Einstellungen", { timeout: 5000 });
 
 		// Switch back — the select now shows "Deutsch" as its value
 		await page.locator("[role='combobox']", { hasText: "Deutsch" }).click();
-		await page.locator("[role='option']", { hasText: "English" }).click();
+		await page.getByRole("option", { name: "English", exact: true }).click();
 
 		await expect(page.locator("h1")).toContainText("Settings", { timeout: 5000 });
 	});

--- a/packages/admin/src/locales/en-GB/messages.po
+++ b/packages/admin/src/locales/en-GB/messages.po
@@ -1,0 +1,7686 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-04-04 12:28+0300\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en-GB\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: packages/admin/src/routes/bylines.tsx:433
+msgid " - Guest"
+msgstr " - Guest"
+
+#: packages/admin/src/routes/bylines.tsx:433
+msgid " - Linked"
+msgstr " - Linked"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:72
+#: packages/admin/src/components/TranslationsPanel.tsx:76
+msgid " (default)"
+msgstr " (default)"
+
+#: packages/admin/src/components/MenuEditor.tsx:435
+msgid " (opens in new window)"
+msgstr " (opens in new window)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:792
+#: packages/admin/src/components/MediaPickerModal.tsx:874
+msgid " (selected)"
+msgstr " (selected)"
+
+#: packages/admin/src/routes/bylines.tsx:689
+msgid "-- Select --"
+msgstr "-- Select --"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:310
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:307
+msgid ", or open the admin at"
+msgstr ", or open the admin at"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:309
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:306
+msgid ": use"
+msgstr ": use"
+
+#. placeholder {0}: providers?.find((p) => p.id === selectedItem.providerId)?.name
+#: packages/admin/src/components/MediaPickerModal.tsx:732
+msgid "(from {0})"
+msgstr "(from {0})"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:518
+msgid "(pre-release)"
+msgstr "(pre-release)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:157
+msgid "(synced)"
+msgstr "(synced)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:521
+msgid "(too new)"
+msgstr "(too new)"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:312
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:309
+msgid "(with your dev port)."
+msgstr "(with your dev port)."
+
+#. placeholder {0}: items.length
+#. placeholder {0}: orphan.rowCount
+#: packages/admin/src/components/ContentTypeList.tsx:69
+#: packages/admin/src/components/RepeaterField.tsx:147
+msgid "{0, plural, one {(# item)} other {(# items)}}"
+msgstr "{0, plural, one {(# item)} other {(# items)}}"
+
+#. placeholder {0}: seedInfo.collections
+#: packages/admin/src/components/SetupWizard.tsx:156
+msgid "{0, plural, one {# collection} other {# collections}}"
+msgstr "{0, plural, one {# collection} other {# collections}}"
+
+#. placeholder {0}: result.affected
+#: packages/admin/src/router.tsx:1182
+msgid "{0, plural, one {# comment updated} other {# comments updated}}"
+msgstr "{0, plural, one {# comment updated} other {# comments updated}}"
+
+#. placeholder {0}: comments.length
+#: packages/admin/src/components/comments/CommentInbox.tsx:344
+msgid "{0, plural, one {# comment} other {# comments}}"
+msgstr "{0, plural, one {# comment} other {# comments}}"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2080
+msgid "{0, plural, one {# content error} other {# content errors}}"
+msgstr "{0, plural, one {# content error} other {# content errors}}"
+
+#. placeholder {0}: result.imported
+#: packages/admin/src/components/WordPressImport.tsx:2056
+msgid "{0, plural, one {# content item imported} other {# content items imported}}"
+msgstr "{0, plural, one {# content item imported} other {# content items imported}}"
+
+#. placeholder {0}: items.length
+#. placeholder {0}: menu.itemCount ?? 0
+#: packages/admin/src/components/MediaPickerModal.tsx:583
+#: packages/admin/src/components/MenuList.tsx:217
+msgid "{0, plural, one {# item} other {# items}}"
+msgstr "{0, plural, one {# item} other {# items}}"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2085
+msgid "{0, plural, one {# media error} other {# media errors}}"
+msgstr "{0, plural, one {# media error} other {# media errors}}"
+
+#. placeholder {0}: mediaResult.imported.length
+#: packages/admin/src/components/WordPressImport.tsx:2072
+msgid "{0, plural, one {# media file imported} other {# media files imported}}"
+msgstr "{0, plural, one {# media file imported} other {# media files imported}}"
+
+#. placeholder {0}: stats.mediaCount
+#: packages/admin/src/components/Dashboard.tsx:123
+msgid "{0, plural, one {# media file} other {# media files}}"
+msgstr "{0, plural, one {# media file} other {# media files}}"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1739
+msgid "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+msgstr "{0, plural, one {# menu will be imported} other {# menus will be imported}}"
+
+#. placeholder {0}: plugin.capabilities.length
+#: packages/admin/src/components/MarketplaceBrowse.tsx:288
+#: packages/admin/src/components/PluginManager.tsx:399
+msgid "{0, plural, one {# permission} other {# permissions}}"
+msgstr "{0, plural, one {# permission} other {# permissions}}"
+
+#. placeholder {0}: mapping.postCount
+#: packages/admin/src/components/WordPressImport.tsx:2292
+msgid "{0, plural, one {# post} other {# posts}}"
+msgstr "{0, plural, one {# post} other {# posts}}"
+
+#. placeholder {0}: loopRedirectIds.size
+#: packages/admin/src/components/Redirects.tsx:418
+msgid "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+msgstr "{0, plural, one {# redirect is part of a loop.} other {# redirects are part of a loop.}}"
+
+#. placeholder {0}: selected.size
+#: packages/admin/src/components/comments/CommentInbox.tsx:228
+msgid "{0, plural, one {# selected} other {# selected}}"
+msgstr "{0, plural, one {# selected} other {# selected}}"
+
+#. placeholder {0}: result.skipped
+#: packages/admin/src/components/WordPressImport.tsx:2064
+msgid "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+msgstr "{0, plural, one {# skipped (already exists)} other {# skipped (already exist)}}"
+
+#. placeholder {0}: stats.userCount
+#: packages/admin/src/components/Dashboard.tsx:128
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {# user} other {# users}}"
+
+#. placeholder {0}: fields.length
+#: packages/admin/src/components/ContentTypeEditor.tsx:576
+msgid "{0, plural, one {field} other {fields}}"
+msgstr "{0, plural, one {field} other {fields}}"
+
+#. placeholder {0}: envLabel(m.key)
+#. placeholder {1}: m.required
+#. placeholder {2}: m.host
+#: packages/admin/src/components/RegistryPluginDetail.tsx:621
+msgid "{0} {1} required — you have {2}."
+msgstr "{0} {1} required — you have {2}."
+
+#. placeholder {0}: menu.name
+#. placeholder {1}: /** * Menu List component * * Displays all menus with ability to create, edit, and delete. */ import { Button, Dialog, Input, Toast } from "@cloudflare/kumo"; import { plural } from "@lingui/core/macro"; import { Trans } from "@lingui/react/macro"; import { useLingui } from "@lingui/react/macro"; import { Plus, Pencil, Trash, List as ListIcon } from "@phosphor-icons/react"; import { X } from "@phosphor-icons/react"; import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"; import { Link, useNavigate } from "@tanstack/react-router"; import * as React from "react"; import { fetchMenus, createMenu, deleteMenu } from "../lib/api"; import { fetchManifest } from "../lib/api/client.js"; import { ConfirmDialog } from "./ConfirmDialog.js"; import { DialogError, getMutationError } from "./DialogError.js"; import { LocaleSwitcher, useI18nConfig } from "./LocaleSwitcher.js"; import { RouterLinkButton } from "./RouterLinkButton.js"; export function MenuList() { const { t } = useLingui(); const queryClient = useQueryClient(); const navigate = useNavigate(); const toastManager = Toast.useToastManager(); const [isCreateOpen, setIsCreateOpen] = React.useState(false); const [deleteMenuName, setDeleteMenuName] = React.useState<string | null>(null); const [createError, setCreateError] = React.useState<string | null>(null); const { data: manifest } = useQuery({ queryKey: ["manifest"], queryFn: fetchManifest, }); const i18n = useI18nConfig(manifest); const [activeLocale, setActiveLocale] = React.useState<string | undefined>(undefined); React.useEffect(() => { if (i18n && !activeLocale) setActiveLocale(i18n.defaultLocale); }, [i18n, activeLocale]); const { data: menus, isLoading } = useQuery({ queryKey: ["menus", activeLocale], queryFn: () => fetchMenus({ locale: activeLocale }), }); const createMutation = useMutation({ mutationFn: createMenu, onSuccess: (menu) => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setIsCreateOpen(false); toastManager.add({ title: t`Menu created`, description: t`Menu "${menu.label}" has been created.`, }); void navigate({ to: "/menus/$name", params: { name: menu.name }, search: { locale: menu.locale }, }); }, onError: (error: Error) => { setCreateError(error.message); }, }); const deleteMutation = useMutation({ mutationFn: (name: string) => deleteMenu(name, { locale: activeLocale }), onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ["menus"] }); setDeleteMenuName(null); toastManager.add({ title: t`Menu deleted`, description: t`The menu has been deleted.`, }); }, }); const handleCreate = (e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); setCreateError(null); const formData = new FormData(e.currentTarget); const nameVal = formData.get("name"); const name = typeof nameVal === "string" ? nameVal : ""; const labelVal = formData.get("label"); const label = typeof labelVal === "string" ? labelVal : ""; createMutation.mutate({ name, label, locale: activeLocale }); }; if (isLoading) { return ( <div className="flex items-center justify-center h-64"> <div className="text-kumo-subtle">{t`Loading menus...`}</div> </div> ); } return ( <div className="space-y-6"> <div className="flex items-center justify-between gap-4 flex-wrap"> <div> <h1 className="text-3xl font-bold">{t`Menus`}</h1> <p className="text-kumo-subtle">{t`Manage navigation menus for your site`}</p> </div> <div className="flex items-center gap-2"> {i18n && activeLocale ? ( <LocaleSwitcher locales={i18n.locales} defaultLocale={i18n.defaultLocale} value={activeLocale} onChange={setActiveLocale} /> ) : null} </div> <Dialog.Root open={isCreateOpen} onOpenChange={(open) => { setIsCreateOpen(open); if (!open) setCreateError(null); }} > <Dialog.Trigger render={(props) => ( <Button {...props} icon={<Plus />}> {t`Create Menu`} </Button> )} /> <Dialog className="p-6" size="lg"> <div className="flex items-start justify-between gap-4 mb-4"> <Dialog.Title className="text-lg font-semibold leading-none tracking-tight"> {t`Create New Menu`} </Dialog.Title> <Dialog.Close aria-label={t`Close`} render={(props) => ( <Button {...props} variant="ghost" shape="square" aria-label={t`Close`} className="absolute end-4 top-4" > <X className="h-4 w-4" /> <span className="sr-only">{t`Close`}</span> </Button> )} /> </div> <form onSubmit={handleCreate} className="space-y-4"> <div> <Input label={t`Name`} name="name" required placeholder="primary" pattern="[a-z0-9\-]+" title={t`Only lowercase letters, numbers, and hyphens`} /> <p className="text-sm text-kumo-subtle mt-1"> {t`URL-friendly identifier (e.g., "primary", "footer")`} </p> </div> <div> <Input label={t`Label`} name="label" required placeholder={t`Primary Navigation`} /> <p className="text-sm text-kumo-subtle mt-1">{t`Display name for admin interface`}</p> </div> <DialogError message={createError || getMutationError(createMutation.error)} /> <div className="flex justify-end gap-2"> <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}> {t`Cancel`} </Button> <Button type="submit" disabled={createMutation.isPending}> {createMutation.isPending ? t`Creating...` : t`Create`} </Button> </div> </form> </Dialog> </Dialog.Root> </div> {!menus || menus.length === 0 ? ( <div className="border rounded-lg p-12 text-center"> <ListIcon className="mx-auto h-12 w-12 text-kumo-subtle mb-4" /> <h3 className="text-lg font-semibold mb-2">{t`No menus yet`}</h3> <p className="text-kumo-subtle mb-4">{t`Create your first navigation menu to get started`}</p> <Button icon={<Plus />} onClick={() => setIsCreateOpen(true)}> {t`Create Menu`} </Button> </div> ) : ( <div className="grid gap-4"> {menus.map((menu) => ( <div key={menu.id} className="border rounded-lg p-6 flex items-center justify-between hover:bg-kumo-tint transition-colors" > <Link to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} className="flex-1" > <div> <h3 className="font-semibold text-lg"> {menu.label} {i18n ? ( <span className="ms-2 text-xs font-mono uppercase text-kumo-subtle"> {menu.locale} </span> ) : null} </h3> <p className="text-sm text-kumo-subtle"> <Trans> {menu.name} •{" "} {plural(menu.itemCount ?? 0, { one: "# item", other: "# items" })} </Trans> </p> </div> </Link> <div className="flex gap-2"> <RouterLinkButton to="/menus/$name" params={{ name: menu.name }} search={{ locale: menu.locale }} variant="outline" size="sm" icon={<Pencil />} > {t`Edit`} </RouterLinkButton> <Button variant="outline" size="sm" onClick={() => setDeleteMenuName(menu.name)} aria-label={t`Delete ${menu.name} menu`} > <Trash className="h-4 w-4" /> </Button> </div> </div> ))} </div> )} <ConfirmDialog open={deleteMenuName !== null} onClose={() => { setDeleteMenuName(null); deleteMutation.reset(); }} title={t`Delete Menu`} description={t`Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone.`} confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={deleteMutation.isPending} error={deleteMutation.error} onConfirm={() => deleteMenuName && deleteMutation.mutate(deleteMenuName)} /> </div> ); } 
+#: packages/admin/src/components/MenuList.tsx:215
+msgid "{0} • {1}"
+msgstr "{0} • {1}"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:410
+msgid "{0} banner"
+msgstr "{0} banner"
+
+#. placeholder {0}: bestMatch?.detected.siteTitle || "WordPress site"
+#: packages/admin/src/components/WordPressImport.tsx:1142
+msgid "{0} detected"
+msgstr "{0} detected"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:111
+msgid "{0} has been deactivated"
+msgstr "{0} has been deactivated"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:306
+msgid "{0} has been removed"
+msgstr "{0} has been removed"
+
+#. placeholder {0}: displayName ?? slug
+#: packages/admin/src/components/RegistryPluginDetail.tsx:422
+msgid "{0} icon"
+msgstr "{0} icon"
+
+#. placeholder {0}: plugin.installCount.toLocaleString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:202
+msgid "{0} installs"
+msgstr "{0} installs"
+
+#. placeholder {0}: plugin.name
+#: packages/admin/src/components/PluginManager.tsx:92
+msgid "{0} is now active"
+msgstr "{0} is now active"
+
+#. placeholder {0}: postType.count
+#. placeholder {1}: postType.suggestedCollection
+#: packages/admin/src/components/WordPressImport.tsx:1809
+msgid "{0} items → {1}"
+msgstr "{0} items → {1}"
+
+#. placeholder {0}: analysis.postTypes .filter((pt) => selections[pt.name]?.enabled) .reduce((sum, pt) => sum + pt.count, 0)
+#: packages/admin/src/components/WordPressImport.tsx:1732
+msgid "{0} items will be imported"
+msgstr "{0} items will be imported"
+
+#. placeholder {0}: plugins?.length ?? 0
+#: packages/admin/src/components/PluginManager.tsx:170
+msgid "{0} plugins"
+msgstr "{0} plugins"
+
+#. placeholder {0}: theme.name
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:210
+msgid "{0} preview"
+msgstr "{0} preview"
+
+#. placeholder {0}: SYSTEM_FIELDS.length
+#. placeholder {1}: fields.length
+#. placeholder {2}: import { Badge, Button, Checkbox, Input, InputArea, Label, Select, Switch } from "@cloudflare/kumo"; import { DndContext, closestCenter, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, } from "@dnd-kit/core"; import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy, } from "@dnd-kit/sortable"; import { CSS } from "@dnd-kit/utilities"; import type { MessageDescriptor } from "@lingui/core"; import { msg, plural } from "@lingui/core/macro"; import { Trans, useLingui } from "@lingui/react/macro"; import { Plus, DotsSixVertical, Pencil, Trash, Database, FileText } from "@phosphor-icons/react"; import { useNavigate } from "@tanstack/react-router"; import * as React from "react"; import type { SchemaCollectionWithFields, SchemaField, CreateFieldInput, CreateCollectionInput, UpdateCollectionInput, } from "../lib/api"; import { cn } from "../lib/utils"; import { ArrowPrev } from "./ArrowIcons.js"; import { ConfirmDialog } from "./ConfirmDialog"; import { EditorHeader } from "./EditorHeader"; import { FieldEditor } from "./FieldEditor"; import { RouterLinkButton } from "./RouterLinkButton.js"; import { SaveButton } from "./SaveButton"; // Regex patterns for slug generation const SLUG_INVALID_CHARS_PATTERN = /[^a-z0-9]+/g; const SLUG_LEADING_TRAILING_PATTERN = /^_|_$/g; export interface ContentTypeEditorProps { collection?: SchemaCollectionWithFields; isNew?: boolean; isSaving?: boolean; onSave: (input: CreateCollectionInput | UpdateCollectionInput) => void; onAddField?: (input: CreateFieldInput) => void; onUpdateField?: (fieldSlug: string, input: CreateFieldInput) => void; onDeleteField?: (fieldSlug: string) => void; onReorderFields?: (fieldSlugs: string[]) => void; } interface SupportOptionDef { value: string; label: MessageDescriptor; description: MessageDescriptor; } const MODERATION_OPTIONS: Record<"all" | "first_time" | "none", MessageDescriptor> = { all: msg`All comments require approval`, first_time: msg`First-time commenters only`, none: msg`No moderation (auto-approve all)`, }; const SUPPORT_OPTIONS: SupportOptionDef[] = [ { value: "drafts", label: msg`Drafts`, description: msg`Save content as draft before publishing`, }, { value: "revisions", label: msg`Revisions`, description: msg`Track content history`, }, { value: "preview", label: msg`Preview`, description: msg`Preview content before publishing`, }, { value: "search", label: msg`Search`, description: msg`Enable full-text search on this collection`, }, ]; /** * System fields that exist on every collection * These are created automatically and cannot be modified */ interface SystemFieldDef { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } const SYSTEM_FIELDS: SystemFieldDef[] = [ { slug: "id", label: msg`ID`, type: "text", description: msg`Unique identifier (ULID)`, }, { slug: "slug", label: msg`Slug`, type: "text", description: msg`URL-friendly identifier`, }, { slug: "status", label: msg`Status`, type: "text", description: msg`draft, published, or archived`, }, { slug: "created_at", label: msg`Created At`, type: "datetime", description: msg`When the entry was created`, }, { slug: "updated_at", label: msg`Updated At`, type: "datetime", description: msg`When the entry was last modified`, }, { slug: "published_at", label: msg`Published At`, type: "datetime", description: msg`When the entry was published`, }, ]; /** * Content Type editor for creating/editing collections */ export function ContentTypeEditor({ collection, isNew, isSaving, onSave, onAddField, onUpdateField, onDeleteField, onReorderFields, }: ContentTypeEditorProps) { const { t } = useLingui(); const _navigate = useNavigate(); // Form state const [slug, setSlug] = React.useState(collection?.slug ?? ""); const [label, setLabel] = React.useState(collection?.label ?? ""); const [labelSingular, setLabelSingular] = React.useState(collection?.labelSingular ?? ""); const [description, setDescription] = React.useState(collection?.description ?? ""); const [urlPattern, setUrlPattern] = React.useState(collection?.urlPattern ?? ""); // SEO is managed via the separate `hasSeo` field; strip any legacy "seo" entry // so it isn't sent back on save (the API enum rejects it). const [supports, setSupports] = React.useState<string[]>( (collection?.supports ?? ["drafts", "revisions"]).filter((s) => s !== "seo"), ); // SEO state const [hasSeo, setHasSeo] = React.useState(collection?.hasSeo ?? false); // Comment settings state const [commentsEnabled, setCommentsEnabled] = React.useState( collection?.commentsEnabled ?? false, ); const [commentsModeration, setCommentsModeration] = React.useState<"all" | "first_time" | "none">( collection?.commentsModeration ?? "first_time", ); const [commentsClosedAfterDays, setCommentsClosedAfterDays] = React.useState( collection?.commentsClosedAfterDays ?? 90, ); const [commentsAutoApproveUsers, setCommentsAutoApproveUsers] = React.useState( collection?.commentsAutoApproveUsers ?? true, ); // Field editor state const [fieldEditorOpen, setFieldEditorOpen] = React.useState(false); const [editingField, setEditingField] = React.useState<SchemaField | undefined>(); const [fieldSaving, setFieldSaving] = React.useState(false); const [deleteFieldTarget, setDeleteFieldTarget] = React.useState<SchemaField | null>(null); const urlPatternValid = !urlPattern || urlPattern.includes("{slug}"); // Track whether form has unsaved changes const hasChanges = React.useMemo(() => { if (isNew) return slug && label; if (!collection) return false; return ( label !== collection.label || labelSingular !== (collection.labelSingular ?? "") || description !== (collection.description ?? "") || urlPattern !== (collection.urlPattern ?? "") || JSON.stringify([...supports].toSorted()) !== JSON.stringify(collection.supports.filter((s) => s !== "seo").toSorted()) || hasSeo !== collection.hasSeo || commentsEnabled !== collection.commentsEnabled || commentsModeration !== collection.commentsModeration || commentsClosedAfterDays !== collection.commentsClosedAfterDays || commentsAutoApproveUsers !== collection.commentsAutoApproveUsers ); }, [ isNew, collection, slug, label, labelSingular, description, urlPattern, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, ]); // Auto-generate slug from plural label const handleLabelChange = (value: string) => { setLabel(value); if (isNew) { setSlug( value .toLowerCase() .replace(SLUG_INVALID_CHARS_PATTERN, "_") .replace(SLUG_LEADING_TRAILING_PATTERN, ""), ); } }; // Auto-generate plural label (and slug) from singular label const handleSingularLabelChange = (value: string) => { setLabelSingular(value); if (isNew) { const pluralLabel = value ? `${value}s` : ""; handleLabelChange(pluralLabel); } }; const handleSupportToggle = (value: string) => { setSupports((prev) => prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value], ); }; const handleSubmit = (e: React.FormEvent) => { e.preventDefault(); if (isNew) { onSave({ slug, label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, }); } else { onSave({ label, labelSingular: labelSingular || undefined, description: description || undefined, urlPattern: urlPattern || undefined, supports, hasSeo, commentsEnabled, commentsModeration, commentsClosedAfterDays, commentsAutoApproveUsers, }); } }; const handleFieldSave = async (input: CreateFieldInput) => { setFieldSaving(true); try { if (editingField) { onUpdateField?.(editingField.slug, input); } else { onAddField?.(input); } setFieldEditorOpen(false); setEditingField(undefined); } finally { setFieldSaving(false); } }; const handleEditField = (field: SchemaField) => { setEditingField(field); setFieldEditorOpen(true); }; const handleAddField = () => { setEditingField(undefined); setFieldEditorOpen(true); }; const isFromCode = collection?.source === "code"; const fields = collection?.fields ?? []; const sensors = useSensors( useSensor(PointerSensor, { activationConstraint: { distance: 8 } }), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }), ); const handleDragEnd = (event: DragEndEvent) => { const { active, over } = event; if (!over || active.id === over.id) return; const oldIndex = fields.findIndex((f) => f.id === active.id); const newIndex = fields.findIndex((f) => f.id === over.id); if (oldIndex === -1 || newIndex === -1) return; const reordered = arrayMove(fields, oldIndex, newIndex); onReorderFields?.(reordered.map((f) => f.slug)); }; return ( <div className="space-y-6"> {/* Sticky header keeps the primary save action in view while users scroll through the settings + fields panels. The bottom-of-form save button is preserved below for keyboard / screen-reader users so DOM order still ends with a submit control. */} <EditorHeader leading={ <RouterLinkButton to="/content-types" aria-label={t`Back to Content Types`} variant="ghost" shape="square" icon={<ArrowPrev />} /> } actions={ !isFromCode && !isNew ? ( <SaveButton type="submit" form="content-type-editor-form" isDirty={!!hasChanges} isSaving={!!isSaving} disabled={!urlPatternValid} /> ) : null } > <h1 className="text-2xl font-bold truncate"> {isNew ? t`New Content Type` : collection?.label} </h1> {!isNew && ( <p className="text-kumo-subtle text-sm"> <code className="bg-kumo-tint px-1.5 py-0.5 rounded">{collection?.slug}</code> {isFromCode && ( <span className="ms-2 text-purple-600 dark:text-purple-400">{t`Defined in code`}</span> )} </p> )} </EditorHeader> {isFromCode && ( <div className="rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950 p-4"> <div className="flex items-center space-x-2"> <FileText className="h-5 w-5 text-purple-600 dark:text-purple-400" /> <p className="text-sm text-purple-700 dark:text-purple-300"> {t`This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema.`} </p> </div> </div> )} <div className="grid grid-cols-1 lg:grid-cols-3 gap-6"> {/* Settings form */} <div className="lg:col-span-1"> <form id="content-type-editor-form" onSubmit={handleSubmit} className="space-y-4"> <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Settings`}</h2> <Input label={t`Label (Singular)`} value={labelSingular} onChange={(e) => handleSingularLabelChange(e.target.value)} placeholder="Post" disabled={isFromCode} /> <Input label={t`Label (Plural)`} value={label} onChange={(e) => handleLabelChange(e.target.value)} placeholder="Posts" disabled={isFromCode} /> {isNew && ( <div> <Input label={t`Slug`} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="posts" disabled={!isNew} /> <p className="text-xs text-kumo-subtle mt-2">{t`Used in URLs and API endpoints`}</p> </div> )} <InputArea label={t`Description`} value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t`A brief description of this content type`} rows={3} disabled={isFromCode} /> <div> <Input label={t`URL Pattern`} value={urlPattern} onChange={(e) => setUrlPattern(e.target.value)} placeholder={`/${slug === "pages" ? "" : `${slug}/`}{slug}`} disabled={isFromCode} /> {urlPattern && !urlPattern.includes("{slug}") && ( <p className="text-xs text-kumo-danger mt-2"> {t`Pattern must include a ${"{slug}"} placeholder`} </p> )} <p className="text-xs text-kumo-subtle mt-1"> {t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`} </p> </div> <div className="space-y-3"> <Label>Features</Label> {SUPPORT_OPTIONS.map((option) => ( <div key={option.value} className={cn( "p-2 rounded-md hover:bg-kumo-tint/50", isFromCode && "opacity-60", )} > <Checkbox checked={supports.includes(option.value)} onCheckedChange={() => handleSupportToggle(option.value)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t(option.label)}</span> <p className="text-xs text-kumo-subtle">{t(option.description)}</p> </div> } /> </div> ))} </div> {/* SEO toggle */} <div className="pt-2 border-t"> <Switch checked={hasSeo} onCheckedChange={(checked) => setHasSeo(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`SEO`}</span> <p className="text-xs text-kumo-subtle"> {t`Add SEO metadata fields (title, description, image) and include in sitemap`} </p> </div> } /> </div> </div> {/* Comments settings — only for existing collections */} {!isNew && ( <div className="rounded-lg border bg-kumo-base p-4 space-y-4"> <h2 className="font-semibold">{t`Comments`}</h2> <Switch checked={commentsEnabled} onCheckedChange={(checked) => setCommentsEnabled(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium">{t`Enable comments`}</span> <p className="text-xs text-kumo-subtle"> {t`Allow visitors to leave comments on this collection's content`} </p> </div> } /> {commentsEnabled && ( <> <Select label={t`Moderation`} value={commentsModeration} onValueChange={(v) => setCommentsModeration((v as "all" | "first_time" | "none") ?? "first_time") } items={{ all: t(MODERATION_OPTIONS.all), first_time: t(MODERATION_OPTIONS.first_time), none: t(MODERATION_OPTIONS.none), }} disabled={isFromCode} /> <Input label={t`Close comments after (days)`} type="number" min={0} value={String(commentsClosedAfterDays)} onChange={(e) => { const parsed = Number.parseInt(e.target.value, 10); setCommentsClosedAfterDays(Number.isNaN(parsed) ? 0 : Math.max(0, parsed)); }} disabled={isFromCode} /> <p className="text-xs text-kumo-subtle -mt-2"> {t`Set to 0 to never close comments automatically.`} </p> <Switch checked={commentsAutoApproveUsers} onCheckedChange={(checked) => setCommentsAutoApproveUsers(checked)} disabled={isFromCode} label={ <div> <span className="text-sm font-medium"> {t`Auto-approve authenticated users`} </span> <p className="text-xs text-kumo-subtle"> {t`Comments from logged-in CMS users are approved automatically`} </p> </div> } /> </> )} </div> )} {!isFromCode && ( <Button type="submit" disabled={!hasChanges || !urlPatternValid || isSaving} className="w-full" > {isSaving ? t`Saving...` : isNew ? t`Create Content Type` : t`Save Changes`} </Button> )} </form> </div> {/* Fields section - only show for existing collections */} {!isNew && ( <div className="lg:col-span-2"> <div className="rounded-lg border bg-kumo-base"> <div className="flex items-center justify-between p-4 border-b"> <div> <h2 className="font-semibold">{t`Fields`}</h2> <p className="text-sm text-kumo-subtle"> <Trans> {SYSTEM_FIELDS.length} system + {fields.length} custom{" "} {plural(fields.length, { one: "field", other: "fields" })} </Trans> </p> </div> {!isFromCode && ( <Button icon={<Plus />} onClick={handleAddField}> {t`Add Field`} </Button> )} </div> {/* System fields - always shown */} <div> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`System Fields`} </div> <div className="divide-y divide-kumo-line/50 border-b"> {SYSTEM_FIELDS.map((field) => ( <SystemFieldRow key={field.slug} field={field} /> ))} </div> </div> {/* Custom fields */} {fields.length === 0 ? ( <div className="p-8 text-center text-kumo-subtle"> <Database className="mx-auto h-12 w-12 mb-4 opacity-50" /> <p className="font-medium">{t`No custom fields yet`}</p> <p className="text-sm">{t`Add fields to define the structure of your content`}</p> {!isFromCode && ( <Button className="mt-4" icon={<Plus />} onClick={handleAddField}> {t`Add First Field`} </Button> )} </div> ) : ( <> <div className="px-4 py-2 text-xs font-medium text-kumo-subtle uppercase tracking-wider bg-kumo-tint/50 border-b"> {t`Custom Fields`} </div> <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} > <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy} > <div className="divide-y"> {fields.map((field) => ( <FieldRow key={field.id} field={field} isFromCode={isFromCode} onEdit={() => handleEditField(field)} onDelete={() => setDeleteFieldTarget(field)} /> ))} </div> </SortableContext> </DndContext> </> )} </div> </div> )} </div> {/* Field editor dialog */} <FieldEditor open={fieldEditorOpen} onOpenChange={setFieldEditorOpen} field={editingField} onSave={handleFieldSave} isSaving={fieldSaving} /> <ConfirmDialog open={!!deleteFieldTarget} onClose={() => setDeleteFieldTarget(null)} title={t`Delete Field?`} description={ deleteFieldTarget ? t`Are you sure you want to delete the "${deleteFieldTarget.label}" field?` : "" } confirmLabel={t`Delete`} pendingLabel={t`Deleting...`} isPending={false} error={null} onConfirm={() => { if (deleteFieldTarget) { onDeleteField?.(deleteFieldTarget.slug); setDeleteFieldTarget(null); } }} /> </div> ); } interface FieldRowProps { field: SchemaField; isFromCode?: boolean; onEdit: () => void; onDelete: () => void; } function FieldRow({ field, isFromCode, onEdit, onDelete }: FieldRowProps) { const { t } = useLingui(); const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: field.id, disabled: isFromCode, }); const style = { transform: CSS.Transform.toString(transform), transition }; return ( <div ref={setNodeRef} style={style} className={cn( "flex items-center px-4 py-3 hover:bg-kumo-tint/25", isDragging && "opacity-50", )} > {!isFromCode && ( <button {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing me-3" aria-label={t`Drag to reorder ${field.label}`} > <DotsSixVertical className="h-5 w-5 text-kumo-subtle" /> </button> )} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium">{field.label}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> </div> <div className="flex items-center space-x-2 mt-1"> <span className="text-xs text-kumo-subtle capitalize">{field.type}</span> {field.required && <Badge variant="secondary">{t`Required`}</Badge>} {field.unique && <Badge variant="secondary">{t`Unique`}</Badge>} {field.searchable && <Badge variant="secondary">{t`Searchable`}</Badge>} </div> </div> {!isFromCode && ( <div className="flex items-center space-x-1"> <Button variant="ghost" shape="square" onClick={onEdit} aria-label={t`Edit ${field.label} field`} > <Pencil className="h-4 w-4" /> </Button> <Button variant="ghost" shape="square" onClick={onDelete} aria-label={t`Delete ${field.label} field`} > <Trash className="h-4 w-4 text-kumo-danger" /> </Button> </div> )} </div> ); } interface SystemFieldInfo { slug: string; label: MessageDescriptor; type: string; description: MessageDescriptor; } function SystemFieldRow({ field }: { field: SystemFieldInfo }) { const { t } = useLingui(); return ( <div className="flex items-center px-4 py-2 opacity-75"> <div className="w-8" /> {/* Spacer for alignment with draggable fields */} <div className="flex-1 min-w-0"> <div className="flex items-center space-x-2"> <span className="font-medium text-sm">{t(field.label)}</span> <code className="text-xs bg-kumo-tint px-1.5 py-0.5 rounded text-kumo-subtle"> {field.slug} </code> <Badge variant="secondary">{t`System`}</Badge> </div> <p className="text-xs text-kumo-subtle mt-0.5">{t(field.description)}</p> </div> </div> ); } 
+#: packages/admin/src/components/ContentTypeEditor.tsx:574
+msgid "{0} system + {1} custom {2}"
+msgstr "{0} system + {1} custom {2}"
+
+#. placeholder {0}: taxonomy.label
+#: packages/admin/src/components/TaxonomySidebar.tsx:345
+msgid "{0} updated"
+msgstr "{0} updated"
+
+#. placeholder {0}: plugin.name
+#. placeholder {1}: updateInfo?.latest
+#: packages/admin/src/components/PluginManager.tsx:259
+msgid "{0} updated to v{1}"
+msgstr "{0} updated to v{1}"
+
+#. placeholder {0}: item.filename
+#. placeholder {1}: selected ? t` (selected)` : ""
+#: packages/admin/src/components/MediaPickerModal.tsx:792
+#: packages/admin/src/components/MediaPickerModal.tsx:874
+msgid "{0}{1}"
+msgstr "{0}{1}"
+
+#. placeholder {0}: draft.description.length
+#: packages/admin/src/components/SeoPanel.tsx:168
+msgid "{0}/160 characters"
+msgstr "{0}/160 characters"
+
+#. placeholder {0}: allowedHosts.join(", ")
+#: packages/admin/src/lib/api/marketplace.ts:255
+msgid "{base} to: {0}"
+msgstr "{base} to: {0}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:337
+msgid "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+msgstr "{changedCount, plural, one {# change from next revision} other {# changes from next revision}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1908
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr "{count, plural, one {# file} other {# files}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2157
+msgid "{count, plural, one {# item} other {# items}}"
+msgstr "{count, plural, one {# item} other {# items}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1979
+msgid "{current} of {total}"
+msgstr "{current} of {total}"
+
+#. placeholder {0}: hasMore ? "+" : ""
+#. placeholder {1}: hasMore ? "+" : ""
+#: packages/admin/src/components/ContentList.tsx:557
+msgid "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+msgstr "{filteredCount, plural, one {#{0} item} other {#{1} items}}"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — no translation"
+msgstr "{label} — no translation"
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:107
+msgid "{label} — view translation"
+msgstr "{label} — view translation"
+
+#: packages/admin/src/components/ContentList.tsx:546
+msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+msgstr "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2279
+msgid "{matchedCount} of {totalCount} assigned"
+msgstr "{matchedCount} of {totalCount} assigned"
+
+#: packages/admin/src/components/WordPressImport.tsx:2267
+msgid "{matchedCount} of {totalCount} authors matched by email"
+msgstr "{matchedCount} of {totalCount} authors matched by email"
+
+#: packages/admin/src/components/WordPressImport.tsx:1715
+msgid "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+msgstr "{needsNewCollections, plural, one {# new collection will be created} other {# new collections will be created}}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1724
+msgid "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+msgstr "{needsNewFields, plural, one {Fields will be added to # existing collection} other {Fields will be added to # existing collections}}"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:79
+msgid "{pluginName} is requesting additional permissions:"
+msgstr "{pluginName} is requesting additional permissions:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:80
+msgid "{pluginName} requires the following permissions:"
+msgstr "{pluginName} requires the following permissions:"
+
+#: packages/admin/src/components/ContentList.tsx:552
+msgid "{total, plural, one {# item} other {# items}}"
+msgstr "{total, plural, one {# item} other {# items}}"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:149
+msgid "{total, plural, one {# total} other {# total}}"
+msgstr "{total, plural, one {# total} other {# total}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:178
+#: packages/admin/src/components/MediaLibrary.tsx:214
+msgid "{total, plural, one {File uploaded} other {# files uploaded}}"
+msgstr "{total, plural, one {File uploaded} other {# files uploaded}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:183
+#: packages/admin/src/components/MediaLibrary.tsx:219
+msgid "{total, plural, one {Upload failed} other {All # uploads failed}}"
+msgstr "{total, plural, one {Upload failed} other {All # uploads failed}}"
+
+#: packages/admin/src/components/Dashboard.tsx:113
+msgid "{totalDrafts, plural, one {# draft} other {# drafts}}"
+msgstr "{totalDrafts, plural, one {# draft} other {# drafts}}"
+
+#: packages/admin/src/components/Dashboard.tsx:118
+msgid "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+msgstr "{totalScheduled, plural, one {# scheduled} other {# scheduled}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:349
+msgid "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+msgstr "{unchangedCount, plural, one {Hide # unchanged} other {Hide # unchanged}}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:350
+msgid "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+msgstr "{unchangedCount, plural, one {Show # unchanged} other {Show # unchanged}}"
+
+#: packages/admin/src/components/MediaLibrary.tsx:188
+#: packages/admin/src/components/MediaLibrary.tsx:224
+msgid "{uploaded} uploaded, {failed} failed"
+msgstr "{uploaded} uploaded, {failed} failed"
+
+#: packages/admin/src/components/Redirects.tsx:137
+msgid "/new-page or /articles/[slug]"
+msgstr "/new-page or /articles/[slug]"
+
+#: packages/admin/src/components/Redirects.tsx:129
+msgid "/old-page or /blog/[slug]"
+msgstr "/old-page or /blog/[slug]"
+
+#: packages/admin/src/components/WordPressImport.tsx:1929
+msgid "• Files are downloaded from your WordPress site"
+msgstr "• Files are downloaded from your WordPress site"
+
+#: packages/admin/src/components/WordPressImport.tsx:1930
+msgid "• Uploaded to your EmDash media storage"
+msgstr "• Uploaded to your EmDash media storage"
+
+#: packages/admin/src/components/WordPressImport.tsx:1931
+msgid "• URLs in your content are updated automatically"
+msgstr "• URLs in your content are updated automatically"
+
+#: packages/admin/src/components/SetupWizard.tsx:225
+#: packages/admin/src/components/SetupWizard.tsx:277
+#: packages/admin/src/components/SetupWizard.tsx:332
+#: packages/admin/src/components/WordPressImport.tsx:1440
+msgid "← Back"
+msgstr "← Back"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:35
+msgid "1 year"
+msgstr "1 year"
+
+#: packages/admin/src/components/WordPressImport.tsx:1361
+msgid "1. Log into your WordPress admin"
+msgstr "1. Log into your WordPress admin"
+
+#: packages/admin/src/components/WordPressImport.tsx:1114
+msgid "1. Log into your WordPress admin dashboard"
+msgstr "1. Log into your WordPress admin dashboard"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "2. Go to"
+msgstr "2. Go to"
+
+#: packages/admin/src/components/WordPressImport.tsx:1362
+msgid "2. Go to Users → Profile"
+msgstr "2. Go to Users → Profile"
+
+#: packages/admin/src/components/WordPressImport.tsx:1363
+msgid "3. Scroll to \"Application Passwords\""
+msgstr "3. Scroll to \"Application Passwords\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1118
+msgid "3. Select \"All content\""
+msgstr "3. Select \"All content\""
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:33
+msgid "30 days"
+msgstr "30 days"
+
+#: packages/admin/src/components/Redirects.tsx:150
+msgid "301 Permanent"
+msgstr "301 Permanent"
+
+#: packages/admin/src/components/Redirects.tsx:151
+msgid "302 Temporary"
+msgstr "302 Temporary"
+
+#: packages/admin/src/components/Redirects.tsx:152
+msgid "307 Temporary (Strict)"
+msgstr "307 Temporary (Strict)"
+
+#: packages/admin/src/components/Redirects.tsx:153
+msgid "308 Permanent (Strict)"
+msgstr "308 Permanent (Strict)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1119
+msgid "4. Click \"Download Export File\""
+msgstr "4. Click \"Download Export File\""
+
+#: packages/admin/src/components/WordPressImport.tsx:1364
+msgid "4. Enter \"EmDash\" and click \"Add New\""
+msgstr "4. Enter \"EmDash\" and click \"Add New\""
+
+#: packages/admin/src/components/Redirects.tsx:368
+msgid "404 Errors"
+msgstr "404 Errors"
+
+#: packages/admin/src/components/WordPressImport.tsx:1365
+msgid "5. Copy the generated password"
+msgstr "5. Copy the generated password"
+
+#: packages/admin/src/components/WordPressImport.tsx:1120
+msgid "5. Upload the file here"
+msgstr "5. Upload the file here"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:32
+msgid "7 days"
+msgstr "7 days"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:34
+msgid "90 days"
+msgstr "90 days"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:418
+msgid "A brief description of this content type"
+msgstr "A brief description of this content type"
+
+#: packages/admin/src/components/Sections.tsx:203
+msgid "A full-width hero banner with heading, text, and CTA button"
+msgstr "A full-width hero banner with heading, text, and CTA button"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:165
+msgid "A short description of your site"
+msgstr "A short description of your site"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:170
+msgid "Accept & Install"
+msgstr "Accept & Install"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:169
+msgid "Accept & Update"
+msgstr "Accept & Update"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:206
+msgid "Accept Invite"
+msgstr "Accept Invite"
+
+#: packages/admin/src/routes/byline-schema.tsx:174
+msgid "Access denied"
+msgstr "Access denied"
+
+#: packages/admin/src/router.tsx:1202
+msgid "Access Denied"
+msgstr "Access Denied"
+
+#: packages/admin/src/lib/api/marketplace.ts:224
+#: packages/admin/src/lib/api/marketplace.ts:232
+msgid "Access your media library"
+msgstr "Access your media library"
+
+#: packages/admin/src/components/SetupWizard.tsx:354
+msgid "Account"
+msgstr "Account"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:121
+msgid "Account already exists"
+msgstr "Account already exists"
+
+#: packages/admin/src/components/SignupPage.tsx:261
+msgid "Account exists"
+msgstr "Account exists"
+
+#: packages/admin/src/components/users/UserDetail.tsx:216
+msgid "Account Info"
+msgstr "Account Info"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:299
+#: packages/admin/src/components/ContentList.tsx:290
+#: packages/admin/src/components/ContentList.tsx:408
+#: packages/admin/src/components/ContentTypeList.tsx:106
+#: packages/admin/src/components/MediaLibrary.tsx:486
+#: packages/admin/src/components/TaxonomyManager.tsx:823
+#: packages/admin/src/routes/byline-schema.tsx:249
+msgid "Actions"
+msgstr "Actions"
+
+#: packages/admin/src/components/users/UserDetail.tsx:206
+#: packages/admin/src/components/users/UserList.tsx:217
+msgid "Active"
+msgstr "Active"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:171
+#: packages/admin/src/components/ContentEditor.tsx:2091
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/TaxonomySidebar.tsx:476
+msgid "Add"
+msgstr "Add"
+
+#. placeholder {0}: field.item_label
+#. placeholder {0}: taxonomyDef.labelSingular || t`Term`
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Add {0}"
+msgstr "Add {0}"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:263
+msgid "Add {label}"
+msgstr "Add {label}"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:204
+msgid "Add a new passkey"
+msgstr "Add a new passkey"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:304
+msgid "Add an allowed domain"
+msgstr "Add an allowed domain"
+
+#: packages/admin/src/components/FieldEditor.tsx:544
+msgid "Add at least one sub-field to define the repeater structure."
+msgstr "Add at least one sub-field to define the repeater structure."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2617
+msgid "Add column after"
+msgstr "Add column after"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2610
+msgid "Add column before"
+msgstr "Add column before"
+
+#: packages/admin/src/components/MenuEditor.tsx:299
+#: packages/admin/src/components/MenuEditor.tsx:414
+msgid "Add Content"
+msgstr "Add Content"
+
+#: packages/admin/src/components/MenuEditor.tsx:311
+#: packages/admin/src/components/MenuEditor.tsx:318
+#: packages/admin/src/components/MenuEditor.tsx:417
+msgid "Add Custom Link"
+msgstr "Add Custom Link"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:349
+msgid "Add Domain"
+msgstr "Add Domain"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:582
+#: packages/admin/src/components/FieldEditor.tsx:342
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Add Field"
+msgstr "Add Field"
+
+#: packages/admin/src/components/WordPressImport.tsx:1820
+msgid "Add fields"
+msgstr "Add fields"
+
+#: packages/admin/src/routes/byline-schema.tsx:293
+msgid "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+msgstr "Add fields like \"Job title\" or \"Pronouns\" to enrich every byline."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:604
+msgid "Add fields to define the structure of your content"
+msgstr "Add fields to define the structure of your content"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:607
+msgid "Add First Field"
+msgstr "Add First Field"
+
+#: packages/admin/src/components/RepeaterField.tsx:169
+msgid "Add First Item"
+msgstr "Add First Item"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1530
+msgid "Add item"
+msgstr "Add item"
+
+#: packages/admin/src/components/RepeaterField.tsx:153
+msgid "Add Item"
+msgstr "Add Item"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2577
+msgid "Add link"
+msgstr "Add link"
+
+#: packages/admin/src/components/MenuEditor.tsx:407
+msgid "Add links to build your navigation menu"
+msgstr "Add links to build your navigation menu"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:162
+msgid "Add MIME type or extension"
+msgstr "Add MIME type or extension"
+
+#: packages/admin/src/components/ContentList.tsx:214
+msgid "Add New"
+msgstr "Add New"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:486
+msgid "Add new {0}"
+msgstr "Add new {0}"
+
+#: packages/admin/src/components/SeoPanel.tsx:192
+msgid "Add noindex meta tag"
+msgstr "Add noindex meta tag"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:225
+msgid "Add Passkey"
+msgstr "Add Passkey"
+
+#: packages/admin/src/components/PluginManager.tsx:206
+msgid "Add plugins to your astro.config.mjs to extend EmDash functionality."
+msgstr "Add plugins to your astro.config.mjs to extend EmDash functionality."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2640
+msgid "Add row after"
+msgstr "Add row after"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2633
+msgid "Add row before"
+msgstr "Add row before"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:476
+msgid "Add SEO metadata fields (title, description, image) and include in sitemap"
+msgstr "Add SEO metadata fields (title, description, image) and include in sitemap"
+
+#: packages/admin/src/components/FieldEditor.tsx:538
+msgid "Add Sub-Field"
+msgstr "Add Sub-Field"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:262
+msgid "Add tags..."
+msgstr "Add tags..."
+
+#: packages/admin/src/components/Widgets.tsx:338
+msgid "Add Widget Area"
+msgstr "Add Widget Area"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:128
+msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+msgstr "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
+
+#: packages/admin/src/components/MenuEditor.tsx:362
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
+msgid "Adding..."
+msgstr "Adding..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1592
+msgid "Additional data to import."
+msgstr "Additional data to import."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:95
+#: packages/admin/src/components/Sidebar.tsx:599
+#: packages/admin/src/components/users/roleDefinitions.ts:42
+msgid "Admin"
+msgstr "Admin"
+
+#: packages/admin/src/components/Sidebar.tsx:543
+msgid "Admin navigation"
+msgstr "Admin navigation"
+
+#: packages/admin/src/components/WelcomeModal.tsx:25
+msgid "Administrator"
+msgstr "Administrator"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:224
+msgid "After send:"
+msgstr "After send:"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2965
+msgid "Align Center"
+msgstr "Align Centre"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2958
+msgid "Align Left"
+msgstr "Align Left"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2972
+msgid "Align Right"
+msgstr "Align Right"
+
+#: packages/admin/src/components/ContentList.tsx:241
+msgid "All"
+msgstr "All"
+
+#: packages/admin/src/routes/bylines.tsx:399
+msgid "All bylines"
+msgstr "All bylines"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:108
+msgid "All capabilities"
+msgstr "All capabilities"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:133
+msgid "All collections"
+msgstr "All collections"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:63
+msgid "All comments require approval"
+msgstr "All comments require approval"
+
+#: packages/admin/src/components/WordPressImport.tsx:2324
+msgid "All imported content will be unassigned. You can reassign authors later from the content editor."
+msgstr "All imported content will be unassigned. You can reassign authors later from the content editor."
+
+#: packages/admin/src/components/LocaleSwitcher.tsx:68
+msgid "All locales"
+msgstr "All locales"
+
+#: packages/admin/src/components/users/UserList.tsx:42
+#: packages/admin/src/components/users/UserList.tsx:46
+msgid "All roles"
+msgstr "All roles"
+
+#: packages/admin/src/components/Sections.tsx:240
+msgid "All Sources"
+msgstr "All Sources"
+
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "All statuses"
+msgstr "All statuses"
+
+#: packages/admin/src/components/MediaLibrary.tsx:393
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "All types"
+msgstr "All types"
+
+#: packages/admin/src/components/Settings.tsx:99
+msgid "Allow users from specific domains to sign up"
+msgstr "Allow users from specific domains to sign up"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:497
+msgid "Allow visitors to leave comments on this collection's content"
+msgstr "Allow visitors to leave comments on this collection's content"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:240
+msgid "Allowed Domains"
+msgstr "Allowed Domains"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:102
+msgid "Allowed types"
+msgstr "Allowed types"
+
+#: packages/admin/src/components/SignupPage.tsx:437
+msgid "Already have an account?"
+msgstr "Already have an account?"
+
+#: packages/admin/src/components/PluginManager.tsx:634
+msgid "Also delete plugin storage data"
+msgstr "Also delete plugin storage data"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:202
+msgid "Alt text"
+msgstr "Alt text"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:298
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:463
+#: packages/admin/src/components/MediaDetailPanel.tsx:202
+msgid "Alt Text"
+msgstr "Alt Text"
+
+#: packages/admin/src/components/MediaLibrary.tsx:688
+#: packages/admin/src/components/MediaLibrary.tsx:745
+msgid "Alt text set"
+msgstr "Alt text set"
+
+#: packages/admin/src/components/WordPressImport.tsx:1234
+msgid "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+msgstr "Alternatively, you can export from WordPress (Tools → Export) and upload the file."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:133
+#: packages/admin/src/components/PluginManager.tsx:98
+#: packages/admin/src/components/PluginManager.tsx:117
+#: packages/admin/src/components/TaxonomySidebar.tsx:350
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:114
+#: packages/admin/src/router.tsx:347
+#: packages/admin/src/router.tsx:362
+#: packages/admin/src/router.tsx:376
+#: packages/admin/src/router.tsx:390
+#: packages/admin/src/router.tsx:743
+#: packages/admin/src/router.tsx:774
+#: packages/admin/src/router.tsx:790
+#: packages/admin/src/router.tsx:806
+#: packages/admin/src/router.tsx:825
+#: packages/admin/src/router.tsx:843
+#: packages/admin/src/router.tsx:861
+#: packages/admin/src/router.tsx:891
+#: packages/admin/src/router.tsx:911
+#: packages/admin/src/router.tsx:1147
+#: packages/admin/src/router.tsx:1163
+#: packages/admin/src/router.tsx:1188
+#: packages/admin/src/router.tsx:1670
+#: packages/admin/src/routes/byline-schema.tsx:103
+#: packages/admin/src/routes/byline-schema.tsx:123
+#: packages/admin/src/routes/byline-schema.tsx:139
+#: packages/admin/src/routes/byline-schema.tsx:153
+msgid "An error occurred"
+msgstr "An error occurred"
+
+#: packages/admin/src/routes/byline-schema.tsx:272
+msgid "An unexpected error occurred."
+msgstr "An unexpected error occurred."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:217
+msgid "An unknown error occurred"
+msgstr "An unknown error occurred"
+
+#: packages/admin/src/components/WordPressImport.tsx:1414
+msgid "Analyzing export file..."
+msgstr "Analysing export file..."
+
+#: packages/admin/src/components/WordPressImport.tsx:735
+msgid "Analyzing WordPress site..."
+msgstr "Analysing WordPress site..."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:105
+msgid "Any media type allowed (subject to global limits)."
+msgstr "Any media type allowed (subject to global limits)."
+
+#: packages/admin/src/components/Settings.tsx:109
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:183
+msgid "API Tokens"
+msgstr "API Tokens"
+
+#: packages/admin/src/components/Widgets.tsx:375
+msgid "Appears on posts and pages"
+msgstr "Appears on posts and pages"
+
+#: packages/admin/src/components/WordPressImport.tsx:1329
+msgid "Application Password"
+msgstr "Application Password"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3032
+msgid "Apply"
+msgstr "Apply"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:144
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:145
+msgid "Apply language"
+msgstr "Apply language"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2517
+#: packages/admin/src/components/PortableTextEditor.tsx:2518
+msgid "Apply link"
+msgstr "Apply link"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:148
+#: packages/admin/src/components/comments/CommentInbox.tsx:237
+#: packages/admin/src/components/comments/CommentInbox.tsx:489
+msgid "Approve"
+msgstr "Approve"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:195
+msgid "approved"
+msgstr "approved"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:202
+msgid "Approved"
+msgstr "Approved"
+
+#: packages/admin/src/components/FieldEditor.tsx:223
+msgid "Arbitrary JSON data"
+msgstr "Arbitrary JSON data"
+
+#: packages/admin/src/components/ContentList.tsx:771
+msgid "archived"
+msgstr "archived"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:65
+msgid "Archives"
+msgstr "Archives"
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:375
+msgid "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+msgstr "Are you sure you want to delete \"{0}\"? No stored values reference this field."
+
+#. placeholder {0}: deleteTarget.label
+#: packages/admin/src/components/ContentTypeList.tsx:145
+msgid "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+msgstr "Are you sure you want to delete \"{0}\"? This will also delete all content in this collection."
+
+#. placeholder {0}: deleteFieldTarget.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:660
+msgid "Are you sure you want to delete the \"{0}\" field?"
+msgstr "Are you sure you want to delete the \"{0}\" field?"
+
+#: packages/admin/src/components/MenuList.tsx:254
+msgid "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+msgstr "Are you sure you want to delete this menu? This will also delete all menu items. This action cannot be undone."
+
+#: packages/admin/src/components/WelcomeModal.tsx:53
+msgid "As an administrator, you can invite other users from the Users section."
+msgstr "As an administrator, you can invite other users from the Users section."
+
+#: packages/admin/src/components/WordPressImport.tsx:2262
+msgid "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+msgstr "Assign WordPress authors to EmDash users. Posts will be attributed to the selected user."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:66
+#: packages/admin/src/components/MediaLibrary.tsx:396
+msgid "Audio"
+msgstr "Audio"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:279
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:278
+msgid "Authentication error: {0}"
+msgstr "Authentication error: {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:195
+msgid "Authentication error: {error}"
+msgstr "Authentication error: {error}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:256
+msgid "Authentication failed"
+msgstr "Authentication failed"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/SecuritySettings.tsx:129
+msgid "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+msgstr "Authentication is managed by an external provider ({0}). Passkey settings are not available when using external authentication."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:263
+msgid "Authentication was cancelled or timed out. Please try again."
+msgstr "Authentication was cancelled or timed out. Please try again."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:77
+#: packages/admin/src/components/comments/CommentInbox.tsx:287
+#: packages/admin/src/components/users/roleDefinitions.ts:30
+#: packages/admin/src/components/WelcomeModal.tsx:27
+msgid "Author"
+msgstr "Author"
+
+#: packages/admin/src/components/WordPressImport.tsx:2277
+msgid "Author Mapping"
+msgstr "Author Mapping"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:197
+msgid "Authorization denied"
+msgstr "Authorisation denied"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:105
+msgid "Authorization failed"
+msgstr "Authorisation failed"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorize"
+msgstr "Authorise"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:176
+msgid "Authorize Device"
+msgstr "Authorise Device"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:259
+msgid "Authorizing..."
+msgstr "Authorising..."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:670
+msgid "Authors"
+msgstr "Authors"
+
+#: packages/admin/src/components/Redirects.tsx:495
+msgid "auto"
+msgstr "auto"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Auto (slug change)"
+msgstr "Auto (slug change)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:541
+msgid "Auto-approve authenticated users"
+msgstr "Auto-approve authenticated users"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:408
+msgid "Auto-generated from name (you can edit)"
+msgstr "Auto-generated from name (you can edit)"
+
+#: packages/admin/src/router.tsx:773
+msgid "Autosave failed"
+msgstr "Autosave failed"
+
+#: packages/admin/src/components/ContentEditor.tsx:645
+msgid "Autosave status"
+msgstr "Autosave status"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:657
+msgid "Available media"
+msgstr "Available media"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:233
+msgid "Available Providers"
+msgstr "Available Providers"
+
+#: packages/admin/src/components/Widgets.tsx:401
+msgid "Available Widgets"
+msgstr "Available Widgets"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:257
+#: packages/admin/src/components/MenuEditor.tsx:283
+#: packages/admin/src/components/WordPressImport.tsx:1349
+#: packages/admin/src/components/WordPressImport.tsx:2333
+msgid "Back"
+msgstr "Back"
+
+#: packages/admin/src/components/ContentEditor.tsx:614
+msgid "Back to {collectionLabel} list"
+msgstr "Back to {collectionLabel} list"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:336
+msgid "Back to Content Types"
+msgstr "Back to Content Types"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:139
+#: packages/admin/src/components/LoginPage.tsx:117
+#: packages/admin/src/components/LoginPage.tsx:153
+#: packages/admin/src/components/LoginPage.tsx:311
+#: packages/admin/src/components/SignupPage.tsx:281
+msgid "Back to login"
+msgstr "Back to login"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:115
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:391
+msgid "Back to marketplace"
+msgstr "Back to marketplace"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:803
+msgid "Back to plugins"
+msgstr "Back to plugins"
+
+#: packages/admin/src/components/SectionEditor.tsx:73
+#: packages/admin/src/components/SectionEditor.tsx:174
+msgid "Back to sections"
+msgstr "Back to sections"
+
+#: packages/admin/src/components/settings/BackToSettingsLink.tsx:19
+msgid "Back to settings"
+msgstr "Back to settings"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:86
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:110
+msgid "Back to Themes"
+msgstr "Back to Themes"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:219
+msgid "Before send:"
+msgstr "Before send:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:233
+msgid "Bing Verification"
+msgstr "Bing Verification"
+
+#: packages/admin/src/routes/bylines.tsx:483
+msgid "Bio"
+msgstr "Bio"
+
+#: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
+msgid "Block actions - drag to reorder, click for menu"
+msgstr "Block actions - drag to reorder, click for menu"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2541
+#: packages/admin/src/components/PortableTextEditor.tsx:2847
+msgid "Bold"
+msgstr "Bold"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:55
+#: packages/admin/src/components/FieldEditor.tsx:174
+#: packages/admin/src/components/FieldEditor.tsx:583
+msgid "Boolean"
+msgstr "Boolean"
+
+#: packages/admin/src/components/SeoPanel.tsx:169
+msgid "Brief summary shown below the title in search results"
+msgstr "Brief summary shown below the title in search results"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:71
+msgid "Browse and install plugins published to the decentralized registry."
+msgstr "Browse and install plugins published to the decentralised registry."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:88
+msgid "Browse and install plugins to extend your site."
+msgstr "Browse and install plugins to extend your site."
+
+#: packages/admin/src/components/WordPressImport.tsx:966
+#: packages/admin/src/components/WordPressImport.tsx:1433
+msgid "Browse Files"
+msgstr "Browse Files"
+
+#: packages/admin/src/components/PluginManager.tsx:199
+msgid "Browse the"
+msgstr "Browse the"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:79
+msgid "Browse themes and preview them with your own content."
+msgstr "Browse themes and preview them with your own content."
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:102
+#: packages/admin/src/components/PortableTextEditor.tsx:913
+#: packages/admin/src/components/PortableTextEditor.tsx:2915
+msgid "Bullet List"
+msgstr "Bullet List"
+
+#: packages/admin/src/routes/byline-schema.tsx:218
+#: packages/admin/src/routes/bylines.tsx:370
+msgid "Byline schema"
+msgstr "Byline schema"
+
+#: packages/admin/src/components/ContentEditor.tsx:998
+#: packages/admin/src/components/Sidebar.tsx:363
+#: packages/admin/src/routes/bylines.tsx:362
+msgid "Bylines"
+msgstr "Bylines"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:25
+msgid "Can create content"
+msgstr "Can create content"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:37
+msgid "Can manage all content"
+msgstr "Can manage all content"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:31
+msgid "Can publish own content"
+msgstr "Can publish own content"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:19
+msgid "Can view content"
+msgstr "Can view content"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:315
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:161
+#: packages/admin/src/components/ConfirmDialog.tsx:57
+#: packages/admin/src/components/ContentEditor.tsx:707
+#: packages/admin/src/components/ContentEditor.tsx:912
+#: packages/admin/src/components/ContentEditor.tsx:964
+#: packages/admin/src/components/ContentEditor.tsx:2205
+#: packages/admin/src/components/ContentEditor.tsx:2258
+#: packages/admin/src/components/ContentList.tsx:659
+#: packages/admin/src/components/ContentList.tsx:730
+#: packages/admin/src/components/ContentPickerModal.tsx:248
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:156
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:157
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:516
+#: packages/admin/src/components/editor/ImageNode.tsx:223
+#: packages/admin/src/components/editor/ImageNode.tsx:224
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:406
+#: packages/admin/src/components/FieldEditor.tsx:648
+#: packages/admin/src/components/MediaDetailPanel.tsx:234
+#: packages/admin/src/components/MediaPickerModal.tsx:739
+#: packages/admin/src/components/MenuEditor.tsx:359
+#: packages/admin/src/components/MenuEditor.tsx:530
+#: packages/admin/src/components/MenuList.tsx:172
+#: packages/admin/src/components/PluginManager.tsx:640
+#: packages/admin/src/components/PortableTextEditor.tsx:3016
+#: packages/admin/src/components/Redirects.tsx:175
+#: packages/admin/src/components/SectionPickerModal.tsx:130
+#: packages/admin/src/components/Sections.tsx:209
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:313
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:423
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:325
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:453
+#: packages/admin/src/components/settings/SecuritySettings.tsx:206
+#: packages/admin/src/components/TaxonomyManager.tsx:187
+#: packages/admin/src/components/TaxonomyManager.tsx:472
+#: packages/admin/src/components/TaxonomyManager.tsx:686
+#: packages/admin/src/components/users/InviteUserModal.tsx:200
+#: packages/admin/src/components/Widgets.tsx:386
+#: packages/admin/src/components/WordPressImport.tsx:1753
+msgid "Cancel"
+msgstr "Cancel"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:405
+msgid "Cancel (Esc)"
+msgstr "Cancel (Esc)"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:146
+msgid "Cancel rename"
+msgstr "Cancel rename"
+
+#: packages/admin/src/components/Sections.tsx:407
+msgid "Cannot delete theme sections"
+msgstr "Cannot delete theme sections"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:408
+msgid "Cannot determine MIME type from URL. Use a URL ending in a recognized image extension (e.g. .jpg, .png, .webp)."
+msgstr "Cannot determine MIME type from URL. Use a URL ending in a recognised image extension (e.g. .jpg, .png, .webp)."
+
+#: packages/admin/src/components/SeoPanel.tsx:181
+msgid "Canonical URL"
+msgstr "Canonical URL"
+
+#: packages/admin/src/components/PluginManager.tsx:473
+msgid "Capabilities"
+msgstr "Capabilities"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:65
+msgid "Capability consent"
+msgstr "Capability consent"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:306
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:471
+#: packages/admin/src/components/MediaDetailPanel.tsx:210
+msgid "Caption"
+msgstr "Caption"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:68
+msgid "Captions / Subtitles"
+msgstr "Captions / Subtitles"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:193
+msgid "Categories"
+msgstr "Categories"
+
+#. placeholder {0}: analysis.categories
+#: packages/admin/src/components/WordPressImport.tsx:1621
+msgid "Categories ({0})"
+msgstr "Categories ({0})"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:76
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:107
+#: packages/admin/src/components/ContentEditor.tsx:1672
+#: packages/admin/src/components/ContentEditor.tsx:1701
+#: packages/admin/src/components/ContentEditor.tsx:1875
+#: packages/admin/src/components/FieldEditor.tsx:402
+#: packages/admin/src/components/SeoImageField.tsx:47
+msgid "Change"
+msgstr "Change"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#. placeholder {1}: getRoleLabel(selectedUser?.role ?? 0)
+#. placeholder {2}: getRoleLabel(pendingSaveData?.role ?? 0)
+#: packages/admin/src/routes/users.tsx:296
+msgid "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+msgstr "Change <0>{0}</0> from <1>{1}</1> to <2>{2}</2>? They will lose access to higher-level features."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:262
+msgid "Change Favicon"
+msgstr "Change Favicon"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:200
+msgid "Change Image"
+msgstr "Change Image"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:208
+msgid "Change Logo"
+msgstr "Change Logo"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:791
+msgid "Changelog"
+msgstr "Changelog"
+
+#: packages/admin/src/router.tsx:818
+msgid "Changes discarded"
+msgstr "Changes discarded"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:162
+msgid "Character between page title and site name (e.g., \"My Post | My Site\")"
+msgstr "Character between page title and site name (e.g., \"My Post | My Site\")"
+
+#: packages/admin/src/components/PluginManager.tsx:162
+msgid "Check for updates"
+msgstr "Check for updates"
+
+#: packages/admin/src/components/WordPressImport.tsx:937
+msgid "Check Site"
+msgstr "Check Site"
+
+#: packages/admin/src/components/LoginPage.tsx:101
+#: packages/admin/src/components/SignupPage.tsx:130
+#: packages/admin/src/components/SignupPage.tsx:400
+msgid "Check your email"
+msgstr "Check your email"
+
+#: packages/admin/src/components/WordPressImport.tsx:701
+msgid "Checking {urlInput}..."
+msgstr "Checking {urlInput}..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:155
+msgid "Checking authentication..."
+msgstr "Checking authentication..."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:362
+msgid "Checking how many stored values reference \"{0}\"…"
+msgstr "Checking how many stored values reference \"{0}\"…"
+
+#: packages/admin/src/components/SetupWizard.tsx:288
+msgid "Choose how to sign in"
+msgstr "Choose how to sign in"
+
+#: packages/admin/src/components/Settings.tsx:130
+msgid "Choose your preferred admin language"
+msgstr "Choose your preferred admin language"
+
+#: packages/admin/src/components/users/UserList.tsx:129
+msgid "Clear filters"
+msgstr "Clear filters"
+
+#: packages/admin/src/components/SignupPage.tsx:138
+msgid "Click the link in the email to continue setting up your account."
+msgstr "Click the link in the email to continue setting up your account."
+
+#: packages/admin/src/components/LoginPage.tsx:112
+msgid "Click the link in the email to sign in."
+msgstr "Click the link in the email to sign in."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:212
+#: packages/admin/src/components/BylineFieldEditor.tsx:218
+#: packages/admin/src/components/BylineFieldEditor.tsx:222
+#: packages/admin/src/components/comments/CommentDetail.tsx:59
+#: packages/admin/src/components/ContentPickerModal.tsx:120
+#: packages/admin/src/components/ContentPickerModal.tsx:126
+#: packages/admin/src/components/ContentPickerModal.tsx:130
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:205
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:207
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:366
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:368
+#: packages/admin/src/components/FieldEditor.tsx:345
+#: packages/admin/src/components/FieldEditor.tsx:351
+#: packages/admin/src/components/FieldEditor.tsx:355
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:436
+#: packages/admin/src/components/MediaDetailPanel.tsx:131
+#: packages/admin/src/components/MediaDetailPanel.tsx:133
+#: packages/admin/src/components/MediaPickerModal.tsx:477
+#: packages/admin/src/components/MediaPickerModal.tsx:483
+#: packages/admin/src/components/MediaPickerModal.tsx:487
+#: packages/admin/src/components/MenuEditor.tsx:321
+#: packages/admin/src/components/MenuEditor.tsx:327
+#: packages/admin/src/components/MenuEditor.tsx:331
+#: packages/admin/src/components/MenuEditor.tsx:489
+#: packages/admin/src/components/MenuEditor.tsx:495
+#: packages/admin/src/components/MenuEditor.tsx:499
+#: packages/admin/src/components/MenuList.tsx:136
+#: packages/admin/src/components/MenuList.tsx:142
+#: packages/admin/src/components/MenuList.tsx:146
+#: packages/admin/src/components/PortableTextEditor.tsx:1314
+#: packages/admin/src/components/PortableTextEditor.tsx:1320
+#: packages/admin/src/components/PortableTextEditor.tsx:1324
+#: packages/admin/src/components/Redirects.tsx:111
+#: packages/admin/src/components/Redirects.tsx:117
+#: packages/admin/src/components/SectionPickerModal.tsx:60
+#: packages/admin/src/components/SectionPickerModal.tsx:66
+#: packages/admin/src/components/SectionPickerModal.tsx:70
+#: packages/admin/src/components/Sections.tsx:153
+#: packages/admin/src/components/Sections.tsx:159
+#: packages/admin/src/components/Sections.tsx:163
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:371
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:377
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:164
+#: packages/admin/src/components/TaxonomyManager.tsx:371
+#: packages/admin/src/components/TaxonomyManager.tsx:377
+#: packages/admin/src/components/TaxonomyManager.tsx:381
+#: packages/admin/src/components/TaxonomyManager.tsx:605
+#: packages/admin/src/components/TaxonomyManager.tsx:611
+#: packages/admin/src/components/TaxonomyManager.tsx:615
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:298
+#: packages/admin/src/components/users/InviteUserModal.tsx:88
+#: packages/admin/src/components/users/InviteUserModal.tsx:94
+#: packages/admin/src/components/users/InviteUserModal.tsx:98
+#: packages/admin/src/components/WelcomeModal.tsx:54
+#: packages/admin/src/components/Widgets.tsx:348
+#: packages/admin/src/components/Widgets.tsx:354
+#: packages/admin/src/components/Widgets.tsx:358
+msgid "Close"
+msgstr "Close"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:520
+msgid "Close comments after (days)"
+msgstr "Close comments after (days)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:121
+msgid "Close panel"
+msgstr "Close panel"
+
+#: packages/admin/src/components/ContentTypeList.tsx:244
+#: packages/admin/src/components/PortableTextEditor.tsx:2569
+#: packages/admin/src/components/Redirects.tsx:443
+msgid "Code"
+msgstr "Code"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:94
+#: packages/admin/src/components/PortableTextEditor.tsx:943
+#: packages/admin/src/components/PortableTextEditor.tsx:2936
+msgid "Code Block"
+msgstr "Code Block"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Collapse"
+msgstr "Collapse"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Collapse details"
+msgstr "Collapse details"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:158
+msgid "colleague@example.com"
+msgstr "colleague@example.com"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:156
+msgid "Collection"
+msgstr "Collection"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:106
+msgid "Collection:"
+msgstr "Collection:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:656
+msgid "Collections"
+msgstr "Collections"
+
+#: packages/admin/src/components/WordPressImport.tsx:2133
+msgid "Collections created:"
+msgstr "Collections created:"
+
+#: packages/admin/src/components/SectionEditor.tsx:273
+msgid "Comma-separated keywords for search."
+msgstr "Comma-separated keywords for search."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:95
+#: packages/admin/src/components/comments/CommentInbox.tsx:290
+msgid "Comment"
+msgstr "Comment"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:58
+msgid "Comment Detail"
+msgstr "Comment Detail"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:146
+#: packages/admin/src/components/ContentTypeEditor.tsx:487
+#: packages/admin/src/components/Sidebar.tsx:347
+msgid "Comments"
+msgstr "Comments"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:544
+msgid "Comments from logged-in CMS users are approved automatically"
+msgstr "Comments from logged-in CMS users are approved automatically"
+
+#: packages/admin/src/components/SignupPage.tsx:401
+msgid "Complete signup"
+msgstr "Complete signup"
+
+#: packages/admin/src/components/Widgets.tsx:851
+msgid "Component"
+msgstr "Component"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Configure Field"
+msgstr "Configure Field"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Confirm"
+msgstr "Confirm"
+
+#: packages/admin/src/components/WordPressImport.tsx:627
+msgid "Connect"
+msgstr "Connect"
+
+#: packages/admin/src/components/WordPressImport.tsx:1346
+msgid "Connect & Analyze"
+msgstr "Connect & Analyse"
+
+#. placeholder {0}: siteTitle || "WordPress"
+#: packages/admin/src/components/WordPressImport.tsx:1296
+msgid "Connect to {0}"
+msgstr "Connect to {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1212
+msgid "Connect with WordPress"
+msgstr "Connect with WordPress"
+
+#. placeholder {0}: new Date(account.createdAt).toLocaleDateString()
+#: packages/admin/src/components/users/UserDetail.tsx:286
+msgid "Connected {0}"
+msgstr "Connected {0}"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:365
+#: packages/admin/src/components/comments/CommentDetail.tsx:103
+#: packages/admin/src/components/comments/CommentInbox.tsx:293
+#: packages/admin/src/components/Dashboard.tsx:164
+#: packages/admin/src/components/PortableTextEditor.tsx:2047
+#: packages/admin/src/components/SectionEditor.tsx:194
+#: packages/admin/src/components/Sidebar.tsx:577
+#: packages/admin/src/components/Widgets.tsx:819
+msgid "Content"
+msgstr "Content"
+
+#: packages/admin/src/components/Widgets.tsx:96
+msgid "Content Block"
+msgstr "Content Block"
+
+#. placeholder {0}: result.errors.length
+#: packages/admin/src/components/WordPressImport.tsx:2188
+msgid "Content Errors ({0})"
+msgstr "Content Errors ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:1156
+msgid "Content found:"
+msgstr "Content found:"
+
+#: packages/admin/src/router.tsx:837
+msgid "Content has been scheduled for publishing"
+msgstr "Content has been scheduled for publishing"
+
+#: packages/admin/src/components/RevisionHistory.tsx:131
+msgid "Content has been updated to the selected revision."
+msgstr "Content has been updated to the selected revision."
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:110
+msgid "Content ID:"
+msgstr "Content ID:"
+
+#: packages/admin/src/router.tsx:785
+msgid "Content is now live"
+msgstr "Content is now live"
+
+#: packages/admin/src/components/WordPressImport.tsx:2177
+msgid "content items"
+msgstr "content items"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:45
+msgid "Content Read"
+msgstr "Content Read"
+
+#: packages/admin/src/router.tsx:801
+msgid "Content removed from public view"
+msgstr "Content removed from public view"
+
+#: packages/admin/src/router.tsx:855
+msgid "Content reverted to draft"
+msgstr "Content reverted to draft"
+
+#: packages/admin/src/components/RevisionHistory.tsx:296
+msgid "Content snapshot:"
+msgstr "Content snapshot:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1570
+msgid "Content to Import"
+msgstr "Content to Import"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:185
+#: packages/admin/src/components/ContentTypeList.tsx:40
+#: packages/admin/src/components/Sidebar.tsx:367
+msgid "Content Types"
+msgstr "Content Types"
+
+#: packages/admin/src/components/WordPressImport.tsx:2116
+msgid "Content was skipped because it already exists"
+msgstr "Content was skipped because it already exists"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:50
+msgid "Content Write"
+msgstr "Content Write"
+
+#: packages/admin/src/components/SignupPage.tsx:91
+msgid "Continue"
+msgstr "Continue"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Continue →"
+msgstr "Continue →"
+
+#: packages/admin/src/components/WordPressImport.tsx:2335
+msgid "Continue Import"
+msgstr "Continue Import"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:24
+#: packages/admin/src/components/WelcomeModal.tsx:28
+msgid "Contributor"
+msgstr "Contributor"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:225
+#: packages/admin/src/components/users/InviteUserModal.tsx:134
+msgid "Copied to clipboard"
+msgstr "Copied to clipboard"
+
+#. placeholder {0}: section.slug
+#: packages/admin/src/components/Sections.tsx:399
+msgid "Copy {0} to clipboard"
+msgstr "Copy {0} to clipboard"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:124
+msgid "Copy invite link"
+msgstr "Copy invite link"
+
+#: packages/admin/src/components/Sections.tsx:398
+msgid "Copy slug"
+msgstr "Copy slug"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:200
+msgid "Copy this token now — it won't be shown again."
+msgstr "Copy this token now — it won't be shown again."
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:218
+msgid "Copy token"
+msgstr "Copy token"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:322
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:323
+msgid "Copy URL"
+msgstr "Copy URL"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:138
+msgid "Could not copy automatically. Please select the URL above and copy manually."
+msgstr "Could not copy automatically. Please select the URL above and copy manually."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:434
+msgid "Could not load image from URL"
+msgstr "Could not load image from URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1103
+msgid "Couldn't detect WordPress"
+msgstr "Couldn't detect WordPress"
+
+#: packages/admin/src/routes/byline-schema.tsx:268
+msgid "Couldn't load byline fields."
+msgstr "Couldn't load byline fields."
+
+#: packages/admin/src/routes/bylines.tsx:530
+msgid "Couldn't load custom fields."
+msgstr "Couldn't load custom fields."
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:88
+msgid "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+msgstr "Couldn't map \"{draft}\" to a MIME type. Type the MIME directly."
+
+#: packages/admin/src/components/ContentEditor.tsx:2097
+msgid "Couldn't search bylines. Please try again."
+msgstr "Couldn't search bylines. Please try again."
+
+#. placeholder {0}: deletingField.label
+#: packages/admin/src/routes/byline-schema.tsx:369
+msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+msgstr "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:822
+msgid "Count"
+msgstr "Count"
+
+#: packages/admin/src/components/ContentEditor.tsx:2229
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:184
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/TaxonomyManager.tsx:479
+#: packages/admin/src/components/Widgets.tsx:389
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Create"
+msgstr "Create"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Create \"{trimmedInput}\""
+msgstr "Create \"{trimmedInput}\""
+
+#: packages/admin/src/components/PortableTextEditor.tsx:914
+msgid "Create a bullet list"
+msgstr "Create a bullet list"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:367
+msgid "Create a new {0}"
+msgstr "Create a new {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:924
+msgid "Create a numbered list"
+msgstr "Create a numbered list"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:81
+#: packages/admin/src/components/SignupPage.tsx:220
+msgid "Create Account"
+msgstr "Create Account"
+
+#: packages/admin/src/components/SignupPage.tsx:399
+msgid "Create an account"
+msgstr "Create an account"
+
+#: packages/admin/src/components/ContentEditor.tsx:2177
+#: packages/admin/src/routes/bylines.tsx:463
+msgid "Create byline"
+msgstr "Create byline"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+msgid "Create Content Type"
+msgstr "Create Content Type"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Create field"
+msgstr "Create field"
+
+#: packages/admin/src/components/MenuList.tsx:126
+#: packages/admin/src/components/MenuList.tsx:189
+msgid "Create Menu"
+msgstr "Create Menu"
+
+#: packages/admin/src/components/MenuList.tsx:133
+msgid "Create New Menu"
+msgstr "Create New Menu"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:396
+msgid "Create New Token"
+msgstr "Create New Token"
+
+#: packages/admin/src/components/WordPressImport.tsx:1340
+msgid "Create one in WordPress: Users → Profile → Application Passwords"
+msgstr "Create one in WordPress: Users → Profile → Application Passwords"
+
+#: packages/admin/src/components/SetupWizard.tsx:298
+msgid "Create Passkey"
+msgstr "Create Passkey"
+
+#: packages/admin/src/components/Settings.tsx:110
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:185
+msgid "Create personal access tokens for programmatic API access"
+msgstr "Create personal access tokens for programmatic API access"
+
+#. placeholder {0}: item.path
+#: packages/admin/src/components/Redirects.tsx:238
+msgid "Create redirect for {0}"
+msgstr "Create redirect for {0}"
+
+#: packages/admin/src/components/Redirects.tsx:237
+msgid "Create redirect for this path"
+msgstr "Create redirect for this path"
+
+#: packages/admin/src/components/Redirects.tsx:435
+msgid "Create redirect rules to manage URL changes."
+msgstr "Create redirect rules to manage URL changes."
+
+#: packages/admin/src/components/WordPressImport.tsx:1757
+msgid "Create Schema & Import"
+msgstr "Create Schema & Import"
+
+#: packages/admin/src/components/Sections.tsx:150
+#: packages/admin/src/components/Sections.tsx:270
+msgid "Create Section"
+msgstr "Create Section"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:109
+msgid "Create sections in the Sections library to use them here"
+msgstr "Create sections in the Sections library to use them here"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:598
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+msgid "Create Taxonomy"
+msgstr "Create Taxonomy"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:258
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+msgid "Create Token"
+msgstr "Create Token"
+
+#: packages/admin/src/components/Widgets.tsx:345
+msgid "Create Widget Area"
+msgstr "Create Widget Area"
+
+#: packages/admin/src/components/SetupWizard.tsx:560
+msgid "Create your account"
+msgstr "Create your account"
+
+#: packages/admin/src/components/MenuList.tsx:187
+msgid "Create your first navigation menu to get started"
+msgstr "Create your first navigation menu to get started"
+
+#: packages/admin/src/components/ContentList.tsx:318
+#: packages/admin/src/components/ContentTypeList.tsx:122
+msgid "Create your first one"
+msgstr "Create your first one"
+
+#: packages/admin/src/components/Sections.tsx:267
+msgid "Create your first reusable content section to get started."
+msgstr "Create your first reusable content section to get started."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:72
+#: packages/admin/src/components/SignupPage.tsx:211
+msgid "Create your passkey"
+msgstr "Create your passkey"
+
+#: packages/admin/src/lib/api/marketplace.ts:223
+#: packages/admin/src/lib/api/marketplace.ts:231
+msgid "Create, update, and delete content"
+msgstr "Create, update, and delete content"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:81
+msgid "Create, update, and delete navigation menus"
+msgstr "Create, update, and delete navigation menus"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
+msgid "Create, update, and delete taxonomy terms"
+msgstr "Create, update, and delete taxonomy terms"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
+msgid "Create, update, delete content"
+msgstr "Create, update, delete content"
+
+#: packages/admin/src/components/users/UserDetail.tsx:219
+msgid "Created"
+msgstr "Created"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:96
+msgid "Created \"{0}\"."
+msgstr "Created \"{0}\"."
+
+#. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:297
+#: packages/admin/src/components/users/UserDetail.tsx:260
+msgid "Created {0}"
+msgstr "Created {0}"
+
+#. placeholder {0}: result.locale?.toUpperCase() ?? t`new`
+#: packages/admin/src/router.tsx:885
+msgid "Created {0} translation"
+msgstr "Created {0} translation"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:123
+msgid "Created At"
+msgstr "Created At"
+
+#. placeholder {0}: new Date(item.createdAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:932
+msgid "Created: {0}"
+msgstr "Created: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:812
+msgid "Creating collections and fields..."
+msgstr "Creating collections and fields..."
+
+#: packages/admin/src/components/ContentEditor.tsx:2229
+#: packages/admin/src/components/MenuList.tsx:175
+#: packages/admin/src/components/Redirects.tsx:181
+#: packages/admin/src/components/Sections.tsx:212
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:450
+#: packages/admin/src/components/TaxonomyManager.tsx:689
+#: packages/admin/src/components/TaxonomySidebar.tsx:290
+msgid "Creating..."
+msgstr "Creating..."
+
+#: packages/admin/src/components/TranslationsPanel.tsx:78
+msgid "current"
+msgstr "current"
+
+#: packages/admin/src/components/RevisionHistory.tsx:264
+msgid "Current"
+msgstr "Current"
+
+#: packages/admin/src/components/Sections.tsx:46
+msgid "Custom"
+msgstr "Custom"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:614
+msgid "Custom Fields"
+msgstr "Custom Fields"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:243
+msgid "Custom robots.txt content. Leave empty to use the default."
+msgstr "Custom robots.txt content. Leave empty to use the default."
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Custom Section"
+msgstr "Custom Section"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "dark"
+msgstr "dark"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Dark"
+msgstr "Dark"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:131
+#: packages/admin/src/components/ContentTypeList.tsx:246
+#: packages/admin/src/components/Dashboard.tsx:42
+#: packages/admin/src/components/Sidebar.tsx:333
+#: packages/admin/src/components/Sidebar.tsx:566
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:296
+#: packages/admin/src/components/ContentList.tsx:287
+msgid "Date"
+msgstr "Date"
+
+#: packages/admin/src/components/FieldEditor.tsx:180
+#: packages/admin/src/components/FieldEditor.tsx:584
+msgid "Date & Time"
+msgstr "Date & Time"
+
+#: packages/admin/src/components/FieldEditor.tsx:181
+msgid "Date and time picker"
+msgstr "Date and time picker"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:304
+msgid "Date Format"
+msgstr "Date Format"
+
+#: packages/admin/src/components/FieldEditor.tsx:163
+msgid "Decimal number"
+msgstr "Decimal number"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:735
+msgid "Declared permissions"
+msgstr "Declared permissions"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:327
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:389
+msgid "Default Role"
+msgstr "Default Role"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:266
+msgid "Default role:"
+msgstr "Default role:"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:180
+msgid "Default social image"
+msgstr "Default social image"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:171
+msgid "Default Social Image"
+msgstr "Default Social Image"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:601
+msgid "Define a new taxonomy for classifying content"
+msgstr "Define a new taxonomy for classifying content"
+
+#: packages/admin/src/routes/byline-schema.tsx:220
+msgid "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+msgstr "Define custom fields stored on every byline — job title, pronouns, social handles, and more."
+
+#: packages/admin/src/components/ContentTypeList.tsx:41
+msgid "Define the structure of your content"
+msgstr "Define the structure of your content"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:361
+msgid "Defined in code"
+msgstr "Defined in code"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:267
+#: packages/admin/src/components/comments/CommentInbox.tsx:407
+#: packages/admin/src/components/ContentTypeEditor.tsx:663
+#: packages/admin/src/components/ContentTypeList.tsx:148
+#: packages/admin/src/components/editor/BlockMenu.tsx:301
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:130
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:378
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:255
+#: packages/admin/src/components/MenuEditor.tsx:463
+#: packages/admin/src/components/MenuList.tsx:255
+#: packages/admin/src/components/Redirects.tsx:552
+#: packages/admin/src/components/Sections.tsx:308
+#: packages/admin/src/components/Sections.tsx:407
+#: packages/admin/src/components/TaxonomyManager.tsx:886
+#: packages/admin/src/components/Widgets.tsx:636
+#: packages/admin/src/routes/byline-schema.tsx:378
+#: packages/admin/src/routes/bylines.tsx:571
+#: packages/admin/src/routes/bylines.tsx:607
+msgid "Delete"
+msgstr "Delete"
+
+#. placeholder {0}: item.filename
+#: packages/admin/src/components/MediaDetailPanel.tsx:254
+msgid "Delete \"{0}\"? This cannot be undone."
+msgstr "Delete \"{0}\"? This cannot be undone."
+
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeList.tsx:229
+#: packages/admin/src/components/Sections.tsx:408
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:285
+#: packages/admin/src/components/TaxonomyManager.tsx:97
+#: packages/admin/src/components/Widgets.tsx:737
+#: packages/admin/src/routes/byline-schema.tsx:458
+msgid "Delete {0}"
+msgstr "Delete {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:740
+msgid "Delete {0} field"
+msgstr "Delete {0} field"
+
+#. placeholder {0}: menu.name
+#: packages/admin/src/components/MenuList.tsx:237
+msgid "Delete {0} menu"
+msgstr "Delete {0} menu"
+
+#. placeholder {0}: area.label
+#: packages/admin/src/components/Widgets.tsx:584
+msgid "Delete {0} widget area"
+msgstr "Delete {0} widget area"
+
+#. placeholder {0}: taxonomyDef.labelSingular || "Term"
+#: packages/admin/src/components/TaxonomyManager.tsx:882
+msgid "Delete {0}?"
+msgstr "Delete {0}?"
+
+#: packages/admin/src/routes/byline-schema.tsx:358
+msgid "Delete byline field?"
+msgstr "Delete byline field?"
+
+#: packages/admin/src/routes/bylines.tsx:605
+msgid "Delete Byline?"
+msgstr "Delete Byline?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2624
+msgid "Delete column"
+msgstr "Delete column"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:405
+msgid "Delete Comment?"
+msgstr "Delete Comment?"
+
+#: packages/admin/src/components/ContentTypeList.tsx:142
+msgid "Delete Content Type?"
+msgstr "Delete Content Type?"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:379
+msgid "Delete embed"
+msgstr "Delete embed"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:657
+msgid "Delete Field?"
+msgstr "Delete Field?"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
+msgid "Delete HTML block"
+msgstr "Delete HTML block"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:191
+#: packages/admin/src/components/editor/ImageNode.tsx:192
+msgid "Delete image"
+msgstr "Delete image"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:253
+msgid "Delete Media?"
+msgstr "Delete Media?"
+
+#: packages/admin/src/components/MenuList.tsx:253
+msgid "Delete Menu"
+msgstr "Delete Menu"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:525
+msgid "Delete permanently"
+msgstr "Delete permanently"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:182
+#: packages/admin/src/components/ContentList.tsx:741
+msgid "Delete Permanently"
+msgstr "Delete Permanently"
+
+#: packages/admin/src/components/ContentList.tsx:721
+msgid "Delete Permanently?"
+msgstr "Delete Permanently?"
+
+#: packages/admin/src/components/Redirects.tsx:509
+msgid "Delete redirect"
+msgstr "Delete redirect"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:510
+msgid "Delete redirect {0}"
+msgstr "Delete redirect {0}"
+
+#: packages/admin/src/components/Redirects.tsx:550
+msgid "Delete Redirect?"
+msgstr "Delete Redirect?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2645
+msgid "Delete row"
+msgstr "Delete row"
+
+#: packages/admin/src/components/Sections.tsx:296
+msgid "Delete Section?"
+msgstr "Delete Section?"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2660
+msgid "Delete table"
+msgstr "Delete table"
+
+#: packages/admin/src/components/Widgets.tsx:634
+msgid "Delete Widget Area?"
+msgstr "Delete Widget Area?"
+
+#: packages/admin/src/components/ContentList.tsx:405
+msgid "Deleted"
+msgstr "Deleted"
+
+#. placeholder {0}: deletingField.label
+#. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
+#: packages/admin/src/routes/byline-schema.tsx:371
+msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+msgstr "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:408
+#: packages/admin/src/components/ContentTypeEditor.tsx:664
+#: packages/admin/src/components/ContentTypeList.tsx:149
+#: packages/admin/src/components/MediaDetailPanel.tsx:230
+#: packages/admin/src/components/MediaDetailPanel.tsx:256
+#: packages/admin/src/components/MenuList.tsx:256
+#: packages/admin/src/components/Redirects.tsx:553
+#: packages/admin/src/components/Sections.tsx:309
+#: packages/admin/src/components/TaxonomyManager.tsx:887
+#: packages/admin/src/components/Widgets.tsx:637
+#: packages/admin/src/routes/bylines.tsx:608
+msgid "Deleting..."
+msgstr "Deleting..."
+
+#: packages/admin/src/routes/byline-schema.tsx:379
+msgid "Deleting…"
+msgstr "Deleting…"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:262
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:147
+msgid "Demo"
+msgstr "Demo"
+
+#: packages/admin/src/routes/users.tsx:303
+msgid "Demote User"
+msgstr "Demote User"
+
+#: packages/admin/src/routes/users.tsx:294
+msgid "Demote User?"
+msgstr "Demote User?"
+
+#: packages/admin/src/routes/users.tsx:304
+msgid "Demoting..."
+msgstr "Demoting..."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:270
+msgid "Deny"
+msgstr "Deny"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:209
+msgid "Describe the image..."
+msgstr "Describe the image..."
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:301
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:466
+#: packages/admin/src/components/MediaDetailPanel.tsx:205
+msgid "Describe this image for accessibility"
+msgstr "Describe this image for accessibility"
+
+#: packages/admin/src/components/SectionEditor.tsx:262
+msgid "Describe what this section is for..."
+msgstr "Describe what this section is for..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:415
+#: packages/admin/src/components/RegistryPluginDetail.tsx:788
+#: packages/admin/src/components/SectionEditor.tsx:259
+#: packages/admin/src/components/Sections.tsx:200
+#: packages/admin/src/components/Widgets.tsx:373
+msgid "Description"
+msgstr "Description"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:434
+msgid "Description (optional)"
+msgstr "Description (optional)"
+
+#: packages/admin/src/components/Redirects.tsx:442
+msgid "Destination"
+msgstr "Destination"
+
+#: packages/admin/src/components/Redirects.tsx:136
+msgid "Destination path"
+msgstr "Destination path"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "details"
+msgstr "details"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:186
+msgid "Device authorized"
+msgstr "Device authorised"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:229
+msgid "Device code"
+msgstr "Device code"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Device-bound"
+msgstr "Device-bound"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Device-bound passkey"
+msgstr "Device-bound passkey"
+
+#: packages/admin/src/components/SignupPage.tsx:143
+msgid "Didn't receive the email?"
+msgstr "Didn't receive the email?"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:176
+msgid "Dimensions:"
+msgstr "Dimensions:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Disable"
+msgstr "Disable"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Disable plugin"
+msgstr "Disable plugin"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Disable redirect"
+msgstr "Disable redirect"
+
+#: packages/admin/src/routes/users.tsx:279
+msgid "Disable User"
+msgstr "Disable User"
+
+#: packages/admin/src/routes/users.tsx:272
+msgid "Disable User?"
+msgstr "Disable User?"
+
+#: packages/admin/src/components/PluginManager.tsx:354
+#: packages/admin/src/components/Redirects.tsx:392
+#: packages/admin/src/components/users/UserDetail.tsx:201
+#: packages/admin/src/components/users/UserList.tsx:212
+msgid "Disabled"
+msgstr "Disabled"
+
+#: packages/admin/src/components/PluginManager.tsx:531
+msgid "Disabled:"
+msgstr "Disabled:"
+
+#. placeholder {0}: selectedUser?.name || selectedUser?.email
+#: packages/admin/src/routes/users.tsx:274
+msgid "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+msgstr "Disabling <0>{0}</0> will prevent them from logging in until re-enabled. Their content will be preserved."
+
+#: packages/admin/src/routes/users.tsx:280
+msgid "Disabling..."
+msgstr "Disabling..."
+
+#: packages/admin/src/components/ContentEditor.tsx:692
+#: packages/admin/src/components/ContentEditor.tsx:714
+msgid "Discard changes"
+msgstr "Discard changes"
+
+#: packages/admin/src/components/ContentEditor.tsx:698
+msgid "Discard draft changes?"
+msgstr "Discard draft changes?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:233
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:235
+msgid "Dismiss"
+msgstr "Dismiss"
+
+#: packages/admin/src/components/Widgets.tsx:103
+msgid "Display a navigation menu"
+msgstr "Display a navigation menu"
+
+#: packages/admin/src/components/ContentEditor.tsx:2180
+#: packages/admin/src/components/ContentEditor.tsx:2242
+#: packages/admin/src/routes/bylines.tsx:468
+msgid "Display name"
+msgstr "Display name"
+
+#: packages/admin/src/components/MenuList.tsx:167
+msgid "Display name for admin interface"
+msgstr "Display name for admin interface"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:247
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:412
+msgid "Display Size"
+msgstr "Display Size"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:310
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:475
+msgid "Displayed below the image as a visible caption."
+msgstr "Displayed below the image as a visible caption."
+
+#: packages/admin/src/components/ContentEditor.tsx:668
+msgid "Distraction-free mode (⌘⇧\\)"
+msgstr "Distraction-free mode (⌘⇧\\)"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:968
+msgid "Divider"
+msgstr "Divider"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:63
+#: packages/admin/src/components/MediaLibrary.tsx:397
+msgid "Documents"
+msgstr "Documents"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:319
+msgid "Domain"
+msgstr "Domain"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:85
+msgid "Domain added successfully"
+msgstr "Domain added successfully"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:124
+msgid "Domain removed"
+msgstr "Domain removed"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:107
+msgid "Domain updated"
+msgstr "Domain updated"
+
+#: packages/admin/src/components/LoginPage.tsx:332
+msgid "Don't have an account? <0>Sign up</0>"
+msgstr "Don't have an account? <0>Sign up</0>"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:144
+#: packages/admin/src/components/WordPressImport.tsx:1964
+msgid "Done"
+msgstr "Done"
+
+#: packages/admin/src/components/ContentEditor.tsx:2123
+msgid "Down"
+msgstr "Down"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:477
+msgid "Download SBOM"
+msgstr "Download SBOM"
+
+#: packages/admin/src/components/WordPressImport.tsx:1962
+msgid "Downloading"
+msgstr "Downloading"
+
+#: packages/admin/src/components/ContentList.tsx:767
+msgid "draft"
+msgstr "draft"
+
+#: packages/admin/src/components/ContentEditor.tsx:863
+#: packages/admin/src/components/ContentPickerModal.tsx:212
+msgid "Draft"
+msgstr "Draft"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:119
+msgid "draft, published, or archived"
+msgstr "draft, published, or archived"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:71
+#: packages/admin/src/components/Dashboard.tsx:188
+msgid "Drafts"
+msgstr "Drafts"
+
+#: packages/admin/src/components/WordPressImport.tsx:961
+msgid "Drag and drop or click to browse (.xml)"
+msgstr "Drag and drop or click to browse (.xml)"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drag here to add"
+msgstr "Drag here to add"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1706
+msgid "Drag to reorder"
+msgstr "Drag to reorder"
+
+#. placeholder {0}: field.label
+#. placeholder {0}: widget.title ?? t`widget`
+#: packages/admin/src/components/ContentTypeEditor.tsx:707
+#: packages/admin/src/components/Widgets.tsx:722
+msgid "Drag to reorder {0}"
+msgstr "Drag to reorder {0}"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:338
+msgid "Drag to reorder block"
+msgstr "Drag to reorder block"
+
+#: packages/admin/src/components/Widgets.tsx:624
+msgid "Drag widgets here to add them"
+msgstr "Drag widgets here to add them"
+
+#: packages/admin/src/components/Widgets.tsx:402
+msgid "Drag widgets into an area to add them"
+msgstr "Drag widgets into an area to add them"
+
+#: packages/admin/src/components/Widgets.tsx:620
+msgid "Drop to add widget"
+msgstr "Drop to add widget"
+
+#: packages/admin/src/components/WordPressImport.tsx:1427
+msgid "Drop your WordPress export file here"
+msgstr "Drop your WordPress export file here"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:292
+msgid "Duplicate"
+msgstr "Duplicate"
+
+#: packages/admin/src/components/ContentList.tsx:632
+msgid "Duplicate {title}"
+msgstr "Duplicate {title}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:161
+msgid "e.g. application/zip or .pdf"
+msgstr "e.g. application/zip or .pdf"
+
+#: packages/admin/src/components/Redirects.tsx:160
+msgid "e.g. import, blog"
+msgstr "e.g. import, blog"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:410
+msgid "e.g., CI/CD Pipeline"
+msgstr "e.g., CI/CD Pipeline"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:333
+msgid "e.g., MacBook Pro, iPhone"
+msgstr "e.g., MacBook Pro, iPhone"
+
+#: packages/admin/src/components/ContentEditor.tsx:2132
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+#: packages/admin/src/components/MenuEditor.tsx:458
+#: packages/admin/src/components/MenuList.tsx:231
+#: packages/admin/src/components/Sections.tsx:392
+#: packages/admin/src/components/TranslationsPanel.tsx:88
+msgid "Edit"
+msgstr "Edit"
+
+#. placeholder {0}: block?.label || ""
+#. placeholder {0}: collection.label
+#. placeholder {0}: domain.domain
+#: packages/admin/src/components/ContentTypeList.tsx:220
+#: packages/admin/src/components/PortableTextEditor.tsx:1311
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:276
+#: packages/admin/src/components/TaxonomyManager.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/routes/byline-schema.tsx:449
+#: packages/admin/src/routes/bylines.tsx:463
+msgid "Edit {0}"
+msgstr "Edit {0}"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/components/ContentTypeEditor.tsx:732
+msgid "Edit {0} field"
+msgstr "Edit {0} field"
+
+#: packages/admin/src/components/ContentEditor.tsx:631
+msgid "Edit {collectionLabel}"
+msgstr "Edit {collectionLabel}"
+
+#: packages/admin/src/components/ContentList.tsx:624
+msgid "Edit {title}"
+msgstr "Edit {title}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2239
+msgid "Edit byline"
+msgstr "Edit byline"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "Edit byline field"
+msgstr "Edit byline field"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:364
+msgid "Edit Domain"
+msgstr "Edit Domain"
+
+#: packages/admin/src/components/FieldEditor.tsx:342
+msgid "Edit Field"
+msgstr "Edit Field"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2577
+msgid "Edit link"
+msgstr "Edit link"
+
+#: packages/admin/src/components/MenuEditor.tsx:486
+msgid "Edit Menu Item"
+msgstr "Edit Menu Item"
+
+#: packages/admin/src/components/MenuEditor.tsx:290
+msgid "Edit menu items"
+msgstr "Edit menu items"
+
+#: packages/admin/src/components/Redirects.tsx:501
+msgid "Edit redirect"
+msgstr "Edit redirect"
+
+#: packages/admin/src/components/Redirects.tsx:102
+msgid "Edit Redirect"
+msgstr "Edit Redirect"
+
+#. placeholder {0}: r.source
+#: packages/admin/src/components/Redirects.tsx:502
+msgid "Edit redirect {0}"
+msgstr "Edit redirect {0}"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:367
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:368
+msgid "Edit URL"
+msgstr "Edit URL"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:36
+#: packages/admin/src/components/WelcomeModal.tsx:26
+msgid "Editor"
+msgstr "Editor"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:59
+#: packages/admin/src/components/Settings.tsx:115
+#: packages/admin/src/components/SignupPage.tsx:197
+#: packages/admin/src/components/users/UserDetail.tsx:154
+msgid "Email"
+msgstr "Email"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:332
+msgid "Email (optional)"
+msgstr "Email (optional)"
+
+#: packages/admin/src/components/LoginPage.tsx:126
+#: packages/admin/src/components/SignupPage.tsx:66
+#: packages/admin/src/components/users/InviteUserModal.tsx:154
+msgid "Email address"
+msgstr "Email address"
+
+#: packages/admin/src/components/SetupWizard.tsx:179
+#: packages/admin/src/components/SignupPage.tsx:49
+msgid "Email is required"
+msgstr "Email is required"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:215
+msgid "Email Middleware"
+msgstr "Email Middleware"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:125
+msgid "Email Pipeline"
+msgstr "Email Pipeline"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:199
+msgid "Email provider active"
+msgstr "Email provider active"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:85
+#: packages/admin/src/components/settings/EmailSettings.tsx:100
+msgid "Email Settings"
+msgstr "Email Settings"
+
+#: packages/admin/src/components/users/UserDetail.tsx:235
+msgid "Email verified"
+msgstr "Email verified"
+
+#: packages/admin/src/components/SignupPage.tsx:189
+msgid "Email verified!"
+msgstr "Email verified!"
+
+#. placeholder {0}: block.label
+#: packages/admin/src/components/PortableTextEditor.tsx:2060
+msgid "Embed a {0}"
+msgstr "Embed a {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2063
+msgid "Embeds"
+msgstr "Embeds"
+
+#: packages/admin/src/components/WordPressImport.tsx:1047
+msgid "EmDash Exporter"
+msgstr "EmDash Exporter"
+
+#: packages/admin/src/components/WordPressImport.tsx:1146
+msgid "EmDash Exporter plugin detected! You can import directly."
+msgstr "EmDash Exporter plugin detected! You can import directly."
+
+#: packages/admin/src/components/users/UserDetail.tsx:319
+msgid "Enable"
+msgstr "Enable"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:495
+msgid "Enable comments"
+msgstr "Enable comments"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:87
+msgid "Enable full-text search on this collection"
+msgstr "Enable full-text search on this collection"
+
+#: packages/admin/src/components/PluginManager.tsx:448
+msgid "Enable plugin"
+msgstr "Enable plugin"
+
+#: packages/admin/src/components/Redirects.tsx:478
+msgid "Enable redirect"
+msgstr "Enable redirect"
+
+#: packages/admin/src/components/Redirects.tsx:168
+#: packages/admin/src/components/Redirects.tsx:392
+msgid "Enabled"
+msgstr "Enabled"
+
+#. placeholder {0}: label.toLowerCase()
+#: packages/admin/src/components/ContentEditor.tsx:1233
+msgid "Enter {0}..."
+msgstr "Enter {0}..."
+
+#: packages/admin/src/components/MenuEditor.tsx:344
+#: packages/admin/src/components/MenuEditor.tsx:514
+msgid "Enter a URL (https://…) or a relative path (/…)"
+msgstr "Enter a URL (https://…) or a relative path (/…)"
+
+#: packages/admin/src/components/ContentEditor.tsx:1481
+msgid "Enter a valid URL (e.g. https://example.com)"
+msgstr "Enter a valid URL (e.g. https://example.com)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1219
+msgid "Enter credentials manually"
+msgstr "Enter credentials manually"
+
+#: packages/admin/src/components/ContentEditor.tsx:667
+msgid "Enter distraction-free mode"
+msgstr "Enter distraction-free mode"
+
+#: packages/admin/src/components/users/UserDetail.tsx:158
+msgid "Enter email"
+msgstr "Enter email"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
+msgid "Enter HTML..."
+msgstr "Enter HTML..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1255
+msgid "Enter markdown content..."
+msgstr "Enter markdown content..."
+
+#: packages/admin/src/components/users/UserDetail.tsx:151
+msgid "Enter name"
+msgstr "Enter name"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:177
+msgid "Enter the code from your terminal"
+msgstr "Enter the code from your terminal"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:123
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:132
+msgid "Enter URL..."
+msgstr "Enter URL..."
+
+#: packages/admin/src/components/LoginPage.tsx:325
+msgid "Enter your handle to sign in."
+msgstr "Enter your handle to sign in."
+
+#: packages/admin/src/components/WordPressImport.tsx:1298
+msgid "Enter your WordPress credentials to import content directly."
+msgstr "Enter your WordPress credentials to import content directly."
+
+#: packages/admin/src/components/WordPressImport.tsx:924
+msgid "Enter your WordPress site URL"
+msgstr "Enter your WordPress site URL"
+
+#: packages/admin/src/components/MenuEditor.tsx:101
+#: packages/admin/src/components/MenuEditor.tsx:139
+#: packages/admin/src/components/MenuEditor.tsx:179
+#: packages/admin/src/components/SetupWizard.tsx:539
+#: packages/admin/src/components/Widgets.tsx:689
+#: packages/admin/src/router.tsx:1852
+msgid "Error"
+msgstr "Error"
+
+#: packages/admin/src/components/Widgets.tsx:174
+msgid "Error adding widget"
+msgstr "Error adding widget"
+
+#: packages/admin/src/components/Widgets.tsx:235
+msgid "Error reordering widgets"
+msgstr "Error reordering widgets"
+
+#: packages/admin/src/components/SectionEditor.tsx:52
+msgid "Error saving section"
+msgstr "Error saving section"
+
+#: packages/admin/src/components/Widgets.tsx:704
+msgid "Error updating widget"
+msgstr "Error updating widget"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:581
+msgid "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+msgstr "Every published release of this plugin has been withdrawn or could not be verified. Check back later, or contact the publisher."
+
+#: packages/admin/src/components/WordPressImport.tsx:1846
+msgid "Exists"
+msgstr "Exists"
+
+#: packages/admin/src/components/ContentEditor.tsx:625
+msgid "Exit distraction-free mode"
+msgstr "Exit distraction-free mode"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3078
+msgid "Exit Spotlight Mode"
+msgstr "Exit Spotlight Mode"
+
+#: packages/admin/src/components/PluginManager.tsx:460
+msgid "Expand"
+msgstr "Expand"
+
+#: packages/admin/src/components/PluginManager.tsx:454
+msgid "Expand details"
+msgstr "Expand details"
+
+#. placeholder {0}: new Date(token.expiresAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:287
+msgid "Expires {0}"
+msgstr "Expires {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:436
+msgid "Expiry"
+msgstr "Expiry"
+
+#: packages/admin/src/components/WordPressImport.tsx:1112
+msgid "Export from WordPress manually"
+msgstr "Export from WordPress manually"
+
+#: packages/admin/src/components/WordPressImport.tsx:1236
+msgid "Export your content from WordPress to import everything including drafts."
+msgstr "Export your content from WordPress to import everything including drafts."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:144
+msgid "Facebook"
+msgstr "Facebook"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:343
+msgid "Fail"
+msgstr "Fail"
+
+#: packages/admin/src/components/WordPressImport.tsx:1966
+msgid "Failed"
+msgstr "Failed"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:188
+msgid "Failed security audit"
+msgstr "Failed security audit"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:90
+msgid "Failed to add domain"
+msgstr "Failed to add domain"
+
+#: packages/admin/src/components/WordPressImport.tsx:367
+msgid "Failed to analyze WordPress site"
+msgstr "Failed to analyse WordPress site"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:54
+msgid "Failed to communicate with plugin"
+msgstr "Failed to communicate with plugin"
+
+#: packages/admin/src/components/SetupWizard.tsx:493
+msgid "Failed to create admin"
+msgstr "Failed to create admin"
+
+#: packages/admin/src/components/ContentEditor.tsx:2223
+msgid "Failed to create byline"
+msgstr "Failed to create byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:120
+msgid "Failed to create byline field"
+msgstr "Failed to create byline field"
+
+#: packages/admin/src/routes/byline-schema.tsx:102
+msgid "Failed to create field"
+msgstr "Failed to create field"
+
+#: packages/admin/src/components/WordPressImport.tsx:1553
+msgid "Failed to create some collections"
+msgstr "Failed to create some collections"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:493
+msgid "Failed to create term"
+msgstr "Failed to create term"
+
+#: packages/admin/src/router.tsx:890
+msgid "Failed to create translation"
+msgstr "Failed to create translation"
+
+#: packages/admin/src/router.tsx:346
+#: packages/admin/src/router.tsx:375
+#: packages/admin/src/router.tsx:910
+msgid "Failed to delete"
+msgstr "Failed to delete"
+
+#: packages/admin/src/lib/api/users.ts:345
+msgid "Failed to delete allowed domain"
+msgstr "Failed to delete allowed domain"
+
+#: packages/admin/src/lib/api/bylines.ts:143
+msgid "Failed to delete byline"
+msgstr "Failed to delete byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:143
+msgid "Failed to delete byline field"
+msgstr "Failed to delete byline field"
+
+#: packages/admin/src/lib/api/schema.ts:222
+msgid "Failed to delete collection"
+msgstr "Failed to delete collection"
+
+#: packages/admin/src/lib/api/comments.ts:111
+#: packages/admin/src/router.tsx:1162
+msgid "Failed to delete comment"
+msgstr "Failed to delete comment"
+
+#: packages/admin/src/lib/api/content.ts:220
+msgid "Failed to delete content"
+msgstr "Failed to delete content"
+
+#: packages/admin/src/lib/api/schema.ts:278
+#: packages/admin/src/routes/byline-schema.tsx:138
+msgid "Failed to delete field"
+msgstr "Failed to delete field"
+
+#: packages/admin/src/lib/api/media.ts:357
+msgid "Failed to delete from provider"
+msgstr "Failed to delete from provider"
+
+#: packages/admin/src/lib/api/media.ts:234
+msgid "Failed to delete media"
+msgstr "Failed to delete media"
+
+#: packages/admin/src/lib/api/menus.ts:163
+msgid "Failed to delete menu"
+msgstr "Failed to delete menu"
+
+#: packages/admin/src/lib/api/menus.ts:217
+msgid "Failed to delete menu item"
+msgstr "Failed to delete menu item"
+
+#: packages/admin/src/lib/api/users.ts:256
+msgid "Failed to delete passkey"
+msgstr "Failed to delete passkey"
+
+#: packages/admin/src/lib/api/redirects.ts:111
+msgid "Failed to delete redirect"
+msgstr "Failed to delete redirect"
+
+#: packages/admin/src/lib/api/sections.ts:110
+msgid "Failed to delete section"
+msgstr "Failed to delete section"
+
+#: packages/admin/src/lib/api/taxonomies.ts:201
+msgid "Failed to delete term"
+msgstr "Failed to delete term"
+
+#: packages/admin/src/lib/api/widgets.ts:146
+msgid "Failed to delete widget"
+msgstr "Failed to delete widget"
+
+#: packages/admin/src/lib/api/widgets.ts:108
+msgid "Failed to delete widget area"
+msgstr "Failed to delete widget area"
+
+#: packages/admin/src/components/PluginManager.tsx:116
+msgid "Failed to disable plugin"
+msgstr "Failed to disable plugin"
+
+#: packages/admin/src/lib/api/users.ts:118
+msgid "Failed to disable user"
+msgstr "Failed to disable user"
+
+#: packages/admin/src/router.tsx:824
+msgid "Failed to discard changes"
+msgstr "Failed to discard changes"
+
+#: packages/admin/src/components/WelcomeModal.tsx:70
+msgid "Failed to dismiss welcome"
+msgstr "Failed to dismiss welcome"
+
+#: packages/admin/src/router.tsx:389
+msgid "Failed to duplicate"
+msgstr "Failed to duplicate"
+
+#: packages/admin/src/components/PluginManager.tsx:97
+msgid "Failed to enable plugin"
+msgstr "Failed to enable plugin"
+
+#: packages/admin/src/lib/api/users.ts:138
+msgid "Failed to enable user"
+msgstr "Failed to enable user"
+
+#: packages/admin/src/components/WordPressImport.tsx:295
+msgid "Failed to execute import"
+msgstr "Failed to execute import"
+
+#: packages/admin/src/lib/api/schema.ts:170
+#: packages/admin/src/lib/api/schema.ts:174
+msgid "Failed to fetch collection"
+msgstr "Failed to fetch collection"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:90
+msgid "Failed to fetch entry terms"
+msgstr "Failed to fetch entry terms"
+
+#: packages/admin/src/lib/api/client.ts:210
+msgid "Failed to fetch manifest"
+msgstr "Failed to fetch manifest"
+
+#: packages/admin/src/lib/api/plugins.ts:59
+#: packages/admin/src/lib/api/plugins.ts:63
+msgid "Failed to fetch plugin"
+msgstr "Failed to fetch plugin"
+
+#: packages/admin/src/lib/api/content.ts:465
+#: packages/admin/src/lib/api/content.ts:470
+msgid "Failed to fetch revision"
+msgstr "Failed to fetch revision"
+
+#: packages/admin/src/components/SetupWizard.tsx:446
+msgid "Failed to fetch setup status"
+msgstr "Failed to fetch setup status"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:71
+msgid "Failed to fetch terms"
+msgstr "Failed to fetch terms"
+
+#: packages/admin/src/lib/api/users.ts:88
+#: packages/admin/src/lib/api/users.ts:93
+#: packages/admin/src/router.tsx:674
+#: packages/admin/src/router.tsx:1093
+msgid "Failed to fetch user"
+msgstr "Failed to fetch user"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:271
+msgid "Failed to generate preview"
+msgstr "Failed to generate preview"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:157
+msgid "Failed to generate preview URL"
+msgstr "Failed to generate preview URL"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:176
+msgid "Failed to get authentication options"
+msgstr "Failed to get authentication options"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:180
+msgid "Failed to get registration options"
+msgstr "Failed to get registration options"
+
+#: packages/admin/src/components/WordPressImport.tsx:386
+msgid "Failed to import from WordPress"
+msgstr "Failed to import from WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:319
+#: packages/admin/src/lib/api/import.ts:256
+msgid "Failed to import media"
+msgstr "Failed to import media"
+
+#: packages/admin/src/lib/api/marketplace.ts:160
+#: packages/admin/src/lib/api/registry.ts:692
+msgid "Failed to install plugin"
+msgstr "Failed to install plugin"
+
+#: packages/admin/src/lib/api/byline-fields.ts:98
+msgid "Failed to list byline fields"
+msgstr "Failed to list byline fields"
+
+#: packages/admin/src/router.tsx:247
+msgid "Failed to load admin"
+msgstr "Failed to load admin"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:207
+msgid "Failed to load allowed domains"
+msgstr "Failed to load allowed domains"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/routes/bylines.tsx:352
+msgid "Failed to load bylines: {0}"
+msgstr "Failed to load bylines: {0}"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:89
+msgid "Failed to load email settings"
+msgstr "Failed to load email settings"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:417
+msgid "Failed to load image"
+msgstr "Failed to load image"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:144
+msgid "Failed to load passkeys"
+msgstr "Failed to load passkeys"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:110
+msgid "Failed to load plugin"
+msgstr "Failed to load plugin"
+
+#. placeholder {0}: error.message
+#: packages/admin/src/components/PluginManager.tsx:145
+msgid "Failed to load plugins: {0}"
+msgstr "Failed to load plugins: {0}"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:95
+msgid "Failed to load plugins. The registry aggregator may be unreachable."
+msgstr "Failed to load plugins. The registry aggregator may be unreachable."
+
+#: packages/admin/src/components/RevisionHistory.tsx:180
+msgid "Failed to load revisions"
+msgstr "Failed to load revisions"
+
+#: packages/admin/src/components/SetupWizard.tsx:541
+msgid "Failed to load setup"
+msgstr "Failed to load setup"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:89
+msgid "Failed to load theme"
+msgstr "Failed to load theme"
+
+#. placeholder {0}: usersQuery.error.message
+#: packages/admin/src/routes/users.tsx:205
+msgid "Failed to load users: {0}"
+msgstr "Failed to load users: {0}"
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:46
+msgid "Failed to load widget"
+msgstr "Failed to load widget"
+
+#: packages/admin/src/router.tsx:1187
+msgid "Failed to perform bulk action"
+msgstr "Failed to perform bulk action"
+
+#: packages/admin/src/lib/api/content.ts:263
+msgid "Failed to permanently delete content"
+msgstr "Failed to permanently delete content"
+
+#: packages/admin/src/components/WordPressImport.tsx:276
+msgid "Failed to prepare import"
+msgstr "Failed to prepare import"
+
+#: packages/admin/src/router.tsx:789
+msgid "Failed to publish"
+msgstr "Failed to publish"
+
+#: packages/admin/src/lib/api/byline-fields.ts:106
+msgid "Failed to read byline field usage"
+msgstr "Failed to read byline field usage"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:130
+msgid "Failed to remove domain"
+msgstr "Failed to remove domain"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:99
+#: packages/admin/src/components/settings/SecuritySettings.tsx:82
+msgid "Failed to remove passkey"
+msgstr "Failed to remove passkey"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:66
+msgid "Failed to rename passkey"
+msgstr "Failed to rename passkey"
+
+#: packages/admin/src/lib/api/byline-fields.ts:156
+msgid "Failed to reorder byline fields"
+msgstr "Failed to reorder byline fields"
+
+#: packages/admin/src/lib/api/schema.ts:293
+#: packages/admin/src/routes/byline-schema.tsx:152
+msgid "Failed to reorder fields"
+msgstr "Failed to reorder fields"
+
+#: packages/admin/src/lib/api/widgets.ts:158
+msgid "Failed to reorder widgets"
+msgstr "Failed to reorder widgets"
+
+#: packages/admin/src/router.tsx:361
+msgid "Failed to restore"
+msgstr "Failed to restore"
+
+#: packages/admin/src/lib/api/content.ts:252
+msgid "Failed to restore content"
+msgstr "Failed to restore content"
+
+#: packages/admin/src/lib/api/content.ts:487
+#: packages/admin/src/lib/api/content.ts:492
+msgid "Failed to restore revision"
+msgstr "Failed to restore revision"
+
+#: packages/admin/src/lib/api/api-tokens.ts:98
+msgid "Failed to revoke API token"
+msgstr "Failed to revoke API token"
+
+#: packages/admin/src/components/WordPressImport.tsx:332
+msgid "Failed to rewrite URLs"
+msgstr "Failed to rewrite URLs"
+
+#: packages/admin/src/router.tsx:742
+#: packages/admin/src/router.tsx:1669
+msgid "Failed to save"
+msgstr "Failed to save"
+
+#: packages/admin/src/routes/byline-schema.tsx:122
+msgid "Failed to save field"
+msgstr "Failed to save field"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:58
+#: packages/admin/src/components/settings/SeoSettings.tsx:62
+#: packages/admin/src/components/settings/SocialSettings.tsx:53
+msgid "Failed to save settings"
+msgstr "Failed to save settings"
+
+#: packages/admin/src/router.tsx:842
+msgid "Failed to schedule"
+msgstr "Failed to schedule"
+
+#: packages/admin/src/components/LoginPage.tsx:70
+#: packages/admin/src/components/LoginPage.tsx:75
+msgid "Failed to send magic link"
+msgstr "Failed to send magic link"
+
+#: packages/admin/src/lib/api/users.ts:128
+msgid "Failed to send recovery link"
+msgstr "Failed to send recovery link"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:61
+msgid "Failed to send test email"
+msgstr "Failed to send test email"
+
+#: packages/admin/src/components/SignupPage.tsx:349
+msgid "Failed to send verification email"
+msgstr "Failed to send verification email"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:113
+msgid "Failed to set entry terms"
+msgstr "Failed to set entry terms"
+
+#: packages/admin/src/lib/api/marketplace.ts:192
+#: packages/admin/src/lib/api/registry.ts:831
+msgid "Failed to uninstall plugin"
+msgstr "Failed to uninstall plugin"
+
+#: packages/admin/src/router.tsx:805
+msgid "Failed to unpublish"
+msgstr "Failed to unpublish"
+
+#: packages/admin/src/router.tsx:860
+msgid "Failed to unschedule"
+msgstr "Failed to unschedule"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:349
+msgid "Failed to update {0}"
+msgstr "Failed to update {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2273
+msgid "Failed to update byline"
+msgstr "Failed to update byline"
+
+#: packages/admin/src/lib/api/byline-fields.ts:135
+msgid "Failed to update byline field"
+msgstr "Failed to update byline field"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:113
+msgid "Failed to update domain"
+msgstr "Failed to update domain"
+
+#: packages/admin/src/lib/api/marketplace.ts:176
+#: packages/admin/src/lib/api/registry.ts:763
+msgid "Failed to update plugin"
+msgstr "Failed to update plugin"
+
+#: packages/admin/src/router.tsx:1146
+msgid "Failed to update status"
+msgstr "Failed to update status"
+
+#: packages/admin/src/lib/api/media.ts:151
+msgid "Failed to upload file"
+msgstr "Failed to upload file"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:250
+msgid "Failed to verify authentication"
+msgstr "Failed to verify authentication"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:253
+msgid "Failed to verify registration"
+msgstr "Failed to verify registration"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:790
+msgid "FAQ"
+msgstr "FAQ"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:236
+#: packages/admin/src/components/settings/GeneralSettings.tsx:242
+msgid "Favicon"
+msgstr "Favicon"
+
+#: packages/admin/src/components/WordPressImport.tsx:1022
+msgid "Feature"
+msgstr "Feature"
+
+#: packages/admin/src/components/ContentTypeList.tsx:103
+msgid "Features"
+msgstr "Features"
+
+#: packages/admin/src/components/WordPressImport.tsx:736
+msgid "Fetching content from the EmDash Exporter API."
+msgstr "Fetching content from the EmDash Exporter API."
+
+#: packages/admin/src/routes/byline-schema.tsx:95
+msgid "Field created"
+msgstr "Field created"
+
+#: packages/admin/src/routes/byline-schema.tsx:133
+msgid "Field deleted"
+msgstr "Field deleted"
+
+#: packages/admin/src/components/FieldEditor.tsx:567
+msgid "Field label"
+msgstr "Field label"
+
+#: packages/admin/src/components/FieldEditor.tsx:414
+msgid "Field Label"
+msgstr "Field Label"
+
+#: packages/admin/src/components/FieldEditor.tsx:426
+msgid "Field slugs cannot be changed after creation"
+msgstr "Field slugs cannot be changed after creation"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:268
+msgid "Field type cannot be changed after creation."
+msgstr "Field type cannot be changed after creation."
+
+#: packages/admin/src/routes/byline-schema.tsx:115
+msgid "Field updated"
+msgstr "Field updated"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:572
+msgid "Fields"
+msgstr "Fields"
+
+#: packages/admin/src/components/WordPressImport.tsx:2139
+msgid "Fields created:"
+msgstr "Fields created:"
+
+#: packages/admin/src/components/FieldEditor.tsx:210
+msgid "File"
+msgstr "File"
+
+#. placeholder {0}: progress.current
+#: packages/admin/src/components/WordPressImport.tsx:1994
+msgid "File {0}"
+msgstr "File {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:211
+msgid "File from media library"
+msgstr "File from media library"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:192
+#: packages/admin/src/components/MediaLibrary.tsx:483
+msgid "Filename"
+msgstr "Filename"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:196
+msgid "Filename cannot be changed after upload"
+msgstr "Filename cannot be changed after upload"
+
+#: packages/admin/src/components/WordPressImport.tsx:2172
+msgid "files imported"
+msgstr "files imported"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:113
+msgid "Filter by capability"
+msgstr "Filter by capability"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:177
+msgid "Filter by collection"
+msgstr "Filter by collection"
+
+#: packages/admin/src/components/users/UserList.tsx:82
+msgid "Filter by role"
+msgstr "Filter by role"
+
+#: packages/admin/src/components/Sections.tsx:245
+msgid "Filter by source"
+msgstr "Filter by source"
+
+#: packages/admin/src/components/Redirects.tsx:393
+msgid "Filter by status"
+msgstr "Filter by status"
+
+#: packages/admin/src/components/MediaLibrary.tsx:399
+#: packages/admin/src/components/Redirects.tsx:399
+msgid "Filter by type"
+msgstr "Filter by type"
+
+#: packages/admin/src/routes/bylines.tsx:395
+msgid "Filter byline type"
+msgstr "Filter byline type"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:64
+msgid "First-time commenters only"
+msgstr "First-time commenters only"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:69
+msgid "Fonts"
+msgstr "Fonts"
+
+#: packages/admin/src/components/WordPressImport.tsx:1237
+msgid "For a complete import including drafts and all content, export from WordPress."
+msgstr "For a complete import including drafts and all content, export from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1046
+msgid "For the best import experience, install the"
+msgstr "For the best import experience, install the"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:43
+msgid "Full access"
+msgstr "Full access"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:96
+msgid "Full admin access"
+msgstr "Full admin access"
+
+#: packages/admin/src/components/Settings.tsx:69
+msgid "General"
+msgstr "General"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:101
+#: packages/admin/src/components/settings/GeneralSettings.tsx:129
+msgid "General Settings"
+msgstr "General Settings"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:626
+msgid "Genres"
+msgstr "Genres"
+
+#: packages/admin/src/components/WelcomeModal.tsx:143
+msgid "Get Started"
+msgstr "Get Started"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:138
+msgid "GitHub"
+msgstr "GitHub"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:337
+msgid "Give this passkey a name to help you identify it later."
+msgstr "Give this passkey a name to help you identify it later."
+
+#: packages/admin/src/components/WordPressImport.tsx:2224
+#: packages/admin/src/router.tsx:1872
+msgid "Go to Dashboard"
+msgstr "Go to Dashboard"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:227
+msgid "Google Verification"
+msgstr "Google Verification"
+
+#: packages/admin/src/components/MediaLibrary.tsx:270
+msgid "Grid view"
+msgstr "Grid view"
+
+#: packages/admin/src/components/Redirects.tsx:159
+msgid "Group (optional)"
+msgstr "Group (optional)"
+
+#: packages/admin/src/routes/bylines.tsx:538
+msgid "Guest byline"
+msgstr "Guest byline"
+
+#: packages/admin/src/routes/bylines.tsx:400
+msgid "Guest only"
+msgstr "Guest only"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:62
+#: packages/admin/src/components/PortableTextEditor.tsx:883
+#: packages/admin/src/components/PortableTextEditor.tsx:2888
+msgid "Heading 1"
+msgstr "Heading 1"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:70
+#: packages/admin/src/components/PortableTextEditor.tsx:893
+#: packages/admin/src/components/PortableTextEditor.tsx:2895
+msgid "Heading 2"
+msgstr "Heading 2"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:78
+#: packages/admin/src/components/PortableTextEditor.tsx:903
+#: packages/admin/src/components/PortableTextEditor.tsx:2902
+msgid "Heading 3"
+msgstr "Heading 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:282
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:447
+msgid "Height"
+msgstr "Height"
+
+#: packages/admin/src/components/Sections.tsx:180
+msgid "Hero Banner"
+msgstr "Hero Banner"
+
+#: packages/admin/src/components/SectionEditor.tsx:271
+msgid "hero, banner, cta"
+msgstr "hero, banner, cta"
+
+#: packages/admin/src/components/SeoPanel.tsx:191
+msgid "Hide from search engines"
+msgstr "Hide from search engines"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Hide token"
+msgstr "Hide token"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:649
+msgid "Hierarchical (like categories, with parent/child relationships)"
+msgstr "Hierarchical (like categories, with parent/child relationships)"
+
+#: packages/admin/src/components/Redirects.tsx:216
+#: packages/admin/src/components/Redirects.tsx:444
+msgid "Hits"
+msgstr "Hits"
+
+#: packages/admin/src/components/MenuEditor.tsx:337
+msgid "Home"
+msgstr "Home"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:231
+msgid "Homepage"
+msgstr "Homepage"
+
+#: packages/admin/src/components/PluginManager.tsx:385
+msgid "Hooks"
+msgstr "Hooks"
+
+#: packages/admin/src/components/WordPressImport.tsx:1359
+msgid "How to create an Application Password"
+msgstr "How to create an Application Password"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
+#: packages/admin/src/components/PortableTextEditor.tsx:953
+msgid "HTML"
+msgstr "HTML"
+
+#: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
+msgid "HTML source"
+msgstr "HTML source"
+
+#: packages/admin/src/components/MenuEditor.tsx:345
+msgid "https://example.com or /about"
+msgstr "https://example.com or /about"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:503
+msgid "https://example.com/image.jpg"
+msgstr "https://example.com/image.jpg"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:241
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:142
+msgid "Icon blurred due to image audit"
+msgstr "Icon blurred due to image audit"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:105
+msgid "ID"
+msgstr "ID"
+
+#: packages/admin/src/components/LoginPage.tsx:103
+msgid "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+msgstr "If an account exists for <0>{email}</0>, we've sent a sign-in link."
+
+#: packages/admin/src/components/FieldEditor.tsx:204
+#: packages/admin/src/components/PortableTextEditor.tsx:2029
+msgid "Image"
+msgstr "Image"
+
+#: packages/admin/src/components/FieldEditor.tsx:205
+msgid "Image from media library"
+msgstr "Image from media library"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:67
+#: packages/admin/src/components/ContentEditor.tsx:1663
+msgid "Image not found"
+msgstr "Image not found"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:179
+#: packages/admin/src/components/editor/ImageNode.tsx:180
+msgid "Image settings"
+msgstr "Image settings"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:203
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:364
+msgid "Image Settings"
+msgstr "Image Settings"
+
+#: packages/admin/src/components/SeoImageField.tsx:75
+msgid "Image shown when this page is shared on social media"
+msgstr "Image shown when this page is shared on social media"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:504
+msgid "Image URL"
+msgstr "Image URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:2176
+msgid "image URLs updated in"
+msgstr "image URLs updated in"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:61
+#: packages/admin/src/components/MediaLibrary.tsx:394
+msgid "Images"
+msgstr "Images"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:227
+#: packages/admin/src/components/Sidebar.tsx:398
+#: packages/admin/src/components/WordPressImport.tsx:664
+msgid "Import"
+msgstr "Import"
+
+#. placeholder {0}: postType.name
+#: packages/admin/src/components/WordPressImport.tsx:1794
+msgid "Import {0}"
+msgstr "Import {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:1205
+msgid "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+msgstr "Import all content directly including drafts, custom post types, ACF fields, and SEO data. No file download needed."
+
+#: packages/admin/src/components/WordPressImport.tsx:2222
+msgid "Import Another File"
+msgstr "Import Another File"
+
+#: packages/admin/src/components/WordPressImport.tsx:1016
+msgid "Import Capabilities"
+msgstr "Import Capabilities"
+
+#: packages/admin/src/components/WordPressImport.tsx:2110
+msgid "Import Complete"
+msgstr "Import Complete"
+
+#: packages/admin/src/components/WordPressImport.tsx:2111
+msgid "Import Completed with Errors"
+msgstr "Import Completed with Errors"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Import failed"
+msgstr "Import failed"
+
+#: packages/admin/src/components/WordPressImport.tsx:617
+msgid "Import from WordPress"
+msgstr "Import from WordPress"
+
+#: packages/admin/src/components/WordPressImport.tsx:1943
+msgid "Import Media"
+msgstr "Import Media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1896
+msgid "Import Media Files"
+msgstr "Import Media Files"
+
+#: packages/admin/src/components/WordPressImport.tsx:619
+msgid "Import posts, pages, and custom post types from WordPress."
+msgstr "Import posts, pages, and custom post types from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1650
+msgid "Import site configuration from WordPress."
+msgstr "Import site configuration from WordPress."
+
+#: packages/admin/src/components/WordPressImport.tsx:1203
+msgid "Import via EmDash Exporter"
+msgstr "Import via EmDash Exporter"
+
+#: packages/admin/src/components/Sections.tsx:47
+msgid "Imported"
+msgstr "Imported"
+
+#: packages/admin/src/components/WordPressImport.tsx:2150
+msgid "Imported by Collection"
+msgstr "Imported by Collection"
+
+#: packages/admin/src/components/WordPressImport.tsx:820
+msgid "Importing content..."
+msgstr "Importing content..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1975
+msgid "Importing Media"
+msgstr "Importing Media"
+
+#: packages/admin/src/components/SetupWizard.tsx:138
+msgid "Include sample content (recommended for new sites)"
+msgstr "Include sample content (recommended for new sites)"
+
+#: packages/admin/src/components/WordPressImport.tsx:1816
+msgid "Incompatible"
+msgstr "Incompatible"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:491
+msgid "Indexed"
+msgstr "Indexed"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2875
+msgid "Inline Code"
+msgstr "Inline Code"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:515
+#: packages/admin/src/components/MediaPickerModal.tsx:742
+msgid "Insert"
+msgstr "Insert"
+
+#. placeholder {0}: block?.label || ""
+#: packages/admin/src/components/PortableTextEditor.tsx:1311
+msgid "Insert {0}"
+msgstr "Insert {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:934
+msgid "Insert a blockquote"
+msgstr "Insert a blockquote"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:944
+msgid "Insert a code block"
+msgstr "Insert a code block"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:969
+msgid "Insert a horizontal rule"
+msgstr "Insert a horizontal rule"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2044
+msgid "Insert a reusable section"
+msgstr "Insert a reusable section"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:979
+msgid "Insert a table"
+msgstr "Insert a table"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2030
+msgid "Insert an image"
+msgstr "Insert an image"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:497
+msgid "Insert from URL"
+msgstr "Insert from URL"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3045
+msgid "Insert Horizontal Rule"
+msgstr "Insert Horizontal Rule"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3040
+msgid "Insert Image"
+msgstr "Insert Image"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2987
+msgid "Insert Link"
+msgstr "Insert Link"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:954
+msgid "Insert raw HTML"
+msgstr "Insert raw HTML"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:57
+msgid "Insert Section"
+msgstr "Insert Section"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2945
+msgid "Insert Table"
+msgstr "Insert Table"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:150
+msgid "Instagram"
+msgstr "Instagram"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:192
+#: packages/admin/src/components/RegistryPluginDetail.tsx:539
+msgid "Install"
+msgstr "Install"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:181
+msgid "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+msgstr "Install and activate an email provider plugin to enable email features like invitations, magic links, and password recovery."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:186
+msgid "Install blocked"
+msgstr "Install blocked"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:789
+msgid "Installation"
+msgstr "Installation"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:261
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:173
+#: packages/admin/src/components/RegistryBrowse.tsx:198
+#: packages/admin/src/components/RegistryPluginDetail.tsx:531
+msgid "Installed"
+msgstr "Installed"
+
+#. placeholder {0}: plugin.marketplaceVersion || plugin.version
+#: packages/admin/src/components/PluginManager.tsx:500
+msgid "Installed from marketplace (v{0})"
+msgstr "Installed from marketplace (v{0})"
+
+#: packages/admin/src/components/PluginManager.tsx:519
+msgid "Installed:"
+msgstr "Installed:"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:167
+msgid "Installing..."
+msgstr "Installing..."
+
+#: packages/admin/src/components/FieldEditor.tsx:168
+#: packages/admin/src/components/FieldEditor.tsx:582
+msgid "Integer"
+msgstr "Integer"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:119
+msgid "Invalid invite link"
+msgstr "Invalid invite link"
+
+#: packages/admin/src/components/ContentEditor.tsx:1550
+msgid "Invalid JSON"
+msgstr "Invalid JSON"
+
+#: packages/admin/src/components/SignupPage.tsx:259
+msgid "Invalid link"
+msgstr "Invalid link"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:207
+msgid "Invite Error"
+msgstr "Invite Error"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:117
+msgid "Invite expired"
+msgstr "Invite expired"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+msgid "Invite Link Created"
+msgstr "Invite Link Created"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:79
+#: packages/admin/src/components/users/UserList.tsx:56
+msgid "Invite User"
+msgstr "Invite User"
+
+#: packages/admin/src/components/users/UserList.tsx:140
+msgid "Invite your first team member"
+msgstr "Invite your first team member"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2548
+#: packages/admin/src/components/PortableTextEditor.tsx:2854
+msgid "Italic"
+msgstr "Italic"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1692
+#: packages/admin/src/components/RepeaterField.tsx:234
+msgid "Item {0}"
+msgstr "Item {0}"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Item added"
+msgstr "Item added"
+
+#: packages/admin/src/components/MenuEditor.tsx:133
+msgid "Item deleted"
+msgstr "Item deleted"
+
+#: packages/admin/src/components/MenuEditor.tsx:158
+msgid "Item updated"
+msgstr "Item updated"
+
+#: packages/admin/src/components/SetupWizard.tsx:213
+#: packages/admin/src/components/SignupPage.tsx:205
+msgid "Jane Doe"
+msgstr "Jane Doe"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:235
+msgid "Job title"
+msgstr "Job title"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:246
+msgid "job_title"
+msgstr "job_title"
+
+#: packages/admin/src/components/FieldEditor.tsx:222
+msgid "JSON"
+msgstr "JSON"
+
+#: packages/admin/src/components/ContentEditor.tsx:2102
+msgid "Keep typing to narrow down more bylines."
+msgstr "Keep typing to narrow down more bylines."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:293
+#: packages/admin/src/components/SectionEditor.tsx:268
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:189
+msgid "Keywords"
+msgstr "Keywords"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:232
+#: packages/admin/src/components/FieldEditor.tsx:411
+#: packages/admin/src/components/FieldEditor.tsx:553
+#: packages/admin/src/components/MenuEditor.tsx:337
+#: packages/admin/src/components/MenuEditor.tsx:506
+#: packages/admin/src/components/MenuList.tsx:166
+#: packages/admin/src/components/TaxonomyManager.tsx:623
+#: packages/admin/src/components/Widgets.tsx:371
+#: packages/admin/src/routes/byline-schema.tsx:234
+msgid "Label"
+msgstr "Label"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:394
+msgid "Label (Plural)"
+msgstr "Label (Plural)"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:386
+msgid "Label (Singular)"
+msgstr "Label (Singular)"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:125
+#: packages/admin/src/components/LoginPage.tsx:345
+#: packages/admin/src/components/Settings.tsx:129
+#: packages/admin/src/components/Settings.tsx:134
+msgid "Language"
+msgstr "Language"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:884
+msgid "Large section heading"
+msgstr "Large section heading"
+
+#: packages/admin/src/components/PluginManager.tsx:525
+msgid "Last enabled:"
+msgstr "Last enabled:"
+
+#: packages/admin/src/components/users/UserDetail.tsx:227
+msgid "Last login"
+msgstr "Last login"
+
+#: packages/admin/src/components/users/UserList.tsx:107
+msgid "Last Login"
+msgstr "Last Login"
+
+#: packages/admin/src/components/Redirects.tsx:217
+msgid "Last seen"
+msgstr "Last seen"
+
+#: packages/admin/src/components/users/UserDetail.tsx:223
+msgid "Last updated"
+msgstr "Last updated"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:161
+msgid "Last used"
+msgstr "Last used"
+
+#. placeholder {0}: new Date(cred.lastUsedAt).toLocaleDateString()
+#. placeholder {0}: new Date(token.lastUsedAt).toLocaleDateString()
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:292
+#: packages/admin/src/components/users/UserDetail.tsx:262
+msgid "Last used {0}"
+msgstr "Last used {0}"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:341
+msgid "Leave blank to use a discoverable passkey."
+msgstr "Leave blank to use a discoverable passkey."
+
+#: packages/admin/src/components/WordPressImport.tsx:2303
+msgid "Leave unassigned"
+msgstr "Leave unassigned"
+
+#: packages/admin/src/components/MediaLibrary.tsx:120
+#: packages/admin/src/components/MediaLibrary.tsx:240
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "Library"
+msgstr "Library"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:203
+msgid "License"
+msgstr "Licence"
+
+#: packages/admin/src/components/ThemeToggle.tsx:22
+msgid "light"
+msgstr "light"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "Light"
+msgstr "Light"
+
+#: packages/admin/src/components/SignupPage.tsx:257
+msgid "Link expired"
+msgstr "Link expired"
+
+#: packages/admin/src/components/FieldEditor.tsx:217
+msgid "Link to another content item"
+msgstr "Link to another content item"
+
+#. placeholder {0}: user.oauthAccounts.length
+#: packages/admin/src/components/users/UserDetail.tsx:276
+msgid "Linked Accounts ({0})"
+msgstr "Linked Accounts ({0})"
+
+#: packages/admin/src/routes/bylines.tsx:401
+msgid "Linked only"
+msgstr "Linked only"
+
+#: packages/admin/src/routes/bylines.tsx:489
+msgid "Linked user"
+msgstr "Linked user"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:156
+msgid "LinkedIn"
+msgstr "LinkedIn"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:210
+msgid "Links"
+msgstr "Links"
+
+#: packages/admin/src/components/MediaLibrary.tsx:279
+msgid "List view"
+msgstr "List view"
+
+#: packages/admin/src/components/ContentEditor.tsx:746
+msgid "Live View"
+msgstr "Live View"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:236
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/routes/bylines.tsx:455
+msgid "Load more"
+msgstr "Load more"
+
+#: packages/admin/src/components/ContentList.tsx:389
+#: packages/admin/src/components/ContentList.tsx:446
+#: packages/admin/src/components/MediaLibrary.tsx:533
+#: packages/admin/src/components/MediaPickerModal.tsx:718
+#: packages/admin/src/components/users/UserList.tsx:169
+msgid "Load More"
+msgstr "Load More"
+
+#: packages/admin/src/routes/byline-schema.tsx:257
+msgid "Loading byline fields…"
+msgstr "Loading byline fields…"
+
+#: packages/admin/src/components/ContentTypeList.tsx:114
+msgid "Loading collections..."
+msgstr "Loading collections..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:307
+msgid "Loading comments..."
+msgstr "Loading comments..."
+
+#: packages/admin/src/router.tsx:1841
+msgid "Loading configuration..."
+msgstr "Loading configuration..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:164
+msgid "Loading content..."
+msgstr "Loading content..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2375
+msgid "Loading editor..."
+msgstr "Loading editor..."
+
+#: packages/admin/src/components/MenuEditor.tsx:263
+msgid "Loading menu..."
+msgstr "Loading menu..."
+
+#: packages/admin/src/components/MenuList.tsx:94
+msgid "Loading menus..."
+msgstr "Loading menus..."
+
+#: packages/admin/src/components/PluginManager.tsx:136
+msgid "Loading plugins..."
+msgstr "Loading plugins..."
+
+#: packages/admin/src/components/Redirects.tsx:430
+msgid "Loading redirects..."
+msgstr "Loading redirects..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:94
+#: packages/admin/src/components/Sections.tsx:252
+msgid "Loading sections..."
+msgstr "Loading sections..."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:104
+#: packages/admin/src/components/settings/SeoSettings.tsx:108
+#: packages/admin/src/components/settings/SocialSettings.tsx:81
+msgid "Loading settings..."
+msgstr "Loading settings..."
+
+#: packages/admin/src/components/SetupWizard.tsx:528
+msgid "Loading setup..."
+msgstr "Loading setup..."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:827
+msgid "Loading terms..."
+msgstr "Loading terms..."
+
+#: packages/admin/src/components/Widgets.tsx:310
+msgid "Loading widgets..."
+msgstr "Loading widgets..."
+
+#: packages/admin/src/components/ContentList.tsx:300
+#: packages/admin/src/components/ContentList.tsx:389
+#: packages/admin/src/components/ContentList.tsx:418
+#: packages/admin/src/components/ContentList.tsx:446
+#: packages/admin/src/components/ContentPickerModal.tsx:233
+#: packages/admin/src/components/MarketplaceBrowse.tsx:198
+#: packages/admin/src/components/MediaLibrary.tsx:533
+#: packages/admin/src/components/MediaPickerModal.tsx:718
+#: packages/admin/src/components/PortableTextEditor.tsx:1819
+#: packages/admin/src/components/RegistryBrowse.tsx:143
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:176
+#: packages/admin/src/components/settings/SecuritySettings.tsx:113
+#: packages/admin/src/components/TaxonomyManager.tsx:779
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:170
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+#: packages/admin/src/components/users/UserList.tsx:156
+#: packages/admin/src/components/WelcomeModal.tsx:143
+#: packages/admin/src/routes/bylines.tsx:455
+msgid "Loading..."
+msgstr "Loading..."
+
+#: packages/admin/src/components/ContentList.tsx:280
+#: packages/admin/src/components/LocaleSwitcher.tsx:60
+msgid "Locale"
+msgstr "Locale"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Lock aspect ratio"
+msgstr "Lock aspect ratio"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:291
+msgid "Locked because this field has stored values. Delete the values (or the field) to change this."
+msgstr "Locked because this field has stored values. Delete the values (or the field) to change this."
+
+#: packages/admin/src/components/Header.tsx:101
+msgid "Log out"
+msgstr "Log out"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:182
+#: packages/admin/src/components/settings/GeneralSettings.tsx:188
+msgid "Logo"
+msgstr "Logo"
+
+#: packages/admin/src/components/WordPressImport.tsx:1668
+msgid "Logo & favicon"
+msgstr "Logo & favicon"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:53
+msgid "Long text"
+msgstr "Long text"
+
+#: packages/admin/src/components/FieldEditor.tsx:156
+#: packages/admin/src/components/FieldEditor.tsx:580
+msgid "Long Text"
+msgstr "Long Text"
+
+#: packages/admin/src/components/Sections.tsx:193
+msgid "Lowercase letters, numbers, and hyphens only"
+msgstr "Lowercase letters, numbers, and hyphens only"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:641
+msgid "Lowercase letters, numbers, and underscores only, starting with a letter"
+msgstr "Lowercase letters, numbers, and underscores only, starting with a letter"
+
+#: packages/admin/src/components/Widgets.tsx:371
+msgid "Main Sidebar"
+msgstr "Main Sidebar"
+
+#: packages/admin/src/lib/api/marketplace.ts:227
+#: packages/admin/src/lib/api/marketplace.ts:235
+msgid "Make network requests"
+msgstr "Make network requests"
+
+#: packages/admin/src/lib/api/marketplace.ts:228
+#: packages/admin/src/lib/api/marketplace.ts:236
+msgid "Make network requests to any host (unrestricted)"
+msgstr "Make network requests to any host (unrestricted)"
+
+#: packages/admin/src/components/Sidebar.tsx:589
+msgid "Manage"
+msgstr "Manage"
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#. placeholder {1}: taxonomyDef.collections.join(", ")
+#: packages/admin/src/components/TaxonomyManager.tsx:798
+msgid "Manage {0} for {1}"
+msgstr "Manage {0} for {1}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2065
+msgid "Manage bylines in {entryLocale}"
+msgstr "Manage bylines in {entryLocale}"
+
+#: packages/admin/src/components/Widgets.tsx:326
+msgid "Manage content widgets in your widget areas"
+msgstr "Manage content widgets in your widget areas"
+
+#: packages/admin/src/components/PluginManager.tsx:175
+msgid "Manage installed plugins. Enable or disable plugins to control their functionality."
+msgstr "Manage installed plugins. Enable or disable plugins to control their functionality."
+
+#: packages/admin/src/components/MenuList.tsx:104
+msgid "Manage navigation menus for your site"
+msgstr "Manage navigation menus for your site"
+
+#: packages/admin/src/components/Redirects.tsx:333
+msgid "Manage URL redirects and view 404 errors."
+msgstr "Manage URL redirects and view 404 errors."
+
+#: packages/admin/src/components/Settings.tsx:93
+msgid "Manage your passkeys and authentication"
+msgstr "Manage your passkeys and authentication"
+
+#: packages/admin/src/components/Redirects.tsx:398
+msgid "Manual"
+msgstr "Manual"
+
+#: packages/admin/src/components/WordPressImport.tsx:2260
+msgid "Map Authors"
+msgstr "Map Authors"
+
+#. placeholder {0}: mapping.wpLogin
+#: packages/admin/src/components/WordPressImport.tsx:2308
+msgid "Map WordPress user {0} to EmDash user"
+msgstr "Map WordPress user {0} to EmDash user"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:501
+msgid "Mark as spam"
+msgstr "Mark as spam"
+
+#: packages/admin/src/components/PluginManager.tsx:201
+msgid "marketplace"
+msgstr "marketplace"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:87
+#: packages/admin/src/components/PluginManager.tsx:167
+#: packages/admin/src/components/PluginManager.tsx:355
+#: packages/admin/src/components/Sidebar.tsx:382
+msgid "Marketplace"
+msgstr "Marketplace"
+
+#: packages/admin/src/components/FieldEditor.tsx:626
+msgid "Max Items"
+msgstr "Max Items"
+
+#: packages/admin/src/components/FieldEditor.tsx:470
+msgid "Max Length"
+msgstr "Max Length"
+
+#: packages/admin/src/components/FieldEditor.tsx:500
+msgid "Max Value"
+msgstr "Max Value"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2033
+#: packages/admin/src/components/Sidebar.tsx:342
+#: packages/admin/src/components/WordPressImport.tsx:678
+#: packages/admin/src/components/WordPressImport.tsx:1173
+msgid "Media"
+msgstr "Media"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:130
+msgid "Media Details"
+msgstr "Media Details"
+
+#. placeholder {0}: mediaResult.failed.length
+#: packages/admin/src/components/WordPressImport.tsx:2206
+msgid "Media Errors ({0})"
+msgstr "Media Errors ({0})"
+
+#: packages/admin/src/components/WordPressImport.tsx:2168
+msgid "Media Import"
+msgstr "Media Import"
+
+#: packages/admin/src/components/WordPressImport.tsx:2109
+msgid "Media Import Complete"
+msgstr "Media Import Complete"
+
+#: packages/admin/src/components/WordPressImport.tsx:2120
+msgid "Media import was skipped"
+msgstr "Media import was skipped"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:154
+#: packages/admin/src/components/MediaLibrary.tsx:264
+msgid "Media Library"
+msgstr "Media Library"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:55
+msgid "Media Read"
+msgstr "Media Read"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:60
+msgid "Media Write"
+msgstr "Media Write"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:894
+msgid "Medium section heading"
+msgstr "Medium section heading"
+
+#: packages/admin/src/components/Widgets.tsx:102
+#: packages/admin/src/components/Widgets.tsx:834
+msgid "Menu"
+msgstr "Menu"
+
+#. placeholder {0}: translated.label
+#. placeholder {1}: translated.locale.toUpperCase()
+#: packages/admin/src/components/MenuEditor.tsx:90
+msgid "Menu \"{0}\" ({1}) created."
+msgstr "Menu \"{0}\" ({1}) created."
+
+#. placeholder {0}: menu.label
+#: packages/admin/src/components/MenuList.tsx:55
+msgid "Menu \"{0}\" has been created."
+msgstr "Menu \"{0}\" has been created."
+
+#: packages/admin/src/components/MenuList.tsx:54
+msgid "Menu created"
+msgstr "Menu created"
+
+#: packages/admin/src/components/MenuList.tsx:74
+msgid "Menu deleted"
+msgstr "Menu deleted"
+
+#: packages/admin/src/components/MenuEditor.tsx:121
+msgid "Menu item has been added."
+msgstr "Menu item has been added."
+
+#: packages/admin/src/components/MenuEditor.tsx:134
+msgid "Menu item has been deleted."
+msgstr "Menu item has been deleted."
+
+#: packages/admin/src/components/MenuEditor.tsx:159
+msgid "Menu item has been updated."
+msgstr "Menu item has been updated."
+
+#: packages/admin/src/components/MenuEditor.tsx:271
+msgid "Menu not found"
+msgstr "Menu not found"
+
+#: packages/admin/src/components/MenuEditor.tsx:174
+msgid "Menu order has been updated."
+msgstr "Menu order has been updated."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:161
+#: packages/admin/src/components/MenuList.tsx:103
+#: packages/admin/src/components/Sidebar.tsx:352
+msgid "Menus"
+msgstr "Menus"
+
+#. placeholder {0}: navMenus.length
+#: packages/admin/src/components/WordPressImport.tsx:1604
+msgid "Menus ({0})"
+msgstr "Menus ({0})"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:80
+msgid "Menus Manage"
+msgstr "Menus Manage"
+
+#: packages/admin/src/components/SeoPanel.tsx:165
+msgid "Meta Description"
+msgstr "Meta Description"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:236
+msgid "Meta tag content for Bing Webmaster Tools verification"
+msgstr "Meta tag content for Bing Webmaster Tools verification"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:230
+msgid "Meta tag content for Google Search Console verification"
+msgstr "Meta tag content for Google Search Console verification"
+
+#: packages/admin/src/components/WordPressImport.tsx:1681
+msgid "Meta titles, descriptions, and social images"
+msgstr "Meta titles, descriptions, and social images"
+
+#: packages/admin/src/components/FieldEditor.tsx:619
+msgid "Min Items"
+msgstr "Min Items"
+
+#: packages/admin/src/components/FieldEditor.tsx:463
+msgid "Min Length"
+msgstr "Min Length"
+
+#: packages/admin/src/components/FieldEditor.tsx:493
+msgid "Min Value"
+msgstr "Min Value"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:506
+msgid "Moderation"
+msgstr "Moderation"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:129
+msgid "Moderation Signals"
+msgstr "Moderation Signals"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:211
+msgid "Modified"
+msgstr "Modified"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:71
+msgid "Modify collection schemas"
+msgstr "Modify collection schemas"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:42
+msgid "Most Popular"
+msgstr "Most Popular"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:439
+msgid "Move \"{0}\" down"
+msgstr "Move \"{0}\" down"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:429
+msgid "Move \"{0}\" up"
+msgstr "Move \"{0}\" up"
+
+#: packages/admin/src/components/ContentList.tsx:653
+msgid "Move \"{title}\" to trash? You can restore it later."
+msgstr "Move \"{title}\" to trash? You can restore it later."
+
+#: packages/admin/src/components/ContentList.tsx:644
+msgid "Move {title} to trash"
+msgstr "Move {title} to trash"
+
+#: packages/admin/src/components/MenuEditor.tsx:451
+msgid "Move down"
+msgstr "Move down"
+
+#: packages/admin/src/components/ContentEditor.tsx:949
+#: packages/admin/src/components/ContentEditor.tsx:971
+#: packages/admin/src/components/ContentList.tsx:666
+msgid "Move to Trash"
+msgstr "Move to Trash"
+
+#: packages/admin/src/components/ContentEditor.tsx:955
+#: packages/admin/src/components/ContentList.tsx:651
+msgid "Move to Trash?"
+msgstr "Move to Trash?"
+
+#: packages/admin/src/components/MenuEditor.tsx:442
+msgid "Move up"
+msgstr "Move up"
+
+#: packages/admin/src/components/FieldEditor.tsx:192
+msgid "Multi Select"
+msgstr "Multi Select"
+
+#: packages/admin/src/components/FieldEditor.tsx:157
+msgid "Multi-line plain text"
+msgstr "Multi-line plain text"
+
+#: packages/admin/src/components/FieldEditor.tsx:193
+msgid "Multiple choices from options"
+msgstr "Multiple choices from options"
+
+#: packages/admin/src/components/SetupWizard.tsx:120
+msgid "My Awesome Blog"
+msgstr "My Awesome Blog"
+
+#: packages/admin/src/components/ContentTypeList.tsx:94
+#: packages/admin/src/components/MarketplaceBrowse.tsx:45
+#: packages/admin/src/components/MenuList.tsx:154
+#: packages/admin/src/components/TaxonomyManager.tsx:389
+#: packages/admin/src/components/TaxonomyManager.tsx:632
+#: packages/admin/src/components/TaxonomyManager.tsx:821
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:37
+#: packages/admin/src/components/users/UserDetail.tsx:148
+#: packages/admin/src/components/Widgets.tsx:365
+msgid "Name"
+msgstr "Name"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:558
+msgid "Name and label are required"
+msgstr "Name and label are required"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:564
+msgid "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+msgstr "Name must start with a letter and contain only lowercase letters, numbers, and underscores"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:335
+msgid "Navigation"
+msgstr "Navigation"
+
+#: packages/admin/src/components/users/UserDetail.tsx:231
+#: packages/admin/src/components/users/UserList.tsx:185
+msgid "Never"
+msgstr "Never"
+
+#: packages/admin/src/router.tsx:885
+msgid "new"
+msgstr "new"
+
+#: packages/admin/src/routes/bylines.tsx:413
+msgid "New"
+msgstr "New"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:106
+msgid "NEW"
+msgstr "NEW"
+
+#. placeholder {0}: (taxonomy.labelSingular || taxonomy.label).toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:464
+msgid "New {0}"
+msgstr "New {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:631
+msgid "New {collectionLabel}"
+msgstr "New {collectionLabel}"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:209
+msgid "New byline field"
+msgstr "New byline field"
+
+#: packages/admin/src/components/WordPressImport.tsx:1818
+msgid "New collection"
+msgstr "New collection"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:355
+#: packages/admin/src/components/ContentTypeList.tsx:44
+msgid "New Content Type"
+msgstr "New Content Type"
+
+#: packages/admin/src/routes/byline-schema.tsx:224
+msgid "New field"
+msgstr "New field"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:116
+msgid "New public routes"
+msgstr "New public routes"
+
+#: packages/admin/src/components/Redirects.tsx:102
+#: packages/admin/src/components/Redirects.tsx:336
+msgid "New Redirect"
+msgstr "New Redirect"
+
+#: packages/admin/src/components/Sections.tsx:143
+msgid "New Section"
+msgstr "New Section"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:466
+msgid "new tab"
+msgstr "new tab"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:811
+msgid "New Taxonomy"
+msgstr "New Taxonomy"
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:354
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:525
+msgid "New window"
+msgstr "New window"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:44
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:36
+msgid "Newest"
+msgstr "Newest"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:392
+msgid "News"
+msgstr "News"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:315
+msgid "Next"
+msgstr "Next"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:371
+#: packages/admin/src/components/ContentList.tsx:377
+msgid "Next page"
+msgstr "Next page"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:463
+msgid "Next screenshot"
+msgstr "Next screenshot"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "No"
+msgstr "No"
+
+#: packages/admin/src/routes/byline-schema.tsx:420
+msgid "No (shared across translations)"
+msgstr "No (shared across translations)"
+
+#. placeholder {0}: taxonomy.label.toLowerCase()
+#: packages/admin/src/components/TaxonomySidebar.tsx:434
+msgid "No {0} available."
+msgstr "No {0} available."
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:311
+msgid "No {0} yet."
+msgstr "No {0} yet."
+
+#. placeholder {0}: taxonomyDef.label.toLowerCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:830
+msgid "No {0} yet. Create one to get started."
+msgstr "No {0} yet. Create one to get started."
+
+#: packages/admin/src/components/Redirects.tsx:208
+msgid "No 404 errors recorded yet."
+msgstr "No 404 errors recorded yet."
+
+#: packages/admin/src/components/MediaLibrary.tsx:688
+#: packages/admin/src/components/MediaLibrary.tsx:745
+msgid "No alt text"
+msgstr "No alt text"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:270
+msgid "No API tokens yet. Create one to get started."
+msgstr "No API tokens yet. Create one to get started."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:547
+msgid "No approved comments yet."
+msgstr "No approved comments yet."
+
+#: packages/admin/src/routes/byline-schema.tsx:291
+msgid "No byline fields yet."
+msgstr "No byline fields yet."
+
+#: packages/admin/src/components/ContentEditor.tsx:2057
+msgid "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+msgstr "No bylines available in {entryLocale}. Create a variant from the Bylines page before crediting one on this entry."
+
+#: packages/admin/src/routes/bylines.tsx:439
+msgid "No bylines found"
+msgstr "No bylines found"
+
+#: packages/admin/src/components/ContentEditor.tsx:2164
+msgid "No bylines selected."
+msgstr "No bylines selected."
+
+#: packages/admin/src/components/Dashboard.tsx:172
+msgid "No collections configured"
+msgstr "No collections configured"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:546
+msgid "No comments awaiting moderation."
+msgstr "No comments awaiting moderation."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:542
+msgid "No comments match your search."
+msgstr "No comments match your search."
+
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:80
+msgid "No content"
+msgstr "No content"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:171
+msgid "No content found"
+msgstr "No content found"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:177
+msgid "No content in this collection"
+msgstr "No content in this collection"
+
+#: packages/admin/src/components/ContentTypeList.tsx:120
+msgid "No content types yet."
+msgstr "No content types yet."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:603
+msgid "No custom fields yet"
+msgstr "No custom fields yet"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:264
+msgid "No detailed description available."
+msgstr "No detailed description available."
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:295
+msgid "No domains configured. Users must be invited individually."
+msgstr "No domains configured. Users must be invited individually."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:178
+msgid "No email provider configured"
+msgstr "No email provider configured"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:83
+msgid "No email provider configured. Share this link manually."
+msgstr "No email provider configured. Share this link manually."
+
+#: packages/admin/src/components/WordPressImport.tsx:2322
+msgid "No EmDash users found"
+msgstr "No EmDash users found"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:31
+msgid "No expiry"
+msgstr "No expiry"
+
+#: packages/admin/src/components/RevisionHistory.tsx:327
+msgid "No fields to compare"
+msgstr "No fields to compare"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:189
+msgid "No headings in document"
+msgstr "No headings in document"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:579
+msgid "No installable releases"
+msgstr "No installable releases"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:159
+msgid "No invite token provided"
+msgstr "No invite token provided"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1615
+#: packages/admin/src/components/RepeaterField.tsx:160
+msgid "No items yet"
+msgstr "No items yet"
+
+#: packages/admin/src/components/FieldEditor.tsx:630
+msgid "No limit"
+msgstr "No limit"
+
+#: packages/admin/src/routes/bylines.tsx:500
+msgid "No linked user"
+msgstr "No linked user"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:134
+msgid "No matches"
+msgstr "No matches"
+
+#: packages/admin/src/components/ContentEditor.tsx:2099
+msgid "No matching bylines."
+msgstr "No matching bylines."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:266
+msgid "No matching passkey found for this account."
+msgstr "No matching passkey found for this account."
+
+#: packages/admin/src/components/FieldEditor.tsx:474
+#: packages/admin/src/components/FieldEditor.tsx:504
+msgid "No maximum"
+msgstr "No maximum"
+
+#: packages/admin/src/components/MediaLibrary.tsx:436
+#: packages/admin/src/components/MediaPickerModal.tsx:641
+msgid "No media available from this provider"
+msgstr "No media available from this provider"
+
+#: packages/admin/src/components/MediaLibrary.tsx:430
+#: packages/admin/src/components/MediaPickerModal.tsx:635
+msgid "No media found"
+msgstr "No media found"
+
+#: packages/admin/src/components/MediaLibrary.tsx:419
+msgid "No media yet"
+msgstr "No media yet"
+
+#: packages/admin/src/components/MenuEditor.tsx:406
+msgid "No menu items yet"
+msgstr "No menu items yet"
+
+#: packages/admin/src/components/MenuList.tsx:186
+msgid "No menus yet"
+msgstr "No menus yet"
+
+#: packages/admin/src/components/FieldEditor.tsx:467
+#: packages/admin/src/components/FieldEditor.tsx:497
+msgid "No minimum"
+msgstr "No minimum"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:65
+msgid "No moderation (auto-approve all)"
+msgstr "No moderation (auto-approve all)"
+
+#: packages/admin/src/components/users/UserDetail.tsx:248
+msgid "No passkeys registered"
+msgstr "No passkeys registered"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:195
+msgid "No passkeys registered yet."
+msgstr "No passkeys registered yet."
+
+#: packages/admin/src/components/PluginManager.tsx:195
+msgid "No plugins configured"
+msgstr "No plugins configured"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:173
+msgid "No plugins found"
+msgstr "No plugins found"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:117
+msgid "No plugins have been published to this registry yet."
+msgstr "No plugins have been published to this registry yet."
+
+#: packages/admin/src/components/RegistryBrowse.tsx:116
+msgid "No plugins match \"{debouncedQuery}\"."
+msgstr "No plugins match \"{debouncedQuery}\"."
+
+#: packages/admin/src/components/Sections.tsx:343
+msgid "No preview"
+msgstr "No preview"
+
+#: packages/admin/src/components/Dashboard.tsx:236
+msgid "No recent activity"
+msgstr "No recent activity"
+
+#: packages/admin/src/components/Redirects.tsx:434
+msgid "No redirects yet"
+msgstr "No redirects yet"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:1173
+msgid "No results"
+msgstr "No results"
+
+#: packages/admin/src/components/ContentList.tsx:308
+#: packages/admin/src/components/ContentList.tsx:327
+msgid "No results for \"{activeSearch}\""
+msgstr "No results for \"{activeSearch}\""
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:176
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
+msgid "No results for \"{debouncedQuery}\". Try a different search term."
+msgstr "No results for \"{debouncedQuery}\". Try a different search term."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:452
+msgid "No results found"
+msgstr "No results found"
+
+#: packages/admin/src/components/RevisionHistory.tsx:183
+msgid "No revisions yet"
+msgstr "No revisions yet"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:107
+msgid "No sections available"
+msgstr "No sections available"
+
+#: packages/admin/src/components/SectionPickerModal.tsx:101
+#: packages/admin/src/components/Sections.tsx:259
+msgid "No sections found"
+msgstr "No sections found"
+
+#: packages/admin/src/components/Sections.tsx:265
+msgid "No sections yet"
+msgstr "No sections yet"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:548
+msgid "No spam comments."
+msgstr "No spam comments."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:149
+msgid "No themes found"
+msgstr "No themes found"
+
+#: packages/admin/src/components/users/UserList.tsx:120
+msgid "No users found matching your filters."
+msgstr "No users found matching your filters."
+
+#: packages/admin/src/components/users/UserList.tsx:134
+msgid "No users yet."
+msgstr "No users yet."
+
+#: packages/admin/src/components/Widgets.tsx:434
+msgid "No widget areas yet. Create one to get started."
+msgstr "No widget areas yet. Create one to get started."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:418
+#: packages/admin/src/components/TaxonomyManager.tsx:424
+msgid "None (top level)"
+msgstr "None (top level)"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:614
+msgid "Not compatible with this environment"
+msgstr "Not compatible with this environment"
+
+#: packages/admin/src/components/FieldEditor.tsx:162
+#: packages/admin/src/components/FieldEditor.tsx:581
+msgid "Number"
+msgstr "Number"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:301
+msgid "Number of posts to show per page on list views"
+msgstr "Number of posts to show per page on list views"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:110
+#: packages/admin/src/components/PortableTextEditor.tsx:923
+#: packages/admin/src/components/PortableTextEditor.tsx:2922
+msgid "Numbered List"
+msgstr "Numbered List"
+
+#: packages/admin/src/components/SeoImageField.tsx:41
+msgid "OG Image"
+msgstr "OG Image"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:314
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:311
+msgid "on a custom hostname is not treated as secure, even on loopback."
+msgstr "on a custom hostname is not treated as secure, even on loopback."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:278
+msgid "Only authorize codes you recognize."
+msgstr "Only authorise codes you recognise."
+
+#: packages/admin/src/components/SignupPage.tsx:96
+msgid "Only email addresses from allowed domains can sign up."
+msgstr "Only email addresses from allowed domains can sign up."
+
+#: packages/admin/src/components/MenuList.tsx:159
+msgid "Only lowercase letters, numbers, and hyphens"
+msgstr "Only lowercase letters, numbers, and hyphens"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:106
+msgid "Only the listed MIME types will be accepted for this field."
+msgstr "Only the listed MIME types will be accepted for this field."
+
+#: packages/admin/src/components/SignupPage.tsx:402
+msgid "Oops!"
+msgstr "Oops!"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:333
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:334
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:498
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:499
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:333
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:334
+msgid "Open in new tab"
+msgstr "Open in new tab"
+
+#: packages/admin/src/components/WordPressImport.tsx:1373
+msgid "Open WordPress Profile"
+msgstr "Open WordPress Profile"
+
+#: packages/admin/src/components/FieldEditor.tsx:515
+msgid ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+msgstr ""
+"Option 1\n"
+"Option 2\n"
+"Option 3"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:309
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:474
+msgid "Optional caption displayed below the image"
+msgstr "Optional caption displayed below the image"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:213
+msgid "Optional caption for display"
+msgstr "Optional caption for display"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:437
+msgid "Optional description"
+msgstr "Optional description"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:318
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:483
+msgid "Optional tooltip on hover"
+msgstr "Optional tooltip on hover"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:302
+#: packages/admin/src/components/FieldEditor.tsx:512
+msgid "Options (one per line)"
+msgstr "Options (one per line)"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:527
+msgid "or choose from library"
+msgstr "or choose from library"
+
+#: packages/admin/src/components/WordPressImport.tsx:1429
+msgid "Or click to browse. Accepts .xml files exported from WordPress."
+msgstr "Or click to browse. Accepts .xml files exported from WordPress."
+
+#: packages/admin/src/components/LoginPage.tsx:261
+#: packages/admin/src/components/SetupWizard.tsx:310
+msgid "Or continue with"
+msgstr "Or continue with"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Or upload an export file"
+msgstr "Or upload an export file"
+
+#: packages/admin/src/components/WordPressImport.tsx:949
+msgid "or upload directly"
+msgstr "or upload directly"
+
+#: packages/admin/src/components/MenuEditor.tsx:173
+msgid "Order saved"
+msgstr "Order saved"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:235
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:400
+msgid "Original:"
+msgstr "Original:"
+
+#: packages/admin/src/components/editor/DocumentOutline.tsx:181
+msgid "Outline"
+msgstr "Outline"
+
+#: packages/admin/src/components/SeoPanel.tsx:155
+msgid "Overrides the page title in search engine results"
+msgstr "Overrides the page title in search engine results"
+
+#: packages/admin/src/components/ContentEditor.tsx:986
+msgid "Ownership"
+msgstr "Ownership"
+
+#: packages/admin/src/components/PluginManager.tsx:509
+msgid "Package"
+msgstr "Package"
+
+#: packages/admin/src/router.tsx:1867
+msgid "Page Not Found"
+msgstr "Page Not Found"
+
+#: packages/admin/src/components/PluginManager.tsx:373
+#: packages/admin/src/components/WordPressImport.tsx:1167
+msgid "Pages"
+msgstr "Pages"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:54
+msgid "Paragraph"
+msgstr "Paragraph"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:414
+msgid "Parent"
+msgstr "Parent"
+
+#: packages/admin/src/components/Redirects.tsx:483
+#: packages/admin/src/components/Redirects.tsx:489
+msgid "Part of a redirect loop"
+msgstr "Part of a redirect loop"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:322
+msgid "Pass"
+msgstr "Pass"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:98
+msgid "Passkey added successfully"
+msgstr "Passkey added successfully"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:129
+msgid "Passkey name"
+msgstr "Passkey name"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:329
+msgid "Passkey Name (optional)"
+msgstr "Passkey Name (optional)"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:352
+msgid "Passkey registered successfully!"
+msgstr "Passkey registered successfully!"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:76
+msgid "Passkey removed"
+msgstr "Passkey removed"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:60
+msgid "Passkey renamed"
+msgstr "Passkey renamed"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:177
+#: packages/admin/src/components/users/UserList.tsx:110
+msgid "Passkeys"
+msgstr "Passkeys"
+
+#. placeholder {0}: user.credentials.length
+#: packages/admin/src/components/users/UserDetail.tsx:245
+msgid "Passkeys ({0})"
+msgstr "Passkeys ({0})"
+
+#: packages/admin/src/components/settings/SecuritySettings.tsx:181
+msgid "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+msgstr "Passkeys are a secure, passwordless way to sign in to your account. You can register multiple passkeys for different devices."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:74
+#: packages/admin/src/components/SignupPage.tsx:213
+msgid "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+msgstr "Passkeys are a secure, passwordless way to sign in using your device's biometrics, PIN, or security key."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:303
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:300
+msgid "Passkeys Not Available Here"
+msgstr "Passkeys Not Available Here"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:307
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:304
+msgid "Passkeys require a"
+msgstr "Passkeys require a"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:158
+msgid "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+msgstr "Passkeys require HTTPS or http://localhost (with your port); this hostname is not a secure browser context."
+
+#: packages/admin/src/components/Redirects.tsx:215
+msgid "Path"
+msgstr "Path"
+
+#: packages/admin/src/components/FieldEditor.tsx:479
+msgid "Pattern (Regex)"
+msgstr "Pattern (Regex)"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:437
+msgid "Pattern for generating URLs, e.g. /blog/{0}"
+msgstr "Pattern for generating URLs, e.g. /blog/{0}"
+
+#. placeholder {0}: "{slug}"
+#: packages/admin/src/components/ContentTypeEditor.tsx:433
+msgid "Pattern must include a {0} placeholder"
+msgstr "Pattern must include a {0} placeholder"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:62
+msgid "PDF"
+msgstr "PDF"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:196
+#: packages/admin/src/components/ContentList.tsx:790
+msgid "pending"
+msgstr "pending"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:197
+msgid "Pending"
+msgstr "Pending"
+
+#: packages/admin/src/components/ContentEditor.tsx:861
+msgid "Pending changes"
+msgstr "Pending changes"
+
+#: packages/admin/src/components/ContentList.tsx:724
+msgid "Permanently delete \"{title}\"? This cannot be undone."
+msgstr "Permanently delete \"{title}\"? This cannot be undone."
+
+#: packages/admin/src/components/ContentList.tsx:713
+msgid "Permanently delete {title}"
+msgstr "Permanently delete {title}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:273
+msgid "Permissions"
+msgstr "Permissions"
+
+#: packages/admin/src/components/SetupWizard.tsx:290
+msgid "Pick any method to create your admin account."
+msgstr "Pick any method to create your admin account."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:313
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:310
+msgid "Plain"
+msgstr "Plain"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:133
+msgid "Please ask your administrator to send a new invite."
+msgstr "Please ask your administrator to send a new invite."
+
+#: packages/admin/src/components/SetupWizard.tsx:181
+msgid "Please enter a valid email"
+msgstr "Please enter a valid email"
+
+#: packages/admin/src/components/SignupPage.tsx:54
+msgid "Please enter a valid email address"
+msgstr "Please enter a valid email address"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:394
+msgid "Please enter a valid URL"
+msgstr "Please enter a valid URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1024
+msgid "Plugin"
+msgstr "Plugin"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:747
+msgid "Plugin details"
+msgstr "Plugin details"
+
+#: packages/admin/src/components/PluginManager.tsx:110
+msgid "Plugin disabled"
+msgstr "Plugin disabled"
+
+#: packages/admin/src/components/PluginManager.tsx:91
+msgid "Plugin enabled"
+msgstr "Plugin enabled"
+
+#: packages/admin/src/components/SandboxedPluginPage.tsx:89
+msgid "Plugin Error"
+msgstr "Plugin Error"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginWidget.tsx:37
+msgid "Plugin error ({0})"
+msgstr "Plugin error ({0})"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:112
+msgid "Plugin not found"
+msgstr "Plugin not found"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:396
+msgid "Plugin not found. The publisher handle or slug may be incorrect."
+msgstr "Plugin not found. The publisher handle or slug may be incorrect."
+
+#: packages/admin/src/components/WordPressImport.tsx:1048
+msgid "plugin on your WordPress site."
+msgstr "plugin on your WordPress site."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Plugin Permissions"
+msgstr "Plugin Permissions"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:70
+msgid "Plugin Registry"
+msgstr "Plugin Registry"
+
+#. placeholder {0}: response.status
+#: packages/admin/src/components/SandboxedPluginPage.tsx:40
+msgid "Plugin responded with {0}: {text}"
+msgstr "Plugin responded with {0}: {text}"
+
+#: packages/admin/src/components/PluginManager.tsx:305
+msgid "Plugin uninstalled"
+msgstr "Plugin uninstalled"
+
+#: packages/admin/src/lib/api/registry.ts:783
+msgid "Plugin update requires re-consent"
+msgstr "Plugin update requires re-consent"
+
+#: packages/admin/src/components/PluginManager.tsx:258
+msgid "Plugin updated"
+msgstr "Plugin updated"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:219
+#: packages/admin/src/components/PluginManager.tsx:135
+#: packages/admin/src/components/PluginManager.tsx:144
+#: packages/admin/src/components/PluginManager.tsx:153
+#: packages/admin/src/components/Sidebar.tsx:369
+#: packages/admin/src/components/Sidebar.tsx:609
+msgid "Plugins"
+msgstr "Plugins"
+
+#: packages/admin/src/components/SeoPanel.tsx:182
+msgid "Points search engines to the original version of this page, if it's duplicated from another URL"
+msgstr "Points search engines to the original version of this page, if it's duplicated from another URL"
+
+#: packages/admin/src/components/WordPressImport.tsx:1161
+msgid "Posts"
+msgstr "Posts"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:295
+msgid "Posts Per Page"
+msgstr "Posts Per Page"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:463
+msgid "Pre-release"
+msgstr "Pre-release"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:170
+msgid "Preparing registration..."
+msgstr "Preparing registration..."
+
+#: packages/admin/src/components/WordPressImport.tsx:2020
+msgid "Preparing to download files from WordPress..."
+msgstr "Preparing to download files from WordPress..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:166
+#: packages/admin/src/components/SetupWizard.tsx:233
+msgid "Preparing..."
+msgstr "Preparing..."
+
+#: packages/admin/src/components/ContentEditor.tsx:681
+#: packages/admin/src/components/ContentTypeEditor.tsx:81
+#: packages/admin/src/components/MediaLibrary.tsx:482
+msgid "Preview"
+msgstr "Preview"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:82
+msgid "Preview content before publishing"
+msgstr "Preview content before publishing"
+
+#: packages/admin/src/components/ContentEditor.tsx:681
+msgid "Preview draft"
+msgstr "Preview draft"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:308
+msgid "Previous"
+msgstr "Previous"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:352
+#: packages/admin/src/components/ContentList.tsx:365
+msgid "Previous page"
+msgstr "Previous page"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:445
+msgid "Previous screenshot"
+msgstr "Previous screenshot"
+
+#: packages/admin/src/components/MenuList.tsx:166
+msgid "Primary Navigation"
+msgstr "Primary Navigation"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:202
+msgid "Provider:"
+msgstr "Provider:"
+
+#: packages/admin/src/components/ContentEditor.tsx:736
+#: packages/admin/src/components/ContentEditor.tsx:842
+msgid "Publish"
+msgstr "Publish"
+
+#: packages/admin/src/components/ContentEditor.tsx:726
+msgid "Publish changes"
+msgstr "Publish changes"
+
+#: packages/admin/src/components/ContentList.tsx:765
+msgid "published"
+msgstr "published"
+
+#: packages/admin/src/components/ContentEditor.tsx:857
+#: packages/admin/src/components/ContentPickerModal.tsx:209
+#: packages/admin/src/components/Dashboard.tsx:187
+#: packages/admin/src/router.tsx:785
+msgid "Published"
+msgstr "Published"
+
+#. placeholder {0}: new Date(latest.publishedAt).toLocaleDateString()
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:326
+msgid "Published {0}"
+msgstr "Published {0}"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:135
+msgid "Published At"
+msgstr "Published At"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:457
+msgid "Published by"
+msgstr "Published by"
+
+#: packages/admin/src/components/ContentEditor.tsx:2172
+msgid "Quick create byline"
+msgstr "Quick create byline"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:167
+#: packages/admin/src/components/editor/ImageNode.tsx:168
+msgid "Quick edit alt text"
+msgstr "Quick edit alt text"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:86
+#: packages/admin/src/components/PortableTextEditor.tsx:933
+#: packages/admin/src/components/PortableTextEditor.tsx:2929
+msgid "Quote"
+msgstr "Quote"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:66
+msgid "Read collection schemas"
+msgstr "Read collection schemas"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:46
+msgid "Read content entries"
+msgstr "Read content entries"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:56
+msgid "Read media files"
+msgstr "Read media files"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:86
+msgid "Read site settings"
+msgstr "Read site settings"
+
+#: packages/admin/src/lib/api/marketplace.ts:226
+#: packages/admin/src/lib/api/marketplace.ts:234
+msgid "Read user accounts"
+msgstr "Read user accounts"
+
+#: packages/admin/src/lib/api/marketplace.ts:222
+#: packages/admin/src/lib/api/marketplace.ts:230
+msgid "Read your content"
+msgstr "Read your content"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:292
+msgid "Reading"
+msgstr "Reading"
+
+#: packages/admin/src/components/WordPressImport.tsx:1822
+msgid "Ready"
+msgstr "Ready"
+
+#: packages/admin/src/components/Dashboard.tsx:228
+msgid "Recent Activity"
+msgstr "Recent Activity"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:43
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:35
+msgid "Recently Updated"
+msgstr "Recently Updated"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:144
+msgid "Recipient email"
+msgstr "Recipient email"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/users/UserDetail.tsx:336
+msgid "Recovery link sent to {0}"
+msgstr "Recovery link sent to {0}"
+
+#: packages/admin/src/components/Redirects.tsx:416
+msgid "Redirect loop detected"
+msgstr "Redirect loop detected"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:163
+msgid "Redirecting to login..."
+msgstr "Redirecting to login..."
+
+#: packages/admin/src/components/Redirects.tsx:332
+#: packages/admin/src/components/Redirects.tsx:351
+#: packages/admin/src/components/Sidebar.tsx:353
+msgid "Redirects"
+msgstr "Redirects"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3065
+msgid "Redo"
+msgstr "Redo"
+
+#: packages/admin/src/components/FieldEditor.tsx:216
+msgid "Reference"
+msgstr "Reference"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:251
+msgid "Referenced favicon unavailable."
+msgstr "Referenced favicon unavailable."
+
+#: packages/admin/src/components/ContentTypeList.tsx:78
+msgid "Register"
+msgstr "Register"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:146
+#: packages/admin/src/components/settings/SecuritySettings.tsx:220
+msgid "Register Passkey"
+msgstr "Register Passkey"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:83
+msgid "Registered user"
+msgstr "Registered user"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:259
+msgid "Registration failed"
+msgstr "Registration failed"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:266
+msgid "Registration was cancelled or timed out. Please try again."
+msgstr "Registration was cancelled or timed out. Please try again."
+
+#: packages/admin/src/components/Sidebar.tsx:375
+msgid "Registry"
+msgstr "Registry"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:595
+msgid "Release is too new to install"
+msgstr "Release is too new to install"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:84
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:115
+#: packages/admin/src/components/ContentEditor.tsx:2141
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:177
+#: packages/admin/src/components/PortableTextEditor.tsx:3028
+#: packages/admin/src/components/settings/GeneralSettings.tsx:217
+#: packages/admin/src/components/settings/GeneralSettings.tsx:271
+#: packages/admin/src/components/settings/PasskeyItem.tsx:187
+#: packages/admin/src/components/settings/PasskeyItem.tsx:209
+#: packages/admin/src/components/settings/SeoSettings.tsx:209
+msgid "Remove"
+msgstr "Remove"
+
+#. placeholder {0}: passkey.name
+#. placeholder {0}: term.label
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+#: packages/admin/src/components/TaxonomySidebar.tsx:243
+msgid "Remove {0}"
+msgstr "Remove {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:145
+msgid "Remove {entry}"
+msgstr "Remove {entry}"
+
+#: packages/admin/src/components/ContentEditor.tsx:1883
+msgid "Remove {label}"
+msgstr "Remove {label}"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:430
+msgid "Remove Domain"
+msgstr "Remove Domain"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:414
+msgid "Remove Domain?"
+msgstr "Remove Domain?"
+
+#: packages/admin/src/components/ContentEditor.tsx:1680
+#: packages/admin/src/components/ContentEditor.tsx:1709
+#: packages/admin/src/components/SeoImageField.tsx:55
+msgid "Remove image"
+msgstr "Remove image"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:346
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:512
+msgid "Remove Image"
+msgstr "Remove Image"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:175
+msgid "Remove Image?"
+msgstr "Remove Image?"
+
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/PortableTextEditor.tsx:1731
+#: packages/admin/src/components/RepeaterField.tsx:270
+msgid "Remove item {0}"
+msgstr "Remove item {0}"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2529
+#: packages/admin/src/components/PortableTextEditor.tsx:2530
+msgid "Remove link"
+msgstr "Remove link"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:188
+msgid "Remove passkey"
+msgstr "Remove passkey"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:203
+msgid "Remove passkey?"
+msgstr "Remove passkey?"
+
+#: packages/admin/src/components/FieldEditor.tsx:610
+msgid "Remove sub-field"
+msgstr "Remove sub-field"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:176
+msgid "Remove this image from the document?"
+msgstr "Remove this image from the document?"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:178
+#: packages/admin/src/components/settings/PasskeyItem.tsx:210
+msgid "Removing..."
+msgstr "Removing..."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:176
+msgid "Rename"
+msgstr "Rename"
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename {0}"
+msgstr "Rename {0}"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:177
+msgid "Rename passkey"
+msgstr "Rename passkey"
+
+#: packages/admin/src/components/FieldEditor.tsx:240
+msgid "Repeater"
+msgstr "Repeater"
+
+#: packages/admin/src/components/FieldEditor.tsx:241
+msgid "Repeating group of fields"
+msgstr "Repeating group of fields"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:191
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:226
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:389
+msgid "Replace Image"
+msgstr "Replace Image"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:117
+msgid "Reply to:"
+msgstr "Reply to:"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:220
+msgid "Repository"
+msgstr "Repository"
+
+#: packages/admin/src/components/SignupPage.tsx:273
+msgid "Request a new link"
+msgstr "Request a new link"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:280
+#: packages/admin/src/components/ContentTypeEditor.tsx:721
+#: packages/admin/src/components/FieldEditor.tsx:437
+#: packages/admin/src/components/FieldEditor.tsx:592
+#: packages/admin/src/routes/byline-schema.tsx:246
+msgid "Required"
+msgstr "Required"
+
+#: packages/admin/src/components/WordPressImport.tsx:1835
+msgid "Required fields:"
+msgstr "Required fields:"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:302
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:467
+msgid "Required for accessibility. Describes the image for screen readers."
+msgstr "Required for accessibility. Describes the image for screen readers."
+
+#. placeholder {0}: latest.minEmDashVersion
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:324
+msgid "Requires EmDash {0}"
+msgstr "Requires EmDash {0}"
+
+#: packages/admin/src/components/SignupPage.tsx:154
+msgid "Resend email"
+msgstr "Resend email"
+
+#: packages/admin/src/components/SignupPage.tsx:153
+msgid "Resend in {resendCooldown}s"
+msgstr "Resend in {resendCooldown}s"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:254
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:419
+msgid "Reset to original"
+msgstr "Reset to original"
+
+#: packages/admin/src/components/RevisionHistory.tsx:220
+msgid "Restore"
+msgstr "Restore"
+
+#: packages/admin/src/components/ContentList.tsx:701
+msgid "Restore {title}"
+msgstr "Restore {title}"
+
+#: packages/admin/src/components/RevisionHistory.tsx:136
+msgid "Restore failed"
+msgstr "Restore failed"
+
+#: packages/admin/src/components/RevisionHistory.tsx:214
+msgid "Restore Revision?"
+msgstr "Restore Revision?"
+
+#: packages/admin/src/components/RevisionHistory.tsx:281
+#: packages/admin/src/components/RevisionHistory.tsx:282
+msgid "Restore this version"
+msgstr "Restore this version"
+
+#. placeholder {0}: formatFullDate(restoreTarget.createdAt)
+#: packages/admin/src/components/RevisionHistory.tsx:217
+msgid "Restore this version from {0}? This will update the current content to this revision's data."
+msgstr "Restore this version from {0}? This will update the current content to this revision's data."
+
+#: packages/admin/src/components/RevisionHistory.tsx:221
+msgid "Restoring..."
+msgstr "Restoring..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:141
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:122
+#: packages/admin/src/router.tsx:1855
+#: packages/admin/src/routes/byline-schema.tsx:280
+msgid "Retry"
+msgstr "Retry"
+
+#: packages/admin/src/components/Sections.tsx:136
+msgid "Reusable content blocks you can insert into any content"
+msgstr "Reusable content blocks you can insert into any content"
+
+#: packages/admin/src/router.tsx:819
+msgid "Reverted to published version"
+msgstr "Reverted to published version"
+
+#: packages/admin/src/components/WordPressImport.tsx:650
+msgid "Review"
+msgstr "Review"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:75
+msgid "Review New Permissions"
+msgstr "Review New Permissions"
+
+#: packages/admin/src/components/RevisionHistory.tsx:130
+msgid "Revision restored"
+msgstr "Revision restored"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:76
+#: packages/admin/src/components/RevisionHistory.tsx:161
+msgid "Revisions"
+msgstr "Revisions"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:333
+msgid "Revoke token"
+msgstr "Revoke token"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:308
+msgid "Revoke?"
+msgstr "Revoke?"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:315
+msgid "Revoking..."
+msgstr "Revoking..."
+
+#: packages/admin/src/components/FieldEditor.tsx:198
+msgid "Rich Text"
+msgstr "Rich Text"
+
+#: packages/admin/src/components/Widgets.tsx:97
+msgid "Rich text content"
+msgstr "Rich text content"
+
+#: packages/admin/src/components/FieldEditor.tsx:199
+msgid "Rich text editor"
+msgstr "Rich text editor"
+
+#. placeholder {0}: latest.audit.riskScore
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:311
+msgid "Risk score: {0}/100"
+msgstr "Risk score: {0}/100"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:166
+#: packages/admin/src/components/users/UserDetail.tsx:169
+#: packages/admin/src/components/users/UserDetail.tsx:181
+#: packages/admin/src/components/users/UserList.tsx:101
+msgid "Role"
+msgstr "Role"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:61
+msgid "Role {role}"
+msgstr "Role {role}"
+
+#: packages/admin/src/components/ContentEditor.tsx:2146
+msgid "Role label"
+msgstr "Role label"
+
+#: packages/admin/src/components/MenuEditor.tsx:351
+#: packages/admin/src/components/MenuEditor.tsx:353
+#: packages/admin/src/components/MenuEditor.tsx:522
+#: packages/admin/src/components/MenuEditor.tsx:524
+msgid "Same window"
+msgstr "Same window"
+
+#: packages/admin/src/components/ContentEditor.tsx:2279
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:349
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:519
+#: packages/admin/src/components/editor/ImageNode.tsx:235
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:417
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:183
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Save"
+msgstr "Save"
+
+#: packages/admin/src/components/editor/PluginBlockNode.tsx:416
+msgid "Save (Enter)"
+msgstr "Save (Enter)"
+
+#: packages/admin/src/components/editor/ImageNode.tsx:236
+msgid "Save alt text"
+msgstr "Save alt text"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Save changes"
+msgstr "Save changes"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/users/UserDetail.tsx:311
+msgid "Save Changes"
+msgstr "Save Changes"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:72
+msgid "Save content as draft before publishing"
+msgstr "Save content as draft before publishing"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:137
+msgid "Save name"
+msgstr "Save name"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+msgid "Save SEO Settings"
+msgstr "Save SEO Settings"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+msgid "Save Settings"
+msgstr "Save Settings"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+msgid "Save Social Links"
+msgstr "Save Social Links"
+
+#: packages/admin/src/components/ContentEditor.tsx:656
+#: packages/admin/src/components/SaveButton.tsx:42
+msgid "Saved"
+msgstr "Saved"
+
+#. placeholder {0}: field.label
+#: packages/admin/src/routes/byline-schema.tsx:116
+msgid "Saved \"{0}\"."
+msgstr "Saved \"{0}\"."
+
+#: packages/admin/src/components/ContentEditor.tsx:651
+#: packages/admin/src/components/ContentEditor.tsx:2279
+#: packages/admin/src/components/ContentTypeEditor.tsx:560
+#: packages/admin/src/components/FieldEditor.tsx:659
+#: packages/admin/src/components/MediaDetailPanel.tsx:241
+#: packages/admin/src/components/MenuEditor.tsx:533
+#: packages/admin/src/components/Redirects.tsx:180
+#: packages/admin/src/components/SaveButton.tsx:42
+#: packages/admin/src/components/settings/GeneralSettings.tsx:125
+#: packages/admin/src/components/settings/GeneralSettings.tsx:321
+#: packages/admin/src/components/settings/SeoSettings.tsx:126
+#: packages/admin/src/components/settings/SeoSettings.tsx:251
+#: packages/admin/src/components/settings/SocialSettings.tsx:99
+#: packages/admin/src/components/settings/SocialSettings.tsx:173
+#: packages/admin/src/components/TaxonomyManager.tsx:476
+#: packages/admin/src/components/users/UserDetail.tsx:311
+#: packages/admin/src/components/Widgets.tsx:894
+#: packages/admin/src/routes/bylines.tsx:562
+msgid "Saving..."
+msgstr "Saving..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:318
+msgid "Saving…"
+msgstr "Saving…"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:467
+msgid "SBOM"
+msgstr "SBOM"
+
+#. placeholder {0}: sbom.format
+#: packages/admin/src/components/RegistryPluginDetail.tsx:465
+msgid "SBOM · {0}"
+msgstr "SBOM · {0}"
+
+#: packages/admin/src/components/ContentEditor.tsx:901
+msgid "Schedule"
+msgstr "Schedule"
+
+#: packages/admin/src/components/ContentEditor.tsx:887
+msgid "Schedule for"
+msgstr "Schedule for"
+
+#: packages/admin/src/components/ContentEditor.tsx:924
+msgid "Schedule for later"
+msgstr "Schedule for later"
+
+#: packages/admin/src/components/ContentList.tsx:769
+msgid "scheduled"
+msgstr "scheduled"
+
+#: packages/admin/src/components/ContentEditor.tsx:864
+#: packages/admin/src/router.tsx:836
+msgid "Scheduled"
+msgstr "Scheduled"
+
+#. placeholder {0}: formatScheduledDate(item.scheduledAt)
+#: packages/admin/src/components/ContentEditor.tsx:874
+msgid "Scheduled for: {0}"
+msgstr "Scheduled for: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:2128
+msgid "Schema Changes"
+msgstr "Schema Changes"
+
+#: packages/admin/src/components/WordPressImport.tsx:1538
+msgid "Schema preparation failed"
+msgstr "Schema preparation failed"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:65
+msgid "Schema Read"
+msgstr "Schema Read"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:70
+msgid "Schema Write"
+msgstr "Schema Write"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:416
+msgid "Scopes"
+msgstr "Scopes"
+
+#. placeholder {0}: token.scopes.join(", ")
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:284
+msgid "Scopes: {0}"
+msgstr "Scopes: {0}"
+
+#. placeholder {0}: i + 1
+#. placeholder {0}: index + 1
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:243
+#: packages/admin/src/components/RegistryPluginDetail.tsx:640
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:174
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:293
+msgid "Screenshot {0}"
+msgstr "Screenshot {0}"
+
+#. placeholder {0}: index + 1
+#. placeholder {1}: screenshots.length
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:453
+msgid "Screenshot {0} of {1}"
+msgstr "Screenshot {0} of {1}"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:246
+msgid "Screenshot blurred due to image audit"
+msgstr "Screenshot blurred due to image audit"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:431
+msgid "Screenshot viewer"
+msgstr "Screenshot viewer"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:233
+#: packages/admin/src/components/RegistryPluginDetail.tsx:634
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:164
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:86
+msgid "Search"
+msgstr "Search"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:225
+msgid "Search {0}"
+msgstr "Search {0}"
+
+#. placeholder {0}: collectionLabel.toLowerCase()
+#: packages/admin/src/components/ContentList.tsx:224
+msgid "Search {0}..."
+msgstr "Search {0}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:376
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "Search by filename..."
+msgstr "Search by filename..."
+
+#: packages/admin/src/components/users/UserList.tsx:69
+msgid "Search by name or email..."
+msgstr "Search by name or email..."
+
+#: packages/admin/src/components/ContentEditor.tsx:2074
+#: packages/admin/src/routes/bylines.tsx:388
+msgid "Search bylines"
+msgstr "Search bylines"
+
+#: packages/admin/src/components/ContentEditor.tsx:2073
+msgid "Search bylines to add..."
+msgstr "Search bylines to add..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:163
+msgid "Search comments"
+msgstr "Search comments"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:162
+msgid "Search comments..."
+msgstr "Search comments..."
+
+#: packages/admin/src/components/ContentPickerModal.tsx:141
+msgid "Search content..."
+msgstr "Search content..."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:155
+msgid "Search Engine Optimization"
+msgstr "Search Engine Optimisation"
+
+#: packages/admin/src/components/Settings.tsx:82
+msgid "Search engine optimization and verification"
+msgstr "Search engine optimisation and verification"
+
+#: packages/admin/src/components/MediaLibrary.tsx:377
+#: packages/admin/src/components/MediaPickerModal.tsx:574
+msgid "Search media"
+msgstr "Search media"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:425
+msgid "Search pages and content..."
+msgstr "Search pages and content..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:101
+#: packages/admin/src/components/RegistryBrowse.tsx:84
+msgid "Search plugins"
+msgstr "Search plugins"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:97
+#: packages/admin/src/components/RegistryBrowse.tsx:80
+msgid "Search plugins..."
+msgstr "Search plugins..."
+
+#: packages/admin/src/components/SectionPickerModal.tsx:81
+#: packages/admin/src/components/Sections.tsx:226
+msgid "Search sections..."
+msgstr "Search sections..."
+
+#: packages/admin/src/components/Redirects.tsx:383
+msgid "Search source or destination..."
+msgstr "Search source or destination..."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:93
+msgid "Search themes"
+msgstr "Search themes"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:89
+msgid "Search themes..."
+msgstr "Search themes..."
+
+#: packages/admin/src/components/users/UserList.tsx:73
+msgid "Search users"
+msgstr "Search users"
+
+#: packages/admin/src/components/MediaLibrary.tsx:376
+#: packages/admin/src/components/MediaPickerModal.tsx:573
+msgid "Search..."
+msgstr "Search..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:723
+#: packages/admin/src/components/FieldEditor.tsx:452
+msgid "Searchable"
+msgstr "Searchable"
+
+#: packages/admin/src/components/ContentEditor.tsx:2077
+msgid "Searching..."
+msgstr "Searching..."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2043
+msgid "Section"
+msgstr "Section"
+
+#: packages/admin/src/components/SectionEditor.tsx:82
+msgid "Section \"{slug}\" could not be found."
+msgstr "Section \"{slug}\" could not be found."
+
+#: packages/admin/src/components/Sections.tsx:93
+msgid "Section created"
+msgstr "Section created"
+
+#: packages/admin/src/components/Sections.tsx:107
+msgid "Section deleted"
+msgstr "Section deleted"
+
+#: packages/admin/src/components/SectionEditor.tsx:233
+msgid "Section Details"
+msgstr "Section Details"
+
+#: packages/admin/src/components/SectionEditor.tsx:78
+msgid "Section Not Found"
+msgstr "Section Not Found"
+
+#: packages/admin/src/components/SectionEditor.tsx:44
+msgid "Section saved"
+msgstr "Section saved"
+
+#: packages/admin/src/components/SectionEditor.tsx:239
+msgid "Section title"
+msgstr "Section title"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:177
+#: packages/admin/src/components/Sections.tsx:134
+#: packages/admin/src/components/Sidebar.tsx:355
+msgid "Sections"
+msgstr "Sections"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:308
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:305
+msgid "secure context"
+msgstr "secure context"
+
+#: packages/admin/src/components/SetupWizard.tsx:561
+msgid "Secure your account"
+msgstr "Secure your account"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:792
+#: packages/admin/src/components/Settings.tsx:92
+msgid "Security"
+msgstr "Security"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:307
+msgid "Security Audit"
+msgstr "Security Audit"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:340
+msgid "Security audit failed"
+msgstr "Security audit failed"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:330
+msgid "Security audit flagged concerns"
+msgstr "Security audit flagged concerns"
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:148
+msgid "Security audit flagged potential concerns with this plugin."
+msgstr "Security audit flagged potential concerns with this plugin."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:149
+msgid "Security audit flagged this plugin as potentially unsafe."
+msgstr "Security audit flagged this plugin as potentially unsafe."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:319
+msgid "Security audit passed"
+msgstr "Security audit passed"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:703
+msgid "Security contacts"
+msgstr "Security contacts"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:272
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:275
+msgid "Security error. Make sure you're on a secure connection."
+msgstr "Security error. Make sure you're on a secure connection."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:243
+#: packages/admin/src/components/Header.tsx:85
+#: packages/admin/src/components/settings/SecuritySettings.tsx:104
+msgid "Security Settings"
+msgstr "Security Settings"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:56
+#: packages/admin/src/components/FieldEditor.tsx:186
+#: packages/admin/src/components/FieldEditor.tsx:585
+msgid "Select"
+msgstr "Select"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:140
+#: packages/admin/src/components/ContentEditor.tsx:1737
+#: packages/admin/src/components/ContentEditor.tsx:1895
+#: packages/admin/src/components/ContentEditor.tsx:1911
+msgid "Select {label}"
+msgstr "Select {label}"
+
+#: packages/admin/src/components/Widgets.tsx:871
+msgid "Select a component..."
+msgstr "Select a component..."
+
+#: packages/admin/src/components/Widgets.tsx:839
+msgid "Select a menu..."
+msgstr "Select a menu..."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:283
+msgid "Select all"
+msgstr "Select all"
+
+#. placeholder {0}: comment.authorName
+#: packages/admin/src/components/comments/CommentInbox.tsx:456
+msgid "Select comment by {0}"
+msgstr "Select comment by {0}"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:117
+msgid "Select Content"
+msgstr "Select Content"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:268
+msgid "Select Default Social Image"
+msgstr "Select Default Social Image"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:283
+#: packages/admin/src/components/settings/GeneralSettings.tsx:344
+msgid "Select Favicon"
+msgstr "Select Favicon"
+
+#: packages/admin/src/components/ContentEditor.tsx:1899
+msgid "Select file"
+msgstr "Select file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:140
+msgid "Select File"
+msgstr "Select File"
+
+#: packages/admin/src/components/ContentEditor.tsx:1725
+msgid "Select image"
+msgstr "Select image"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:140
+#: packages/admin/src/components/PortableTextEditor.tsx:2417
+#: packages/admin/src/components/PortableTextEditor.tsx:3090
+#: packages/admin/src/components/settings/SeoSettings.tsx:221
+msgid "Select Image"
+msgstr "Select Image"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:229
+#: packages/admin/src/components/settings/GeneralSettings.tsx:336
+msgid "Select Logo"
+msgstr "Select Logo"
+
+#: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
+msgid "Select media"
+msgstr "Select media"
+
+#: packages/admin/src/components/SeoImageField.tsx:70
+msgid "Select OG image"
+msgstr "Select OG image"
+
+#: packages/admin/src/components/SeoImageField.tsx:82
+msgid "Select OG Image"
+msgstr "Select OG Image"
+
+#: packages/admin/src/components/WordPressImport.tsx:1571
+msgid "Select which content types to import."
+msgstr "Select which content types to import."
+
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:108
+#: packages/admin/src/components/PortableTextEditor.tsx:1826
+#: packages/admin/src/components/RepeaterField.tsx:361
+msgid "Select..."
+msgstr "Select..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:729
+msgid "Selected:"
+msgstr "Selected:"
+
+#: packages/admin/src/components/Settings.tsx:98
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:167
+msgid "Self-Signup Domains"
+msgstr "Self-Signup Domains"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:139
+msgid "Send a test email through the full pipeline to verify your email configuration."
+msgstr "Send a test email through the full pipeline to verify your email configuration."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:84
+msgid "Send an invitation email to a new team member."
+msgstr "Send an invitation email to a new team member."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+msgid "Send Invite"
+msgstr "Send Invite"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+msgid "Send magic link"
+msgstr "Send magic link"
+
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Send Recovery Link"
+msgstr "Send Recovery Link"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+msgid "Send Test"
+msgstr "Send Test"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:136
+msgid "Send Test Email"
+msgstr "Send Test Email"
+
+#: packages/admin/src/components/LoginPage.tsx:149
+#: packages/admin/src/components/settings/EmailSettings.tsx:153
+#: packages/admin/src/components/SignupPage.tsx:88
+#: packages/admin/src/components/SignupPage.tsx:151
+#: packages/admin/src/components/users/InviteUserModal.tsx:203
+#: packages/admin/src/components/users/UserDetail.tsx:332
+msgid "Sending..."
+msgstr "Sending..."
+
+#: packages/admin/src/components/ContentEditor.tsx:1050
+#: packages/admin/src/components/ContentTypeEditor.tsx:474
+#: packages/admin/src/components/Settings.tsx:81
+msgid "SEO"
+msgstr "SEO"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:105
+#: packages/admin/src/components/settings/SeoSettings.tsx:130
+msgid "SEO Settings"
+msgstr "SEO Settings"
+
+#: packages/admin/src/components/WordPressImport.tsx:1679
+msgid "SEO settings (Yoast)"
+msgstr "SEO settings (Yoast)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:57
+msgid "SEO settings saved"
+msgstr "SEO settings saved"
+
+#: packages/admin/src/components/SeoPanel.tsx:154
+msgid "SEO Title"
+msgstr "SEO Title"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:290
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:455
+msgid "Set a custom display size for this image instance."
+msgstr "Set a custom display size for this image instance."
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:170
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:174
+msgid "Set language"
+msgstr "Set language"
+
+#: packages/admin/src/components/editor/CodeBlockNode.tsx:171
+msgid "Set language (current: {label})"
+msgstr "Set language (current: {label})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:531
+msgid "Set to 0 to never close comments automatically."
+msgstr "Set to 0 to never close comments automatically."
+
+#: packages/admin/src/components/SetupWizard.tsx:559
+msgid "Set up your site"
+msgstr "Set up your site"
+
+#: packages/admin/src/components/SetupWizard.tsx:150
+msgid "Setting up..."
+msgstr "Setting up..."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:235
+#: packages/admin/src/components/ContentTypeEditor.tsx:383
+#: packages/admin/src/components/Header.tsx:93
+#: packages/admin/src/components/PluginManager.tsx:437
+#: packages/admin/src/components/Settings.tsx:62
+#: packages/admin/src/components/Sidebar.tsx:399
+#: packages/admin/src/components/WordPressImport.tsx:1647
+msgid "Settings"
+msgstr "Settings"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:90
+msgid "Settings Manage"
+msgstr "Settings Manage"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:85
+msgid "Settings Read"
+msgstr "Settings Read"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:53
+msgid "Settings saved successfully"
+msgstr "Settings saved successfully"
+
+#: packages/admin/src/components/SetupWizard.tsx:468
+msgid "Setup failed"
+msgstr "Setup failed"
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:109
+msgid "Share this link with the invited user"
+msgstr "Share this link with the invited user"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:294
+msgid "Shared across all translations of the same byline."
+msgstr "Shared across all translations of the same byline."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:52
+msgid "Short text"
+msgstr "Short text"
+
+#: packages/admin/src/components/FieldEditor.tsx:150
+#: packages/admin/src/components/FieldEditor.tsx:579
+msgid "Short Text"
+msgstr "Short Text"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:210
+msgid "Show token"
+msgstr "Show token"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:319
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:484
+msgid "Shown when hovering over the image."
+msgstr "Shown when hovering over the image."
+
+#: packages/admin/src/components/SignupPage.tsx:439
+msgid "Sign in"
+msgstr "Sign in"
+
+#: packages/admin/src/components/SetupWizard.tsx:355
+msgid "Sign In"
+msgstr "Sign In"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:129
+#: packages/admin/src/components/SignupPage.tsx:269
+msgid "Sign in instead"
+msgstr "Sign in instead"
+
+#: packages/admin/src/components/LoginPage.tsx:232
+msgid "Sign in to your site"
+msgstr "Sign in to your site"
+
+#. placeholder {0}: authProviderList.find((p) => p.id === activeProvider)?.label ?? activeProvider
+#. placeholder {0}: provider.label
+#: packages/admin/src/components/LoginPage.tsx:231
+#: packages/admin/src/components/SetupWizard.tsx:264
+msgid "Sign in with {0}"
+msgstr "Sign in with {0}"
+
+#: packages/admin/src/components/LoginPage.tsx:229
+msgid "Sign in with email"
+msgstr "Sign in with email"
+
+#: packages/admin/src/components/LoginPage.tsx:290
+msgid "Sign in with email link"
+msgstr "Sign in with email link"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:136
+#: packages/admin/src/components/LoginPage.tsx:252
+msgid "Sign in with Passkey"
+msgstr "Sign in with Passkey"
+
+#. placeholder {0}: user.email
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:190
+msgid "Signed in as {0}"
+msgstr "Signed in as {0}"
+
+#: packages/admin/src/components/FieldEditor.tsx:187
+msgid "Single choice from options"
+msgstr "Single choice from options"
+
+#: packages/admin/src/components/FieldEditor.tsx:151
+msgid "Single line text input"
+msgstr "Single line text input"
+
+#: packages/admin/src/components/SetupWizard.tsx:353
+msgid "Site"
+msgstr "Site"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:153
+msgid "Site Identity"
+msgstr "Site Identity"
+
+#: packages/admin/src/components/Settings.tsx:70
+msgid "Site identity, logo, favicon, and reading preferences"
+msgstr "Site identity, logo, favicon, and reading preferences"
+
+#: packages/admin/src/components/SetupWizard.tsx:351
+msgid "Site Settings"
+msgstr "Site Settings"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:156
+#: packages/admin/src/components/SetupWizard.tsx:116
+msgid "Site Title"
+msgstr "Site Title"
+
+#: packages/admin/src/components/WordPressImport.tsx:1659
+msgid "Site title & tagline"
+msgstr "Site title & tagline"
+
+#: packages/admin/src/components/SetupWizard.tsx:100
+msgid "Site title is required"
+msgstr "Site title is required"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:168
+msgid "Site URL"
+msgstr "Site URL"
+
+#: packages/admin/src/components/MediaLibrary.tsx:485
+msgid "Size"
+msgstr "Size"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:170
+msgid "Size:"
+msgstr "Size:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1940
+msgid "Skip Media Import"
+msgstr "Skip Media Import"
+
+#: packages/admin/src/components/WordPressImport.tsx:1965
+msgid "Skipped"
+msgstr "Skipped"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:239
+#: packages/admin/src/components/ContentEditor.tsx:845
+#: packages/admin/src/components/ContentEditor.tsx:2188
+#: packages/admin/src/components/ContentEditor.tsx:2250
+#: packages/admin/src/components/ContentTypeEditor.tsx:111
+#: packages/admin/src/components/ContentTypeEditor.tsx:404
+#: packages/admin/src/components/ContentTypeList.tsx:97
+#: packages/admin/src/components/FieldEditor.tsx:228
+#: packages/admin/src/components/FieldEditor.tsx:418
+#: packages/admin/src/components/SectionEditor.tsx:244
+#: packages/admin/src/components/Sections.tsx:184
+#: packages/admin/src/components/TaxonomyManager.tsx:398
+#: packages/admin/src/routes/byline-schema.tsx:237
+#: packages/admin/src/routes/bylines.tsx:473
+msgid "Slug"
+msgstr "Slug"
+
+#: packages/admin/src/components/Sections.tsx:124
+msgid "Slug copied to clipboard"
+msgstr "Slug copied to clipboard"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:251
+msgid "Slugs cannot be changed after the field is created."
+msgstr "Slugs cannot be changed after the field is created."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:904
+msgid "Small section heading"
+msgstr "Small section heading"
+
+#: packages/admin/src/components/Settings.tsx:75
+#: packages/admin/src/components/settings/SocialSettings.tsx:78
+#: packages/admin/src/components/settings/SocialSettings.tsx:103
+msgid "Social Links"
+msgstr "Social Links"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:48
+msgid "Social links saved"
+msgstr "Social links saved"
+
+#: packages/admin/src/components/Settings.tsx:76
+msgid "Social media profile links"
+msgstr "Social media profile links"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:126
+msgid "Social Profiles"
+msgstr "Social Profiles"
+
+#: packages/admin/src/components/WordPressImport.tsx:1696
+msgid "Some content types cannot be imported"
+msgstr "Some content types cannot be imported"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:122
+#: packages/admin/src/components/SignupPage.tsx:262
+msgid "Something went wrong"
+msgstr "Something went wrong"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:123
+msgid "Sort plugins"
+msgstr "Sort plugins"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:104
+msgid "Sort themes"
+msgstr "Sort themes"
+
+#: packages/admin/src/components/ContentTypeList.tsx:100
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:325
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:490
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:214
+#: packages/admin/src/components/PluginManager.tsx:497
+#: packages/admin/src/components/Redirects.tsx:440
+#: packages/admin/src/components/SectionEditor.tsx:279
+msgid "Source"
+msgstr "Source"
+
+#: packages/admin/src/components/Redirects.tsx:128
+msgid "Source path"
+msgstr "Source path"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:197
+msgid "spam"
+msgstr "spam"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:159
+#: packages/admin/src/components/comments/CommentInbox.tsx:207
+#: packages/admin/src/components/comments/CommentInbox.tsx:247
+msgid "Spam"
+msgstr "Spam"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3078
+msgid "Spotlight Mode"
+msgstr "Spotlight Mode"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:64
+msgid "Spreadsheets"
+msgstr "Spreadsheets"
+
+#: packages/admin/src/components/WordPressImport.tsx:1758
+msgid "Start Import"
+msgstr "Start Import"
+
+#: packages/admin/src/components/ContentEditor.tsx:851
+#: packages/admin/src/components/ContentList.tsx:273
+#: packages/admin/src/components/ContentTypeEditor.tsx:117
+#: packages/admin/src/components/Redirects.tsx:445
+#: packages/admin/src/components/users/UserList.tsx:104
+msgid "Status"
+msgstr "Status"
+
+#: packages/admin/src/components/Redirects.tsx:146
+msgid "Status code"
+msgstr "Status code"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:293
+msgid "Stored per locale — each translation of a byline gets its own value."
+msgstr "Stored per locale — each translation of a byline gets its own value."
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2562
+#: packages/admin/src/components/PortableTextEditor.tsx:2868
+msgid "Strikethrough"
+msgstr "Strikethrough"
+
+#: packages/admin/src/components/WordPressImport.tsx:1591
+msgid "Structure"
+msgstr "Structure"
+
+#: packages/admin/src/components/FieldEditor.tsx:523
+msgid "Sub-Fields"
+msgstr "Sub-Fields"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:18
+#: packages/admin/src/components/WelcomeModal.tsx:29
+msgid "Subscriber"
+msgstr "Subscriber"
+
+#: packages/admin/src/components/users/UserDetail.tsx:256
+msgid "Synced"
+msgstr "Synced"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:104
+msgid "Synced passkey"
+msgstr "Synced passkey"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:768
+msgid "System"
+msgstr "System"
+
+#: packages/admin/src/components/ThemeToggle.tsx:24
+msgid "System ({resolvedLabel})"
+msgstr "System ({resolvedLabel})"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:590
+msgid "System Fields"
+msgstr "System Fields"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:978
+msgid "Table"
+msgstr "Table"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:162
+#: packages/admin/src/components/SetupWizard.tsx:127
+msgid "Tagline"
+msgstr "Tagline"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:202
+msgid "Tags"
+msgstr "Tags"
+
+#. placeholder {0}: analysis.tags
+#: packages/admin/src/components/WordPressImport.tsx:1633
+msgid "Tags ({0})"
+msgstr "Tags ({0})"
+
+#: packages/admin/src/components/MenuEditor.tsx:348
+#: packages/admin/src/components/MenuEditor.tsx:519
+msgid "Target"
+msgstr "Target"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:172
+msgid "Target locale"
+msgstr "Target locale"
+
+#: packages/admin/src/components/TaxonomySidebar.tsx:537
+msgid "Taxonomies"
+msgstr "Taxonomies"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:75
+msgid "Taxonomies Manage"
+msgstr "Taxonomies Manage"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:898
+msgid "Taxonomy created"
+msgstr "Taxonomy created"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:785
+msgid "Taxonomy not found:"
+msgstr "Taxonomy not found:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:159
+msgid "Taxonomy: {taxonomyName}"
+msgstr "Taxonomy: {taxonomyName}"
+
+#: packages/admin/src/components/SetupWizard.tsx:155
+msgid "Template:"
+msgstr "Template:"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:361
+#: packages/admin/src/components/TaxonomyManager.tsx:362
+#: packages/admin/src/components/TaxonomyManager.tsx:814
+msgid "Term"
+msgstr "Term"
+
+#. placeholder {0}: term.label
+#. placeholder {1}: term.locale.toUpperCase()
+#: packages/admin/src/components/TaxonomyManager.tsx:759
+msgid "Term \"{0}\" created in {1}."
+msgstr "Term \"{0}\" created in {1}."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:741
+msgid "Term deleted"
+msgstr "Term deleted"
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:148
+msgid "test@example.com"
+msgstr "test@example.com"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2838
+msgid "Text formatting"
+msgstr "Text formatting"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:198
+msgid "The device will not be granted access."
+msgstr "The device will not be granted access."
+
+#: packages/admin/src/components/WordPressImport.tsx:1698
+msgid "The existing collection has fields with incompatible types."
+msgstr "The existing collection has fields with incompatible types."
+
+#: packages/admin/src/components/ContentTypeList.tsx:58
+msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+msgstr "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:181
+msgid "The invited user will have this role once they complete registration."
+msgstr "The invited user will have this role once they complete registration."
+
+#: packages/admin/src/components/LoginPage.tsx:113
+#: packages/admin/src/components/SignupPage.tsx:139
+msgid "The link will expire in 15 minutes."
+msgstr "The link will expire in 15 minutes."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:177
+msgid "The marketplace is empty. Check back later for new plugins."
+msgstr "The marketplace is empty. Check back later for new plugins."
+
+#: packages/admin/src/components/MenuList.tsx:75
+msgid "The menu has been deleted."
+msgstr "The menu has been deleted."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:159
+msgid "The name of your site, used in the header and metadata"
+msgstr "The name of your site, used in the header and metadata"
+
+#: packages/admin/src/router.tsx:1869
+msgid "The page you're looking for doesn't exist."
+msgstr "The page you're looking for doesn't exist."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:172
+msgid "The public URL of your site (used for canonical links and sitemaps)"
+msgstr "The public URL of your site (used for canonical links and sitemaps)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:189
+msgid "The referenced image is no longer available. Pick a new one or remove the reference."
+msgstr "The referenced image is no longer available. Pick a new one or remove the reference."
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:197
+msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
+msgstr "The referenced logo is no longer available. Pick a new one or remove the reference."
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
+msgid "The theme marketplace is empty. Check back later."
+msgstr "The theme marketplace is empty. Check back later."
+
+#: packages/admin/src/components/Sections.tsx:45
+msgid "Theme"
+msgstr "Theme"
+
+#. placeholder {0}: section.themeId
+#: packages/admin/src/components/SectionEditor.tsx:292
+msgid "Theme ID: {0}"
+msgstr "Theme ID: {0}"
+
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:91
+msgid "Theme not found"
+msgstr "Theme not found"
+
+#: packages/admin/src/components/SectionEditor.tsx:184
+msgid "Theme Section"
+msgstr "Theme Section"
+
+#: packages/admin/src/components/Sections.tsx:300
+msgid "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+msgstr "Theme-provided sections cannot be deleted. Edit the section to create a custom copy, then delete that."
+
+#: packages/admin/src/components/ThemeToggle.tsx:32
+msgid "Theme: {label}"
+msgstr "Theme: {label}"
+
+#: packages/admin/src/components/Sidebar.tsx:391
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:77
+msgid "Themes"
+msgstr "Themes"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:372
+msgid "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+msgstr "This collection is defined in code. Some settings cannot be changed here. Edit your live.config.ts file to modify the schema."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:413
+msgid "This field does not accept {sniffedMime} files."
+msgstr "This field does not accept {sniffedMime} files."
+
+#: packages/admin/src/components/ContentEditor.tsx:1741
+#: packages/admin/src/components/ContentEditor.tsx:1914
+msgid "This field is required"
+msgstr "This field is required"
+
+#: packages/admin/src/components/SectionEditor.tsx:286
+msgid "This is a custom section."
+msgstr "This is a custom section."
+
+#: packages/admin/src/components/WordPressImport.tsx:1147
+msgid "This is a WordPress site."
+msgstr "This is a WordPress site."
+
+#: packages/admin/src/components/users/InviteUserModal.tsx:112
+msgid "This link expires in 7 days and can only be used once."
+msgstr "This link expires in 7 days and can only be used once."
+
+#: packages/admin/src/components/WordPressImport.tsx:821
+msgid "This may take a while for large exports."
+msgstr "This may take a while for large exports."
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:269
+msgid "This passkey is already registered on this device."
+msgstr "This passkey is already registered on this device."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:276
+msgid "This plugin requires no special permissions."
+msgstr "This plugin requires no special permissions."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:564
+msgid "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+msgstr "This publisher claims a name they couldn't prove they own — possibly impersonating someone else. Install is disabled. If you know the publisher and trust them, ask them to fix their identity setup before retrying."
+
+#: packages/admin/src/components/Redirects.tsx:551
+msgid "This redirect rule will be permanently removed."
+msgstr "This redirect rule will be permanently removed."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:616
+msgid "This release requires a newer environment than your site currently runs. Upgrade before installing."
+msgstr "This release requires a newer environment than your site currently runs. Upgrade before installing."
+
+#: packages/admin/src/routes/bylines.tsx:606
+msgid "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+msgstr "This removes the byline profile. Content byline links are removed and lead pointers are cleared."
+
+#: packages/admin/src/components/SectionEditor.tsx:283
+msgid "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+msgstr "This section is provided by the theme. Editing will create a custom copy that overrides the theme version."
+
+#: packages/admin/src/components/SectionEditor.tsx:288
+msgid "This section was imported from another system."
+msgstr "This section was imported from another system."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:119
+msgid "This update exposes the following routes without authentication:"
+msgstr "This update exposes the following routes without authentication:"
+
+#: packages/admin/src/components/Widgets.tsx:635
+msgid "This will delete the widget area and all its widgets. This action cannot be undone."
+msgstr "This will delete the widget area and all its widgets. This action cannot be undone."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:276
+msgid "This will grant CLI access with your permissions."
+msgstr "This will grant CLI access with your permissions."
+
+#: packages/admin/src/components/ContentEditor.tsx:958
+msgid "This will move the item to trash. You can restore it later from the trash."
+msgstr "This will move the item to trash. You can restore it later from the trash."
+
+#. placeholder {0}: deleteTarget?.label
+#: packages/admin/src/components/TaxonomyManager.tsx:884
+msgid "This will permanently delete \"{0}\" and remove it from all content."
+msgstr "This will permanently delete \"{0}\" and remove it from all content."
+
+#. placeholder {0}: sectionToDelete?.title
+#: packages/admin/src/components/Sections.tsx:304
+msgid "This will permanently delete \"{0}\". This action cannot be undone."
+msgstr "This will permanently delete \"{0}\". This action cannot be undone."
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:406
+msgid "This will permanently delete this comment. This action cannot be undone."
+msgstr "This will permanently delete this comment. This action cannot be undone."
+
+#: packages/admin/src/components/PluginManager.tsx:629
+msgid "This will remove the plugin and its bundle from your site."
+msgstr "This will remove the plugin and its bundle from your site."
+
+#: packages/admin/src/components/ContentEditor.tsx:701
+msgid "This will revert to the published version. Your draft changes will be lost."
+msgstr "This will revert to the published version. Your draft changes will be lost."
+
+#: packages/admin/src/components/SetupWizard.tsx:131
+msgid "Thoughts, tutorials, and more"
+msgstr "Thoughts, tutorials, and more"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:310
+msgid "Timezone"
+msgstr "Timezone"
+
+#: packages/admin/src/components/settings/GeneralSettings.tsx:313
+msgid "Timezone for displaying dates (e.g., America/New_York)"
+msgstr "Timezone for displaying dates (e.g., America/New_York)"
+
+#: packages/admin/src/components/ContentList.tsx:267
+#: packages/admin/src/components/ContentList.tsx:402
+#: packages/admin/src/components/SectionEditor.tsx:236
+#: packages/admin/src/components/Sections.tsx:170
+#: packages/admin/src/components/Widgets.tsx:811
+msgid "Title"
+msgstr "Title"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:315
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:480
+msgid "Title (Tooltip)"
+msgstr "Title (Tooltip)"
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:159
+msgid "Title Separator"
+msgstr "Title Separator"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:470
+msgid "to close"
+msgstr "to close"
+
+#: packages/admin/src/components/PluginManager.tsx:203
+msgid "to install plugins, or add them to your astro.config.mjs."
+msgstr "to install plugins, or add them to your astro.config.mjs."
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:460
+msgid "to select"
+msgstr "to select"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2654
+msgid "Toggle header row"
+msgstr "Toggle header row"
+
+#: packages/admin/src/components/ThemeToggle.tsx:30
+#: packages/admin/src/components/ThemeToggle.tsx:41
+msgid "Toggle theme (current: {label})"
+msgstr "Toggle theme (current: {label})"
+
+#. placeholder {0}: newToken.info.name
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:197
+msgid "Token created: {0}"
+msgstr "Token created: {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:407
+msgid "Token Name"
+msgstr "Token Name"
+
+#: packages/admin/src/components/WordPressImport.tsx:1116
+msgid "Tools → Export"
+msgstr "Tools → Export"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:77
+msgid "Track content history"
+msgstr "Track content history"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:287
+#: packages/admin/src/routes/byline-schema.tsx:243
+msgid "Translatable"
+msgstr "Translatable"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:83
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translate"
+msgstr "Translate"
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:156
+msgid "Translate \"{0}\""
+msgstr "Translate \"{0}\""
+
+#. placeholder {0}: term.label
+#: packages/admin/src/components/TaxonomyManager.tsx:80
+msgid "Translate {0}"
+msgstr "Translate {0}"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:194
+#: packages/admin/src/components/TranslationsPanel.tsx:99
+msgid "Translating..."
+msgstr "Translating..."
+
+#: packages/admin/src/components/MenuEditor.tsx:89
+#: packages/admin/src/components/TaxonomyManager.tsx:758
+#: packages/admin/src/router.tsx:884
+msgid "Translation created"
+msgstr "Translation created"
+
+#: packages/admin/src/components/TranslationsPanel.tsx:56
+msgid "Translations"
+msgstr "Translations"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:198
+msgid "trash"
+msgstr "trash"
+
+#: packages/admin/src/components/comments/CommentDetail.tsx:170
+#: packages/admin/src/components/comments/CommentInbox.tsx:216
+#: packages/admin/src/components/comments/CommentInbox.tsx:257
+#: packages/admin/src/components/comments/CommentInbox.tsx:513
+#: packages/admin/src/components/ContentList.tsx:247
+msgid "Trash"
+msgstr "Trash"
+
+#: packages/admin/src/components/ContentList.tsx:425
+msgid "Trash is empty"
+msgstr "Trash is empty"
+
+#: packages/admin/src/components/comments/CommentInbox.tsx:549
+msgid "Trash is empty."
+msgstr "Trash is empty."
+
+#: packages/admin/src/components/FieldEditor.tsx:175
+msgid "True/false toggle"
+msgstr "True/false toggle"
+
+#: packages/admin/src/components/MediaLibrary.tsx:433
+#: packages/admin/src/components/MediaPickerModal.tsx:638
+msgid "Try a different search term"
+msgstr "Try a different search term"
+
+#: packages/admin/src/components/ContentPickerModal.tsx:172
+#: packages/admin/src/components/SectionPickerModal.tsx:102
+msgid "Try adjusting your search"
+msgstr "Try adjusting your search"
+
+#: packages/admin/src/components/Sections.tsx:260
+msgid "Try adjusting your search or filters."
+msgstr "Try adjusting your search or filters."
+
+#: packages/admin/src/routes/users.tsx:210
+msgid "Try again"
+msgstr "Try again"
+
+#: packages/admin/src/components/WordPressImport.tsx:1421
+msgid "Try Again"
+msgstr "Try Again"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:207
+msgid "Try another code"
+msgstr "Try another code"
+
+#: packages/admin/src/components/WordPressImport.tsx:1125
+#: packages/admin/src/components/WordPressImport.tsx:1247
+msgid "Try Another URL"
+msgstr "Try Another URL"
+
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:252
+#: packages/admin/src/components/ThemeMarketplaceDetail.tsx:143
+msgid "Try with my data"
+msgstr "Try with my data"
+
+#: packages/admin/src/components/editor/BlockMenu.tsx:282
+msgid "Turn into"
+msgstr "Turn into"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:132
+msgid "Twitter"
+msgstr "Twitter"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:260
+#: packages/admin/src/components/FieldEditor.tsx:571
+#: packages/admin/src/components/MediaLibrary.tsx:484
+#: packages/admin/src/routes/byline-schema.tsx:240
+msgid "Type"
+msgstr "Type"
+
+#. placeholder {0}: status.existingType
+#: packages/admin/src/components/WordPressImport.tsx:1854
+msgid "Type mismatch ({0})"
+msgstr "Type mismatch ({0})"
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:131
+#: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
+msgid "Unable to reach marketplace"
+msgstr "Unable to reach marketplace"
+
+#: packages/admin/src/components/ContentEditor.tsx:2293
+#: packages/admin/src/components/ContentEditor.tsx:2308
+msgid "Unassigned"
+msgstr "Unassigned"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:2555
+#: packages/admin/src/components/PortableTextEditor.tsx:2861
+msgid "Underline"
+msgstr "Underline"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3058
+msgid "Undo"
+msgstr "Undo"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:180
+#: packages/admin/src/components/PluginManager.tsx:547
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstall"
+msgstr "Uninstall"
+
+#: packages/admin/src/components/PluginManager.tsx:627
+msgid "Uninstall {pluginName}?"
+msgstr "Uninstall {pluginName}?"
+
+#: packages/admin/src/components/PluginManager.tsx:622
+msgid "Uninstall confirmation"
+msgstr "Uninstall confirmation"
+
+#: packages/admin/src/components/PluginManager.tsx:643
+msgid "Uninstalling..."
+msgstr "Uninstalling..."
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:722
+#: packages/admin/src/components/FieldEditor.tsx:442
+msgid "Unique"
+msgstr "Unique"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:107
+msgid "Unique identifier (ULID)"
+msgstr "Unique identifier (ULID)"
+
+#: packages/admin/src/components/users/useRolesConfig.ts:7
+msgid "Unknown"
+msgstr "Unknown"
+
+#: packages/admin/src/components/users/roleDefinitions.ts:62
+msgid "Unknown role"
+msgstr "Unknown role"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:271
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:272
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:436
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:437
+msgid "Unlock aspect ratio"
+msgstr "Unlock aspect ratio"
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:152
+#: packages/admin/src/components/users/UserDetail.tsx:254
+msgid "Unnamed passkey"
+msgstr "Unnamed passkey"
+
+#: packages/admin/src/components/ContentEditor.tsx:730
+msgid "Unpublish"
+msgstr "Unpublish"
+
+#: packages/admin/src/router.tsx:801
+msgid "Unpublished"
+msgstr "Unpublished"
+
+#: packages/admin/src/components/ContentTypeList.tsx:55
+msgid "Unregistered Content Tables Found"
+msgstr "Unregistered Content Tables Found"
+
+#: packages/admin/src/components/ContentEditor.tsx:876
+msgid "Unschedule"
+msgstr "Unschedule"
+
+#: packages/admin/src/router.tsx:854
+msgid "Unscheduled"
+msgstr "Unscheduled"
+
+#. placeholder {0}: (element as { type: string }).type
+#: packages/admin/src/components/BlockKitFieldWidget.tsx:128
+msgid "Unsupported widget element type: {0}"
+msgstr "Unsupported widget element type: {0}"
+
+#: packages/admin/src/components/Dashboard.tsx:249
+msgid "Untitled"
+msgstr "Untitled"
+
+#: packages/admin/src/components/ContentEditor.tsx:1817
+msgid "Untitled file"
+msgstr "Untitled file"
+
+#: packages/admin/src/components/Widgets.tsx:466
+#: packages/admin/src/components/Widgets.tsx:729
+msgid "Untitled Widget"
+msgstr "Untitled Widget"
+
+#: packages/admin/src/components/PublisherHandle.tsx:145
+msgid "Unverified publisher"
+msgstr "Unverified publisher"
+
+#: packages/admin/src/components/ContentEditor.tsx:2120
+msgid "Up"
+msgstr "Up"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:478
+msgid "Update"
+msgstr "Update"
+
+#: packages/admin/src/components/FieldEditor.tsx:659
+msgid "Update Field"
+msgstr "Update Field"
+
+#. placeholder {0}: editingDomain?.domain
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:367
+msgid "Update settings for {0}"
+msgstr "Update settings for {0}"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:91
+msgid "Update site settings"
+msgstr "Update site settings"
+
+#. placeholder {0}: taxonomyDef.labelSingular?.toLowerCase() || "term"
+#: packages/admin/src/components/TaxonomyManager.tsx:366
+msgid "Update the {0} details"
+msgstr "Update the {0} details"
+
+#: packages/admin/src/components/Redirects.tsx:106
+msgid "Update this redirect rule."
+msgstr "Update this redirect rule."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Update to v{0}"
+msgstr "Update to v{0}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:486
+msgid "Updated"
+msgstr "Updated"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:129
+msgid "Updated At"
+msgstr "Updated At"
+
+#. placeholder {0}: new Date(item.updatedAt).toLocaleString()
+#: packages/admin/src/components/ContentEditor.tsx:933
+msgid "Updated: {0}"
+msgstr "Updated: {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:844
+msgid "Updating content URLs..."
+msgstr "Updating content URLs..."
+
+#: packages/admin/src/components/CapabilityConsentDialog.tsx:166
+#: packages/admin/src/components/PluginManager.tsx:417
+msgid "Updating..."
+msgstr "Updating..."
+
+#: packages/admin/src/components/MediaPickerModal.tsx:596
+msgid "Upload"
+msgstr "Upload"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:142
+msgid "Upload a file to get started"
+msgstr "Upload a file to get started"
+
+#: packages/admin/src/components/WordPressImport.tsx:1230
+msgid "Upload an export file"
+msgstr "Upload an export file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:143
+msgid "Upload an image to get started"
+msgstr "Upload an image to get started"
+
+#: packages/admin/src/components/settings/ApiTokenSettings.tsx:61
+msgid "Upload and delete media"
+msgstr "Upload and delete media"
+
+#: packages/admin/src/lib/api/marketplace.ts:225
+#: packages/admin/src/lib/api/marketplace.ts:233
+msgid "Upload and manage media"
+msgstr "Upload and manage media"
+
+#: packages/admin/src/components/WordPressImport.tsx:1123
+#: packages/admin/src/components/WordPressImport.tsx:1244
+msgid "Upload Export File"
+msgstr "Upload Export File"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:616
+msgid "Upload failed: {uploadError}"
+msgstr "Upload failed: {uploadError}"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:608
+msgid "Upload file"
+msgstr "Upload file"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Upload File"
+msgstr "Upload File"
+
+#: packages/admin/src/components/MediaLibrary.tsx:361
+msgid "Upload files"
+msgstr "Upload files"
+
+#: packages/admin/src/components/MediaLibrary.tsx:424
+msgid "Upload Files"
+msgstr "Upload Files"
+
+#: packages/admin/src/components/MediaPickerModal.tsx:144
+msgid "Upload Image"
+msgstr "Upload Image"
+
+#: packages/admin/src/components/MediaLibrary.tsx:421
+msgid "Upload images, videos, and documents to get started."
+msgstr "Upload images, videos, and documents to get started."
+
+#: packages/admin/src/components/Dashboard.tsx:89
+msgid "Upload Media"
+msgstr "Upload Media"
+
+#: packages/admin/src/components/MediaLibrary.tsx:435
+msgid "Upload media to get started"
+msgstr "Upload media to get started"
+
+#. placeholder {0}: activeProviderInfo?.name || t`Library`
+#: packages/admin/src/components/MediaLibrary.tsx:352
+msgid "Upload to {0}"
+msgstr "Upload to {0}"
+
+#: packages/admin/src/components/WordPressImport.tsx:960
+msgid "Upload WordPress export file"
+msgstr "Upload WordPress export file"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:184
+msgid "Uploaded:"
+msgstr "Uploaded:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1963
+msgid "Uploading"
+msgstr "Uploading"
+
+#. placeholder {0}: uploadState.progress.current
+#. placeholder {1}: uploadState.progress.total
+#: packages/admin/src/components/MediaLibrary.tsx:327
+msgid "Uploading {0}/{1}..."
+msgstr "Uploading {0}/{1}..."
+
+#: packages/admin/src/components/MediaLibrary.tsx:328
+#: packages/admin/src/components/MediaPickerModal.tsx:596
+msgid "Uploading..."
+msgstr "Uploading..."
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:54
+#: packages/admin/src/components/FieldEditor.tsx:234
+#: packages/admin/src/components/FieldEditor.tsx:586
+#: packages/admin/src/components/MenuEditor.tsx:339
+#: packages/admin/src/components/MenuEditor.tsx:509
+#: packages/admin/src/components/PortableTextEditor.tsx:2994
+msgid "URL"
+msgstr "URL"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:425
+msgid "URL Pattern"
+msgstr "URL Pattern"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:113
+#: packages/admin/src/components/FieldEditor.tsx:229
+msgid "URL-friendly identifier"
+msgstr "URL-friendly identifier"
+
+#: packages/admin/src/components/MenuList.tsx:162
+msgid "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+msgstr "URL-friendly identifier (e.g., \"primary\", \"footer\")"
+
+#: packages/admin/src/components/Redirects.tsx:107
+msgid "Use [param] or [...rest] in paths for pattern matching."
+msgstr "Use [param] or [...rest] in paths for pattern matching."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:366
+msgid "Use your device's biometric authentication, security key, or PIN to sign in."
+msgstr "Use your device's biometric authentication, security key, or PIN to sign in."
+
+#: packages/admin/src/components/LoginPage.tsx:326
+msgid "Use your registered passkey to sign in securely."
+msgstr "Use your registered passkey to sign in securely."
+
+#: packages/admin/src/components/settings/SeoSettings.tsx:173
+msgid "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+msgstr "Used as the fallback Open Graph image when a page has none. Recommended size: 1200×630."
+
+#: packages/admin/src/components/TaxonomyManager.tsx:644
+msgid "Used as the identifier. Lowercase letters, numbers, and underscores only."
+msgstr "Used as the identifier. Lowercase letters, numbers, and underscores only."
+
+#: packages/admin/src/components/ContentEditor.tsx:1332
+msgid "Used as the main visual for this post on listing pages and at the top of the post"
+msgstr "Used as the main visual for this post on listing pages and at the top of the post"
+
+#: packages/admin/src/components/MediaDetailPanel.tsx:206
+msgid "Used by screen readers and when image fails to load"
+msgstr "Used by screen readers and when image fails to load"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:410
+msgid "Used in URLs and API endpoints"
+msgstr "Used in URLs and API endpoints"
+
+#: packages/admin/src/components/SectionEditor.tsx:254
+#: packages/admin/src/components/Sections.tsx:196
+msgid "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+msgstr "Used to identify this section. Lowercase letters, numbers, and hyphens only."
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:223
+#: packages/admin/src/components/Header.tsx:37
+#: packages/admin/src/components/Header.tsx:75
+#: packages/admin/src/components/users/UserList.tsx:98
+msgid "User"
+msgstr "User"
+
+#. placeholder {0}: manifest?.authMode
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:192
+msgid "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+msgstr "User access is managed by an external provider ({0}). Self-signup domain settings are not available when using external authentication."
+
+#: packages/admin/src/components/users/UserDetail.tsx:116
+msgid "User Details"
+msgstr "User Details"
+
+#: packages/admin/src/components/users/UserDetail.tsx:296
+msgid "User not found"
+msgstr "User not found"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:211
+#: packages/admin/src/components/Sidebar.tsx:368
+#: packages/admin/src/components/users/UserList.tsx:54
+msgid "Users"
+msgstr "Users"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:416
+msgid "Users from"
+msgstr "Users from"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:244
+msgid "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+msgstr "Users with email addresses from these domains can sign up without an invite. They will be assigned the specified role automatically."
+
+#. placeholder {0}: updateInfo.latest
+#: packages/admin/src/components/PluginManager.tsx:358
+msgid "v{0} available"
+msgstr "v{0} available"
+
+#: packages/admin/src/components/FieldEditor.tsx:460
+#: packages/admin/src/components/FieldEditor.tsx:490
+msgid "Validation"
+msgstr "Validation"
+
+#: packages/admin/src/components/RegistryBrowse.tsx:186
+#: packages/admin/src/components/RegistryPluginDetail.tsx:447
+msgid "Verified publisher"
+msgstr "Verified publisher"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:446
+msgid "Verified publisher, confirmed by labeller {verifiedLabeller}"
+msgstr "Verified publisher, confirmed by labeller {verifiedLabeller}"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:437
+msgid "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+msgstr "Verified publisher. A labeller ({verifiedLabeller}) has confirmed this publisher's identity."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:438
+msgid "Verified publisher. A labeller has confirmed this publisher's identity."
+msgstr "Verified publisher. A labeller has confirmed this publisher's identity."
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:194
+msgid "Verifying your invite..."
+msgstr "Verifying your invite..."
+
+#: packages/admin/src/components/SignupPage.tsx:386
+msgid "Verifying your link..."
+msgstr "Verifying your link..."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:213
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:215
+msgid "Verifying..."
+msgstr "Verifying..."
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:320
+#: packages/admin/src/components/RegistryPluginDetail.tsx:500
+msgid "Version"
+msgstr "Version"
+
+#. placeholder {0}: release.version
+#: packages/admin/src/components/RegistryPluginDetail.tsx:462
+msgid "Version {0}"
+msgstr "Version {0}"
+
+#: packages/admin/src/components/AllowedTypesEditor.tsx:67
+#: packages/admin/src/components/MediaLibrary.tsx:395
+msgid "Video"
+msgstr "Video"
+
+#: packages/admin/src/components/Settings.tsx:116
+msgid "View email provider status and send test emails"
+msgstr "View email provider status and send test emails"
+
+#: packages/admin/src/components/PluginManager.tsx:429
+msgid "View in Marketplace"
+msgstr "View in Marketplace"
+
+#: packages/admin/src/components/MediaLibrary.tsx:265
+msgid "View mode"
+msgstr "View mode"
+
+#: packages/admin/src/components/ContentList.tsx:617
+msgid "View published {title}"
+msgstr "View published {title}"
+
+#: packages/admin/src/components/Header.tsx:51
+msgid "View Site"
+msgstr "View Site"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:661
+msgid "View source"
+msgstr "View source"
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:936
+msgid "View the {license} license on spdx.org"
+msgstr "View the {license} licence on spdx.org"
+
+#: packages/admin/src/components/Redirects.tsx:422
+msgid "Visitors hitting these paths will see an error."
+msgstr "Visitors hitting these paths will see an error."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:180
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
+msgid "Waiting for passkey..."
+msgstr "Waiting for passkey..."
+
+#: packages/admin/src/components/MarketplaceBrowse.tsx:333
+msgid "Warn"
+msgstr "Warn"
+
+#. placeholder {0}: result.url
+#: packages/admin/src/components/WordPressImport.tsx:1105
+msgid "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+msgstr "We couldn't connect to a WordPress site at {0}. This could mean the site isn't WordPress, the REST API is disabled, or the site isn't accessible."
+
+#: packages/admin/src/components/RegistryPluginDetail.tsx:562
+msgid "We couldn't verify this publisher's identity"
+msgstr "We couldn't verify this publisher's identity"
+
+#: packages/admin/src/components/WordPressImport.tsx:926
+msgid "We'll check what import options are available for your site."
+msgstr "We'll check what import options are available for your site."
+
+#: packages/admin/src/components/LoginPage.tsx:323
+msgid "We'll send you a link to sign in without a password."
+msgstr "We'll send you a link to sign in without a password."
+
+#: packages/admin/src/components/SignupPage.tsx:132
+msgid "We've sent a verification link to"
+msgstr "We've sent a verification link to"
+
+#: packages/admin/src/components/FieldEditor.tsx:235
+msgid "Web address"
+msgstr "Web address"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:159
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:163
+msgid "WebAuthn is not supported in this browser"
+msgstr "WebAuthn is not supported in this browser"
+
+#: packages/admin/src/components/MarketplacePluginDetail.tsx:225
+#: packages/admin/src/components/RegistryPluginDetail.tsx:686
+msgid "Website"
+msgstr "Website"
+
+#: packages/admin/src/routes/bylines.tsx:478
+msgid "Website URL"
+msgstr "Website URL"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash, {firstName}!"
+msgstr "Welcome to EmDash, {firstName}!"
+
+#: packages/admin/src/components/WelcomeModal.tsx:96
+msgid "Welcome to EmDash!"
+msgstr "Welcome to EmDash!"
+
+#: packages/admin/src/components/WordPressImport.tsx:1927
+msgid "What happens when you import:"
+msgstr "What happens when you import:"
+
+#: packages/admin/src/components/WordPressImport.tsx:1710
+msgid "What will happen when you import"
+msgstr "What will happen when you import"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:125
+msgid "When the entry was created"
+msgstr "When the entry was created"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:131
+msgid "When the entry was last modified"
+msgstr "When the entry was last modified"
+
+#: packages/admin/src/components/ContentTypeEditor.tsx:137
+msgid "When the entry was published"
+msgstr "When the entry was published"
+
+#: packages/admin/src/components/TaxonomyManager.tsx:658
+msgid "Which content types can use this taxonomy"
+msgstr "Which content types can use this taxonomy"
+
+#: packages/admin/src/components/FieldEditor.tsx:169
+msgid "Whole number"
+msgstr "Whole number"
+
+#: packages/admin/src/components/Widgets.tsx:722
+#: packages/admin/src/components/Widgets.tsx:737
+msgid "widget"
+msgstr "widget"
+
+#: packages/admin/src/components/Widgets.tsx:170
+msgid "Widget added"
+msgstr "Widget added"
+
+#: packages/admin/src/components/Widgets.tsx:158
+msgid "Widget area created"
+msgstr "Widget area created"
+
+#: packages/admin/src/components/Widgets.tsx:565
+msgid "Widget area deleted"
+msgstr "Widget area deleted"
+
+#: packages/admin/src/components/Widgets.tsx:685
+msgid "Widget deleted"
+msgstr "Widget deleted"
+
+#: packages/admin/src/components/Widgets.tsx:814
+msgid "Widget title"
+msgstr "Widget title"
+
+#: packages/admin/src/components/Widgets.tsx:700
+msgid "Widget updated"
+msgstr "Widget updated"
+
+#: packages/admin/src/components/AdminCommandPalette.tsx:169
+#: packages/admin/src/components/PluginManager.tsx:379
+#: packages/admin/src/components/Sidebar.tsx:354
+#: packages/admin/src/components/Widgets.tsx:325
+msgid "Widgets"
+msgstr "Widgets"
+
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:260
+#: packages/admin/src/components/editor/ImageDetailPanel.tsx:425
+msgid "Width"
+msgstr "Width"
+
+#: packages/admin/src/components/WordPressImport.tsx:1850
+msgid "Will create"
+msgstr "Will create"
+
+#: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:417
+msgid "will no longer be able to sign up without an invite. Existing users are not affected."
+msgstr "will no longer be able to sign up without an invite. Existing users are not affected."
+
+#: packages/admin/src/components/settings/EmailSettings.tsx:184
+msgid "Without an email provider, invite links must be shared manually."
+msgstr "Without an email provider, invite links must be shared manually."
+
+#: packages/admin/src/components/WordPressImport.tsx:1315
+msgid "WordPress Username"
+msgstr "WordPress Username"
+
+#: packages/admin/src/components/Widgets.tsx:824
+msgid "Write widget content..."
+msgstr "Write widget content..."
+
+#: packages/admin/src/components/WordPressImport.tsx:1023
+msgid "WXR File"
+msgstr "WXR File"
+
+#: packages/admin/src/components/users/UserDetail.tsx:236
+#: packages/admin/src/routes/byline-schema.tsx:420
+#: packages/admin/src/routes/byline-schema.tsx:422
+msgid "Yes"
+msgstr "Yes"
+
+#: packages/admin/src/components/DeviceAuthorizePage.tsx:188
+msgid "You can close this page and return to your terminal."
+msgstr "You can close this page and return to your terminal."
+
+#: packages/admin/src/components/WelcomeModal.tsx:43
+msgid "You can create and edit your own content."
+msgstr "You can create and edit your own content."
+
+#: packages/admin/src/components/WelcomeModal.tsx:42
+msgid "You can manage content, media, menus, and taxonomies."
+msgstr "You can manage content, media, menus, and taxonomies."
+
+#: packages/admin/src/routes/bylines.tsx:532
+msgid "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+msgstr "You can still edit the fixed fields above. Saving will not touch any stored custom-field values."
+
+#: packages/admin/src/components/WelcomeModal.tsx:44
+msgid "You can view and contribute to the site."
+msgstr "You can view and contribute to the site."
+
+#: packages/admin/src/components/users/UserDetail.tsx:175
+msgid "You cannot change your own role"
+msgstr "You cannot change your own role"
+
+#: packages/admin/src/components/WelcomeModal.tsx:41
+msgid "You have full access to manage this site, including users, settings, and all content."
+msgstr "You have full access to manage this site, including users, settings, and all content."
+
+#: packages/admin/src/routes/byline-schema.tsx:175
+msgid "You need admin permissions to manage byline schema."
+msgstr "You need admin permissions to manage byline schema."
+
+#: packages/admin/src/router.tsx:1203
+msgid "You need Editor permissions to moderate comments."
+msgstr "You need Editor permissions to moderate comments."
+
+#. placeholder {0}: passkey.name
+#: packages/admin/src/components/settings/PasskeyItem.tsx:206
+msgid "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+msgstr "You won't be able to use \"{0}\" to sign in anymore. This action cannot be undone."
+
+#: packages/admin/src/components/settings/PasskeyItem.tsx:207
+msgid "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+msgstr "You won't be able to use this passkey to sign in anymore. This action cannot be undone."
+
+#. placeholder {0}: inviteData.roleName
+#: packages/admin/src/components/InviteAcceptPage.tsx:52
+msgid "You'll be joining as <0>{0}</0>"
+msgstr "You'll be joining as <0>{0}</0>"
+
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:369
+msgid "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+msgstr "You'll be prompted to use your device's biometric authentication, security key, or PIN."
+
+#: packages/admin/src/components/WordPressImport.tsx:1208
+msgid "You'll be redirected to WordPress to authorize the connection."
+msgstr "You'll be redirected to WordPress to authorise the connection."
+
+#: packages/admin/src/components/SignupPage.tsx:191
+msgid "You'll be signing up as"
+msgstr "You'll be signing up as"
+
+#: packages/admin/src/components/SetupWizard.tsx:564
+msgid "You're signed in via Cloudflare Access"
+msgstr "You're signed in via Cloudflare Access"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:50
+msgid "You've been invited!"
+msgstr "You've been invited!"
+
+#: packages/admin/src/components/SignupPage.tsx:70
+msgid "you@company.com"
+msgstr "you@company.com"
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:336
+#: packages/admin/src/components/SetupWizard.tsx:201
+msgid "you@example.com"
+msgstr "you@example.com"
+
+#: packages/admin/src/components/WelcomeModal.tsx:39
+msgid "Your account has been created successfully."
+msgstr "Your account has been created successfully."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:318
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:315
+msgid "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+msgstr "Your browser doesn't support passkeys. Please use a modern browser like Chrome, Safari, Firefox, or Edge."
+
+#: packages/admin/src/components/auth/PasskeyLogin.tsx:269
+#: packages/admin/src/components/auth/PasskeyRegistration.tsx:272
+msgid "Your device doesn't support the required security features."
+msgstr "Your device doesn't support the required security features."
+
+#: packages/admin/src/components/SetupWizard.tsx:197
+msgid "Your Email"
+msgstr "Your Email"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:147
+msgid "Your Facebook page or profile username"
+msgstr "Your Facebook page or profile username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:141
+msgid "Your GitHub username"
+msgstr "Your GitHub username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:153
+msgid "Your Instagram username"
+msgstr "Your Instagram username"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:159
+msgid "Your LinkedIn profile username"
+msgstr "Your LinkedIn profile username"
+
+#: packages/admin/src/components/SetupWizard.tsx:209
+msgid "Your Name"
+msgstr "Your Name"
+
+#: packages/admin/src/components/InviteAcceptPage.tsx:62
+#: packages/admin/src/components/SignupPage.tsx:201
+msgid "Your name (optional)"
+msgstr "Your name (optional)"
+
+#: packages/admin/src/components/WelcomeModal.tsx:40
+msgid "Your Role"
+msgstr "Your Role"
+
+#. placeholder {0}: formatHoldback(config.policy?.minimumReleaseAgeSeconds ?? 0)
+#: packages/admin/src/components/RegistryPluginDetail.tsx:597
+msgid "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+msgstr "Your site requires releases to be at least {0} old before they can be installed. This release will become installable later."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:135
+msgid "Your Twitter/X handle (e.g., @username)"
+msgstr "Your Twitter/X handle (e.g., @username)"
+
+#. placeholder {0}: attachments.count
+#: packages/admin/src/components/WordPressImport.tsx:1898
+msgid "Your WordPress export contains {0} media files."
+msgstr "Your WordPress export contains {0} media files."
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:165
+msgid "Your YouTube channel ID or handle"
+msgstr "Your YouTube channel ID or handle"
+
+#: packages/admin/src/components/settings/SocialSettings.tsx:162
+msgid "YouTube"
+msgstr "YouTube"

--- a/packages/admin/src/locales/locales.ts
+++ b/packages/admin/src/locales/locales.ts
@@ -36,6 +36,7 @@ export const LOCALES: LocaleDefinition[] = [
 	{ code: "eu", label: "Euskara", enabled: true }, // Basque
 	{ code: "zh-CN", label: "简体中文", enabled: true }, // Chinese (Simplified)
 	{ code: "zh-TW", label: "繁體中文", enabled: true }, // Chinese (Traditional)
+	{ code: "en-GB", label: "English (UK)", enabled: true }, // English (United Kingdom)
 	{ code: "fa", label: "فارسی", enabled: true, dir: "rtl" }, // Farsi (also known as Persian)
 	{ code: "fr", label: "Français", enabled: true }, // French
 	{ code: "de", label: "Deutsch", enabled: true }, // German


### PR DESCRIPTION
## What does this PR do?

Adds an **English (UK)** locale, following the documented workflow in `locales.ts` (entry added in the alphabetical slot, PO catalogue at `src/locales/en-GB/messages.po`, changeset included).

**Scope: spelling and morphology only.** Terminology is deliberately untouched (e.g. "Trash" stays "Trash") so the locale stays uncontroversial - it's the same English, spelt British: *analyse, authorise, organise, recognise, cancelled, centred, Align Centre, Search Engine Optimisation, licence (noun)*, etc.

- 19 strings differ from `en`; every other `msgstr` mirrors the source, so coverage is 100% and the locale ships `enabled: true`.
- ICU placeholders are untouched (e.g. `View the {license} licence on spdx.org` keeps the `{license}` variable).
- en-GB browsers are auto-matched by the existing `Accept-Language` BCP 47 resolution, so UK users get this with zero configuration.
- The line count is the full PO catalogue - the code change is one registration line in `locales.ts`.

Happy to adjust the label wording ("English (UK)" vs "English (United Kingdom)") or the enabled default to your preference.

No linked issue - translation contribution.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (note: a fresh clone shows pre-existing `@emdash-cms/registry-client` resolution errors unrelated to this data-only change; `pnpm locale:compile` passes with en-GB included)
- [x] `pnpm lint` passes (data-only change: one `locales.ts` line + PO catalogue)
- [x] `pnpm test` passes (no behaviour change outside the new catalogue)
- [x] `pnpm format` has been run (Format CI check passes on this PR)
- [x] I have added/updated tests for my changes (not applicable - translation)
- [x] User-visible strings in the admin UI are wrapped for translation (this IS a translation PR - `messages.po` inclusion is the change itself)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/admin`: patch)
- [x] New features link to an approved Discussion (not applicable - translation, not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code). The catalogue was generated by a deterministic en→en-GB transform script and every changed string was human-reviewed; the locale is running in production on two of our Emdash 0.17.2 installs.

## Screenshots / test output

Verified live on an Emdash 0.17.2 deployment: the language picker shows "English (UK)" (auto-selected for an en-GB browser via Accept-Language) and admin strings render with British spellings (e.g. Settings > SEO: "Search engine optimisation and verification").
