### PR TITLE
fix(core): tick the piggyback cron scheduler from the middleware request path

### DIFF
--- a/.changeset/fix-piggyback-cron-tick.md
+++ b/.changeset/fix-piggyback-cron-tick.md
@@ -1,0 +1,12 @@
+---
+"emdash": patch
+---
+
+Plugin cron tasks now actually run on Cloudflare Workers (#1422)
+
+The middleware selected the `PiggybackScheduler` on Workers, but nothing ever
+called `runtime.tickCron()`, so scheduled plugin tasks sat overdue at
+`status = idle` forever. The middleware now ticks the cron system once per
+request (both the anonymous fast path and the full runtime path). The
+scheduler debounces internally (60s) and runs fire-and-forget, so requests
+gain no latency.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -437,6 +437,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					try {
 						const runtime = await getRuntime(config, initSubTimings);
 						markSetupVerified();
+						// Drive the piggyback cron scheduler. On platforms without a
+						// dedicated scheduler (Cloudflare Workers) this is the only
+						// thing that executes due plugin cron tasks. Debounced
+						// internally (60s) and fire-and-forget — adds no latency.
+						runtime.tickCron();
 						const handlePublicPluginApiRoute = createPublicPluginApiRouteHandler(runtime);
 						// eslint-disable-next-line typescript/no-unsafe-type-assertion -- partial object; getPageRuntime() only checks for the page-contribution methods
 						locals.emdash = {
@@ -520,6 +525,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 				// Runtime init runs migrations, so the DB is guaranteed set up
 				markSetupVerified();
+
+				// Drive the piggyback cron scheduler (see the anonymous fast path
+				// above for rationale) — admin/API traffic must tick it too.
+				runtime.tickCron();
 
 				// The manifest is no longer pre-loaded here. It's admin-only
 				// content that public/anonymous requests never read, and

--- a/packages/core/tests/unit/astro/middleware-cron-tick.test.ts
+++ b/packages/core/tests/unit/astro/middleware-cron-tick.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Piggyback cron tick on public requests (issue #1422).
+ *
+ * On platforms without a dedicated scheduler (Cloudflare Workers), cron
+ * execution relies on the PiggybackScheduler being driven from the request
+ * path via `runtime.tickCron()`. The bug: `tickCron()` existed but had no
+ * call sites, so plugin cron tasks never ran on Workers — overdue tasks sat
+ * at `status = idle` forever.
+ *
+ * These tests pin the contract: a public page request must tick the cron
+ * system exactly once (the scheduler debounces internally).
+ */
+
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+// vi.mock factories are hoisted above normal `const` declarations; use
+// vi.hoisted so the marker objects are available to both the factories and
+// the assertions below.
+const { DB_CONFIG_MARKER } = vi.hoisted(() => ({
+	DB_CONFIG_MARKER: { binding: "DB", session: "auto" },
+}));
+
+const { MOCK_RUNTIME, mockTickCron } = vi.hoisted(() => {
+	const ok = async () => ({ success: true });
+	const tickCron = vi.fn();
+
+	return {
+		MOCK_RUNTIME: {
+			storage: { getPublicUrl: (key: string) => `https://media.example.com/${key}` },
+			db: {},
+			hooks: {},
+			email: null,
+			configuredPlugins: [],
+			handleContentList: ok,
+			handleContentGet: ok,
+			handleContentCreate: ok,
+			handleContentUpdate: ok,
+			handleContentDelete: ok,
+			handleContentListTrashed: ok,
+			handleContentRestore: ok,
+			handleContentPermanentDelete: ok,
+			handleContentCountTrashed: ok,
+			handleContentGetIncludingTrashed: ok,
+			handleContentDuplicate: ok,
+			handleContentPublish: ok,
+			handleContentUnpublish: ok,
+			handleContentSchedule: ok,
+			handleContentUnschedule: ok,
+			handleContentCountScheduled: ok,
+			handleContentDiscardDraft: ok,
+			handleContentCompare: ok,
+			handleContentTranslations: ok,
+			handleMediaList: ok,
+			handleMediaGet: ok,
+			handleMediaCreate: ok,
+			handleMediaUpdate: ok,
+			handleMediaDelete: ok,
+			handleRevisionList: ok,
+			handleRevisionGet: ok,
+			handleRevisionRestore: ok,
+			getPluginRouteMeta: () => null,
+			handlePluginApiRoute: ok,
+			getMediaProvider: () => undefined,
+			getMediaProviderList: () => [],
+			collectPageMetadata: async () => [],
+			collectPageFragments: async () => [],
+			ensureSearchHealthy: async () => undefined,
+			getManifest: async () => ({}),
+			getSandboxRunner: () => null,
+			isSandboxBypassed: () => false,
+			syncMarketplacePlugins: async () => undefined,
+			syncRegistryPlugins: async () => undefined,
+			setPluginStatus: async () => undefined,
+			tickCron,
+		},
+		mockTickCron: tickCron,
+	};
+});
+
+vi.mock(
+	"virtual:emdash/config",
+	() => ({
+		default: {
+			database: { config: DB_CONFIG_MARKER },
+			auth: { mode: "none" },
+		},
+	}),
+	{ virtual: true },
+);
+
+vi.mock(
+	"virtual:emdash/dialect",
+	() => ({
+		createDialect: vi.fn(),
+		createRequestScopedDb: vi.fn().mockReturnValue(null),
+	}),
+	{ virtual: true },
+);
+
+vi.mock("virtual:emdash/media-providers", () => ({ mediaProviders: [] }), { virtual: true });
+vi.mock("virtual:emdash/plugins", () => ({ plugins: [] }), { virtual: true });
+vi.mock(
+	"virtual:emdash/sandbox-runner",
+	() => ({
+		createSandboxRunner: null,
+		sandboxBypassed: false,
+		sandboxEnabled: false,
+	}),
+	{ virtual: true },
+);
+vi.mock("virtual:emdash/sandboxed-plugins", () => ({ sandboxedPlugins: [] }), { virtual: true });
+vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: true });
+vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
+
+vi.mock("../../../src/emdash-runtime.js", () => ({
+	DB_INIT_DEADLINE_MS: 30_000,
+	EmDashRuntime: {
+		create: async () => MOCK_RUNTIME,
+	},
+}));
+
+vi.mock("../../../src/loader.js", () => ({
+	getDb: vi.fn(async () => ({
+		selectFrom: () => ({
+			selectAll: () => ({
+				limit: () => ({
+					execute: async () => [],
+				}),
+			}),
+		}),
+	})),
+}));
+
+import onRequest from "../../../src/astro/middleware.js";
+
+function anonymousPublicPageContext() {
+	const cookies = {
+		get: vi.fn(() => undefined),
+		set: vi.fn(),
+	};
+	return {
+		request: new Request("https://example.com/blog/hello"),
+		url: new URL("https://example.com/blog/hello"),
+		cookies,
+		locals: {} as Record<string, unknown>,
+		redirect: vi.fn(),
+		isPrerendered: false,
+		session: { get: vi.fn(async () => null) },
+	} as Record<string, unknown>;
+}
+
+describe("astro middleware piggyback cron tick", () => {
+	beforeEach(() => {
+		mockTickCron.mockClear();
+	});
+
+	it("ticks the cron system on anonymous public page requests", async () => {
+		const context = anonymousPublicPageContext();
+
+		const response = await onRequest(
+			context as Parameters<typeof onRequest>[0],
+			async () => new Response("ok"),
+		);
+
+		expect(response.status).toBe(200);
+		// One tick per request — the scheduler debounces internally, so the
+		// middleware must not try to be clever about frequency.
+		expect(mockTickCron).toHaveBeenCalledTimes(1);
+	});
+
+	it("ticks once per request on the full runtime path too", async () => {
+		// Prerendered public runtime routes take the full-runtime branch of the
+		// middleware — the tick must happen there as well (it is a no-op unless
+		// the platform actually uses the PiggybackScheduler).
+		const context = anonymousPublicPageContext();
+		(context as { isPrerendered: boolean }).isPrerendered = true;
+
+		await onRequest(context as Parameters<typeof onRequest>[0], async () => new Response("ok"));
+
+		expect(mockTickCron).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -76,6 +76,7 @@ const {
 			syncMarketplacePlugins: async () => undefined,
 			syncRegistryPlugins: async () => undefined,
 			setPluginStatus: async () => undefined,
+			tickCron: () => undefined,
 		},
 		PUBLIC_PLUGIN_RESULT: publicPluginResult,
 		mockGetPluginRouteMeta: getPluginRouteMeta,


### PR DESCRIPTION
## What does this PR do?

On Cloudflare Workers the middleware selects the `PiggybackScheduler`, whose contract is "call this from middleware on each request" — but `runtime.tickCron()` had no call sites, so plugin cron tasks never executed on Workers (overdue tasks sat at `status = idle` forever; details and field evidence in #1422).

This adds the tick to both request branches of the middleware:

- the anonymous fast path (right after the runtime is initialized for page hooks), and
- the full runtime path (admin/API/authenticated traffic).

`PiggybackScheduler.onRequest()` debounces internally (60s) and runs fire-and-forget via `Promise.allSettled`, so requests gain no latency. On Node the scheduler is the `NodeCronScheduler`, for which `tickCron()` is a type-guarded no-op.

Tests: new `middleware-cron-tick.test.ts` (modeled on `middleware-prerender.test.ts`) pins one tick per request on both paths — red before the fix, green after. The existing prerender test's `MOCK_RUNTIME` gained the `tickCron` member to match the runtime interface.

Closes #1422

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (packages/core)
- [x] `pnpm lint` passes (`lint:quick` clean)
- [x] `pnpm test` passes (targeted: `tests/unit/astro/middleware-*.test.ts` — 13/13 green; `tests/unit/astro/vite-config.test.ts` fails 8/8 on my machine on unmodified main too — environmental, untouched by this PR)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no UI strings)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Fable 5 (reviewed and verified by a human before submission)

## Screenshots / test output

```
❯ vitest run tests/unit/astro/middleware-cron-tick.test.ts   # before fix
  × ticks the cron system on anonymous public page requests  (expected 1 call, got 0)

❯ vitest run tests/unit/astro/middleware-cron-tick.test.ts tests/unit/astro/middleware-prerender.test.ts   # after fix
  Test Files  2 passed (2)
       Tests  13 passed (13)
```