### PR TITLE
fix(seed): honor non-en default locale across export-seed → seed round-trip

### DIFF
--- a/.changeset/fix-seed-default-locale.md
+++ b/.changeset/fix-seed-default-locale.md
@@ -1,0 +1,12 @@
+---
+"emdash": patch
+---
+
+Fix seed CLI hardcoding `en` as the default locale (#1421)
+
+`emdash export-seed` now emits a top-level `defaultLocale` for single-locale
+projects, and `emdash seed` (`applySeed`) honors it when backfilling the locale
+of menus, taxonomies, and content rows that omit an explicit `locale`. Previously
+an `export-seed` → `seed` round-trip silently rewrote a non-`en` default locale
+(e.g. `de`) to `en`, since the CLI runs outside the Astro runtime and the
+fallback collapsed to `en`. Projects whose default locale is `en` are unaffected.

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -20,7 +20,7 @@ import { OptionsRepository } from "../../database/repositories/options.js";
 import { TaxonomyRepository } from "../../database/repositories/taxonomy.js";
 import type { Database } from "../../database/types.js";
 import { validateIdentifier } from "../../database/validate.js";
-import { isI18nEnabled } from "../../i18n/config.js";
+import { getI18nConfig, isI18nEnabled } from "../../i18n/config.js";
 import { SchemaRegistry } from "../../schema/registry.js";
 import type { FieldType } from "../../schema/types.js";
 import type {
@@ -128,7 +128,12 @@ export async function exportSeed(db: Kysely<Database>, withContent?: string): Pr
 	// middleware, but the CLI never does, so `isI18nEnabled()` is always false
 	// under `emdash export-seed` (#1330). Detecting multiple locales in the data
 	// keeps the export locale-aware without the runtime flag.
-	const i18nEnabled = await detectI18nEnabled(db, seed.collections);
+	const { i18nEnabled, defaultLocale } = await detectLocaleInfo(db, seed.collections);
+
+	// Self-describe the default locale so a non-`en` single-locale project
+	// survives the round-trip: `emdash seed` runs outside the runtime and would
+	// otherwise backfill omitted locales as `en` (#1421).
+	if (defaultLocale) seed.defaultLocale = defaultLocale;
 
 	// 3. Export taxonomy definitions and terms
 	seed.taxonomies = await exportTaxonomies(db, i18nEnabled);
@@ -216,7 +221,7 @@ async function exportBylines(
 }
 
 /**
- * Determine whether the export should emit locale-suffixed seed ids.
+ * Determine locale-awareness and the data's default locale for the export.
  *
  * The runtime initializes the i18n config in middleware, but the CLI never does,
  * so `isI18nEnabled()` is always false under `emdash export-seed` (#1330). When
@@ -227,39 +232,50 @@ async function exportBylines(
  * genuinely single-locale project from a multi-locale one. This keeps
  * single-locale exports on bare ids and gives multi-locale exports the
  * per-locale suffix they need to avoid duplicate seed ids.
+ *
+ * `defaultLocale` self-describes the single-locale case so a non-`en` default
+ * survives the round-trip (#1421). When more than one locale is present every
+ * row already carries its own `locale`, so no fallback is needed and we leave it
+ * undefined rather than guess which locale is the "default" without the runtime
+ * config.
  */
-async function detectI18nEnabled(
+async function detectLocaleInfo(
 	db: Kysely<Database>,
 	collections: SeedCollection[],
-): Promise<boolean> {
-	if (isI18nEnabled()) return true;
+): Promise<{ i18nEnabled: boolean; defaultLocale: string | undefined }> {
+	const config = getI18nConfig();
+	if (isI18nEnabled() && config) {
+		return { i18nEnabled: true, defaultLocale: config.defaultLocale };
+	}
 
 	const locales = new Set<string>();
-	const collectDistinctLocales = async (tableRef: ReturnType<typeof sql.ref>): Promise<boolean> => {
+	const collectDistinctLocales = async (tableRef: ReturnType<typeof sql.ref>): Promise<void> => {
 		const result = await sql<{ locale: string | null }>`
 			SELECT DISTINCT locale FROM ${tableRef}
 		`.execute(db);
 		for (const row of result.rows) {
 			if (row.locale) locales.add(row.locale);
 		}
-		return locales.size > 1;
 	};
 
-	if (await collectDistinctLocales(sql.ref("_emdash_taxonomy_defs"))) return true;
-	if (await collectDistinctLocales(sql.ref("_emdash_menus"))) return true;
+	await collectDistinctLocales(sql.ref("_emdash_taxonomy_defs"));
+	await collectDistinctLocales(sql.ref("_emdash_menus"));
 
 	for (const collection of collections) {
 		validateIdentifier(collection.slug, "collection slug");
 		// On D1, deleteCollection is non-atomic, so a collection row can outlive
 		// its ec_* table. Skip missing tables rather than crashing the export.
 		try {
-			if (await collectDistinctLocales(sql.ref(`ec_${collection.slug}`))) return true;
+			await collectDistinctLocales(sql.ref(`ec_${collection.slug}`));
 		} catch (error) {
 			if (!isMissingTableError(error)) throw error;
 		}
 	}
 
-	return false;
+	return {
+		i18nEnabled: locales.size > 1,
+		defaultLocale: locales.size === 1 ? [...locales][0] : undefined,
+	};
 }
 
 /**

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -115,6 +115,13 @@ export async function applySeed(
 	const seedIdMap = new Map<string, string>(); // seed id -> real entry id
 	const seedBylineIdMap = new Map<string, string>(); // seed byline id -> real byline id
 
+	// Fallback locale for rows that omit an explicit `locale`. Prefer the runtime
+	// config (runtime-driven seeds), then the seed's self-described `defaultLocale`
+	// (CLI exports run outside the runtime), and only then `en`. Without the
+	// seed-carried default, a non-`en` single-locale project would be rewritten to
+	// `en` on apply (#1421).
+	const defaultLocale = getI18nConfig()?.defaultLocale ?? seed.defaultLocale ?? "en";
+
 	// 1. Site settings
 	if (seed.settings) {
 		await setSiteSettings(seed.settings, db);
@@ -224,10 +231,9 @@ export async function applySeed(
 		// seed-local id -> resolved info, used to wire `translationOf` refs.
 		const defSeedIdMap = new Map<string, { id: string; translationGroup: string }>();
 		const termSeedIdMap = new Map<string, string>();
-		const fallbackLocale = getI18nConfig()?.defaultLocale ?? "en";
 
 		for (const taxonomy of seed.taxonomies) {
-			const defLocale = taxonomy.locale ?? fallbackLocale;
+			const defLocale = taxonomy.locale ?? defaultLocale;
 
 			// (name, locale) is the UNIQUE key after migration 036.
 			const existingDef = await db
@@ -418,8 +424,13 @@ export async function applySeed(
 		// Create content entries
 		for (const [collectionSlug, entries] of Object.entries(seed.content)) {
 			for (const entry of entries) {
+				// Resolve the entry's locale up front so a non-`en` single-locale
+				// export (which omits `locale`) is filed under the project default
+				// rather than `en` (#1421).
+				const entryLocale = entry.locale ?? defaultLocale;
+
 				// Check if entry exists (by slug + locale for locale-aware lookup)
-				const existing = await contentRepo.findBySlug(collectionSlug, entry.slug, entry.locale);
+				const existing = await contentRepo.findBySlug(collectionSlug, entry.slug, entryLocale);
 
 				if (existing) {
 					if (onConflict === "error") {
@@ -515,7 +526,7 @@ export async function applySeed(
 						slug: entry.slug,
 						status,
 						data: resolvedData,
-						locale: entry.locale,
+						locale: entryLocale,
 						translationOf,
 						publishedAt: status === "published" ? new Date().toISOString() : null,
 					});
@@ -545,10 +556,9 @@ export async function applySeed(
 		const menuSeedIdMap = new Map<string, { id: string; translationGroup: string }>();
 		// Shared across menus: translated items reference anchor items in sibling menus.
 		const itemSeedIdMap = new Map<string, { id: string; translationGroup: string }>();
-		const fallbackLocale = getI18nConfig()?.defaultLocale ?? "en";
 
 		for (const menu of seed.menus) {
-			const locale = menu.locale ?? fallbackLocale;
+			const locale = menu.locale ?? defaultLocale;
 			let lookup = db
 				.selectFrom("_emdash_menus")
 				.selectAll()

--- a/packages/core/src/seed/types.ts
+++ b/packages/core/src/seed/types.ts
@@ -19,6 +19,15 @@ export interface SeedFile {
 	/** Seed format version */
 	version: "1";
 
+	/**
+	 * Default locale for locale-bearing rows (menus, taxonomies, content) that
+	 * omit an explicit `locale`. Lets a non-`en` single-locale project survive an
+	 * `export-seed` → `seed` round-trip: `apply` runs outside the Astro runtime
+	 * (no i18n config), so without this it would backfill the omitted locale as
+	 * `en`. See #1421.
+	 */
+	defaultLocale?: string;
+
 	/** Metadata about the seed */
 	meta?: {
 		name?: string;

--- a/packages/core/src/seed/validate.ts
+++ b/packages/core/src/seed/validate.ts
@@ -57,6 +57,21 @@ export function validateSeed(data: unknown): ValidationResult {
 		errors.push(`Unsupported seed version: ${String(seed.version)}`);
 	}
 
+	// defaultLocale backfills the locale of rows that omit one, so a blank or
+	// whitespace-padded value would silently write empty/invalid locales to the DB.
+	// Exported seeds never hit this, but it's part of the public schema now.
+	if (seed.defaultLocale !== undefined) {
+		if (
+			typeof seed.defaultLocale !== "string" ||
+			seed.defaultLocale.length === 0 ||
+			seed.defaultLocale !== seed.defaultLocale.trim()
+		) {
+			errors.push(
+				"defaultLocale: must be a non-empty string with no leading or trailing whitespace",
+			);
+		}
+	}
+
 	// Validate collections
 	if (seed.collections) {
 		if (!Array.isArray(seed.collections)) {

--- a/packages/core/tests/integration/seed-i18n-default-locale.test.ts
+++ b/packages/core/tests/integration/seed-i18n-default-locale.test.ts
@@ -1,0 +1,119 @@
+import type { Kysely } from "kysely";
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportSeed } from "../../src/cli/commands/export-seed.js";
+import type { Database } from "../../src/database/types.js";
+import { setI18nConfig } from "../../src/i18n/config.js";
+import { applySeed } from "../../src/seed/apply.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+/**
+ * Regression for #1421: the seed CLI hardcodes `en` as the default locale.
+ *
+ * A project whose only authored locale is a non-`en` default (e.g. `de`) is
+ * treated as non-i18n by `export-seed` (single distinct locale → no `locale`
+ * emitted), and `apply` — running outside the Astro runtime with no i18n
+ * config — backfills the missing locale as `en`. The round-trip silently
+ * rewrites `de` rows to `en`, breaking locale-scoped runtime lookups.
+ *
+ * These tests run with the i18n config UNSET (the CLI environment) and assert
+ * the data's real default locale survives an export → apply round-trip.
+ */
+describe("seed round-trip preserves a non-en default locale (#1421)", () => {
+	let source: Kysely<Database>;
+	let target: Kysely<Database>;
+
+	beforeEach(() => {
+		setI18nConfig(null);
+	});
+
+	afterEach(async () => {
+		if (source) await teardownTestDatabase(source);
+		if (target) await teardownTestDatabase(target);
+		setI18nConfig(null);
+	});
+
+	it("keeps menus, taxonomies, and content at their real default locale", async () => {
+		source = await setupTestDatabaseWithCollections();
+		const now = new Date().toISOString();
+
+		// A genuine single-locale `de` project: every locale-bearing row is `de`.
+		// The built-in taxonomy defs are created at the project default, so move
+		// the seeded `category`/`tag` defs to `de` rather than leaving stray `en`
+		// rows that would make the data look multi-locale.
+		await source.updateTable("_emdash_taxonomy_defs").set({ locale: "de" }).execute();
+
+		// A single-locale `de` project: one menu, one taxonomy def, one post,
+		// all in `de`.
+		await source
+			.insertInto("_emdash_menus")
+			.values({
+				id: ulid(),
+				name: "primary",
+				label: "Hauptmenü",
+				created_at: now,
+				updated_at: now,
+				locale: "de",
+				translation_group: ulid(),
+			})
+			.execute();
+
+		await source
+			.insertInto("_emdash_taxonomy_defs")
+			.values({
+				id: ulid(),
+				name: "genre",
+				label: "Kategorien",
+				hierarchical: 0,
+				collections: JSON.stringify(["post"]),
+				created_at: now,
+				locale: "de",
+				translation_group: ulid(),
+			})
+			.execute();
+
+		await source
+			.insertInto("ec_post")
+			.values({
+				id: ulid(),
+				slug: "hallo",
+				status: "published",
+				created_at: now,
+				updated_at: now,
+				version: 1,
+				locale: "de",
+				translation_group: ulid(),
+				title: "Hallo",
+			} as never)
+			.execute();
+
+		// Export from the CLI environment (i18n config unset).
+		const seed = await exportSeed(source, "post");
+
+		// Apply into a fresh DB, also outside the runtime.
+		target = await setupTestDatabaseWithCollections();
+		await applySeed(target, seed, { includeContent: true });
+
+		const menu = await target
+			.selectFrom("_emdash_menus")
+			.select("locale")
+			.where("name", "=", "primary")
+			.executeTakeFirstOrThrow();
+		expect(menu.locale).toBe("de");
+
+		const def = await target
+			.selectFrom("_emdash_taxonomy_defs")
+			.select("locale")
+			.where("name", "=", "genre")
+			.executeTakeFirstOrThrow();
+		expect(def.locale).toBe("de");
+
+		const post = await target
+			.selectFrom("ec_post")
+			.select("locale")
+			.where("slug", "=", "hallo")
+			.executeTakeFirstOrThrow();
+		expect(post.locale).toBe("de");
+	});
+});

--- a/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-cli-i18n.test.ts
@@ -275,4 +275,43 @@ describe("exportSeed: CLI (no runtime i18n config) stays locale-aware (#1330)", 
 		expect(cat?.locale).toBeUndefined();
 		expect(cat?.translationOf).toBeUndefined();
 	});
+
+	it("self-describes the default locale for a single-locale non-en project (#1421)", async () => {
+		db = await setupTestDatabase();
+
+		// Every locale-bearing row is `de` — a genuine single-locale project whose
+		// default is not `en`. Move the built-in defs to `de` so no stray `en` row
+		// makes the data look multi-locale.
+		await db.updateTable("_emdash_taxonomy_defs").set({ locale: "de" }).execute();
+		await insertTaxonomyDef(db, {
+			id: ulid(),
+			name: "genre",
+			label: "Kategorien",
+			locale: "de",
+			group: ulid(),
+		});
+
+		const seed = await exportSeed(db);
+
+		// Bare ids (single-locale), but the seed carries the real default so apply
+		// — which runs outside the runtime — can backfill `de` instead of `en`.
+		expect(seed.defaultLocale).toBe("de");
+		const cat = seed.taxonomies?.find((t) => t.name === "genre");
+		expect(cat?.id).toBe("tax:genre");
+		expect(cat?.locale).toBeUndefined();
+	});
+
+	it("omits defaultLocale for multi-locale data (rows self-describe their locale)", async () => {
+		db = await setupTestDatabase();
+
+		const group = ulid();
+		await insertMenu(db, { id: ulid(), name: "primary", label: "Primary", locale: "en", group });
+		await insertMenu(db, { id: ulid(), name: "primary", label: "الرئيسية", locale: "ar", group });
+
+		const seed = await exportSeed(db);
+
+		// Multiple locales → every row already emits its own `locale`, so there is
+		// no omitted-locale fallback to fill and no single "default" to infer.
+		expect(seed.defaultLocale).toBeUndefined();
+	});
 });

--- a/packages/core/tests/unit/seed/validate.test.ts
+++ b/packages/core/tests/unit/seed/validate.test.ts
@@ -36,6 +36,43 @@ describe("validateSeed", () => {
 		});
 	});
 
+	describe("defaultLocale validation", () => {
+		it("should accept an omitted defaultLocale", () => {
+			const result = validateSeed({ version: "1" });
+			expect(result.valid).toBe(true);
+		});
+
+		it("should accept a non-en defaultLocale", () => {
+			const result = validateSeed({ version: "1", defaultLocale: "de" });
+			expect(result.valid).toBe(true);
+			expect(result.errors).toHaveLength(0);
+		});
+
+		it("should reject a non-string defaultLocale", () => {
+			const result = validateSeed({ version: "1", defaultLocale: 5 });
+			expect(result.valid).toBe(false);
+			expect(result.errors).toContain(
+				"defaultLocale: must be a non-empty string with no leading or trailing whitespace",
+			);
+		});
+
+		it("should reject an empty defaultLocale", () => {
+			const result = validateSeed({ version: "1", defaultLocale: "" });
+			expect(result.valid).toBe(false);
+			expect(result.errors).toContain(
+				"defaultLocale: must be a non-empty string with no leading or trailing whitespace",
+			);
+		});
+
+		it("should reject a whitespace-padded defaultLocale", () => {
+			const result = validateSeed({ version: "1", defaultLocale: " de " });
+			expect(result.valid).toBe(false);
+			expect(result.errors).toContain(
+				"defaultLocale: must be a non-empty string with no leading or trailing whitespace",
+			);
+		});
+	});
+
 	describe("collection validation", () => {
 		it("should require collections to be an array", () => {
 			const result = validateSeed({


### PR DESCRIPTION
## What does this PR do?

`emdash export-seed` now emits a top-level `defaultLocale` for single-locale projects, and `applySeed` honors it when backfilling the locale of menus, taxonomies, and content rows that omit an explicit `locale`.

Previously an `export-seed` → `seed` round-trip silently rewrote a non-`en` default locale (e.g. `de`) to `en`: the CLI runs outside the Astro runtime, so the locale fallback collapsed to `en`. Projects whose default locale is already `en` are unaffected.

Closes #1421

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- not run: the type-aware check OOM-killed the dev machine; changes are localized to seed/CLI types -->
- [ ] `pnpm lint` passes <!-- not run: type-aware lint OOM-killed the dev machine -->
- [x] `pnpm test` passes (or targeted tests for my change) — 8/8 in the two seed test files below
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

```
✓ tests/unit/seed/export-seed-cli-i18n.test.ts
✓ tests/integration/seed-i18n-default-locale.test.ts
Test Files  2 passed (2)
     Tests  8 passed (8)
```

> Note: `pnpm typecheck`, `pnpm lint`, and `pnpm format` were not run locally — the type-aware tooling OOM-killed the dev machine. Targeted seed tests pass; CI will cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)