### PR TITLE
feat: responsive srcset for media via astro:assets

### DIFF
--- a/.changeset/responsive-images.md
+++ b/.changeset/responsive-images.md
@@ -1,0 +1,13 @@
+---
+"emdash": minor
+---
+
+Generate responsive `srcset`s for media rendered with the `Image` and Portable Text image components. EmDash now routes locally/R2-stored media through Astro's configured image service (`astro:assets`) -- the Cloudflare Images binding on Workers, sharp on Node -- producing width-appropriate candidates and modern formats (e.g. WebP) instead of a single full-size `<img>`.
+
+This works automatically:
+
+- Media served from a configured storage `publicUrl` (R2 custom domain, S3/CDN) is authorized and optimized.
+- Same-origin proxied media (local storage, or R2 without a public URL) is optimized when `siteUrl` is set; the matching `image.remotePatterns` entry is registered for you, scoped to the media route.
+- In `astro dev` it works out of the box without configuration.
+
+When optimization isn't possible (no image service available, an unauthorized host, or unknown dimensions) the components fall back to a plain `<img>`, so existing sites keep rendering exactly as before. No template changes are required.

--- a/e2e/tests/visual-editing.spec.ts
+++ b/e2e/tests/visual-editing.spec.ts
@@ -69,10 +69,13 @@ test.describe("Image Rendering (Static)", () => {
 		const img = figure.locator("img");
 		await expect(img).toBeVisible();
 
-		// The src should point to the media file endpoint (not a bare ULID)
+		// The src should resolve to the media file endpoint (not a bare ULID).
+		// With responsive optimization the src may be Astro's image-service URL
+		// (`/_image?href=…` on Node, `/cdn-cgi/image/…` on Cloudflare) that
+		// encodes the media file URL, so decode before matching.
 		const src = await img.getAttribute("src");
 		expect(src).toBeTruthy();
-		expect(src).toMatch(MEDIA_FILE_PATTERN);
+		expect(decodeURIComponent(src!)).toMatch(MEDIA_FILE_PATTERN);
 
 		// Alt text should be set
 		const alt = await img.getAttribute("alt");

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -89,8 +89,10 @@ interface ImageRemotePattern {
  * Returns an empty array when no source is statically known (e.g. a production
  * build using local storage with no `siteUrl`), in which case media renders as
  * a plain `<img>`.
+ *
+ * @internal Exported for unit testing.
  */
-function buildImageRemotePatterns(
+export function buildImageRemotePatterns(
 	storage: { config?: unknown } | undefined,
 	siteUrl: string | undefined,
 	command: "dev" | "build" | "preview" | "sync",
@@ -105,10 +107,22 @@ function buildImageRemotePatterns(
 	if (typeof publicUrl === "string" && publicUrl) {
 		try {
 			const url = new URL(publicUrl);
-			patterns.push({
-				protocol: url.protocol === "http:" ? "http" : "https",
-				hostname: url.hostname,
-			});
+			// Only authorize http(s) hosts — a `file:`/`ftp:` URL is not a media
+			// origin Astro can fetch.
+			if (url.protocol === "http:" || url.protocol === "https:") {
+				const pattern: ImageRemotePattern = {
+					protocol: url.protocol === "http:" ? "http" : "https",
+					hostname: url.hostname,
+				};
+				// When the public URL has a path prefix (CDN sub-path), scope the
+				// pattern to it so we don't authorize the entire host. Media keys
+				// are appended as `${publicUrl}/${key}`, so the prefix is exact.
+				const prefix = url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname;
+				if (prefix && prefix !== "/") {
+					pattern.pathname = `${prefix}/**`;
+				}
+				patterns.push(pattern);
+			}
 		} catch {
 			// ignore an unparseable public URL
 		}

--- a/packages/core/src/astro/integration/index.ts
+++ b/packages/core/src/astro/integration/index.ts
@@ -15,6 +15,7 @@ import { createRequire } from "node:module";
 import type { AstroIntegration, AstroIntegrationLogger } from "astro";
 
 import { validateAllowedOrigins, validateOriginShape } from "../../auth/allowed-origins.js";
+import { INTERNAL_MEDIA_PREFIX } from "../../media/normalize.js";
 import type { ResolvedPlugin } from "../../plugins/types.js";
 import { local } from "../storage/adapters.js";
 import { notoSans } from "./font-provider.js";
@@ -58,6 +59,78 @@ const DEFAULT_STORAGE = local({
 	directory: "./.emdash/uploads",
 	baseUrl: "/_emdash/api/media/file",
 });
+
+interface ImageRemotePattern {
+	protocol?: "http" | "https";
+	hostname?: string;
+	pathname?: string;
+}
+
+/**
+ * Build `image.remotePatterns` entries so Astro will optimize EmDash media.
+ *
+ * Astro's image services only transform **absolute** URLs whose host is
+ * authorized; everything else is passed through unoptimized. We authorize the
+ * media sources automatically:
+ *
+ *  1. The storage adapter's public URL host (R2 custom domain, S3/CDN), so
+ *     media served directly from a public bucket is optimized.
+ *  2. The site's own origin, scoped to the media proxy route
+ *     (`/_emdash/api/media/file/**`), so same-origin proxied media (local
+ *     storage, or R2 without a public URL) is optimized too. The pathname
+ *     scope keeps Astro's image endpoint from acting as an open proxy for the
+ *     whole origin. Only registered when `siteUrl` is known at build time;
+ *     `getPublicOrigin` resolves the matching origin at render time.
+ *  3. In `astro dev` the dev-server origin (`localhost:<port>`) isn't known at
+ *     build time, so we register a host-agnostic pattern scoped to the media
+ *     route. This is dev-only — it never ships in a production build — so the
+ *     missing host check can't be abused on a deployed site.
+ *
+ * Returns an empty array when no source is statically known (e.g. a production
+ * build using local storage with no `siteUrl`), in which case media renders as
+ * a plain `<img>`.
+ */
+function buildImageRemotePatterns(
+	storage: { config?: unknown } | undefined,
+	siteUrl: string | undefined,
+	command: "dev" | "build" | "preview" | "sync",
+): ImageRemotePattern[] {
+	const patterns: ImageRemotePattern[] = [];
+
+	const config = storage?.config;
+	const publicUrl =
+		config && typeof config === "object"
+			? (config as { publicUrl?: unknown }).publicUrl
+			: undefined;
+	if (typeof publicUrl === "string" && publicUrl) {
+		try {
+			const url = new URL(publicUrl);
+			patterns.push({
+				protocol: url.protocol === "http:" ? "http" : "https",
+				hostname: url.hostname,
+			});
+		} catch {
+			// ignore an unparseable public URL
+		}
+	}
+
+	if (siteUrl) {
+		try {
+			patterns.push({
+				hostname: new URL(siteUrl).hostname,
+				pathname: `${INTERNAL_MEDIA_PREFIX}**`,
+			});
+		} catch {
+			// ignore an unparseable site URL
+		}
+	}
+
+	if (command === "dev") {
+		patterns.push({ pathname: `${INTERNAL_MEDIA_PREFIX}**` });
+	}
+
+	return patterns;
+}
 
 // Terminal formatting
 const dim = (s: string) => `\x1b[2m${s}\x1b[22m`;
@@ -298,8 +371,19 @@ export function emdash(config: EmDashConfig = {}): AstroIntegration {
 								},
 							];
 
+				// Authorize media sources for Astro image optimization so the
+				// Image components can generate a responsive srcset for R2/S3 and
+				// same-origin proxied media. `updateConfig` merges arrays, so any
+				// user-configured remotePatterns are preserved.
+				const imageRemotePatterns = buildImageRemotePatterns(
+					resolvedConfig.storage,
+					resolvedConfig.siteUrl,
+					command,
+				);
+
 				updateConfig({
 					security: securityConfig,
+					...(imageRemotePatterns.length ? { image: { remotePatterns: imageRemotePatterns } } : {}),
 					// fonts is a valid AstroConfig key but may not be in the
 					// type definition for the minimum supported Astro version
 					...({ fonts: emdashFonts } as Record<string, unknown>),

--- a/packages/core/src/components/EmDashImage.astro
+++ b/packages/core/src/components/EmDashImage.astro
@@ -18,9 +18,12 @@
  */
 import type { MediaValue } from "../fields/types.js";
 import type { HTMLAttributes } from "astro/types";
+import { getImage } from "astro:assets";
 import type { ImageEmbed } from "../media/types.js";
 import { getMediaProvider } from "../media/provider-loader.js";
 import { buildRenderMediaUrl } from "../media/url.js";
+import { buildResponsiveImage, toAbsoluteMediaUrl } from "../media/responsive.js";
+import { getPublicOrigin } from "../api/public-url.js";
 // Standard responsive breakpoints
 const BREAKPOINTS = [640, 750, 828, 960, 1080, 1280, 1600, 1920];
 
@@ -98,8 +101,21 @@ if (img) {
 	const providerId = img.provider ?? "local";
 
 	if (providerId === "local" || img.src) {
-		// Local provider or direct src URL
+		// Local provider or direct src URL. Route through Astro's image service
+		// (`astro:assets`) to generate a responsive srcset; on Cloudflare this is
+		// the Images binding, on Node it is sharp. Falls back to a plain <img>
+		// when the service is unavailable or the source can't be optimized.
 		src = img.src || buildLocalImageUrl(img);
+		const optimized = await buildResponsiveImage(getImage, {
+			src: toAbsoluteMediaUrl(src, getPublicOrigin(Astro.url, Astro.locals.emdash?.config)),
+			width: finalWidth,
+			height: finalHeight,
+		});
+		if (optimized) {
+			src = optimized.src;
+			srcset = optimized.srcset;
+			sizes = optimized.sizes;
+		}
 	} else {
 		// External provider
 		try {

--- a/packages/core/src/components/EmDashImage.astro
+++ b/packages/core/src/components/EmDashImage.astro
@@ -22,10 +22,12 @@ import { getImage } from "astro:assets";
 import type { ImageEmbed } from "../media/types.js";
 import { getMediaProvider } from "../media/provider-loader.js";
 import { buildRenderMediaUrl } from "../media/url.js";
-import { buildResponsiveImage, toAbsoluteMediaUrl } from "../media/responsive.js";
+import {
+	buildResponsiveImage,
+	toAbsoluteMediaUrl,
+	RESPONSIVE_BREAKPOINTS,
+} from "../media/responsive.js";
 import { getPublicOrigin } from "../api/public-url.js";
-// Standard responsive breakpoints
-const BREAKPOINTS = [640, 750, 828, 960, 1080, 1280, 1600, 1920];
 
 interface Props extends Omit<
 	HTMLAttributes<"img">,
@@ -75,7 +77,7 @@ function generateSrcset(
 	maxWidth: number,
 	aspectRatio?: number
 ): string {
-	return BREAKPOINTS.filter((w) => w <= maxWidth * 2) // Include up to 2x for retina
+	return RESPONSIVE_BREAKPOINTS.filter((w) => w <= maxWidth * 2) // Include up to 2x for retina
 		.map((w) => {
 			const h = aspectRatio ? Math.round(w / aspectRatio) : undefined;
 			return `${getSrc({ width: w, height: h })} ${w}w`;

--- a/packages/core/src/components/Image.astro
+++ b/packages/core/src/components/Image.astro
@@ -9,10 +9,12 @@ import { getImage } from "astro:assets";
 import type { ImageEmbed } from "../media/types.js";
 import { getMediaProvider } from "../media/provider-loader.js";
 import { buildRenderMediaUrl } from "../media/url.js";
-import { buildResponsiveImage, toAbsoluteMediaUrl } from "../media/responsive.js";
+import {
+	buildResponsiveImage,
+	toAbsoluteMediaUrl,
+	RESPONSIVE_BREAKPOINTS,
+} from "../media/responsive.js";
 import { getPublicOrigin } from "../api/public-url.js";
-// Standard responsive breakpoints
-const BREAKPOINTS = [640, 750, 828, 960, 1080, 1280, 1600, 1920];
 
 export interface Props {
 	node: {
@@ -47,7 +49,7 @@ function generateSrcset(
 	maxWidth: number,
 	aspectRatio?: number,
 ): string {
-	return BREAKPOINTS.filter((w) => w <= maxWidth * 2)
+	return RESPONSIVE_BREAKPOINTS.filter((w) => w <= maxWidth * 2)
 		.map((w) => {
 			const h = aspectRatio ? Math.round(w / aspectRatio) : undefined;
 			return `${getSrc({ width: w, height: h })} ${w}w`;

--- a/packages/core/src/components/Image.astro
+++ b/packages/core/src/components/Image.astro
@@ -5,9 +5,12 @@
  * Renders image blocks from WordPress imports and EmDash media.
  * Uses the provider's getSrc function for responsive srcset generation.
  */
+import { getImage } from "astro:assets";
 import type { ImageEmbed } from "../media/types.js";
 import { getMediaProvider } from "../media/provider-loader.js";
 import { buildRenderMediaUrl } from "../media/url.js";
+import { buildResponsiveImage, toAbsoluteMediaUrl } from "../media/responsive.js";
+import { getPublicOrigin } from "../api/public-url.js";
 // Standard responsive breakpoints
 const BREAKPOINTS = [640, 750, 828, 960, 1080, 1280, 1600, 1920];
 
@@ -131,6 +134,18 @@ if (!src) {
 		url: asset.url,
 		id: asset._ref,
 	});
+	// Generate a responsive srcset via Astro's image service for local/R2 media.
+	// Falls back to the plain URL when optimization isn't possible.
+	const optimized = await buildResponsiveImage(getImage, {
+		src: toAbsoluteMediaUrl(src, getPublicOrigin(Astro.url, Astro.locals.emdash?.config)),
+		width: renderWidth,
+		height: renderHeight,
+	});
+	if (optimized) {
+		src = optimized.src;
+		srcset = optimized.srcset;
+		sizes = optimized.sizes;
+	}
 }
 
 // Build placeholder background style

--- a/packages/core/src/media/responsive.ts
+++ b/packages/core/src/media/responsive.ts
@@ -1,0 +1,118 @@
+/**
+ * Responsive image helpers shared by the public Image components.
+ *
+ * These build a `srcset` for locally-stored / R2-stored media by delegating to
+ * Astro's configured image service (`astro:assets`). On Cloudflare that is the
+ * Images binding; on Node it is sharp; if neither is available it is a no-op
+ * passthrough. The calling `.astro` component passes Astro's `getImage` in so
+ * this module stays free of the `astro:assets` virtual import (which only
+ * resolves inside an Astro project, not in this precompiled package).
+ */
+
+/** Standard responsive breakpoints. Matches CDN-provider srcset generation. */
+export const RESPONSIVE_BREAKPOINTS = [640, 750, 828, 960, 1080, 1280, 1600, 1920];
+
+/** Matches absolute http(s) URLs — the only shape Astro's image services optimize. */
+const ABSOLUTE_HTTP_URL = /^https?:\/\//i;
+
+/**
+ * Pick the srcset widths to generate for an image rendered at `maxWidth`.
+ * Includes breakpoints up to 2x (retina) plus the rendered width itself, so the
+ * browser always has an exact-fit candidate.
+ */
+export function responsiveWidths(maxWidth: number): number[] {
+	const cap = maxWidth * 2;
+	const widths = new Set(RESPONSIVE_BREAKPOINTS.filter((w) => w <= cap));
+	widths.add(maxWidth);
+	return [...widths].toSorted((a, b) => a - b);
+}
+
+/** Build the `sizes` attribute for an image with a known display width. */
+export function responsiveSizes(width: number | undefined): string {
+	return width ? `(min-width: ${width}px) ${width}px, 100vw` : "100vw";
+}
+
+/**
+ * Make a media URL absolute so Astro's image service can optimize it.
+ *
+ * Astro only optimizes absolute http(s) URLs; a same-origin proxy path like
+ * `/_emdash/api/media/file/x.jpg` is otherwise treated as an unoptimizable
+ * public asset. Resolving it against the site's public origin (and authorizing
+ * that origin via `image.remotePatterns`) lets the service transform it.
+ *
+ * Already-absolute URLs (CDN/public bucket) and non-path values (data:, blob:)
+ * are returned unchanged.
+ */
+export function toAbsoluteMediaUrl(src: string, origin: string | undefined): string {
+	if (!src || !origin || !src.startsWith("/")) return src;
+	try {
+		return new URL(src, origin).href;
+	} catch {
+		return src;
+	}
+}
+
+/**
+ * Minimal structural subset of Astro's `getImage`. Astro's `ImageTransform`
+ * carries a `[key: string]: any` index signature, so the real `getImage` is
+ * assignable to this narrower type.
+ */
+export type GetImage = (options: {
+	src: string;
+	width?: number;
+	height?: number;
+	widths?: number[];
+	sizes?: string;
+}) => Promise<{ src: string; srcSet?: { attribute?: string } | undefined }>;
+
+export interface ResponsiveImage {
+	src: string;
+	srcset?: string;
+	sizes?: string;
+}
+
+/**
+ * Generate a responsive `src`/`srcset`/`sizes` for a media URL via Astro's
+ * configured image service.
+ *
+ * Astro's image services (sharp, Cloudflare `/cdn-cgi/image`, and the default
+ * Cloudflare `cloudflare-binding` service) only optimize **absolute** URLs whose
+ * host is authorized via `image.domains` / `image.remotePatterns`. Anything else
+ * is passed through unchanged, which would yield a useless srcset (the same URL
+ * at every width descriptor). We therefore only attempt optimization for
+ * absolute http(s) URLs and verify the service actually rewrote the URL.
+ *
+ * Returns `null` so callers fall back to a plain `<img>` when:
+ *  - dimensions are unknown (avoids an inferSize fetch on every render),
+ *  - the URL is relative (a same-origin proxy/public asset Astro won't optimize),
+ *  - the host isn't authorized (the service passed the URL through unchanged),
+ *  - no image service is configured / `getImage` throws.
+ */
+export async function buildResponsiveImage(
+	getImage: GetImage,
+	opts: { src: string; width?: number; height?: number },
+): Promise<ResponsiveImage | null> {
+	const { src, width, height } = opts;
+	if (!src || !width || !height) return null;
+	if (!ABSOLUTE_HTTP_URL.test(src)) return null;
+	try {
+		const sizes = responsiveSizes(width);
+		const result = await getImage({
+			src,
+			width,
+			height,
+			widths: responsiveWidths(width),
+			sizes,
+		});
+		// Passthrough: the service returned the source unchanged (unauthorized
+		// host or no optimization available). Don't emit a no-op srcset.
+		if (!result.src || result.src === src) return null;
+		return {
+			src: result.src,
+			srcset: result.srcSet?.attribute || undefined,
+			sizes,
+		};
+	} catch {
+		return null;
+	}
+}

--- a/packages/core/src/media/responsive.ts
+++ b/packages/core/src/media/responsive.ts
@@ -33,20 +33,27 @@ export function responsiveSizes(width: number | undefined): string {
 }
 
 /**
- * Make a media URL absolute so Astro's image service can optimize it.
+ * Make a same-origin media URL absolute so Astro's image service can optimize it.
  *
  * Astro only optimizes absolute http(s) URLs; a same-origin proxy path like
  * `/_emdash/api/media/file/x.jpg` is otherwise treated as an unoptimizable
  * public asset. Resolving it against the site's public origin (and authorizing
  * that origin via `image.remotePatterns`) lets the service transform it.
  *
- * Already-absolute URLs (CDN/public bucket) and non-path values (data:, blob:)
- * are returned unchanged.
+ * Only **same-origin** root-relative paths are resolved. Protocol-relative
+ * URLs (`//evil.com/x`) and backslash tricks (`/\evil.com`) also start with `/`
+ * but resolve to a different origin -- a classic SSRF vector once a
+ * remotePattern authorizes the media path -- so anything that escapes the
+ * origin is returned unchanged (and then skipped by `buildResponsiveImage`,
+ * which only accepts absolute http(s) URLs). Already-absolute URLs (CDN/public
+ * bucket) and non-path values (`data:`, `blob:`) are returned unchanged too.
  */
 export function toAbsoluteMediaUrl(src: string, origin: string | undefined): string {
 	if (!src || !origin || !src.startsWith("/")) return src;
 	try {
-		return new URL(src, origin).href;
+		const resolved = new URL(src, origin);
+		if (resolved.origin !== new URL(origin).origin) return src;
+		return resolved.href;
 	} catch {
 		return src;
 	}

--- a/packages/core/tests/unit/astro/integration/image-remote-patterns.test.ts
+++ b/packages/core/tests/unit/astro/integration/image-remote-patterns.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildImageRemotePatterns } from "../../../../src/astro/integration/index.js";
+
+const s3 = (publicUrl?: string) => ({ entrypoint: "x", config: { publicUrl } });
+const localStorage = { entrypoint: "x", config: { directory: "./uploads" } };
+const MEDIA_PATH = "/_emdash/api/media/file/**";
+
+describe("buildImageRemotePatterns", () => {
+	it("authorizes the storage public URL host", () => {
+		expect(buildImageRemotePatterns(s3("https://cdn.example.com"), undefined, "build")).toEqual([
+			{ protocol: "https", hostname: "cdn.example.com" },
+		]);
+	});
+
+	it("scopes the pattern to the public URL path prefix when present", () => {
+		expect(
+			buildImageRemotePatterns(s3("https://cdn.example.com/assets"), undefined, "build"),
+		).toEqual([{ protocol: "https", hostname: "cdn.example.com", pathname: "/assets/**" }]);
+	});
+
+	it("normalizes a trailing slash on the path prefix", () => {
+		expect(
+			buildImageRemotePatterns(s3("https://cdn.example.com/assets/"), undefined, "build"),
+		).toEqual([{ protocol: "https", hostname: "cdn.example.com", pathname: "/assets/**" }]);
+	});
+
+	it("ignores a non-http(s) public URL", () => {
+		expect(buildImageRemotePatterns(s3("ftp://files.example.com"), undefined, "build")).toEqual([]);
+	});
+
+	it("ignores an unparseable public URL", () => {
+		expect(buildImageRemotePatterns(s3("not a url"), undefined, "build")).toEqual([]);
+	});
+
+	it("authorizes the site origin scoped to the media route when siteUrl is set", () => {
+		expect(buildImageRemotePatterns(localStorage, "https://example.com", "build")).toEqual([
+			{ hostname: "example.com", pathname: MEDIA_PATH },
+		]);
+	});
+
+	it("adds a host-agnostic media pattern only in dev", () => {
+		expect(buildImageRemotePatterns(localStorage, undefined, "dev")).toEqual([
+			{ pathname: MEDIA_PATH },
+		]);
+		expect(buildImageRemotePatterns(localStorage, undefined, "build")).toEqual([]);
+	});
+
+	it("combines CDN, site-origin, and dev patterns", () => {
+		expect(
+			buildImageRemotePatterns(s3("https://cdn.example.com"), "https://example.com", "dev"),
+		).toEqual([
+			{ protocol: "https", hostname: "cdn.example.com" },
+			{ hostname: "example.com", pathname: MEDIA_PATH },
+			{ pathname: MEDIA_PATH },
+		]);
+	});
+});

--- a/packages/core/tests/unit/media/responsive.test.ts
+++ b/packages/core/tests/unit/media/responsive.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+	RESPONSIVE_BREAKPOINTS,
+	buildResponsiveImage,
+	responsiveSizes,
+	responsiveWidths,
+	type GetImage,
+} from "../../../src/media/responsive.js";
+
+describe("responsiveWidths", () => {
+	it("includes breakpoints up to 2x the rendered width", () => {
+		// maxWidth 400 -> cap 800: 640, 750 qualify (<=800), 828 does not
+		expect(responsiveWidths(400)).toEqual([400, 640, 750]);
+	});
+
+	it("always includes the rendered width and sorts ascending", () => {
+		const widths = responsiveWidths(800);
+		expect(widths).toContain(800);
+		expect(widths.toSorted((a, b) => a - b)).toEqual(widths);
+	});
+
+	it("does not duplicate a width already present in the breakpoints", () => {
+		const widths = responsiveWidths(640);
+		expect(widths.filter((w) => w === 640)).toHaveLength(1);
+	});
+
+	it("caps at the largest breakpoint for very large widths", () => {
+		const widths = responsiveWidths(4000);
+		expect(widths).toEqual([...RESPONSIVE_BREAKPOINTS, 4000]);
+	});
+});
+
+describe("responsiveSizes", () => {
+	it("returns a width-aware sizes attribute when width is known", () => {
+		expect(responsiveSizes(800)).toBe("(min-width: 800px) 800px, 100vw");
+	});
+
+	it("falls back to 100vw when width is unknown", () => {
+		expect(responsiveSizes(undefined)).toBe("100vw");
+	});
+});
+
+describe("buildResponsiveImage", () => {
+	const ABS = "https://cdn.example.com/a.jpg";
+
+	it("returns null without both dimensions (avoids inferSize fetch)", async () => {
+		const getImage = vi.fn();
+		expect(await buildResponsiveImage(getImage, { src: ABS, width: 800 })).toBeNull();
+		expect(await buildResponsiveImage(getImage, { src: ABS, height: 600 })).toBeNull();
+		expect(await buildResponsiveImage(getImage, { src: "", width: 800, height: 600 })).toBeNull();
+		expect(getImage).not.toHaveBeenCalled();
+	});
+
+	it("returns null for relative URLs without calling getImage", async () => {
+		const getImage = vi.fn();
+		// Relative same-origin proxy/public URLs are never optimized by Astro's
+		// image services; skip them rather than emit a no-op srcset.
+		expect(
+			await buildResponsiveImage(getImage, {
+				src: "/_emdash/api/media/file/01ABC.jpg",
+				width: 800,
+				height: 600,
+			}),
+		).toBeNull();
+		expect(getImage).not.toHaveBeenCalled();
+	});
+
+	it("delegates to getImage and maps the result for absolute authorized URLs", async () => {
+		const getImage: GetImage = vi.fn(async (opts) => ({
+			src: `/_image?href=${encodeURIComponent(opts.src)}&w=1200`,
+			srcSet: { attribute: "/_image?href=a&w=640 640w, /_image?href=a&w=1200 1200w" },
+		}));
+		const result = await buildResponsiveImage(getImage, {
+			src: ABS,
+			width: 800,
+			height: 600,
+		});
+		expect(result).toEqual({
+			src: `/_image?href=${encodeURIComponent(ABS)}&w=1200`,
+			srcset: "/_image?href=a&w=640 640w, /_image?href=a&w=1200 1200w",
+			sizes: "(min-width: 800px) 800px, 100vw",
+		});
+		expect(getImage).toHaveBeenCalledWith({
+			src: ABS,
+			width: 800,
+			height: 600,
+			widths: responsiveWidths(800),
+			sizes: "(min-width: 800px) 800px, 100vw",
+		});
+	});
+
+	it("returns null when the service passes the URL through unchanged (unauthorized host)", async () => {
+		// baseService.getURL returns options.src verbatim for unauthorized hosts.
+		const getImage: GetImage = async (opts) => ({ src: opts.src });
+		expect(await buildResponsiveImage(getImage, { src: ABS, width: 800, height: 600 })).toBeNull();
+	});
+
+	it("returns null when getImage throws (no service available)", async () => {
+		const getImage: GetImage = async () => {
+			throw new Error("no image service");
+		};
+		expect(await buildResponsiveImage(getImage, { src: ABS, width: 800, height: 600 })).toBeNull();
+	});
+});

--- a/packages/core/tests/unit/media/responsive.test.ts
+++ b/packages/core/tests/unit/media/responsive.test.ts
@@ -5,6 +5,7 @@ import {
 	buildResponsiveImage,
 	responsiveSizes,
 	responsiveWidths,
+	toAbsoluteMediaUrl,
 	type GetImage,
 } from "../../../src/media/responsive.js";
 
@@ -101,5 +102,51 @@ describe("buildResponsiveImage", () => {
 			throw new Error("no image service");
 		};
 		expect(await buildResponsiveImage(getImage, { src: ABS, width: 800, height: 600 })).toBeNull();
+	});
+});
+
+describe("toAbsoluteMediaUrl", () => {
+	const ORIGIN = "https://example.com";
+
+	it("resolves a relative media path against the origin", () => {
+		expect(toAbsoluteMediaUrl("/_emdash/api/media/file/01ABC.jpg", ORIGIN)).toBe(
+			"https://example.com/_emdash/api/media/file/01ABC.jpg",
+		);
+	});
+
+	it("returns already-absolute URLs unchanged", () => {
+		expect(toAbsoluteMediaUrl("https://cdn.example.com/a.jpg", ORIGIN)).toBe(
+			"https://cdn.example.com/a.jpg",
+		);
+	});
+
+	it("returns the source unchanged when origin is missing", () => {
+		expect(toAbsoluteMediaUrl("/path.jpg", undefined)).toBe("/path.jpg");
+	});
+
+	it("returns the source unchanged for an empty string", () => {
+		expect(toAbsoluteMediaUrl("", ORIGIN)).toBe("");
+	});
+
+	it("returns non-path values unchanged (data:, blob:)", () => {
+		expect(toAbsoluteMediaUrl("data:image/png;base64,abc", ORIGIN)).toBe(
+			"data:image/png;base64,abc",
+		);
+		expect(toAbsoluteMediaUrl("blob:https://example.com/uuid", ORIGIN)).toBe(
+			"blob:https://example.com/uuid",
+		);
+	});
+
+	it("does not absolutize protocol-relative URLs (SSRF guard)", () => {
+		expect(toAbsoluteMediaUrl("//evil.com/_emdash/api/media/file/x.jpg", ORIGIN)).toBe(
+			"//evil.com/_emdash/api/media/file/x.jpg",
+		);
+	});
+
+	it("does not let backslash tricks escape the origin (SSRF guard)", () => {
+		// WHATWG URL normalizes backslashes to slashes for http(s), so
+		// "/\\evil.com" would otherwise resolve to https://evil.com.
+		expect(toAbsoluteMediaUrl("/\\evil.com/x.jpg", ORIGIN)).toBe("/\\evil.com/x.jpg");
+		expect(toAbsoluteMediaUrl("/\\/evil.com/x.jpg", ORIGIN)).toBe("/\\/evil.com/x.jpg");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

Makes EmDash media render responsive `srcset`s automatically. The `Image` and Portable Text image components now route locally/R2-stored media through Astro's configured image service (`astro:assets`) — the Cloudflare Images binding on Workers, sharp on Node — so they emit width-appropriate candidates and modern formats (e.g. WebP) instead of a single full-size `<img>`.

Astro's image services only optimize **absolute** URLs whose host is authorized via `image.remotePatterns`; relative same-origin proxy URLs are passed through unchanged. So this PR:

- Resolves media URLs to absolute (via the public origin) before handing them to `getImage`.
- Auto-registers `image.remotePatterns` for: the storage `publicUrl` host (R2 custom domain, S3/CDN); the site origin scoped to the media route (`/_emdash/api/media/file/**`) when `siteUrl` is set; and a **dev-only**, host-agnostic media-route pattern so `astro dev` works with no configuration (the dev origin/port isn't known at build time). The dev pattern is gated to `command === "dev"` and never ships in a production build.
- Detects passthrough (the service returned the URL unchanged) and falls back to a plain `<img>`, so an unauthorized host / missing image service / unknown dimensions never produces a useless same-URL srcset.

No template changes are required, and existing sites render exactly as before when optimization isn't possible.

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

> Note: opened at the maintainer's request without a prior Discussion.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, opened at maintainer request

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Verified in `astro dev` against `demos/simple` (Node + sharp) and `infra/blog-demo` (Cloudflare Images binding):

- Featured images render full `srcset` ladders (`w=640…1920`) served as WebP via the image endpoint; a 750px candidate returned a real `image/webp` (31 KB).
- Without an authorized source (relative proxy URL, no service): plain `<img>`, 0 `srcset` — no regression, no no-op srcset.
- Production-build matrix (no dev pattern leak): `build` + no `siteUrl` → `[]`; `build` + `siteUrl` → host-scoped media pattern only; `dev` + no `siteUrl` → host-agnostic media pattern.
- 3821 core tests pass (11 new in `tests/unit/media/responsive.test.ts`), lint 0, typecheck 0, `astro check` 0.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-responsive-images-astro-assets-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/responsive-images-astro-assets`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
