### PR TITLE
Add Insert HTML toolbar button to PortableTextEditor

### DIFF
--- a/.changeset/html-block-toolbar.md
+++ b/.changeset/html-block-toolbar.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Add a visible WYSIWYG toolbar button for inserting HTML blocks, matching the existing `/html` shortcut.

--- a/packages/admin/src/components/PortableTextEditor.tsx
+++ b/packages/admin/src/components/PortableTextEditor.tsx
@@ -3127,6 +3127,18 @@ function EditorToolbar({
 					<ImageIcon className="h-4 w-4" aria-hidden="true" />
 				</ToolbarButton>
 				<ToolbarButton
+					onClick={() =>
+						editor
+							.chain()
+							.focus()
+							.insertContent({ type: "htmlBlock", attrs: { html: "" } })
+							.run()
+					}
+					title={t`Insert HTML`}
+				>
+					<BracketsAngle className="h-4 w-4" aria-hidden="true" />
+				</ToolbarButton>
+				<ToolbarButton
 					onClick={() => editor.chain().focus().setHorizontalRule().run()}
 					title={t`Insert Horizontal Rule`}
 				>

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -186,6 +186,7 @@ describe("Toolbar Presence and Structure", () => {
 		const { screen } = await renderEditor();
 		await expect.element(screen.getByRole("button", { name: "Insert Link" })).toBeVisible();
 		await expect.element(screen.getByRole("button", { name: "Insert Image" })).toBeVisible();
+		await expect.element(screen.getByRole("button", { name: "Insert HTML" })).toBeVisible();
 		await expect
 			.element(screen.getByRole("button", { name: "Insert Horizontal Rule" }))
 			.toBeVisible();
@@ -546,6 +547,19 @@ describe("Undo/Redo", () => {
 // =============================================================================
 
 describe("Link Insertion", () => {
+	it("clicking Insert HTML inserts an empty HTML block", async () => {
+		const { screen, editor } = await renderEditor();
+		editor.commands.focus("end");
+
+		getToolbarButton(screen, "Insert HTML").element().click();
+
+		await vi.waitFor(() => {
+			const htmlBlock = editor.getJSON().content?.find((node) => node.type === "htmlBlock");
+			expect(htmlBlock).toBeDefined();
+			expect((htmlBlock as { attrs?: { html?: string } }).attrs?.html).toBe("");
+		});
+	});
+
 	it("clicking Insert Link opens a popover with URL input", async () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);

--- a/packages/admin/tests/editor/toolbar.test.tsx
+++ b/packages/admin/tests/editor/toolbar.test.tsx
@@ -543,10 +543,10 @@ describe("Undo/Redo", () => {
 });
 
 // =============================================================================
-// 5. Link Insertion (Toolbar Popover)
+// 5. HTML Block Insertion
 // =============================================================================
 
-describe("Link Insertion", () => {
+describe("HTML Block Insertion", () => {
 	it("clicking Insert HTML inserts an empty HTML block", async () => {
 		const { screen, editor } = await renderEditor();
 		editor.commands.focus("end");
@@ -559,7 +559,13 @@ describe("Link Insertion", () => {
 			expect((htmlBlock as { attrs?: { html?: string } }).attrs?.html).toBe("");
 		});
 	});
+});
 
+// =============================================================================
+// 6. Link Insertion (Toolbar Popover)
+// =============================================================================
+
+describe("Link Insertion", () => {
 	it("clicking Insert Link opens a popover with URL input", async () => {
 		const { screen } = await renderEditor();
 		await focusAndSelectAll(screen);
@@ -656,7 +662,7 @@ describe("Link Insertion", () => {
 });
 
 // =============================================================================
-// 6. Focus Mode Toggle
+// 7. Focus Mode Toggle
 // =============================================================================
 
 describe("Focus Mode Toggle", () => {
@@ -726,7 +732,7 @@ describe("Focus Mode Toggle", () => {
 });
 
 // =============================================================================
-// 7. WAI-ARIA Keyboard Navigation
+// 8. WAI-ARIA Keyboard Navigation
 // =============================================================================
 
 describe("WAI-ARIA Keyboard Navigation", () => {


### PR DESCRIPTION
## What does this PR do?

Adds a visible `Insert HTML` toolbar button to the WYSIWYG Portable Text editor. This exposes the existing `htmlBlock` insertion path that was previously only discoverable through the `/html` slash command.

Closes #1341

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode + GPT-5.5

## Screenshots / test output
<img width="1075" height="517" alt="Screenshot 2026-06-12 at 14 29 38" src="https://github.com/user-attachments/assets/2ae5434e-2a36-4eca-a0d9-110f2f81f906" />

Verified locally:

- `pnpm lint:json | jq '.diagnostics | length'` -> `0`
- `pnpm lint:quick`
- `pnpm --filter @emdash-cms/admin typecheck`
- `pnpm exec vitest run tests/editor/toolbar.test.tsx` -> `47 passed`
- `pnpm exec vitest run` in `packages/admin` -> `79 files passed`, `997 tests passed`

Formatting was run on touched files:

- `pnpm exec oxfmt --ignore-path .gitignore packages/admin/src/components/PortableTextEditor.tsx packages/admin/tests/editor/toolbar.test.tsx`
- `pnpm exec prettier --write .changeset/html-block-toolbar.md`