### PR TITLE
feat(core): RelationRepository (content-references data layer)

### DIFF
--- a/.changeset/content-references-repository.md
+++ b/.changeset/content-references-repository.md
@@ -1,5 +1,0 @@
----
-"emdash": minor
----
-
-Add `RelationRepository`: the application data-access layer over the content-references schema (migration `043`). Manages relation definitions (`_emdash_relations`, row-per-locale) and directed, locale-agnostic reference edges (`_emdash_content_references`). Additive — typed inputs, no API/validation surface yet (Zod schemas and routes arrive in a following slice). Provides `clearReferencesForGroup` as the entry-deletion cleanup primitive; wiring it into the content-delete path is deferred.

--- a/.changeset/content-references-repository.md
+++ b/.changeset/content-references-repository.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Add `RelationRepository`: the application data-access layer over the content-references schema (migration `043`). Manages relation definitions (`_emdash_relations`, row-per-locale) and directed, locale-agnostic reference edges (`_emdash_content_references`). Additive — typed inputs, no API/validation surface yet (Zod schemas and routes arrive in a following slice). Provides `clearReferencesForGroup` as the entry-deletion cleanup primitive; wiring it into the content-delete path is deferred.

--- a/packages/core/src/database/repositories/index.ts
+++ b/packages/core/src/database/repositories/index.ts
@@ -42,3 +42,10 @@ export { BylineRepository } from "./byline.js";
 export type { CreateBylineInput, UpdateBylineInput, ContentBylineInput } from "./byline.js";
 export type * from "./types.js";
 export { EmDashValidationError, InvalidCursorError, encodeCursor, decodeCursor } from "./types.js";
+export { RelationRepository } from "./relation.js";
+export type {
+	Relation,
+	CreateRelationInput,
+	UpdateRelationInput,
+	ContentReference,
+} from "./relation.js";

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -351,10 +351,16 @@ export class RelationRepository {
 
 	/**
 	 * Replace all children of `parentGroup` under a relation with `childGroups`,
-	 * assigning positional sort_order (index in the array). Deletes the old set
-	 * for this (relation, parent) and re-inserts — simple and correct; the set
-	 * is small (one parent's children). Mirrors the intent of
+	 * assigning positional sort_order (index in the deduped array). Deletes the
+	 * old set for this (relation, parent) and re-inserts — simple and correct;
+	 * the set is small (one parent's children). Mirrors the intent of
 	 * `TaxonomyRepository.setTermsForEntry`.
+	 *
+	 * A parent references a given child at most once (the unique edge), so
+	 * duplicate `childGroups` are collapsed first-occurrence-wins rather than
+	 * relying on the insert's onConflict to silently drop them. Not wrapped in a
+	 * transaction: a crash between the delete and insert leaves the parent with
+	 * no children — acceptable for a replace-all, since a retry restores state.
 	 */
 	async setChildren(
 		relation: string,
@@ -370,13 +376,15 @@ export class RelationRepository {
 			.where("parent_group", "=", parentGroup)
 			.execute();
 
-		if (childGroups.length === 0) return;
+		// Collapse duplicates so positional sort_order has no gaps.
+		const uniqueChildGroups = [...new Set(childGroups)];
+		if (uniqueChildGroups.length === 0) return;
 
 		const now = new Date().toISOString();
 		await this.db
 			.insertInto("_emdash_content_references")
 			.values(
-				childGroups.map((childGroup, index) => ({
+				uniqueChildGroups.map((childGroup, index) => ({
 					id: ulid(),
 					relation_group: relationGroup,
 					parent_group: parentGroup,

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -2,6 +2,7 @@ import type { Kysely, Selectable } from "kysely";
 import { ulid } from "ulidx";
 
 import type { Database, RelationTable, ContentReferenceTable } from "../types.js";
+import { chunks, SQL_BATCH_SIZE } from "../../utils/chunks.js";
 
 export interface Relation {
 	id: string;
@@ -395,6 +396,78 @@ export class RelationRepository {
 			)
 			.onConflict((oc) => oc.doNothing())
 			.execute();
+	}
+
+	/**
+	 * Remove every edge where `group` is the parent OR the child. The primitive
+	 * for entry-deletion cleanup (parent spec write-path invariant 4). Wiring
+	 * this into the content-delete path is a later (handler) slice. Returns the
+	 * number of edges removed.
+	 */
+	async clearReferencesForGroup(group: string): Promise<number> {
+		const result = await this.db
+			.deleteFrom("_emdash_content_references")
+			.where((eb) =>
+				eb.or([eb("parent_group", "=", group), eb("child_group", "=", group)]),
+			)
+			.executeTakeFirst();
+		return Number(result.numDeletedRows ?? 0);
+	}
+
+	/** Count a parent's children under a relation. */
+	async countChildren(relation: string, parentGroup: string): Promise<number> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return 0;
+		const result = await this.db
+			.selectFrom("_emdash_content_references")
+			.select((eb) => eb.fn.count("id").as("count"))
+			.where("relation_group", "=", relationGroup)
+			.where("parent_group", "=", parentGroup)
+			.executeTakeFirst();
+		return Number(result?.count ?? 0);
+	}
+
+	/** Count a child's parents (backlinks) under a relation. */
+	async countParents(relation: string, childGroup: string): Promise<number> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return 0;
+		const result = await this.db
+			.selectFrom("_emdash_content_references")
+			.select((eb) => eb.fn.count("id").as("count"))
+			.where("relation_group", "=", relationGroup)
+			.where("child_group", "=", childGroup)
+			.executeTakeFirst();
+		return Number(result?.count ?? 0);
+	}
+
+	/**
+	 * Batch child-counts for many parents under a relation. Chunks at
+	 * SQL_BATCH_SIZE for D1's bind-parameter limit. Returns parent_group → count
+	 * (parents with no children are absent from the map). Mirrors
+	 * `TaxonomyRepository.countEntriesForTerms`.
+	 */
+	async countChildrenForParents(
+		relation: string,
+		parentGroups: string[],
+	): Promise<Map<string, number>> {
+		const counts = new Map<string, number>();
+		if (parentGroups.length === 0) return counts;
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return counts;
+
+		for (const chunk of chunks(parentGroups, SQL_BATCH_SIZE)) {
+			const rows = await this.db
+				.selectFrom("_emdash_content_references")
+				.select(["parent_group", (eb) => eb.fn.count("id").as("count")])
+				.where("relation_group", "=", relationGroup)
+				.where("parent_group", "in", chunk)
+				.groupBy("parent_group")
+				.execute();
+			for (const row of rows) {
+				counts.set(row.parent_group, Number(row.count || 0));
+			}
+		}
+		return counts;
 	}
 
 	private rowToRelation(row: Selectable<RelationTable>): Relation {

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -63,8 +63,9 @@ export class RelationRepository {
 	/**
 	 * Create a relation. Without `translationOf`, mints a fresh group
 	 * (`translation_group = id`, matching the migration backfill pattern). With
-	 * `translationOf`, joins the source's group and inherits its structural
-	 * fields (name + both collections); only locale + labels vary per locale.
+	 * `translationOf`, the structural fields (name, parentCollection,
+	 * childCollection) and the translation_group are inherited from the source;
+	 * locale and the two labels are taken from `input`.
 	 */
 	async create(input: CreateRelationInput): Promise<Relation> {
 		const id = ulid();
@@ -77,6 +78,9 @@ export class RelationRepository {
 
 		if (input.translationOf) {
 			const source = await this.findById(input.translationOf);
+			// translation_group is NOT NULL here, so we cannot fall back to a
+			// fresh group like TaxonomyRepository does — a bad translationOf must
+			// fail loudly rather than silently mint an unlinked relation.
 			if (!source) throw new Error("Source relation for translation not found");
 			translationGroup = source.translationGroup;
 			name = source.name;

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -180,6 +180,57 @@ export class RelationRepository {
 		return rows.map((row) => this.rowToRelation(row));
 	}
 
+	/** Update the localized labels of one relation row. Structural fields are
+	 * immutable here (a cross-group concern). No-ops when nothing is supplied. */
+	async update(id: string, input: UpdateRelationInput): Promise<Relation | null> {
+		const existing = await this.findById(id);
+		if (!existing) return null;
+
+		const updates: Record<string, unknown> = {};
+		if (input.parentLabel !== undefined) updates.parent_label = input.parentLabel;
+		if (input.childLabel !== undefined) updates.child_label = input.childLabel;
+
+		if (Object.keys(updates).length > 0) {
+			updates.updated_at = new Date().toISOString();
+			await this.db
+				.updateTable("_emdash_relations")
+				.set(updates)
+				.where("id", "=", id)
+				.execute();
+		}
+
+		return this.findById(id);
+	}
+
+	/**
+	 * Delete one relation row. When it is the *last* translation of its group,
+	 * purge edges referencing that group (application-layer cascade — group
+	 * linking precludes a SQL FK). Mirrors `TaxonomyRepository.delete`.
+	 */
+	async delete(id: string): Promise<boolean> {
+		const relation = await this.findById(id);
+		if (!relation) return false;
+
+		const siblings = await this.db
+			.selectFrom("_emdash_relations")
+			.select("id")
+			.where("translation_group", "=", relation.translationGroup)
+			.where("id", "!=", id)
+			.execute();
+		if (siblings.length === 0) {
+			await this.db
+				.deleteFrom("_emdash_content_references")
+				.where("relation_group", "=", relation.translationGroup)
+				.execute();
+		}
+
+		const result = await this.db
+			.deleteFrom("_emdash_relations")
+			.where("id", "=", id)
+			.executeTakeFirst();
+		return (result.numDeletedRows ?? 0n) > 0n;
+	}
+
 	private rowToRelation(row: Selectable<RelationTable>): Relation {
 		return {
 			id: row.id,

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -123,7 +123,8 @@ export class RelationRepository {
 	/**
 	 * Find a relation by name. With `locale`, filter by it; without, return the
 	 * lowest-locale-code match deterministically. Mirrors
-	 * `TaxonomyRepository.findBySlug`.
+	 * `TaxonomyRepository.findBySlug` — note this returns a single row, unlike
+	 * `TaxonomyRepository.findByName` which returns every term in a taxonomy.
 	 */
 	async findByName(name: string, locale?: string): Promise<Relation | null> {
 		let query = this.db

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -1,8 +1,8 @@
 import type { Kysely, Selectable } from "kysely";
 import { ulid } from "ulidx";
 
-import type { Database, RelationTable, ContentReferenceTable } from "../types.js";
 import { chunks, SQL_BATCH_SIZE } from "../../utils/chunks.js";
+import type { Database, RelationTable, ContentReferenceTable } from "../types.js";
 
 export interface Relation {
 	id: string;
@@ -399,10 +399,11 @@ export class RelationRepository {
 	}
 
 	/**
-	 * Remove every edge where `group` is the parent OR the child. The primitive
-	 * for entry-deletion cleanup (parent spec write-path invariant 4). Wiring
-	 * this into the content-delete path is a later (handler) slice. Returns the
-	 * number of edges removed.
+	 * Remove every edge where `group` is the parent OR the child — i.e. ensure no
+	 * orphaned reference edges survive when a content entry is deleted. The
+	 * application-layer cascade that group-linking precludes at the SQL level.
+	 * Wiring this into the content-delete path is a later (handler) slice.
+	 * Returns the number of edges removed.
 	 */
 	async clearReferencesForGroup(group: string): Promise<number> {
 		const result = await this.db
@@ -464,7 +465,7 @@ export class RelationRepository {
 				.groupBy("parent_group")
 				.execute();
 			for (const row of rows) {
-				counts.set(row.parent_group, Number(row.count || 0));
+				counts.set(row.parent_group, Number(row.count ?? 0));
 			}
 		}
 		return counts;

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -1,0 +1,131 @@
+import type { Kysely, Selectable } from "kysely";
+import { ulid } from "ulidx";
+
+import type { Database, RelationTable } from "../types.js";
+
+export interface Relation {
+	id: string;
+	name: string;
+	parentCollection: string;
+	childCollection: string;
+	parentLabel: string;
+	childLabel: string;
+	locale: string;
+	translationGroup: string;
+}
+
+export interface CreateRelationInput {
+	name: string;
+	parentCollection: string;
+	childCollection: string;
+	parentLabel: string;
+	childLabel: string;
+	/** Omit to let the DB default (current value: 'en') apply. Higher layers
+	 * resolve locale from request context / i18n config. */
+	locale?: string;
+	/** When set, joins the source relation's translation_group AND inherits its
+	 * structural fields (name, parentCollection, childCollection). Only locale +
+	 * labels may differ on a translation. */
+	translationOf?: string;
+}
+
+export interface UpdateRelationInput {
+	/** Only localized fields are mutable per row. Changing structural fields
+	 * (name/collections) is a cross-group operation deferred to a later slice. */
+	parentLabel?: string;
+	childLabel?: string;
+}
+
+export interface ContentReference {
+	id: string;
+	relationGroup: string;
+	parentGroup: string;
+	childGroup: string;
+	sortOrder: number;
+}
+
+/**
+ * Content-references repository.
+ *
+ * Owns relation *definitions* (`_emdash_relations`, row-per-locale, mirroring
+ * `_emdash_taxonomy_defs`) and the *edge* junction (`_emdash_content_references`,
+ * keyed by `translation_group` so edges are locale-agnostic, mirroring
+ * `content_taxonomies`).
+ *
+ * Like `TaxonomyRepository`, this is not the validation boundary: it trusts its
+ * typed inputs. The API slice supplies Zod schemas at the route and enforces
+ * collection-agreement / relation-existence invariants in the handler. The repo
+ * does not resolve locale fallbacks — callers pass the locale they want.
+ */
+export class RelationRepository {
+	constructor(private db: Kysely<Database>) {}
+
+	/**
+	 * Create a relation. Without `translationOf`, mints a fresh group
+	 * (`translation_group = id`, matching the migration backfill pattern). With
+	 * `translationOf`, joins the source's group and inherits its structural
+	 * fields (name + both collections); only locale + labels vary per locale.
+	 */
+	async create(input: CreateRelationInput): Promise<Relation> {
+		const id = ulid();
+		const now = new Date().toISOString();
+
+		let translationGroup = id;
+		let name = input.name;
+		let parentCollection = input.parentCollection;
+		let childCollection = input.childCollection;
+
+		if (input.translationOf) {
+			const source = await this.findById(input.translationOf);
+			if (!source) throw new Error("Source relation for translation not found");
+			translationGroup = source.translationGroup;
+			name = source.name;
+			parentCollection = source.parentCollection;
+			childCollection = source.childCollection;
+		}
+
+		await this.db
+			.insertInto("_emdash_relations")
+			.values({
+				id,
+				name,
+				parent_collection: parentCollection,
+				child_collection: childCollection,
+				parent_label: input.parentLabel,
+				child_label: input.childLabel,
+				created_at: now,
+				updated_at: now,
+				// Omit `locale` so the DB DEFAULT (configured defaultLocale)
+				// applies — matches TaxonomyRepository.create.
+				...(input.locale !== undefined ? { locale: input.locale } : {}),
+				translation_group: translationGroup,
+			})
+			.execute();
+
+		const relation = await this.findById(id);
+		if (!relation) throw new Error("Failed to create relation");
+		return relation;
+	}
+
+	async findById(id: string): Promise<Relation | null> {
+		const row = await this.db
+			.selectFrom("_emdash_relations")
+			.selectAll()
+			.where("id", "=", id)
+			.executeTakeFirst();
+		return row ? this.rowToRelation(row) : null;
+	}
+
+	private rowToRelation(row: Selectable<RelationTable>): Relation {
+		return {
+			id: row.id,
+			name: row.name,
+			parentCollection: row.parent_collection,
+			childCollection: row.child_collection,
+			parentLabel: row.parent_label,
+			childLabel: row.child_label,
+			locale: row.locale,
+			translationGroup: row.translation_group,
+		};
+	}
+}

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -120,6 +120,65 @@ export class RelationRepository {
 		return row ? this.rowToRelation(row) : null;
 	}
 
+	/**
+	 * Find a relation by name. With `locale`, filter by it; without, return the
+	 * lowest-locale-code match deterministically. Mirrors
+	 * `TaxonomyRepository.findBySlug`.
+	 */
+	async findByName(name: string, locale?: string): Promise<Relation | null> {
+		let query = this.db
+			.selectFrom("_emdash_relations")
+			.selectAll()
+			.where("name", "=", name);
+		if (locale !== undefined) query = query.where("locale", "=", locale);
+		const row = await query.orderBy("locale", "asc").executeTakeFirst();
+		return row ? this.rowToRelation(row) : null;
+	}
+
+	/** Every translation sibling (including itself) sharing a translation_group. */
+	async findTranslations(translationGroup: string): Promise<Relation[]> {
+		const rows = await this.db
+			.selectFrom("_emdash_relations")
+			.selectAll()
+			.where("translation_group", "=", translationGroup)
+			.orderBy("locale", "asc")
+			.execute();
+		return rows.map((row) => this.rowToRelation(row));
+	}
+
+	/**
+	 * All relations, ordered by name then id (id is a stable tiebreak for
+	 * relations sharing a name across locales). Optionally filtered by locale.
+	 */
+	async list(locale?: string): Promise<Relation[]> {
+		let query = this.db
+			.selectFrom("_emdash_relations")
+			.selectAll()
+			.orderBy("name", "asc")
+			.orderBy("id", "asc");
+		if (locale !== undefined) query = query.where("locale", "=", locale);
+		const rows = await query.execute();
+		return rows.map((row) => this.rowToRelation(row));
+	}
+
+	/** Relations where `collection` is the parent OR the child side. */
+	async findForCollection(collection: string, locale?: string): Promise<Relation[]> {
+		let query = this.db
+			.selectFrom("_emdash_relations")
+			.selectAll()
+			.where((eb) =>
+				eb.or([
+					eb("parent_collection", "=", collection),
+					eb("child_collection", "=", collection),
+				]),
+			)
+			.orderBy("name", "asc")
+			.orderBy("id", "asc");
+		if (locale !== undefined) query = query.where("locale", "=", locale);
+		const rows = await query.execute();
+		return rows.map((row) => this.rowToRelation(row));
+	}
+
 	private rowToRelation(row: Selectable<RelationTable>): Relation {
 		return {
 			id: row.id,

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -1,7 +1,7 @@
 import type { Kysely, Selectable } from "kysely";
 import { ulid } from "ulidx";
 
-import type { Database, RelationTable } from "../types.js";
+import type { Database, RelationTable, ContentReferenceTable } from "../types.js";
 
 export interface Relation {
 	id: string;
@@ -231,6 +231,117 @@ export class RelationRepository {
 			.where("id", "=", id)
 			.executeTakeFirst();
 		return (result.numDeletedRows ?? 0n) > 0n;
+	}
+
+	/** Normalize a relation id OR group to its translation_group. Returns null
+	 * for an unknown relation (edge methods then no-op, matching
+	 * `TaxonomyRepository.attachToEntry`). */
+	private async resolveRelationGroup(idOrGroup: string): Promise<string | null> {
+		const row = await this.db
+			.selectFrom("_emdash_relations")
+			.select(["translation_group"])
+			.where((eb) =>
+				eb.or([eb("id", "=", idOrGroup), eb("translation_group", "=", idOrGroup)]),
+			)
+			.executeTakeFirst();
+		return row?.translation_group ?? null;
+	}
+
+	private rowToReference(row: Selectable<ContentReferenceTable>): ContentReference {
+		return {
+			id: row.id,
+			relationGroup: row.relation_group,
+			parentGroup: row.parent_group,
+			childGroup: row.child_group,
+			sortOrder: row.sort_order,
+		};
+	}
+
+	/**
+	 * Link `parentGroup → childGroup` under a relation. `relation` is a relation
+	 * id or group. Idempotent (onConflict doNothing against the unique edge).
+	 * `sortOrder` defaults to append: max(sort_order)+1 within (relation, parent).
+	 */
+	async addReference(
+		relation: string,
+		parentGroup: string,
+		childGroup: string,
+		sortOrder?: number,
+	): Promise<void> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return;
+
+		let order = sortOrder;
+		if (order === undefined) {
+			const max = await this.db
+				.selectFrom("_emdash_content_references")
+				.select((eb) => eb.fn.max("sort_order").as("max"))
+				.where("relation_group", "=", relationGroup)
+				.where("parent_group", "=", parentGroup)
+				.executeTakeFirst();
+			order = max?.max === null || max?.max === undefined ? 0 : Number(max.max) + 1;
+		}
+
+		await this.db
+			.insertInto("_emdash_content_references")
+			.values({
+				id: ulid(),
+				relation_group: relationGroup,
+				parent_group: parentGroup,
+				child_group: childGroup,
+				sort_order: order,
+				created_at: new Date().toISOString(),
+			})
+			.onConflict((oc) => oc.doNothing())
+			.execute();
+	}
+
+	/** Remove one `parentGroup → childGroup` edge under a relation. */
+	async removeReference(
+		relation: string,
+		parentGroup: string,
+		childGroup: string,
+	): Promise<void> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return;
+
+		await this.db
+			.deleteFrom("_emdash_content_references")
+			.where("relation_group", "=", relationGroup)
+			.where("parent_group", "=", parentGroup)
+			.where("child_group", "=", childGroup)
+			.execute();
+	}
+
+	/** Forward traversal: a parent's children for a relation, ordered. */
+	async getChildren(relation: string, parentGroup: string): Promise<ContentReference[]> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return [];
+
+		const rows = await this.db
+			.selectFrom("_emdash_content_references")
+			.selectAll()
+			.where("relation_group", "=", relationGroup)
+			.where("parent_group", "=", parentGroup)
+			.orderBy("sort_order", "asc")
+			.orderBy("id", "asc")
+			.execute();
+		return rows.map((row) => this.rowToReference(row));
+	}
+
+	/** Backlink traversal: the parents that reference a child for a relation. */
+	async getParents(relation: string, childGroup: string): Promise<ContentReference[]> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return [];
+
+		const rows = await this.db
+			.selectFrom("_emdash_content_references")
+			.selectAll()
+			.where("relation_group", "=", relationGroup)
+			.where("child_group", "=", childGroup)
+			.orderBy("id", "asc")
+			.execute();
+		return rows.map((row) => this.rowToReference(row));
 	}
 
 	private rowToRelation(row: Selectable<RelationTable>): Relation {

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -349,6 +349,46 @@ export class RelationRepository {
 		return rows.map((row) => this.rowToReference(row));
 	}
 
+	/**
+	 * Replace all children of `parentGroup` under a relation with `childGroups`,
+	 * assigning positional sort_order (index in the array). Deletes the old set
+	 * for this (relation, parent) and re-inserts — simple and correct; the set
+	 * is small (one parent's children). Mirrors the intent of
+	 * `TaxonomyRepository.setTermsForEntry`.
+	 */
+	async setChildren(
+		relation: string,
+		parentGroup: string,
+		childGroups: string[],
+	): Promise<void> {
+		const relationGroup = await this.resolveRelationGroup(relation);
+		if (!relationGroup) return;
+
+		await this.db
+			.deleteFrom("_emdash_content_references")
+			.where("relation_group", "=", relationGroup)
+			.where("parent_group", "=", parentGroup)
+			.execute();
+
+		if (childGroups.length === 0) return;
+
+		const now = new Date().toISOString();
+		await this.db
+			.insertInto("_emdash_content_references")
+			.values(
+				childGroups.map((childGroup, index) => ({
+					id: ulid(),
+					relation_group: relationGroup,
+					parent_group: parentGroup,
+					child_group: childGroup,
+					sort_order: index,
+					created_at: now,
+				})),
+			)
+			.onConflict((oc) => oc.doNothing())
+			.execute();
+	}
+
 	private rowToRelation(row: Selectable<RelationTable>): Relation {
 		return {
 			id: row.id,

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -261,6 +261,11 @@ export class RelationRepository {
 	 * Link `parentGroup → childGroup` under a relation. `relation` is a relation
 	 * id or group. Idempotent (onConflict doNothing against the unique edge).
 	 * `sortOrder` defaults to append: max(sort_order)+1 within (relation, parent).
+	 *
+	 * The default-append MAX→INSERT is not atomic: concurrent appends without an
+	 * explicit `sortOrder` may both read the same max and collide on sort_order,
+	 * and onConflict silently drops the loser. Callers needing strict ordering
+	 * under concurrency should pass `sortOrder` explicitly (or serialize).
 	 */
 	async addReference(
 		relation: string,

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -180,8 +180,10 @@ export class RelationRepository {
 		return rows.map((row) => this.rowToRelation(row));
 	}
 
-	/** Update the localized labels of one relation row. Structural fields are
-	 * immutable here (a cross-group concern). No-ops when nothing is supplied. */
+	/**
+	 * Update the localized labels of one relation row. Structural fields are
+	 * immutable here (a cross-group concern). No-ops when nothing is supplied.
+	 */
 	async update(id: string, input: UpdateRelationInput): Promise<Relation | null> {
 		const existing = await this.findById(id);
 		if (!existing) return null;

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -128,10 +128,7 @@ export class RelationRepository {
 	 * `TaxonomyRepository.findByName` which returns every term in a taxonomy.
 	 */
 	async findByName(name: string, locale?: string): Promise<Relation | null> {
-		let query = this.db
-			.selectFrom("_emdash_relations")
-			.selectAll()
-			.where("name", "=", name);
+		let query = this.db.selectFrom("_emdash_relations").selectAll().where("name", "=", name);
 		if (locale !== undefined) query = query.where("locale", "=", locale);
 		const row = await query.orderBy("locale", "asc").executeTakeFirst();
 		return row ? this.rowToRelation(row) : null;
@@ -169,10 +166,7 @@ export class RelationRepository {
 			.selectFrom("_emdash_relations")
 			.selectAll()
 			.where((eb) =>
-				eb.or([
-					eb("parent_collection", "=", collection),
-					eb("child_collection", "=", collection),
-				]),
+				eb.or([eb("parent_collection", "=", collection), eb("child_collection", "=", collection)]),
 			)
 			.orderBy("name", "asc")
 			.orderBy("id", "asc");
@@ -195,11 +189,7 @@ export class RelationRepository {
 
 		if (Object.keys(updates).length > 0) {
 			updates.updated_at = new Date().toISOString();
-			await this.db
-				.updateTable("_emdash_relations")
-				.set(updates)
-				.where("id", "=", id)
-				.execute();
+			await this.db.updateTable("_emdash_relations").set(updates).where("id", "=", id).execute();
 		}
 
 		return this.findById(id);
@@ -241,9 +231,7 @@ export class RelationRepository {
 		const row = await this.db
 			.selectFrom("_emdash_relations")
 			.select(["translation_group"])
-			.where((eb) =>
-				eb.or([eb("id", "=", idOrGroup), eb("translation_group", "=", idOrGroup)]),
-			)
+			.where((eb) => eb.or([eb("id", "=", idOrGroup), eb("translation_group", "=", idOrGroup)]))
 			.executeTakeFirst();
 		return row?.translation_group ?? null;
 	}
@@ -303,11 +291,7 @@ export class RelationRepository {
 	}
 
 	/** Remove one `parentGroup → childGroup` edge under a relation. */
-	async removeReference(
-		relation: string,
-		parentGroup: string,
-		childGroup: string,
-	): Promise<void> {
+	async removeReference(relation: string, parentGroup: string, childGroup: string): Promise<void> {
 		const relationGroup = await this.resolveRelationGroup(relation);
 		if (!relationGroup) return;
 
@@ -363,11 +347,7 @@ export class RelationRepository {
 	 * transaction: a crash between the delete and insert leaves the parent with
 	 * no children — acceptable for a replace-all, since a retry restores state.
 	 */
-	async setChildren(
-		relation: string,
-		parentGroup: string,
-		childGroups: string[],
-	): Promise<void> {
+	async setChildren(relation: string, parentGroup: string, childGroups: string[]): Promise<void> {
 		const relationGroup = await this.resolveRelationGroup(relation);
 		if (!relationGroup) return;
 
@@ -408,9 +388,7 @@ export class RelationRepository {
 	async clearReferencesForGroup(group: string): Promise<number> {
 		const result = await this.db
 			.deleteFrom("_emdash_content_references")
-			.where((eb) =>
-				eb.or([eb("parent_group", "=", group), eb("child_group", "=", group)]),
-			)
+			.where((eb) => eb.or([eb("parent_group", "=", group), eb("child_group", "=", group)]))
 			.executeTakeFirst();
 		return Number(result.numDeletedRows ?? 0);
 	}

--- a/packages/core/src/database/repositories/relation.ts
+++ b/packages/core/src/database/repositories/relation.ts
@@ -374,6 +374,9 @@ export class RelationRepository {
 					created_at: now,
 				})),
 			)
+			// Belt-and-suspenders: the DELETE above already cleared this
+			// (relation, parent), so no conflict is possible within one call.
+			// This is NOT a concurrency guarantee — delete-then-insert is not atomic.
 			.onConflict((oc) => oc.doNothing())
 			.execute();
 	}

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -268,4 +268,9 @@ describeEachDialect("RelationRepository", (dialect) => {
 		await repo.addReference("unknown-relation", "p1", "cA");
 		expect(await repo.getChildren("unknown-relation", "p1")).toEqual([]);
 	});
+
+	it("removeReference of a nonexistent edge is a no-op", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await expect(repo.removeReference(rel.id, "p1", "never-added")).resolves.toBeUndefined();
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -331,6 +331,10 @@ describeEachDialect("RelationRepository", (dialect) => {
 
 		expect(await repo.countChildren(rel.id, "p1")).toBe(2);
 		expect(await repo.countParents(rel.id, "a")).toBe(2);
+
+		// Unknown relation resolves to no group → zero.
+		expect(await repo.countChildren("unknown-relation", "p1")).toBe(0);
+		expect(await repo.countParents("unknown-relation", "a")).toBe(0);
 	});
 
 	it("countChildrenForParents batches across more than SQL_BATCH_SIZE parents", async () => {

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { RelationRepository } from "../../../src/database/repositories/relation.js";
+import {
+	describeEachDialect,
+	setupForDialect,
+	teardownForDialect,
+	type DialectTestContext,
+} from "../../utils/test-db.js";
+
+describeEachDialect("RelationRepository", (dialect) => {
+	let ctx: DialectTestContext;
+	let repo: RelationRepository;
+
+	beforeEach(async () => {
+		ctx = await setupForDialect(dialect); // runs all migrations
+		repo = new RelationRepository(ctx.db);
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	const baseInput = {
+		name: "manages",
+		parentCollection: "employees",
+		childCollection: "employees",
+		parentLabel: "Manager",
+		childLabel: "Direct report",
+	};
+
+	it("create mints an anchor row (translation_group = id, default locale)", async () => {
+		const rel = await repo.create({ ...baseInput });
+		expect(rel.id).toBeTruthy();
+		expect(rel.translationGroup).toBe(rel.id);
+		expect(rel.locale).toBe("en");
+		expect(rel.name).toBe("manages");
+		expect(rel.parentCollection).toBe("employees");
+		expect(rel.childCollection).toBe("employees");
+
+		const fetched = await repo.findById(rel.id);
+		expect(fetched).toEqual(rel);
+	});
+
+	it("create with translationOf joins the group and inherits structural fields", async () => {
+		const anchor = await repo.create({ ...baseInput });
+		const fr = await repo.create({
+			name: "ignored-name",
+			parentCollection: "ignored",
+			childCollection: "ignored",
+			parentLabel: "Responsable",
+			childLabel: "Subordonné",
+			locale: "fr",
+			translationOf: anchor.id,
+		});
+
+		expect(fr.translationGroup).toBe(anchor.translationGroup);
+		expect(fr.locale).toBe("fr");
+		expect(fr.name).toBe("manages");
+		expect(fr.parentCollection).toBe("employees");
+		expect(fr.childCollection).toBe("employees");
+		expect(fr.parentLabel).toBe("Responsable");
+		expect(fr.childLabel).toBe("Subordonné");
+	});
+
+	it("create with a missing translationOf source throws", async () => {
+		await expect(
+			repo.create({ ...baseInput, locale: "fr", translationOf: "does-not-exist" }),
+		).rejects.toThrow();
+	});
+
+	it("findById returns null for an unknown id", async () => {
+		expect(await repo.findById("nope")).toBeNull();
+	});
+});

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -295,4 +295,17 @@ describeEachDialect("RelationRepository", (dialect) => {
 		await repo.setChildren(rel.id, "p1", []);
 		expect(await repo.getChildren(rel.translationGroup, "p1")).toEqual([]);
 	});
+
+	it("setChildren collapses duplicate childGroups (one edge per child)", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.setChildren(rel.id, "p1", ["a", "b", "a"]);
+		const children = await repo.getChildren(rel.translationGroup, "p1");
+		expect(children.map((c) => c.childGroup)).toEqual(["a", "b"]);
+		expect(children.map((c) => c.sortOrder)).toEqual([0, 1]);
+	});
+
+	it("setChildren no-ops for an unknown relation", async () => {
+		await expect(repo.setChildren("unknown-relation", "p1", ["a"])).resolves.toBeUndefined();
+		expect(await repo.getChildren("unknown-relation", "p1")).toEqual([]);
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -108,12 +108,21 @@ describeEachDialect("RelationRepository", (dialect) => {
 
 	it("list returns relations ordered by name then id, optionally filtered by locale", async () => {
 		await repo.create({ ...baseInput, name: "writes", childCollection: "posts" });
-		await repo.create({ ...baseInput, name: "manages" });
+		const manages = await repo.create({ ...baseInput, name: "manages" });
+		await repo.create({
+			...baseInput,
+			locale: "fr",
+			parentLabel: "Responsable",
+			childLabel: "Subordonné",
+			translationOf: manages.id,
+		});
 
 		const all = await repo.list();
-		expect(all.map((r) => r.name)).toEqual(["manages", "writes"]);
+		expect(all.map((r) => r.name)).toEqual(["manages", "manages", "writes"]);
 
 		const enOnly = await repo.list("en");
+		// The 'fr' row must be filtered out — assert the filter actually removes it.
+		expect(enOnly.length).toBeLessThan(all.length);
 		expect(enOnly.every((r) => r.locale === "en")).toBe(true);
 	});
 
@@ -132,7 +141,8 @@ describeEachDialect("RelationRepository", (dialect) => {
 		});
 
 		const forPosts = await repo.findForCollection("posts");
-		expect(forPosts.map((r) => r.name).toSorted()).toEqual(["tags_rel", "writes"]);
+		// Asserted in returned order to also verify the (name, id) ORDER BY.
+		expect(forPosts.map((r) => r.name)).toEqual(["tags_rel", "writes"]);
 
 		const forTags = await repo.findForCollection("tags");
 		expect(forTags.map((r) => r.name)).toEqual(["tags_rel"]);

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -72,4 +72,69 @@ describeEachDialect("RelationRepository", (dialect) => {
 	it("findById returns null for an unknown id", async () => {
 		expect(await repo.findById("nope")).toBeNull();
 	});
+
+	it("findByName filters by locale, and resolves deterministically without one", async () => {
+		const anchor = await repo.create({ ...baseInput });
+		await repo.create({
+			...baseInput,
+			locale: "fr",
+			parentLabel: "Responsable",
+			childLabel: "Subordonné",
+			translationOf: anchor.id,
+		});
+
+		const fr = await repo.findByName("manages", "fr");
+		expect(fr?.locale).toBe("fr");
+
+		const any = await repo.findByName("manages");
+		expect(any?.locale).toBe("en"); // lowest locale code wins deterministically
+
+		expect(await repo.findByName("missing")).toBeNull();
+	});
+
+	it("findTranslations returns every locale sibling, ordered by locale", async () => {
+		const anchor = await repo.create({ ...baseInput });
+		await repo.create({
+			...baseInput,
+			locale: "fr",
+			parentLabel: "Responsable",
+			childLabel: "Subordonné",
+			translationOf: anchor.id,
+		});
+
+		const sibs = await repo.findTranslations(anchor.translationGroup);
+		expect(sibs.map((r) => r.locale)).toEqual(["en", "fr"]);
+	});
+
+	it("list returns relations ordered by name then id, optionally filtered by locale", async () => {
+		await repo.create({ ...baseInput, name: "writes", childCollection: "posts" });
+		await repo.create({ ...baseInput, name: "manages" });
+
+		const all = await repo.list();
+		expect(all.map((r) => r.name)).toEqual(["manages", "writes"]);
+
+		const enOnly = await repo.list("en");
+		expect(enOnly.every((r) => r.locale === "en")).toBe(true);
+	});
+
+	it("findForCollection matches parent OR child collection", async () => {
+		await repo.create({
+			...baseInput,
+			name: "writes",
+			parentCollection: "authors",
+			childCollection: "posts",
+		});
+		await repo.create({
+			...baseInput,
+			name: "tags_rel",
+			parentCollection: "posts",
+			childCollection: "tags",
+		});
+
+		const forPosts = await repo.findForCollection("posts");
+		expect(forPosts.map((r) => r.name).toSorted()).toEqual(["tags_rel", "writes"]);
+
+		const forTags = await repo.findForCollection("tags");
+		expect(forTags.map((r) => r.name)).toEqual(["tags_rel"]);
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -308,4 +308,41 @@ describeEachDialect("RelationRepository", (dialect) => {
 		await expect(repo.setChildren("unknown-relation", "p1", ["a"])).resolves.toBeUndefined();
 		expect(await repo.getChildren("unknown-relation", "p1")).toEqual([]);
 	});
+
+	it("clearReferencesForGroup removes edges where the group is parent OR child", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.id, "X", "a"); // X as parent
+		await repo.addReference(rel.id, "b", "X"); // X as child
+		await repo.addReference(rel.id, "b", "c"); // unrelated
+
+		const removed = await repo.clearReferencesForGroup("X");
+		expect(removed).toBe(2);
+
+		expect(await repo.getChildren(rel.translationGroup, "X")).toHaveLength(0);
+		expect(await repo.getParents(rel.translationGroup, "X")).toHaveLength(0);
+		expect(await repo.getChildren(rel.translationGroup, "b")).toHaveLength(1);
+	});
+
+	it("countChildren and countParents count edges", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.id, "p1", "a");
+		await repo.addReference(rel.id, "p1", "b");
+		await repo.addReference(rel.id, "p2", "a");
+
+		expect(await repo.countChildren(rel.id, "p1")).toBe(2);
+		expect(await repo.countParents(rel.id, "a")).toBe(2);
+	});
+
+	it("countChildrenForParents batches across more than SQL_BATCH_SIZE parents", async () => {
+		const rel = await repo.create({ ...baseInput });
+		const parents = Array.from({ length: 120 }, (_, i) => `p${i}`);
+		for (const p of parents) await repo.addReference(rel.id, p, "child");
+
+		const counts = await repo.countChildrenForParents(rel.id, parents);
+		expect(counts.size).toBe(120);
+		expect(counts.get("p0")).toBe(1);
+		expect(counts.get("p119")).toBe(1);
+
+		expect((await repo.countChildrenForParents(rel.id, [])).size).toBe(0);
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, expect, it } from "vitest";
 import { ulid } from "ulidx";
+import { afterEach, beforeEach, expect, it } from "vitest";
 
 import { RelationRepository } from "../../../src/database/repositories/relation.js";
 import {

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -66,7 +66,7 @@ describeEachDialect("RelationRepository", (dialect) => {
 	it("create with a missing translationOf source throws", async () => {
 		await expect(
 			repo.create({ ...baseInput, locale: "fr", translationOf: "does-not-exist" }),
-		).rejects.toThrow();
+		).rejects.toThrow("Source relation for translation not found");
 	});
 
 	it("findById returns null for an unknown id", async () => {

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, it } from "vitest";
+import { ulid } from "ulidx";
 
 import { RelationRepository } from "../../../src/database/repositories/relation.js";
 import {
@@ -146,5 +147,72 @@ describeEachDialect("RelationRepository", (dialect) => {
 
 		const forTags = await repo.findForCollection("tags");
 		expect(forTags.map((r) => r.name)).toEqual(["tags_rel"]);
+	});
+
+	it("update changes only the localized labels and bumps updated_at", async () => {
+		const rel = await repo.create({ ...baseInput });
+		const updated = await repo.update(rel.id, { parentLabel: "Lead", childLabel: "Report" });
+
+		expect(updated?.parentLabel).toBe("Lead");
+		expect(updated?.childLabel).toBe("Report");
+		// Structural fields untouched.
+		expect(updated?.name).toBe("manages");
+		expect(updated?.parentCollection).toBe("employees");
+
+		expect(await repo.update("missing", { parentLabel: "x" })).toBeNull();
+	});
+
+	it("delete of a non-last translation leaves edges intact", async () => {
+		const anchor = await repo.create({ ...baseInput });
+		const fr = await repo.create({
+			...baseInput,
+			locale: "fr",
+			parentLabel: "Responsable",
+			childLabel: "Subordonné",
+			translationOf: anchor.id,
+		});
+		// Seed an edge directly (addReference arrives in Task 4).
+		await ctx.db
+			.insertInto("_emdash_content_references")
+			.values({
+				id: ulid(),
+				relation_group: anchor.translationGroup,
+				parent_group: "parentG",
+				child_group: "childG",
+				sort_order: 0,
+			})
+			.execute();
+
+		expect(await repo.delete(fr.id)).toBe(true);
+		// The relation still exists in 'en', so its edges survive.
+		const edges = await ctx.db
+			.selectFrom("_emdash_content_references")
+			.selectAll()
+			.where("relation_group", "=", anchor.translationGroup)
+			.execute();
+		expect(edges).toHaveLength(1);
+	});
+
+	it("delete of the last translation purges edges for that relation group", async () => {
+		const anchor = await repo.create({ ...baseInput });
+		await ctx.db
+			.insertInto("_emdash_content_references")
+			.values({
+				id: ulid(),
+				relation_group: anchor.translationGroup,
+				parent_group: "parentG",
+				child_group: "childG",
+				sort_order: 0,
+			})
+			.execute();
+
+		expect(await repo.delete(anchor.id)).toBe(true);
+		const edges = await ctx.db
+			.selectFrom("_emdash_content_references")
+			.selectAll()
+			.where("relation_group", "=", anchor.translationGroup)
+			.execute();
+		expect(edges).toHaveLength(0);
+		expect(await repo.findById(anchor.id)).toBeNull();
 	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -323,6 +323,19 @@ describeEachDialect("RelationRepository", (dialect) => {
 		expect(await repo.getChildren(rel.translationGroup, "b")).toHaveLength(1);
 	});
 
+	it("clearReferencesForGroup purges the group's edges across every relation", async () => {
+		const relA = await repo.create({ ...baseInput, name: "rel_a" });
+		const relB = await repo.create({ ...baseInput, name: "rel_b" });
+		// The same content group "X" participates in edges under two relations.
+		await repo.addReference(relA.id, "X", "a");
+		await repo.addReference(relB.id, "b", "X");
+
+		const removed = await repo.clearReferencesForGroup("X");
+		expect(removed).toBe(2);
+		expect(await repo.getChildren(relA.translationGroup, "X")).toHaveLength(0);
+		expect(await repo.getParents(relB.translationGroup, "X")).toHaveLength(0);
+	});
+
 	it("countChildren and countParents count edges", async () => {
 		const rel = await repo.create({ ...baseInput });
 		await repo.addReference(rel.id, "p1", "a");

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -273,4 +273,26 @@ describeEachDialect("RelationRepository", (dialect) => {
 		const rel = await repo.create({ ...baseInput });
 		await expect(repo.removeReference(rel.id, "p1", "never-added")).resolves.toBeUndefined();
 	});
+
+	it("setChildren replaces the set and assigns positional sort_order", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.setChildren(rel.id, "p1", ["a", "b", "c"]);
+
+		let children = await repo.getChildren(rel.translationGroup, "p1");
+		expect(children.map((c) => c.childGroup)).toEqual(["a", "b", "c"]);
+		expect(children.map((c) => c.sortOrder)).toEqual([0, 1, 2]);
+
+		// Reorder + drop 'a' + add 'd'.
+		await repo.setChildren(rel.id, "p1", ["c", "b", "d"]);
+		children = await repo.getChildren(rel.translationGroup, "p1");
+		expect(children.map((c) => c.childGroup)).toEqual(["c", "b", "d"]);
+		expect(children.map((c) => c.sortOrder)).toEqual([0, 1, 2]);
+	});
+
+	it("setChildren with an empty list clears the parent's children", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.setChildren(rel.id, "p1", ["a", "b"]);
+		await repo.setChildren(rel.id, "p1", []);
+		expect(await repo.getChildren(rel.translationGroup, "p1")).toEqual([]);
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -217,4 +217,55 @@ describeEachDialect("RelationRepository", (dialect) => {
 		expect(edges).toHaveLength(0);
 		expect(await repo.findById(anchor.id)).toBeNull();
 	});
+
+	it("addReference appends by sort_order and dedupes on conflict", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.id, "p1", "cA");
+		await repo.addReference(rel.id, "p1", "cB");
+		await repo.addReference(rel.id, "p1", "cA"); // duplicate — no-op
+
+		const children = await repo.getChildren(rel.translationGroup, "p1");
+		expect(children.map((c) => c.childGroup)).toEqual(["cA", "cB"]);
+		expect(children.map((c) => c.sortOrder)).toEqual([0, 1]);
+	});
+
+	it("addReference accepts a relation id OR its group, and an explicit sortOrder", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.translationGroup, "p1", "cA", 5);
+		const children = await repo.getChildren(rel.translationGroup, "p1");
+		expect(children).toEqual([
+			{
+				id: expect.any(String),
+				relationGroup: rel.translationGroup,
+				parentGroup: "p1",
+				childGroup: "cA",
+				sortOrder: 5,
+			},
+		]);
+	});
+
+	it("getParents is the backlink view; removeReference removes one edge", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.id, "p1", "shared");
+		await repo.addReference(rel.id, "p2", "shared");
+
+		const parents = await repo.getParents(rel.translationGroup, "shared");
+		expect(parents.map((p) => p.parentGroup).toSorted()).toEqual(["p1", "p2"]);
+
+		await repo.removeReference(rel.id, "p1", "shared");
+		const after = await repo.getParents(rel.translationGroup, "shared");
+		expect(after.map((p) => p.parentGroup)).toEqual(["p2"]);
+	});
+
+	it("self-reference (same group as parent and child) is allowed", async () => {
+		const rel = await repo.create({ ...baseInput });
+		await repo.addReference(rel.id, "self", "self");
+		const children = await repo.getChildren(rel.translationGroup, "self");
+		expect(children.map((c) => c.childGroup)).toEqual(["self"]);
+	});
+
+	it("edge methods no-op for an unknown relation", async () => {
+		await repo.addReference("unknown-relation", "p1", "cA");
+		expect(await repo.getChildren("unknown-relation", "p1")).toEqual([]);
+	});
 });

--- a/packages/core/tests/integration/database/relation-repository.test.ts
+++ b/packages/core/tests/integration/database/relation-repository.test.ts
@@ -149,7 +149,7 @@ describeEachDialect("RelationRepository", (dialect) => {
 		expect(forTags.map((r) => r.name)).toEqual(["tags_rel"]);
 	});
 
-	it("update changes only the localized labels and bumps updated_at", async () => {
+	it("update changes only the localized labels (no-op on missing id)", async () => {
 		const rel = await repo.create({ ...baseInput });
 		const updated = await repo.update(rel.id, { parentLabel: "Lead", childLabel: "Report" });
 
@@ -184,7 +184,9 @@ describeEachDialect("RelationRepository", (dialect) => {
 			.execute();
 
 		expect(await repo.delete(fr.id)).toBe(true);
-		// The relation still exists in 'en', so its edges survive.
+		// The 'en' anchor row must survive (only the 'fr' translation was deleted)...
+		expect(await repo.findById(anchor.id)).not.toBeNull();
+		// ...and so must its edges.
 		const edges = await ctx.db
 			.selectFrom("_emdash_content_references")
 			.selectAll()


### PR DESCRIPTION
## What does this PR do?

Adds `RelationRepository`, the application data-access layer over the content-references database schema that landed in #1367 (migration `043`). It is the next incremental slice in the content-references line of work — schema-only previously, now a typed, tested repository on top.

The class deliberately mirrors `TaxonomyRepository` and owns both halves of the feature, exactly as taxonomy owns terms + `content_taxonomies`:

- **Relation definitions** (`_emdash_relations`, row-per-locale, `translation_group`): `create` (with `translationOf` that inherits structural fields and joins the group), `findById`, `findByName`, `findTranslations`, `list`, `findForCollection`, `update` (labels only), `delete` (purges edges when the last translation of a group is removed).
- **Directed reference edges** (`_emdash_content_references`, locale-agnostic, keyed by `translation_group`): `addReference` (append/dedupe), `removeReference`, `getChildren` (forward), `getParents` (backlink), `setChildren` (replace + positional `sort_order`), `clearReferencesForGroup` (entry-deletion cleanup primitive), and `countChildren` / `countParents` / `countChildrenForParents` (batched at `SQL_BATCH_SIZE`).

**Scope (deliberately thin):** this is a data layer only. There is **no Zod, no request validation, and no API/route** — those are the next slice. The repository trusts its typed inputs; collection-agreement and relation-existence validation belong to the future handler/API layer. `clearReferencesForGroup` is provided as the cleanup primitive, but **wiring it into the content-delete path is also deferred** to that slice.

Backwards-compatible and additive — a new exported class only; no existing behavior changes.

Part of the content-references effort (Discussion #386; schema groundwork in #1367).

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes <!-- full monorepo lint OOMs this local WSL env; verified changed files clean with `oxlint --type-aware --deny-warnings`; CI runs the full pass -->
- [x] `pnpm test` passes (or targeted tests for my change) <!-- 25/25 in relation-repository.test.ts -->
- [x] `pnpm format` has been run <!-- oxfmt -->
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — no admin UI strings; pure data layer)
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- minor -->
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/386

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (implementation via Claude Code subagents; per-task spec + code-quality review and a final holistic review)

## Screenshots / test output

```
Test Files  1 passed (1)
     Tests  25 passed (25)
```