### PR TITLE
fix(core): hydrate taxonomy terms in entry's resolved locale (#1441)

### DIFF
--- a/.changeset/fix-term-hydration-locale.md
+++ b/.changeset/fix-term-hydration-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix `getEmDashEntry` / `getEmDashCollection` hydrating taxonomy terms in the request-context or default locale instead of the entry's resolved locale (#1441). When querying with an explicit `locale` (or via a localized route), `entry.data.terms` could return default-locale term variants even though the content row was correctly localized. Term hydration now uses the same resolved locale as the content query.

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -539,7 +539,9 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 	// round-trip cost on remote databases (D1 replicas, etc.).
 	await Promise.all([
 		hydrateEntryBylines(type, entriesWithEdit),
-		hydrateEntryTerms(type, entriesWithEdit),
+		// Hydrate terms in the same locale the content rows were resolved to,
+		// otherwise localized entries get default-locale taxonomy terms (#1441).
+		hydrateEntryTerms(type, entriesWithEdit, resolvedLocale),
 	]);
 
 	return { entries: entriesWithEdit, nextCursor, cacheHint: cacheHint ?? {} };
@@ -617,7 +619,17 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 		wrapped: ContentEntry<D>,
 		opts: { isPreview: boolean; fallbackLocale?: string; cacheHint: CacheHint },
 	): Promise<EntryResult<D>> {
-		await Promise.all([hydrateEntryBylines(type, [wrapped]), hydrateEntryTerms(type, [wrapped])]);
+		// Hydrate terms in the entry's resolved locale (fallback-aware) so a
+		// localized entry never picks up default-locale taxonomy terms (#1441).
+		// When i18n is disabled we leave the locale unset to preserve the
+		// legacy "do not filter by locale" behaviour.
+		const termLocale = isI18nEnabled()
+			? dataStr(entryData(wrapped), "locale") || undefined
+			: undefined;
+		await Promise.all([
+			hydrateEntryBylines(type, [wrapped]),
+			hydrateEntryTerms(type, [wrapped], termLocale),
+		]);
 		return {
 			entry: wrapped,
 			isPreview: opts.isPreview,
@@ -794,9 +806,18 @@ async function hydrateEntryBylines<D>(type: string, entries: ContentEntry<D>[]):
  * results and call getEntryTerms() per entry. With hydration, the list page
  * stays at a single round-trip for term data.
  *
+ * `locale` must be the locale the entries were resolved to. It is forwarded to
+ * `getAllTermsForEntries` so terms are returned in the entry's locale rather
+ * than falling back to the request-context / default locale (#1441). Pass
+ * `undefined` to keep the legacy "do not filter by locale" behaviour.
+ *
  * Fails silently if the taxonomy tables don't exist yet (pre-migration).
  */
-async function hydrateEntryTerms<D>(type: string, entries: ContentEntry<D>[]): Promise<void> {
+async function hydrateEntryTerms<D>(
+	type: string,
+	entries: ContentEntry<D>[],
+	locale?: string,
+): Promise<void> {
 	if (entries.length === 0) return;
 
 	try {
@@ -805,7 +826,7 @@ async function hydrateEntryTerms<D>(type: string, entries: ContentEntry<D>[]): P
 		const ids = entries.map((e) => dataStr(entryData(e), "id")).filter(Boolean);
 		if (ids.length === 0) return;
 
-		const termsMap = await getAllTermsForEntries(type, ids);
+		const termsMap = await getAllTermsForEntries(type, ids, { locale });
 
 		for (const entry of entries) {
 			const data = entryData(entry);

--- a/packages/core/tests/unit/query-term-hydration-locale.test.ts
+++ b/packages/core/tests/unit/query-term-hydration-locale.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Locale-aware taxonomy term hydration in the public query helpers (#1441).
+ *
+ * `getEmDashEntry` / `getEmDashCollection` resolve the content row to a locale
+ * (explicit option > request context > defaultLocale). Term hydration must use
+ * that same resolved locale, otherwise a `fr-fr` entry can come back with the
+ * default-locale variants of its taxonomy terms.
+ *
+ * The bug was that `hydrateEntryTerms()` called `getAllTermsForEntries(type, ids)`
+ * with no locale, so term lookup fell back to the request-context / default
+ * locale instead of the entry's own locale.
+ */
+
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContentRepository } from "../../src/database/repositories/content.js";
+import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
+import type { Database } from "../../src/database/types.js";
+import { setI18nConfig } from "../../src/i18n/config.js";
+import { getEmDashCollection, getEmDashEntry } from "../../src/query.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+vi.mock("astro:content", () => ({
+	getLiveCollection: vi.fn(),
+	getLiveEntry: vi.fn(),
+}));
+
+import { getLiveCollection, getLiveEntry } from "astro:content";
+
+interface TermFixture {
+	enContentId: string;
+	frContentId: string;
+	frContentSlug: string;
+	enTagId: string;
+	frTagId: string;
+}
+
+/**
+ * Seed an EN + FR post (same translation group) and a tag with EN + FR
+ * variants, attached to both posts by translation_group.
+ */
+async function seedLocalizedTags(db: Kysely<Database>): Promise<TermFixture> {
+	const contentRepo = new ContentRepository(db);
+	const taxRepo = new TaxonomyRepository(db);
+
+	// Two post rows sharing a translation group.
+	const enContent = await contentRepo.create({
+		type: "post",
+		slug: "hello",
+		data: { title: "Hello" },
+		locale: "en",
+	});
+	const frContent = await contentRepo.create({
+		type: "post",
+		slug: "bonjour",
+		data: { title: "Bonjour" },
+		locale: "fr",
+		translationOf: enContent.id,
+	});
+
+	// One tag with EN + FR variants (shared translation_group).
+	const enTag = await taxRepo.create({ name: "tags", slug: "news", label: "News", locale: "en" });
+	const frTag = await taxRepo.create({
+		name: "tags",
+		slug: "actualites",
+		label: "Actualités",
+		locale: "fr",
+		translationOf: enTag.id,
+	});
+
+	// Attach the tag (by group) to both entries.
+	await taxRepo.attachToEntry("post", enContent.id, enTag.id);
+	await taxRepo.attachToEntry("post", frContent.id, enTag.id);
+
+	return {
+		enContentId: enContent.id,
+		frContentId: frContent.id,
+		frContentSlug: frContent.slug,
+		enTagId: enTag.id,
+		frTagId: frTag.id,
+	};
+}
+
+describe("query helpers hydrate terms in the resolved locale (#1441)", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		setI18nConfig({ defaultLocale: "en", locales: ["en", "fr"] });
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		setI18nConfig(null);
+		vi.mocked(getLiveCollection).mockReset();
+		vi.mocked(getLiveEntry).mockReset();
+	});
+
+	it("getEmDashEntry returns the FR term variant for an explicit fr locale", async () => {
+		const fx = await seedLocalizedTags(db);
+
+		vi.mocked(getLiveEntry).mockResolvedValue({
+			entry: {
+				id: fx.frContentSlug,
+				data: { id: fx.frContentId, title: "Bonjour", status: "published", locale: "fr" },
+			},
+			error: undefined,
+			cacheHint: {},
+		} as any);
+
+		const { entry } = await runWithContext({ editMode: false, db }, () =>
+			getEmDashEntry("post", fx.frContentSlug, { locale: "fr" }),
+		);
+
+		const tags = (entry?.data as any)?.terms?.tags as Array<{ id: string; locale: string }>;
+		expect(tags).toHaveLength(1);
+		expect(tags[0]!.id).toBe(fx.frTagId);
+		expect(tags[0]!.locale).toBe("fr");
+	});
+
+	it("getEmDashCollection returns the FR term variant for an explicit fr locale", async () => {
+		const fx = await seedLocalizedTags(db);
+
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: [
+				{
+					id: fx.frContentSlug,
+					data: { id: fx.frContentId, title: "Bonjour", status: "published", locale: "fr" },
+				},
+			],
+			error: undefined,
+			cacheHint: {},
+		} as any);
+
+		const { entries } = await runWithContext({ editMode: false, db }, () =>
+			getEmDashCollection("post", { locale: "fr" }),
+		);
+
+		const tags = (entries[0]?.data as any)?.terms?.tags as Array<{ id: string; locale: string }>;
+		expect(tags).toHaveLength(1);
+		expect(tags[0]!.id).toBe(fx.frTagId);
+		expect(tags[0]!.locale).toBe("fr");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`getEmDashEntry` / `getEmDashCollection` resolve the content row to a locale (explicit option > request context > `defaultLocale`), but `hydrateEntryTerms()` called `getAllTermsForEntries(type, ids)` with no locale. Term lookup therefore fell back to `requestContext.locale` or the default locale. On normal public routes the request context often has no `locale`, so a `fr-fr` entry could come back with default-locale taxonomy term variants on `entry.data.terms`.

The fix plumbs the resolved locale through `hydrateEntryTerms`:

- The collection path forwards its already-computed `resolvedLocale`.
- The single-entry path forwards the resolved entry's own `data.locale` (fallback-aware, so it matches whatever locale actually resolved through the fallback chain) when i18n is enabled, and leaves it unset otherwise to preserve the legacy "do not filter by locale" behaviour. Taxonomies default to `locale = 'en'`, so non-i18n sites are unaffected.

This mirrors how `hydrateEntryBylines` already resolves per-entry locale.

Closes #1441

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a - no admin UI strings changed)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion (n/a - bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

New regression test `packages/core/tests/unit/query-term-hydration-locale.test.ts` fails before the fix (returns the `en` tag variant for an explicit `fr` query) and passes after. Targeted query + taxonomy suites (60 tests) pass; `pnpm typecheck` (core) and `pnpm lint` clean.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-1441-term-hydration-locale-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/1441-term-hydration-locale`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
