### PR TITLE
fix(deps): align Atcute dependency tree on v2 to clear peer warnings

### DIFF
--- a/.changeset/atcute-v2-peer-warnings.md
+++ b/.changeset/atcute-v2-peer-warnings.md
@@ -1,0 +1,10 @@
+---
+"emdash": patch
+"@emdash-cms/admin": patch
+"@emdash-cms/plugin-cli": patch
+"@emdash-cms/registry-client": patch
+"@emdash-cms/auth-atproto": patch
+"@emdash-cms/registry-lexicons": patch
+---
+
+Align the Atcute dependency tree on v2 to clear peer warnings on install (#1435). `@atcute/identity-resolver@2` and `@atcute/identity@2` require `@atcute/lexicons@^2`, but the catalog still pinned `@atcute/client@4`, `@atcute/lexicons@1`, `@atcute/atproto@3`, and `@atcute/oauth-node-client@1`, which dragged v1 `lexicons`/`identity` into the published tree. Bumps `@atcute/client` to `^5`, `@atcute/lexicons` to `^2`, `@atcute/atproto` to `^4`, and `@atcute/oauth-node-client` to `^2`. The only API change is `parseCanonicalResourceUri` now throwing instead of returning a result object.

--- a/.changeset/atcute-v2-peer-warnings.md
+++ b/.changeset/atcute-v2-peer-warnings.md
@@ -7,6 +7,6 @@
 "@emdash-cms/registry-lexicons": patch
 ---
 
-Fix `@atcute` peer dependency warnings on install (#1435)
+Fixes `@atcute` peer dependency warnings on install (#1435)
 
 Installing EmDash pulled in mismatched `@atcute` package versions, so `pnpm install` / `npm install` reported unmet peer warnings for `@atcute/identity` and `@atcute/lexicons`. The bundled `@atcute` dependencies are now aligned on v2 and installs are clean. If your project also depends on `@atcute` packages directly, note they have moved to v2 (`@atcute/client` 5, `@atcute/lexicons` 2, `@atcute/atproto` 4, `@atcute/oauth-node-client` 2).

--- a/.changeset/atcute-v2-peer-warnings.md
+++ b/.changeset/atcute-v2-peer-warnings.md
@@ -7,4 +7,6 @@
 "@emdash-cms/registry-lexicons": patch
 ---
 
-Align the Atcute dependency tree on v2 to clear peer warnings on install (#1435). `@atcute/identity-resolver@2` and `@atcute/identity@2` require `@atcute/lexicons@^2`, but the catalog still pinned `@atcute/client@4`, `@atcute/lexicons@1`, `@atcute/atproto@3`, and `@atcute/oauth-node-client@1`, which dragged v1 `lexicons`/`identity` into the published tree. Bumps `@atcute/client` to `^5`, `@atcute/lexicons` to `^2`, `@atcute/atproto` to `^4`, and `@atcute/oauth-node-client` to `^2`. The only API change is `parseCanonicalResourceUri` now throwing instead of returning a result object.
+Fix `@atcute` peer dependency warnings on install (#1435)
+
+Installing EmDash pulled in mismatched `@atcute` package versions, so `pnpm install` / `npm install` reported unmet peer warnings for `@atcute/identity` and `@atcute/lexicons`. The bundled `@atcute` dependencies are now aligned on v2 and installs are clean. If your project also depends on `@atcute` packages directly, note they have moved to v2 (`@atcute/client` 5, `@atcute/lexicons` 2, `@atcute/atproto` 4, `@atcute/oauth-node-client` 2).

--- a/apps/aggregator/src/backfill.ts
+++ b/apps/aggregator/src/backfill.ts
@@ -32,7 +32,10 @@
  * no periodic scheduler — see plan §"Why no reconciliation cron".
  */
 
-import { parseCanonicalResourceUri } from "@atcute/lexicons/syntax";
+import {
+	parseCanonicalResourceUri,
+	type ParsedCanonicalResourceUri,
+} from "@atcute/lexicons/syntax";
 
 import { WANTED_COLLECTIONS } from "./constants.js";
 import type { DidResolver } from "./did-resolver.js";
@@ -369,8 +372,12 @@ async function paginateAndEnqueue(opts: PaginateOpts): Promise<number> {
 
 		const messages: { body: RecordsJob }[] = [];
 		for (const record of records) {
-			const parsed = parseCanonicalResourceUri(record.uri);
-			if (!parsed.ok) continue;
+			let parsed: ParsedCanonicalResourceUri;
+			try {
+				parsed = parseCanonicalResourceUri(record.uri);
+			} catch {
+				continue;
+			}
 			// Defence vs. a buggy/malicious PDS that returns records under
 			// a different DID (or a different collection) than the one we
 			// asked for. Such jobs would never verify (signature would be
@@ -378,13 +385,13 @@ async function paginateAndEnqueue(opts: PaginateOpts): Promise<number> {
 			// at the source. `parseCanonicalResourceUri` already validated
 			// the rkey grammar and the collection NSID for us, so we only
 			// need the cross-checks here.
-			if (parsed.value.repo !== opts.did) continue;
-			if (parsed.value.collection !== opts.collection) continue;
+			if (parsed.repo !== opts.did) continue;
+			if (parsed.collection !== opts.collection) continue;
 			messages.push({
 				body: {
 					did: opts.did,
 					collection: opts.collection,
-					rkey: parsed.value.rkey,
+					rkey: parsed.rkey,
 					operation: "create",
 					cid: record.cid,
 				},

--- a/apps/aggregator/src/backfill.ts
+++ b/apps/aggregator/src/backfill.ts
@@ -375,8 +375,9 @@ async function paginateAndEnqueue(opts: PaginateOpts): Promise<number> {
 			let parsed: ParsedCanonicalResourceUri;
 			try {
 				parsed = parseCanonicalResourceUri(record.uri);
-			} catch {
-				continue;
+			} catch (err) {
+				if (err instanceof SyntaxError) continue;
+				throw err;
 			}
 			// Defence vs. a buggy/malicious PDS that returns records under
 			// a different DID (or a different collection) than the one we

--- a/packages/auth-atproto/package.json
+++ b/packages/auth-atproto/package.json
@@ -30,7 +30,7 @@
 		"react": ">=18"
 	},
 	"devDependencies": {
-		"@atcute/lexicons": "^1.2.10",
+		"@atcute/lexicons": "catalog:",
 		"@cloudflare/kumo": "catalog:",
 		"@types/react": "^19.0.0",
 		"vitest": "catalog:"
@@ -45,8 +45,8 @@
 		"directory": "packages/auth-atproto"
 	},
 	"dependencies": {
-		"@atcute/identity-resolver": "^1.2.2",
-		"@atcute/oauth-node-client": "^1.1.0",
+		"@atcute/identity-resolver": "catalog:",
+		"@atcute/oauth-node-client": "catalog:",
 		"@emdash-cms/auth": "workspace:*",
 		"kysely": "catalog:"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^5.0.0
       version: 5.0.0
     '@atcute/atproto':
-      specifier: ^3.1.11
-      version: 3.1.11
+      specifier: ^4.0.2
+      version: 4.0.2
     '@atcute/car':
       specifier: ^6.0.0
       version: 6.0.0
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^2.4.1
       version: 2.4.1
     '@atcute/client':
-      specifier: ^4.2.1
-      version: 4.2.1
+      specifier: ^5.0.0
+      version: 5.0.0
     '@atcute/crypto':
       specifier: ^2.4.1
       version: 2.4.1
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^2.8.1
       version: 2.8.1
     '@atcute/lexicons':
-      specifier: ^1.3.0
-      version: 1.3.0
+      specifier: ^2.0.0
+      version: 2.0.0
     '@atcute/mst':
       specifier: ^1.0.1
       version: 1.0.1
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^1.2.0
       version: 1.2.0
     '@atcute/oauth-node-client':
-      specifier: ^1.1.0
-      version: 1.1.0
+      specifier: ^2.0.0
+      version: 2.0.0
     '@atcute/repo':
       specifier: ^1.0.0
       version: 1.0.0
@@ -326,7 +326,7 @@ importers:
     dependencies:
       '@atcute/atproto':
         specifier: 'catalog:'
-        version: 3.1.11
+        version: 4.0.2(@atcute/lexicons@2.0.0)
       '@atcute/car':
         specifier: 'catalog:'
         version: 6.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)
@@ -338,25 +338,25 @@ importers:
         version: 2.4.1
       '@atcute/client':
         specifier: 'catalog:'
-        version: 4.2.1
+        version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/crypto':
         specifier: 'catalog:'
         version: 2.4.1
       '@atcute/firehose':
         specifier: 'catalog:'
-        version: 1.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(react@19.2.4)
+        version: 1.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(react@19.2.4)
       '@atcute/identity':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+        version: 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/identity-resolver':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3))(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/jetstream':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/lexicons@1.3.0)(react@19.2.4)(typescript@6.0.3)
+        version: 2.0.0(@atcute/lexicons@2.0.0)(react@19.2.4)(typescript@6.0.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@atcute/mst':
         specifier: 'catalog:'
         version: 1.0.1(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)
@@ -365,13 +365,13 @@ importers:
         version: 1.2.0
       '@atcute/repo':
         specifier: 'catalog:'
-        version: 1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)
+        version: 1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)
       '@atcute/xrpc-server':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+        version: 2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/xrpc-server-cloudflare':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(typescript@6.0.3))
+        version: 2.0.0(@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3))
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../../packages/registry-lexicons
@@ -959,10 +959,10 @@ importers:
     dependencies:
       '@atcute/identity-resolver':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3))(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@cloudflare/kumo':
         specifier: 'catalog:'
         version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
@@ -1167,13 +1167,13 @@ importers:
         version: 2.4.1
       '@atcute/client':
         specifier: 'catalog:'
-        version: 4.2.1
+        version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/crypto':
         specifier: 'catalog:'
         version: 2.4.1
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@atcute/mst':
         specifier: 'catalog:'
         version: 1.0.1(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)
@@ -1182,7 +1182,7 @@ importers:
         version: 1.2.0
       '@atcute/repo':
         specifier: 'catalog:'
-        version: 1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)
+        version: 1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)
       '@atproto/crypto':
         specifier: 'catalog:'
         version: 0.4.5
@@ -1246,11 +1246,11 @@ importers:
   packages/auth-atproto:
     dependencies:
       '@atcute/identity-resolver':
-        specifier: ^1.2.2
-        version: 1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.2.10)(typescript@6.0.0-beta))
+        specifier: 'catalog:'
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
       '@atcute/oauth-node-client':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: 'catalog:'
+        version: 2.0.0(@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
       '@emdash-cms/auth':
         specifier: workspace:*
         version: link:../auth
@@ -1268,8 +1268,8 @@ importers:
         version: 19.2.4
     devDependencies:
       '@atcute/lexicons':
-        specifier: ^1.2.10
-        version: 1.2.10
+        specifier: 'catalog:'
+        version: 2.0.0
       '@cloudflare/kumo':
         specifier: 'catalog:'
         version: 2.4.1(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(echarts@6.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.1)
@@ -1453,10 +1453,10 @@ importers:
         version: 5.0.0-beta.4(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yaml@2.9.0)
       '@atcute/client':
         specifier: 'catalog:'
-        version: 4.2.1
+        version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@atcute/multibase':
         specifier: 'catalog:'
         version: 1.2.0
@@ -1740,19 +1740,19 @@ importers:
     dependencies:
       '@atcute/client':
         specifier: 'catalog:'
-        version: 4.2.1
+        version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/identity-resolver':
         specifier: 'catalog:'
-        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3))(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+        version: 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@atcute/multibase':
         specifier: 'catalog:'
         version: 1.2.0
       '@atcute/oauth-node-client':
         specifier: 'catalog:'
-        version: 1.1.0
+        version: 2.0.0(@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@clack/prompts':
         specifier: ^1.4.0
         version: 1.4.0
@@ -2047,13 +2047,13 @@ importers:
     dependencies:
       '@atcute/atproto':
         specifier: 'catalog:'
-        version: 3.1.11
+        version: 4.0.2(@atcute/lexicons@2.0.0)
       '@atcute/client':
         specifier: 'catalog:'
-        version: 4.2.1
+        version: 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
       '@emdash-cms/registry-lexicons':
         specifier: workspace:*
         version: link:../registry-lexicons
@@ -2087,10 +2087,10 @@ importers:
     dependencies:
       '@atcute/atproto':
         specifier: 'catalog:'
-        version: 3.1.11
+        version: 4.0.2(@atcute/lexicons@2.0.0)
       '@atcute/lexicons':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 2.0.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -2710,8 +2710,10 @@ packages:
   '@astrojs/yaml2ts@0.2.2':
     resolution: {integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==}
 
-  '@atcute/atproto@3.1.11':
-    resolution: {integrity: sha512-yh+ASvA+iHHQij6UeHEKp2+rwvFvQR8A6/5Dk/xvqDslIikWEFx9VlprNwm/clQIPl2bLuQg+LHS8uY9o5nFTA==}
+  '@atcute/atproto@4.0.2':
+    resolution: {integrity: sha512-hLnvjiIOStpdUm0cEN+R5YydvbV0d6ap17Iv+t7i/nhSCN3TGMya7M0ftCWtCo+xoQ1EU6HK74R8jqXWlyrM0w==}
+    peerDependencies:
+      '@atcute/lexicons': ^2.0.0
 
   '@atcute/car@5.1.1':
     resolution: {integrity: sha512-MeRUJNXYgAHrJZw7mMoZJb9xIqv3LZLQw90rRRAVAo8SGNdICwyqe6Bf2LGesX73QM04MBuYO6Kqhvold3TFfg==}
@@ -2733,8 +2735,10 @@ packages:
   '@atcute/cid@2.4.1':
     resolution: {integrity: sha512-bwhna69RCv7yetXudtj+2qrMPYvhhIQqvJz6YUpUS98v7OdF3X2dnye9Nig2NDrklZcuyOsu7sQo7GOykJXRLQ==}
 
-  '@atcute/client@4.2.1':
-    resolution: {integrity: sha512-ZBFM2pW075JtgGFu5g7HHZBecrClhlcNH8GVP9Zz1aViWR+cjjBsTpeE63rJs+FCOHFYlirUyo5L8SGZ4kMINw==}
+  '@atcute/client@5.0.0':
+    resolution: {integrity: sha512-Dtrc1no1oAtpUTmkBxH0xKSgy8qcnk8orPf/PkEATW+MB3k8FPHtPH2fshiKd55rioZkb+xaN+7A29WtqPQHRA==}
+    peerDependencies:
+      '@atcute/lexicons': ^2.0.0
 
   '@atcute/crypto@2.4.1':
     resolution: {integrity: sha512-tJ3Pi/XYcAsABKtqSlSOTKfO5YiQ4XdqlTuPS8HiRZSezOPcXBFFzAFWpSIJPURbVPFQL3LLrrK0Ea24wl5qeQ==}
@@ -2781,11 +2785,11 @@ packages:
       '@atcute/identity': ^1.1.0
       '@atcute/identity-resolver': ^1.1.3
 
-  '@atcute/lexicons@1.2.10':
-    resolution: {integrity: sha512-0EfRDQQjOgb06VSFOUWXLnqKY11ljWB2bXS3cJVPYJp0jTWudgRp6OTW4vReNAeVZaY4kVr2ud/I/Zn9mjix3g==}
-
   '@atcute/lexicons@1.3.0':
     resolution: {integrity: sha512-Eq5y+9onnCXNVUlNiMf31beSXHKqptB7lUo/68YbhlmxdaR7ooywHmahya9goP5AsmlYEA1z+dRPXIDAa9O7cg==}
+
+  '@atcute/lexicons@2.0.0':
+    resolution: {integrity: sha512-fIlwP+TPEAGoF5aU5s+f8N5sOjOu8Mww/sQL1B57Dp2hj3G/EWG9XwOHPokzycBCgXx+UxIIrzZCGy8whsVDZw==}
 
   '@atcute/mst@1.0.0':
     resolution: {integrity: sha512-pMce2efib+dmKtnGnIvJZitVncJkpr3AmhyfgfYllni8KzsaDGsJmuGavSVpuojAhQe+6jYwHFtpm/beiiH4uw==}
@@ -2799,17 +2803,20 @@ packages:
   '@atcute/multibase@1.2.0':
     resolution: {integrity: sha512-ZK2GRra+qIYq9nNuQB52m2ul0hOmCQEtPobGfTSUxm7pF0OGEkWGkWHugFhNEDVzHzTwPxHp6VGotdZFue4lYQ==}
 
-  '@atcute/oauth-crypto@0.1.0':
-    resolution: {integrity: sha512-qZYDCNLF/4B6AndYT1rsQelN8621AC5u/sL5PHvlr/qqAbmmUwCBGjEgRSyZtHE1AqD60VNiSMlOgAuEQTSl3w==}
+  '@atcute/oauth-crypto@1.0.0':
+    resolution: {integrity: sha512-2UC1msk4PyUArk/5Pl8zgtz1T8O+LZdFfB8ENLHjQVYitpqzGj2ZpDJaWZvCF3Y8lly4KoeUHLpFPDzbP+3u+g==}
 
-  '@atcute/oauth-keyset@0.1.0':
-    resolution: {integrity: sha512-+wqT/+I5Lg9VzKnKY3g88+N45xbq+wsdT6bHDGqCVa2u57gRvolFF4dY+weMfc/OX641BIZO6/o+zFtKBsMQnQ==}
+  '@atcute/oauth-keyset@0.1.1':
+    resolution: {integrity: sha512-BpaaXSuMawxILhWTOR0YIpKzFSA0MQC1W5Hn0HGE+giTqYFAKcdf0oA+2RZG9ZLVIzfO2txBsTeMpxB5qL6lEQ==}
 
-  '@atcute/oauth-node-client@1.1.0':
-    resolution: {integrity: sha512-xCp/VfjtvTeKscKR/oI2hdMTp1/DaF/7ll8b6yZOCgbKlVDDfhCn5mmKNVARGTNaoywxrXG3XffbWCIx3/E87w==}
+  '@atcute/oauth-node-client@2.0.0':
+    resolution: {integrity: sha512-1+q7eszInPXR/aTmYyyhW6RD+rnNTpHXF3vgum3mmCt44oSCTeKuzCBrR538LORpspgNwhopotvKJ1AN5UD4kQ==}
+    peerDependencies:
+      '@atcute/identity-resolver': ^2.0.0
+      '@atcute/lexicons': ^2.0.0
 
-  '@atcute/oauth-types@0.1.1':
-    resolution: {integrity: sha512-u+3KMjse3Uc/9hDyilu1QVN7IpcnjVXgRzhddzBB8Uh6wePHNVBDdi9wQvFTVVA3zmxtMJVptXRyLLg6Ou9bqg==}
+  '@atcute/oauth-types@1.0.0':
+    resolution: {integrity: sha512-YOpjLU8H5PG6oKfgau+dx7rSmGsLxIA36MeGL7BDeopcyq80RqPSBAzOasEEsmbMRJ/nTsMRJhnmGkp3RCa/Zw==}
 
   '@atcute/repo@0.1.4':
     resolution: {integrity: sha512-uzbGJkE+1A8UFviosJrtw7HW87u8nCCH1V3yOQ79FPrRhS67EvEHF6GTg4aMkP21ze/pRtttJ1k9pFfDmyTlTg==}
@@ -2832,6 +2839,9 @@ packages:
 
   '@atcute/util-text@1.2.0':
     resolution: {integrity: sha512-b8WSh+Z7K601eUFFmTFj8QPKDO8Ic0VDDj63sdKzpkm+ySQKsYT5nXekViGqFVKbyKj1V5FyvZvgXad6/aI4QQ==}
+
+  '@atcute/util-text@1.3.1':
+    resolution: {integrity: sha512-MRgJXkx67znuBXuoAYCJkBZyd3OApL7zZlNf5kXhuoCXcdiu1nblRDycYTADSkym4epBSQWxh26kmI9sewaq6A==}
 
   '@atcute/varint@2.0.0':
     resolution: {integrity: sha512-CEY/oVK/nVpL4e5y3sdenLETDL6/Xu5xsE/0TupK+f0Yv8jcD60t2gD8SHROWSvUwYLdkjczLCSA7YrtnjCzWw==}
@@ -9183,11 +9193,6 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -12187,9 +12192,9 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
-  '@atcute/atproto@3.1.11':
+  '@atcute/atproto@4.0.2(@atcute/lexicons@2.0.0)':
     dependencies:
-      '@atcute/lexicons': 1.3.0
+      '@atcute/lexicons': 2.0.0
 
   '@atcute/car@5.1.1':
     dependencies:
@@ -12222,10 +12227,19 @@ snapshots:
       '@atcute/multibase': 1.2.0
       '@atcute/uint8array': 1.1.1
 
-  '@atcute/client@4.2.1':
+  '@atcute/client@5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)':
     dependencies:
-      '@atcute/identity': 1.1.4
-      '@atcute/lexicons': 1.3.0
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/lexicons': 2.0.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@atcute/client@5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)':
+    dependencies:
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/lexicons': 2.0.0
+    transitivePeerDependencies:
+      - typescript
 
   '@atcute/crypto@2.4.1':
     dependencies:
@@ -12233,10 +12247,10 @@ snapshots:
       '@atcute/uint8array': 1.1.1
       '@noble/secp256k1': 3.1.0
 
-  '@atcute/firehose@1.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(react@19.2.4)':
+  '@atcute/firehose@1.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(react@19.2.4)':
     dependencies:
       '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
-      '@atcute/lexicons': 1.3.0
+      '@atcute/lexicons': 2.0.0
       '@atcute/uint8array': 1.1.1
       '@mary-ext/event-iterator': 1.0.0
       '@mary-ext/simple-event-emitter': 1.0.1
@@ -12253,17 +12267,19 @@ snapshots:
       '@atcute/util-fetch': 1.0.5
       '@badrap/valita': 0.4.6
 
-  '@atcute/identity-resolver@1.2.2(@atcute/identity@2.0.0(@atcute/lexicons@1.2.10)(typescript@6.0.0-beta))':
+  '@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)':
     dependencies:
-      '@atcute/identity': 2.0.0(@atcute/lexicons@1.2.10)(typescript@6.0.0-beta)
-      '@atcute/lexicons': 1.3.0
-      '@atcute/util-fetch': 1.0.5
-      '@badrap/valita': 0.4.6
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/lexicons': 2.0.0
+      '@atcute/util-fetch': 2.0.0(typescript@6.0.0-beta)
+      valibot: 1.4.0(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
 
-  '@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3))(@atcute/lexicons@1.3.0)(typescript@6.0.3)':
+  '@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)':
     dependencies:
-      '@atcute/identity': 2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3)
-      '@atcute/lexicons': 1.3.0
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/lexicons': 2.0.0
       '@atcute/util-fetch': 2.0.0(typescript@6.0.3)
       valibot: 1.4.0(typescript@6.0.3)
     transitivePeerDependencies:
@@ -12274,23 +12290,23 @@ snapshots:
       '@atcute/lexicons': 1.3.0
       '@badrap/valita': 0.4.6
 
-  '@atcute/identity@2.0.0(@atcute/lexicons@1.2.10)(typescript@6.0.0-beta)':
+  '@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)':
     dependencies:
-      '@atcute/lexicons': 1.2.10
+      '@atcute/lexicons': 2.0.0
       valibot: 1.4.0(typescript@6.0.0-beta)
     transitivePeerDependencies:
       - typescript
 
-  '@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3)':
+  '@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)':
     dependencies:
-      '@atcute/lexicons': 1.3.0
+      '@atcute/lexicons': 2.0.0
       valibot: 1.4.0(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@atcute/jetstream@2.0.0(@atcute/lexicons@1.3.0)(react@19.2.4)(typescript@6.0.3)':
+  '@atcute/jetstream@2.0.0(@atcute/lexicons@2.0.0)(react@19.2.4)(typescript@6.0.3)':
     dependencies:
-      '@atcute/lexicons': 1.3.0
+      '@atcute/lexicons': 2.0.0
       '@mary-ext/event-iterator': 1.0.0
       '@mary-ext/simple-event-emitter': 1.0.1
       partysocket: 1.1.18(react@19.2.4)
@@ -12332,17 +12348,17 @@ snapshots:
       '@atcute/util-fetch': 1.0.5
       '@badrap/valita': 0.4.6
 
-  '@atcute/lexicons@1.2.10':
+  '@atcute/lexicons@1.3.0':
     dependencies:
       '@atcute/uint8array': 1.1.1
       '@atcute/util-text': 1.2.0
       '@standard-schema/spec': 1.1.0
       esm-env: 1.2.2
 
-  '@atcute/lexicons@1.3.0':
+  '@atcute/lexicons@2.0.0':
     dependencies:
       '@atcute/uint8array': 1.1.1
-      '@atcute/util-text': 1.2.0
+      '@atcute/util-text': 1.3.1
       '@standard-schema/spec': 1.1.0
       esm-env: 1.2.2
 
@@ -12362,36 +12378,83 @@ snapshots:
     dependencies:
       '@atcute/uint8array': 1.1.1
 
-  '@atcute/oauth-crypto@0.1.0':
+  '@atcute/oauth-crypto@1.0.0(typescript@6.0.0-beta)':
     dependencies:
       '@atcute/multibase': 1.2.0
       '@atcute/uint8array': 1.1.1
-      '@badrap/valita': 0.4.6
       nanoid: 5.1.11
+      valibot: 1.4.1(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
 
-  '@atcute/oauth-keyset@0.1.0':
+  '@atcute/oauth-crypto@1.0.0(typescript@6.0.3)':
     dependencies:
-      '@atcute/oauth-crypto': 0.1.0
+      '@atcute/multibase': 1.2.0
+      '@atcute/uint8array': 1.1.1
+      nanoid: 5.1.11
+      valibot: 1.4.1(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
 
-  '@atcute/oauth-node-client@1.1.0':
+  '@atcute/oauth-keyset@0.1.1(typescript@6.0.0-beta)':
     dependencies:
-      '@atcute/client': 4.2.1
-      '@atcute/identity': 1.1.4
-      '@atcute/identity-resolver': 1.2.2(@atcute/identity@1.1.4)
-      '@atcute/lexicons': 1.3.0
-      '@atcute/oauth-crypto': 0.1.0
-      '@atcute/oauth-keyset': 0.1.0
-      '@atcute/oauth-types': 0.1.1
-      '@atcute/util-fetch': 1.0.5
-      '@badrap/valita': 0.4.6
-      nanoid: 5.1.7
+      '@atcute/oauth-crypto': 1.0.0(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
 
-  '@atcute/oauth-types@0.1.1':
+  '@atcute/oauth-keyset@0.1.1(typescript@6.0.3)':
     dependencies:
-      '@atcute/identity': 1.1.4
-      '@atcute/lexicons': 1.3.0
-      '@atcute/oauth-keyset': 0.1.0
-      '@badrap/valita': 0.4.6
+      '@atcute/oauth-crypto': 1.0.0(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@atcute/oauth-node-client@2.0.0(@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)':
+    dependencies:
+      '@atcute/client': 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/identity-resolver': 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta))(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/lexicons': 2.0.0
+      '@atcute/oauth-crypto': 1.0.0(typescript@6.0.0-beta)
+      '@atcute/oauth-keyset': 0.1.1(typescript@6.0.0-beta)
+      '@atcute/oauth-types': 1.0.0(typescript@6.0.0-beta)
+      '@atcute/util-fetch': 2.0.0(typescript@6.0.0-beta)
+      nanoid: 5.1.11
+      valibot: 1.4.1(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
+
+  '@atcute/oauth-node-client@2.0.0(@atcute/identity-resolver@2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)':
+    dependencies:
+      '@atcute/client': 5.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/identity-resolver': 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/lexicons': 2.0.0
+      '@atcute/oauth-crypto': 1.0.0(typescript@6.0.3)
+      '@atcute/oauth-keyset': 0.1.1(typescript@6.0.3)
+      '@atcute/oauth-types': 1.0.0(typescript@6.0.3)
+      '@atcute/util-fetch': 2.0.0(typescript@6.0.3)
+      nanoid: 5.1.11
+      valibot: 1.4.1(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@atcute/oauth-types@1.0.0(typescript@6.0.0-beta)':
+    dependencies:
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.0-beta)
+      '@atcute/lexicons': 2.0.0
+      '@atcute/oauth-keyset': 0.1.1(typescript@6.0.0-beta)
+      valibot: 1.4.1(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
+
+  '@atcute/oauth-types@1.0.0(typescript@6.0.3)':
+    dependencies:
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/lexicons': 2.0.0
+      '@atcute/oauth-keyset': 0.1.1(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
 
   '@atcute/repo@0.1.4':
     dependencies:
@@ -12403,13 +12466,13 @@ snapshots:
       '@atcute/mst': 1.0.0
       '@atcute/uint8array': 1.1.1
 
-  '@atcute/repo@1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)':
+  '@atcute/repo@1.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)':
     dependencies:
       '@atcute/car': 6.0.0(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)
       '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
       '@atcute/cid': 2.4.1
       '@atcute/crypto': 2.4.1
-      '@atcute/lexicons': 1.3.0
+      '@atcute/lexicons': 2.0.0
       '@atcute/mst': 1.0.1(@atcute/cbor@2.3.3(@atcute/cid@2.4.1))(@atcute/cid@2.4.1)
       '@atcute/uint8array': 1.1.1
 
@@ -12418,6 +12481,12 @@ snapshots:
   '@atcute/util-fetch@1.0.5':
     dependencies:
       '@badrap/valita': 0.4.6
+
+  '@atcute/util-fetch@2.0.0(typescript@6.0.0-beta)':
+    dependencies:
+      valibot: 1.4.0(typescript@6.0.0-beta)
+    transitivePeerDependencies:
+      - typescript
 
   '@atcute/util-fetch@2.0.0(typescript@6.0.3)':
     dependencies:
@@ -12429,19 +12498,23 @@ snapshots:
     dependencies:
       unicode-segmenter: 0.14.5
 
+  '@atcute/util-text@1.3.1':
+    dependencies:
+      unicode-segmenter: 0.14.5
+
   '@atcute/varint@2.0.0': {}
 
-  '@atcute/xrpc-server-cloudflare@2.0.0(@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(typescript@6.0.3))':
+  '@atcute/xrpc-server-cloudflare@2.0.0(@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3))':
     dependencies:
-      '@atcute/xrpc-server': 2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(typescript@6.0.3)
+      '@atcute/xrpc-server': 2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3)
 
-  '@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@1.3.0)(typescript@6.0.3)':
+  '@atcute/xrpc-server@2.0.0(@atcute/cid@2.4.1)(@atcute/lexicons@2.0.0)(typescript@6.0.3)':
     dependencies:
       '@atcute/cbor': 2.3.3(@atcute/cid@2.4.1)
       '@atcute/crypto': 2.4.1
-      '@atcute/identity': 2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3)
-      '@atcute/identity-resolver': 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@1.3.0)(typescript@6.0.3))(@atcute/lexicons@1.3.0)(typescript@6.0.3)
-      '@atcute/lexicons': 1.3.0
+      '@atcute/identity': 2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/identity-resolver': 2.0.0(@atcute/identity@2.0.0(@atcute/lexicons@2.0.0)(typescript@6.0.3))(@atcute/lexicons@2.0.0)(typescript@6.0.3)
+      '@atcute/lexicons': 2.0.0
       '@atcute/multibase': 1.2.0
       '@atcute/uint8array': 1.1.1
       nanoid: 5.1.11
@@ -19941,8 +20014,6 @@ snapshots:
 
   nanoid@5.1.11: {}
 
-  nanoid@5.1.7: {}
-
   napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
@@ -21828,6 +21899,10 @@ snapshots:
   valibot@1.4.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
+
+  valibot@1.4.1(typescript@6.0.0-beta):
+    optionalDependencies:
+      typescript: 6.0.0-beta
 
   valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,21 +70,21 @@ catalog:
   "@astrojs/cloudflare": ^13.5.3
   "@astrojs/node": ^10.1.1
   "@astrojs/react": ^5.0.0
-  "@atcute/atproto": ^3.1.11
+  "@atcute/atproto": ^4.0.2
   "@atcute/car": ^6.0.0
   "@atcute/cbor": ^2.3.3
   "@atcute/cid": ^2.4.1
-  "@atcute/client": ^4.2.1
+  "@atcute/client": ^5.0.0
   "@atcute/crypto": ^2.4.1
   "@atcute/firehose": ^1.0.0
   "@atcute/identity": ^2.0.0
   "@atcute/identity-resolver": ^2.0.0
   "@atcute/jetstream": ^2.0.0
   "@atcute/lex-cli": ^2.8.1
-  "@atcute/lexicons": ^1.3.0
+  "@atcute/lexicons": ^2.0.0
   "@atcute/mst": ^1.0.1
   "@atcute/multibase": ^1.2.0
-  "@atcute/oauth-node-client": ^1.1.0
+  "@atcute/oauth-node-client": ^2.0.0
   "@atcute/repo": ^1.0.0
   "@atcute/xrpc-server": ^2.0.0
   "@atcute/xrpc-server-cloudflare": ^2.0.0


### PR DESCRIPTION
## What does this PR do?

Clears the `@atcute` peer-dependency warnings on `pnpm install` / `npm install emdash` reported in #1435.

The catalog was already ~80% on Atcute v2 (`identity`, `identity-resolver`, `repo`, `xrpc-server`, `jetstream`), but four entries lagged on v1. `@atcute/client@4.x` dragged v1 `identity`/`lexicons` into the published `emdash` tree, where they collided with `@atcute/identity-resolver@2`'s `^2` peer requirements. It isn't fixable by nudging one range — `@atcute/repo@1` and `@atcute/xrpc-server@2` already *peer-depend* on `lexicons@^2`, so downgrading just moves the warning. The coherent fix is finishing the v2 migration.

- Catalog bumps: `@atcute/client ^4.2.1→^5.0.0`, `@atcute/lexicons ^1.3.0→^2.0.0`, `@atcute/atproto ^3.1.11→^4.0.2`, `@atcute/oauth-node-client ^1.1.0→^2.0.0`. (Pinned `client` to `^5.0.0` rather than `5.1.0` — the latter published within the repo's `minimumReleaseAge: 1440` window; both carry identical v2 deps.)
- `packages/auth-atproto`: its three direct v1 pins were bleeding into the hoisted v2 tree (the last two warnings) — moved onto `catalog:`.
- `apps/aggregator/src/backfill.ts`: the only code break. Per the lexicons 2.0 changelog its sole API change is `parseCanonicalResourceUri`, which now throws `SyntaxError` instead of returning `{ ok, value }`. Migrated the backfill loop. `atproto@4` and `oauth-node-client@2` are pure lexicons re-bumps with no API changes; client 5's other breaks (`CredentialManager`, `ServiceProxyOptions`, `proxy` shape) have zero usage in the repo.

Verified the fix by simulating the post-publish dependency ranges in a clean consumer: `lexicons@2`/`identity@2` dedupe to single satisfying versions and `npm explain` confirms `identity-resolver@2`'s peers are met.

Closes #1435

## Type of change

- [x] Chore (dependencies, CI, tooling)
- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (all affected packages; pre-existing `infra/flue-review` failures are unrelated and present on `main`)
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (targeted: aggregator, atproto-test-utils, registry-client, plugin-cli, auth-atproto — 691 tests)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a: dependency alignment; the one API migration is covered by the existing aggregator backfill suite
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a: no UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (patch for the six published packages whose resolved deps shift)
- [ ] New features link to an approved Discussion — n/a: not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

Consumer-tree verification (post-publish ranges in a clean project):

```
├─┬ @atcute/client@5.x
│ ├─┬ @atcute/identity@2.0.0
│ │ └── @atcute/lexicons@2.0.0 deduped
│ └── @atcute/lexicons@2.0.0 deduped
├─┬ @atcute/identity-resolver@2.0.0
│ ├── @atcute/identity@2.0.0 deduped
│ └── @atcute/lexicons@2.0.0 deduped
└── @atcute/lexicons@2.0.0
```

No unmet peers.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-atcute-v2-peer-warnings-1435-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/atcute-v2-peer-warnings-1435`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
