### PR TITLE
docs: reframe changeset guidance as user-facing release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ During work:
 
 Before opening a PR: tests pass, lint clean, formatted, changeset added if a published package changed. See [CONTRIBUTING.md § Changesets](CONTRIBUTING.md#changesets).
 
+A changeset is release notes a user reads while upgrading -- **not** a commit message, PR description, or summary of your diff. Do not paste your PR prose into it. Write for someone who will run the new version and wants to know what changed for them: lead with a present-tense verb (`Fixes`, `Adds`, `Updates`, `Removes`), describe the observable effect, and leave out internal mechanics (file names, refactors, how you implemented it). For a breaking change, include the migration step. One sentence is often enough.
+
 When opening a PR with `gh`/the API, copy `.github/PULL_REQUEST_TEMPLATE.md` into the body and fill every section -- the GitHub UI injects it automatically but the CLI does not, and PRs missing it are auto-closed. Check the AI-generated code disclosure box and name the model. Tick checklist items only for what you actually verified; for test-only/docs/CI PRs, note why changeset/i18n/Discussion items are n/a.
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,15 +171,23 @@ The CLI walks you through affected packages, bump type, and description. Edit th
 
 ### Writing the description
 
-Start with a present-tense verb describing what the change does ("This PR..."):
+A changeset is the **release note a user reads while upgrading** -- it lands verbatim in the CHANGELOG. It is not a commit message, a PR description, or a summary of your diff. Don't paste your PR text into it: those explain the change to a reviewer reading the code, the changeset explains the effect to someone who will run the new version.
 
-- **Adds** -- new feature or capability
-- **Fixes** -- bug fix
-- **Updates** -- enhancement to existing behavior
-- **Removes** -- removed functionality
-- **Refactors** -- internal restructuring with no behavior change
+Write for that reader:
 
-Focus on what changes for someone **using** the package, not implementation details. The description ends up in the CHANGELOG that people read once during upgrades.
+- Start with a present-tense verb -- **Fixes** (bug), **Adds** (feature), **Updates** (enhancement), **Removes** (removed functionality), **Refactors** (no behavior change).
+- Describe the observable effect -- what's different for someone using the package.
+- Leave out internal mechanics -- file names, function names, which catalog entry you bumped, how you implemented it. If a sentence only makes sense to someone who has read the diff, it doesn't belong here.
+- For a breaking change, include the migration step.
+
+One sentence is often enough.
+
+```diff
+- # too low-level -- reads like a commit message
+- Align the catalog so identity-resolver's lexicons peer resolves; migrates parseCanonicalResourceUri off the result-object API in backfill.ts.
++ # right altitude -- the effect on the user
++ Fixes peer dependency warnings on install caused by mismatched `@atcute` package versions.
+```
 
 **Patch** (bug fix or small improvement):
 


### PR DESCRIPTION
## What does this PR do?

Changeset bodies keep landing as commit-message dumps (the `@atcute` fix in #1447 is a fresh example — I wrote one myself before catching it). The rule that a changeset is *user-facing release notes* lived only in CONTRIBUTING.md, far from where changesets are authored, and `AGENTS.md` — which agents actually follow — said only "add a changeset" with no guidance on writing one. So agents reuse their PR prose and humans skim past the rule.

This is the docs-only half of fixing that (no CI automation, per discussion):

- **`AGENTS.md`**: adds a concise rule next to the existing changeset line — a changeset is release notes a user reads while upgrading, **not** a commit message or PR description; lead with a present-tense verb, describe the observable effect, leave out internal mechanics.
- **`CONTRIBUTING.md` §Changesets**: drops the self-contradictory "start with a present-tense verb ('This PR...')" phrasing (the examples never used "This PR"), leads with the user-facing framing, and adds a bad→good contrast example so the altitude is concrete.

## Type of change

- [x] Documentation

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a: docs-only, no code changed
- [x] `pnpm lint` passes — n/a: docs-only
- [x] `pnpm test` passes — n/a: docs-only
- [x] `pnpm format` has been run — n/a: Markdown only
- [x] I have added/updated tests for my changes (if applicable) — n/a
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [x] I have added a changeset (if this PR changes a published package) — n/a: docs-only, no published package changed
- [x] New features link to an approved Discussion — n/a: not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8