### PR TITLE
fix(admin): complete missing Indonesian translations

### DIFF
--- a/.changeset/tasty-bobcats-grow.md
+++ b/.changeset/tasty-bobcats-grow.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Updates the Indonesian admin translations for content-list filters, the HTML insert action, and byline field option placeholders.
+Completes the missing Indonesian admin translations for content-list filters, HTML editing actions, byline search UI, media search UI, and byline field option placeholders.

--- a/.changeset/tasty-bobcats-grow.md
+++ b/.changeset/tasty-bobcats-grow.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Updates the Indonesian admin translations for content-list filters, the HTML insert action, and byline field option placeholders.

--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -298,7 +298,7 @@ msgstr "{label} — lihat terjemahan"
 
 #: packages/admin/src/components/ContentList.tsx:546
 msgid "{matchCount, plural, one {# item matching \"{searchQuery}\"} other {# items matching \"{searchQuery}\"}}"
-msgstr ""
+msgstr "{matchCount, plural, other {# item yang cocok dengan \"{searchQuery}\"}}"
 
 #: packages/admin/src/components/WordPressImport.tsx:2279
 msgid "{matchedCount} of {totalCount} assigned"
@@ -1635,7 +1635,7 @@ msgstr "Tidak dapat memetakan \"{draft}\" ke tipe MIME. Ketik MIME secara langsu
 
 #: packages/admin/src/components/ContentEditor.tsx:2097
 msgid "Couldn't search bylines. Please try again."
-msgstr ""
+msgstr "Tidak dapat mencari byline. Silakan coba lagi."
 
 #: packages/admin/src/components/TaxonomyManager.tsx:822
 msgid "Count"
@@ -2012,7 +2012,7 @@ msgstr "Hapus Bidang?"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:131
 msgid "Delete HTML block"
-msgstr ""
+msgstr "Hapus blok HTML"
 
 #: packages/admin/src/components/editor/ImageNode.tsx:191
 #: packages/admin/src/components/editor/ImageNode.tsx:192
@@ -2588,7 +2588,7 @@ msgstr "Masukkan email"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:144
 msgid "Enter HTML..."
-msgstr ""
+msgstr "Masukkan HTML..."
 
 #: packages/admin/src/components/ContentEditor.tsx:1255
 msgid "Enter markdown content..."
@@ -3349,11 +3349,11 @@ msgstr "Cara membuat Kata Sandi Aplikasi"
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:114
 #: packages/admin/src/components/PortableTextEditor.tsx:953
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: packages/admin/src/components/editor/HtmlBlockNode.tsx:147
 msgid "HTML source"
-msgstr ""
+msgstr "Kode sumber HTML"
 
 #: packages/admin/src/components/MenuEditor.tsx:337
 msgid "https://example.com or /about"
@@ -3564,7 +3564,7 @@ msgstr "Sisipkan Tautan"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:954
 msgid "Insert raw HTML"
-msgstr ""
+msgstr "Sisipkan HTML mentah"
 
 #: packages/admin/src/components/SectionPickerModal.tsx:57
 msgid "Insert Section"
@@ -3687,7 +3687,7 @@ msgstr "JSON"
 
 #: packages/admin/src/components/ContentEditor.tsx:2102
 msgid "Keep typing to narrow down more bylines."
-msgstr ""
+msgstr "Lanjutkan mengetik untuk mempersempit hasil byline."
 
 #: packages/admin/src/components/MarketplacePluginDetail.tsx:293
 #: packages/admin/src/components/SectionEditor.tsx:268
@@ -4484,7 +4484,7 @@ msgstr "Tidak ada hasil yang cocok"
 
 #: packages/admin/src/components/ContentEditor.tsx:2099
 msgid "No matching bylines."
-msgstr ""
+msgstr "Tidak ada byline yang cocok."
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:266
 msgid "No matching passkey found for this account."
@@ -4569,7 +4569,7 @@ msgstr "Tidak ada hasil"
 #: packages/admin/src/components/ContentList.tsx:308
 #: packages/admin/src/components/ContentList.tsx:327
 msgid "No results for \"{activeSearch}\""
-msgstr ""
+msgstr "Tidak ada hasil untuk \"{activeSearch}\""
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:176
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
@@ -5655,7 +5655,7 @@ msgstr "Cari {0}..."
 #: packages/admin/src/components/MediaLibrary.tsx:376
 #: packages/admin/src/components/MediaPickerModal.tsx:573
 msgid "Search by filename..."
-msgstr ""
+msgstr "Cari berdasarkan nama file..."
 
 #: packages/admin/src/components/users/UserList.tsx:69
 msgid "Search by name or email..."
@@ -5668,7 +5668,7 @@ msgstr "Cari byline"
 
 #: packages/admin/src/components/ContentEditor.tsx:2073
 msgid "Search bylines to add..."
-msgstr ""
+msgstr "Cari byline untuk ditambahkan..."
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:163
 msgid "Search comments"
@@ -5742,7 +5742,7 @@ msgstr "Dapat Dicari"
 
 #: packages/admin/src/components/ContentEditor.tsx:2077
 msgid "Searching..."
-msgstr ""
+msgstr "Mencari..."
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2043
 msgid "Section"

--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -718,7 +718,12 @@ msgstr "Rata Kanan"
 msgid "All"
 msgstr "Semua"
 
-#: packages/admin/src/routes/bylines.tsx:336
+#: packages/admin/src/components/ContentList.tsx:587
+#: packages/admin/src/components/ContentList.tsx:591
+msgid "All authors"
+msgstr "Semua penulis"
+
+#: packages/admin/src/routes/bylines.tsx:399
 msgid "All bylines"
 msgstr "Semua byline"
 
@@ -892,6 +897,10 @@ msgstr "Data JSON bebas"
 #: packages/admin/src/components/ContentList.tsx:771
 msgid "archived"
 msgstr "diarsipkan"
+
+#: packages/admin/src/components/ContentList.tsx:546
+msgid "Archived"
+msgstr "Diarsipkan"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 msgid "Archives"
@@ -1875,6 +1884,10 @@ msgstr "Tanggal & Waktu"
 msgid "Date and time picker"
 msgstr "Pemilih tanggal dan waktu"
 
+#: packages/admin/src/components/ContentList.tsx:604
+msgid "Date field to filter on"
+msgstr "Bidang tanggal untuk difilter"
+
 #: packages/admin/src/components/settings/GeneralSettings.tsx:304
 msgid "Date Format"
 msgstr "Format Tanggal"
@@ -2447,6 +2460,16 @@ msgstr "Sunting URL"
 #: packages/admin/src/components/WelcomeModal.tsx:26
 msgid "Editor"
 msgstr "Editor"
+
+#: packages/admin/src/components/BylineFieldEditor.tsx:305
+msgid ""
+"Editor\n"
+"Reporter\n"
+"Photographer"
+msgstr ""
+"Editor\n"
+"Reporter\n"
+"Fotografer"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:59
 #: packages/admin/src/components/Settings.tsx:115
@@ -3148,6 +3171,10 @@ msgstr "Nama file tidak dapat diubah setelah diunggah"
 msgid "files imported"
 msgstr "file diimpor"
 
+#: packages/admin/src/components/ContentList.tsx:583
+msgid "Filter by author"
+msgstr "Filter berdasarkan penulis"
+
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
 msgstr "Filter berdasarkan kapabilitas"
@@ -3192,6 +3219,10 @@ msgstr "Untuk impor lengkap termasuk draf dan semua konten, ekspor dari WordPres
 #: packages/admin/src/components/WordPressImport.tsx:1046
 msgid "For the best import experience, install the"
 msgstr "Untuk pengalaman impor terbaik, pasang"
+
+#: packages/admin/src/components/ContentList.tsx:620
+msgid "From date"
+msgstr "Dari tanggal"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3518,6 +3549,10 @@ msgstr "Sisipkan dari URL"
 #: packages/admin/src/components/PortableTextEditor.tsx:3045
 msgid "Insert Horizontal Rule"
 msgstr "Sisipkan Garis Horizontal"
+
+#: packages/admin/src/components/PortableTextEditor.tsx:3137
+msgid "Insert HTML"
+msgstr "Sisipkan HTML"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3040
 msgid "Insert Image"
@@ -6556,9 +6591,17 @@ msgstr "Judul (Tooltip)"
 msgid "Title Separator"
 msgstr "Pemisah Judul"
 
+#: packages/admin/src/components/ContentList.tsx:625
+msgid "to"
+msgstr "sampai"
+
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
 msgstr "untuk menutup"
+
+#: packages/admin/src/components/ContentList.tsx:629
+msgid "To date"
+msgstr "Sampai tanggal"
 
 #: packages/admin/src/components/PluginManager.tsx:203
 msgid "to install plugins, or add them to your astro.config.mjs."

--- a/packages/admin/tests/lib/locales.test.ts
+++ b/packages/admin/tests/lib/locales.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 
 import idCatalog from "../../src/locales/id/messages.po?raw";
-
 import {
 	DEFAULT_LOCALE,
 	getLocaleDir,
@@ -32,7 +31,9 @@ test("Indonesian catalog has no untranslated entries", () => {
 		const msgstrIndex = lines.findIndex((line) => line.startsWith("msgstr"));
 		if (msgstrIndex === -1) return false;
 		const nextLine = lines[msgstrIndex + 1];
-		return lines[msgstrIndex] === 'msgstr ""' && (nextLine === undefined || !nextLine.startsWith('"'));
+		return (
+			lines[msgstrIndex] === 'msgstr ""' && (nextLine === undefined || !nextLine.startsWith('"'))
+		);
 	});
 
 	expect(untranslated).toEqual([]);

--- a/packages/admin/tests/lib/locales.test.ts
+++ b/packages/admin/tests/lib/locales.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 
+import idCatalog from "../../src/locales/id/messages.po?raw";
+
 import {
 	DEFAULT_LOCALE,
 	getLocaleDir,
@@ -20,6 +22,20 @@ for (const { code } of SUPPORTED_LOCALES) {
 test("loadMessages falls back to English for unknown locale", async () => {
 	const [fallback, english] = await Promise.all([loadMessages("xx"), loadMessages("en")]);
 	expect(fallback).toEqual(english);
+});
+
+test("Indonesian catalog has no untranslated entries", () => {
+	const entries = idCatalog.split(/\n{2,}/);
+	const untranslated = entries.filter((entry) => {
+		if (!entry.includes("msgid") || !entry.includes("msgstr")) return false;
+		const lines = entry.split("\n").filter(Boolean);
+		const msgstrIndex = lines.findIndex((line) => line.startsWith("msgstr"));
+		if (msgstrIndex === -1) return false;
+		const nextLine = lines[msgstrIndex + 1];
+		return lines[msgstrIndex] === 'msgstr ""' && (nextLine === undefined || !nextLine.startsWith('"'));
+	});
+
+	expect(untranslated).toEqual([]);
 });
 
 // -- getLocaleDir ----------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Completes the currently missing Indonesian (id) admin translations in packages/admin/src/locales/id/messages.po and adds a regression test to catch future empty msgstr entries in the Indonesian catalog.

Closes #1450

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode (GPT-5.4)

## Screenshots / test output

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @emdash-cms/admin exec vitest run tests/lib/locales.test.ts`
- `pnpm format`

## Notes

This PR started from the initially reported missing id strings, then expanded to cover the remaining empty Indonesian catalog entries found during a clean re-audit against upstream/main.
