### PR TITLE
Fix(admin): Add missing locale strings for ContentTypeEditor

### DIFF
--- a/.changeset/content-type-editor-fixes-untranslated-strings.md
+++ b/.changeset/content-type-editor-fixes-untranslated-strings.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes untranslated ContentTypeEditor form text to let it be translatable

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -386,7 +386,7 @@ export function ContentTypeEditor({
 								label={t`Label (Singular)`}
 								value={labelSingular}
 								onChange={(e) => handleSingularLabelChange(e.target.value)}
-								placeholder="Post"
+								placeholder={t`Post`}
 								disabled={isFromCode}
 							/>
 
@@ -394,7 +394,7 @@ export function ContentTypeEditor({
 								label={t`Label (Plural)`}
 								value={label}
 								onChange={(e) => handleLabelChange(e.target.value)}
-								placeholder="Posts"
+								placeholder={t`Posts`}
 								disabled={isFromCode}
 							/>
 
@@ -439,7 +439,7 @@ export function ContentTypeEditor({
 							</div>
 
 							<div className="space-y-3">
-								<Label>Features</Label>
+								<Label>{t`Features`}</Label>
 								{SUPPORT_OPTIONS.map((option) => (
 									<div
 										key={option.value}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It wraps the `ContentTypeEditor` singular/plural label placeholders and Features label with Lingui so they follow the selected admin locale.
I did not touch the slug placeholder on purpose because this might cause confusion as the slug is primarily used in URL construction.
For now, the ContentTypeEditor is fully covered for translations. Translators can pickup the changes of their `messages.po` to finish this story.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5 <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output
<img width="347" height="1127" alt="Screenshot 2026-06-13 at 15 24 19" src="https://github.com/user-attachments/assets/e27431b9-be3f-4b0d-8e49-13af091fcfae" />

<!-- Optional. Include if the change is visual or if you want to show test results. -->
