### PR TITLE
Fix(admin): Localize PluginFieldErrorBoundary

### DIFF
--- a/.changeset/localize-plugin-field-error-boundary.md
+++ b/.changeset/localize-plugin-field-error-boundary.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes untranslated PluginFieldErrorBoundary strings

--- a/packages/admin/src/components/PluginFieldErrorBoundary.tsx
+++ b/packages/admin/src/components/PluginFieldErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/react/macro";
 import * as React from "react";
 
 interface Props {
@@ -29,16 +30,18 @@ export class PluginFieldErrorBoundary extends React.Component<Props, State> {
 		if (this.state.hasError) {
 			return (
 				<div className="rounded-md border border-kumo-danger/50 bg-kumo-danger/5 p-3">
-					<p className="text-sm font-medium text-kumo-danger">Plugin widget error</p>
+					<p className="text-sm font-medium text-kumo-danger">
+						<Trans>Plugin widget error</Trans>
+					</p>
 					<p className="mt-1 text-xs text-kumo-subtle">
-						{this.state.error?.message || "The plugin field widget failed to render."}
+						{this.state.error?.message || <Trans>The plugin field widget failed to render.</Trans>}
 					</p>
 					<button
 						type="button"
 						className="mt-2 text-xs font-medium text-kumo-brand underline"
 						onClick={() => this.setState({ hasError: false, error: undefined })}
 					>
-						Retry
+						<Trans>Retry</Trans>
 					</button>
 				</div>
 			);


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It wraps the `PluginFieldErrorBoundary` heading, fallback message, and retry action with Lingui so they use the active admin locale.
For now, the `PluginFieldErrorBoundary` is fully covered for translations. Translators can pickup the changes of their `messages.po` to finish this story.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5 <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
