### PR TITLE
fix: npx emdash types crashes due to schema envelope mismatch

### DIFF
--- a/.changeset/emdash-types-schema-unwrap.md
+++ b/.changeset/emdash-types-schema-unwrap.md
@@ -1,0 +1,7 @@
+---
+"emdash": patch
+---
+
+Fix `npx emdash types` crash caused by the schema endpoint envelope (#1188)
+
+The `/schema` route returned an enveloped JSON body while `client.request()` already unwraps the `.data` field, so `emdash types` received `undefined` and crashed. The route now returns the un-enveloped shape the client expects.

--- a/packages/core/src/astro/routes/api/schema/index.ts
+++ b/packages/core/src/astro/routes/api/schema/index.ts
@@ -13,7 +13,7 @@ import type { APIRoute } from "astro";
 import { hashString } from "emdash";
 
 import { requirePerm } from "#api/authorize.js";
-import { handleError, requireDb } from "#api/error.js";
+import { apiSuccess, handleError, requireDb } from "#api/error.js";
 import { SchemaRegistry } from "#schema/registry.js";
 import { generateTypeScript } from "#schema/zod-generator.js";
 
@@ -89,20 +89,12 @@ import type { PortableTextBlock } from "emdash";
 
 		const version = await hashString(JSON.stringify(schemaExport));
 
-		return new Response(
-			JSON.stringify({
-				...schemaExport,
-				version,
-			}),
-			{
-				status: 200,
-				headers: {
-					"Content-Type": "application/json",
-					"Cache-Control": "private, no-store",
-					"X-Schema-Version": version,
-				},
-			},
-		);
+		const response = apiSuccess({
+			...schemaExport,
+			version,
+		});
+		response.headers.set("X-Schema-Version", version);
+		return response;
 	} catch (error) {
 		return handleError(error, "Schema export failed", "SCHEMA_EXPORT_ERROR");
 	}

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
 import { Role } from "@emdash-cms/auth";
+import { describe, it, expect } from "vitest";
 
 import { GET as schemaGET } from "../../../src/astro/routes/api/schema/index.js";
 import { EmDashClient, EmDashApiError } from "../../../src/client/index.js";
@@ -576,9 +576,7 @@ describe("EmDashClient", () => {
 				interceptors: [backend],
 			});
 
-			await expect(client.schemaTypes()).resolves.toBe(
-				"export interface Post { title: string }\n",
-			);
+			await expect(client.schemaTypes()).resolves.toBe("export interface Post { title: string }\n");
 		});
 
 		it("schemaExport() throws EmDashApiError on non-2xx responses", async () => {

--- a/packages/core/tests/unit/client/client.test.ts
+++ b/packages/core/tests/unit/client/client.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { Role } from "@emdash-cms/auth";
 
+import { GET as schemaGET } from "../../../src/astro/routes/api/schema/index.js";
 import { EmDashClient, EmDashApiError } from "../../../src/client/index.js";
 import type { Interceptor } from "../../../src/client/transport.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
 
 // Regex patterns for route matching
 const CONTENT_POSTS_ABC_REGEX = /\/content\/posts\/abc/;
@@ -456,6 +459,37 @@ describe("EmDashClient", () => {
 	});
 
 	describe("schema methods", () => {
+		it("schema route wraps JSON exports in the API data envelope", async () => {
+			const db = await setupTestDatabaseWithCollections();
+
+			try {
+				const response = await schemaGET({
+					request: new Request("http://localhost:4321/_emdash/api/schema"),
+					locals: {
+						emdash: { db },
+						user: { id: "user_1", role: Role.EDITOR },
+					},
+				} as never);
+
+				expect(response.status).toBe(200);
+				const version = response.headers.get("X-Schema-Version");
+				expect(version).toBeTruthy();
+
+				const body = await response.json();
+				expect(body).toEqual({
+					data: expect.objectContaining({
+						collections: expect.arrayContaining([
+							expect.objectContaining({ slug: "page" }),
+							expect.objectContaining({ slug: "post" }),
+						]),
+						version,
+					}),
+				});
+			} finally {
+				await teardownTestDatabase(db);
+			}
+		});
+
 		it("collections() returns list", async () => {
 			const backend = createMockBackend([
 				{
@@ -480,6 +514,102 @@ describe("EmDashClient", () => {
 			const cols = await client.collections();
 			expect(cols).toHaveLength(2);
 			expect(cols[0]?.slug).toBe("posts");
+		});
+
+		it("schemaExport() returns collections and version", async () => {
+			const backend = createMockBackend([
+				{
+					method: "GET",
+					path: "/schema",
+					handler: () =>
+						jsonResponse({
+							collections: [
+								{
+									slug: "posts",
+									label: "Posts",
+									labelSingular: "Post",
+									supports: ["drafts"],
+									fields: [
+										{
+											slug: "title",
+											label: "Title",
+											type: "string",
+											required: true,
+											unique: false,
+										},
+									],
+								},
+							],
+							version: "schema-v1",
+						}),
+				},
+			]);
+
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			const schema = await client.schemaExport();
+			expect(schema.collections).toHaveLength(1);
+			expect(schema.collections[0]?.slug).toBe("posts");
+			expect(schema.version).toBe("schema-v1");
+		});
+
+		it("schemaTypes() returns raw TypeScript", async () => {
+			const backend = createMockBackend([
+				{
+					method: "GET",
+					path: /\/schema\?format=typescript$/,
+					handler: () =>
+						new Response("export interface Post { title: string }\n", {
+							status: 200,
+							headers: { "Content-Type": "text/typescript" },
+						}),
+				},
+			]);
+
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			await expect(client.schemaTypes()).resolves.toBe(
+				"export interface Post { title: string }\n",
+			);
+		});
+
+		it("schemaExport() throws EmDashApiError on non-2xx responses", async () => {
+			const backend = createMockBackend([
+				{
+					method: "GET",
+					path: "/schema",
+					handler: () =>
+						jsonResponse(
+							{
+								error: {
+									code: "SCHEMA_EXPORT_ERROR",
+									message: "Schema export failed",
+								},
+							},
+							500,
+						),
+				},
+			]);
+
+			const client = new EmDashClient({
+				baseUrl: "http://localhost:4321",
+				token: "test",
+				interceptors: [backend],
+			});
+
+			await expect(client.schemaExport()).rejects.toMatchObject({
+				status: 500,
+				code: "SCHEMA_EXPORT_ERROR",
+				message: "Schema export failed",
+			});
 		});
 
 		it("createCollection() sends correct payload", async () => {


### PR DESCRIPTION
## What does this PR do?

`npx emdash types` crashes with `Cannot read properties of undefined (reading 'collections')` against any instance (deployed and local dev — reproduced on 0.15.0 and 0.17.2). Root cause is an envelope inconsistency. `EmDashClient.request()` (packages/core/src/client/index.ts:778-782) returns `json.data` for every response, and `schemaExport()` (client/index.ts:389-391) goes through `request`. But the `/_emdash/api/schema` route (packages/core/src/astro/routes/api/schema/index.ts:92-95) returns the schema un-enveloped as `{ ...schemaExport, version }` with no `data` wrapper. So `client.schemaExport()` returns `undefined`, and the CLI `types` command (packages/core/src/cli/commands/types.ts:42-43) dereferences `schema.collections.length` and throws. Sibling schema endpoints (e.g. `/schema/collections`) do use the `{ success, data }` envelope, confirming the JSON-schema route is the outlier.

Make the JSON `/schema` route consistent with the rest of the API by wrapping its body in the standard `{ success: true, data: { ...schemaExport, version } }` envelope (keep the `?format=typescript` branch and `X-Schema-Version` header unchanged, since `schemaTypes()` uses `requestRaw` and reads text directly). This restores the contract `request()` expects so `schemaExport()` returns the schema object. Verify no other caller depends on the un-enveloped JSON shape; the only consumers are `schemaExport()` (CLI) and any direct `curl`, and enveloping is the documented norm. If enveloping the route risks an external contract, the fallback is to switch `schemaExport()` to `requestRaw` + manual parse, but route-side enveloping is preferred for cross-endpoint consistency.

Closes #1188

## Type of change

- [x] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Codex (GPT-5.x)

## Screenshots / test output

- happy path: `schemaExport()` returns an object with a populated `collections` array against the enveloped route.
- happy path: `version` field is preserved in the returned schema object.
- edge: `schemaTypes()` (`?format=typescript`) still returns raw TS text, unaffected by the envelope change.
- error path: a non-2xx schema response surfaces a clear error instead of an undefined dereference.

AI was used for assistance.
