### PR TITLE
fix(registry): declaredAccess as the plugin trust contract

### DIFF
--- a/.changeset/registry-declared-access-contract.md
+++ b/.changeset/registry-declared-access-contract.md
@@ -1,0 +1,9 @@
+---
+"@emdash-cms/plugin-types": minor
+"@emdash-cms/plugin-cli": minor
+"@emdash-cms/registry-lexicons": patch
+"@emdash-cms/admin": patch
+"emdash": minor
+---
+
+Fixes registry installs failing with "Plugin manifest has changed since you consented" for plugins that declare hook-registration capabilities (email transport, email events, page fragments) or read user records. Plugin bundles now declare their access as a structured `declaredAccess` contract that the registry record, the install-consent dialog, and the sandbox all read consistently, so every capability a plugin declares is shown for consent and enforced — no capability is silently dropped. Re-publish affected plugins to adopt the new bundle format; existing installs are unaffected.

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -38,6 +38,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@emdash-cms/blocks": "workspace:*",
+    "@emdash-cms/plugin-types": "workspace:*",
     "@emdash-cms/registry-client": "workspace:*",
     "@emdash-cms/registry-lexicons": "workspace:*",
     "@floating-ui/react": "^0.27.16",

--- a/packages/admin/src/components/RegistryPluginDetail.tsx
+++ b/packages/admin/src/components/RegistryPluginDetail.tsx
@@ -15,6 +15,7 @@
 
 import { Badge, Button, LinkButton, Select, Tabs, Tooltip } from "@cloudflare/kumo";
 import type { TabsItem } from "@cloudflare/kumo";
+import { declaredAccessToCapabilities, type DeclaredAccess } from "@emdash-cms/plugin-types";
 import { checkEnvCompatibility } from "@emdash-cms/registry-client/env";
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
@@ -178,34 +179,35 @@ export function RegistryPluginDetail({ pluginId, config }: RegistryPluginDetailP
 	const isPreRelease = release ? isPreReleaseVersion(release.version) : false;
 
 	// `release.extensions[com.emdashcms.experimental.package.releaseExtension]`
-	// carries the structured `declaredAccess`. The EmDash bundle manifest
-	// uses the legacy `capabilities: string[]` shape that the sandbox
-	// enforces today, so we lift that from the release's extension when
-	// available and fall back to the structured declaredAccess flattened
-	// to a string list otherwise. This keeps `CapabilityConsentDialog` --
-	// which only understands `capabilities` -- working unchanged.
+	// carries the structured `declaredAccess` -- the trust contract. The sandbox
+	// enforces the legacy `capabilities: string[]` shape, so we derive that list
+	// from declaredAccess using the SAME total converter the bundler and runtime
+	// use (`@emdash-cms/plugin-types`). Deriving via the shared converter -- not
+	// a component-local reimplementation -- is what keeps the consent list equal
+	// to what the install handler enforces; an earlier divergent local flattener
+	// dropped hook-registration capabilities and broke every such install.
 	//
-	// `canonicalCapabilitiesForDriftCheck` filters non-strings, dedupes,
-	// and sorts so an aggregator-supplied array with unstable order or
-	// junk entries can't trigger a spurious server-side drift rejection
-	// later.
+	// `canonicalCapabilitiesForDriftCheck` filters non-strings, dedupes, and
+	// sorts so an aggregator-supplied array with unstable order can't trigger a
+	// spurious server-side drift rejection later.
 	//
-	// NSID is exact-matched, not prefix-matched. RFC 0001 fixes the NSID
-	// for this extension; accepting variants like `…releaseExtensionV2`
-	// or `…releaseExtension.deprecated` would let a publisher render a
-	// different permissions list than another publisher would for the
+	// NSID is exact-matched, not prefix-matched. RFC 0001 fixes the NSID for
+	// this extension; accepting variants like `…releaseExtensionV2` would let a
+	// publisher render a different permissions list than another would for the
 	// same RFC-0001 fields.
 	const RELEASE_EXTENSION_NSID = "com.emdashcms.experimental.package.releaseExtension";
 	// `release` is lexicon-validated at the boundary; `extensions` is the
 	// lexicon's open `unknown` map, so its inner shape still needs narrowing.
 	const extensions = release?.release?.extensions as
-		| Record<string, { declaredAccess?: unknown; capabilities?: unknown }>
+		| Record<string, { declaredAccess?: DeclaredAccess }>
 		| undefined;
 	const ext = extensions?.[RELEASE_EXTENSION_NSID];
 
-	const capabilities: string[] = Array.isArray(ext?.capabilities)
-		? canonicalCapabilitiesForDriftCheck(ext?.capabilities)
-		: canonicalCapabilitiesForDriftCheck(declaredAccessToCapabilityList(ext?.declaredAccess));
+	const capabilities: string[] = ext?.declaredAccess
+		? canonicalCapabilitiesForDriftCheck(
+				declaredAccessToCapabilities(ext.declaredAccess).capabilities,
+			)
+		: [];
 
 	// `profile` / `release` are validated against their lexicons at the
 	// DiscoveryClient boundary, so the shape here is trustworthy (or `null`).
@@ -803,28 +805,6 @@ function BackLink() {
 			{t`Back to plugins`}
 		</Link>
 	);
-}
-
-/**
- * Flatten an RFC-0001 `declaredAccess` block (`{ content: { read: true },
- * email: { send: { allowedHosts: [...] } }, ... }`) into the legacy
- * `capabilities: string[]` shape that the existing sandbox runtime
- * enforces today. One entry per declared operation under each
- * category. Unknown values are skipped silently -- the consent dialog
- * shows only what the current runtime recognises.
- */
-function declaredAccessToCapabilityList(declaredAccess: unknown): string[] {
-	if (!declaredAccess || typeof declaredAccess !== "object") return [];
-	const out: string[] = [];
-	for (const [category, value] of Object.entries(declaredAccess as Record<string, unknown>)) {
-		if (!value || typeof value !== "object") continue;
-		for (const [operation, opValue] of Object.entries(value as Record<string, unknown>)) {
-			// Skip operations explicitly opted out (`false`).
-			if (opValue === false) continue;
-			out.push(`${category}:${operation}`);
-		}
-	}
-	return out;
 }
 
 const PRE_RELEASE_VERSION_RE = /^\d+\.\d+\.\d+-/;

--- a/packages/admin/tests/components/RegistryPluginDetail.test.tsx
+++ b/packages/admin/tests/components/RegistryPluginDetail.test.tsx
@@ -85,6 +85,7 @@ function makePackage(overrides: PkgOverrides = {}): RegistryPackageView {
 
 interface ReleaseOverrides {
 	sbom?: { format?: string; url?: string; checksum?: string };
+	extensions?: Record<string, unknown>;
 }
 
 function makeRelease(overrides: ReleaseOverrides = {}): RegistryReleaseView {
@@ -94,10 +95,13 @@ function makeRelease(overrides: ReleaseOverrides = {}): RegistryReleaseView {
 		labels: [],
 		release: {
 			sbom: overrides.sbom,
+			extensions: overrides.extensions,
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture cast to the validated view shape
 	} as any;
 }
+
+const RELEASE_EXTENSION_NSID = "com.emdashcms.experimental.package.releaseExtension";
 
 function Wrapper({ children }: { children: React.ReactNode }) {
 	const qc = new QueryClient({
@@ -206,6 +210,38 @@ describe("RegistryPluginDetail SBOM", () => {
 		);
 		await expect.element(screen.getByText("SBOM · spdx")).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "Download SBOM" }).query()).toBeNull();
+	});
+});
+
+describe("RegistryPluginDetail declared permissions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("derives the consent list faithfully from declaredAccess, including hook facets", async () => {
+		// declaredAccess carries the hook facets; the consent list must show the
+		// canonical capability strings the install handler enforces. The earlier
+		// component-local flattener dropped these and broke every such install.
+		setup(makePackage(), [
+			makeRelease({
+				extensions: {
+					[RELEASE_EXTENSION_NSID]: {
+						declaredAccess: {
+							network: { request: { allowedHosts: ["api.cloudflare.com"] } },
+							email: { transport: {}, events: {} },
+						},
+					},
+				},
+			}),
+		]);
+		const screen = await render(
+			<Wrapper>
+				<RegistryPluginDetail pluginId="acme.dev/myplugin" config={CONFIG} />
+			</Wrapper>,
+		);
+		await expect.element(screen.getByText("hooks.email-transport:register")).toBeInTheDocument();
+		await expect.element(screen.getByText("hooks.email-events:register")).toBeInTheDocument();
+		await expect.element(screen.getByText("network:request")).toBeInTheDocument();
 	});
 });
 

--- a/packages/admin/tests/components/RegistryPluginDetail.test.tsx
+++ b/packages/admin/tests/components/RegistryPluginDetail.test.tsx
@@ -220,8 +220,8 @@ describe("RegistryPluginDetail declared permissions", () => {
 
 	it("derives the consent list faithfully from declaredAccess, including hook facets", async () => {
 		// declaredAccess carries the hook facets; the consent list must show the
-		// canonical capability strings the install handler enforces. The earlier
-		// component-local flattener dropped these and broke every such install.
+		// canonical capability strings the install handler enforces, derived via
+		// the shared converter rather than a component-local flattener.
 		setup(makePackage(), [
 			makeRelease({
 				extensions: {

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -9,7 +9,7 @@ import type { Kysely } from "kysely";
 
 import type { Database } from "../../database/types.js";
 import { validatePluginIdentifier } from "../../database/validate.js";
-import { pluginManifestSchema } from "../../plugins/manifest-schema.js";
+import { pluginManifestSchema, reconcileManifestAccess } from "../../plugins/manifest-schema.js";
 import { normalizeManifestRoute } from "../../plugins/manifest-schema.js";
 import {
 	createMarketplaceClient,
@@ -274,7 +274,7 @@ export async function loadBundleFromR2(
 		// Elements are validated as unknown[] by Zod; cast to PluginManifest
 		// for the Element[] type (Block Kit validation happens at render time).
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Zod types elements as unknown[]; Element type validated at render time
-		const manifest = result.data as unknown as PluginManifest;
+		const manifest = reconcileManifestAccess(result.data) as unknown as PluginManifest;
 
 		// Try to load admin code (optional)
 		let adminCode: string | undefined;

--- a/packages/core/src/api/handlers/marketplace.ts
+++ b/packages/core/src/api/handlers/marketplace.ts
@@ -271,10 +271,7 @@ export async function loadBundleFromR2(
 		const parsed: unknown = JSON.parse(manifestText);
 		const result = pluginManifestSchema.safeParse(parsed);
 		if (!result.success) return null;
-		// Elements are validated as unknown[] by Zod; cast to PluginManifest
-		// for the Element[] type (Block Kit validation happens at render time).
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Zod types elements as unknown[]; Element type validated at render time
-		const manifest = reconcileManifestAccess(result.data) as unknown as PluginManifest;
+		const manifest = reconcileManifestAccess(result.data);
 
 		// Try to load admin code (optional)
 		let adminCode: string | undefined;

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -49,6 +49,8 @@ import { extractBundle } from "../../plugins/marketplace.js";
 import type { PluginBundle } from "../../plugins/marketplace.js";
 import type { SandboxRunner } from "../../plugins/sandbox/types.js";
 import { PluginStateRepository } from "../../plugins/state.js";
+import { declaredAccessToCapabilities } from "../../plugins/types.js";
+import type { DeclaredAccess } from "../../plugins/types.js";
 import {
 	canonicalCapabilitiesForDriftCheck,
 	coerceRegistryConfig,
@@ -69,6 +71,26 @@ import {
 	loadBundleFromR2,
 	storeBundleInR2,
 } from "./marketplace.js";
+
+const RELEASE_EXTENSION_NSID = "com.emdashcms.experimental.package.releaseExtension";
+
+/**
+ * Whether two `declaredAccess` blocks grant exactly the same enforced access --
+ * the same capabilities AND the same host allow-list. Both are lowered through
+ * the canonical converter so that constraint content (`allowedHosts`), not just
+ * the capability set, is part of the comparison. The capability-set consent
+ * gate is blind to host scope; this is what keeps a bundle from being installed
+ * with a wider (or simply different) host allow-list than its published record
+ * advertised and the user consented to.
+ */
+export function enforcedAccessEqual(a: DeclaredAccess, b: DeclaredAccess): boolean {
+	const aa = declaredAccessToCapabilities(a);
+	const bb = declaredAccessToCapabilities(b);
+	return (
+		JSON.stringify(aa.capabilities.toSorted()) === JSON.stringify(bb.capabilities.toSorted()) &&
+		JSON.stringify(aa.allowedHosts.toSorted()) === JSON.stringify(bb.allowedHosts.toSorted())
+	);
+}
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -998,6 +1020,30 @@ export async function handleRegistryInstall(
 		// in sync and prevents registry installs from colliding with
 		// marketplace plugins that happen to share the publisher's slug.
 		bundle.manifest = { ...bundle.manifest, id: pluginId };
+
+		// Integrity: the bundle that will run MUST declare exactly the access
+		// the signed release record advertises. The consent dialog is driven
+		// from the record's `declaredAccess`, so a bundle enforcing something
+		// different -- a wider host allow-list, an extra capability -- would run
+		// outside what the user reviewed. The capability-set consent gate below
+		// is blind to constraint content (host scope), so compare the full
+		// enforced access of record vs bundle here and refuse on any difference.
+		const recordExt = (
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- extensions is the lexicon's open `unknown` map; narrow to read our own extension
+			release?.extensions as Record<string, { declaredAccess?: DeclaredAccess }> | undefined
+		)?.[RELEASE_EXTENSION_NSID];
+		if (
+			!enforcedAccessEqual(recordExt?.declaredAccess ?? {}, bundle.manifest.declaredAccess ?? {})
+		) {
+			return {
+				success: false,
+				error: {
+					code: "DECLARED_ACCESS_DRIFT",
+					message:
+						"The plugin bundle declares different permissions than its published record. Installation refused.",
+				},
+			};
+		}
 
 		// Capability consent gate: the admin MUST acknowledge the
 		// capabilities the bundle's manifest actually declares before we

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -1535,6 +1535,29 @@ export async function handleRegistryUpdate(
 		// and R2 layout stay in sync across install and update.
 		bundle.manifest = { ...bundle.manifest, id: pluginId };
 
+		// Integrity: same gate as install. The new bundle must declare exactly
+		// the access its signed release record advertises. Without it, an update
+		// that changes only the host scope (e.g. api.good.com -> evil.com) keeps
+		// the capability set identical, sails through the escalation diff below,
+		// and installs a bundle enforcing a scope the record never showed.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- extensions is the lexicon's open `unknown` map; narrow to read our own extension
+		const updateRecordExtensions = signedRelease?.extensions as
+			| Record<string, { declaredAccess?: DeclaredAccess }>
+			| undefined;
+		const recordExt = updateRecordExtensions?.[RELEASE_EXTENSION_NSID];
+		if (
+			!enforcedAccessEqual(recordExt?.declaredAccess ?? {}, bundle.manifest.declaredAccess ?? {})
+		) {
+			return {
+				success: false,
+				error: {
+					code: "DECLARED_ACCESS_DRIFT",
+					message:
+						"The plugin bundle declares different permissions than its published record. Update refused.",
+				},
+			};
+		}
+
 		// Diff capabilities + route visibility against the currently
 		// installed bundle. Loading from R2 keeps us honest: the diff is
 		// against the bytes the sandbox is actually running, not whatever

--- a/packages/core/src/api/handlers/registry.ts
+++ b/packages/core/src/api/handlers/registry.ts
@@ -1028,10 +1028,11 @@ export async function handleRegistryInstall(
 		// outside what the user reviewed. The capability-set consent gate below
 		// is blind to constraint content (host scope), so compare the full
 		// enforced access of record vs bundle here and refuse on any difference.
-		const recordExt = (
+		const recordExt =
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- extensions is the lexicon's open `unknown` map; narrow to read our own extension
-			release?.extensions as Record<string, { declaredAccess?: DeclaredAccess }> | undefined
-		)?.[RELEASE_EXTENSION_NSID];
+			(release?.extensions as Record<string, { declaredAccess?: DeclaredAccess }> | undefined)?.[
+				RELEASE_EXTENSION_NSID
+			];
 		if (
 			!enforcedAccessEqual(recordExt?.declaredAccess ?? {}, bundle.manifest.declaredAccess ?? {})
 		) {

--- a/packages/core/src/cli/commands/bundle-utils.ts
+++ b/packages/core/src/cli/commands/bundle-utils.ts
@@ -13,6 +13,7 @@ import { pipeline } from "node:stream/promises";
 import { imageSize } from "image-size";
 import { packTar } from "modern-tar/fs";
 
+import { capabilitiesToDeclaredAccess } from "../../plugins/types.js";
 import type {
 	PluginManifest,
 	ResolvedPlugin,
@@ -151,6 +152,7 @@ export function extractManifest(plugin: ResolvedPlugin): PluginManifest {
 	return {
 		id: plugin.id,
 		version: plugin.version,
+		declaredAccess: capabilitiesToDeclaredAccess(plugin.capabilities, plugin.allowedHosts),
 		capabilities: plugin.capabilities,
 		allowedHosts: plugin.allowedHosts,
 		storage: plugin.storage,

--- a/packages/core/src/plugins/manifest-schema.ts
+++ b/packages/core/src/plugins/manifest-schema.ts
@@ -245,7 +245,13 @@ const declaredAccessSchema = z.object({
 		.object({ read: accessConstraints.optional(), write: accessConstraints.optional() })
 		.optional(),
 	network: z
-		.object({ request: z.object({ allowedHosts: z.array(z.string()).optional() }).optional() })
+		.object({
+			// allowedHosts: absent = unrestricted; present = host-restricted. Reject
+			// an empty array (which the decoder would otherwise have to treat as
+			// deny-all) to match the record lexicon's `minLength: 1` and keep the
+			// "absent vs empty" distinction from ever reaching enforcement ambiguous.
+			request: z.object({ allowedHosts: z.array(z.string()).min(1).optional() }).optional(),
+		})
 		.optional(),
 	email: z
 		.object({

--- a/packages/core/src/plugins/manifest-schema.ts
+++ b/packages/core/src/plugins/manifest-schema.ts
@@ -8,6 +8,10 @@
  * - Marketplace ingest extends this with publishing-specific fields
  */
 
+import {
+	capabilitiesToDeclaredAccess,
+	declaredAccessToCapabilities,
+} from "@emdash-cms/plugin-types";
 import { z } from "zod";
 
 // ── Enum values (must stay in sync with types.ts) ───────────────
@@ -219,16 +223,57 @@ const pluginAdminConfigSchema = z.object({
 		.optional(),
 });
 
+// ── declaredAccess ──────────────────────────────────────────────
+
+/**
+ * An operation's constraint object. Open vocabulary: keys the runtime
+ * recognises are enforced, others are advisory. The bundler emits `{}` for a
+ * granted operation; presence (not value) signals the grant.
+ */
+const accessConstraints = z.record(z.string(), z.unknown());
+
+/**
+ * Structured trust contract embedded in the bundle manifest. Mirrors
+ * `DeclaredAccess` in `@emdash-cms/plugin-types`. Categories are host
+ * subsystems; operations are modes of participation.
+ */
+const declaredAccessSchema = z.object({
+	content: z
+		.object({ read: accessConstraints.optional(), write: accessConstraints.optional() })
+		.optional(),
+	media: z
+		.object({ read: accessConstraints.optional(), write: accessConstraints.optional() })
+		.optional(),
+	network: z
+		.object({ request: z.object({ allowedHosts: z.array(z.string()).optional() }).optional() })
+		.optional(),
+	email: z
+		.object({
+			send: accessConstraints.optional(),
+			events: accessConstraints.optional(),
+			transport: accessConstraints.optional(),
+		})
+		.optional(),
+	page: z.object({ fragments: accessConstraints.optional() }).optional(),
+	users: z.object({ read: accessConstraints.optional() }).optional(),
+});
+
 // ── Main schema ─────────────────────────────────────────────────
 
 /**
  * Zod schema matching the PluginManifest interface from types.ts.
  *
  * Every JSON.parse of a manifest.json should validate through this.
+ *
+ * `declaredAccess` is the trust contract; `capabilities`/`allowedHosts` are the
+ * runtime's enforcement currency. Apply `reconcileManifestAccess` after parsing
+ * to make them consistent (declaredAccess authoritative when present). Kept a
+ * plain object (no `.transform`) because callers `.pick()`/`.extend()` it.
  */
 export const pluginManifestSchema = z.object({
 	id: z.string().min(1),
 	version: z.string().min(1),
+	declaredAccess: declaredAccessSchema.optional(),
 	capabilities: z.array(z.enum(PLUGIN_CAPABILITIES)),
 	allowedHosts: z.array(z.string()),
 	storage: z.record(z.string(), storageCollectionSchema),
@@ -253,6 +298,27 @@ export const pluginManifestSchema = z.object({
 });
 
 export type ValidatedPluginManifest = z.infer<typeof pluginManifestSchema>;
+
+/**
+ * Reconcile a parsed manifest's trust contract with its enforcement currency.
+ * `declaredAccess` is authoritative: when present, `capabilities`/`allowedHosts`
+ * are re-derived from it so what the runtime enforces always matches what was
+ * recorded and consented to. A pre-migration bundle without `declaredAccess`
+ * has it derived from the legacy capability list instead. The result always
+ * carries both, mutually consistent. Apply this at every bundle-parse site.
+ */
+export function reconcileManifestAccess(
+	manifest: ValidatedPluginManifest,
+): ValidatedPluginManifest {
+	if (manifest.declaredAccess) {
+		const { capabilities, allowedHosts } = declaredAccessToCapabilities(manifest.declaredAccess);
+		return { ...manifest, capabilities, allowedHosts };
+	}
+	return {
+		...manifest,
+		declaredAccess: capabilitiesToDeclaredAccess(manifest.capabilities, manifest.allowedHosts),
+	};
+}
 
 /**
  * Normalize a manifest hook entry — plain strings become `{ name }` objects.

--- a/packages/core/src/plugins/manifest-schema.ts
+++ b/packages/core/src/plugins/manifest-schema.ts
@@ -14,6 +14,8 @@ import {
 } from "@emdash-cms/plugin-types";
 import { z } from "zod";
 
+import type { PluginManifest } from "./types.js";
+
 // ── Enum values (must stay in sync with types.ts) ───────────────
 
 /**
@@ -313,17 +315,18 @@ export type ValidatedPluginManifest = z.infer<typeof pluginManifestSchema>;
  * has it derived from the legacy capability list instead. The result always
  * carries both, mutually consistent. Apply this at every bundle-parse site.
  */
-export function reconcileManifestAccess(
-	manifest: ValidatedPluginManifest,
-): ValidatedPluginManifest {
-	if (manifest.declaredAccess) {
-		const { capabilities, allowedHosts } = declaredAccessToCapabilities(manifest.declaredAccess);
-		return { ...manifest, capabilities, allowedHosts };
-	}
-	return {
-		...manifest,
-		declaredAccess: capabilitiesToDeclaredAccess(manifest.capabilities, manifest.allowedHosts),
-	};
+export function reconcileManifestAccess(manifest: ValidatedPluginManifest): PluginManifest {
+	const reconciled: ValidatedPluginManifest = manifest.declaredAccess
+		? { ...manifest, ...declaredAccessToCapabilities(manifest.declaredAccess) }
+		: {
+				...manifest,
+				declaredAccess: capabilitiesToDeclaredAccess(manifest.capabilities, manifest.allowedHosts),
+			};
+	// Block Kit admin elements are typed as `unknown` by the Zod schema (their
+	// Element shape is validated at render time), so the validated manifest
+	// needs a structural cast up to the runtime PluginManifest.
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- admin elements are unknown[] in Zod; Element type checked at render time
+	return reconciled as unknown as PluginManifest;
 }
 
 /**

--- a/packages/core/src/plugins/marketplace.ts
+++ b/packages/core/src/plugins/marketplace.ts
@@ -495,10 +495,7 @@ export async function extractBundle(tarballBytes: Uint8Array): Promise<PluginBun
 				"INVALID_BUNDLE",
 			);
 		}
-		// Elements are validated as unknown[] by Zod; cast to PluginManifest
-		// for the Element[] type (Block Kit validation happens at render time).
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Zod types elements as unknown[]; Element type validated at render time
-		manifest = reconcileManifestAccess(result.data) as unknown as PluginManifest;
+		manifest = reconcileManifestAccess(result.data);
 	} catch (err) {
 		if (err instanceof MarketplaceError) throw err;
 		throw new MarketplaceError(

--- a/packages/core/src/plugins/marketplace.ts
+++ b/packages/core/src/plugins/marketplace.ts
@@ -8,7 +8,7 @@
 
 import { createGzipDecoder, unpackTar } from "modern-tar";
 
-import { pluginManifestSchema } from "./manifest-schema.js";
+import { pluginManifestSchema, reconcileManifestAccess } from "./manifest-schema.js";
 import type { PluginManifest } from "./types.js";
 
 // ── Module-level regex patterns ───────────────────────────────────
@@ -498,7 +498,7 @@ export async function extractBundle(tarballBytes: Uint8Array): Promise<PluginBun
 		// Elements are validated as unknown[] by Zod; cast to PluginManifest
 		// for the Element[] type (Block Kit validation happens at render time).
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Zod types elements as unknown[]; Element type validated at render time
-		manifest = result.data as unknown as PluginManifest;
+		manifest = reconcileManifestAccess(result.data) as unknown as PluginManifest;
 	} catch (err) {
 		if (err instanceof MarketplaceError) throw err;
 		throw new MarketplaceError(

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -19,10 +19,13 @@ import type { Element } from "@emdash-cms/blocks";
 // (e.g. `import { PluginCapability } from "../plugins/types.js"`).
 import {
 	CAPABILITY_RENAMES,
+	capabilitiesToDeclaredAccess,
+	declaredAccessToCapabilities,
 	isDeprecatedCapability,
 	normalizeCapabilities,
 	normalizeCapability,
 	type CurrentPluginCapability,
+	type DeclaredAccess,
 	type DeprecatedPluginCapability,
 	type ManifestHookEntry,
 	type ManifestRouteEntry,
@@ -40,10 +43,13 @@ import type { FieldType } from "../schema/types.js";
 
 export {
 	CAPABILITY_RENAMES,
+	capabilitiesToDeclaredAccess,
+	declaredAccessToCapabilities,
 	isDeprecatedCapability,
 	normalizeCapabilities,
 	normalizeCapability,
 	type CurrentPluginCapability,
+	type DeclaredAccess,
 	type DeprecatedPluginCapability,
 	type ManifestHookEntry,
 	type ManifestRouteEntry,
@@ -1336,6 +1342,12 @@ export interface PluginAdminExports {
 export interface PluginManifest {
 	id: string;
 	version: string;
+	/**
+	 * The trust contract (see `@emdash-cms/plugin-types`). Authoritative;
+	 * `capabilities`/`allowedHosts` are derived from it at the parse boundary
+	 * via `reconcileManifestAccess`. Optional during the wire-format migration.
+	 */
+	declaredAccess?: DeclaredAccess;
 	capabilities: PluginCapability[];
 	allowedHosts: string[];
 	storage: PluginStorageConfig;

--- a/packages/core/tests/unit/api/registry-access-integrity.test.ts
+++ b/packages/core/tests/unit/api/registry-access-integrity.test.ts
@@ -1,0 +1,50 @@
+import type { DeclaredAccess } from "@emdash-cms/plugin-types";
+import { describe, expect, it } from "vitest";
+
+import { enforcedAccessEqual } from "../../../src/api/handlers/registry.js";
+
+// Finding 2 from the declaredAccess security review: the install consent gate
+// compares capability STRING SETS, which discard `allowedHosts`. So a record
+// advertising one host scope and a bundle enforcing another both reduce to
+// `["network:request"]` and slip through. `enforcedAccessEqual` is the
+// integrity check that compares the full enforced access -- capabilities AND
+// host scope -- of the signed record against the bundle that will run.
+describe("enforcedAccessEqual (record vs bundle integrity)", () => {
+	it("treats identical declaredAccess as equal", () => {
+		const a: DeclaredAccess = {
+			content: { read: {} },
+			network: { request: { allowedHosts: ["api.good.com"] } },
+			email: { transport: {} },
+		};
+		expect(enforcedAccessEqual(a, structuredClone(a))).toBe(true);
+	});
+
+	it("rejects a bundle whose network host scope differs from the record (the bypass)", () => {
+		const record: DeclaredAccess = { network: { request: { allowedHosts: ["api.good.com"] } } };
+		const bundle: DeclaredAccess = { network: { request: { allowedHosts: ["evil.com"] } } };
+		// Both reduce to the same capability set -- the string-set gate would pass.
+		expect(enforcedAccessEqual(record, bundle)).toBe(false);
+	});
+
+	it("rejects host scope widening (restricted record, unrestricted bundle)", () => {
+		const record: DeclaredAccess = { network: { request: { allowedHosts: ["api.good.com"] } } };
+		const bundle: DeclaredAccess = { network: { request: {} } };
+		expect(enforcedAccessEqual(record, bundle)).toBe(false);
+	});
+
+	it("rejects an extra capability in the bundle", () => {
+		const record: DeclaredAccess = { content: { read: {} } };
+		const bundle: DeclaredAccess = { content: { read: {}, write: {} } };
+		expect(enforcedAccessEqual(record, bundle)).toBe(false);
+	});
+
+	it("rejects a record with no access against a capability-bearing bundle", () => {
+		expect(enforcedAccessEqual({}, { email: { transport: {} } })).toBe(false);
+	});
+
+	it("is insensitive to host-list ordering (same scope, different order)", () => {
+		const a: DeclaredAccess = { network: { request: { allowedHosts: ["a.com", "b.com"] } } };
+		const b: DeclaredAccess = { network: { request: { allowedHosts: ["b.com", "a.com"] } } };
+		expect(enforcedAccessEqual(a, b)).toBe(true);
+	});
+});

--- a/packages/core/tests/unit/api/registry-access-integrity.test.ts
+++ b/packages/core/tests/unit/api/registry-access-integrity.test.ts
@@ -3,11 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import { enforcedAccessEqual } from "../../../src/api/handlers/registry.js";
 
-// Finding 2 from the declaredAccess security review: the install consent gate
-// compares capability STRING SETS, which discard `allowedHosts`. So a record
-// advertising one host scope and a bundle enforcing another both reduce to
-// `["network:request"]` and slip through. `enforcedAccessEqual` is the
-// integrity check that compares the full enforced access -- capabilities AND
+// The install consent gate compares capability STRING SETS, which discard
+// `allowedHosts`: a record advertising one host scope and a bundle enforcing
+// another both reduce to `["network:request"]` and would slip through.
+// `enforcedAccessEqual` compares the full enforced access -- capabilities AND
 // host scope -- of the signed record against the bundle that will run.
 describe("enforcedAccessEqual (record vs bundle integrity)", () => {
 	it("treats identical declaredAccess as equal", () => {
@@ -19,7 +18,7 @@ describe("enforcedAccessEqual (record vs bundle integrity)", () => {
 		expect(enforcedAccessEqual(a, structuredClone(a))).toBe(true);
 	});
 
-	it("rejects a bundle whose network host scope differs from the record (the bypass)", () => {
+	it("rejects a bundle whose network host scope differs from the record", () => {
 		const record: DeclaredAccess = { network: { request: { allowedHosts: ["api.good.com"] } } };
 		const bundle: DeclaredAccess = { network: { request: { allowedHosts: ["evil.com"] } } };
 		// Both reduce to the same capability set -- the string-set gate would pass.

--- a/packages/plugin-cli/src/bundle/types.ts
+++ b/packages/plugin-cli/src/bundle/types.ts
@@ -15,8 +15,11 @@
 
 export {
 	CAPABILITY_RENAMES,
+	capabilitiesToDeclaredAccess,
+	declaredAccessToCapabilities,
 	isDeprecatedCapability,
 	type CurrentPluginCapability,
+	type DeclaredAccess,
 	type DeprecatedPluginCapability,
 	type ManifestHookEntry,
 	type ManifestRouteEntry,

--- a/packages/plugin-cli/src/bundle/utils.ts
+++ b/packages/plugin-cli/src/bundle/utils.ts
@@ -15,6 +15,7 @@ import { pipeline } from "node:stream/promises";
 import { imageSize } from "image-size";
 import { packTar } from "modern-tar/fs";
 
+import { capabilitiesToDeclaredAccess } from "./types.js";
 import type { ManifestHookEntry, PluginManifest, ResolvedPlugin } from "./types.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -147,6 +148,7 @@ export function extractManifest(plugin: ResolvedPlugin): PluginManifest {
 	return {
 		id: plugin.id,
 		version: plugin.version,
+		declaredAccess: capabilitiesToDeclaredAccess(plugin.capabilities, plugin.allowedHosts),
 		capabilities: plugin.capabilities,
 		allowedHosts: plugin.allowedHosts,
 		storage: plugin.storage,

--- a/packages/plugin-cli/src/publish/api.ts
+++ b/packages/plugin-cli/src/publish/api.ts
@@ -45,6 +45,7 @@ import { ClientResponseError } from "@atcute/client";
 import type { Nsid } from "@atcute/lexicons";
 import { safeParse } from "@atcute/lexicons/validations";
 import {
+	capabilitiesToDeclaredAccess,
 	deriveSlugFromId,
 	isDeprecatedCapability,
 	isPluginSlug,
@@ -316,13 +317,6 @@ interface PackageReleaseRecordShape {
 	extensions: Record<string, unknown>;
 }
 
-interface DeclaredAccess {
-	content?: { read?: Record<string, unknown>; write?: Record<string, unknown> };
-	media?: { read?: Record<string, unknown>; write?: Record<string, unknown> };
-	network?: { request?: { allowedHosts?: string[] } };
-	email?: { send?: Record<string, unknown> };
-}
-
 interface FetchedRecord {
 	uri: string;
 	cid: string;
@@ -419,26 +413,14 @@ export async function publishRelease(options: PublishOptions): Promise<PublishRe
 	const profileCreated = existingProfile === null;
 	const ignoredProfileFields: string[] = [];
 
-	// Build the EmDash trust extension (declaredAccess) from the manifest's
-	// capabilities + allowedHosts. The lexicon REQUIRES this extension on
-	// every emdash-plugin release; without it, sandbox runtimes have no
-	// contract to enforce, and aggregators may reject the record.
-	const declaredAccess = buildDeclaredAccess(options.manifest);
-
-	// Warn about capabilities that don't appear in the published
-	// declaredAccess. The lexicon's vocabulary is closed today (see
-	// releaseExtension.json line 20: "Categories not enumerated here cannot
-	// be declared"), so any capability not handled by `buildDeclaredAccess`
-	// is invisible to the trust contract. Driving the gap detection from
-	// what was actually emitted (rather than a hard-coded prefix list)
-	// means a future capability added to plugin-types but not to
-	// `buildDeclaredAccess` still fires the warning.
-	const unmappedCaps = findUnmappedCapabilities(normalizedCaps, declaredAccess);
-	if (unmappedCaps.length > 0) {
-		log.warn?.(
-			`Capabilities ${unmappedCaps.join(", ")} are not expressible in declaredAccess today (lexicon limitation). Sandbox runtimes will gate these on manifest.capabilities until the lexicon evolves to cover them.`,
-		);
-	}
+	// The EmDash trust extension carries the manifest's declaredAccess
+	// verbatim -- the lexicon REQUIRES it on every emdash-plugin release, and
+	// the install-time deep-equal compares the bundle's declaredAccess against
+	// it. A tarball built before the wire format carried declaredAccess has it
+	// derived from the (normalized) legacy capability list as a fallback.
+	const declaredAccess =
+		options.manifest.declaredAccess ??
+		capabilitiesToDeclaredAccess(normalizedCaps, options.manifest.allowedHosts);
 	const releaseExtension = {
 		$type: NSID.packageReleaseExtension,
 		declaredAccess,
@@ -636,98 +618,6 @@ function applyArtifacts(
 	if (artifacts.screenshots && artifacts.screenshots.length > 0) {
 		record.artifacts.screenshots = artifacts.screenshots.map((shot) => ({ ...shot }));
 	}
-}
-
-/**
- * Determine which capabilities in `normalizedCaps` have no representation
- * in the `declaredAccess` we just built. The mapping rules are derived
- * from what `buildDeclaredAccess` actually emits, so a future capability
- * added to plugin-types but not to that function will surface here.
- *
- * The check is: for each capability, derive its target declaredAccess
- * coordinate (category + operation). If that coordinate is missing,
- * the capability is unmapped.
- */
-function findUnmappedCapabilities(
-	normalizedCaps: string[],
-	declaredAccess: DeclaredAccess,
-): string[] {
-	const unmapped: string[] = [];
-	for (const cap of normalizedCaps) {
-		if (capabilityIsRepresented(cap, declaredAccess)) continue;
-		unmapped.push(cap);
-	}
-	return unmapped;
-}
-
-function capabilityIsRepresented(cap: string, declared: DeclaredAccess): boolean {
-	switch (cap) {
-		case "content:read":
-			return declared.content?.read !== undefined;
-		case "content:write":
-			return declared.content?.write !== undefined;
-		case "media:read":
-			return declared.media?.read !== undefined;
-		case "media:write":
-			return declared.media?.write !== undefined;
-		case "network:request":
-		case "network:request:unrestricted":
-			return declared.network?.request !== undefined;
-		case "email:send":
-			return declared.email?.send !== undefined;
-		default:
-			// Anything else (users:*, hooks.*:register, future capabilities)
-			// is unmapped. The lexicon doesn't have a category for it yet.
-			return false;
-	}
-}
-
-/**
- * Translate `manifest.capabilities` + `manifest.allowedHosts` into the
- * `declaredAccess` shape required by the EmDash release extension.
- *
- * Only the canonical capability names are inspected here; the manifest's
- * `capabilities` is normalized at publish-time entry, and deprecated names
- * are hard-failed before we get here.
- */
-function buildDeclaredAccess(manifest: PluginManifest): DeclaredAccess {
-	// Normalize so legacy aliases don't slip through (defence in depth -- the
-	// manifest should have been normalized at definePlugin time).
-	const caps = new Set(manifest.capabilities.map((c) => normalizeCapability(c)));
-	const declared: DeclaredAccess = {};
-
-	// The lexicon documents that `content.write` IMPLIES `content.read`
-	// (releaseExtension.json line 53-56) and same for `media.write`.
-	// Canonicalise here so the published trust contract matches the
-	// documented semantics: any capability that implies read also surfaces
-	// `read: {}` in declaredAccess. Aggregators and sandbox runtimes can
-	// then gate on `declaredAccess.content.read` without also having to
-	// know the implication rules.
-	if (caps.has("content:read") || caps.has("content:write")) {
-		declared.content = { read: {} };
-		if (caps.has("content:write")) declared.content.write = {};
-	}
-	if (caps.has("media:read") || caps.has("media:write")) {
-		declared.media = { read: {} };
-		if (caps.has("media:write")) declared.media.write = {};
-	}
-	if (caps.has("network:request") || caps.has("network:request:unrestricted")) {
-		declared.network = {};
-		// The lexicon's `networkRequestConstraints.allowedHosts` is "absent =
-		// no host restriction; empty array MUST NOT appear". So we only set
-		// the key when the manifest declares hosts and the unrestricted
-		// capability is NOT present.
-		const constraint: { allowedHosts?: string[] } = {};
-		if (!caps.has("network:request:unrestricted") && manifest.allowedHosts.length > 0) {
-			constraint.allowedHosts = [...manifest.allowedHosts];
-		}
-		declared.network.request = constraint;
-	}
-	if (caps.has("email:send")) {
-		declared.email = { send: {} };
-	}
-
-	return declared;
 }
 
 /**

--- a/packages/plugin-cli/tests/publish.test.ts
+++ b/packages/plugin-cli/tests/publish.test.ts
@@ -472,9 +472,9 @@ describe("publishRelease", () => {
 		}
 
 		it("carries every facet, including hook registrations, when derived from a legacy bundle", async () => {
-			// The plugin behind the original DECLARED_ACCESS_DRIFT: a bundle with
-			// no declaredAccess (pre-migration) whose hook capabilities must still
-			// reach the record so the consent dialog can show them.
+			// A bundle with no declaredAccess (a pre-migration tarball) whose hook
+			// capabilities must still reach the record so the consent dialog can
+			// show them.
 			const pds = new MockPds({ did: TEST_DID });
 			await publishRelease(
 				buildOptions(pds, {

--- a/packages/plugin-cli/tests/publish.test.ts
+++ b/packages/plugin-cli/tests/publish.test.ts
@@ -460,6 +460,56 @@ describe("publishRelease", () => {
 		});
 	});
 
+	describe("release extension declaredAccess (install-consent contract)", () => {
+		function getDeclaredAccess(pds: MockPds): Record<string, unknown> {
+			const release = pds.records.get(`at://${TEST_DID}/${NSID.packageRelease}/test-plugin:1.0.0`);
+			const ext = (
+				release!.value as {
+					extensions: Record<string, { declaredAccess: Record<string, unknown> }>;
+				}
+			).extensions[NSID.packageReleaseExtension];
+			return ext!.declaredAccess;
+		}
+
+		it("carries every facet, including hook registrations, when derived from a legacy bundle", async () => {
+			// The plugin behind the original DECLARED_ACCESS_DRIFT: a bundle with
+			// no declaredAccess (pre-migration) whose hook capabilities must still
+			// reach the record so the consent dialog can show them.
+			const pds = new MockPds({ did: TEST_DID });
+			await publishRelease(
+				buildOptions(pds, {
+					manifest: buildManifest({
+						capabilities: [
+							"hooks.email-transport:register",
+							"network:request",
+							"hooks.email-events:register",
+						],
+						allowedHosts: ["api.cloudflare.com"],
+					}),
+				}),
+			);
+			expect(getDeclaredAccess(pds)).toEqual({
+				network: { request: { allowedHosts: ["api.cloudflare.com"] } },
+				email: { transport: {}, events: {} },
+			});
+		});
+
+		it("carries the bundle manifest's declaredAccess verbatim when present", async () => {
+			const pds = new MockPds({ did: TEST_DID });
+			const declaredAccess = { content: { read: {} }, email: { transport: {} } };
+			await publishRelease(
+				buildOptions(pds, {
+					manifest: buildManifest({
+						capabilities: ["content:read", "hooks.email-transport:register"],
+						allowedHosts: [],
+						declaredAccess,
+					}),
+				}),
+			);
+			expect(getDeclaredAccess(pds)).toEqual(declaredAccess);
+		});
+	});
+
 	describe("slug derivation", () => {
 		it("strips a leading @ and replaces / with - for scoped npm names", async () => {
 			const pds = new MockPds({ did: TEST_DID });

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -158,6 +158,121 @@ export function normalizeCapabilities(caps: readonly string[]): string[] {
 	return out;
 }
 
+// ── declaredAccess: the structured trust contract ────────────────────────────
+
+/**
+ * Constraint object attached to a declaredAccess operation. An open vocabulary
+ * (`true` is sugar for `{}`): keys the runtime recognises are enforced, unknown
+ * keys are advisory and surfaced in install-consent UI. The only normatively
+ * enforced key today is `network.request.allowedHosts`.
+ */
+export type AccessConstraints = Record<string, unknown>;
+
+/**
+ * Structured per-category access manifest -- the trust contract the registry
+ * record, the bundle manifest, and the install-consent dialog all agree on.
+ * Categories are host subsystems; operations are modes of participation in
+ * them. Resource-access operations (read/write/request/send) gate host calls;
+ * participation operations (email.events/transport, page.fragments) gate
+ * privileged hook registration at load time.
+ *
+ * Isomorphic to a normalized `PluginCapability[]` + `allowedHosts` via
+ * {@link capabilitiesToDeclaredAccess} / {@link declaredAccessToCapabilities}.
+ */
+export interface DeclaredAccess {
+	content?: { read?: AccessConstraints; write?: AccessConstraints };
+	media?: { read?: AccessConstraints; write?: AccessConstraints };
+	network?: { request?: { allowedHosts?: string[] } };
+	email?: { send?: AccessConstraints; events?: AccessConstraints; transport?: AccessConstraints };
+	page?: { fragments?: AccessConstraints };
+	users?: { read?: AccessConstraints };
+}
+
+/**
+ * Lower a normalized capability list + `allowedHosts` into the structured
+ * `declaredAccess` contract. Total over the current capability vocabulary and
+ * the inverse of {@link declaredAccessToCapabilities} for implication-closed
+ * inputs (the shape `definePlugin` produces).
+ *
+ * `network.request` with an empty constraint object means unrestricted (per the
+ * lexicon); a host-restricted plugin carries a non-empty `allowedHosts`. The
+ * lexicon forbids an empty `allowedHosts` array, so "restricted to nothing" is
+ * not representable -- and publish rejects `network:request` with no hosts.
+ */
+export function capabilitiesToDeclaredAccess(
+	capabilities: readonly string[],
+	allowedHosts: readonly string[],
+): DeclaredAccess {
+	const caps = new Set(capabilities.map((c) => normalizeCapability(c)));
+	const out: DeclaredAccess = {};
+
+	if (caps.has("content:read") || caps.has("content:write")) {
+		out.content = { read: {} };
+		if (caps.has("content:write")) out.content.write = {};
+	}
+	if (caps.has("media:read") || caps.has("media:write")) {
+		out.media = { read: {} };
+		if (caps.has("media:write")) out.media.write = {};
+	}
+	if (caps.has("network:request") || caps.has("network:request:unrestricted")) {
+		const request: { allowedHosts?: string[] } = {};
+		if (!caps.has("network:request:unrestricted") && allowedHosts.length > 0) {
+			request.allowedHosts = [...allowedHosts];
+		}
+		out.network = { request };
+	}
+	if (caps.has("email:send")) (out.email ??= {}).send = {};
+	if (caps.has("hooks.email-events:register")) (out.email ??= {}).events = {};
+	if (caps.has("hooks.email-transport:register")) (out.email ??= {}).transport = {};
+	if (caps.has("hooks.page-fragments:register")) out.page = { fragments: {} };
+	if (caps.has("users:read")) out.users = { read: {} };
+
+	return out;
+}
+
+/**
+ * Raise a `declaredAccess` block back to normalized capability strings +
+ * `allowedHosts` -- the runtime's internal enforcement currency. Total: every
+ * facet maps to exactly one capability. The result is closed under the same
+ * implications `definePlugin` applies (write implies read; unrestricted implies
+ * request), so it round-trips with {@link capabilitiesToDeclaredAccess}.
+ */
+export function declaredAccessToCapabilities(declaredAccess: DeclaredAccess): {
+	capabilities: PluginCapability[];
+	allowedHosts: string[];
+} {
+	const caps = new Set<PluginCapability>();
+	let allowedHosts: string[] = [];
+
+	if (declaredAccess.content?.read) caps.add("content:read");
+	if (declaredAccess.content?.write) {
+		caps.add("content:write");
+		caps.add("content:read");
+	}
+	if (declaredAccess.media?.read) caps.add("media:read");
+	if (declaredAccess.media?.write) {
+		caps.add("media:write");
+		caps.add("media:read");
+	}
+	if (declaredAccess.network?.request) {
+		const hosts = declaredAccess.network.request.allowedHosts;
+		if (hosts && hosts.length > 0) {
+			caps.add("network:request");
+			allowedHosts = [...hosts];
+		} else {
+			caps.add("network:request:unrestricted");
+			caps.add("network:request");
+		}
+	}
+	if (declaredAccess.email?.send) caps.add("email:send");
+	if (declaredAccess.email?.events) caps.add("hooks.email-events:register");
+	if (declaredAccess.email?.transport) caps.add("hooks.email-transport:register");
+	if (declaredAccess.page?.fragments) caps.add("hooks.page-fragments:register");
+	if (declaredAccess.users?.read) caps.add("users:read");
+
+	return { capabilities: [...caps], allowedHosts };
+}
+
 // ── Manifest shape ───────────────────────────────────────────────────────────
 
 /**
@@ -249,6 +364,18 @@ export interface PluginAdminConfig {
 export interface PluginManifest {
 	id: string;
 	version: string;
+	/**
+	 * The trust contract: the structured access the plugin declares. Authoritative
+	 * for the registry record, install consent, and the publish/install deep-equal.
+	 * `capabilities` and `allowedHosts` are the runtime's enforcement currency,
+	 * derived from this via `declaredAccessToCapabilities` at the parse boundary --
+	 * never the other way around.
+	 *
+	 * Optional during the migration to a declaredAccess-only wire manifest; once
+	 * every producer populates it (bundler, definePlugin path) and the parse
+	 * boundary derives the strings, this tightens to required.
+	 */
+	declaredAccess?: DeclaredAccess;
 	capabilities: PluginCapability[];
 	allowedHosts: string[];
 	storage: PluginStorageConfig;

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -194,10 +194,13 @@ export interface DeclaredAccess {
  * the inverse of {@link declaredAccessToCapabilities} for implication-closed
  * inputs (the shape `definePlugin` produces).
  *
- * `network.request` with an empty constraint object means unrestricted (per the
- * lexicon); a host-restricted plugin carries a non-empty `allowedHosts`. The
- * lexicon forbids an empty `allowedHosts` array, so "restricted to nothing" is
- * not representable -- and publish rejects `network:request` with no hosts.
+ * Network semantics are faithful to the legacy capability/allowedHosts model:
+ * an ABSENT `allowedHosts` key means unrestricted (`network:request:unrestricted`);
+ * a PRESENT `allowedHosts` -- even an empty array -- means host-restricted
+ * (`network:request`), where the empty list is deny-all at the runtime boundary.
+ * An empty list never widens to unrestricted. (The record lexicon forbids the
+ * empty array and publish rejects `network:request` with no hosts, so deny-all
+ * only arises for non-registry/in-process plugins.)
  */
 export function capabilitiesToDeclaredAccess(
 	capabilities: readonly string[],
@@ -214,12 +217,15 @@ export function capabilitiesToDeclaredAccess(
 		out.media = { read: {} };
 		if (caps.has("media:write")) out.media.write = {};
 	}
-	if (caps.has("network:request") || caps.has("network:request:unrestricted")) {
-		const request: { allowedHosts?: string[] } = {};
-		if (!caps.has("network:request:unrestricted") && allowedHosts.length > 0) {
-			request.allowedHosts = [...allowedHosts];
-		}
-		out.network = { request };
+	if (caps.has("network:request:unrestricted")) {
+		// Unrestricted: omit allowedHosts entirely (its absence is what the
+		// lexicon and the decoder read as "no host restriction").
+		out.network = { request: {} };
+	} else if (caps.has("network:request")) {
+		// Host-restricted: carry the list verbatim, INCLUDING an empty list,
+		// which is deny-all at the runtime boundary. Never collapse an empty
+		// list to `{}` -- that would silently widen deny-all to unrestricted.
+		out.network = { request: { allowedHosts: [...allowedHosts] } };
 	}
 	if (caps.has("email:send")) (out.email ??= {}).send = {};
 	if (caps.has("hooks.email-events:register")) (out.email ??= {}).events = {};
@@ -256,12 +262,16 @@ export function declaredAccessToCapabilities(declaredAccess: DeclaredAccess): {
 	}
 	if (declaredAccess.network?.request) {
 		const hosts = declaredAccess.network.request.allowedHosts;
-		if (hosts && hosts.length > 0) {
-			caps.add("network:request");
-			allowedHosts = [...hosts];
-		} else {
+		if (hosts === undefined) {
+			// No allowedHosts key = unrestricted (lexicon semantics).
 			caps.add("network:request:unrestricted");
 			caps.add("network:request");
+		} else {
+			// allowedHosts present (even empty) = host-restricted. An empty list
+			// is deny-all at the runtime boundary -- NEVER widen it to
+			// unrestricted, or the most-restrictive spelling grants the most.
+			caps.add("network:request");
+			allowedHosts = [...hosts];
 		}
 	}
 	if (declaredAccess.email?.send) caps.add("email:send");

--- a/packages/plugin-types/tests/capabilities.test.ts
+++ b/packages/plugin-types/tests/capabilities.test.ts
@@ -104,8 +104,8 @@ describe("declaredAccess facet mapping", () => {
 	});
 
 	it("never widens an empty allowedHosts (deny-all) to unrestricted", () => {
-		// Finding 1: empty allowedHosts is the most-restrictive spelling and MUST
-		// NOT decode to unrestricted. Both directions must keep it host-restricted.
+		// An empty allowedHosts is the most-restrictive spelling (deny-all); it must
+		// never decode to unrestricted, or the tightest declaration grants the most.
 		expect(capabilitiesToDeclaredAccess(["network:request"], [])).toEqual({
 			network: { request: { allowedHosts: [] } },
 		});
@@ -114,10 +114,9 @@ describe("declaredAccess facet mapping", () => {
 		expect(decoded).toEqual({ capabilities: ["network:request"], allowedHosts: [] });
 	});
 
-	it("carries every facet of the email+network plugin that surfaced the consent bug", () => {
-		// The plugin behind the original DECLARED_ACCESS_DRIFT: an email transport
-		// that also makes outbound calls and observes events. declaredAccess must
-		// carry all three so consent matches the bundle.
+	it("carries every facet of an email transport that also calls out and observes events", () => {
+		// declaredAccess must carry all three facets so the consent list matches
+		// the capability set the runtime enforces.
 		const da = capabilitiesToDeclaredAccess(
 			["hooks.email-transport:register", "network:request", "hooks.email-events:register"],
 			["api.cloudflare.com"],
@@ -137,15 +136,15 @@ describe("declaredAccess <-> capabilities round-trip (total over the vocabulary)
 	// definePlugin closes write->read and unrestricted->request, and publish
 	// rejects network:request with no hosts, so these are the only states that
 	// can reach a published manifest. Every one must round-trip to identity --
-	// the guard that the two representations are isomorphic, which is the
-	// property whose absence caused the original drift bug.
+	// the guard that the two representations are isomorphic, so the consent list
+	// always equals the capability set the runtime enforces.
 	const contentChoices = [[], ["content:read"], ["content:read", "content:write"]];
 	const mediaChoices = [[], ["media:read"], ["media:read", "media:write"]];
 	const networkChoices: { caps: string[]; hosts: string[] }[] = [
 		{ caps: [], hosts: [] },
 		{ caps: ["network:request", "network:request:unrestricted"], hosts: [] },
 		// Host-restricted with an empty allow-list = deny-all. Must round-trip
-		// as restricted, NOT widen to unrestricted (the Finding-1 inversion).
+		// as restricted, never widening to unrestricted.
 		{ caps: ["network:request"], hosts: [] },
 		{ caps: ["network:request"], hosts: ["api.example.com"] },
 		{ caps: ["network:request"], hosts: ["api.example.com", "*.cdn.example.com"] },

--- a/packages/plugin-types/tests/capabilities.test.ts
+++ b/packages/plugin-types/tests/capabilities.test.ts
@@ -103,6 +103,17 @@ describe("declaredAccess facet mapping", () => {
 		).toEqual({ network: { request: {} } });
 	});
 
+	it("never widens an empty allowedHosts (deny-all) to unrestricted", () => {
+		// Finding 1: empty allowedHosts is the most-restrictive spelling and MUST
+		// NOT decode to unrestricted. Both directions must keep it host-restricted.
+		expect(capabilitiesToDeclaredAccess(["network:request"], [])).toEqual({
+			network: { request: { allowedHosts: [] } },
+		});
+		const decoded = declaredAccessToCapabilities({ network: { request: { allowedHosts: [] } } });
+		expect(decoded.capabilities).not.toContain("network:request:unrestricted");
+		expect(decoded).toEqual({ capabilities: ["network:request"], allowedHosts: [] });
+	});
+
 	it("carries every facet of the email+network plugin that surfaced the consent bug", () => {
 		// The plugin behind the original DECLARED_ACCESS_DRIFT: an email transport
 		// that also makes outbound calls and observes events. declaredAccess must
@@ -133,6 +144,9 @@ describe("declaredAccess <-> capabilities round-trip (total over the vocabulary)
 	const networkChoices: { caps: string[]; hosts: string[] }[] = [
 		{ caps: [], hosts: [] },
 		{ caps: ["network:request", "network:request:unrestricted"], hosts: [] },
+		// Host-restricted with an empty allow-list = deny-all. Must round-trip
+		// as restricted, NOT widen to unrestricted (the Finding-1 inversion).
+		{ caps: ["network:request"], hosts: [] },
 		{ caps: ["network:request"], hosts: ["api.example.com"] },
 		{ caps: ["network:request"], hosts: ["api.example.com", "*.cdn.example.com"] },
 	];
@@ -170,7 +184,7 @@ describe("declaredAccess <-> capabilities round-trip (total over the vocabulary)
 			expect(new Set(back.allowedHosts)).toEqual(new Set(input.allowedHosts));
 			count++;
 		}
-		// 3 content x 3 media x 4 network x 2^5 singleton subsets.
-		expect(count).toBe(1152);
+		// 3 content x 3 media x 5 network x 2^5 singleton subsets.
+		expect(count).toBe(1440);
 	});
 });

--- a/packages/plugin-types/tests/capabilities.test.ts
+++ b/packages/plugin-types/tests/capabilities.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
 	CAPABILITY_RENAMES,
+	capabilitiesToDeclaredAccess,
+	declaredAccessToCapabilities,
 	isDeprecatedCapability,
 	normalizeCapabilities,
 	normalizeCapability,
@@ -74,5 +76,105 @@ describe("normalizeCapabilities", () => {
 
 	it("handles an empty array", () => {
 		expect(normalizeCapabilities([])).toEqual([]);
+	});
+});
+
+describe("declaredAccess facet mapping", () => {
+	it("maps each hook-registration capability to its participation facet", () => {
+		expect(capabilitiesToDeclaredAccess(["hooks.email-transport:register"], [])).toEqual({
+			email: { transport: {} },
+		});
+		expect(capabilitiesToDeclaredAccess(["hooks.email-events:register"], [])).toEqual({
+			email: { events: {} },
+		});
+		expect(capabilitiesToDeclaredAccess(["hooks.page-fragments:register"], [])).toEqual({
+			page: { fragments: {} },
+		});
+		expect(capabilitiesToDeclaredAccess(["users:read"], [])).toEqual({ users: { read: {} } });
+	});
+
+	it("distinguishes host-restricted from unrestricted network", () => {
+		expect(capabilitiesToDeclaredAccess(["network:request"], ["api.example.com"])).toEqual({
+			network: { request: { allowedHosts: ["api.example.com"] } },
+		});
+		// An empty constraint object is the lexicon's spelling of "unrestricted".
+		expect(
+			capabilitiesToDeclaredAccess(["network:request:unrestricted", "network:request"], []),
+		).toEqual({ network: { request: {} } });
+	});
+
+	it("carries every facet of the email+network plugin that surfaced the consent bug", () => {
+		// The plugin behind the original DECLARED_ACCESS_DRIFT: an email transport
+		// that also makes outbound calls and observes events. declaredAccess must
+		// carry all three so consent matches the bundle.
+		const da = capabilitiesToDeclaredAccess(
+			["hooks.email-transport:register", "network:request", "hooks.email-events:register"],
+			["api.cloudflare.com"],
+		);
+		expect(da).toEqual({
+			network: { request: { allowedHosts: ["api.cloudflare.com"] } },
+			email: { transport: {}, events: {} },
+		});
+		expect(new Set(declaredAccessToCapabilities(da).capabilities)).toEqual(
+			new Set([
+				"hooks.email-transport:register",
+				"network:request",
+				"hooks.email-events:register",
+			]),
+		);
+	});
+});
+
+describe("declaredAccess <-> capabilities round-trip (total over the vocabulary)", () => {
+	// The full enumeration of implication-closed, valid capability states.
+	// definePlugin closes write->read and unrestricted->request, and publish
+	// rejects network:request with no hosts, so these are the only states that
+	// can reach a published manifest. Every one must round-trip to identity --
+	// the guard that the two representations are isomorphic, which is the
+	// property whose absence caused the original drift bug.
+	const contentChoices = [[], ["content:read"], ["content:read", "content:write"]];
+	const mediaChoices = [[], ["media:read"], ["media:read", "media:write"]];
+	const networkChoices: { caps: string[]; hosts: string[] }[] = [
+		{ caps: [], hosts: [] },
+		{ caps: ["network:request", "network:request:unrestricted"], hosts: [] },
+		{ caps: ["network:request"], hosts: ["api.example.com"] },
+		{ caps: ["network:request"], hosts: ["api.example.com", "*.cdn.example.com"] },
+	];
+	const singletonFacets = [
+		"email:send",
+		"hooks.email-events:register",
+		"hooks.email-transport:register",
+		"hooks.page-fragments:register",
+		"users:read",
+	];
+
+	function* states() {
+		for (const content of contentChoices) {
+			for (const media of mediaChoices) {
+				for (const network of networkChoices) {
+					for (let mask = 0; mask < 1 << singletonFacets.length; mask++) {
+						const extra = singletonFacets.filter((_, i) => mask & (1 << i));
+						yield {
+							capabilities: [...content, ...media, ...network.caps, ...extra],
+							allowedHosts: network.hosts,
+						};
+					}
+				}
+			}
+		}
+	}
+
+	it("recovers every implication-closed valid state exactly", () => {
+		let count = 0;
+		for (const input of states()) {
+			const back = declaredAccessToCapabilities(
+				capabilitiesToDeclaredAccess(input.capabilities, input.allowedHosts),
+			);
+			expect(new Set(back.capabilities)).toEqual(new Set(input.capabilities));
+			expect(new Set(back.allowedHosts)).toEqual(new Set(input.allowedHosts));
+			count++;
+		}
+		// 3 content x 3 media x 4 network x 2^5 singleton subsets.
+		expect(count).toBe(1152);
 	});
 });

--- a/packages/plugin-types/tests/capabilities.test.ts
+++ b/packages/plugin-types/tests/capabilities.test.ts
@@ -116,11 +116,7 @@ describe("declaredAccess facet mapping", () => {
 			email: { transport: {}, events: {} },
 		});
 		expect(new Set(declaredAccessToCapabilities(da).capabilities)).toEqual(
-			new Set([
-				"hooks.email-transport:register",
-				"network:request",
-				"hooks.email-events:register",
-			]),
+			new Set(["hooks.email-transport:register", "network:request", "hooks.email-events:register"]),
 		);
 	});
 });

--- a/packages/registry-lexicons/lexicons/com/emdashcms/experimental/package/releaseExtension.json
+++ b/packages/registry-lexicons/lexicons/com/emdashcms/experimental/package/releaseExtension.json
@@ -37,7 +37,17 @@
 				"email": {
 					"type": "ref",
 					"ref": "#emailAccess",
-					"description": "Sending mail through the host's mail service."
+					"description": "Sending mail through the host's mail service, and participating in its delivery pipeline."
+				},
+				"page": {
+					"type": "ref",
+					"ref": "#pageAccess",
+					"description": "Participation in rendered page output."
+				},
+				"users": {
+					"type": "ref",
+					"ref": "#usersAccess",
+					"description": "Access to site user records."
 				}
 			}
 		},
@@ -124,12 +134,60 @@
 					"type": "ref",
 					"ref": "#emailSendConstraints",
 					"description": "Plugin may send mail."
+				},
+				"events": {
+					"type": "ref",
+					"ref": "#emailEventsConstraints",
+					"description": "Plugin observes and may mutate every outgoing message (before and/or after send), including mail from the host and other plugins."
+				},
+				"transport": {
+					"type": "ref",
+					"ref": "#emailTransportConstraints",
+					"description": "Plugin becomes the host's mail transport; every message the site sends is delivered through it. Exclusive: installing replaces the current transport."
 				}
 			}
 		},
 		"emailSendConstraints": {
 			"type": "object",
 			"description": "Constraint object for email.send. No constraint keys are normatively defined here; vocabulary for rate limits and recipient allow-lists is reserved for a follow-on RFC."
+		},
+		"emailEventsConstraints": {
+			"type": "object",
+			"description": "Constraint object for email.events. No constraint keys are normatively defined here; phase scoping (beforeSend/afterSend) is reserved for a follow-on RFC and surfaced advisorily until then."
+		},
+		"emailTransportConstraints": {
+			"type": "object",
+			"description": "Constraint object for email.transport. No constraint keys are normatively defined here. Exclusivity is a property of the host extension point: clients treat email.transport as exclusive regardless of record contents."
+		},
+		"pageAccess": {
+			"type": "object",
+			"description": "Operations under page (rendered-output participation).",
+			"properties": {
+				"fragments": {
+					"type": "ref",
+					"ref": "#pageFragmentsConstraints",
+					"description": "Plugin injects script and/or style fragments into rendered pages."
+				}
+			}
+		},
+		"pageFragmentsConstraints": {
+			"type": "object",
+			"description": "Constraint object for page.fragments. No constraint keys are normatively defined here; position/placement scoping is reserved for a follow-on RFC."
+		},
+		"usersAccess": {
+			"type": "object",
+			"description": "Operations under users.",
+			"properties": {
+				"read": {
+					"type": "ref",
+					"ref": "#usersReadConstraints",
+					"description": "Plugin may read site user records."
+				}
+			}
+		},
+		"usersReadConstraints": {
+			"type": "object",
+			"description": "Constraint object for users.read. No constraint keys are normatively defined here."
 		}
 	}
 }

--- a/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/releaseExtension.ts
+++ b/packages/registry-lexicons/src/generated/types/com/emdashcms/experimental/package/releaseExtension.ts
@@ -47,7 +47,7 @@ const _declaredAccessSchema = /*#__PURE__*/ v.object({
 		return /*#__PURE__*/ v.optional(contentAccessSchema);
 	},
 	/**
-	 * Sending mail through the host's mail service.
+	 * Sending mail through the host's mail service, and participating in its delivery pipeline.
 	 */
 	get email() {
 		return /*#__PURE__*/ v.optional(emailAccessSchema);
@@ -64,6 +64,18 @@ const _declaredAccessSchema = /*#__PURE__*/ v.object({
 	get network() {
 		return /*#__PURE__*/ v.optional(networkAccessSchema);
 	},
+	/**
+	 * Participation in rendered page output.
+	 */
+	get page() {
+		return /*#__PURE__*/ v.optional(pageAccessSchema);
+	},
+	/**
+	 * Access to site user records.
+	 */
+	get users() {
+		return /*#__PURE__*/ v.optional(usersAccessSchema);
+	},
 });
 const _emailAccessSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
@@ -72,16 +84,42 @@ const _emailAccessSchema = /*#__PURE__*/ v.object({
 		),
 	),
 	/**
+	 * Plugin observes and may mutate every outgoing message (before and/or after send), including mail from the host and other plugins.
+	 */
+	get events() {
+		return /*#__PURE__*/ v.optional(emailEventsConstraintsSchema);
+	},
+	/**
 	 * Plugin may send mail.
 	 */
 	get send() {
 		return /*#__PURE__*/ v.optional(emailSendConstraintsSchema);
 	},
+	/**
+	 * Plugin becomes the host's mail transport; every message the site sends is delivered through it. Exclusive: installing replaces the current transport.
+	 */
+	get transport() {
+		return /*#__PURE__*/ v.optional(emailTransportConstraintsSchema);
+	},
+});
+const _emailEventsConstraintsSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#emailEventsConstraints",
+		),
+	),
 });
 const _emailSendConstraintsSchema = /*#__PURE__*/ v.object({
 	$type: /*#__PURE__*/ v.optional(
 		/*#__PURE__*/ v.literal(
 			"com.emdashcms.experimental.package.releaseExtension#emailSendConstraints",
+		),
+	),
+});
+const _emailTransportConstraintsSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#emailTransportConstraints",
 		),
 	),
 });
@@ -166,13 +204,56 @@ const _networkRequestConstraintsSchema = /*#__PURE__*/ v.object({
 		),
 	),
 });
+const _pageAccessSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#pageAccess",
+		),
+	),
+	/**
+	 * Plugin injects script and/or style fragments into rendered pages.
+	 */
+	get fragments() {
+		return /*#__PURE__*/ v.optional(pageFragmentsConstraintsSchema);
+	},
+});
+const _pageFragmentsConstraintsSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#pageFragmentsConstraints",
+		),
+	),
+});
+const _usersAccessSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#usersAccess",
+		),
+	),
+	/**
+	 * Plugin may read site user records.
+	 */
+	get read() {
+		return /*#__PURE__*/ v.optional(usersReadConstraintsSchema);
+	},
+});
+const _usersReadConstraintsSchema = /*#__PURE__*/ v.object({
+	$type: /*#__PURE__*/ v.optional(
+		/*#__PURE__*/ v.literal(
+			"com.emdashcms.experimental.package.releaseExtension#usersReadConstraints",
+		),
+	),
+});
 
 type contentAccess$schematype = typeof _contentAccessSchema;
 type contentReadConstraints$schematype = typeof _contentReadConstraintsSchema;
 type contentWriteConstraints$schematype = typeof _contentWriteConstraintsSchema;
 type declaredAccess$schematype = typeof _declaredAccessSchema;
 type emailAccess$schematype = typeof _emailAccessSchema;
+type emailEventsConstraints$schematype = typeof _emailEventsConstraintsSchema;
 type emailSendConstraints$schematype = typeof _emailSendConstraintsSchema;
+type emailTransportConstraints$schematype =
+	typeof _emailTransportConstraintsSchema;
 type main$schematype = typeof _mainSchema;
 type mediaAccess$schematype = typeof _mediaAccessSchema;
 type mediaReadConstraints$schematype = typeof _mediaReadConstraintsSchema;
@@ -180,19 +261,30 @@ type mediaWriteConstraints$schematype = typeof _mediaWriteConstraintsSchema;
 type networkAccess$schematype = typeof _networkAccessSchema;
 type networkRequestConstraints$schematype =
 	typeof _networkRequestConstraintsSchema;
+type pageAccess$schematype = typeof _pageAccessSchema;
+type pageFragmentsConstraints$schematype =
+	typeof _pageFragmentsConstraintsSchema;
+type usersAccess$schematype = typeof _usersAccessSchema;
+type usersReadConstraints$schematype = typeof _usersReadConstraintsSchema;
 
 export interface contentAccessSchema extends contentAccess$schematype {}
 export interface contentReadConstraintsSchema extends contentReadConstraints$schematype {}
 export interface contentWriteConstraintsSchema extends contentWriteConstraints$schematype {}
 export interface declaredAccessSchema extends declaredAccess$schematype {}
 export interface emailAccessSchema extends emailAccess$schematype {}
+export interface emailEventsConstraintsSchema extends emailEventsConstraints$schematype {}
 export interface emailSendConstraintsSchema extends emailSendConstraints$schematype {}
+export interface emailTransportConstraintsSchema extends emailTransportConstraints$schematype {}
 export interface mainSchema extends main$schematype {}
 export interface mediaAccessSchema extends mediaAccess$schematype {}
 export interface mediaReadConstraintsSchema extends mediaReadConstraints$schematype {}
 export interface mediaWriteConstraintsSchema extends mediaWriteConstraints$schematype {}
 export interface networkAccessSchema extends networkAccess$schematype {}
 export interface networkRequestConstraintsSchema extends networkRequestConstraints$schematype {}
+export interface pageAccessSchema extends pageAccess$schematype {}
+export interface pageFragmentsConstraintsSchema extends pageFragmentsConstraints$schematype {}
+export interface usersAccessSchema extends usersAccess$schematype {}
+export interface usersReadConstraintsSchema extends usersReadConstraints$schematype {}
 
 export const contentAccessSchema = _contentAccessSchema as contentAccessSchema;
 export const contentReadConstraintsSchema =
@@ -202,8 +294,12 @@ export const contentWriteConstraintsSchema =
 export const declaredAccessSchema =
 	_declaredAccessSchema as declaredAccessSchema;
 export const emailAccessSchema = _emailAccessSchema as emailAccessSchema;
+export const emailEventsConstraintsSchema =
+	_emailEventsConstraintsSchema as emailEventsConstraintsSchema;
 export const emailSendConstraintsSchema =
 	_emailSendConstraintsSchema as emailSendConstraintsSchema;
+export const emailTransportConstraintsSchema =
+	_emailTransportConstraintsSchema as emailTransportConstraintsSchema;
 export const mainSchema = _mainSchema as mainSchema;
 export const mediaAccessSchema = _mediaAccessSchema as mediaAccessSchema;
 export const mediaReadConstraintsSchema =
@@ -213,6 +309,12 @@ export const mediaWriteConstraintsSchema =
 export const networkAccessSchema = _networkAccessSchema as networkAccessSchema;
 export const networkRequestConstraintsSchema =
 	_networkRequestConstraintsSchema as networkRequestConstraintsSchema;
+export const pageAccessSchema = _pageAccessSchema as pageAccessSchema;
+export const pageFragmentsConstraintsSchema =
+	_pageFragmentsConstraintsSchema as pageFragmentsConstraintsSchema;
+export const usersAccessSchema = _usersAccessSchema as usersAccessSchema;
+export const usersReadConstraintsSchema =
+	_usersReadConstraintsSchema as usersReadConstraintsSchema;
 
 export interface ContentAccess extends v.InferInput<
 	typeof contentAccessSchema
@@ -227,8 +329,14 @@ export interface DeclaredAccess extends v.InferInput<
 	typeof declaredAccessSchema
 > {}
 export interface EmailAccess extends v.InferInput<typeof emailAccessSchema> {}
+export interface EmailEventsConstraints extends v.InferInput<
+	typeof emailEventsConstraintsSchema
+> {}
 export interface EmailSendConstraints extends v.InferInput<
 	typeof emailSendConstraintsSchema
+> {}
+export interface EmailTransportConstraints extends v.InferInput<
+	typeof emailTransportConstraintsSchema
 > {}
 export interface Main extends v.InferInput<typeof mainSchema> {}
 export interface MediaAccess extends v.InferInput<typeof mediaAccessSchema> {}
@@ -243,4 +351,12 @@ export interface NetworkAccess extends v.InferInput<
 > {}
 export interface NetworkRequestConstraints extends v.InferInput<
 	typeof networkRequestConstraintsSchema
+> {}
+export interface PageAccess extends v.InferInput<typeof pageAccessSchema> {}
+export interface PageFragmentsConstraints extends v.InferInput<
+	typeof pageFragmentsConstraintsSchema
+> {}
+export interface UsersAccess extends v.InferInput<typeof usersAccessSchema> {}
+export interface UsersReadConstraints extends v.InferInput<
+	typeof usersReadConstraintsSchema
 > {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,6 +978,9 @@ importers:
       '@emdash-cms/blocks':
         specifier: workspace:*
         version: link:../blocks
+      '@emdash-cms/plugin-types':
+        specifier: workspace:*
+        version: link:../plugin-types
       '@emdash-cms/registry-client':
         specifier: workspace:*
         version: link:../registry-client


### PR DESCRIPTION
## What does this PR do?

Makes `declaredAccess` the authoritative plugin trust contract end-to-end, fixing registry installs that failed with **"Plugin manifest has changed since you consented"** for any plugin declaring a hook-registration capability (`hooks.email-transport:register`, `hooks.email-events:register`, `hooks.page-fragments:register`) or `users:read`.

Root cause: the release record only carried the structured `declaredAccess`, whose vocabulary couldn't express hook registrations, so the publish step (`buildDeclaredAccess`) dropped them. The admin reconstructed the consent list from that lossy record, so the acknowledged permissions never matched the bundle the install handler enforced — a guaranteed `DECLARED_ACCESS_DRIFT` no user could clear.

The fix implements Path B from the design discussion: `declaredAccess` is the contract at every boundary (bundle manifest, registry record, install consent), while the runtime keeps enforcing the legacy `capabilities` strings, now **derived** from `declaredAccess` at the parse boundary via a total, isomorphic converter. The security-critical enforcement code is untouched.

- Completes the `declaredAccess` vocabulary in the lexicon (`email.events`/`email.transport`, `page.fragments`, `users`) — this is the RFC update in #694.
- Adds `capabilitiesToDeclaredAccess` / `declaredAccessToCapabilities` to `@emdash-cms/plugin-types`, proven isomorphic by a 1440-state exhaustive round-trip test.
- Bundler emits `declaredAccess`; publish carries it verbatim and deletes the lossy `buildDeclaredAccess`/`findUnmappedCapabilities`.
- `reconcileManifestAccess` re-derives `capabilities`/`allowedHosts` from `declaredAccess` at the two bundle-parse chokepoints both marketplace and registry installs share.
- Admin consent derives the list via the shared converter (one source of truth), replacing a component-local flattener.

An adversarial security pass found and this PR fixes two HIGH issues: (1) an empty `allowedHosts` array decoding to *unrestricted* network (a privilege inversion), and (2) the capability-string consent gate being blind to host scope, letting a record advertising one `allowedHosts` install a bundle enforcing another. The install handler now refuses any bundle whose enforced access (capabilities **and** hosts) differs from its signed record.

Design: RFC #694. Umbrella: Discussion #296.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (plugin-types 32, plugin-cli 393, core 3940, admin 8, aggregator 88)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (round-trip property, publish/admin/consumer regressions, the two security-fix regressions)
- [x] User-visible strings in the admin UI are wrapped for translation — n/a: the admin change is capability-derivation logic; the only rendered values are capability identifiers (data, shown as Badges), not new translatable strings. No `messages.po` changes.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [x] Linked to the registry umbrella Discussion #296 and RFC #694

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

```
plugin-types  32 passed
plugin-cli   393 passed
core        3940 passed (incl. 6 new install-integrity regressions)
admin          8 passed (RegistryPluginDetail)
aggregator    88 passed (extension re-validation)
typecheck    all 25 packages clean
lint         0 diagnostics
```

Migration note (in the changeset): re-publish affected plugins to adopt the new bundle format; existing installs are unaffected.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-registry-declared-access-contract-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/registry-declared-access-contract`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
