### PR TITLE
Fix(admin): Localize CodeBlockLanguages label

### DIFF
--- a/.changeset/whole-radios-tap.md
+++ b/.changeset/whole-radios-tap.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes localization for code block language labels in the admin editor

--- a/packages/admin/src/components/editor/CodeBlockNode.tsx
+++ b/packages/admin/src/components/editor/CodeBlockNode.tsx
@@ -22,25 +22,50 @@ import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import * as React from "react";
 
-import { CODE_BLOCK_LANGUAGES, languageLabel, normalizeLanguage } from "./codeBlockLanguages";
-
-const LANGUAGE_ITEMS = CODE_BLOCK_LANGUAGES.map((l) => l.label);
-
-function filterLanguages(item: string, query: string) {
-	if (!query) return true;
-	const needle = query.toLowerCase();
-	const lang = CODE_BLOCK_LANGUAGES.find((l) => l.label === item);
-	if (!lang) return false;
-	if (lang.label.toLowerCase().includes(needle)) return true;
-	if (lang.id.toLowerCase().includes(needle)) return true;
-	return lang.aliases?.some((alias) => alias.toLowerCase().includes(needle)) ?? false;
-}
+import {
+	CODE_BLOCK_LANGUAGES,
+	languageLabelDescriptor,
+	normalizeLanguage,
+} from "./codeBlockLanguages";
 
 function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) {
 	const { t } = useLingui();
 	const [isEditing, setIsEditing] = React.useState(false);
 	const storedLanguage = typeof node.attrs.language === "string" ? node.attrs.language : "";
-	const [draft, setDraft] = React.useState(() => languageLabel(storedLanguage));
+
+	const labelText = React.useCallback(
+		(value: string | null | undefined) => {
+			const label = languageLabelDescriptor(value);
+			return typeof label === "string" ? label : t(label);
+		},
+		[t],
+	);
+
+	const languageItems = React.useMemo(
+		() => CODE_BLOCK_LANGUAGES.map((language) => t(language.label)),
+		[t],
+	);
+
+	const findLanguageByDisplayLabel = React.useCallback(
+		(label: string) => CODE_BLOCK_LANGUAGES.find((language) => t(language.label) === label),
+		[t],
+	);
+
+	const filterLanguages = React.useCallback(
+		(item: string, query: string) => {
+			if (!query) return true;
+			const searchText = query.toLowerCase();
+			const lang = findLanguageByDisplayLabel(item);
+			if (!lang) return false;
+
+			if (t(lang.label).toLowerCase().includes(searchText)) return true;
+			if (lang.id.toLowerCase().includes(searchText)) return true;
+			return lang.aliases?.some((alias) => alias.toLowerCase().includes(searchText)) ?? false;
+		},
+		[findLanguageByDisplayLabel, t],
+	);
+
+	const [draft, setDraft] = React.useState(() => labelText(storedLanguage));
 	const popoverRef = React.useRef<HTMLDivElement>(null);
 
 	// Sync draft when the stored language changes from outside the node view
@@ -48,28 +73,29 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 	// content). Don't clobber an in-progress edit.
 	React.useEffect(() => {
 		if (!isEditing) {
-			setDraft(languageLabel(storedLanguage));
+			setDraft(labelText(storedLanguage));
 		}
-	}, [storedLanguage, isEditing]);
+	}, [storedLanguage, isEditing, labelText]);
 
 	const openPicker = React.useCallback(() => {
-		setDraft(storedLanguage ? languageLabel(storedLanguage) : "");
+		setDraft(storedLanguage ? labelText(storedLanguage) : "");
 		setIsEditing(true);
-	}, [storedLanguage]);
+	}, [storedLanguage, labelText]);
 
 	const closePicker = React.useCallback(() => {
 		setIsEditing(false);
-		setDraft(languageLabel(storedLanguage));
-	}, [storedLanguage]);
+		setDraft(labelText(storedLanguage));
+	}, [storedLanguage, labelText]);
 
 	const commit = React.useCallback(
 		(value?: string) => {
 			const raw = value ?? draft;
-			const next = normalizeLanguage(raw);
+			const selectedLanguage = findLanguageByDisplayLabel(raw);
+			const next = selectedLanguage?.id ?? normalizeLanguage(raw);
 			updateAttributes({ language: next ?? null });
 			setIsEditing(false);
 		},
-		[draft, updateAttributes],
+		[draft, findLanguageByDisplayLabel, updateAttributes],
 	);
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -95,7 +121,7 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 		return () => document.removeEventListener("mousedown", onMouseDown);
 	}, [isEditing, closePicker]);
 
-	const label = languageLabel(storedLanguage);
+	const label = labelText(storedLanguage);
 	// The chip is always rendered (so it can be discovered via hover) but its
 	// opacity is controlled by CSS: invisible by default, visible on hover,
 	// when this block is selected, when the picker is open, or when the
@@ -117,7 +143,7 @@ function CodeBlockNodeView({ node, updateAttributes, selected }: NodeViewProps) 
 						onKeyDown={handleKeyDown}
 					>
 						<Autocomplete
-							items={LANGUAGE_ITEMS}
+							items={languageItems}
 							value={draft}
 							onValueChange={(next: string) => setDraft(next)}
 							filter={filterLanguages}

--- a/packages/admin/src/components/editor/codeBlockLanguages.ts
+++ b/packages/admin/src/components/editor/codeBlockLanguages.ts
@@ -11,49 +11,52 @@
  * normalize unknown inputs.
  */
 
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+
 export interface CodeBlockLanguage {
 	/** Canonical identifier persisted in storage and emitted as `language-{id}`. */
 	id: string;
 	/** Human-readable label shown in the picker. */
-	label: string;
+	label: MessageDescriptor;
 	/** Alternative identifiers (typed by the user) that resolve to this language. */
 	aliases?: string[];
 }
 
 export const CODE_BLOCK_LANGUAGES: readonly CodeBlockLanguage[] = [
-	{ id: "plaintext", label: "Plain text", aliases: ["text", "plain", "txt"] },
-	{ id: "astro", label: "Astro" },
-	{ id: "bash", label: "Bash", aliases: ["sh", "shell", "zsh"] },
-	{ id: "c", label: "C" },
-	{ id: "cpp", label: "C++", aliases: ["c++"] },
-	{ id: "csharp", label: "C#", aliases: ["cs", "c#"] },
-	{ id: "css", label: "CSS" },
-	{ id: "diff", label: "Diff", aliases: ["patch"] },
-	{ id: "dockerfile", label: "Dockerfile", aliases: ["docker"] },
-	{ id: "go", label: "Go", aliases: ["golang"] },
-	{ id: "graphql", label: "GraphQL", aliases: ["gql"] },
-	{ id: "html", label: "HTML" },
-	{ id: "java", label: "Java" },
-	{ id: "javascript", label: "JavaScript", aliases: ["js"] },
-	{ id: "json", label: "JSON" },
-	{ id: "jsx", label: "JSX" },
-	{ id: "kotlin", label: "Kotlin", aliases: ["kt"] },
-	{ id: "markdown", label: "Markdown", aliases: ["md"] },
-	{ id: "mdx", label: "MDX" },
-	{ id: "php", label: "PHP" },
-	{ id: "python", label: "Python", aliases: ["py"] },
-	{ id: "ruby", label: "Ruby", aliases: ["rb"] },
-	{ id: "rust", label: "Rust", aliases: ["rs"] },
-	{ id: "scss", label: "SCSS", aliases: ["sass"] },
-	{ id: "sql", label: "SQL" },
-	{ id: "svelte", label: "Svelte" },
-	{ id: "swift", label: "Swift" },
-	{ id: "toml", label: "TOML" },
-	{ id: "tsx", label: "TSX" },
-	{ id: "typescript", label: "TypeScript", aliases: ["ts"] },
-	{ id: "vue", label: "Vue" },
-	{ id: "xml", label: "XML" },
-	{ id: "yaml", label: "YAML", aliases: ["yml"] },
+	{ id: "plaintext", label: msg`Plain text`, aliases: ["text", "plain", "txt"] },
+	{ id: "astro", label: msg`Astro` },
+	{ id: "bash", label: msg`Bash`, aliases: ["sh", "shell", "zsh"] },
+	{ id: "c", label: msg`C` },
+	{ id: "cpp", label: msg`C++`, aliases: ["c++"] },
+	{ id: "csharp", label: msg`C#`, aliases: ["cs", "c#"] },
+	{ id: "css", label: msg`CSS` },
+	{ id: "diff", label: msg`Diff`, aliases: ["patch"] },
+	{ id: "dockerfile", label: msg`Dockerfile`, aliases: ["docker"] },
+	{ id: "go", label: msg`Go`, aliases: ["golang"] },
+	{ id: "graphql", label: msg`GraphQL`, aliases: ["gql"] },
+	{ id: "html", label: msg`HTML` },
+	{ id: "java", label: msg`Java` },
+	{ id: "javascript", label: msg`JavaScript`, aliases: ["js"] },
+	{ id: "json", label: msg`JSON` },
+	{ id: "jsx", label: msg`JSX` },
+	{ id: "kotlin", label: msg`Kotlin`, aliases: ["kt"] },
+	{ id: "markdown", label: msg`Markdown`, aliases: ["md"] },
+	{ id: "mdx", label: msg`MDX` },
+	{ id: "php", label: msg`PHP` },
+	{ id: "python", label: msg`Python`, aliases: ["py"] },
+	{ id: "ruby", label: msg`Ruby`, aliases: ["rb"] },
+	{ id: "rust", label: msg`Rust`, aliases: ["rs"] },
+	{ id: "scss", label: msg`SCSS`, aliases: ["sass"] },
+	{ id: "sql", label: msg`SQL` },
+	{ id: "svelte", label: msg`Svelte` },
+	{ id: "swift", label: msg`Swift` },
+	{ id: "toml", label: msg`TOML` },
+	{ id: "tsx", label: msg`TSX` },
+	{ id: "typescript", label: msg`TypeScript`, aliases: ["ts"] },
+	{ id: "vue", label: msg`Vue` },
+	{ id: "xml", label: msg`XML` },
+	{ id: "yaml", label: msg`YAML`, aliases: ["yml"] },
 ];
 
 /**
@@ -62,11 +65,11 @@ export const CODE_BLOCK_LANGUAGES: readonly CodeBlockLanguage[] = [
  */
 export function findLanguage(value: string | null | undefined): CodeBlockLanguage | null {
 	if (!value) return null;
-	const needle = value.trim().toLowerCase();
-	if (!needle) return null;
+	const searchText = value.trim().toLowerCase();
+	if (!searchText) return null;
 	for (const lang of CODE_BLOCK_LANGUAGES) {
-		if (lang.id === needle) return lang;
-		if (lang.aliases?.includes(needle)) return lang;
+		if (lang.id === searchText) return lang;
+		if (lang.aliases?.includes(searchText)) return lang;
 	}
 	return null;
 }
@@ -111,8 +114,10 @@ export function normalizeLanguage(value: string | null | undefined): string | un
  * Human-readable label for a stored language id. Falls back to the id itself
  * for unknown values so the editor never shows "undefined".
  */
-export function languageLabel(value: string | null | undefined): string {
-	if (!value) return "Plain text";
+export function languageLabelDescriptor(
+	value: string | null | undefined,
+): MessageDescriptor | string {
+	if (!value) return msg`Plain text`;
 	const match = findLanguage(value);
 	if (match) return match.label;
 	return value;

--- a/packages/admin/tests/editor/codeBlockLanguages.test.ts
+++ b/packages/admin/tests/editor/codeBlockLanguages.test.ts
@@ -6,20 +6,28 @@
  * and the round-trip between user input and the stored `language` attribute.
  */
 
+import { i18n } from "@lingui/core";
 import { describe, it, expect } from "vitest";
 
 import {
 	CODE_BLOCK_LANGUAGES,
 	findLanguage,
-	languageLabel,
+	languageLabelDescriptor,
 	normalizeLanguage,
 } from "../../src/components/editor/codeBlockLanguages";
+
+function resolveLabel(
+	label: ReturnType<typeof languageLabelDescriptor> | undefined,
+): string | undefined {
+	if (!label) return undefined;
+	return typeof label === "string" ? label : i18n._(label);
+}
 
 describe("findLanguage", () => {
 	it("returns the canonical entry for a known id", () => {
 		const ts = findLanguage("typescript");
 		expect(ts?.id).toBe("typescript");
-		expect(ts?.label).toBe("TypeScript");
+		expect(resolveLabel(ts?.label)).toBe("TypeScript");
 	});
 
 	it("resolves aliases to the canonical entry", () => {
@@ -112,20 +120,20 @@ describe("normalizeLanguage", () => {
 	});
 });
 
-describe("languageLabel", () => {
+describe("languageLabelDescriptor", () => {
 	it("returns the curated label for known languages", () => {
-		expect(languageLabel("typescript")).toBe("TypeScript");
-		expect(languageLabel("ts")).toBe("TypeScript");
-		expect(languageLabel("cpp")).toBe("C++");
+		expect(resolveLabel(languageLabelDescriptor("typescript"))).toBe("TypeScript");
+		expect(resolveLabel(languageLabelDescriptor("ts"))).toBe("TypeScript");
+		expect(resolveLabel(languageLabelDescriptor("cpp"))).toBe("C++");
 	});
 
 	it("falls back to the raw id for unknown languages", () => {
-		expect(languageLabel("brainfuck")).toBe("brainfuck");
+		expect(resolveLabel(languageLabelDescriptor("brainfuck"))).toBe("brainfuck");
 	});
 
 	it("returns a friendly default for empty input", () => {
-		expect(languageLabel(null)).toBe("Plain text");
-		expect(languageLabel(undefined)).toBe("Plain text");
-		expect(languageLabel("")).toBe("Plain text");
+		expect(resolveLabel(languageLabelDescriptor(null))).toBe("Plain text");
+		expect(resolveLabel(languageLabelDescriptor(undefined))).toBe("Plain text");
+		expect(resolveLabel(languageLabelDescriptor(""))).toBe("Plain text");
 	});
 });


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It localizes the `codeBlockLanguages` labels used by the admin editor picker.
It keeps the persisted languages IDs and aliases stable while resolving display labels through Lingui.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5<!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
