### PR TITLE
Fix(admin): Localize plugin API errors

### DIFF
--- a/.changeset/vast-otters-kiss.md
+++ b/.changeset/vast-otters-kiss.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes localization for plugin API fallback error messages in the admin UI

--- a/packages/admin/src/lib/api/plugins.ts
+++ b/packages/admin/src/lib/api/plugins.ts
@@ -42,7 +42,7 @@ export async function fetchPlugins(): Promise<PluginInfo[]> {
 	const response = await apiFetch(`${API_BASE}/admin/plugins`);
 	const result = await parseApiResponse<{ items: PluginInfo[] }>(
 		response,
-		"Failed to fetch plugins",
+		i18n._(msg`Failed to fetch plugins`),
 	);
 	return result.items;
 }
@@ -54,7 +54,7 @@ export async function fetchPlugin(pluginId: string): Promise<PluginInfo> {
 	const response = await apiFetch(`${API_BASE}/admin/plugins/${pluginId}`);
 	if (!response.ok) {
 		if (response.status === 404) {
-			throw new Error(`Plugin "${pluginId}" not found`);
+			throw new Error(i18n._(msg`Plugin "${pluginId}" not found`));
 		}
 		await throwResponseError(response, i18n._(msg`Failed to fetch plugin`));
 	}
@@ -72,7 +72,10 @@ export async function enablePlugin(pluginId: string): Promise<PluginInfo> {
 	const response = await apiFetch(`${API_BASE}/admin/plugins/${pluginId}/enable`, {
 		method: "POST",
 	});
-	const result = await parseApiResponse<{ item: PluginInfo }>(response, "Failed to enable plugin");
+	const result = await parseApiResponse<{ item: PluginInfo }>(
+		response,
+		i18n._(msg`Failed to enable plugin`),
+	);
 	return result.item;
 }
 
@@ -83,6 +86,9 @@ export async function disablePlugin(pluginId: string): Promise<PluginInfo> {
 	const response = await apiFetch(`${API_BASE}/admin/plugins/${pluginId}/disable`, {
 		method: "POST",
 	});
-	const result = await parseApiResponse<{ item: PluginInfo }>(response, "Failed to disable plugin");
+	const result = await parseApiResponse<{ item: PluginInfo }>(
+		response,
+		i18n._(msg`Failed to disable plugin`),
+	);
 	return result.item;
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It localizes the plugin API fallback error messages to get them covered by Lingui.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5<!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
