### PR TITLE
Fix(admin): Localize media API errors

### DIFF
--- a/.changeset/dirty-monkeys-rule.md
+++ b/.changeset/dirty-monkeys-rule.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes localization for media API fallback error messages in the admin UI

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -69,7 +69,7 @@ export async function fetchMediaList(options?: {
 
 	const url = `${API_BASE}/media${params.toString() ? `?${params}` : ""}`;
 	const response = await apiFetch(url);
-	return parseApiResponse<FindManyResult<MediaItem>>(response, "Failed to fetch media");
+	return parseApiResponse<FindManyResult<MediaItem>>(response, i18n._(msg`Failed to fetch media`));
 }
 
 /**
@@ -109,7 +109,7 @@ async function getUploadUrl(
 			return null;
 		}
 
-		return parseApiResponse<UploadUrlResponse>(response, "Failed to get upload URL");
+		return parseApiResponse<UploadUrlResponse>(response, i18n._(msg`Failed to get upload URL`));
 	} catch (error) {
 		// If the endpoint doesn't exist, fall back to direct upload
 		if (error instanceof TypeError && error.message.includes("fetch")) {
@@ -131,7 +131,10 @@ async function confirmUpload(
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(metadata || {}),
 	});
-	const data = await parseApiResponse<{ item: MediaItem }>(response, "Failed to confirm upload");
+	const data = await parseApiResponse<{ item: MediaItem }>(
+		response,
+		i18n._(msg`Failed to confirm upload`),
+	);
 	return data.item;
 }
 
@@ -191,7 +194,10 @@ async function uploadMediaDirect(file: File, opts?: { fieldId?: string }): Promi
 		method: "POST",
 		body: formData,
 	});
-	const data = await parseApiResponse<{ item: MediaItem }>(response, "Failed to upload media");
+	const data = await parseApiResponse<{ item: MediaItem }>(
+		response,
+		i18n._(msg`Failed to upload media`),
+	);
 	return data.item;
 }
 
@@ -246,7 +252,10 @@ export async function updateMedia(
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(input),
 	});
-	const data = await parseApiResponse<{ item: MediaItem }>(response, "Failed to update media");
+	const data = await parseApiResponse<{ item: MediaItem }>(
+		response,
+		i18n._(msg`Failed to update media`),
+	);
 	return data.item;
 }
 
@@ -290,7 +299,7 @@ export async function fetchMediaProviders(): Promise<MediaProviderInfo[]> {
 	const response = await apiFetch(`${API_BASE}/media/providers`);
 	const data = await parseApiResponse<{ items: MediaProviderInfo[] }>(
 		response,
-		"Failed to fetch media providers",
+		i18n._(msg`Failed to fetch media providers`),
 	);
 	return data.items;
 }
@@ -320,7 +329,7 @@ export async function fetchProviderMedia(
 	const response = await apiFetch(url);
 	return parseApiResponse<FindManyResult<MediaProviderItem>>(
 		response,
-		"Failed to fetch provider media",
+		i18n._(msg`Failed to fetch provider media`),
 	);
 }
 
@@ -342,7 +351,7 @@ export async function uploadToProvider(
 	});
 	const data = await parseApiResponse<{ item: MediaProviderItem }>(
 		response,
-		"Failed to upload to provider",
+		i18n._(msg`Failed to upload to provider`),
 	);
 	return data.item;
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It localizes the media API fallback error messages to get them covered by Lingui.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5<!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
