### PR TITLE
Fix(admin): Localize email settings API errors

### DIFF
--- a/.changeset/short-bugs-rush.md
+++ b/.changeset/short-bugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes localization for email settings API fallback error messages in the admin UI

--- a/packages/admin/src/lib/api/email-settings.ts
+++ b/packages/admin/src/lib/api/email-settings.ts
@@ -2,6 +2,9 @@
  * Email settings API client functions
  */
 
+import { i18n } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+
 import { API_BASE, apiFetch, parseApiResponse } from "./client.js";
 
 // =============================================================================
@@ -28,7 +31,7 @@ export interface EmailSettings {
 
 export async function fetchEmailSettings(): Promise<EmailSettings> {
 	const res = await apiFetch(`${API_BASE}/settings/email`);
-	return parseApiResponse<EmailSettings>(res, "Failed to fetch email settings");
+	return parseApiResponse<EmailSettings>(res, i18n._(msg`Failed to fetch email settings`));
 }
 
 export async function sendTestEmail(to: string): Promise<{ success: boolean; message: string }> {
@@ -37,5 +40,8 @@ export async function sendTestEmail(to: string): Promise<{ success: boolean; mes
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ to }),
 	});
-	return parseApiResponse<{ success: boolean; message: string }>(res, "Failed to send test email");
+	return parseApiResponse<{ success: boolean; message: string }>(
+		res,
+		i18n._(msg`Failed to send test email`),
+	);
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It localizes the email settings API fallback error messages to get them covered by Lingui.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: Codex with GPT 5.5<!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
