### PR TITLE
Fix(admin): Localize sections API errors

### DIFF
--- a/.changeset/big-cameras-own.md
+++ b/.changeset/big-cameras-own.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes localization for sections API fallback error messages in the admin UI

--- a/packages/admin/src/lib/api/sections.ts
+++ b/packages/admin/src/lib/api/sections.ts
@@ -65,7 +65,7 @@ export async function fetchSections(options?: GetSectionsOptions): Promise<Secti
 
 	const url = params.toString() ? `${API_BASE}/sections?${params}` : `${API_BASE}/sections`;
 	const response = await apiFetch(url);
-	return parseApiResponse<SectionsResult>(response, "Failed to fetch sections");
+	return parseApiResponse<SectionsResult>(response, i18n._(msg`Failed to fetch sections`));
 }
 
 /**
@@ -73,7 +73,7 @@ export async function fetchSections(options?: GetSectionsOptions): Promise<Secti
  */
 export async function fetchSection(slug: string): Promise<Section> {
 	const response = await apiFetch(`${API_BASE}/sections/${slug}`);
-	return parseApiResponse<Section>(response, "Failed to fetch section");
+	return parseApiResponse<Section>(response, i18n._(msg`Failed to fetch section`));
 }
 
 /**
@@ -85,7 +85,7 @@ export async function createSection(input: CreateSectionInput): Promise<Section>
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(input),
 	});
-	return parseApiResponse<Section>(response, "Failed to create section");
+	return parseApiResponse<Section>(response, i18n._(msg`Failed to create section`));
 }
 
 /**
@@ -97,7 +97,7 @@ export async function updateSection(slug: string, input: UpdateSectionInput): Pr
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(input),
 	});
-	return parseApiResponse<Section>(response, "Failed to update section");
+	return parseApiResponse<Section>(response, i18n._(msg`Failed to update section`));
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->
This PR is a follow-up on: https://github.com/emdash-cms/emdash/pull/1244

It localizes the sections API fallback error messages to get them covered by Lingui.

Closes #

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [x] This PR includes AI-generated code — model/tool: Codex with GPT 5.5<!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
