### PR TITLE
fix: read OAuth env from cloudflare workers runtime

### DIFF
--- a/.changeset/bright-socks-taste.md
+++ b/.changeset/bright-socks-taste.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes GitHub and Google OAuth login on Cloudflare Workers deployments using Astro v6.

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider].ts
@@ -11,6 +11,7 @@ export const prerender = false;
 import { createAuthorizationUrl, type OAuthConsumerConfig } from "@emdash-cms/auth";
 
 import { getPublicOrigin } from "#api/public-url.js";
+import { getOAuthEnv } from "#auth/oauth-env.js";
 import { createOAuthStateStore } from "#auth/oauth-state-store.js";
 
 type ProviderName = "github" | "google";
@@ -93,12 +94,7 @@ export const GET: APIRoute = async ({ params, request, locals, redirect }) => {
 	try {
 		const url = new URL(request.url);
 
-		// Get OAuth providers from environment
-		// Access via locals.runtime for Cloudflare, or import.meta.env for Node
-		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- locals.runtime is injected by the Cloudflare adapter at runtime; not declared on App.Locals since the adapter is optional
-		const runtimeLocals = locals as unknown as { runtime?: { env?: Record<string, unknown> } };
-		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = runtimeLocals.runtime?.env ?? (import.meta.env as Record<string, unknown>);
+		const env = await getOAuthEnv();
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {

--- a/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
+++ b/packages/core/src/astro/routes/api/auth/oauth/[provider]/callback.ts
@@ -19,6 +19,7 @@ import { createKyselyAdapter } from "@emdash-cms/auth/adapters/kysely";
 
 import { getPublicOrigin } from "#api/public-url.js";
 import { finalizeSetup } from "#api/setup-complete.js";
+import { getOAuthEnv } from "#auth/oauth-env.js";
 import { createOAuthStateStore } from "#auth/oauth-state-store.js";
 import { OptionsRepository } from "#db/repositories/options.js";
 
@@ -115,11 +116,7 @@ export const GET: APIRoute = async ({ params, request, locals, session, redirect
 	}
 
 	try {
-		// Get OAuth providers from environment
-		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- locals.runtime is injected by the Cloudflare adapter at runtime; not declared on App.Locals since the adapter is optional
-		const runtimeLocals = locals as unknown as { runtime?: { env?: Record<string, unknown> } };
-		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- import.meta.env is typed as ImportMetaEnv but we need Record<string, unknown> for getOAuthConfig
-		const env = runtimeLocals.runtime?.env ?? (import.meta.env as Record<string, unknown>);
+		const env = await getOAuthEnv();
 		const providers = getOAuthConfig(env);
 
 		if (!providers[provider]) {

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -16,12 +16,10 @@ function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
 	// Keep the Cloudflare virtual module out of Node-target bundles. Otherwise
 	// non-Cloudflare builds try to resolve it before the runtime fallback runs.
-	// eslint-disable-next-line no-implied-eval
-	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
-	const dynamicImport = new Function("specifier", "return import(specifier);") as (
-		specifier: string,
-	) => Promise<unknown>;
-	const module = await dynamicImport("cloudflare:workers");
+	const moduleUrl = `data:text/javascript,${encodeURIComponent(
+		'export { env } from "cloudflare:workers";',
+	)}`;
+	const module = await import(/* @vite-ignore */ moduleUrl);
 	return hasEnv(module) ? module.env : {};
 }
 

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -8,12 +8,16 @@
 
 type OAuthEnvLoader = () => Promise<Record<string, unknown>>;
 
+function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
+	if (typeof value !== "object" || value === null || !("env" in value)) return false;
+	return typeof value.env === "object" && value.env !== null;
+}
+
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
-	const specifier = "cloudflare:workers";
-	const module = (await import(/* @vite-ignore */ specifier)) as {
-		env?: Record<string, unknown>;
-	};
-	return module.env ?? {};
+	const dynamicImport = async (specifier: string): Promise<unknown> =>
+		new Function("specifier", "return import(specifier);")(specifier);
+	const module = await dynamicImport("cloudflare:workers");
+	return hasEnv(module) ? module.env : {};
 }
 
 function isMissingCloudflareWorkersModule(error: unknown): boolean {
@@ -36,6 +40,6 @@ export async function getOAuthEnv(
 		return await loadEnv();
 	} catch (error) {
 		if (!isMissingCloudflareWorkersModule(error)) throw error;
-		return import.meta.env as Record<string, unknown>;
+		return import.meta.env;
 	}
 }

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -10,9 +10,7 @@ type OAuthEnvLoader = () => Promise<Record<string, unknown>>;
 
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
 	const specifier = "cloudflare:workers";
-	const module = (await import(
-		/* @vite-ignore */ specifier
-	)) as {
+	const module = (await import(/* @vite-ignore */ specifier)) as {
 		env?: Record<string, unknown>;
 	};
 	return module.env ?? {};
@@ -31,7 +29,9 @@ function isMissingCloudflareWorkersModule(error: unknown): boolean {
 	);
 }
 
-export async function getOAuthEnv(loadEnv: OAuthEnvLoader = loadCloudflareOAuthEnv): Promise<Record<string, unknown>> {
+export async function getOAuthEnv(
+	loadEnv: OAuthEnvLoader = loadCloudflareOAuthEnv,
+): Promise<Record<string, unknown>> {
 	try {
 		return await loadEnv();
 	} catch (error) {

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -5,12 +5,37 @@
  * now read from `cloudflare:workers`. On Node-based adapters that module does
  * not exist, so fall back to `import.meta.env`.
  */
-export async function getOAuthEnv(): Promise<Record<string, unknown>> {
+
+type OAuthEnvLoader = () => Promise<Record<string, unknown>>;
+
+async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
+	const specifier = "cloudflare:workers";
+	const module = (await import(
+		/* @vite-ignore */ specifier
+	)) as {
+		env?: Record<string, unknown>;
+	};
+	return module.env ?? {};
+}
+
+function isMissingCloudflareWorkersModule(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message;
+	return (
+		message.includes("cloudflare:workers") &&
+		(message.includes("Cannot find package") ||
+			message.includes("ERR_MODULE_NOT_FOUND") ||
+			message.includes("Failed to resolve") ||
+			message.includes("Could not resolve") ||
+			message.includes("No such module"))
+	);
+}
+
+export async function getOAuthEnv(loadEnv: OAuthEnvLoader = loadCloudflareOAuthEnv): Promise<Record<string, unknown>> {
 	try {
-		// @ts-ignore - runtime-only Cloudflare Workers virtual module
-		const { env } = await import("cloudflare:workers");
-		return env as Record<string, unknown>;
-	} catch {
+		return await loadEnv();
+	} catch (error) {
+		if (!isMissingCloudflareWorkersModule(error)) throw error;
 		return import.meta.env as Record<string, unknown>;
 	}
 }

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -14,8 +14,13 @@ function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
 }
 
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
-	const specifier = "cloudflare:workers";
-	const module = await import(/* @vite-ignore */ specifier);
+	// Keep the Cloudflare virtual module out of Node-target bundles. Otherwise
+	// non-Cloudflare builds try to resolve it before the runtime fallback runs.
+	// oxlint-disable-next-line no-new-func
+	const dynamicImport = new Function("specifier", "return import(specifier);") as (
+		specifier: string,
+	) => Promise<unknown>;
+	const module = await dynamicImport("cloudflare:workers");
 	return hasEnv(module) ? module.env : {};
 }
 

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -16,7 +16,7 @@ function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
 	// Keep the Cloudflare virtual module out of Node-target bundles. Otherwise
 	// non-Cloudflare builds try to resolve it before the runtime fallback runs.
-	// oxlint-disable-next-line no-implied-eval
+	// eslint-disable-next-line no-implied-eval
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 	const dynamicImport = new Function("specifier", "return import(specifier);") as (
 		specifier: string,

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -17,6 +17,7 @@ async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
 	// Keep the Cloudflare virtual module out of Node-target bundles. Otherwise
 	// non-Cloudflare builds try to resolve it before the runtime fallback runs.
 	// oxlint-disable-next-line no-new-func
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 	const dynamicImport = new Function("specifier", "return import(specifier);") as (
 		specifier: string,
 	) => Promise<unknown>;

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -16,7 +16,7 @@ function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
 	// Keep the Cloudflare virtual module out of Node-target bundles. Otherwise
 	// non-Cloudflare builds try to resolve it before the runtime fallback runs.
-	// oxlint-disable-next-line no-new-func
+	// oxlint-disable-next-line no-implied-eval
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 	const dynamicImport = new Function("specifier", "return import(specifier);") as (
 		specifier: string,

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -14,9 +14,8 @@ function hasEnv(value: unknown): value is { env: Record<string, unknown> } {
 }
 
 async function loadCloudflareOAuthEnv(): Promise<Record<string, unknown>> {
-	const dynamicImport = async (specifier: string): Promise<unknown> =>
-		new Function("specifier", "return import(specifier);")(specifier);
-	const module = await dynamicImport("cloudflare:workers");
+	const specifier = "cloudflare:workers";
+	const module = await import(/* @vite-ignore */ specifier);
 	return hasEnv(module) ? module.env : {};
 }
 

--- a/packages/core/src/auth/oauth-env.ts
+++ b/packages/core/src/auth/oauth-env.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve runtime environment for OAuth providers.
+ *
+ * Astro v6 removed `locals.runtime.env`. On Cloudflare Workers, bindings are
+ * now read from `cloudflare:workers`. On Node-based adapters that module does
+ * not exist, so fall back to `import.meta.env`.
+ */
+export async function getOAuthEnv(): Promise<Record<string, unknown>> {
+	try {
+		// @ts-ignore - runtime-only Cloudflare Workers virtual module
+		const { env } = await import("cloudflare:workers");
+		return env as Record<string, unknown>;
+	} catch {
+		return import.meta.env as Record<string, unknown>;
+	}
+}

--- a/packages/core/tests/unit/auth/oauth-env.test.ts
+++ b/packages/core/tests/unit/auth/oauth-env.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { getOAuthEnv } from "../../../src/auth/oauth-env.js";
+
+describe("getOAuthEnv", () => {
+	it("returns env from the provided loader", async () => {
+		const env = { EMDASH_OAUTH_GITHUB_CLIENT_ID: "abc" };
+		await expect(getOAuthEnv(async () => env)).resolves.toBe(env);
+	});
+
+	it("falls back to import.meta.env when cloudflare:workers is unavailable", async () => {
+		const env = await getOAuthEnv(async () => {
+			throw new Error("Cannot find package 'cloudflare:workers' imported from test");
+		});
+
+		expect(env).toBe(import.meta.env);
+	});
+
+	it("rethrows unexpected loader errors", async () => {
+		await expect(
+			getOAuthEnv(async () => {
+				throw new Error("Unexpected runtime failure");
+			}),
+		).rejects.toThrow("Unexpected runtime failure");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes OAuth login on Cloudflare Workers/Astro v6 by stopping the OAuth routes from reading provider secrets from the removed `Astro.locals.runtime.env` path. Instead, the routes read runtime bindings from `cloudflare:workers` when available and fall back to `import.meta.env` elsewhere.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm --filter emdash typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

Notes:
- This is intentionally narrow and only addresses the OAuth env lookup path.
- The issue was reproduced on a Cloudflare Workers deployment where `/_emdash/api/auth/oauth/github` failed at runtime with: `Astro.locals.runtime.env has been removed in Astro v6`.
- Targeted package validation run: `pnpm --filter emdash typecheck`.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5.4 / OpenCode

## Screenshots / test output

- Verified the fix by patching the published package in a real Cloudflare deployment and confirming `/_emdash/api/auth/oauth/github` now redirects correctly to GitHub OAuth instead of failing back to the local login page.