### PR TITLE
chore: bump flue/bonk coding agents to kimi-k2.7-code

### DIFF
--- a/.flue/README.md
+++ b/.flue/README.md
@@ -15,7 +15,7 @@ When a maintainer adds `bot:repro` to an issue:
    - `repro-public` — `agent-browser` against the rendered public site
 3. **Diagnose** — read the source paths that explain the symptom, rate confidence in the root cause, choose a fix approach (`mechanical` / `clear-best-option` / `needs-design-decision`), and write a concrete proposed fix.
 4. **Verify** — decide whether the behaviour is a bug or intended-by-design. Gates the fix stage.
-5. **Fix** — conditional on `verdict=bug`, `confidence!=low`, and `fixApproach!=needs-design-decision`. Runs on a cheaper model (kimi-k2.6) in its own session — diagnose already produced the plan, so this stage is guided implementation. Writes the change, runs the reproduce test, the broader package tests, typecheck, lint, format. Stages but does not commit.
+5. **Fix** — conditional on `verdict=bug`, `confidence!=low`, and `fixApproach!=needs-design-decision`. Runs on a cheaper coding model (kimi-k2.7-code) in its own session — diagnose already produced the plan, so this stage is guided implementation. Writes the change, runs the reproduce test, the broader package tests, typecheck, lint, format. Stages but does not commit.
 
 The orchestrator (`.github/workflows/investigate.yml`) reads the structured JSON output and performs all GitHub writes — labels, comments, branch pushes, PR creation. The agent itself has no write access to GitHub.
 

--- a/.flue/workflows/investigate.ts
+++ b/.flue/workflows/investigate.ts
@@ -245,7 +245,7 @@ const investigatorAgent = createAgent(() => {
 	};
 });
 
-// Fix implementer: a cheaper model (Kimi) is enough here because the
+// Fix implementer: a cheaper coding model (Kimi K2.7 Code) is enough here because the
 // expensive reasoning is already done -- diagnose hands over a concrete
 // `proposedFix`, and this stage only runs for `mechanical` /
 // `clear-best-option` approaches. Its job is guided implementation:
@@ -257,7 +257,8 @@ const fixAgent = createAgent(() => {
 	const cwd = process.env.GITHUB_WORKSPACE ?? process.cwd();
 	return {
 		model:
-			process.env.FLUE_FIX_MODEL ?? "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6",
+			process.env.FLUE_FIX_MODEL ??
+			"cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code",
 		cwd,
 		sandbox: investigateSandbox(cwd),
 		instructions: [

--- a/.github/bonk-models.json
+++ b/.github/bonk-models.json
@@ -15,9 +15,9 @@
 			}
 		},
 		"kimi": {
-			"id": "workers-ai/@cf/moonshotai/kimi-k2.6",
+			"id": "workers-ai/@cf/moonshotai/kimi-k2.7-code",
 			"registration": {
-				"id": "workers-ai/@cf/moonshotai/kimi-k2.6"
+				"id": "workers-ai/@cf/moonshotai/kimi-k2.7-code"
 			}
 		}
 	}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,7 +6,7 @@ name: Bonk
 #
 #   /bonk <task>                         -> default model (currently opus)
 #   /bonk opus <task>                    -> Claude Opus 4.7 (default)
-#   /bonk kimi <task>                    -> Kimi K2.6 (cheap pass for tiny tasks)
+#   /bonk kimi <task>                    -> Kimi K2.7 Code (cheap pass for tiny tasks)
 #   @ask-bonk opus how would you do X?   -> Claude Opus 4.7
 #
 # Add new aliases by editing .github/bonk-models.json -- the resolver script

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ name: Review PR
 #
 #   /review                              -> default model (currently opus)
 #   /review opus                         -> Claude Opus 4.7 (default)
-#   /review kimi                         -> Kimi K2.6 (cheap pass for tiny PRs)
+#   /review kimi                         -> Kimi K2.7 Code (cheap pass for tiny PRs)
 #
 # Add new aliases by editing .github/bonk-models.json.
 

--- a/infra/flue-review/.flue/workflows/review.ts
+++ b/infra/flue-review/.flue/workflows/review.ts
@@ -46,7 +46,7 @@ interface ReviewPayload {
 // reserved by Flue's generated CF entry and routed through `env.AI`, so no
 // model API key is needed anywhere.
 const reviewAgent = createAgent<ReviewPayload, Env>(({ env }) => ({
-	model: "cloudflare/@cf/moonshotai/kimi-k2.6",
+	model: "cloudflare/@cf/moonshotai/kimi-k2.7-code",
 	// The container's working dir is the checked-out PR. AGENTS.md at the repo
 	// root is auto-discovered into the agent's context from here.
 	cwd: "/workspace",

--- a/infra/flue-review/wrangler.jsonc
+++ b/infra/flue-review/wrangler.jsonc
@@ -6,7 +6,7 @@
 	"compatibility_flags": ["nodejs_compat"],
 	// Workers AI binding. Flue's generated Cloudflare entry reserves the
 	// `cloudflare/` model prefix and routes it through this binding, so the
-	// reviewer model (`cloudflare/@cf/moonshotai/kimi-k2.6`) needs no API key.
+	// reviewer model (`cloudflare/@cf/moonshotai/kimi-k2.7-code`) needs no API key.
 	"ai": {
 		"binding": "AI",
 	},


### PR DESCRIPTION
## What does this PR do?

Bumps the Kimi model used by our coding automations from `kimi-k2.6` to `kimi-k2.7-code`. Only the coding-related agents are moved; the structured classifiers stay on `kimi-k2.6`.

Bumped to `kimi-k2.7-code`:
- `.flue/workflows/investigate.ts` — the fix implementer (`FLUE_FIX_MODEL` default), which writes the patch and runs tests/lint
- `infra/flue-review/.flue/workflows/review.ts` — the PR review agent
- `.github/bonk-models.json` — the `kimi` alias used by `/bonk` and `/review` (both run coding tasks)

Left on `kimi-k2.6` (not coding):
- `.flue/lib/classifier.ts` — shared structured-output classifier
- `.flue/workflows/investigate.ts` classifier agent — maps issues to kind/area

Comment/doc references updated to match (`bonk.yml`, `review.yml`, `infra/flue-review/wrangler.jsonc`, `.flue/README.md`).

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- n/a: CI/automation config only, no package source touched -->
- [ ] `pnpm lint` passes <!-- n/a: deps not installed in worktree; oxfmt --check passes on changed TS files -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: config-only change -->
- [x] `pnpm format` has been run <!-- oxfmt --check clean on the two changed .ts files -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a -->
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI -->
- [ ] I have added a changeset (if this PR changes a published package) <!-- n/a: no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: chore -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

\`oxfmt --check\` clean on the two changed TypeScript files; \`bonk-models.json\` validated with \`jq\`.