### PR TITLE
fix(admin): add avatar picker to byline editor (#1250)

### DIFF
--- a/.changeset/byline-avatar-upload.md
+++ b/.changeset/byline-avatar-upload.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Adds an avatar image picker to the byline editor. The `avatarMediaId` field was already part of the byline model and API but had no admin control, so byline avatars could only be set programmatically, and editing a byline through the UI cleared any avatar that had been set. You can now choose, change, and remove a byline's avatar from the editor.

--- a/e2e/tests/bylines.spec.ts
+++ b/e2e/tests/bylines.spec.ts
@@ -1,8 +1,13 @@
+import { join } from "node:path";
+
 import { test, expect } from "../fixtures";
 
 // The edit route preserves the entry's locale as a `?locale=` search param
 // (see #1242), so the URL may carry a query string after the ULID.
 const CONTENT_EDIT_URL_PATTERN = /\/content\/posts\/[A-Z0-9]+(?:\?.*)?$/;
+
+// Shared 1x1 PNG fixture used by the media upload flows.
+const TEST_IMAGE_PATH = join(process.cwd(), "e2e/fixtures/assets/test-image.png");
 
 function apiHeaders(token: string, baseUrl: string) {
 	return {
@@ -40,6 +45,98 @@ test.describe("Bylines", () => {
 		await page.getByRole("button", { name: "Save" }).click();
 
 		await expect(page.getByRole("button", { name: updatedName })).toBeVisible({ timeout: 5000 });
+	});
+
+	test("sets a byline avatar via the media picker and preserves it across edits (#1250)", async ({
+		admin,
+		page,
+		serverInfo,
+	}) => {
+		const unique = Date.now();
+		const name = `Avatar Byline ${unique}`;
+		const slug = `avatar-byline-${unique}`;
+		const headers = apiHeaders(serverInfo.token, serverInfo.baseUrl);
+
+		const getByline = async (id: string) => {
+			const response = await fetch(`${serverInfo.baseUrl}/_emdash/api/admin/bylines/${id}`, {
+				headers,
+			});
+			expect(response.ok).toBe(true);
+			const body: any = await response.json();
+			return body.data as { avatarMediaId: string | null };
+		};
+
+		// Create the byline up front via API so there's a stable id to assert
+		// against. It starts with no avatar — the field had no UI control before
+		// this fix, so the only way to set it was programmatically.
+		const createResponse = await fetch(`${serverInfo.baseUrl}/_emdash/api/admin/bylines`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ displayName: name, slug, isGuest: true }),
+		});
+		expect(createResponse.ok).toBe(true);
+		const createBody: any = await createResponse.json();
+		const bylineId = createBody.data.id as string;
+		expect(createBody.data.avatarMediaId).toBeNull();
+
+		await admin.goto("/bylines");
+		await admin.waitForShell();
+		await admin.waitForLoading();
+
+		// Open the byline in the editor and confirm the avatar field renders.
+		await page.getByRole("button", { name }).click();
+		await expect(page.getByText("Avatar", { exact: true })).toBeVisible();
+
+		// Open the avatar picker and upload an image. The picker auto-selects
+		// the freshly uploaded item, enabling the Insert button.
+		await page.getByRole("button", { name: "Select image" }).click();
+		const dialog = page.locator('[role="dialog"]').filter({ hasText: "Select Avatar" });
+		await expect(dialog).toBeVisible();
+
+		const uploadDone = page.waitForResponse(
+			(res) => /\/api\/media/.test(res.url()) && res.request().method() === "POST" && res.ok(),
+			{ timeout: 15000 },
+		);
+		await dialog.locator('input[type="file"]').setInputFiles(TEST_IMAGE_PATH);
+		await uploadDone;
+
+		// Two "Insert" buttons exist (the disabled "Insert from URL" action and
+		// the footer confirm); the confirm enables once an item is selected.
+		await dialog.getByRole("button", { name: "Insert", disabled: false }).click();
+		await expect(dialog).not.toBeVisible();
+
+		// Persist the byline and wait for the PUT to land.
+		const firstSave = page.waitForResponse(
+			(res) =>
+				res.url().includes(`/api/admin/bylines/${bylineId}`) &&
+				res.request().method() === "PUT" &&
+				res.ok(),
+			{ timeout: 10000 },
+		);
+		await page.getByRole("button", { name: "Save" }).click();
+		await firstSave;
+
+		// The avatar id is now persisted through the UI.
+		const afterSet = await getByline(bylineId);
+		expect(afterSet.avatarMediaId).toBeTruthy();
+		const avatarId = afterSet.avatarMediaId;
+
+		// Regression guard for #1250: editing another field through the UI must
+		// not wipe the avatar. The PUT route coerces a missing `avatarMediaId`
+		// back to null, so before the fix every save dropped the avatar.
+		await page.getByLabel("Display name").fill(`${name} edited`);
+		const secondSave = page.waitForResponse(
+			(res) =>
+				res.url().includes(`/api/admin/bylines/${bylineId}`) &&
+				res.request().method() === "PUT" &&
+				res.ok(),
+			{ timeout: 10000 },
+		);
+		await page.getByRole("button", { name: "Save" }).click();
+		await secondSave;
+
+		const afterEdit = await getByline(bylineId);
+		expect(afterEdit.avatarMediaId).toBe(avatarId);
 	});
 
 	test("assigns and reorders bylines, preserves bylines on ownership change", async ({

--- a/packages/admin/src/components/BylineAvatarField.tsx
+++ b/packages/admin/src/components/BylineAvatarField.tsx
@@ -1,0 +1,76 @@
+/**
+ * Avatar picker for the byline editor (#1250).
+ *
+ * Bylines store only an `avatarMediaId` (the media item's id), not a
+ * URL or embedded media object. This component resolves that id back
+ * into a full media item so it can hand a populated value to the
+ * shared {@link ImageFieldRenderer} — reusing its picker, preview, and
+ * broken-image handling rather than duplicating the markup.
+ *
+ * On change it strips the resolved media back down to the bare id for
+ * the byline update body.
+ */
+
+import { Label, Loader } from "@cloudflare/kumo";
+import { useLingui } from "@lingui/react/macro";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchMediaItem } from "../lib/api";
+import { ImageFieldRenderer, type ImageFieldValue } from "./ImageFieldRenderer";
+
+export interface BylineAvatarFieldProps {
+	/** The byline's stored `avatarMediaId`, or null when unset. */
+	value: string | null;
+	/** Receives the selected media id, or null when the avatar is removed. */
+	onChange: (mediaId: string | null) => void;
+}
+
+export function BylineAvatarField({ value, onChange }: BylineAvatarFieldProps) {
+	const { t } = useLingui();
+
+	// Resolve the stored id into a media item for display. Local media is
+	// served from a storageKey-keyed URL (not the id), so we can't build a
+	// usable preview URL until this lands.
+	const { data: media, isLoading } = useQuery({
+		queryKey: ["media", value],
+		queryFn: () => (value ? fetchMediaItem(value) : Promise.resolve(null)),
+		enabled: !!value,
+	});
+
+	// Show a placeholder while resolving an existing avatar so the wrong
+	// (id-keyed) local URL isn't requested and flashed as a broken image
+	// before the fetch lands.
+	if (value && isLoading) {
+		return (
+			<div>
+				<Label>{t`Avatar`}</Label>
+				<div className="mt-2 flex h-32 items-center justify-center rounded-lg border">
+					<Loader />
+				</div>
+			</div>
+		);
+	}
+
+	const fieldValue: ImageFieldValue | undefined =
+		value && media
+			? {
+					id: media.id,
+					provider: media.provider || "local",
+					// External providers supply a direct URL; local media derives
+					// its URL from meta.storageKey inside ImageFieldRenderer.
+					previewUrl: media.provider && media.provider !== "local" ? media.url : undefined,
+					alt: media.alt ?? "",
+					width: media.width,
+					height: media.height,
+					meta: media.storageKey ? { storageKey: media.storageKey } : undefined,
+				}
+			: undefined;
+
+	return (
+		<ImageFieldRenderer
+			label={t`Avatar`}
+			value={fieldValue}
+			onChange={(next) => onChange(next?.id ?? null)}
+		/>
+	);
+}

--- a/packages/admin/src/lib/api/index.ts
+++ b/packages/admin/src/lib/api/index.ts
@@ -63,6 +63,7 @@ export {
 	type MediaProviderItem,
 	MEDIA_SEARCH_MAX_LENGTH,
 	fetchMediaList,
+	fetchMediaItem,
 	uploadMedia,
 	deleteMedia,
 	updateMedia,

--- a/packages/admin/src/lib/api/media.ts
+++ b/packages/admin/src/lib/api/media.ts
@@ -73,6 +73,21 @@ export async function fetchMediaList(options?: {
 }
 
 /**
+ * Fetch a single media item by id.
+ *
+ * Used to resolve an id-only reference (e.g. a byline's `avatarMediaId`)
+ * back into a full media item for display.
+ */
+export async function fetchMediaItem(id: string): Promise<MediaItem> {
+	const response = await apiFetch(`${API_BASE}/media/${id}`);
+	const data = await parseApiResponse<{ item: MediaItem }>(
+		response,
+		i18n._(msg`Failed to fetch media item`),
+	);
+	return data.item;
+}
+
+/**
  * Upload URL response from the API
  */
 interface UploadUrlResponse {

--- a/packages/admin/src/routes/bylines.tsx
+++ b/packages/admin/src/routes/bylines.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import * as React from "react";
 
+import { BylineAvatarField } from "../components/BylineAvatarField.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { DialogError, getMutationError } from "../components/DialogError.js";
 import { LocaleSwitcher, useI18nConfig } from "../components/LocaleSwitcher.js";
@@ -35,6 +36,8 @@ interface BylineFormState {
 	websiteUrl: string;
 	userId: string | null;
 	isGuest: boolean;
+	/** Media id of the byline's avatar image, or null when unset (#1250). */
+	avatarMediaId: string | null;
 	/**
 	 * Custom-field values keyed by field slug (Phase 6 of #1174). Always
 	 * a defined object — `{}` when no fields are registered or the byline
@@ -75,6 +78,7 @@ function toFormState(byline?: BylineSummary | null): BylineFormState {
 			websiteUrl: "",
 			userId: null,
 			isGuest: false,
+			avatarMediaId: null,
 			customFields: {},
 		};
 	}
@@ -86,6 +90,7 @@ function toFormState(byline?: BylineSummary | null): BylineFormState {
 		websiteUrl: byline.websiteUrl ?? "",
 		userId: byline.userId,
 		isGuest: byline.isGuest,
+		avatarMediaId: byline.avatarMediaId ?? null,
 		customFields: byline.customFields ?? {},
 	};
 }
@@ -247,6 +252,7 @@ export function BylinesPage() {
 				websiteUrl: form.websiteUrl || null,
 				userId: form.userId,
 				isGuest: form.isGuest,
+				avatarMediaId: form.avatarMediaId,
 				locale: activeLocale,
 			};
 			if (!customFieldsError && Object.keys(form.customFields).length > 0) {
@@ -282,6 +288,7 @@ export function BylinesPage() {
 				websiteUrl: form.websiteUrl || null,
 				userId: form.userId,
 				isGuest: form.isGuest,
+				avatarMediaId: form.avatarMediaId,
 			};
 			if (!customFieldsError) {
 				body.customFields = form.customFields;
@@ -484,6 +491,10 @@ export function BylinesPage() {
 							value={form.bio}
 							onChange={(e) => setForm((prev) => ({ ...prev, bio: e.target.value }))}
 							rows={5}
+						/>
+						<BylineAvatarField
+							value={form.avatarMediaId}
+							onChange={(mediaId) => setForm((prev) => ({ ...prev, avatarMediaId: mediaId }))}
 						/>
 						<Select
 							label={t`Linked user`}

--- a/packages/admin/tests/byline-form-avatar.test.tsx
+++ b/packages/admin/tests/byline-form-avatar.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Byline avatar field tests (#1250).
+ *
+ * The `avatarMediaId` field is part of the byline data model and is
+ * accepted by the create/update API, but the admin editor never
+ * rendered a control for it — so editors had no way to set a byline
+ * avatar, and (worse) every UI edit coerced the field back to `null`,
+ * wiping any value set programmatically.
+ *
+ * These tests assert the avatar picker renders in the editor and that
+ * a hydrated `avatarMediaId` round-trips through the PATCH body on
+ * save. Driving the MediaPickerModal dialog itself is out of scope
+ * here (its overlay blocks Playwright clicks — see the custom-fields
+ * test for the same constraint); the round-trip proves the form state
+ * is wired into the update body, which is the regression that matters.
+ */
+
+import { Toast } from "@cloudflare/kumo";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { BylineSummary } from "../src/lib/api/bylines";
+import type { MediaItem } from "../src/lib/api/media";
+import { render } from "./utils/render.tsx";
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual =
+		await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+	return {
+		...actual,
+		useSearch: () => ({ locale: undefined }),
+		useNavigate: () => vi.fn(),
+	};
+});
+
+vi.mock("../src/lib/api/bylines", async () => {
+	const actual =
+		await vi.importActual<typeof import("../src/lib/api/bylines")>("../src/lib/api/bylines");
+	return {
+		...actual,
+		fetchBylines: vi.fn(),
+		fetchByline: vi.fn(),
+		fetchBylineTranslations: vi.fn().mockResolvedValue({ items: [] }),
+		createByline: vi.fn(),
+		updateByline: vi.fn(),
+		deleteByline: vi.fn(),
+		createBylineTranslation: vi.fn(),
+	};
+});
+
+vi.mock("../src/lib/api/users", async () => {
+	const actual =
+		await vi.importActual<typeof import("../src/lib/api/users")>("../src/lib/api/users");
+	return {
+		...actual,
+		fetchUsers: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+	};
+});
+
+vi.mock("../src/lib/api/byline-fields", async () => {
+	const actual = await vi.importActual<typeof import("../src/lib/api/byline-fields")>(
+		"../src/lib/api/byline-fields",
+	);
+	return {
+		...actual,
+		// No custom fields — keeps the editor to its fixed columns.
+		listBylineFields: vi.fn().mockResolvedValue({ items: [] }),
+	};
+});
+
+vi.mock("../src/lib/api/media", async () => {
+	const actual =
+		await vi.importActual<typeof import("../src/lib/api/media")>("../src/lib/api/media");
+	return {
+		...actual,
+		fetchMediaItem: vi.fn(),
+	};
+});
+
+vi.mock("../src/lib/api/client", async () => {
+	const actual =
+		await vi.importActual<typeof import("../src/lib/api/client")>("../src/lib/api/client");
+	return {
+		...actual,
+		fetchManifest: vi.fn().mockResolvedValue({
+			version: "0.0.0",
+			hash: "test",
+			collections: {},
+			plugins: {},
+			authMode: "passkey",
+			taxonomies: [],
+		}),
+	};
+});
+
+const { fetchBylines, fetchByline, updateByline } = await import("../src/lib/api/bylines");
+const { fetchMediaItem } = await import("../src/lib/api/media");
+const { BylinesPage } = await import("../src/routes/bylines");
+
+function makeByline(overrides: Partial<BylineSummary> = {}): BylineSummary {
+	return {
+		id: "byline_01",
+		slug: "jane-doe",
+		displayName: "Jane Doe",
+		bio: null,
+		avatarMediaId: null,
+		websiteUrl: null,
+		userId: null,
+		isGuest: true,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		locale: "en",
+		translationGroup: null,
+		customFields: {},
+		...overrides,
+	};
+}
+
+function makeMediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
+	return {
+		id: "media_avatar_01",
+		filename: "avatar.jpg",
+		mimeType: "image/jpeg",
+		url: "/_emdash/api/media/file/media_avatar_01.jpg",
+		storageKey: "media_avatar_01.jpg",
+		size: 1024,
+		createdAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return (
+		<QueryClientProvider client={queryClient}>
+			<Toast.Provider>{children}</Toast.Provider>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("BylinesPage — avatar field (#1250)", () => {
+	it("renders the avatar picker in create mode", async () => {
+		vi.mocked(fetchBylines).mockResolvedValue({ items: [], nextCursor: undefined });
+
+		const screen = await render(
+			<TestWrapper>
+				<BylinesPage />
+			</TestWrapper>,
+		);
+
+		await expect.element(screen.getByText("Create byline")).toBeInTheDocument();
+		// The avatar field renders its label and an empty-state select button.
+		await expect.element(screen.getByText("Avatar")).toBeInTheDocument();
+		// No avatar set → no resolve query fires.
+		expect(vi.mocked(fetchMediaItem)).not.toHaveBeenCalled();
+	});
+
+	it("resolves the stored avatar media for preview when editing", async () => {
+		const byline = makeByline({ avatarMediaId: "media_avatar_01" });
+		vi.mocked(fetchBylines).mockResolvedValue({ items: [byline], nextCursor: undefined });
+		vi.mocked(fetchByline).mockResolvedValue(byline);
+		vi.mocked(fetchMediaItem).mockResolvedValue(makeMediaItem());
+
+		const screen = await render(
+			<TestWrapper>
+				<BylinesPage />
+			</TestWrapper>,
+		);
+
+		await screen.getByRole("button", { name: /Jane Doe/ }).click();
+
+		await expect.element(screen.getByText("Avatar")).toBeInTheDocument();
+		// The field resolves the stored id into a media item for display.
+		await vi.waitFor(() =>
+			expect(vi.mocked(fetchMediaItem)).toHaveBeenCalledWith("media_avatar_01"),
+		);
+	});
+
+	it("forwards avatarMediaId in the PATCH body on save", async () => {
+		const byline = makeByline({ avatarMediaId: "media_avatar_01" });
+		vi.mocked(fetchBylines).mockResolvedValue({ items: [byline], nextCursor: undefined });
+		vi.mocked(fetchByline).mockResolvedValue(byline);
+		vi.mocked(fetchMediaItem).mockResolvedValue(makeMediaItem());
+		vi.mocked(updateByline).mockResolvedValue(byline);
+
+		const screen = await render(
+			<TestWrapper>
+				<BylinesPage />
+			</TestWrapper>,
+		);
+
+		await screen.getByRole("button", { name: /Jane Doe/ }).click();
+		await screen.getByRole("button", { name: "Save" }).click();
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(vi.mocked(updateByline)).toHaveBeenCalledTimes(1);
+		const [bylineId, body] = vi.mocked(updateByline).mock.calls[0]!;
+		expect(bylineId).toBe(byline.id);
+		expect(body.avatarMediaId).toBe("media_avatar_01");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The byline `avatarMediaId` field is part of the byline data model and is accepted by the create/update API, but the admin byline editor never rendered a control for it. Editors could not attach an avatar through the UI, and (worse) because the update route coerces a missing `avatarMediaId` back to `null`, every edit through the UI silently wiped any value that had been set programmatically.

This adds an avatar image picker to the byline editor:

- New `BylineAvatarField` resolves the stored `avatarMediaId` into a media item (via a new `fetchMediaItem` API helper) and delegates to the shared `ImageFieldRenderer`, reusing its picker, preview, and broken-image handling rather than duplicating markup.
- `avatarMediaId` is now wired into the byline form state and included in both the create and update payloads, so avatars can be chosen, changed, and removed from the UI and persist across edits.

Closes #1250

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/... (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Targeted tests run green:

- `packages/admin` component test `byline-form-avatar.test.tsx` (3 tests): avatar picker renders in create mode, resolves the stored media on edit, and forwards `avatarMediaId` in the PATCH body.
- Existing `byline-form-customfields.test.tsx` (5 tests) still pass.
- New e2e `bylines.spec.ts` case: uploads an avatar through the picker, saves, asserts `avatarMediaId` persists, then edits another field and asserts the avatar is not wiped (regression guard). Full `bylines.spec.ts` (3 tests) green.

`pnpm typecheck`, `pnpm lint`, and `pnpm format` are clean.