### PR TITLE
chore: relax PR compliance check for maintainers

### DIFF
--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -30,6 +30,11 @@ jobs:
             const body = context.payload.pull_request.body || '';
             const pr = context.payload.pull_request;
 
+            // Maintainers (repo owners, org members, and collaborators) are trusted
+            // to land features without a pre-approved Discussion link.
+            const association = pr.author_association || '';
+            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+
             const errors = [];
 
             // Check if the PR body looks like it used the template at all
@@ -61,17 +66,20 @@ jobs:
                 errors.push('Check at least one "Type of change" checkbox.');
               }
 
-              // If Feature is checked, require a discussion link
+              // If Feature is checked, require a discussion link.
+              // Maintainers are exempt: they can approve their own features.
               const isFeature = /- \[x\] Feature/i.test(body);
-              if (isFeature) {
+              if (isFeature && !isMaintainer) {
                 const hasDiscussionLink = /github\.com\/emdash-cms\/emdash\/discussions\/\d+/.test(body);
                 if (!hasDiscussionLink) {
                   errors.push('Feature PRs require a link to an approved Discussion (https://github.com/emdash-cms/emdash/discussions/categories/ideas). Open a Discussion first, get approval, then link it in the PR.');
                 }
               }
 
-              // Must check the "I have read CONTRIBUTING.md" box
-              const hasReadContributing = /- \[x\] I have read \[CONTRIBUTING\.md\]/i.test(body);
+              // Must check the "I have read CONTRIBUTING.md" box. Be lenient about
+              // formatting: accept the box whether or not CONTRIBUTING.md is still a
+              // markdown link (authors often strip the link or tweak the wording).
+              const hasReadContributing = /- \[x\][^\n]*\bI have read\b[^\n]*CONTRIBUTING/i.test(body);
               if (!hasReadContributing) {
                 errors.push('Check the "I have read CONTRIBUTING.md" checkbox.');
               }


### PR DESCRIPTION
## What does this PR do?

Loosens two over-strict rules in the PR compliance workflow:

- **Maintainers are exempt from the Feature/Discussion-link requirement.** A new `isMaintainer` flag derived from `pull_request.author_association` (`OWNER`, `MEMBER`, `COLLABORATOR`) skips the "Feature PRs require an approved Discussion link" error. Maintainers can approve their own features, so the check was pure friction for them. External contributors (`CONTRIBUTOR`/`NONE`) are unaffected.
- **The CONTRIBUTING checkbox is matched more leniently.** It previously required the exact `[CONTRIBUTING.md]` markdown link. It now matches a checked box that references reading CONTRIBUTING even if the author stripped the link or reworded the line.

Using `author_association` is safe here because it is tied to the PR author, not the triggering actor (the existing top-of-file comment notes `github.actor` can be spoofed on synchronize/edited events; this avoids that pitfall).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, CI workflow only, no source changes
- [ ] `pnpm lint` passes — n/a, CI workflow only
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, CI workflow only
- [ ] `pnpm format` has been run — n/a, CI workflow only
- [ ] I have added/updated tests for my changes (if applicable) — n/a, no test harness for workflow YAML
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no UI strings
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, no published package changed
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

n/a — workflow logic change. Verified the regex updates by hand against the current PR template wording.