### PR TITLE
fix(core): prevent isolate-poisoning hangs from cached in-flight promises

### DIFF
--- a/.changeset/fix-isolate-cache-poisoning.md
+++ b/.changeset/fix-isolate-cache-poisoning.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin pages hanging indefinitely (and eventually returning 524 timeouts) on Cloudflare Workers. The worker-lifetime caches for site settings and search-index health could be left holding a request that never completed (for example when a visitor's request was cancelled mid-load), which then stalled every later request served by that worker until it was recycled. These caches now keep resolved values rather than in-flight requests, so a cancelled or interrupted request can no longer wedge the rest.

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -45,6 +45,7 @@ import type {
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
 import { createInitLock, type InitLock, initWithLock } from "./utils/init-lock.js";
+import { createIsolateCache, isolateCachedAsync } from "./utils/isolate-cache.js";
 import { COMMIT, VERSION } from "./version.js";
 
 const LEADING_SLASH_PATTERN = /^\//;
@@ -417,12 +418,12 @@ export class EmDashRuntime {
 	private pluginStates: Map<string, string>;
 
 	/**
-	 * Set to true after FTS indexes have been verified for this worker
-	 * lifetime so we don't re-scan on every admin request. See
-	 * ensureSearchHealthy().
+	 * Isolate-lifetime guard so FTS indexes are verified at most once per
+	 * worker rather than on every admin request. See ensureSearchHealthy().
+	 * Uses the poison-immune isolate cache (never a shared awaitable promise)
+	 * so a cancelled first caller can't wedge later ones.
 	 */
-	private _searchHealthChecked = false;
-	private _searchHealthPromise: Promise<void> | null = null;
+	private readonly _searchHealthCache = createIsolateCache<void>();
 
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
@@ -2228,27 +2229,32 @@ export class EmDashRuntime {
 	 * defend against FTS not existing yet (pre-setup).
 	 */
 	async ensureSearchHealthy(): Promise<void> {
-		if (this._searchHealthChecked) return;
-		if (this._searchHealthPromise) return this._searchHealthPromise;
-		if (!isSqlite(this._db)) {
-			this._searchHealthChecked = true;
-			return;
+		// Non-SQLite has no FTS to verify; the check is a cheap synchronous
+		// branch, no need to cache it.
+		if (!isSqlite(this._db)) return;
+		try {
+			await isolateCachedAsync(
+				this._searchHealthCache,
+				async () => {
+					try {
+						const ftsManager = new FTSManager(this._db);
+						const repaired = await ftsManager.verifyAndRepairAll();
+						if (repaired > 0) {
+							console.log(`Repaired ${repaired} corrupted FTS index(es)`);
+						}
+					} catch {
+						// FTS tables may not exist yet (pre-setup). Non-fatal — cache
+						// the "checked" state regardless so we don't re-scan.
+					}
+				},
+				{ anchor: (promise) => after(() => promise), ownerTimeoutMs: 30_000 },
+			);
+		} catch {
+			// This check is best-effort and must never fail the calling request.
+			// The inner body already swallows verify errors; this guards the
+			// outer failure modes (owner timeout, waiter give-up) so a slow FTS
+			// scan degrades to "unverified", not a 500 on admin/search routes.
 		}
-		this._searchHealthPromise = (async () => {
-			try {
-				const ftsManager = new FTSManager(this._db);
-				const repaired = await ftsManager.verifyAndRepairAll();
-				if (repaired > 0) {
-					console.log(`Repaired ${repaired} corrupted FTS index(es)`);
-				}
-			} catch {
-				// FTS tables may not exist yet (pre-setup). Non-fatal.
-			} finally {
-				this._searchHealthChecked = true;
-				this._searchHealthPromise = null;
-			}
-		})();
-		return this._searchHealthPromise;
 	}
 
 	// =========================================================================

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -7,12 +7,19 @@
 
 import type { Kysely } from "kysely";
 
+import { after } from "../after.js";
 import { MediaRepository } from "../database/repositories/media.js";
 import { OptionsRepository } from "../database/repositories/options.js";
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
 import { peekRequestCache, requestCached } from "../request-cache.js";
 import type { Storage } from "../storage/types.js";
+import {
+	createIsolateCache,
+	type IsolateCache,
+	invalidateIsolateCache,
+	isolateCachedAsync,
+} from "../utils/isolate-cache.js";
 import type { SiteSettings, SiteSettingKey, MediaReference, SeoSettings } from "./types.js";
 
 /** Prefix for site settings in the options table */
@@ -27,29 +34,22 @@ const SETTINGS_PREFIX = "site:";
  * once-per-isolate. Cross-isolate staleness is bounded by isolate lifetime
  * (workerd typically recycles within minutes); acceptable for chrome.
  *
- * Stored on globalThis with a Symbol.for key so Vite SSR chunk duplication
- * doesn't produce two independent caches (same pattern as request-context.ts).
- *
- * Invalidation: every `site:*` write bumps `version`. Reads compare the
- * cached promise's version against the current version and refetch on
- * mismatch. Caching the promise (not the resolved value) lets concurrent
- * cold-isolate readers share the in-flight query.
+ * Backed by isolate-cache.ts: concurrent cold-isolate reads coalesce onto one
+ * query via a reclaimable single-flight lock and the resolved *value* is
+ * cached — never a shared in-flight promise, so a cancelled request can't
+ * poison the isolate (see that file's header). Stored on globalThis with a
+ * Symbol.for key so Vite SSR chunk duplication doesn't produce two
+ * independent caches (same pattern as request-context.ts).
  */
-interface SiteSettingsHolder {
-	version: number;
-	cached: Promise<Partial<SiteSettings>> | null;
-	cachedVersion: number;
-}
-
 const SITE_SETTINGS_CACHE_KEY = Symbol.for("emdash:site-settings");
 const g = globalThis as Record<symbol, unknown>;
-const holder: SiteSettingsHolder =
+const settingsCache: IsolateCache<Partial<SiteSettings>> =
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see request-context.ts)
-	(g[SITE_SETTINGS_CACHE_KEY] as SiteSettingsHolder | undefined) ??
+	(g[SITE_SETTINGS_CACHE_KEY] as IsolateCache<Partial<SiteSettings>> | undefined) ??
 	(() => {
-		const h: SiteSettingsHolder = { version: 0, cached: null, cachedVersion: -1 };
-		g[SITE_SETTINGS_CACHE_KEY] = h;
-		return h;
+		const c = createIsolateCache<Partial<SiteSettings>>();
+		g[SITE_SETTINGS_CACHE_KEY] = c;
+		return c;
 	})();
 
 /**
@@ -60,9 +60,7 @@ const holder: SiteSettingsHolder =
  * own cached copy until they expire — staleness bounded by isolate lifetime.
  */
 export function invalidateSiteSettingsCache(): void {
-	holder.version++;
-	holder.cached = null;
-	holder.cachedVersion = -1;
+	invalidateIsolateCache(settingsCache);
 }
 
 /**
@@ -210,25 +208,19 @@ export async function getSiteSettingWithDb<K extends SiteSettingKey>(
  * ```
  */
 export function getSiteSettings(): Promise<Partial<SiteSettings>> {
-	return requestCached("siteSettings", () => {
-		const versionAtCall = holder.version;
-		if (holder.cached && holder.cachedVersion === versionAtCall) {
-			return holder.cached;
-		}
-		const fetchPromise = (async () => {
-			const db = await getDb();
-			return getSiteSettingsWithDb(db);
-		})().catch((error) => {
-			if (holder.cached === fetchPromise) {
-				holder.cached = null;
-				holder.cachedVersion = -1;
-			}
-			throw error;
-		});
-		holder.cached = fetchPromise;
-		holder.cachedVersion = versionAtCall;
-		return fetchPromise;
-	});
+	// requestCached dedupes within a single request; isolateCachedAsync
+	// coalesces across requests and caches the resolved value for the
+	// isolate's lifetime without ever sharing an awaitable promise.
+	return requestCached("siteSettings", () =>
+		isolateCachedAsync(
+			settingsCache,
+			async () => {
+				const db = await getDb();
+				return getSiteSettingsWithDb(db);
+			},
+			{ anchor: (promise) => after(() => promise), ownerTimeoutMs: 30_000 },
+		),
+	);
 }
 
 /**

--- a/packages/core/src/utils/isolate-cache.ts
+++ b/packages/core/src/utils/isolate-cache.ts
@@ -1,0 +1,189 @@
+/**
+ * Isolate-lifetime async value cache with single-flight and poison-immunity.
+ *
+ * Built for the "compute once per isolate, read on every request" caches
+ * (site settings, search-health verification, ...). These must coalesce
+ * concurrent cold-isolate reads into one query — but the obvious way to do
+ * that, caching the in-flight *promise* on an isolate-global and awaiting it
+ * from later requests, is unsafe on workerd: if the request that created the
+ * promise is cancelled mid-await (client disconnect, context teardown), its
+ * continuation never runs, so the promise neither resolves nor rejects. Every
+ * later request that awaits that shared promise then hangs until the isolate
+ * is evicted (observed as 524s at the 100s wall, near-zero CPU). A `.catch`
+ * that clears the cache doesn't help — a cancelled request doesn't reject.
+ *
+ * This cache stores the resolved *value* (not a promise) and coalesces via
+ * `initWithLock`: one request becomes the owner and runs `fetch`, everyone
+ * else polls for the published value and never awaits the owner's promise.
+ * A cancelled owner can therefore never strand a waiter — the worst case is
+ * the lock looks held until `deadlineMs`, then the next caller reclaims. The
+ * owner's `fetch` is also anchored (waitUntil) so a cancelled originator's
+ * query still completes and populates the cache, and bounded by
+ * `ownerTimeoutMs` so a genuinely stuck fetch reclaims instead of hanging.
+ *
+ * Invalidation bumps `version`; reads compare against the version captured at
+ * call time and refetch on mismatch.
+ */
+
+import { createInitLock, type InitLock, initWithLock } from "./init-lock.js";
+
+export interface IsolateCache<T> {
+	/** Last resolved value, valid only when `hasValue` is true. */
+	value: T | null;
+	/**
+	 * Presence flag, separate from `value` so that falsy/`undefined`/`void`
+	 * results cache correctly (a plain null check can't distinguish "cached
+	 * undefined" from "never fetched").
+	 */
+	hasValue: boolean;
+	/** Invalidation counter; bumped by `invalidateIsolateCache`. */
+	version: number;
+	/** The `version` the cached value was fetched at. */
+	valueVersion: number;
+	/** Reclaimable single-flight lock (see init-lock.ts). */
+	lock: InitLock;
+}
+
+export function createIsolateCache<T>(): IsolateCache<T> {
+	return { value: null, hasValue: false, version: 0, valueVersion: -1, lock: createInitLock() };
+}
+
+/**
+ * Force the next `isolateCachedAsync` call to refetch. An in-flight owner
+ * fetched at the old version will not publish into the new version, so its
+ * result is ignored by subsequent reads.
+ */
+export function invalidateIsolateCache(cache: IsolateCache<unknown>): void {
+	cache.version++;
+	cache.hasValue = false;
+	cache.value = null;
+	cache.valueVersion = -1;
+	// Free the single-flight lock so a reader at the new version starts the
+	// refetch immediately instead of waiting out a stale owner's deadline. A
+	// still-running old-version owner can neither publish into the new version
+	// (version gate) nor clobber a new owner (claim gate), so releasing here
+	// is safe; the worst case is one brief duplicate fetch.
+	cache.lock.ownerStartedAt = null;
+}
+
+/**
+ * Headroom between the owner's own timeout and the waiter reclaim deadline.
+ * The reclaim deadline must sit *above* `ownerTimeoutMs` so a slow-but-live
+ * owner times out (and releases the lock) before a waiter would reclaim it —
+ * otherwise a fetch slower than the deadline is superseded before it can
+ * publish, and steady traffic turns that into a self-sustaining stampede.
+ */
+const RECLAIM_HEADROOM_MS = 5_000;
+
+export interface IsolateCachedOptions {
+	/**
+	 * Hand the in-flight fetch to the host's lifetime extender (waitUntil via
+	 * `after()`), so a cancelled originating request still drives it to
+	 * completion and populates the cache.
+	 */
+	anchor?: (promise: Promise<void>) => void;
+	/** Reclaim the single-flight lock if the owner holds it past this. */
+	deadlineMs?: number;
+	/** Waiter poll interval. */
+	pollMs?: number;
+	/** Waiter gives up and throws after this long rather than hanging. */
+	maxWaitMs?: number;
+	/**
+	 * Bound the owner's own `fetch`: if it doesn't settle within this, the
+	 * owner rejects (and releases the lock) instead of waiting indefinitely.
+	 * The anchored copy keeps running, so a slow-but-live fetch can still
+	 * publish for a later caller. Omit to leave the owner unbounded.
+	 */
+	ownerTimeoutMs?: number;
+}
+
+/** Boxed cache hit so a `void`/falsy value is still distinguishable from a miss. */
+interface Box<T> {
+	v: T;
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`isolateCachedAsync: owner fetch exceeded ${ms}ms`));
+		}, ms);
+		// Settle from the underlying promise (whichever wins the race with the
+		// timer), and always clear the timer so a resolved fetch doesn't leave
+		// a pending timeout holding the isolate alive.
+		promise.then(resolve, reject).finally(() => {
+			clearTimeout(timer);
+		});
+	});
+}
+
+/**
+ * Return the cached value for `cache`, computing it via `fetch` under a
+ * single-flight lock on a miss. Concurrent callers coalesce onto one fetch;
+ * a cancelled owner cannot poison later callers (see file header).
+ */
+export function isolateCachedAsync<T>(
+	cache: IsolateCache<T>,
+	fetch: () => Promise<T>,
+	options: IsolateCachedOptions = {},
+): Promise<T> {
+	// Capture the version once: a value published at this version satisfies
+	// this call; an invalidation that lands mid-fetch makes the published
+	// value stale for *later* calls (which captured the newer version) but
+	// still valid for this one.
+	const versionAtCall = cache.version;
+
+	// Ignore a non-positive / non-finite owner timeout rather than letting it
+	// degenerate into an instant-reject (setTimeout coerces NaN/0 to ~0ms).
+	const ownerTimeoutMs =
+		options.ownerTimeoutMs !== undefined &&
+		Number.isFinite(options.ownerTimeoutMs) &&
+		options.ownerTimeoutMs > 0
+			? options.ownerTimeoutMs
+			: undefined;
+
+	// Keep the reclaim deadline above the owner timeout (see RECLAIM_HEADROOM_MS):
+	// the owner's own timeout, not a waiter reclaim, is the primary release.
+	const deadlineMs =
+		ownerTimeoutMs === undefined
+			? options.deadlineMs
+			: Math.max(options.deadlineMs ?? 0, ownerTimeoutMs + RECLAIM_HEADROOM_MS);
+
+	return initWithLock<Box<T>>(
+		cache.lock,
+		() =>
+			cache.hasValue && cache.valueVersion === versionAtCall
+				? // eslint-disable-next-line typescript/no-unsafe-type-assertion -- hasValue gates that `value` holds a real T
+					({ v: cache.value as T } satisfies Box<T>)
+				: null,
+		(isCurrentClaim) => {
+			// The real work, anchored independently so a cancelled owner's
+			// fetch still settles and publishes. Publication is gated on the
+			// claim so a reclaimed slow owner can't clobber the reclaimer's
+			// value (same contract as initWithLock's own callers).
+			const real = (async (): Promise<Box<T>> => {
+				const value = await fetch();
+				if (isCurrentClaim()) {
+					cache.value = value;
+					cache.hasValue = true;
+					cache.valueVersion = versionAtCall;
+				}
+				return { v: value };
+			})();
+			// Anchor the real fetch (not the timeout race): this is what must
+			// survive a cancelled owner and run to publication. initWithLock is
+			// left to manage only the lock; we don't double-anchor.
+			options.anchor?.(
+				real.then(
+					() => undefined,
+					() => undefined,
+				),
+			);
+			return ownerTimeoutMs === undefined ? real : withTimeout(real, ownerTimeoutMs);
+		},
+		{
+			deadlineMs,
+			pollMs: options.pollMs,
+			maxWaitMs: options.maxWaitMs,
+		},
+	).then((box) => box.v);
+}

--- a/packages/core/tests/unit/utils/isolate-cache.test.ts
+++ b/packages/core/tests/unit/utils/isolate-cache.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	createIsolateCache,
+	invalidateIsolateCache,
+	isolateCachedAsync,
+} from "../../../src/utils/isolate-cache.js";
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** A promise that never settles — simulates a fetch whose owning request
+ * context was torn down mid-await (workerd cancels the continuation, so
+ * neither `then` nor `finally` ever runs). This is the production poisoning
+ * scenario. */
+function neverSettles<T>(): Promise<T> {
+	return new Promise<T>(() => {});
+}
+
+describe("isolateCachedAsync", () => {
+	it("caches the resolved value across calls (one fetch)", async () => {
+		const cache = createIsolateCache<number>();
+		let calls = 0;
+		const fetch = async () => {
+			calls++;
+			return 5;
+		};
+		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(5);
+		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(5);
+		expect(calls).toBe(1);
+	});
+
+	it("caches a void/undefined result so it is not treated as a miss", async () => {
+		// The reason the cache stores a boxed value + presence flag rather
+		// than relying on a null check: a falsy/void result must still count
+		// as cached. Without the box this would refetch every call.
+		const cache = createIsolateCache<void>();
+		let calls = 0;
+		const fetch = async () => {
+			calls++;
+		};
+		await isolateCachedAsync(cache, fetch, { pollMs: 10 });
+		await isolateCachedAsync(cache, fetch, { pollMs: 10 });
+		expect(calls).toBe(1);
+	});
+
+	it("coalesces concurrent callers into a single fetch", async () => {
+		const cache = createIsolateCache<number>();
+		let calls = 0;
+		const fetch = async () => {
+			calls++;
+			await sleep(30);
+			return 7;
+		};
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () => isolateCachedAsync(cache, fetch, { pollMs: 5 })),
+		);
+		expect(results).toEqual([7, 7, 7, 7, 7]);
+		expect(calls).toBe(1);
+	});
+
+	it("invalidateIsolateCache forces a refetch", async () => {
+		const cache = createIsolateCache<number>();
+		let n = 0;
+		const fetch = async () => ++n;
+		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(1);
+		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(1);
+		invalidateIsolateCache(cache);
+		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(2);
+	});
+
+	it("a stranded owner fetch does not poison later callers", async () => {
+		// The whole point of the rewrite. First caller claims, then its
+		// fetch never settles (cancelled request). With the old "cache the
+		// in-flight promise" approach every later caller awaited that dead
+		// promise forever. Here later callers poll a value, reclaim the stale
+		// lock after the deadline, and succeed.
+		const cache = createIsolateCache<string>();
+
+		void isolateCachedAsync(cache, () => neverSettles<string>(), {
+			deadlineMs: 100,
+			pollMs: 10,
+		});
+		expect(cache.lock.ownerStartedAt).not.toBeNull();
+
+		await sleep(120);
+
+		const result = await isolateCachedAsync(cache, async () => "recovered", {
+			deadlineMs: 100,
+			pollMs: 10,
+			maxWaitMs: 1000,
+		});
+		expect(result).toBe("recovered");
+	});
+
+	it("rejects the owner at ownerTimeoutMs instead of hanging forever", async () => {
+		const cache = createIsolateCache<string>();
+		await expect(
+			isolateCachedAsync(cache, () => neverSettles<string>(), {
+				ownerTimeoutMs: 50,
+				deadlineMs: 60_000, // high so reclaim doesn't mask the owner timeout
+				pollMs: 10,
+			}),
+		).rejects.toThrow(/exceeded/i);
+	});
+
+	it("anchored fetch still publishes for a later caller after the owner times out", async () => {
+		// A slow-but-live fetch: the owner gives up at ownerTimeoutMs, but the
+		// anchored copy keeps running and populates the cache, so the next
+		// caller is served without refetching.
+		const cache = createIsolateCache<string>();
+		let release!: (value: string) => void;
+		const slow = new Promise<string>((resolve) => {
+			release = resolve;
+		});
+		const anchored: Promise<void>[] = [];
+
+		await expect(
+			isolateCachedAsync(cache, () => slow, {
+				ownerTimeoutMs: 50,
+				deadlineMs: 60_000,
+				pollMs: 10,
+				anchor: (promise) => anchored.push(promise),
+			}),
+		).rejects.toThrow(/exceeded/i);
+
+		release("late-value");
+		await Promise.all(anchored);
+
+		let calls = 0;
+		const result = await isolateCachedAsync(
+			cache,
+			async () => {
+				calls++;
+				return "fresh";
+			},
+			{ pollMs: 10 },
+		);
+		expect(result).toBe("late-value");
+		expect(calls).toBe(0);
+	});
+
+	it("keeps the reclaim deadline above ownerTimeoutMs so a slow-but-live owner is not superseded", async () => {
+		// A deadlineMs smaller than ownerTimeoutMs, left unguarded, would let a
+		// waiter reclaim before the owner finishes — a self-sustaining stampede
+		// that never populates the cache. The helper must raise the effective
+		// deadline above the owner timeout.
+		const cache = createIsolateCache<string>();
+		let calls = 0;
+		const fetch = async () => {
+			calls++;
+			await sleep(150);
+			return "v";
+		};
+		const opts = { deadlineMs: 30, ownerTimeoutMs: 1000, pollMs: 10, maxWaitMs: 5000 };
+		const a = isolateCachedAsync(cache, fetch, opts);
+		await sleep(20);
+		const b = isolateCachedAsync(cache, fetch, opts);
+		expect(await a).toBe("v");
+		expect(await b).toBe("v");
+		expect(calls).toBe(1);
+	});
+
+	it("invalidation frees the lock so a fresh reader doesn't wait out a stale owner", async () => {
+		const cache = createIsolateCache<string>();
+		// A slow/stuck in-flight owner holds the lock.
+		void isolateCachedAsync(cache, () => neverSettles<string>(), {
+			deadlineMs: 10_000,
+			pollMs: 10,
+		});
+		expect(cache.lock.ownerStartedAt).not.toBeNull();
+
+		invalidateIsolateCache(cache);
+		expect(cache.lock.ownerStartedAt).toBeNull();
+
+		// maxWaitMs (200) is far below deadlineMs (10s): without the lock being
+		// freed, the fresh reader would give up before it could ever reclaim.
+		const result = await isolateCachedAsync(cache, async () => "fresh", {
+			deadlineMs: 10_000,
+			pollMs: 10,
+			maxWaitMs: 200,
+		});
+		expect(result).toBe("fresh");
+	});
+
+	it("ignores a non-positive ownerTimeoutMs instead of rejecting instantly", async () => {
+		const cache = createIsolateCache<string>();
+		const result = await isolateCachedAsync(cache, async () => "v", {
+			ownerTimeoutMs: 0,
+			pollMs: 10,
+		});
+		expect(result).toBe("v");
+	});
+
+	it("propagates a fetch rejection to the caller and lets the next caller retry", async () => {
+		const cache = createIsolateCache<string>();
+		await expect(
+			isolateCachedAsync(cache, () => Promise.reject(new Error("boom")), { pollMs: 10 }),
+		).rejects.toThrow("boom");
+		expect(cache.lock.ownerStartedAt).toBeNull();
+
+		const result = await isolateCachedAsync(cache, async () => "ok", { pollMs: 10 });
+		expect(result).toBe("ok");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes admin pages (and any settings-reading SSR path) hanging indefinitely and eventually returning 524 timeouts on Cloudflare Workers.

The worker-isolate caches for site settings (`getSiteSettings`) and search-index health (`ensureSearchHealthy`) stored an **in-flight promise** on a `globalThis` singleton and awaited it from later requests. On workerd, when the request that created that promise is cancelled mid-await (client disconnect, context teardown), its continuation never runs, so the promise neither resolves nor rejects, and the `.catch` that would clear the cache never fires. Every later request in that isolate then awaits the dead promise and hangs until the isolate is evicted (observed as 524 at the 100s wall with near-zero CPU). Because Smart Placement concentrates traffic onto a small number of isolates, a single cancelled request can take down all admin traffic until the isolate recycles, then it appears to "heal on its own."

This is the same failure class as the init-lock fix in #1405, in two caches that were never migrated to that pattern.

### Fix

- New `isolateCachedAsync` helper (`packages/core/src/utils/isolate-cache.ts`), built on `initWithLock`: callers poll a cached **value** and never await another request's promise. The owner fetch is anchored via `after()` (so a cancelled originator's query still completes and populates the cache) and bounded by an owner timeout; invalidation frees the single-flight lock so a fresh reader doesn't wait out a stale owner.
- Migrated `getSiteSettings`/`invalidateSiteSettingsCache` and `ensureSearchHealthy` onto it. Cross-request coalescing (dogpile protection) is preserved; the never-settling-promise hazard is gone.

The implementation was adversarially reviewed by a different model; that pass surfaced four issues (reclaim deadline needing to sit above the owner timeout, `ensureSearchHealthy` needing to stay non-fatal, invalidation needing to release the lock, and owner-timeout validation), all fixed here with tests.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no UI strings changed
- [x] I have added a changeset (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (implementation), GPT-5.5 (independent root-cause confirmation + adversarial review)

## Screenshots / test output

11 unit tests for the new helper (including a reproduction of the cancelled-creator poisoning, coalescing, invalidation, owner-timeout, and the stampede-deadline guard). Full suite: 3945 core tests pass; lint clean; typecheck clean.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-isolate-cache-poisoning-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/isolate-cache-poisoning`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
