### PR TITLE
fix(flue): switch kimi automations to k2.7-code and handle 429 capacity gracefully

### DIFF
--- a/.flue/README.md
+++ b/.flue/README.md
@@ -8,7 +8,7 @@ For the design rationale, see the [PR description](https://github.com/emdash-cms
 
 When a maintainer adds `bot:repro` to an issue:
 
-1. **Classify** — kimi-k2.6 decides issue kind/area/whether a browser is needed.
+1. **Classify** — kimi-k2.7-code decides issue kind/area/whether a browser is needed.
 2. **Reproduce** — opus runs in a `local()` sandbox on the GH Actions runner. Picks one of three sub-skills:
    - `repro-api` — `pnpm test`, CLI commands, direct API hits, no browser
    - `repro-admin` — `agent-browser` against `pnpm dev` with the dev-bypass auth shortcut

--- a/.flue/lib/capacity.ts
+++ b/.flue/lib/capacity.ts
@@ -1,0 +1,160 @@
+// Graceful handling for Workers AI capacity (HTTP 429) errors and stalled
+// inference calls.
+//
+// Workers AI returns 429 when a model is over capacity. Under sustained load
+// the binding can also hold a request open well past any useful deadline, which
+// (without a bound) leaves a review workflow hung forever -- the agent call
+// never returns, nothing posts, and the only artifact is the container DO's
+// keep-alive alarm firing for minutes. `withCapacityRetry` bounds each attempt
+// with a hard timeout (so a stalled call fails loudly instead of hanging) and
+// retries genuine capacity errors with exponential backoff + jitter.
+//
+// `ModelConfig` in @flue/runtime is just a model-id string, so there is no
+// provider-level retry/timeout knob to set; this is the application-level
+// contract. The wrapped call receives an AbortSignal it must forward to the
+// model call (`session.skill(..., { signal })`) for the timeout to take effect.
+
+/** Thrown when every attempt was exhausted by capacity errors. */
+export class CapacityExhaustedError extends Error {
+	constructor(label: string, attempts: number, cause: unknown) {
+		super(`${label}: model over capacity after ${attempts} attempt(s)`, { cause });
+		this.name = "CapacityExhaustedError";
+	}
+}
+
+/** Thrown when a single attempt exceeded its per-attempt timeout. */
+export class ModelTimeoutError extends Error {
+	constructor(label: string, timeoutMs: number, cause: unknown) {
+		super(`${label}: model call exceeded ${timeoutMs}ms timeout`, { cause });
+		this.name = "ModelTimeoutError";
+	}
+}
+
+export interface CapacityRetryOptions {
+	/** Human-readable label for logs/errors, e.g. "review" or "classify-reply". */
+	label: string;
+	/** Total attempts including the first. Default 3. */
+	attempts?: number;
+	/**
+	 * Hard per-attempt deadline. On expiry the attempt is aborted and a
+	 * `ModelTimeoutError` is thrown (NOT retried -- a timeout can't be told apart
+	 * from slow-but-working progress, so we fail loudly and bounded rather than
+	 * burning the full attempt budget). Omit to disable the timeout.
+	 */
+	perAttemptTimeoutMs?: number;
+	/** Base backoff delay. Default 3000ms. */
+	baseDelayMs?: number;
+	/** Backoff ceiling. Default 30000ms. */
+	maxDelayMs?: number;
+	/** Caller cancellation, merged with the per-attempt timeout signal. */
+	signal?: AbortSignal;
+	/** Invoked before each backoff sleep. */
+	onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
+}
+
+const CAPACITY_MARKERS = [
+	"429",
+	"too many requests",
+	"capacity",
+	"over capacity",
+	"rate limit",
+	"overloaded",
+	"3040", // Workers AI "Capacity temporarily exceeded" code
+];
+
+/** Best-effort classification of a Workers AI / gateway capacity (429) error. */
+export function isCapacityError(error: unknown): boolean {
+	const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+	return CAPACITY_MARKERS.some((marker) => message.includes(marker));
+}
+
+function isTimeoutAbort(error: unknown, timeoutSignal: AbortSignal | undefined): boolean {
+	if (!timeoutSignal?.aborted) return false;
+	return (
+		(error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) ||
+		// Some SDKs reject with the signal's reason rather than an AbortError.
+		error === timeoutSignal.reason
+	);
+}
+
+function backoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+	const exponential = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+	// Full jitter: random within [0, exponential] to spread retries across many
+	// concurrent callers hammering the same overloaded model.
+	return Math.round(Math.random() * exponential);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal?.reason);
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * Run a model-bearing call with a per-attempt timeout and capacity-aware retry.
+ *
+ * - Capacity (429) errors are retried with exponential backoff + full jitter.
+ * - A per-attempt timeout aborts a stalled call and throws `ModelTimeoutError`
+ *   (loud, bounded -- the workflow's at-least-once restart handles re-running).
+ * - Any other error is rethrown immediately.
+ *
+ * @param fn receives the per-attempt `AbortSignal`; forward it to the model call.
+ *   Returns a `PromiseLike` so Flue's awaitable `CallHandle` can be passed through
+ *   directly (`session.skill(..., { signal })`).
+ */
+export async function withCapacityRetry<T>(
+	fn: (signal: AbortSignal) => PromiseLike<T>,
+	options: CapacityRetryOptions,
+): Promise<T> {
+	const attempts = options.attempts ?? 3;
+	const baseDelayMs = options.baseDelayMs ?? 3000;
+	const maxDelayMs = options.maxDelayMs ?? 30000;
+
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		const timeoutSignal =
+			options.perAttemptTimeoutMs !== undefined
+				? AbortSignal.timeout(options.perAttemptTimeoutMs)
+				: undefined;
+		const signals = [options.signal, timeoutSignal].filter(
+			(s): s is AbortSignal => s !== undefined,
+		);
+		const signal =
+			signals.length > 1 ? AbortSignal.any(signals) : (signals[0] ?? new AbortController().signal);
+
+		try {
+			return await fn(signal);
+		} catch (error) {
+			lastError = error;
+
+			// A per-attempt timeout: fail loudly, do not retry.
+			if (isTimeoutAbort(error, timeoutSignal)) {
+				throw new ModelTimeoutError(options.label, options.perAttemptTimeoutMs ?? 0, error);
+			}
+			// Caller cancellation: propagate untouched.
+			if (options.signal?.aborted) throw error;
+			// Non-capacity error: not our concern, rethrow.
+			if (!isCapacityError(error)) throw error;
+			// Capacity error on the final attempt: give up loudly.
+			if (attempt === attempts) break;
+
+			const delayMs = backoffDelay(attempt, baseDelayMs, maxDelayMs);
+			options.onRetry?.({ attempt, delayMs, error });
+			await sleep(delayMs, options.signal);
+		}
+	}
+
+	throw new CapacityExhaustedError(options.label, attempts, lastError);
+}

--- a/.flue/lib/classifier.ts
+++ b/.flue/lib/classifier.ts
@@ -1,5 +1,5 @@
 // Lightweight classifier shared between investigate and classify-reply
-// workflows. Uses kimi-k2.6 via our Cloudflare AI Gateway -- cheap and
+// workflows. Uses kimi-k2.7-code via our Cloudflare AI Gateway -- cheap and
 // fast for structured classification tasks.
 
 import { writeFileSync } from "node:fs";
@@ -12,7 +12,7 @@ import * as v from "valibot";
  * Used for cheap structured-output prompts that don't need a shell.
  */
 export const classifier = createAgent(() => ({
-	model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6",
+	model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code",
 }));
 
 /**

--- a/.flue/workflows/classify-maintainer-reply.ts
+++ b/.flue/workflows/classify-maintainer-reply.ts
@@ -11,6 +11,7 @@
 
 import type { FlueContext } from "@flue/runtime";
 
+import { withCapacityRetry } from "../lib/capacity.js";
 import {
 	classifier,
 	maintainerIntentSchema,
@@ -74,7 +75,21 @@ export async function run({
 		"Quote the specific phrase that drove your decision in the reasoning field.",
 	].join("\n");
 
-	const { data } = await session.prompt(prompt, { result: maintainerIntentSchema });
+	const { data } = await withCapacityRetry(
+		(signal) => session.prompt(prompt, { result: maintainerIntentSchema, signal }),
+		{
+			label: `classify-maintainer-reply#${payload.issueNumber}`,
+			attempts: 4,
+			perAttemptTimeoutMs: 90_000,
+			onRetry: ({ attempt, delayMs, error }) =>
+				log.warn?.("model over capacity, backing off", {
+					issueNumber: payload.issueNumber,
+					attempt,
+					delayMs,
+					error: String(error),
+				}),
+		},
+	);
 	log.info("classified maintainer reply", {
 		issueNumber: payload.issueNumber,
 		intent: data.intent,

--- a/.flue/workflows/classify-reply.ts
+++ b/.flue/workflows/classify-reply.ts
@@ -10,6 +10,7 @@
 
 import type { FlueContext } from "@flue/runtime";
 
+import { withCapacityRetry } from "../lib/capacity.js";
 import {
 	classifier,
 	persistClassifierResult,
@@ -64,7 +65,21 @@ export async function run({
 		"Quote the specific phrase that drove your decision in the reasoning field.",
 	].join("\n");
 
-	const { data } = await session.prompt(prompt, { result: replyClassificationSchema });
+	const { data } = await withCapacityRetry(
+		(signal) => session.prompt(prompt, { result: replyClassificationSchema, signal }),
+		{
+			label: `classify-reply#${payload.issueNumber}`,
+			attempts: 4,
+			perAttemptTimeoutMs: 90_000,
+			onRetry: ({ attempt, delayMs, error }) =>
+				log.warn?.("model over capacity, backing off", {
+					issueNumber: payload.issueNumber,
+					attempt,
+					delayMs,
+					error: String(error),
+				}),
+		},
+	);
 	log.info("classified reply", {
 		issueNumber: payload.issueNumber,
 		classification: data.classification,

--- a/.flue/workflows/investigate.ts
+++ b/.flue/workflows/investigate.ts
@@ -37,6 +37,7 @@ import { createAgent, type FlueContext } from "@flue/runtime";
 import { local } from "@flue/runtime/node";
 import * as v from "valibot";
 
+import { withCapacityRetry } from "../lib/capacity.js";
 import { issueClassificationSchema, type IssueClassification } from "../lib/classifier.js";
 // Skill imports. Each is bundled as a SkillReference by the Flue build
 // and works the same on Node (this workflow runs on GH Actions) or
@@ -184,7 +185,7 @@ interface InvestigateResult {
 // correct `area` instead of guessing. Without it, kimi spends most of
 // its budget reasoning about what EmDash is and where a bug lives.
 const classifierAgent = createAgent(() => ({
-	model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6",
+	model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code",
 	instructions: [
 		"You classify GitHub issues for the EmDash CMS investigation bot. Output strictly matches the requested schema.",
 		"",
@@ -370,26 +371,54 @@ async function runImpl({
 	// couldn't be carried out rather than getting a silent no-op.
 	const directed = Boolean(payload.maintainerDirective);
 
+	// Every model-bearing stage goes through this: it bounds each attempt with a
+	// hard timeout (so a stalled Workers AI call fails loudly instead of hanging
+	// the run) and retries genuine capacity (429) errors with backoff. Workers AI
+	// returns 429 under load, which is why the classifier and fix stages (kimi)
+	// are the most exposed.
+	const withRetry = <T>(
+		label: string,
+		fn: (signal: AbortSignal) => PromiseLike<T>,
+		perAttemptTimeoutMs: number,
+	): Promise<T> =>
+		withCapacityRetry(fn, {
+			label: `${label}#${payload.issueNumber}`,
+			attempts: 3,
+			perAttemptTimeoutMs,
+			onRetry: ({ attempt, delayMs, error }) =>
+				log.warn?.(`${label}: model over capacity, backing off`, {
+					issueNumber: payload.issueNumber,
+					attempt,
+					delayMs,
+					error: String(error),
+				}),
+		});
+
 	// --- Stage 0: classify ---
 
 	const classifierHarness = await init(classifierAgent, { name: "classify" });
 	const classifierSession = await classifierHarness.session();
-	const { data: classification } = await classifierSession.prompt(
-		[
-			"Classify the following EmDash issue.",
-			"",
-			issueContext(payload),
-			"",
-			"## Decide",
-			"",
-			"- kind: bug | enhancement | documentation | question",
-			"- area: api | admin | public | migration | build | other",
-			"- requiresBrowser: true for admin/public bugs, false otherwise",
-			"- summary: one factual sentence describing the reported behaviour",
-			"",
-			"Return strictly the requested schema. No prose outside it.",
-		].join("\n"),
-		{ result: issueClassificationSchema },
+	const { data: classification } = await withRetry(
+		"classify",
+		(signal) =>
+			classifierSession.prompt(
+				[
+					"Classify the following EmDash issue.",
+					"",
+					issueContext(payload),
+					"",
+					"## Decide",
+					"",
+					"- kind: bug | enhancement | documentation | question",
+					"- area: api | admin | public | migration | build | other",
+					"- requiresBrowser: true for admin/public bugs, false otherwise",
+					"- summary: one factual sentence describing the reported behaviour",
+					"",
+					"Return strictly the requested schema. No prose outside it.",
+				].join("\n"),
+				{ result: issueClassificationSchema, signal },
+			),
+		90_000,
 	);
 	log.info("classified", { issueNumber: payload.issueNumber, ...classification });
 
@@ -415,13 +444,19 @@ async function runImpl({
 	const investigatorSession = await investigatorHarness.session();
 
 	const reproduceSkill = pickReproduceSkill(classification.area);
-	const { data: reproduce } = await investigatorSession.skill(reproduceSkill, {
-		args: {
-			issueContext: issueContext(payload),
-			classification,
-		},
-		result: reproduceResultSchema,
-	});
+	const { data: reproduce } = await withRetry(
+		"reproduce",
+		(signal) =>
+			investigatorSession.skill(reproduceSkill, {
+				args: {
+					issueContext: issueContext(payload),
+					classification,
+				},
+				result: reproduceResultSchema,
+				signal,
+			}),
+		12 * 60_000,
+	);
 	log.info("reproduce", {
 		issueNumber: payload.issueNumber,
 		reproduced: reproduce.reproduced,
@@ -449,14 +484,20 @@ async function runImpl({
 	// --- Stage 2: diagnose (runs even if reproduce failed; the body alone
 	// is often enough to point at the code path, with lower confidence). ---
 
-	const { data: diagnoseOut } = await investigatorSession.skill(diagnose, {
-		args: {
-			issueContext: issueContext(payload),
-			classification,
-			reproduce,
-		},
-		result: diagnoseResultSchema,
-	});
+	const { data: diagnoseOut } = await withRetry(
+		"diagnose",
+		(signal) =>
+			investigatorSession.skill(diagnose, {
+				args: {
+					issueContext: issueContext(payload),
+					classification,
+					reproduce,
+				},
+				result: diagnoseResultSchema,
+				signal,
+			}),
+		12 * 60_000,
+	);
 	log.info("diagnose", {
 		issueNumber: payload.issueNumber,
 		confidence: diagnoseOut.confidence,
@@ -464,14 +505,20 @@ async function runImpl({
 
 	// --- Stage 3: verify ---
 
-	const { data: verifyOut } = await investigatorSession.skill(verify, {
-		args: {
-			issueContext: issueContext(payload),
-			classification,
-			diagnose: diagnoseOut,
-		},
-		result: verifyResultSchema,
-	});
+	const { data: verifyOut } = await withRetry(
+		"verify",
+		(signal) =>
+			investigatorSession.skill(verify, {
+				args: {
+					issueContext: issueContext(payload),
+					classification,
+					diagnose: diagnoseOut,
+				},
+				result: verifyResultSchema,
+				signal,
+			}),
+		12 * 60_000,
+	);
 	log.info("verify", { issueNumber: payload.issueNumber, verdict: verifyOut.verdict });
 
 	if (verifyOut.verdict === "intended-behavior" && !directed) {
@@ -585,15 +632,21 @@ async function runImpl({
 	// what the orchestrator commits.
 	const fixHarness = await init(fixAgent, { name: "fix" });
 	const fixSession = await fixHarness.session();
-	const { data: fixOut } = await fixSession.skill(fix, {
-		args: {
-			issueContext: issueContext(payload),
-			classification,
-			reproduce,
-			diagnose: diagnoseOut,
-		},
-		result: fixResultSchema,
-	});
+	const { data: fixOut } = await withRetry(
+		"fix",
+		(signal) =>
+			fixSession.skill(fix, {
+				args: {
+					issueContext: issueContext(payload),
+					classification,
+					reproduce,
+					diagnose: diagnoseOut,
+				},
+				result: fixResultSchema,
+				signal,
+			}),
+		12 * 60_000,
+	);
 	log.info("fix", { issueNumber: payload.issueNumber, fixed: fixOut.fixed });
 
 	if (!fixOut.fixed) {

--- a/infra/flue-review/.flue/lib/capacity.ts
+++ b/infra/flue-review/.flue/lib/capacity.ts
@@ -1,0 +1,160 @@
+// Graceful handling for Workers AI capacity (HTTP 429) errors and stalled
+// inference calls.
+//
+// Workers AI returns 429 when a model is over capacity. Under sustained load
+// the binding can also hold a request open well past any useful deadline, which
+// (without a bound) leaves a review workflow hung forever -- the agent call
+// never returns, nothing posts, and the only artifact is the container DO's
+// keep-alive alarm firing for minutes. `withCapacityRetry` bounds each attempt
+// with a hard timeout (so a stalled call fails loudly instead of hanging) and
+// retries genuine capacity errors with exponential backoff + jitter.
+//
+// `ModelConfig` in @flue/runtime is just a model-id string, so there is no
+// provider-level retry/timeout knob to set; this is the application-level
+// contract. The wrapped call receives an AbortSignal it must forward to the
+// model call (`session.skill(..., { signal })`) for the timeout to take effect.
+
+/** Thrown when every attempt was exhausted by capacity errors. */
+export class CapacityExhaustedError extends Error {
+	constructor(label: string, attempts: number, cause: unknown) {
+		super(`${label}: model over capacity after ${attempts} attempt(s)`, { cause });
+		this.name = "CapacityExhaustedError";
+	}
+}
+
+/** Thrown when a single attempt exceeded its per-attempt timeout. */
+export class ModelTimeoutError extends Error {
+	constructor(label: string, timeoutMs: number, cause: unknown) {
+		super(`${label}: model call exceeded ${timeoutMs}ms timeout`, { cause });
+		this.name = "ModelTimeoutError";
+	}
+}
+
+export interface CapacityRetryOptions {
+	/** Human-readable label for logs/errors, e.g. "review" or "classify-reply". */
+	label: string;
+	/** Total attempts including the first. Default 3. */
+	attempts?: number;
+	/**
+	 * Hard per-attempt deadline. On expiry the attempt is aborted and a
+	 * `ModelTimeoutError` is thrown (NOT retried -- a timeout can't be told apart
+	 * from slow-but-working progress, so we fail loudly and bounded rather than
+	 * burning the full attempt budget). Omit to disable the timeout.
+	 */
+	perAttemptTimeoutMs?: number;
+	/** Base backoff delay. Default 3000ms. */
+	baseDelayMs?: number;
+	/** Backoff ceiling. Default 30000ms. */
+	maxDelayMs?: number;
+	/** Caller cancellation, merged with the per-attempt timeout signal. */
+	signal?: AbortSignal;
+	/** Invoked before each backoff sleep. */
+	onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
+}
+
+const CAPACITY_MARKERS = [
+	"429",
+	"too many requests",
+	"capacity",
+	"over capacity",
+	"rate limit",
+	"overloaded",
+	"3040", // Workers AI "Capacity temporarily exceeded" code
+];
+
+/** Best-effort classification of a Workers AI / gateway capacity (429) error. */
+export function isCapacityError(error: unknown): boolean {
+	const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+	return CAPACITY_MARKERS.some((marker) => message.includes(marker));
+}
+
+function isTimeoutAbort(error: unknown, timeoutSignal: AbortSignal | undefined): boolean {
+	if (!timeoutSignal?.aborted) return false;
+	return (
+		(error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) ||
+		// Some SDKs reject with the signal's reason rather than an AbortError.
+		error === timeoutSignal.reason
+	);
+}
+
+function backoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+	const exponential = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+	// Full jitter: random within [0, exponential] to spread retries across many
+	// concurrent callers hammering the same overloaded model.
+	return Math.round(Math.random() * exponential);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal?.reason);
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * Run a model-bearing call with a per-attempt timeout and capacity-aware retry.
+ *
+ * - Capacity (429) errors are retried with exponential backoff + full jitter.
+ * - A per-attempt timeout aborts a stalled call and throws `ModelTimeoutError`
+ *   (loud, bounded -- the workflow's at-least-once restart handles re-running).
+ * - Any other error is rethrown immediately.
+ *
+ * @param fn receives the per-attempt `AbortSignal`; forward it to the model call.
+ *   Returns a `PromiseLike` so Flue's awaitable `CallHandle` can be passed through
+ *   directly (`session.skill(..., { signal })`).
+ */
+export async function withCapacityRetry<T>(
+	fn: (signal: AbortSignal) => PromiseLike<T>,
+	options: CapacityRetryOptions,
+): Promise<T> {
+	const attempts = options.attempts ?? 3;
+	const baseDelayMs = options.baseDelayMs ?? 3000;
+	const maxDelayMs = options.maxDelayMs ?? 30000;
+
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		const timeoutSignal =
+			options.perAttemptTimeoutMs !== undefined
+				? AbortSignal.timeout(options.perAttemptTimeoutMs)
+				: undefined;
+		const signals = [options.signal, timeoutSignal].filter(
+			(s): s is AbortSignal => s !== undefined,
+		);
+		const signal =
+			signals.length > 1 ? AbortSignal.any(signals) : (signals[0] ?? new AbortController().signal);
+
+		try {
+			return await fn(signal);
+		} catch (error) {
+			lastError = error;
+
+			// A per-attempt timeout: fail loudly, do not retry.
+			if (isTimeoutAbort(error, timeoutSignal)) {
+				throw new ModelTimeoutError(options.label, options.perAttemptTimeoutMs ?? 0, error);
+			}
+			// Caller cancellation: propagate untouched.
+			if (options.signal?.aborted) throw error;
+			// Non-capacity error: not our concern, rethrow.
+			if (!isCapacityError(error)) throw error;
+			// Capacity error on the final attempt: give up loudly.
+			if (attempt === attempts) break;
+
+			const delayMs = backoffDelay(attempt, baseDelayMs, maxDelayMs);
+			options.onRetry?.({ attempt, delayMs, error });
+			await sleep(delayMs, options.signal);
+		}
+	}
+
+	throw new CapacityExhaustedError(options.label, attempts, lastError);
+}

--- a/infra/flue-review/.flue/workflows/review.ts
+++ b/infra/flue-review/.flue/workflows/review.ts
@@ -17,6 +17,7 @@ import { getSandbox, type Sandbox } from "@cloudflare/sandbox";
 import { createAgent, type FlueContext, type WorkflowRouteHandler } from "@flue/runtime";
 import { cfSandboxToSessionEnv } from "@flue/runtime/cloudflare";
 
+import { withCapacityRetry } from "../lib/capacity.js";
 import {
 	readAppCreds,
 	mintInstallationToken,
@@ -171,17 +172,38 @@ export async function run(ctx: FlueContext<ReviewPayload, Env>): Promise<ReviewR
 			);
 		}
 
-		const { data } = await session.skill(review, {
-			args: {
-				prContext: buildPrContext(payload, priorReview),
-				owner: payload.owner,
-				repo: payload.repo,
-				prNumber: payload.prNumber,
-				baseRef: payload.baseRef,
-				headRef: payload.headRef,
+		// Workers AI returns 429 when kimi is over capacity, and under sustained
+		// load the binding can hold the request open indefinitely. Bound each
+		// attempt and retry genuine capacity errors so a transient spike doesn't
+		// silently hang the review forever (it used to: no result, no post, just
+		// the container's keep-alive alarm firing for minutes).
+		const { data } = await withCapacityRetry(
+			(signal) =>
+				session.skill(review, {
+					args: {
+						prContext: buildPrContext(payload, priorReview),
+						owner: payload.owner,
+						repo: payload.repo,
+						prNumber: payload.prNumber,
+						baseRef: payload.baseRef,
+						headRef: payload.headRef,
+					},
+					result: reviewResultSchema,
+					signal,
+				}),
+			{
+				label: `review#${payload.prNumber}`,
+				attempts: 3,
+				perAttemptTimeoutMs: 6 * 60_000,
+				onRetry: ({ attempt, delayMs, error }) =>
+					ctx.log.warn?.("[review] model over capacity, backing off", {
+						prNumber: payload.prNumber,
+						attempt,
+						delayMs,
+						error: String(error),
+					}),
 			},
-			result: reviewResultSchema,
-		});
+		);
 
 		// Post from this trusted DO context (durable, not bound by the webhook's
 		// 30s waitUntil budget). In dev (no creds) we just log and return.


### PR DESCRIPTION
## What does this PR do?

Fixes the regression where the automated PR reviewer (`emdash-flue-review`) stopped posting reviews around #1484, with no deploy and no error in logs.

**Root cause:** Workers AI returns HTTP 429 when a model is over capacity. We confirmed sustained 429s on `@cf/moonshotai/kimi-k2.6` (and, to a lesser extent, 2.7). Under load the AI binding can hold a request open indefinitely, so the review workflow's `session.skill` call never returned: no result, no posted review, just the Sandbox container's keep-alive alarm firing for minutes. There was no timeout or capacity handling anywhere, so a transient capacity spike turned into a permanent silent hang.

Changes:

- **Move every kimi usage to `kimi-k2.7-code`** (less loaded right now): the review agent, the fix agent, both reply classifiers, and the investigate classifier. (`/bonk`/`/review` kimi alias already moved in #1485.)
- **Add `withCapacityRetry`** (one copy per flue deploy unit, since `.flue` and `infra/flue-review` are independent workspaces): bounds each model call with a hard per-attempt timeout so a stalled call fails loudly instead of hanging, and retries genuine 429 capacity errors with exponential backoff + full jitter. Per-attempt timeouts are intentionally *not* retried (can't distinguish a stall from slow-but-working progress) — they fail loud and bounded, and the workflow's at-least-once restart handles re-running.
- **Apply it** to the flue-review review skill and to every model-bearing stage of the investigate/classify workflows.

Note: `ModelConfig` in `@flue/runtime` is just a model-id string, so there's no provider-level retry/timeout knob — this is the application-level contract.

Verified by live `wrangler tail` of `emdash-flue-review`: the pipeline is healthy through git checkout and `git diff`, then goes silent at the (kimi) inference call with zero exceptions — consistent with a held-open 429.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- tsc --noEmit clean in both infra/flue-review and .flue (after wrangler types) -->
- [x] `pnpm lint` passes <!-- oxfmt clean on changed files -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: no test harness for the flue automation workspaces -->
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a: see above -->
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI -->
- [ ] I have added a changeset (if this PR changes a published package) <!-- n/a: flue automation/infra, no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

`tsc --noEmit` clean in `infra/flue-review` (after `wrangler types`) and `.flue`; oxfmt clean on all changed files.