### PR TITLE
i18n(zh-CN): Updated and corrected the Simplified Chinese translation.

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -164,7 +164,7 @@ msgstr "{0, plural, one {# 位用户} other {# 位用户}}"
 #. placeholder {0}: fields.length
 #: packages/admin/src/components/ContentTypeEditor.tsx:576
 msgid "{0, plural, one {field} other {fields}}"
-msgstr "{0} 个字段"
+msgstr "{0, plural, one {# 个字段} other {# 个字段}}"
 
 #. placeholder {0}: envLabel(m.key)
 #. placeholder {1}: m.required
@@ -686,7 +686,7 @@ msgstr "添加小部件区域"
 
 #: packages/admin/src/components/settings/SocialSettings.tsx:128
 msgid "Add your social media profiles. These are available to your site's theme and can be displayed in headers, footers, or author bios."
-msgstr "添加您的社交媒体资料。这些可供您网站的主题使用，并可以显示在页眉、页脚或作者简介中。"
+msgstr "添加您的社交媒体资料。这些可供您站点的主题使用，并可以显示在页眉、页脚或作者简介中。"
 
 #: packages/admin/src/components/MenuEditor.tsx:362
 #: packages/admin/src/components/settings/AllowedDomainsSettings.tsx:344
@@ -734,7 +734,7 @@ msgstr "全部"
 #: packages/admin/src/components/ContentList.tsx:587
 #: packages/admin/src/components/ContentList.tsx:591
 msgid "All authors"
-msgstr ""
+msgstr "所有作者"
 
 #: packages/admin/src/routes/bylines.tsx:406
 msgid "All bylines"
@@ -858,7 +858,7 @@ msgstr "发生意外错误。"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:217
 msgid "An unknown error occurred"
-msgstr "发生了未知错误"
+msgstr "发生了未知错误。"
 
 #: packages/admin/src/components/WordPressImport.tsx:1414
 msgid "Analyzing export file..."
@@ -923,7 +923,7 @@ msgstr "已归档"
 
 #: packages/admin/src/components/ContentList.tsx:546
 msgid "Archived"
-msgstr ""
+msgstr "已归档"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:65
 msgid "Archives"
@@ -958,7 +958,7 @@ msgstr "将 WordPress 作者分配给 EmDash 用户。文章将归属于所选�
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:28
 msgid "Astro"
-msgstr ""
+msgstr "Astro"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:66
 #: packages/admin/src/components/MediaLibrary.tsx:396
@@ -1062,7 +1062,7 @@ msgstr "可用小部件"
 #: packages/admin/src/components/BylineAvatarField.tsx:46
 #: packages/admin/src/components/BylineAvatarField.tsx:71
 msgid "Avatar"
-msgstr ""
+msgstr "头像"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:257
 #: packages/admin/src/components/MenuEditor.tsx:283
@@ -1112,7 +1112,7 @@ msgstr "返回主题列表"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:29
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: packages/admin/src/components/settings/EmailSettings.tsx:219
 msgid "Before send:"
@@ -1128,7 +1128,7 @@ msgstr "简介"
 
 #: packages/admin/src/components/editor/DragHandleWrapper.tsx:125
 msgid "Block actions - drag to reorder, click for menu"
-msgstr "操作块 - 拖动重新排序，点击打开菜单"
+msgstr "操作块 —— 拖动重新排序，点击打开菜单"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2627
 #: packages/admin/src/components/PortableTextEditor.tsx:2933
@@ -1185,15 +1185,15 @@ msgstr "署名"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:30
 msgid "C"
-msgstr ""
+msgstr "C"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:32
 msgid "C#"
-msgstr ""
+msgstr "C#"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:31
 msgid "C++"
-msgstr ""
+msgstr "C++"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:25
 msgid "Can create content"
@@ -1327,7 +1327,7 @@ msgstr "更换图片"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:208
 msgid "Change Logo"
-msgstr "更改标志"
+msgstr "更改徽标"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:791
 msgid "Changelog"
@@ -1366,7 +1366,7 @@ msgstr "正在检查认证..."
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:362
 msgid "Checking how many stored values reference \"{0}\"…"
-msgstr "正在检查有多少存储值引用了\\”{0}\\“..."
+msgstr "正在检查有多少存储值引用了 \"{0}\"…"
 
 #: packages/admin/src/components/SetupWizard.tsx:288
 msgid "Choose how to sign in"
@@ -1717,7 +1717,7 @@ msgstr "无法搜索署名。请重试。"
 #. placeholder {0}: deletingField.label
 #: packages/admin/src/routes/byline-schema.tsx:369
 msgid "Couldn't verify how many values reference \"{0}\". Deleting will still remove every stored value for this field — but the count above could not be checked."
-msgstr "无法验证有多少值引用了\\”{0}\\“。删除仍将移除此字段的所有存储值 — 但上方的计数无法被检查。"
+msgstr "无法验证有多少值引用了 \"{0}\"。删除仍将移除此字段的所有存储值 — 但上方的计数无法被检查。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:822
 msgid "Count"
@@ -1871,7 +1871,7 @@ msgstr "创建、更新、删除导航菜单"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:76
 msgid "Create, update, and delete taxonomy terms"
-msgstr "创建、更新、删除分类术语"
+msgstr "创建、更新、删除分类词条"
 
 #: packages/admin/src/components/settings/ApiTokenSettings.tsx:51
 msgid "Create, update, delete content"
@@ -1885,7 +1885,7 @@ msgstr "已创建"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:96
 msgid "Created \"{0}\"."
-msgstr "已创建\\”{0}\\“。"
+msgstr "已创建 \"{0}\"."
 
 #. placeholder {0}: new Date(cred.createdAt).toLocaleDateString()
 #. placeholder {0}: new Date(token.createdAt).toLocaleDateString()
@@ -1924,7 +1924,7 @@ msgstr "创建中..."
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:33
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: packages/admin/src/components/TranslationsPanel.tsx:78
 msgid "current"
@@ -1982,7 +1982,7 @@ msgstr "日期和时间选择器"
 
 #: packages/admin/src/components/ContentList.tsx:604
 msgid "Date field to filter on"
-msgstr ""
+msgstr "用于筛选的日期字段"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:304
 msgid "Date Format"
@@ -2183,7 +2183,7 @@ msgstr "已删除"
 #. placeholder {1}: deleteUsageQuery.data.totalAffectedRows
 #: packages/admin/src/routes/byline-schema.tsx:371
 msgid "Deleting \"{0}\" will also remove {1, plural, one {# stored value} other {# stored values}} across all bylines. This cannot be undone."
-msgstr "删除\\”{0}\\“将同时移除所有署名中的 {1, plural, one {# 个存储值} other {# 个存储值}}。此操作无法撤销。"
+msgstr "删除 \"{0}\" 将同时移除所有署名中的 {1, plural, one {# 个存储值} other {# 个存储值}}。此操作无法撤销。"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:408
 #: packages/admin/src/components/ContentTypeEditor.tsx:664
@@ -2284,7 +2284,7 @@ msgstr "未收到邮件？"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:34
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:176
 msgid "Dimensions:"
@@ -2378,7 +2378,7 @@ msgstr "分隔线"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:35
 msgid "Dockerfile"
-msgstr ""
+msgstr "Dockerfile"
 
 #: packages/admin/src/components/AllowedTypesEditor.tsx:63
 #: packages/admin/src/components/MediaLibrary.tsx:397
@@ -2845,7 +2845,7 @@ msgstr "与插件通信失败"
 
 #: packages/admin/src/lib/api/media.ts:151
 msgid "Failed to confirm upload"
-msgstr ""
+msgstr "确认上传失败"
 
 #: packages/admin/src/components/SetupWizard.tsx:493
 msgid "Failed to create admin"
@@ -2865,7 +2865,7 @@ msgstr "创建字段失败"
 
 #: packages/admin/src/lib/api/sections.ts:88
 msgid "Failed to create section"
-msgstr ""
+msgstr "创建分区失败"
 
 #: packages/admin/src/components/WordPressImport.tsx:1553
 msgid "Failed to create some collections"
@@ -2873,7 +2873,7 @@ msgstr "创建部分合集失败"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:493
 msgid "Failed to create term"
-msgstr "创建分类项失败"
+msgstr "创建词条失败"
 
 #: packages/admin/src/router.tsx:975
 msgid "Failed to create translation"
@@ -2945,7 +2945,7 @@ msgstr "删除分区失败"
 
 #: packages/admin/src/lib/api/taxonomies.ts:201
 msgid "Failed to delete term"
-msgstr "删除术语失败"
+msgstr "删除词条失败"
 
 #: packages/admin/src/lib/api/widgets.ts:146
 msgid "Failed to delete widget"
@@ -2962,7 +2962,7 @@ msgstr "禁用插件失败"
 
 #: packages/admin/src/lib/api/search.ts:32
 msgid "Failed to disable search"
-msgstr ""
+msgstr "禁用搜索失败"
 
 #: packages/admin/src/lib/api/users.ts:118
 msgid "Failed to disable user"
@@ -2987,7 +2987,7 @@ msgstr "启用插件失败"
 
 #: packages/admin/src/lib/api/search.ts:31
 msgid "Failed to enable search"
-msgstr ""
+msgstr "启用搜索失败"
 
 #: packages/admin/src/lib/api/users.ts:138
 msgid "Failed to enable user"
@@ -2999,7 +2999,7 @@ msgstr "执行导入失败"
 
 #: packages/admin/src/lib/api/client.ts:227
 msgid "Failed to fetch auth mode"
-msgstr ""
+msgstr "获取认证模式失败"
 
 #: packages/admin/src/lib/api/schema.ts:170
 #: packages/admin/src/lib/api/schema.ts:174
@@ -3008,15 +3008,15 @@ msgstr "获取合集失败"
 
 #: packages/admin/src/lib/api/dashboard.ts:41
 msgid "Failed to fetch dashboard stats"
-msgstr ""
+msgstr "获取仪表盘统计数据失败"
 
 #: packages/admin/src/lib/api/email-settings.ts:34
 msgid "Failed to fetch email settings"
-msgstr ""
+msgstr "获取邮件设置失败"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:90
 msgid "Failed to fetch entry terms"
-msgstr "获取条目术语失败"
+msgstr "获取条目词条失败"
 
 #: packages/admin/src/lib/api/client.ts:210
 msgid "Failed to fetch manifest"
@@ -3024,15 +3024,15 @@ msgstr "获取清单失败"
 
 #: packages/admin/src/lib/api/media.ts:72
 msgid "Failed to fetch media"
-msgstr ""
+msgstr "获取媒体失败"
 
 #: packages/admin/src/lib/api/media.ts:85
 msgid "Failed to fetch media item"
-msgstr ""
+msgstr "获取媒体项失败"
 
 #: packages/admin/src/lib/api/media.ts:317
 msgid "Failed to fetch media providers"
-msgstr ""
+msgstr "获取媒体提供者失败"
 
 #: packages/admin/src/lib/api/plugins.ts:59
 #: packages/admin/src/lib/api/plugins.ts:63
@@ -3041,11 +3041,11 @@ msgstr "获取插件失败"
 
 #: packages/admin/src/lib/api/plugins.ts:45
 msgid "Failed to fetch plugins"
-msgstr ""
+msgstr "获取插件失败"
 
 #: packages/admin/src/lib/api/media.ts:347
 msgid "Failed to fetch provider media"
-msgstr ""
+msgstr "获取提供者媒体失败"
 
 #: packages/admin/src/lib/api/content.ts:556
 #: packages/admin/src/lib/api/content.ts:561
@@ -3054,15 +3054,15 @@ msgstr "获取版本失败"
 
 #: packages/admin/src/lib/api/sections.ts:76
 msgid "Failed to fetch section"
-msgstr ""
+msgstr "获取分区失败"
 
 #: packages/admin/src/lib/api/sections.ts:68
 msgid "Failed to fetch sections"
-msgstr ""
+msgstr "获取分区列表失败"
 
 #: packages/admin/src/lib/api/settings.ts:50
 msgid "Failed to fetch settings"
-msgstr ""
+msgstr "获取设置失败"
 
 #: packages/admin/src/components/SetupWizard.tsx:446
 msgid "Failed to fetch setup status"
@@ -3070,7 +3070,7 @@ msgstr "获取设置状态失败"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:71
 msgid "Failed to fetch terms"
-msgstr "获取术语失败"
+msgstr "获取词条失败"
 
 #: packages/admin/src/lib/api/current-user.ts:22
 #: packages/admin/src/lib/api/users.ts:88
@@ -3098,7 +3098,7 @@ msgstr "获取注册选项失败"
 
 #: packages/admin/src/lib/api/media.ts:127
 msgid "Failed to get upload URL"
-msgstr ""
+msgstr "获取上传 URL 失败"
 
 #: packages/admin/src/components/WordPressImport.tsx:386
 msgid "Failed to import from WordPress"
@@ -3283,7 +3283,7 @@ msgstr "发送验证邮件失败"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:113
 msgid "Failed to set entry terms"
-msgstr "设置条目术语失败"
+msgstr "设置条目词条失败"
 
 #: packages/admin/src/lib/api/marketplace.ts:192
 #: packages/admin/src/lib/api/registry.ts:831
@@ -3317,7 +3317,7 @@ msgstr "更新域名失败"
 
 #: packages/admin/src/lib/api/media.ts:272
 msgid "Failed to update media"
-msgstr ""
+msgstr "更新媒体失败"
 
 #: packages/admin/src/lib/api/marketplace.ts:176
 #: packages/admin/src/lib/api/registry.ts:763
@@ -3326,11 +3326,11 @@ msgstr "更新插件失败"
 
 #: packages/admin/src/lib/api/sections.ts:100
 msgid "Failed to update section"
-msgstr ""
+msgstr "更新分区失败"
 
 #: packages/admin/src/lib/api/settings.ts:64
 msgid "Failed to update settings"
-msgstr ""
+msgstr "更新设置失败"
 
 #: packages/admin/src/router.tsx:1231
 msgid "Failed to update status"
@@ -3342,11 +3342,11 @@ msgstr "上传文件失败"
 
 #: packages/admin/src/lib/api/media.ts:214
 msgid "Failed to upload media"
-msgstr ""
+msgstr "上传媒体失败"
 
 #: packages/admin/src/lib/api/media.ts:369
 msgid "Failed to upload to provider"
-msgstr ""
+msgstr "上传到提供者失败"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:250
 msgid "Failed to verify authentication"
@@ -3442,7 +3442,7 @@ msgstr "文件已导入"
 
 #: packages/admin/src/components/ContentList.tsx:583
 msgid "Filter by author"
-msgstr ""
+msgstr "按作者筛选"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:113
 msgid "Filter by capability"
@@ -3492,7 +3492,7 @@ msgstr "为获得最佳导入体验，请安装"
 
 #: packages/admin/src/components/ContentList.tsx:620
 msgid "From date"
-msgstr ""
+msgstr "起始日期"
 
 #: packages/admin/src/components/users/roleDefinitions.ts:43
 msgid "Full access"
@@ -3529,7 +3529,7 @@ msgstr "为此通行密钥命名以便日后识别。"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:36
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: packages/admin/src/components/WordPressImport.tsx:2224
 #: packages/admin/src/router.tsx:1957
@@ -3542,7 +3542,7 @@ msgstr "Google 验证"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:37
 msgid "GraphQL"
-msgstr ""
+msgstr "GraphQL"
 
 #: packages/admin/src/components/MediaLibrary.tsx:270
 msgid "Grid view"
@@ -3832,7 +3832,7 @@ msgstr "插入水平线"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3137
 msgid "Insert HTML"
-msgstr ""
+msgstr "插入 HTML"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:3126
 msgid "Insert Image"
@@ -3963,11 +3963,11 @@ msgstr "张三"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:39
 msgid "Java"
-msgstr ""
+msgstr "Java"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:40
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:235
 msgid "Job title"
@@ -3984,7 +3984,7 @@ msgstr "JSON"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:42
 msgid "JSX"
-msgstr ""
+msgstr "JSX"
 
 #: packages/admin/src/components/ContentEditor.tsx:1930
 msgid "Keep typing to narrow down more bylines."
@@ -3998,7 +3998,7 @@ msgstr "关键词"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:43
 msgid "Kotlin"
-msgstr ""
+msgstr "Kotlin"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:232
 #: packages/admin/src/components/FieldEditor.tsx:411
@@ -4251,11 +4251,11 @@ msgstr "退出登录"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:182
 #: packages/admin/src/components/settings/GeneralSettings.tsx:188
 msgid "Logo"
-msgstr "标志"
+msgstr "徽标"
 
 #: packages/admin/src/components/WordPressImport.tsx:1668
 msgid "Logo & favicon"
-msgstr "标志和网站图标"
+msgstr "徽标和网站图标"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:53
 msgid "Long text"
@@ -4341,7 +4341,7 @@ msgstr "标记为垃圾"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:44
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 #: packages/admin/src/components/PluginManager.tsx:201
 msgid "marketplace"
@@ -4368,7 +4368,7 @@ msgstr "最大值"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:45
 msgid "MDX"
-msgstr ""
+msgstr "MDX"
 
 #: packages/admin/src/components/PortableTextEditor.tsx:2119
 #: packages/admin/src/components/Sidebar.tsx:342
@@ -4424,7 +4424,7 @@ msgstr "菜单"
 #. placeholder {1}: translated.locale.toUpperCase()
 #: packages/admin/src/components/MenuEditor.tsx:90
 msgid "Menu \"{0}\" ({1}) created."
-msgstr "菜单 \"{0}\"（{1}）已创建。"
+msgstr "菜单 \"{0}\" ({1}) 已创建。"
 
 #. placeholder {0}: menu.label
 #: packages/admin/src/components/MenuList.tsx:55
@@ -4525,12 +4525,12 @@ msgstr "最受欢迎"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:439
 msgid "Move \"{0}\" down"
-msgstr ""
+msgstr "将 \"{0}\" 下移"
 
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:429
 msgid "Move \"{0}\" up"
-msgstr ""
+msgstr "将 \"{0}\" 上移"
 
 #: packages/admin/src/components/ContentList.tsx:845
 msgid "Move \"{title}\" to trash? You can restore it later."
@@ -4925,7 +4925,7 @@ msgstr "无结果"
 #: packages/admin/src/components/ContentList.tsx:363
 #: packages/admin/src/components/ContentList.tsx:382
 msgid "No results for \"{activeSearch}\""
-msgstr "msgstr “没有\\”{activeSearch}\\“的搜索结果”"
+msgstr "没有 \"{activeSearch}\"的搜索结果"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:176
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:152
@@ -5250,7 +5250,7 @@ msgstr "权限"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:46
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 #: packages/admin/src/components/SetupWizard.tsx:290
 msgid "Pick any method to create your admin account."
@@ -5264,7 +5264,7 @@ msgstr "普通"
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:27
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:120
 msgid "Plain text"
-msgstr ""
+msgstr "纯文本"
 
 #: packages/admin/src/components/InviteAcceptPage.tsx:133
 msgid "Please ask your administrator to send a new invite."
@@ -5288,7 +5288,7 @@ msgstr "插件"
 
 #: packages/admin/src/lib/api/plugins.ts:57
 msgid "Plugin \"{pluginId}\" not found"
-msgstr ""
+msgstr "插件 \"{pluginId}\" 未找到"
 
 #: packages/admin/src/components/RegistryPluginDetail.tsx:747
 msgid "Plugin details"
@@ -5350,7 +5350,7 @@ msgstr "插件已更新"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:34
 msgid "Plugin widget error"
-msgstr ""
+msgstr "插件组件错误"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:219
 #: packages/admin/src/components/PluginManager.tsx:135
@@ -5367,7 +5367,7 @@ msgstr "如果此页面是从另一个 URL 复制的，则引导搜索引擎到�
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:389
 msgid "Post"
-msgstr ""
+msgstr "文章"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:397
 #: packages/admin/src/components/WordPressImport.tsx:1161
@@ -5467,7 +5467,7 @@ msgstr "发布者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:47
 msgid "Python"
-msgstr ""
+msgstr "Python"
 
 #: packages/admin/src/components/ContentEditor.tsx:2000
 msgid "Quick create byline"
@@ -5715,7 +5715,7 @@ msgstr "请求新链接"
 
 #: packages/admin/src/lib/api/client.ts:198
 msgid "Request failed"
-msgstr ""
+msgstr "请求失败"
 
 #: packages/admin/src/components/BylineFieldEditor.tsx:280
 #: packages/admin/src/components/ContentTypeEditor.tsx:721
@@ -5861,11 +5861,11 @@ msgstr "角色标签"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:48
 msgid "Ruby"
-msgstr ""
+msgstr "Ruby"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:49
 msgid "Rust"
-msgstr ""
+msgstr "Rust"
 
 #: packages/admin/src/components/MenuEditor.tsx:351
 #: packages/admin/src/components/MenuEditor.tsx:353
@@ -5936,7 +5936,7 @@ msgstr "已保存"
 #. placeholder {0}: field.label
 #: packages/admin/src/routes/byline-schema.tsx:116
 msgid "Saved \"{0}\"."
-msgstr ""
+msgstr "已保存 \"{0}\"."
 
 #: packages/admin/src/components/ContentEditor.tsx:650
 #: packages/admin/src/components/ContentEditor.tsx:2107
@@ -6055,7 +6055,7 @@ msgstr "截图"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:50
 msgid "SCSS"
-msgstr ""
+msgstr "SCSS"
 
 #: packages/admin/src/components/ContentTypeEditor.tsx:86
 msgid "Search"
@@ -6319,7 +6319,7 @@ msgstr "选择图片"
 #: packages/admin/src/components/settings/GeneralSettings.tsx:229
 #: packages/admin/src/components/settings/GeneralSettings.tsx:336
 msgid "Select Logo"
-msgstr "选择标志"
+msgstr "选择徽标"
 
 #: packages/admin/src/components/BlockKitMediaPickerField.tsx:131
 msgid "Select media"
@@ -6550,7 +6550,7 @@ msgstr "站点标识"
 
 #: packages/admin/src/components/Settings.tsx:70
 msgid "Site identity, logo, favicon, and reading preferences"
-msgstr "网站标识、徽标、网站图标和阅读偏好"
+msgstr "站点标识、徽标、网站图标和阅读偏好"
 
 #: packages/admin/src/components/SetupWizard.tsx:351
 msgid "Site Settings"
@@ -6687,7 +6687,7 @@ msgstr "电子表格"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:51
 msgid "SQL"
-msgstr ""
+msgstr "SQL"
 
 #: packages/admin/src/components/WordPressImport.tsx:1758
 msgid "Start Import"
@@ -6729,11 +6729,11 @@ msgstr "订阅者"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:52
 msgid "Svelte"
-msgstr ""
+msgstr "Svelte"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:53
 msgid "Swift"
-msgstr ""
+msgstr "Swift"
 
 #: packages/admin/src/components/users/UserDetail.tsx:256
 msgid "Synced"
@@ -6780,7 +6780,7 @@ msgstr "目标"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:172
 msgid "Target locale"
-msgstr "目标语言环境"
+msgstr "目标语言区域"
 
 #: packages/admin/src/components/TaxonomySidebar.tsx:537
 msgid "Taxonomies"
@@ -6816,7 +6816,7 @@ msgstr "词条"
 #. placeholder {1}: term.locale.toUpperCase()
 #: packages/admin/src/components/TaxonomyManager.tsx:759
 msgid "Term \"{0}\" created in {1}."
-msgstr "术语 \"{0}\" 已在 {1} 中创建。\"\"术语 \"{0}\" 已在 {1} 中创建。"
+msgstr "词条 \"{0}\" 已在 {1} 中创建。"
 
 #: packages/admin/src/components/TaxonomyManager.tsx:741
 msgid "Term deleted"
@@ -6840,7 +6840,7 @@ msgstr "现有合集包含类型不兼容的字段。"
 
 #: packages/admin/src/components/ContentTypeList.tsx:58
 msgid "The following tables contain content but aren't registered as collections. Register them to manage this content in the admin."
-msgstr "以下表格包含内容但未注册为合集。注册它们以便在管理中管理此内容。"
+msgstr "以下表格包含内容但未注册为合集。注册它们以便在管理后台中管理此内容。"
 
 #: packages/admin/src/components/users/InviteUserModal.tsx:181
 msgid "The invited user will have this role once they complete registration."
@@ -6869,7 +6869,7 @@ msgstr "您查找的页面不存在。"
 
 #: packages/admin/src/components/PluginFieldErrorBoundary.tsx:37
 msgid "The plugin field widget failed to render."
-msgstr ""
+msgstr "插件字段组件渲染失败。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:172
 msgid "The public URL of your site (used for canonical links and sitemaps)"
@@ -6881,7 +6881,7 @@ msgstr "引用的图片已不可用。请选择新图片或移除该引用。"
 
 #: packages/admin/src/components/settings/GeneralSettings.tsx:197
 msgid "The referenced logo is no longer available. Pick a new one or remove the reference."
-msgstr "引用的标志已不可用。请选择新标志或移除该引用。"
+msgstr "引用的徽标已不可用。请选择新标志或移除该引用。"
 
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:153
 msgid "The theme marketplace is empty. Check back later."
@@ -7047,7 +7047,7 @@ msgstr "标题分隔符"
 
 #: packages/admin/src/components/ContentList.tsx:625
 msgid "to"
-msgstr ""
+msgstr "至"
 
 #: packages/admin/src/components/AdminCommandPalette.tsx:470
 msgid "to close"
@@ -7055,7 +7055,7 @@ msgstr "关闭"
 
 #: packages/admin/src/components/ContentList.tsx:629
 msgid "To date"
-msgstr ""
+msgstr "截止日期"
 
 #: packages/admin/src/components/PluginManager.tsx:203
 msgid "to install plugins, or add them to your astro.config.mjs."
@@ -7085,7 +7085,7 @@ msgstr "令牌名称"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:54
 msgid "TOML"
-msgstr ""
+msgstr "TOML"
 
 #: packages/admin/src/components/WordPressImport.tsx:1116
 msgid "Tools → Export"
@@ -7193,7 +7193,7 @@ msgstr "使用我的数据尝试"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:55
 msgid "TSX"
-msgstr ""
+msgstr "TSX"
 
 #: packages/admin/src/components/editor/BlockMenu.tsx:282
 msgid "Turn into"
@@ -7217,7 +7217,7 @@ msgstr "类型不匹配 ({0})"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:56
 msgid "TypeScript"
-msgstr ""
+msgstr "TypeScript"
 
 #: packages/admin/src/components/MarketplaceBrowse.tsx:131
 #: packages/admin/src/components/ThemeMarketplaceBrowse.tsx:112
@@ -7657,11 +7657,11 @@ msgstr "在 spdx.org 上查看 {license} 许可证"
 
 #: packages/admin/src/components/Redirects.tsx:422
 msgid "Visitors hitting these paths will see an error."
-msgstr "访问这些路径的访问者将看到错误。"
+msgstr "访问这些路径的用户将看到错误。"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:57
 msgid "Vue"
-msgstr ""
+msgstr "Vue"
 
 #: packages/admin/src/components/auth/PasskeyLogin.tsx:180
 #: packages/admin/src/components/auth/PasskeyRegistration.tsx:184
@@ -7814,11 +7814,11 @@ msgstr "WXR 文件"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:58
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: packages/admin/src/components/editor/codeBlockLanguages.ts:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: packages/admin/src/components/users/UserDetail.tsx:236
 #: packages/admin/src/routes/byline-schema.tsx:420


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Updated and corrected the Simplified Chinese translation.

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
