### PR TITLE
feat(sitemap): add SEO image to per-collection sitemaps (<image:image>)

### DIFF
--- a/.changeset/sitemap-image-support.md
+++ b/.changeset/sitemap-image-support.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Adds image entries to per-collection sitemaps. When a content entry has an SEO image, the sitemap now emits it as a Google `<image:image>` entry, helping Google discover and index page images for Google Images.

--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -29,6 +29,12 @@ export interface SitemapContentEntry {
 	 * alternates between siblings.
 	 */
 	translationGroup: string | null;
+	/**
+	 * Stored SEO image reference (`_emdash_seo.seo_image`), or null when
+	 * the entry has no SEO image. The route resolves it to an absolute
+	 * URL and emits it as an `<image:image>` sitemap entry.
+	 */
+	image: string | null;
 }
 
 /** Per-collection sitemap data with entries and URL pattern */
@@ -106,8 +112,9 @@ export async function handleSitemapData(
 					updated_at: string;
 					locale: string;
 					translation_group: string | null;
+					seo_image: string | null;
 				}>`
-					SELECT c.slug, c.id, c.updated_at, c.locale, c.translation_group
+					SELECT c.slug, c.id, c.updated_at, c.locale, c.translation_group, s.seo_image
 					FROM ${sql.ref(tableName)} c
 					LEFT JOIN _emdash_seo s
 						ON s.collection = ${col.slug}
@@ -129,6 +136,7 @@ export async function handleSitemapData(
 						updatedAt: row.updated_at,
 						locale: row.locale,
 						translationGroup: row.translation_group,
+						image: row.seo_image ?? null,
 					});
 				}
 

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -23,6 +23,7 @@ import { getSiteSettingsWithDb } from "#settings/index.js";
 
 import { getI18nConfig, isI18nEnabled } from "../../i18n/config.js";
 import { interpolateUrlPattern, localizePath } from "../../i18n/resolve.js";
+import { buildSeoImageUrl } from "../../seo/media-url.js";
 
 export const prerender = false;
 
@@ -112,8 +113,8 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 		const lines: string[] = ['<?xml version="1.0" encoding="UTF-8"?>'];
 		lines.push(
 			useXhtml
-				? '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
-				: '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+				? '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
+				: '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
 		);
 
 		const writeUrl = async (entry: Entry, siblings: Entry[] | null) => {
@@ -126,6 +127,16 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 			lines.push("  <url>");
 			lines.push(`    <loc>${escapeXml(loc)}</loc>`);
 			lines.push(`    <lastmod>${escapeXml(entry.updatedAt)}</lastmod>`);
+
+			// Google image sitemap extension: advertise the entry's SEO
+			// image (the same "preferred image" used for og:image) so it
+			// can be discovered and indexed for Google Images.
+			if (entry.image) {
+				const imageLoc = buildSeoImageUrl(entry.image, siteUrl);
+				lines.push("    <image:image>");
+				lines.push(`      <image:loc>${escapeXml(imageLoc)}</image:loc>`);
+				lines.push("    </image:image>");
+			}
 
 			if (useXhtml && siblings && siblings.length > 1) {
 				// Emit one xhtml:link per sibling (including self -- Google

--- a/packages/core/src/seo/index.ts
+++ b/packages/core/src/seo/index.ts
@@ -30,6 +30,7 @@
  */
 
 import type { ContentSeo } from "../database/repositories/types.js";
+import { buildSeoImageUrl } from "./media-url.js";
 
 const TRAILING_SLASH_RE = /\/$/;
 const ABSOLUTE_URL_RE = /^https?:\/\//i;
@@ -117,7 +118,7 @@ export function getSeoMeta<T>(content: SeoContentInput<T>, options: SeoMetaOptio
 		null;
 
 	// OG image: SEO image > default
-	const ogImage = seo.image ? buildMediaUrl(seo.image, siteUrl) : (defaultOgImage ?? null);
+	const ogImage = seo.image ? buildSeoImageUrl(seo.image, siteUrl) : (defaultOgImage ?? null);
 
 	// Canonical: explicit > path-based > null
 	let canonical: string | null = null;
@@ -158,31 +159,4 @@ export function getSeoMeta<T>(content: SeoContentInput<T>, options: SeoMetaOptio
  */
 export function getContentSeo<T>(content: SeoContentInput<T>): ContentSeo | undefined {
 	return content.seo ?? content.data.seo;
-}
-
-/**
- * Build a media URL from a media reference ID.
- * If it's already an absolute URL, return as-is.
- */
-function buildMediaUrl(imageRef: string, siteUrl?: string): string {
-	// If already an absolute URL, return as-is
-	if (ABSOLUTE_URL_RE.test(imageRef)) {
-		return imageRef;
-	}
-
-	// Root-relative path — the CMS SEO panel stores seo_image as
-	// "/_emdash/api/media/file/01KS....svg" (already includes the API
-	// prefix). Without this branch we'd re-prefix and produce
-	// "${siteUrl}/_emdash/api/media/file//_emdash/api/media/file/<id>"
-	// which 404s and breaks <meta property="og:image">.
-	if (imageRef.startsWith("/")) {
-		return siteUrl ? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}` : imageRef;
-	}
-
-	// Bare media_id — build the full media API path
-	const mediaPath = `/_emdash/api/media/file/${imageRef}`;
-	if (siteUrl) {
-		return `${siteUrl.replace(TRAILING_SLASH_RE, "")}${mediaPath}`;
-	}
-	return mediaPath;
 }

--- a/packages/core/src/seo/media-url.ts
+++ b/packages/core/src/seo/media-url.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolve a stored SEO image reference to a URL.
+ *
+ * The CMS SEO panel stores `seo_image` in one of these shapes:
+ * - an absolute URL (`https://...`) — returned as-is;
+ * - a root-relative path that already includes the media API prefix
+ *   (`/_emdash/api/media/file/01KS....webp`) — prefixed with `siteUrl`;
+ * - a bare media id (`01KS...`) — expanded to the media API path, then
+ *   prefixed with `siteUrl`.
+ *
+ * Shared by the SEO meta builder (`og:image`) and the sitemap route
+ * (`<image:image>`) so both resolve image references identically.
+ */
+const TRAILING_SLASH_RE = /\/$/;
+const ABSOLUTE_URL_RE = /^https?:\/\//i;
+
+export function buildSeoImageUrl(imageRef: string, siteUrl?: string): string {
+	// Already absolute — use as-is.
+	if (ABSOLUTE_URL_RE.test(imageRef)) {
+		return imageRef;
+	}
+
+	// Root-relative path (already includes the media API prefix). Without
+	// this branch we'd re-prefix and produce a doubled path that 404s.
+	if (imageRef.startsWith("/")) {
+		return siteUrl ? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${imageRef}` : imageRef;
+	}
+
+	// Bare media id — build the full media API path.
+	const mediaPath = `/_emdash/api/media/file/${imageRef}`;
+	return siteUrl ? `${siteUrl.replace(TRAILING_SLASH_RE, "")}${mediaPath}` : mediaPath;
+}

--- a/packages/core/tests/integration/seo/sitemap-route.test.ts
+++ b/packages/core/tests/integration/seo/sitemap-route.test.ts
@@ -97,13 +97,66 @@ describe("sitemap-[collection].xml route", () => {
 		expect(res.status).toBe(200);
 		const xml = await res.text();
 
-		// Plain urlset namespace -- no xhtml when i18n is off.
-		expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+		// Sitemap + image namespaces declared; no xhtml when i18n is off.
+		expect(xml).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"');
+		expect(xml).toContain('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"');
 		expect(xml).not.toContain("xmlns:xhtml");
 		expect(xml).not.toContain("xhtml:link");
 
 		expect(xml).toContain("<loc>http://localhost:4321/blog/hello</loc>");
 		expect(xml).toContain("<loc>http://localhost:4321/blog/world</loc>");
+	});
+
+	it("emits an <image:image> entry for rows with an SEO image", async () => {
+		setI18nConfig(null);
+		const post = await repo.create({
+			type: "post",
+			slug: "hello",
+			data: { title: "Hello" },
+			status: "published",
+		});
+		// SEO panel stores seo_image as a root-relative media API path.
+		await db
+			.insertInto("_emdash_seo")
+			.values({
+				collection: "post",
+				content_id: post.id,
+				seo_title: null,
+				seo_description: null,
+				seo_image: "/_emdash/api/media/file/01ABCDEF.webp",
+				seo_canonical: null,
+				seo_no_index: 0,
+			})
+			.execute();
+
+		const res = await getSitemap(mockContext({ collectionSlug: "post", db }));
+		expect(res.status).toBe(200);
+		const xml = await res.text();
+
+		// image namespace declared + absolute <image:loc> emitted.
+		expect(xml).toContain(
+			'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
+		);
+		expect(xml).toContain(
+			"<image:loc>http://localhost:4321/_emdash/api/media/file/01ABCDEF.webp</image:loc>",
+		);
+	});
+
+	it("omits <image:image> for rows without an SEO image", async () => {
+		setI18nConfig(null);
+		await repo.create({
+			type: "post",
+			slug: "no-image",
+			data: { title: "No image" },
+			status: "published",
+		});
+
+		const res = await getSitemap(mockContext({ collectionSlug: "post", db }));
+		expect(res.status).toBe(200);
+		const xml = await res.text();
+
+		expect(xml).toContain("<loc>http://localhost:4321/blog/no-image</loc>");
+		expect(xml).not.toContain("<image:image>");
 	});
 
 	it("emits hreflang alternates for translation siblings when i18n is enabled", async () => {

--- a/packages/core/tests/integration/seo/sitemap-route.test.ts
+++ b/packages/core/tests/integration/seo/sitemap-route.test.ts
@@ -134,9 +134,7 @@ describe("sitemap-[collection].xml route", () => {
 		const xml = await res.text();
 
 		// image namespace declared + absolute <image:loc> emitted.
-		expect(xml).toContain(
-			'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
-		);
+		expect(xml).toContain('xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"');
 		expect(xml).toContain(
 			"<image:loc>http://localhost:4321/_emdash/api/media/file/01ABCDEF.webp</image:loc>",
 		);


### PR DESCRIPTION
## What does this PR do?

Adds the entry's **SEO image** to EmDash's native per-collection sitemaps using the Google image-sitemap extension, so page images can be discovered and indexed for Google Images.

Today the sitemap (`/sitemap-{collection}.xml`) emits `<loc>` + `<lastmod>` (+ `hreflang`) but **no images**. [Google's image SEO guidance](https://developers.google.com/search/docs/appearance/google-images) recommends advertising a page's images (and a representative/"preferred" image) in the sitemap. This wires the existing `_emdash_seo.seo_image` — the same "preferred image" already used for `og:image` — into the sitemap:

```xml
<url>
  <loc>https://example.com/blog/my-post</loc>
  <lastmod>2026-06-15T09:35:41.837Z</lastmod>
  <image:image>
    <image:loc>https://example.com/_emdash/api/media/file/01ABC.webp</image:loc>
  </image:image>
</url>
```

**Why only the SEO image (for now):** it is the only image core knows **generically across all collections** and that is already a resolvable URL. Other images live in collection-specific media fields and in Portable Text bodies, and resolving those to correct (storage-key-based) URLs needs either per-image lookups or a usage index. That broader "all used images per page" work — plus a media "Used in" view and safe deletes — is proposed in a dedicated discussion as the natural follow-up.

Related discussion: https://github.com/emdash-cms/emdash/discussions/1503

### Implementation
- `seo/media-url.ts` *(new)*: extracts the existing `og:image` URL-resolution logic into a shared `buildSeoImageUrl()` (no behaviour change; removes a private duplicate in `seo/index.ts`).
- `api/handlers/seo.ts`: the sitemap query already `LEFT JOIN`s `_emdash_seo` for the noindex flag — now also selects `seo_image` and returns it per entry.
- `astro/routes/sitemap-[collection].xml.ts`: declares the `xmlns:image` namespace and emits one `<image:image>` per entry that has an SEO image.

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`emdash` package — ran clean)
- [ ] `pnpm lint` passes (left to CI)
- [x] `pnpm test` passes (targeted: `tests/integration/seo/*`, `tests/unit/seo/*` — 72/72)
- [ ] `pnpm format` has been run (left to CI)
- [x] I have added/updated tests for my changes (sitemap route: image present / absent; existing namespace assertion updated)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, this is XML output, no admin strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1503

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Opus 4.8

## Screenshots / test output

```
Test Files  3 passed (3)
     Tests  72 passed (72)
```