### PR TITLE
fix(infra): pin blog-demo to explicit placement (eu-west-2)

### DIFF
--- a/infra/blog-demo/wrangler.jsonc
+++ b/infra/blog-demo/wrangler.jsonc
@@ -5,7 +5,7 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
-	"placement": { "mode": "smart" },
+	"placement": { "mode": "targeted", "region": "aws:eu-west-2" },
 	"routes": [
 		{
 			"pattern": "blog-demo.emdashcms.com",


### PR DESCRIPTION
## What does this PR do?

Pins the `blog-demo` perf site to explicit Placement (`{ mode: "targeted", region: "aws:eu-west-2" }`), matching `cache-demo`. It was the only perf demo still on `placement: { mode: "smart" }`.

Smart Placement relearns on every deploy. When it drifts the worker from `remote-LHR` (co-located with the D1 primary) to the local edge, the homepage cold path's ~18 sequential runtime-init queries each have to cross to the primary. On 2026-06-16 this surfaced as an apparent regression at the `b01aa9b` deploy: Asia-Pacific cold TTFB jumped ~1.2s -> ~5s (`db.total` ~0.5s -> ~6s) while EU/US and all warm TTFB stayed flat. It was a placement flip, not a code regression in the deployed SHA. Confirmed via `cf_placement` + `cold_server_timings` in the perf-monitor `/api/results`, and by diffing the built bundles across the two commits (byte-identical).

Explicit Placement Hints are deterministic with no relearn window, so placement now survives deploys. This also removes a confound from the dashboard's baseline-vs-cache comparison, which was partly measuring placement rather than the cache provider.

No issue to close (the "regression" was investigated, not filed).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, one-line `wrangler.jsonc` config in a private demo site, no source change
- [ ] `pnpm lint` passes — n/a, see above
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, no testable code path
- [ ] `pnpm format` has been run — n/a, JSONC config
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, `@emdash-cms/perf-demo-site` is private
- [ ] New features link to an approved Discussion — n/a

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Per-region cold TTFB on `/` across the `b01aa9b` deploy (perf-monitor `/api/results`):

| region | cf_placement (pre) | cold (pre) | cf_placement (post) | cold (post) |
| --- | --- | --- | --- | --- |
| AP East (NRT) | remote-LHR | 1247 ms | local-NRT | ~5000 ms |
| AP South | remote-* | ~1150 ms | local-* | ~3800 ms |
| EU West / US East | unchanged | ~1.1-1.2s | unchanged | ~1.1-1.2s |

Warm TTFB unchanged (~210 ms) throughout. Placement self-corrected to `remote-` by 16:01 UTC, confirming the cause.