### PR TITLE
fix(cli): correct users table in doctor command

### DIFF
--- a/.changeset/doctor-users-table.md
+++ b/.changeset/doctor-users-table.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash doctor` always reporting "could not query users table". The users check now queries the correct table and reports the actual user count.

--- a/packages/core/src/cli/commands/doctor.ts
+++ b/packages/core/src/cli/commands/doctor.ts
@@ -124,7 +124,7 @@ async function checkDatabase(dbPath: string): Promise<CheckResult[]> {
 		try {
 			const usersResult = await sql<{
 				count: number;
-			}>`SELECT COUNT(id) as count FROM _emdash_users`.execute(db);
+			}>`SELECT COUNT(id) as count FROM users`.execute(db);
 			const count = usersResult.rows[0]?.count ?? 0;
 			results.push({
 				name: "users",


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change and why it's needed. Link to a related issue or discussion. -->

Closes #1434

### The issue
EmDash CLI doctor command's user-count check queried a table called _emdash_users, which doesn't exist. The user table is named `users`. As a result, the command reported warn: could not query users table, even with users present.

`{ "name": "users", "status": "warn", "message": "could not query users table" }`

### The fix
The query is now fixed and uses the `users` table. `emdash doctor --json` now returns the correct user count:

`{ "name": "users", "status": "pass", "message": "1 users"}`

## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
