### PR TITLE
i18n(id): translate media detail URL label

### DIFF
--- a/packages/admin/src/locales/id/messages.po
+++ b/packages/admin/src/locales/id/messages.po
@@ -7504,7 +7504,7 @@ msgstr "Pengenal ramah URL (mis., \"utama\", \"footer\")"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:193
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:107
 msgid "Use [param] or [...rest] in paths for pattern matching."


### PR DESCRIPTION
## What does this PR do?

Fixes the missing Indonesian translation for the media detail URL label by translating `URL:` as `URL:` in `packages/admin/src/locales/id/messages.po`.

This PR updates only the Indonesian PO catalog and leaves all other locales untouched.

No changeset is included for this translation-only catalog update.

Closes #1513

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode with GPT-5.4

## Screenshots / test output

- `pnpm format` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ❌ fails in `packages/plugin-cli` on missing exports from `@emdash-cms/plugin-types`; unrelated to this PO-only change
- `pnpm --filter @emdash-cms/admin test -- --run` ❌ existing browser/runtime baseline failures unrelated to this PO-only change (React hook/runtime import issues, plugin-types export mismatch, and existing editor/browser test failures)

Please review when convenient.