### PR TITLE
fix(admin): keep byline list mounted during search refetch (#1220)

### DIFF
--- a/.changeset/fix-byline-search-loader-flash.md
+++ b/.changeset/fix-byline-search-loader-flash.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the byline search box still blanking the page while you type. Searching now keeps the current results on screen as the new query loads, instead of collapsing into a full-page loader and dropping the input's focus on each settled keystroke.

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ assets/templates/*/[0-9]*
 
 # Vitest browser-mode failure screenshots
 __screenshots__/
+.vitest-attachments/
 
 # AI review artifacts
 *-review.md

--- a/packages/admin/src/routes/bylines.tsx
+++ b/packages/admin/src/routes/bylines.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, InputArea, Loader, Select, Switch } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import { IdentificationCard } from "@phosphor-icons/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import * as React from "react";
 
@@ -153,6 +153,13 @@ export function BylinesPage() {
 				locale: activeLocale,
 				limit: 50,
 			}),
+		// Keep the previous results on screen while a new search/filter query
+		// loads. Without this, changing the query key drops `data` to
+		// `undefined`, the `isLoading && !data` gate re-engages, and the whole
+		// page collapses into the full-page loader on every settled keystroke —
+		// the focus-losing "reload" reported in #1220 that the debounce alone
+		// only reduced in frequency. Matches ContentEditor's search pattern.
+		placeholderData: keepPreviousData,
 	});
 
 	// Reset accumulated items when filters change

--- a/packages/admin/tests/routes/bylines.test.tsx
+++ b/packages/admin/tests/routes/bylines.test.tsx
@@ -91,4 +91,54 @@ describe("BylinesPage search", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	it("keeps the previous results mounted while a search refetch is in flight", async () => {
+		vi.useFakeTimers();
+		try {
+			// Initial load returns one byline; the search refetch is held
+			// in-flight so we can observe what the page renders *during* the
+			// new query — the moment the original full-page loader takeover
+			// (#1220) blanks the screen and drops input focus.
+			let resolveSearch: (value: { items: unknown[]; nextCursor: undefined }) => void = () => {};
+			const pendingSearch = new Promise<{ items: unknown[]; nextCursor: undefined }>((resolve) => {
+				resolveSearch = resolve;
+			});
+			fetchBylinesMock
+				.mockResolvedValueOnce({
+					items: [
+						{ id: "1", slug: "alice", displayName: "Alice Example", isGuest: false, userId: null },
+					],
+					nextCursor: undefined,
+				} as never)
+				.mockReturnValueOnce(pendingSearch as never);
+
+			const screen = await render(
+				<QueryWrapper>
+					<BylinesPage />
+				</QueryWrapper>,
+			);
+
+			await vi.advanceTimersByTimeAsync(0);
+			await expect.element(screen.getByText("Alice Example")).toBeInTheDocument();
+
+			const input = screen.getByPlaceholder("Search bylines");
+			await input.fill("ali");
+
+			// Elapse the debounce so the (still-pending) search refetch fires.
+			await vi.advanceTimersByTimeAsync(300);
+			await vi.waitFor(() => {
+				expect(searchArgs()).toEqual([undefined, "ali"]);
+			});
+
+			// While the refetch is in flight the page must NOT collapse into
+			// the centered full-page loader: the search input keeps focus and
+			// the previous results stay visible.
+			await expect.element(screen.getByPlaceholder("Search bylines")).toBeInTheDocument();
+			await expect.element(screen.getByText("Alice Example")).toBeInTheDocument();
+
+			resolveSearch({ items: [], nextCursor: undefined });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });


### PR DESCRIPTION
## What does this PR do?

The byline search box still blanks the page while you type, even after the debounce fix in #1222. The debounce reduced how often it happened but never stopped it.

Root cause: the bylines `useQuery` has no `placeholderData`. In react-query v5, when the query key changes (`debouncedSearch` updates), it's a brand-new query, so `data` drops to `undefined`, the `isLoading && !data` gate re-engages, and the whole page collapses into the centered `<Loader />` — unmounting the search input and losing focus. To the user that reads as a "reload" on each settled keystroke.

Fix: add `placeholderData: keepPreviousData` so the previous results stay mounted while the new search/filter query loads. The full-page loader now only shows on first load. This matches the search-as-you-type pattern already used in `ContentEditor.tsx`. The existing debounce stays — the two together give smooth typing with zero flashes.

Also gitignores vitest browser-mode `.vitest-attachments/` artifacts.

Closes #1220

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). No new strings in this change.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Added a regression test in `bylines.test.tsx` that holds the search refetch in-flight and asserts the input and prior results stay mounted. It fails on `main` (page collapses to the loader) and passes with this fix. Full admin suite: 1014 passing.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-byline-search-loader-flash-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/byline-search-loader-flash`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
