### PR TITLE
feat(core): WordPress-style date tokens in url_pattern ({year}/{month}/{day})

### DIFF
--- a/.changeset/permalink-date-tokens.md
+++ b/.changeset/permalink-date-tokens.md
@@ -1,0 +1,6 @@
+---
+"emdash": minor
+"@emdash-cms/admin": minor
+---
+
+Adds WordPress-style date tokens to collection URL patterns. `url_pattern` now supports `{year}`, `{month}`, `{day}`, `{hour}`, `{minute}`, `{second}` (resolved from the entry's publish date, zero-padded) alongside `{slug}` and `{id}` — so you can reproduce permalinks like `/{year}/{month}/{day}/{slug}.html`. The tokens resolve in sitemap canonical URLs and the admin "View published" links.

--- a/.changeset/permalink-date-tokens.md
+++ b/.changeset/permalink-date-tokens.md
@@ -3,4 +3,4 @@
 "@emdash-cms/admin": minor
 ---
 
-Adds WordPress-style date tokens to collection URL patterns. `url_pattern` now supports `{year}`, `{month}`, `{day}`, `{hour}`, `{minute}`, `{second}` (resolved from the entry's publish date, zero-padded) alongside `{slug}` and `{id}` — so you can reproduce permalinks like `/{year}/{month}/{day}/{slug}.html`. The tokens resolve in sitemap canonical URLs and the admin "View published" links.
+Adds WordPress-style date tokens to collection URL patterns. `url_pattern` now supports `{year}`, `{month}`, `{day}`, `{hour}`, `{minute}`, `{second}` (resolved from the entry's publish date, zero-padded) alongside `{slug}` and `{id}` — so you can reproduce permalinks like `/{year}/{month}/{day}/{slug}.html`. The tokens resolve everywhere the pattern is used: sitemap canonical URLs, hreflang alternates, navigation menu links, slug-change auto-redirects, and the admin's preview and "View published" links. Tokens stay literal when an entry has no publish date, so canonical URLs remain stable across edits.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -522,14 +522,14 @@ export function ContentEditor({
 				window.open(result.url, "_blank", "noopener,noreferrer");
 			} else {
 				window.open(
-					contentUrl(collection, slug || item.id, urlPattern),
+					contentUrl(collection, slug || item.id, urlPattern, item.publishedAt ?? item.updatedAt),
 					"_blank",
 					"noopener,noreferrer",
 				);
 			}
 		} catch {
 			window.open(
-				contentUrl(collection, slug || item?.id || "", urlPattern),
+				contentUrl(collection, slug || item?.id || "", urlPattern, item?.publishedAt ?? item?.updatedAt),
 				"_blank",
 				"noopener,noreferrer",
 			);
@@ -559,7 +559,10 @@ export function ContentEditor({
 	const draftStatus = item ? getDraftStatus(item) : "unpublished";
 	const hasPendingChanges = draftStatus === "published_with_changes";
 	const isLive = draftStatus === "published" || draftStatus === "published_with_changes";
-	const liveViewUrl = isLive && item?.slug ? contentUrl(collection, item.slug, urlPattern) : null;
+	const liveViewUrl =
+		isLive && item?.slug
+			? contentUrl(collection, item.slug, urlPattern, item.publishedAt ?? item.updatedAt)
+			: null;
 
 	// Scheduling — keyed off scheduledAt rather than status, since published
 	// posts can now have a pending schedule without changing status.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -560,9 +560,7 @@ export function ContentEditor({
 	const hasPendingChanges = draftStatus === "published_with_changes";
 	const isLive = draftStatus === "published" || draftStatus === "published_with_changes";
 	const liveViewUrl =
-		isLive && item?.slug
-			? contentUrl(collection, item.slug, urlPattern, item.publishedAt)
-			: null;
+		isLive && item?.slug ? contentUrl(collection, item.slug, urlPattern, item.publishedAt) : null;
 
 	// Scheduling — keyed off scheduledAt rather than status, since published
 	// posts can now have a pending schedule without changing status.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -522,14 +522,14 @@ export function ContentEditor({
 				window.open(result.url, "_blank", "noopener,noreferrer");
 			} else {
 				window.open(
-					contentUrl(collection, slug || item.id, urlPattern, item.publishedAt ?? item.updatedAt),
+					contentUrl(collection, slug || item.id, urlPattern, item.publishedAt),
 					"_blank",
 					"noopener,noreferrer",
 				);
 			}
 		} catch {
 			window.open(
-				contentUrl(collection, slug || item?.id || "", urlPattern, item?.publishedAt ?? item?.updatedAt),
+				contentUrl(collection, slug || item?.id || "", urlPattern, item?.publishedAt),
 				"_blank",
 				"noopener,noreferrer",
 			);
@@ -561,7 +561,7 @@ export function ContentEditor({
 	const isLive = draftStatus === "published" || draftStatus === "published_with_changes";
 	const liveViewUrl =
 		isLive && item?.slug
-			? contentUrl(collection, item.slug, urlPattern, item.publishedAt ?? item.updatedAt)
+			? contentUrl(collection, item.slug, urlPattern, item.publishedAt)
 			: null;
 
 	// Scheduling — keyed off scheduledAt rather than status, since published

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -755,6 +755,7 @@ export function ContentEditor({
 					contentUrl(collection, slug || item.id, urlPattern, {
 						locale: item.locale,
 						i18n,
+						id: item.id,
 						date: item.publishedAt,
 					}),
 					"_blank",
@@ -766,6 +767,7 @@ export function ContentEditor({
 				contentUrl(collection, slug || item?.id || "", urlPattern, {
 					locale: item?.locale,
 					i18n,
+					id: item?.id,
 					date: item?.publishedAt,
 				}),
 				"_blank",
@@ -802,6 +804,7 @@ export function ContentEditor({
 			? contentUrl(collection, item.slug, urlPattern, {
 					locale: item.locale,
 					i18n,
+					id: item.id,
 					date: item.publishedAt,
 				})
 			: null;

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -755,6 +755,7 @@ export function ContentEditor({
 					contentUrl(collection, slug || item.id, urlPattern, {
 						locale: item.locale,
 						i18n,
+						date: item.publishedAt,
 					}),
 					"_blank",
 					"noopener,noreferrer",
@@ -765,6 +766,7 @@ export function ContentEditor({
 				contentUrl(collection, slug || item?.id || "", urlPattern, {
 					locale: item?.locale,
 					i18n,
+					date: item?.publishedAt,
 				}),
 				"_blank",
 				"noopener,noreferrer",
@@ -800,6 +802,7 @@ export function ContentEditor({
 			? contentUrl(collection, item.slug, urlPattern, {
 					locale: item.locale,
 					i18n,
+					date: item.publishedAt,
 				})
 			: null;
 

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1002,12 +1002,7 @@ function ContentListItem({
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (
 						<LinkButton
-							href={contentUrl(
-								collection,
-								item.slug,
-								urlPattern,
-								item.publishedAt ?? item.updatedAt,
-							)}
+							href={contentUrl(collection, item.slug, urlPattern, item.publishedAt)}
 							external
 							variant="ghost"
 							shape="square"

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1002,7 +1002,12 @@ function ContentListItem({
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (
 						<LinkButton
-							href={contentUrl(collection, item.slug, urlPattern, item.publishedAt ?? item.updatedAt)}
+							href={contentUrl(
+								collection,
+								item.slug,
+								urlPattern,
+								item.publishedAt ?? item.updatedAt,
+							)}
 							external
 							variant="ghost"
 							shape="square"

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1002,7 +1002,7 @@ function ContentListItem({
 				<div className="flex items-center justify-end space-x-1">
 					{item.status === "published" && item.slug && (
 						<LinkButton
-							href={contentUrl(collection, item.slug, urlPattern)}
+							href={contentUrl(collection, item.slug, urlPattern, item.publishedAt ?? item.updatedAt)}
 							external
 							variant="ghost"
 							shape="square"

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1326,6 +1326,7 @@ function ContentListItem({
 							href={contentUrl(collection, item.slug, urlPattern, {
 								locale: item.locale,
 								i18n,
+								date: item.publishedAt,
 							})}
 							external
 							variant="ghost"

--- a/packages/admin/src/components/ContentList.tsx
+++ b/packages/admin/src/components/ContentList.tsx
@@ -1326,6 +1326,7 @@ function ContentListItem({
 							href={contentUrl(collection, item.slug, urlPattern, {
 								locale: item.locale,
 								i18n,
+								id: item.id,
 								date: item.publishedAt,
 							})}
 							external

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -432,7 +432,7 @@ export function ContentTypeEditor({
 									</p>
 								)}
 								<p className="text-xs text-kumo-subtle mt-1">
-									{t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`}
+									{t`Pattern for generating URLs, e.g. /blog/${"{slug}"}. Tokens: ${"{slug}"}, ${"{id}"}, and date tokens ${"{year}"}/${"{month}"}/${"{day}"} (also ${"{hour}"}/${"{minute}"}/${"{second}"}) from the publish date — e.g. ${"/{year}/{month}/{day}/{slug}.html"} for WordPress-style permalinks.`}
 								</p>
 							</div>
 

--- a/packages/admin/src/components/ContentTypeEditor.tsx
+++ b/packages/admin/src/components/ContentTypeEditor.tsx
@@ -447,7 +447,7 @@ export function ContentTypeEditor({
 									</p>
 								)}
 								<p className="text-xs text-kumo-subtle mt-1">
-									{t`Pattern for generating URLs, e.g. /blog/${"{slug}"}`}
+									{t`Pattern for generating URLs, e.g. /blog/${"{slug}"}. Tokens: ${"{slug}"}, ${"{id}"}, and date tokens ${"{year}"}/${"{month}"}/${"{day}"} (also ${"{hour}"}/${"{minute}"}/${"{second}"}) from the publish date — e.g. ${"/{year}/{month}/{day}/{slug}.html"} for WordPress-style permalinks.`}
 								</p>
 							</div>
 

--- a/packages/admin/src/lib/url.ts
+++ b/packages/admin/src/lib/url.ts
@@ -21,16 +21,46 @@ export function sanitizeRedirectUrl(raw: string): string {
 	return DEFAULT_REDIRECT;
 }
 
+const DATE_TOKEN = /\{(year|month|day|hour|minute|second)\}/g;
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Substitute WordPress-style date tokens from a publish date (zero-padded).
+ * Tokens are left untouched when no valid date is available. Kept in sync with
+ * the core `interpolateUrlPattern` resolver used for sitemap/canonical URLs.
+ */
+function applyDateTokens(path: string, date?: string | null): string {
+	const d = date == null ? null : new Date(date);
+	if (!d || Number.isNaN(d.getTime())) return path;
+	const parts: Record<string, string> = {
+		year: String(d.getUTCFullYear()),
+		month: pad2(d.getUTCMonth() + 1),
+		day: pad2(d.getUTCDate()),
+		hour: pad2(d.getUTCHours()),
+		minute: pad2(d.getUTCMinutes()),
+		second: pad2(d.getUTCSeconds()),
+	};
+	return path.replace(DATE_TOKEN, (match, key: string) => parts[key] ?? match);
+}
+
 /**
  * Build a public content URL from collection metadata and slug.
  *
  * Uses the collection's `urlPattern` when available (e.g. `/blog/{slug}`),
- * otherwise falls back to `/{collection}/{slug}`. Leading slashes are
+ * otherwise falls back to `/{collection}/{slug}`. Also resolves the date
+ * tokens `{year}`/`{month}`/`{day}`/`{hour}`/`{minute}`/`{second}` from the
+ * entry's publish `date` (for WordPress-style permalinks). Leading slashes are
  * stripped from the slug to prevent protocol-relative URLs.
  */
-export function contentUrl(collection: string, slug: string, urlPattern?: string): string {
+export function contentUrl(
+	collection: string,
+	slug: string,
+	urlPattern?: string,
+	date?: string | null,
+): string {
 	const safe = slug.replace(LEADING_SLASHES, "");
-	return urlPattern ? urlPattern.replace("{slug}", safe) : `/${collection}/${safe}`;
+	const path = urlPattern ? urlPattern.replaceAll("{slug}", safe) : `/${collection}/${safe}`;
+	return applyDateTokens(path, date);
 }
 
 /** Matches http:// or https:// URLs */

--- a/packages/admin/src/lib/url.ts
+++ b/packages/admin/src/lib/url.ts
@@ -12,6 +12,8 @@ export interface ContentUrlOptions {
 		locales: string[];
 		prefixDefaultLocale?: boolean;
 	};
+	/** Entry id used to resolve `{id}` tokens in the pattern. */
+	id?: string;
 	/** Publish date used to resolve `{year}`/`{month}`/... tokens in the pattern. */
 	date?: string | null;
 }
@@ -76,7 +78,8 @@ export function contentUrl(
 	const safe = slug.replace(LEADING_SLASHES, "");
 	// Date tokens resolve against the pattern before the slug is inserted, so
 	// a slug that happens to contain `{year}`-style text stays untouched.
-	const pattern = urlPattern && applyDateTokens(urlPattern, options?.date);
+	let pattern = urlPattern && applyDateTokens(urlPattern, options?.date);
+	if (pattern && options?.id) pattern = pattern.replaceAll("{id}", options.id);
 	const path = pattern ? pattern.replaceAll("{slug}", safe) : `/${collection}/${safe}`;
 	const { locale, i18n } = options ?? {};
 	const shouldPrefix =

--- a/packages/admin/src/lib/url.ts
+++ b/packages/admin/src/lib/url.ts
@@ -12,6 +12,8 @@ export interface ContentUrlOptions {
 		locales: string[];
 		prefixDefaultLocale?: boolean;
 	};
+	/** Publish date used to resolve `{year}`/`{month}`/... tokens in the pattern. */
+	date?: string | null;
 }
 
 /**
@@ -30,11 +32,39 @@ export function sanitizeRedirectUrl(raw: string): string {
 	return DEFAULT_REDIRECT;
 }
 
+const DATE_TOKEN = /\{(year|month|day|hour|minute|second)\}/g;
+// SQLite-style datetime without timezone info; stored values are UTC.
+const OFFSETLESS_DATETIME = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)$/;
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Substitute WordPress-style date tokens from a publish date (zero-padded).
+ * Tokens are left untouched when no valid date is available. Kept in sync with
+ * the core `interpolateUrlPattern` resolver used for sitemap/canonical URLs.
+ */
+function applyDateTokens(path: string, date?: string | null): string {
+	if (date == null) return path;
+	const offsetless = OFFSETLESS_DATETIME.exec(date);
+	const d = new Date(offsetless ? `${offsetless[1]}T${offsetless[2]}Z` : date);
+	if (Number.isNaN(d.getTime())) return path;
+	const parts: Record<string, string> = {
+		year: String(d.getUTCFullYear()),
+		month: pad2(d.getUTCMonth() + 1),
+		day: pad2(d.getUTCDate()),
+		hour: pad2(d.getUTCHours()),
+		minute: pad2(d.getUTCMinutes()),
+		second: pad2(d.getUTCSeconds()),
+	};
+	return path.replace(DATE_TOKEN, (match, key: string) => parts[key] ?? match);
+}
+
 /**
  * Build a public content URL from collection metadata and slug.
  *
  * Uses the collection's `urlPattern` when available (e.g. `/blog/{slug}`),
- * otherwise falls back to `/{collection}/{slug}`. Leading slashes are
+ * otherwise falls back to `/{collection}/{slug}`. Also resolves the date
+ * tokens `{year}`/`{month}`/`{day}`/`{hour}`/`{minute}`/`{second}` from the
+ * entry's publish `date` (for WordPress-style permalinks). Leading slashes are
  * stripped from the slug to prevent protocol-relative URLs.
  */
 export function contentUrl(
@@ -44,7 +74,10 @@ export function contentUrl(
 	options?: ContentUrlOptions,
 ): string {
 	const safe = slug.replace(LEADING_SLASHES, "");
-	const path = urlPattern ? urlPattern.replace("{slug}", safe) : `/${collection}/${safe}`;
+	// Date tokens resolve against the pattern before the slug is inserted, so
+	// a slug that happens to contain `{year}`-style text stays untouched.
+	const pattern = urlPattern && applyDateTokens(urlPattern, options?.date);
+	const path = pattern ? pattern.replaceAll("{slug}", safe) : `/${collection}/${safe}`;
 	const { locale, i18n } = options ?? {};
 	const shouldPrefix =
 		locale && i18n && (locale !== i18n.defaultLocale || i18n.prefixDefaultLocale === true);

--- a/packages/admin/tests/lib/url.test.ts
+++ b/packages/admin/tests/lib/url.test.ts
@@ -29,6 +29,20 @@ describe("contentUrl", () => {
 			}),
 		).toBe("/en/posts/english-test");
 	});
+
+	it("resolves date tokens from the publish date and still applies the locale prefix", () => {
+		expect(
+			contentUrl("posts", "witaj", "/{year}/{month}/{day}/{slug}", {
+				locale: "pl",
+				i18n: { defaultLocale: "en", locales: ["en", "pl"], prefixDefaultLocale: false },
+				date: "2023-05-08T12:00:00.000Z",
+			}),
+		).toBe("/pl/2023/05/08/witaj");
+	});
+
+	it("keeps date tokens literal without a publish date", () => {
+		expect(contentUrl("posts", "hello", "/{year}/{slug}", { date: null })).toBe("/{year}/hello");
+	});
 });
 
 describe("sanitizeRedirectUrl", () => {

--- a/packages/admin/tests/lib/url.test.ts
+++ b/packages/admin/tests/lib/url.test.ts
@@ -43,6 +43,10 @@ describe("contentUrl", () => {
 	it("keeps date tokens literal without a publish date", () => {
 		expect(contentUrl("posts", "hello", "/{year}/{slug}", { date: null })).toBe("/{year}/hello");
 	});
+
+	it("resolves {id} tokens from the entry id", () => {
+		expect(contentUrl("posts", "hello", "/p/{id}", { id: "01ABC" })).toBe("/p/01ABC");
+	});
 });
 
 describe("sanitizeRedirectUrl", () => {

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -374,6 +374,15 @@ async function createSlugChangeRedirect(
 		.where("slug", "=", collection)
 		.executeTakeFirst();
 
+	// Date tokens in the URL pattern resolve from the publish date, so the
+	// redirect URLs must be built with it — otherwise they'd keep literal
+	// `{year}`-style braces and never match a real request.
+	validateIdentifier(collection, "collection slug");
+	const entryRow = await sql<{ published_at: string | null }>`
+		SELECT published_at FROM ${sql.ref(`ec_${collection}`)} WHERE id = ${contentId}
+	`.execute(db);
+	const publishedAt = entryRow.rows[0]?.published_at ?? null;
+
 	const redirectRepo = new RedirectRepository(db);
 	await redirectRepo.createAutoRedirect(
 		collection,
@@ -381,6 +390,7 @@ async function createSlugChangeRedirect(
 		newSlug,
 		contentId,
 		collectionRow?.url_pattern ?? null,
+		publishedAt,
 	);
 	invalidateRedirectCache();
 }

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -425,6 +425,8 @@ async function createSlugChangeRedirect(
 	oldSlug: string,
 	newSlug: string,
 	contentId: string,
+	oldPublishedAt: string | null,
+	newPublishedAt: string | null,
 ): Promise<void> {
 	// A URL pattern has no locale token, so every locale variant of an entry
 	// generates the same URL, and slugs are unique per (slug, locale) — a
@@ -448,6 +450,8 @@ async function createSlugChangeRedirect(
 		newSlug,
 		contentId,
 		collectionRow?.url_pattern ?? null,
+		oldPublishedAt,
+		newPublishedAt,
 	);
 	invalidateRedirectCache();
 }
@@ -1095,9 +1099,20 @@ export async function handleContentUpdate(
 				updated.primaryBylineId = credits[0]?.byline.translationGroup ?? null;
 			}
 
-			// Create auto-redirect when slug changes
+			// Create auto-redirect when slug changes. Date tokens in the URL
+			// pattern resolve from the publish date, so the old URL uses the
+			// pre-update date (the URL that was actually live) and the new URL
+			// the post-update one.
 			if (oldSlug && body.slug) {
-				await createSlugChangeRedirect(trx, collection, oldSlug, body.slug, resolvedId);
+				await createSlugChangeRedirect(
+					trx,
+					collection,
+					oldSlug,
+					body.slug,
+					resolvedId,
+					existing?.publishedAt ?? null,
+					updated.publishedAt ?? null,
+				);
 			}
 
 			// Sync non-translatable fields to sibling locales in the same
@@ -1640,7 +1655,15 @@ export async function handleContentPublish(
 				published.slug &&
 				existing.slug !== published.slug
 			) {
-				await createSlugChangeRedirect(trx, collection, existing.slug, published.slug, resolvedId);
+				await createSlugChangeRedirect(
+					trx,
+					collection,
+					existing.slug,
+					published.slug,
+					resolvedId,
+					existing.publishedAt ?? null,
+					published.publishedAt ?? null,
+				);
 			}
 
 			return published;

--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -19,6 +19,13 @@ export interface SitemapContentEntry {
 	/** ISO date of last modification */
 	updatedAt: string;
 	/**
+	 * ISO publish date, or null when never published. Used to resolve
+	 * date tokens (`{year}`/`{month}`/`{day}`) in the collection's
+	 * `url_pattern` — the published date keeps permalinks stable across
+	 * later edits (unlike `updatedAt`).
+	 */
+	publishedAt: string | null;
+	/**
 	 * Locale of this row (e.g. `"en"`, `"fr"`). Always present — rows in
 	 * pre-i18n databases are backfilled to the configured `defaultLocale`.
 	 */
@@ -138,11 +145,12 @@ export async function handleSitemapData(
 					slug: string | null;
 					id: string;
 					updated_at: string;
+					published_at: string | null;
 					locale: string;
 					translation_group: string | null;
 					seo_image: string | null;
 				}>`
-					SELECT c.slug, c.id, c.updated_at, c.locale, c.translation_group, s.seo_image
+					SELECT c.slug, c.id, c.updated_at, c.published_at, c.locale, c.translation_group, s.seo_image
 					FROM ${sql.ref(tableName)} c
 					LEFT JOIN _emdash_seo s
 						ON s.collection = ${col.slug}
@@ -162,6 +170,7 @@ export async function handleSitemapData(
 						id: row.id,
 						slug: row.slug,
 						updatedAt: toW3CDate(row.updated_at),
+						publishedAt: row.published_at ?? null,
 						locale: row.locale,
 						translationGroup: row.translation_group,
 						image: row.seo_image ?? null,

--- a/packages/core/src/api/handlers/seo.ts
+++ b/packages/core/src/api/handlers/seo.ts
@@ -19,6 +19,13 @@ export interface SitemapContentEntry {
 	/** ISO date of last modification */
 	updatedAt: string;
 	/**
+	 * ISO publish date, or null when never published. Used to resolve
+	 * date tokens (`{year}`/`{month}`/`{day}`) in the collection's
+	 * `url_pattern` — the published date keeps permalinks stable across
+	 * later edits (unlike `updatedAt`).
+	 */
+	publishedAt: string | null;
+	/**
 	 * Locale of this row (e.g. `"en"`, `"fr"`). Always present — rows in
 	 * pre-i18n databases are backfilled to the configured `defaultLocale`.
 	 */
@@ -139,11 +146,12 @@ export async function handleSitemapData(
 					slug: string | null;
 					id: string;
 					updated_at: string;
+					published_at: string | null;
 					locale: string;
 					translation_group: string | null;
 					seo_image: string | null;
 				}>`
-					SELECT c.slug, c.id, c.updated_at, c.locale, c.translation_group, s.seo_image
+					SELECT c.slug, c.id, c.updated_at, c.published_at, c.locale, c.translation_group, s.seo_image
 					FROM ${sql.ref(tableName)} c
 					LEFT JOIN _emdash_seo s
 						ON s.collection = ${col.slug}
@@ -165,6 +173,7 @@ export async function handleSitemapData(
 						id: row.id,
 						slug: row.slug,
 						updatedAt: toW3CDate(row.updated_at),
+						publishedAt: row.published_at ?? null,
 						locale: row.locale,
 						translationGroup: row.translation_group,
 						image: row.seo_image ?? null,

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -102,6 +102,8 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 				collection: col.collection,
 				slug: entry.slug || entry.id,
 				id: entry.id,
+				// Published date keeps date-token permalinks stable across edits.
+				date: entry.publishedAt ?? entry.updatedAt,
 			});
 			const localized = await localizePath(path, entry.locale);
 			const absolute = localized === null ? null : `${siteUrl}${localized}`;

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -102,6 +102,10 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 				collection: col.collection,
 				slug: entry.slug || entry.id,
 				id: entry.id,
+				// Published date keeps date-token permalinks stable across edits;
+				// no updatedAt fallback — tokens stay literal without a publish
+				// date, consistent with the resolver's documented behavior.
+				date: entry.publishedAt,
 			});
 			const localized = await localizePath(path, entry.locale);
 			const absolute = localized === null ? null : `${siteUrl}${localized}`;

--- a/packages/core/src/astro/routes/sitemap-[collection].xml.ts
+++ b/packages/core/src/astro/routes/sitemap-[collection].xml.ts
@@ -102,8 +102,10 @@ export const GET: APIRoute = async ({ params, locals, url }) => {
 				collection: col.collection,
 				slug: entry.slug || entry.id,
 				id: entry.id,
-				// Published date keeps date-token permalinks stable across edits.
-				date: entry.publishedAt ?? entry.updatedAt,
+				// Published date keeps date-token permalinks stable across edits;
+				// no updatedAt fallback — tokens stay literal without a publish
+				// date, consistent with the resolver's documented behavior.
+				date: entry.publishedAt,
 			});
 			const localized = await localizePath(path, entry.locale);
 			const absolute = localized === null ? null : `${siteUrl}${localized}`;

--- a/packages/core/src/database/repositories/redirect.ts
+++ b/packages/core/src/database/repositories/redirect.ts
@@ -1,6 +1,7 @@
 import { sql, type Kysely } from "kysely";
 import { ulid } from "ulidx";
 
+import { interpolateUrlPattern } from "../../i18n/resolve.js";
 import {
 	compilePattern,
 	matchPattern,
@@ -355,13 +356,22 @@ export class RedirectRepository {
 		newSlug: string,
 		contentId: string,
 		urlPattern: string | null,
+		publishedAt?: string | null,
 	): Promise<Redirect> {
-		const oldUrl = urlPattern
-			? urlPattern.replace("{slug}", oldSlug).replace("{id}", contentId)
-			: `/${collection}/${oldSlug}`;
-		const newUrl = urlPattern
-			? urlPattern.replace("{slug}", newSlug).replace("{id}", contentId)
-			: `/${collection}/${newSlug}`;
+		const oldUrl = interpolateUrlPattern({
+			pattern: urlPattern,
+			collection,
+			slug: oldSlug,
+			id: contentId,
+			date: publishedAt,
+		});
+		const newUrl = interpolateUrlPattern({
+			pattern: urlPattern,
+			collection,
+			slug: newSlug,
+			id: contentId,
+			date: publishedAt,
+		});
 
 		// Collapse chains: update any existing redirects pointing to the old URL
 		await this.collapseChains(oldUrl, newUrl);

--- a/packages/core/src/database/repositories/redirect.ts
+++ b/packages/core/src/database/repositories/redirect.ts
@@ -1,6 +1,7 @@
 import { sql, type Kysely } from "kysely";
 import { ulid } from "ulidx";
 
+import { interpolateUrlPattern } from "../../i18n/resolve.js";
 import {
 	compilePattern,
 	matchPattern,
@@ -359,13 +360,23 @@ export class RedirectRepository {
 		newSlug: string,
 		contentId: string,
 		urlPattern: string | null,
+		oldPublishedAt?: string | null,
+		newPublishedAt?: string | null,
 	): Promise<Redirect | null> {
-		const oldUrl = urlPattern
-			? urlPattern.replace("{slug}", oldSlug).replace("{id}", contentId)
-			: `/${collection}/${oldSlug}`;
-		const newUrl = urlPattern
-			? urlPattern.replace("{slug}", newSlug).replace("{id}", contentId)
-			: `/${collection}/${newSlug}`;
+		const oldUrl = interpolateUrlPattern({
+			pattern: urlPattern,
+			collection,
+			slug: oldSlug,
+			id: contentId,
+			date: oldPublishedAt,
+		});
+		const newUrl = interpolateUrlPattern({
+			pattern: urlPattern,
+			collection,
+			slug: newSlug,
+			id: contentId,
+			date: newPublishedAt,
+		});
 
 		// A redirect from a URL to itself would make the page unreachable
 		if (oldUrl === newUrl) return null;

--- a/packages/core/src/i18n/resolve.ts
+++ b/packages/core/src/i18n/resolve.ts
@@ -37,9 +37,36 @@ export function resolveLocaleChain(explicit?: string): string[] {
 }
 
 const REPEATED_SLASHES = /\/{2,}/g;
+const DATE_TOKEN = /\{(year|month|day|hour|minute|second)\}/g;
+const pad2 = (n: number) => String(n).padStart(2, "0");
 
 /**
- * Interpolate a collection `url_pattern` with a row's slug and id.
+ * Substitute WordPress-style date tokens (`{year}`, `{month}`, `{day}`,
+ * `{hour}`, `{minute}`, `{second}`) from a publish date. Month/day/time parts
+ * are zero-padded, mirroring WordPress (`%monthnum%`, `%day%`, ...). Tokens are
+ * left untouched when no valid date is available, so callers without a date
+ * (or unpublished entries) never produce a half-resolved URL.
+ */
+function applyDateTokens(path: string, date: string | Date | null | undefined): string {
+	const d = date == null ? null : new Date(date);
+	if (!d || Number.isNaN(d.getTime())) return path;
+	const parts: Record<string, string> = {
+		year: String(d.getUTCFullYear()),
+		month: pad2(d.getUTCMonth() + 1),
+		day: pad2(d.getUTCDate()),
+		hour: pad2(d.getUTCHours()),
+		minute: pad2(d.getUTCMinutes()),
+		second: pad2(d.getUTCSeconds()),
+	};
+	return path.replace(DATE_TOKEN, (match, key: string) => parts[key] ?? match);
+}
+
+/**
+ * Interpolate a collection `url_pattern` with a row's slug, id and publish date.
+ *
+ * Supported tokens: `{slug}`, `{id}`, and the date tokens `{year}`,
+ * `{month}`, `{day}`, `{hour}`, `{minute}`, `{second}` (resolved from `date`,
+ * for WordPress-style permalinks like `/{year}/{month}/{day}/{slug}.html`).
  *
  * Falls back to `/{collection}/{slug}` when no pattern is configured.
  * Does NOT apply any locale prefix — pass the result through
@@ -51,12 +78,15 @@ export function interpolateUrlPattern(options: {
 	collection: string;
 	slug: string;
 	id: string;
+	/** Publish date used for date tokens; tokens stay literal when absent. */
+	date?: string | Date | null;
 }): string {
-	const { pattern, collection, slug, id } = options;
+	const { pattern, collection, slug, id, date } = options;
 	const basePattern = pattern ?? `/${encodeURIComponent(collection)}/{slug}`;
 	let path = basePattern
-		.replace("{slug}", encodeURIComponent(slug))
-		.replace("{id}", encodeURIComponent(id));
+		.replaceAll("{slug}", encodeURIComponent(slug))
+		.replaceAll("{id}", encodeURIComponent(id));
+	path = applyDateTokens(path, date);
 	path = path.replace(REPEATED_SLASHES, "/");
 	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
 	if (!path.startsWith("/")) path = `/${path}`;

--- a/packages/core/src/i18n/resolve.ts
+++ b/packages/core/src/i18n/resolve.ts
@@ -37,9 +37,46 @@ export function resolveLocaleChain(explicit?: string): string[] {
 }
 
 const REPEATED_SLASHES = /\/{2,}/g;
+const DATE_TOKEN = /\{(year|month|day|hour|minute|second)\}/g;
+// SQLite-style datetime without timezone info ("2023-05-08 10:00:00").
+// Stored values are UTC; without this, `new Date()` would parse them in the
+// server's local zone and the same row could yield different URLs per host.
+const OFFSETLESS_DATETIME = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)$/;
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+function parseUtcDate(date: string | Date): Date {
+	if (date instanceof Date) return date;
+	const offsetless = OFFSETLESS_DATETIME.exec(date);
+	return new Date(offsetless ? `${offsetless[1]}T${offsetless[2]}Z` : date);
+}
 
 /**
- * Interpolate a collection `url_pattern` with a row's slug and id.
+ * Substitute WordPress-style date tokens (`{year}`, `{month}`, `{day}`,
+ * `{hour}`, `{minute}`, `{second}`) from a publish date. Month/day/time parts
+ * are zero-padded, mirroring WordPress (`%monthnum%`, `%day%`, ...). Tokens are
+ * left untouched when no valid date is available, so callers without a date
+ * (or unpublished entries) never produce a half-resolved URL.
+ */
+function applyDateTokens(path: string, date: string | Date | null | undefined): string {
+	const d = date == null ? null : parseUtcDate(date);
+	if (!d || Number.isNaN(d.getTime())) return path;
+	const parts: Record<string, string> = {
+		year: String(d.getUTCFullYear()),
+		month: pad2(d.getUTCMonth() + 1),
+		day: pad2(d.getUTCDate()),
+		hour: pad2(d.getUTCHours()),
+		minute: pad2(d.getUTCMinutes()),
+		second: pad2(d.getUTCSeconds()),
+	};
+	return path.replace(DATE_TOKEN, (match, key: string) => parts[key] ?? match);
+}
+
+/**
+ * Interpolate a collection `url_pattern` with a row's slug, id and publish date.
+ *
+ * Supported tokens: `{slug}`, `{id}`, and the date tokens `{year}`,
+ * `{month}`, `{day}`, `{hour}`, `{minute}`, `{second}` (resolved from `date`,
+ * for WordPress-style permalinks like `/{year}/{month}/{day}/{slug}.html`).
  *
  * Falls back to `/{collection}/{slug}` when no pattern is configured.
  * Does NOT apply any locale prefix — pass the result through
@@ -51,12 +88,15 @@ export function interpolateUrlPattern(options: {
 	collection: string;
 	slug: string;
 	id: string;
+	/** Publish date used for date tokens; tokens stay literal when absent. */
+	date?: string | Date | null;
 }): string {
-	const { pattern, collection, slug, id } = options;
+	const { pattern, collection, slug, id, date } = options;
 	const basePattern = pattern ?? `/${encodeURIComponent(collection)}/{slug}`;
 	let path = basePattern
-		.replace("{slug}", encodeURIComponent(slug))
-		.replace("{id}", encodeURIComponent(id));
+		.replaceAll("{slug}", encodeURIComponent(slug))
+		.replaceAll("{id}", encodeURIComponent(id));
+	path = applyDateTokens(path, date);
 	path = path.replace(REPEATED_SLASHES, "/");
 	if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
 	if (!path.startsWith("/")) path = `/${path}`;

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -13,7 +13,7 @@ import { sql } from "kysely";
 
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
-import { resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
+import { interpolateUrlPattern, resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
 import { getDb } from "../loader.js";
 import { cachedQuery, CacheNamespace } from "../object-cache/index.js";
 import { requestCached } from "../request-cache.js";
@@ -284,18 +284,6 @@ async function resolveMenuItem(
 	};
 }
 
-const SLUG_PLACEHOLDER = /\{slug\}/g;
-const ID_PLACEHOLDER = /\{id\}/g;
-
-/**
- * Interpolate a URL pattern with entry data
- *
- * Replaces `{slug}` and `{id}` placeholders.
- */
-function interpolateUrlPattern(pattern: string, slug: string, id: string): string {
-	return pattern.replace(SLUG_PLACEHOLDER, slug).replace(ID_PLACEHOLDER, id);
-}
-
 /**
  * Resolve the URL for a content reference. `referenceGroup` is the content
  * row's translation_group; we look up the row in the requested locale
@@ -315,15 +303,15 @@ async function resolveContentUrl(
 		validateIdentifier(collection, "menu item collection");
 
 		// Try the requested locale first, then any locale (deterministic).
-		let result = await sql<{ id: string; slug: string }>`
-			SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
+		let result = await sql<{ id: string; slug: string; published_at: string | null }>`
+			SELECT id, slug, published_at FROM ${sql.ref(`ec_${collection}`)}
 			WHERE translation_group = ${referenceGroup} AND locale = ${locale}
 			LIMIT 1
 		`.execute(db);
 		let row = result.rows[0];
 		if (!row) {
-			result = await sql<{ id: string; slug: string }>`
-				SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
+			result = await sql<{ id: string; slug: string; published_at: string | null }>`
+				SELECT id, slug, published_at FROM ${sql.ref(`ec_${collection}`)}
 				WHERE translation_group = ${referenceGroup}
 				ORDER BY locale ASC LIMIT 1
 			`.execute(db);
@@ -333,17 +321,21 @@ async function resolveContentUrl(
 			// Legacy rows whose reference_id still points at an id directly
 			// (defensive — migration 036 normalised these, but a row inserted
 			// between migrations could predate the remap).
-			const legacy = await sql<{ id: string; slug: string }>`
-				SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
+			const legacy = await sql<{ id: string; slug: string; published_at: string | null }>`
+				SELECT id, slug, published_at FROM ${sql.ref(`ec_${collection}`)}
 				WHERE id = ${referenceGroup} LIMIT 1
 			`.execute(db);
 			row = legacy.rows[0];
 		}
 		if (!row) return null;
 
-		const pattern = urlPatterns.get(collection);
-		if (pattern) return interpolateUrlPattern(pattern, row.slug, row.id);
-		return `/${collection}/${row.slug}`;
+		return interpolateUrlPattern({
+			pattern: urlPatterns.get(collection) ?? null,
+			collection,
+			slug: row.slug,
+			id: row.id,
+			date: row.published_at,
+		});
 	} catch (error) {
 		console.error(`Failed to resolve content URL for ${collection}/${referenceGroup}:`, error);
 		return null;

--- a/packages/core/src/menus/index.ts
+++ b/packages/core/src/menus/index.ts
@@ -14,7 +14,7 @@ import { sql } from "kysely";
 import { menuTag } from "../cache/chrome-tags.js";
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
-import { resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
+import { interpolateUrlPattern, resolveLocale, resolveLocaleChain } from "../i18n/resolve.js";
 import { getDb } from "../loader.js";
 import { cachedQuery, CacheNamespace } from "../object-cache/index.js";
 import type { CacheHint } from "../query.js";
@@ -332,21 +332,10 @@ function resolveMenuItem(
 	};
 }
 
-const SLUG_PLACEHOLDER = /\{slug\}/g;
-const ID_PLACEHOLDER = /\{id\}/g;
-
-/**
- * Interpolate a URL pattern with entry data
- *
- * Replaces `{slug}` and `{id}` placeholders.
- */
-function interpolateUrlPattern(pattern: string, slug: string, id: string): string {
-	return pattern.replace(SLUG_PLACEHOLDER, slug).replace(ID_PLACEHOLDER, id);
-}
-
 interface ContentReferenceRow {
 	id: string;
 	slug: string;
+	published_at: string | null;
 	locale: string;
 	translation_group: string;
 }
@@ -354,6 +343,7 @@ interface ContentReferenceRow {
 interface ResolvedContentReference {
 	id: string;
 	slug: string;
+	publishedAt: string | null;
 }
 
 type ContentReferenceLookup = Map<string, Map<string, ResolvedContentReference>>;
@@ -371,7 +361,7 @@ async function resolveContentReferences(
 				validateIdentifier(collection, "menu item collection");
 				for (const batch of chunks([...referenceGroups], SQL_BATCH_SIZE)) {
 					const result = await sql<ContentReferenceRow>`
-						SELECT id, slug, locale, translation_group
+						SELECT id, slug, published_at, locale, translation_group
 						FROM ${sql.ref(`ec_${collection}`)}
 						WHERE translation_group IN (${sql.join(batch)})
 					`.execute(db);
@@ -383,16 +373,18 @@ async function resolveContentReferences(
 					}
 				}
 				for (const [referenceGroup, row] of localized) {
-					lookup.set(referenceGroup, { id: row.id, slug: row.slug });
+					lookup.set(referenceGroup, { id: row.id, slug: row.slug, publishedAt: row.published_at });
 				}
 
 				const unresolved = [...referenceGroups].filter((id) => !lookup.has(id));
 				for (const batch of chunks(unresolved, SQL_BATCH_SIZE)) {
-					const result = await sql<ResolvedContentReference>`
-						SELECT id, slug FROM ${sql.ref(`ec_${collection}`)}
+					const result = await sql<Pick<ContentReferenceRow, "id" | "slug" | "published_at">>`
+						SELECT id, slug, published_at FROM ${sql.ref(`ec_${collection}`)}
 						WHERE id IN (${sql.join(batch)})
 					`.execute(db);
-					for (const row of result.rows) lookup.set(row.id, row);
+					for (const row of result.rows) {
+						lookup.set(row.id, { id: row.id, slug: row.slug, publishedAt: row.published_at });
+					}
 				}
 			} catch (error) {
 				console.error(`Failed to resolve content URLs for ${collection}:`, error);
@@ -437,9 +429,13 @@ function resolveContentUrl(
 	if (!referenceGroup) return null;
 	const row = contentLookup.get(collection)?.get(referenceGroup);
 	if (!row) return null;
-	const pattern = urlPatterns.get(collection);
-	if (pattern) return interpolateUrlPattern(pattern, row.slug, row.id);
-	return `/${collection}/${row.slug}`;
+	return interpolateUrlPattern({
+		pattern: urlPatterns.get(collection) ?? null,
+		collection,
+		slug: row.slug,
+		id: row.id,
+		date: row.publishedAt,
+	});
 }
 
 interface TaxonomyReferenceRow {

--- a/packages/core/src/seo/hreflang.ts
+++ b/packages/core/src/seo/hreflang.ts
@@ -167,6 +167,7 @@ export async function getHreflangAlternatesWithDb(
 			collection,
 			slug: variant.slug || variant.id,
 			id: variant.id,
+			date: variant.publishedAt,
 		});
 		const localized = await localizePath(path, locale);
 		if (localized === null) continue;

--- a/packages/core/tests/integration/redirects/redirect-repository.test.ts
+++ b/packages/core/tests/integration/redirects/redirect-repository.test.ts
@@ -386,6 +386,34 @@ describe("RedirectRepository", () => {
 			expect(redirect.type).toBe(301);
 		});
 
+		it("resolves date tokens from the publish date (#1526)", async () => {
+			const redirect = await repo.createAutoRedirect(
+				"posts",
+				"old-title",
+				"new-title",
+				"id1",
+				"/{year}/{month}/{day}/{slug}.html",
+				"2023-05-08T12:00:00.000Z",
+			);
+
+			expect(redirect.source).toBe("/2023/05/08/old-title.html");
+			expect(redirect.destination).toBe("/2023/05/08/new-title.html");
+		});
+
+		it("keeps date tokens literal without a publish date", async () => {
+			const redirect = await repo.createAutoRedirect(
+				"posts",
+				"old-title",
+				"new-title",
+				"id1",
+				"/{year}/{slug}",
+				null,
+			);
+
+			expect(redirect.source).toBe("/{year}/old-title");
+			expect(redirect.destination).toBe("/{year}/new-title");
+		});
+
 		it("uses fallback URL when no url pattern", async () => {
 			const redirect = await repo.createAutoRedirect("posts", "old-slug", "new-slug", "id1", null);
 

--- a/packages/core/tests/integration/redirects/redirect-repository.test.ts
+++ b/packages/core/tests/integration/redirects/redirect-repository.test.ts
@@ -386,6 +386,51 @@ describe("RedirectRepository", () => {
 			expect(redirect.type).toBe(301);
 		});
 
+		it("resolves date tokens from the publish date (#1526)", async () => {
+			const redirect = await repo.createAutoRedirect(
+				"posts",
+				"old-title",
+				"new-title",
+				"id1",
+				"/{year}/{month}/{day}/{slug}.html",
+				"2023-05-08T12:00:00.000Z",
+				"2023-05-08T12:00:00.000Z",
+			);
+
+			expect(redirect!.source).toBe("/2023/05/08/old-title.html");
+			expect(redirect!.destination).toBe("/2023/05/08/new-title.html");
+		});
+
+		it("builds the source from the old publish date and the destination from the new one", async () => {
+			const redirect = await repo.createAutoRedirect(
+				"posts",
+				"old-title",
+				"new-title",
+				"id1",
+				"/{year}/{month}/{day}/{slug}",
+				"2023-05-08T12:00:00.000Z",
+				"2024-01-02T12:00:00.000Z",
+			);
+
+			expect(redirect!.source).toBe("/2023/05/08/old-title");
+			expect(redirect!.destination).toBe("/2024/01/02/new-title");
+		});
+
+		it("keeps date tokens literal without a publish date", async () => {
+			const redirect = await repo.createAutoRedirect(
+				"posts",
+				"old-title",
+				"new-title",
+				"id1",
+				"/{year}/{slug}",
+				null,
+				null,
+			);
+
+			expect(redirect!.source).toBe("/{year}/old-title");
+			expect(redirect!.destination).toBe("/{year}/new-title");
+		});
+
 		it("uses fallback URL when no url pattern", async () => {
 			const redirect = await repo.createAutoRedirect("posts", "old-slug", "new-slug", "id1", null);
 

--- a/packages/core/tests/integration/seo/hreflang.test.ts
+++ b/packages/core/tests/integration/seo/hreflang.test.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Kysely } from "kysely";
+import { sql } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createDatabase } from "../../../src/database/connection.js";
@@ -79,6 +80,29 @@ describe("getHreflangAlternates (#1690)", () => {
 			{ hreflang: "en", href: `${SITE}/blog/hello` },
 			{ hreflang: "fr", href: `${SITE}/fr/blog/bonjour` },
 			{ hreflang: "x-default", href: `${SITE}/blog/hello` },
+		]);
+	});
+
+	it("resolves date tokens from each variant's publish date, matching the sitemap", async () => {
+		await db
+			.updateTable("_emdash_collections")
+			.set({ url_pattern: "/{year}/{month}/{day}/{slug}" })
+			.where("slug", "=", "post")
+			.execute();
+		const { en, fr } = await createPair();
+		await sql`UPDATE ec_post SET published_at = ${"2023-05-08T10:00:00.000Z"} WHERE id = ${en.id}`.execute(
+			db,
+		);
+		await sql`UPDATE ec_post SET published_at = ${"2024-01-02T10:00:00.000Z"} WHERE id = ${fr.id}`.execute(
+			db,
+		);
+
+		const alternates = await getHreflangAlternatesWithDb(db, "post", en.id, { siteUrl: SITE });
+
+		expect(alternates).toEqual([
+			{ hreflang: "en", href: `${SITE}/2023/05/08/hello` },
+			{ hreflang: "fr", href: `${SITE}/fr/2024/01/02/bonjour` },
+			{ hreflang: "x-default", href: `${SITE}/2023/05/08/hello` },
 		]);
 	});
 

--- a/packages/core/tests/unit/i18n/resolve.test.ts
+++ b/packages/core/tests/unit/i18n/resolve.test.ts
@@ -83,6 +83,41 @@ describe("interpolateUrlPattern", () => {
 			}),
 		).toBe("/blog/hello");
 	});
+
+	it("substitutes WordPress-style date tokens from the publish date (zero-padded)", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{month}/{day}/{slug}.html",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+				date: "2018-05-08T09:03:07Z",
+			}),
+		).toBe("/2018/05/08/hello.html");
+	});
+
+	it("supports hour/minute/second date tokens", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{hour}{minute}{second}/{slug}",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+				date: "2018-05-08T09:03:07Z",
+			}),
+		).toBe("/2018/090307/hello");
+	});
+
+	it("leaves date tokens untouched when no valid date is provided", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{month}/{slug}",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+			}),
+		).toBe("/{year}/{month}/hello");
+	});
 });
 
 describe("localizePath", () => {

--- a/packages/core/tests/unit/i18n/resolve.test.ts
+++ b/packages/core/tests/unit/i18n/resolve.test.ts
@@ -83,6 +83,56 @@ describe("interpolateUrlPattern", () => {
 			}),
 		).toBe("/blog/hello");
 	});
+
+	it("substitutes WordPress-style date tokens from the publish date (zero-padded)", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{month}/{day}/{slug}.html",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+				date: "2018-05-08T09:03:07Z",
+			}),
+		).toBe("/2018/05/08/hello.html");
+	});
+
+	it("treats offset-less SQLite datetimes as UTC regardless of server timezone", () => {
+		// "2018-05-08 23:30:00" parsed in a western local zone would land on
+		// May 8 local = correct only by luck; in an eastern zone it shifts to
+		// May 9. Stored values are UTC, so the URL must be /2018/05/08 always.
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{month}/{day}/{slug}",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+				date: "2018-05-08 23:30:00",
+			}),
+		).toBe("/2018/05/08/hello");
+	});
+
+	it("supports hour/minute/second date tokens", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{hour}{minute}{second}/{slug}",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+				date: "2018-05-08T09:03:07Z",
+			}),
+		).toBe("/2018/090307/hello");
+	});
+
+	it("leaves date tokens untouched when no valid date is provided", () => {
+		expect(
+			interpolateUrlPattern({
+				pattern: "/{year}/{month}/{slug}",
+				collection: "post",
+				slug: "hello",
+				id: "abc",
+			}),
+		).toBe("/{year}/{month}/hello");
+	});
 });
 
 describe("localizePath", () => {

--- a/packages/core/tests/unit/menus/menus.test.ts
+++ b/packages/core/tests/unit/menus/menus.test.ts
@@ -473,6 +473,23 @@ describe("Navigation Menus", () => {
 			expect(menu!.items[0].url).toBe("/work/widget-co");
 		});
 
+		it("resolves date tokens in the url_pattern from the publish date (#1526)", async () => {
+			await setupProjectsCollection("/{year}/{month}/{slug}");
+			await sql`
+				INSERT INTO ec_projects (id, slug, locale, translation_group, published_at)
+				VALUES ('proj-1', 'widget-co', 'en', 'group-proj-1', '2023-05-08T12:00:00.000Z')
+			`.execute(db);
+			await insertMenuWithCollectionItem({
+				referenceCollection: "projects",
+				referenceId: "group-proj-1",
+			});
+
+			const menu = await getMenuWithDb("primary", db);
+			expect(menu).not.toBeNull();
+			expect(menu!.items).toHaveLength(1);
+			expect(menu!.items[0].url).toBe("/2023/05/widget-co");
+		});
+
 		it("resolves items without a reference_id to the collection archive URL", async () => {
 			// Archive links (no entry reference) keep their root-relative
 			// /{collection}/ shape — the same URL shape as every other


### PR DESCRIPTION
## What does this PR do?

Adds **WordPress-style date tokens** to collection `url_pattern`, so teams migrating from WordPress can reproduce their permalink structure (e.g. `/2018/05/28/my-post` or the classic `/{year}/{month}/{day}/{slug}.html`).

`url_pattern` now resolves these tokens in addition to the existing `{slug}` / `{id}`:

- `{year}` `{month}` `{day}` `{hour}` `{minute}` `{second}` — from the entry's **publish date** (zero-padded). Using the publish date (not `updated_at`) keeps permalinks stable across later edits.

Literal suffixes like `.html` already work (they're literal text in the pattern). The tokens are substituted by the single core resolver `interpolateUrlPattern`, so they apply consistently to **sitemap** canonical URLs (+ hreflang) and the admin **"View published"** links. Tokens are left untouched when no valid publish date is available, so an unpublished/dateless entry never produces a half-resolved URL.

`url_pattern` is presentational in EmDash core (core serves no content routes — templates own routing), so this is the forward / canonical-URL side. Reverse-matching an incoming dated URL back to an entry remains the template's job, unchanged here.

Discussion: https://github.com/emdash-cms/emdash/discussions/1525

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — `emdash` (core) is clean. The admin package shows 8 pre-existing `RegistryPluginDetail.tsx` implicit-any errors that also occur on `main` without this change (shallow-clone/unbuilt-dep artifact); none are in the files this PR touches.
- [x] `pnpm lint` passes (`oxlint --type-aware --deny-warnings`, clean on changed files)
- [x] `pnpm test` — added unit tests for the date-token substitution; `tests/unit/i18n/resolve.test.ts` passes (15/15) locally. (The admin browser-vitest harness doesn't start in my local env — relying on repo CI for it.)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] User-visible strings wrapped for translation (URL-pattern help text). No `messages.po` changes included.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` + `@emdash-cms/admin`, minor)
- [x] New features link to a Discussion: https://github.com/emdash-cms/emdash/discussions/1525

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Opus 4.8

## Screenshots / test output

```
✓ tests/unit/i18n/resolve.test.ts (15 tests)
  ✓ interpolateUrlPattern > substitutes WordPress-style date tokens from the publish date (zero-padded)
  ✓ interpolateUrlPattern > supports hour/minute/second date tokens
  ✓ interpolateUrlPattern > leaves date tokens untouched when no valid date is provided
```

Example: pattern `/{year}/{month}/{day}/{slug}.html` + publish date `2018-05-08` → `/2018/05/08/hello.html`.

## Notes / follow-ups

The menu resolver now routes through the shared `interpolateUrlPattern` (its private `{slug}`/`{id}`-only copy is deleted), so menu links resolve date tokens too.

Known limitation, inherent to date-based permalinks (WordPress has the same): editing the publish date of an already-published entry moves its URL without leaving a redirect. Slug changes do leave one (built from the old publish date for the source and the new one for the destination).

