### PR TITLE
fix: close remaining isolate-poisoning hangs after #1489

### DIFF
--- a/.changeset/fix-atproto-refresh-poisoning.md
+++ b/.changeset/fix-atproto-refresh-poisoning.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/plugin-atproto": patch
+---
+
+Fixes AT Protocol syndication hanging on Cloudflare Workers when a request was cancelled while refreshing the session token. The token refresh is still coalesced so concurrent publishes don't race, but it no longer shares an in-flight promise that a cancelled request could leave pending forever; a later publish now recovers instead of hanging.

--- a/.changeset/fix-isolate-poisoning-byline-secrets.md
+++ b/.changeset/fix-isolate-poisoning-byline-secrets.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes admin and content pages intermittently hanging and returning 524 timeouts on Cloudflare Workers. The per-isolate caches for byline custom-field definitions and resolved site secrets could retain a never-settling promise left behind by a cancelled request, which wedged every later request on that isolate until it was evicted. Both caches now cache the resolved value behind a reclaimable single-flight lock, so a cancelled request can no longer stall the isolate.

--- a/.changeset/fix-x402-isolate-poisoning.md
+++ b/.changeset/fix-x402-isolate-poisoning.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/x402": patch
+---
+
+Fixes x402-protected routes hanging and returning 524 timeouts on Cloudflare Workers when the very first request to a cold isolate was cancelled mid-initialization. The resource server is now cached only once it is fully initialized, so a cancelled initializer no longer strands later requests.

--- a/packages/core/src/bylines/field-defs-cache.ts
+++ b/packages/core/src/bylines/field-defs-cache.ts
@@ -8,8 +8,12 @@
  * but are read on every byline hydration (admin pages, content rendering,
  * API responses). Caching at the isolate level drops the SELECT-from-
  * `_emdash_byline_fields` from once-per-hydration to once-per-isolate-
- * after-bump. The cache holds a Promise (not the resolved value) so
- * concurrent cold-isolate readers share the in-flight query.
+ * after-bump. The cache holds the resolved *value* behind a reclaimable
+ * single-flight lock (see `utils/single-flight-cache.ts`), never an
+ * in-flight promise: concurrent cold-isolate readers coalesce onto one
+ * query by polling the published value, so a reader whose request is
+ * cancelled mid-query can never strand later byline hydrations on the
+ * isolate (the workerd never-settling-promise hazard that produced 524s).
  *
  * Stored on globalThis under `Symbol.for("emdash:byline-field-defs")` so
  * Vite SSR chunk duplication can't produce two independent caches (same
@@ -50,17 +54,23 @@
 
 import type { Kysely } from "kysely";
 
+import { after } from "../after.js";
 import type { Database } from "../database/types.js";
 import { requestCached } from "../request-cache.js";
 import { getRequestContext } from "../request-context.js";
 import { BylineSchemaRegistry } from "../schema/byline-registry.js";
 import type { BylineFieldDefinition } from "../schema/types.js";
+import { createInitLock, type InitLock, initWithLock } from "../utils/init-lock.js";
 
 interface FieldDefsHolder {
-	/** In-flight or resolved defs promise for the cached version. Null until first read. */
-	cached: Promise<BylineFieldDefinition[]> | null;
-	/** Persisted-version value that `cached` was fetched against. */
+	/** Last resolved defs, valid only when `hasValue` is true. */
+	value: BylineFieldDefinition[] | null;
+	/** Presence flag, separate from `value` so an empty-array result still caches. */
+	hasValue: boolean;
+	/** Persisted-version value that `value` was fetched against. */
 	cachedVersion: number;
+	/** Reclaimable single-flight lock so a cancelled owner can't wedge readers. */
+	lock: InitLock;
 }
 
 const HOLDER_KEY = Symbol.for("emdash:byline-field-defs");
@@ -69,13 +79,28 @@ const holder: FieldDefsHolder =
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see request-cache.ts)
 	(g[HOLDER_KEY] as FieldDefsHolder | undefined) ??
 	(() => {
-		const h: FieldDefsHolder = { cached: null, cachedVersion: -1 };
+		const h: FieldDefsHolder = {
+			value: null,
+			hasValue: false,
+			cachedVersion: -1,
+			lock: createInitLock(),
+		};
 		g[HOLDER_KEY] = h;
 		return h;
 	})();
 
 const REQUEST_CACHE_KEY_VERSION = "byline-fields-version";
 const REQUEST_CACHE_KEY_DEFS_PREFIX = "byline-field-defs:";
+
+/**
+ * Reclaim window for the single-flight lock: if an owner holds it past
+ * this without publishing (e.g. its request was cancelled and the
+ * anchored fetch hasn't completed yet), the next reader reclaims and
+ * refetches. `listFields` is a single fast SELECT, so this only needs to
+ * cover a genuinely slow/stranded query. Mutable solely so tests can
+ * shorten it; production never changes it.
+ */
+let reclaimDeadlineMs = 10_000;
 
 /**
  * Read the persisted `options.byline_fields_version` counter. Cached for
@@ -107,19 +132,29 @@ export async function getBylineFieldDefs(db: Kysely<Database>): Promise<BylineFi
 		if (isolated || dirty) {
 			return new BylineSchemaRegistry(db).listFields();
 		}
-		if (holder.cached !== null && holder.cachedVersion === version) {
-			return holder.cached;
-		}
-		const defs = new BylineSchemaRegistry(db).listFields().catch((error) => {
-			if (holder.cached === defs) {
-				holder.cached = null;
-				holder.cachedVersion = -1;
-			}
-			throw error;
-		});
-		holder.cached = defs;
-		holder.cachedVersion = version;
-		return defs;
+		// Per-isolate single-flight cache keyed on the persisted version.
+		// Coalesce concurrent cold readers via the lock and read the
+		// published value; never await another request's in-flight promise
+		// (a cancelled owner would otherwise strand every later byline
+		// hydration on the isolate). The fetch is anchored so a cancelled
+		// originator still drives it to completion and populates the cache.
+		return initWithLock<BylineFieldDefinition[]>(
+			holder.lock,
+			() => (holder.hasValue && holder.cachedVersion === version ? holder.value : null),
+			(isCurrentClaim) =>
+				(async () => {
+					const defs = await new BylineSchemaRegistry(db).listFields();
+					// Publish only while still the current claim, and never
+					// regress over a newer version a concurrent reader stored.
+					if (isCurrentClaim() && version >= holder.cachedVersion) {
+						holder.value = defs;
+						holder.hasValue = true;
+						holder.cachedVersion = version;
+					}
+					return defs;
+				})(),
+			{ deadlineMs: reclaimDeadlineMs, anchor: (promise) => after(() => promise) },
+		);
 	});
 }
 
@@ -133,6 +168,21 @@ export async function getBylineFieldDefs(db: Kysely<Database>): Promise<BylineFi
  * coordination that lets other isolates see the change.
  */
 export function resetBylineFieldDefsCacheForTests(): void {
-	holder.cached = null;
+	holder.value = null;
+	holder.hasValue = false;
 	holder.cachedVersion = -1;
+	holder.lock.ownerStartedAt = null;
+	holder.lock.generation = 0;
+	reclaimDeadlineMs = 10_000;
+}
+
+/**
+ * Test-only: shorten the single-flight reclaim window so a "stranded
+ * owner" scenario can be exercised without waiting out the production
+ * deadline. Reset by `resetBylineFieldDefsCacheForTests`.
+ *
+ * @internal
+ */
+export function setBylineFieldDefsReclaimDeadlineForTests(ms: number): void {
+	reclaimDeadlineMs = ms;
 }

--- a/packages/core/src/config/secrets.ts
+++ b/packages/core/src/config/secrets.ts
@@ -31,9 +31,15 @@ import { sha256 } from "@oslojs/crypto/sha2";
 import { encodeHexLowerCase } from "@oslojs/encoding";
 import type { Kysely } from "kysely";
 
+import { after } from "../after.js";
 import { OptionsRepository } from "../database/repositories/options.js";
 import type { Database } from "../database/types.js";
 import { decodeBase64url, encodeBase64url } from "../utils/base64.js";
+import {
+	createSingleFlightCache,
+	type SingleFlightCache,
+	singleFlightCached,
+} from "../utils/single-flight-cache.js";
 
 /** v1 encryption key prefix. Bumping requires a separate KDF version. */
 export const ENCRYPTION_KEY_PREFIX = "emdash_enc_v1_";
@@ -370,17 +376,23 @@ export async function validateEncryptionKeyAtStartup(env?: SecretsEnv): Promise<
  *
  * Lives on `globalThis` so module-duplication during SSR bundling can't
  * fragment the cache. See `request-context.ts` for the same pattern.
+ *
+ * Each db gets its own poison-immune single-flight cache (see
+ * `utils/single-flight-cache.ts`): the resolved *value* is cached, never an
+ * in-flight promise, so a request cancelled mid-resolve can't strand later
+ * preview/comment requests on the isolate.
  */
 // Versioned to prevent cache fragmentation if `ResolvedSecrets`'s shape
 // ever changes. Bump the suffix on incompatible changes so a co-resident
-// older build doesn't read a newer-shape value.
-const SECRETS_CACHE_KEY = Symbol.for("@emdash-cms/core/secrets-cache@1");
+// older build doesn't read a newer-shape value. Bumped to @2 when the cached
+// value changed from a bare promise to a single-flight cache.
+const SECRETS_CACHE_KEY = Symbol.for("@emdash-cms/core/secrets-cache@2");
 
 interface SecretsCacheHolder {
-	cache: WeakMap<Kysely<Database>, Promise<ResolvedSecrets>>;
+	cache: WeakMap<Kysely<Database>, SingleFlightCache<ResolvedSecrets>>;
 }
 
-function getSecretsCache(): WeakMap<Kysely<Database>, Promise<ResolvedSecrets>> {
+function getSecretsCache(): WeakMap<Kysely<Database>, SingleFlightCache<ResolvedSecrets>> {
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern
 	const holder = globalThis as Record<symbol, SecretsCacheHolder | undefined>;
 	let entry = holder[SECRETS_CACHE_KEY];
@@ -397,19 +409,21 @@ function getSecretsCache(): WeakMap<Kysely<Database>, Promise<ResolvedSecrets>> 
  * env / re-query options on every request.
  *
  * The cache is keyed by `Kysely` instance, so playground / per-DO / per-test
- * databases each get their own resolution.
+ * databases each get their own resolution. Concurrent cold callers coalesce
+ * onto one resolution via the single-flight lock; a failed resolution
+ * propagates to the caller and releases the lock so the next caller retries.
  */
 export function resolveSecretsCached(db: Kysely<Database>): Promise<ResolvedSecrets> {
-	const cache = getSecretsCache();
-	const cached = cache.get(db);
-	if (cached) return cached;
-	const promise = resolveSecrets({ db }).catch((error) => {
-		// Don't poison the cache on transient failure; next caller retries.
-		cache.delete(db);
-		throw error;
+	const caches = getSecretsCache();
+	let cache = caches.get(db);
+	if (!cache) {
+		cache = createSingleFlightCache<ResolvedSecrets>();
+		caches.set(db, cache);
+	}
+	return singleFlightCached(cache, () => resolveSecrets({ db }), {
+		anchor: (promise) => after(() => promise),
+		ownerTimeoutMs: 30_000,
 	});
-	cache.set(db, promise);
-	return promise;
 }
 
 /**

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -45,7 +45,7 @@ import type {
 import type { FieldType } from "./schema/types.js";
 import { hashString } from "./utils/hash.js";
 import { createInitLock, type InitLock, initWithLock } from "./utils/init-lock.js";
-import { createIsolateCache, isolateCachedAsync } from "./utils/isolate-cache.js";
+import { createSingleFlightCache, singleFlightCached } from "./utils/single-flight-cache.js";
 import { COMMIT, VERSION } from "./version.js";
 
 const LEADING_SLASH_PATTERN = /^\//;
@@ -420,10 +420,10 @@ export class EmDashRuntime {
 	/**
 	 * Isolate-lifetime guard so FTS indexes are verified at most once per
 	 * worker rather than on every admin request. See ensureSearchHealthy().
-	 * Uses the poison-immune isolate cache (never a shared awaitable promise)
-	 * so a cancelled first caller can't wedge later ones.
+	 * Uses the poison-immune single-flight cache (never a shared awaitable
+	 * promise) so a cancelled first caller can't wedge later ones.
 	 */
-	private readonly _searchHealthCache = createIsolateCache<void>();
+	private readonly _searchHealthCache = createSingleFlightCache<void>();
 
 	/** Current hook pipeline. Use the `hooks` getter for external access. */
 	get hooks(): HookPipeline {
@@ -2233,7 +2233,7 @@ export class EmDashRuntime {
 		// branch, no need to cache it.
 		if (!isSqlite(this._db)) return;
 		try {
-			await isolateCachedAsync(
+			await singleFlightCached(
 				this._searchHealthCache,
 				async () => {
 					try {

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -15,11 +15,11 @@ import { getDb } from "../loader.js";
 import { peekRequestCache, requestCached } from "../request-cache.js";
 import type { Storage } from "../storage/types.js";
 import {
-	createIsolateCache,
-	type IsolateCache,
-	invalidateIsolateCache,
-	isolateCachedAsync,
-} from "../utils/isolate-cache.js";
+	createSingleFlightCache,
+	type SingleFlightCache,
+	invalidateSingleFlightCache,
+	singleFlightCached,
+} from "../utils/single-flight-cache.js";
 import type { SiteSettings, SiteSettingKey, MediaReference, SeoSettings } from "./types.js";
 
 /** Prefix for site settings in the options table */
@@ -34,7 +34,7 @@ const SETTINGS_PREFIX = "site:";
  * once-per-isolate. Cross-isolate staleness is bounded by isolate lifetime
  * (workerd typically recycles within minutes); acceptable for chrome.
  *
- * Backed by isolate-cache.ts: concurrent cold-isolate reads coalesce onto one
+ * Backed by single-flight-cache.ts: concurrent cold reads coalesce onto one
  * query via a reclaimable single-flight lock and the resolved *value* is
  * cached — never a shared in-flight promise, so a cancelled request can't
  * poison the isolate (see that file's header). Stored on globalThis with a
@@ -43,11 +43,11 @@ const SETTINGS_PREFIX = "site:";
  */
 const SITE_SETTINGS_CACHE_KEY = Symbol.for("emdash:site-settings");
 const g = globalThis as Record<symbol, unknown>;
-const settingsCache: IsolateCache<Partial<SiteSettings>> =
+const settingsCache: SingleFlightCache<Partial<SiteSettings>> =
 	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see request-context.ts)
-	(g[SITE_SETTINGS_CACHE_KEY] as IsolateCache<Partial<SiteSettings>> | undefined) ??
+	(g[SITE_SETTINGS_CACHE_KEY] as SingleFlightCache<Partial<SiteSettings>> | undefined) ??
 	(() => {
-		const c = createIsolateCache<Partial<SiteSettings>>();
+		const c = createSingleFlightCache<Partial<SiteSettings>>();
 		g[SITE_SETTINGS_CACHE_KEY] = c;
 		return c;
 	})();
@@ -60,7 +60,7 @@ const settingsCache: IsolateCache<Partial<SiteSettings>> =
  * own cached copy until they expire — staleness bounded by isolate lifetime.
  */
 export function invalidateSiteSettingsCache(): void {
-	invalidateIsolateCache(settingsCache);
+	invalidateSingleFlightCache(settingsCache);
 }
 
 /**
@@ -208,11 +208,11 @@ export async function getSiteSettingWithDb<K extends SiteSettingKey>(
  * ```
  */
 export function getSiteSettings(): Promise<Partial<SiteSettings>> {
-	// requestCached dedupes within a single request; isolateCachedAsync
+	// requestCached dedupes within a single request; singleFlightCached
 	// coalesces across requests and caches the resolved value for the
-	// isolate's lifetime without ever sharing an awaitable promise.
+	// global scope's lifetime without ever sharing an awaitable promise.
 	return requestCached("siteSettings", () =>
-		isolateCachedAsync(
+		singleFlightCached(
 			settingsCache,
 			async () => {
 				const db = await getDb();

--- a/packages/core/src/utils/single-flight-cache.ts
+++ b/packages/core/src/utils/single-flight-cache.ts
@@ -1,16 +1,21 @@
 /**
- * Isolate-lifetime async value cache with single-flight and poison-immunity.
+ * Global-scope async value cache with single-flight and poison-immunity.
  *
- * Built for the "compute once per isolate, read on every request" caches
- * (site settings, search-health verification, ...). These must coalesce
- * concurrent cold-isolate reads into one query — but the obvious way to do
- * that, caching the in-flight *promise* on an isolate-global and awaiting it
- * from later requests, is unsafe on workerd: if the request that created the
- * promise is cancelled mid-await (client disconnect, context teardown), its
- * continuation never runs, so the promise neither resolves nor rejects. Every
- * later request that awaits that shared promise then hangs until the isolate
- * is evicted (observed as 524s at the 100s wall, near-zero CPU). A `.catch`
- * that clears the cache doesn't help — a cancelled request doesn't reject.
+ * Built for the "compute once for the lifetime of the JS global scope, read
+ * on every request" caches (site settings, search-health verification, ...).
+ * That global scope is the process on Node and the isolate on Cloudflare
+ * Workers — this helper is platform-neutral; the hazard it defends against is
+ * specific to workerd but the cache itself is not.
+ *
+ * These caches must coalesce concurrent cold reads into one query — but the
+ * obvious way to do that, caching the in-flight *promise* on a global and
+ * awaiting it from later requests, is unsafe on workerd: if the request that
+ * created the promise is cancelled mid-await (client disconnect, context
+ * teardown), its continuation never runs, so the promise neither resolves nor
+ * rejects. Every later request that awaits that shared promise then hangs
+ * until the isolate is evicted (observed as 524s at the 100s wall, near-zero
+ * CPU). A `.catch`/`.finally` that clears the cache doesn't help — a cancelled
+ * request settles neither way.
  *
  * This cache stores the resolved *value* (not a promise) and coalesces via
  * `initWithLock`: one request becomes the owner and runs `fetch`, everyone
@@ -27,7 +32,7 @@
 
 import { createInitLock, type InitLock, initWithLock } from "./init-lock.js";
 
-export interface IsolateCache<T> {
+export interface SingleFlightCache<T> {
 	/** Last resolved value, valid only when `hasValue` is true. */
 	value: T | null;
 	/**
@@ -36,7 +41,7 @@ export interface IsolateCache<T> {
 	 * undefined" from "never fetched").
 	 */
 	hasValue: boolean;
-	/** Invalidation counter; bumped by `invalidateIsolateCache`. */
+	/** Invalidation counter; bumped by `invalidateSingleFlightCache`. */
 	version: number;
 	/** The `version` the cached value was fetched at. */
 	valueVersion: number;
@@ -44,16 +49,16 @@ export interface IsolateCache<T> {
 	lock: InitLock;
 }
 
-export function createIsolateCache<T>(): IsolateCache<T> {
+export function createSingleFlightCache<T>(): SingleFlightCache<T> {
 	return { value: null, hasValue: false, version: 0, valueVersion: -1, lock: createInitLock() };
 }
 
 /**
- * Force the next `isolateCachedAsync` call to refetch. An in-flight owner
+ * Force the next `singleFlightCached` call to refetch. An in-flight owner
  * fetched at the old version will not publish into the new version, so its
  * result is ignored by subsequent reads.
  */
-export function invalidateIsolateCache(cache: IsolateCache<unknown>): void {
+export function invalidateSingleFlightCache(cache: SingleFlightCache<unknown>): void {
 	cache.version++;
 	cache.hasValue = false;
 	cache.value = null;
@@ -75,7 +80,7 @@ export function invalidateIsolateCache(cache: IsolateCache<unknown>): void {
  */
 const RECLAIM_HEADROOM_MS = 5_000;
 
-export interface IsolateCachedOptions {
+export interface SingleFlightCachedOptions {
 	/**
 	 * Hand the in-flight fetch to the host's lifetime extender (waitUntil via
 	 * `after()`), so a cancelled originating request still drives it to
@@ -105,7 +110,7 @@ interface Box<T> {
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
 		const timer = setTimeout(() => {
-			reject(new Error(`isolateCachedAsync: owner fetch exceeded ${ms}ms`));
+			reject(new Error(`singleFlightCached: owner fetch exceeded ${ms}ms`));
 		}, ms);
 		// Settle from the underlying promise (whichever wins the race with the
 		// timer), and always clear the timer so a resolved fetch doesn't leave
@@ -121,10 +126,10 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * single-flight lock on a miss. Concurrent callers coalesce onto one fetch;
  * a cancelled owner cannot poison later callers (see file header).
  */
-export function isolateCachedAsync<T>(
-	cache: IsolateCache<T>,
+export function singleFlightCached<T>(
+	cache: SingleFlightCache<T>,
 	fetch: () => Promise<T>,
-	options: IsolateCachedOptions = {},
+	options: SingleFlightCachedOptions = {},
 ): Promise<T> {
 	// Capture the version once: a value published at this version satisfies
 	// this call; an invalidation that lands mid-fetch makes the published

--- a/packages/core/tests/unit/bylines/field-defs-cache.test.ts
+++ b/packages/core/tests/unit/bylines/field-defs-cache.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getBylineFieldDefs,
 	resetBylineFieldDefsCacheForTests,
+	setBylineFieldDefsReclaimDeadlineForTests,
 } from "../../../src/bylines/field-defs-cache.js";
 import { runMigrations } from "../../../src/database/migrations/runner.js";
 import type { Database as EmDashDatabase } from "../../../src/database/types.js";
@@ -64,7 +65,7 @@ describe("getBylineFieldDefs — dirty-version bypass (#1174 BUG 1)", () => {
 		await db.destroy();
 	});
 
-	it("coalesces concurrent cold global reads on the same in-flight defs promise", async () => {
+	it("coalesces concurrent cold global reads onto a single query", async () => {
 		await insertFieldDirect(db, "shared_field");
 
 		const original = BylineSchemaRegistry.prototype.listFields;
@@ -91,6 +92,47 @@ describe("getBylineFieldDefs — dirty-version bypass (#1174 BUG 1)", () => {
 		expect(calls).toBe(1);
 		expect(results[0].map((f) => f.slug)).toEqual(["shared_field"]);
 		expect(results[1].map((f) => f.slug)).toEqual(["shared_field"]);
+	});
+
+	it("a stranded owner (cancelled request) does not poison later byline hydrations", async () => {
+		// Regression for the isolate-poisoning class (companion to
+		// #1489): the old global holder cached the in-flight *promise*, so a
+		// first reader whose request was cancelled mid-query left a
+		// never-settling promise that every later byline hydration on the
+		// isolate awaited forever (524 at the 100s wall). The value+lock
+		// cache must let a later reader reclaim and recover instead.
+		await insertFieldDirect(db, "f1");
+		// Short reclaim window so the stranded-owner path is exercised fast.
+		setBylineFieldDefsReclaimDeadlineForTests(100);
+
+		const original = BylineSchemaRegistry.prototype.listFields;
+		let calls = 0;
+		vi.spyOn(BylineSchemaRegistry.prototype, "listFields").mockImplementation(
+			async function (this: BylineSchemaRegistry) {
+				calls += 1;
+				if (calls === 1) {
+					// Owner A's request is cancelled mid-query: on workerd the
+					// continuation never runs, so this promise never settles.
+					await new Promise(() => {});
+				}
+				return original.call(this);
+			},
+		);
+
+		// Owner A claims the lock and strands. Its request is gone, so nobody
+		// awaits its result.
+		const stranded = getBylineFieldDefs(db);
+		void stranded.catch(() => {});
+
+		// Let A claim before B arrives.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Reader B must recover by reclaiming the stale lock, not hang on A's
+		// dead promise. With the old promise-caching holder this awaited
+		// forever and the test would time out.
+		const recovered = await getBylineFieldDefs(db);
+		expect(recovered.map((f) => f.slug)).toEqual(["f1"]);
+		expect(calls).toBeGreaterThanOrEqual(2);
 	});
 
 	it("returns fresh defs when the global cache was primed under the same odd version", async () => {

--- a/packages/core/tests/unit/config/secrets.test.ts
+++ b/packages/core/tests/unit/config/secrets.test.ts
@@ -356,7 +356,7 @@ describe("config/secrets", () => {
 	});
 
 	describe("resolveSecretsCached", () => {
-		it("memoizes per-db so multiple callers share one resolution promise", async () => {
+		it("memoizes per-db so multiple callers share one resolved value", async () => {
 			// First caller starts the resolution; second caller piggybacks.
 			// We can verify they share a value (and the cache key is the db
 			// instance) by comparing against a freshly cleared cache.

--- a/packages/core/tests/unit/utils/single-flight-cache.test.ts
+++ b/packages/core/tests/unit/utils/single-flight-cache.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	createIsolateCache,
-	invalidateIsolateCache,
-	isolateCachedAsync,
-} from "../../../src/utils/isolate-cache.js";
+	createSingleFlightCache,
+	invalidateSingleFlightCache,
+	singleFlightCached,
+} from "../../../src/utils/single-flight-cache.js";
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -18,16 +18,16 @@ function neverSettles<T>(): Promise<T> {
 	return new Promise<T>(() => {});
 }
 
-describe("isolateCachedAsync", () => {
+describe("singleFlightCached", () => {
 	it("caches the resolved value across calls (one fetch)", async () => {
-		const cache = createIsolateCache<number>();
+		const cache = createSingleFlightCache<number>();
 		let calls = 0;
 		const fetch = async () => {
 			calls++;
 			return 5;
 		};
-		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(5);
-		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(5);
+		expect(await singleFlightCached(cache, fetch, { pollMs: 10 })).toBe(5);
+		expect(await singleFlightCached(cache, fetch, { pollMs: 10 })).toBe(5);
 		expect(calls).toBe(1);
 	});
 
@@ -35,18 +35,18 @@ describe("isolateCachedAsync", () => {
 		// The reason the cache stores a boxed value + presence flag rather
 		// than relying on a null check: a falsy/void result must still count
 		// as cached. Without the box this would refetch every call.
-		const cache = createIsolateCache<void>();
+		const cache = createSingleFlightCache<void>();
 		let calls = 0;
 		const fetch = async () => {
 			calls++;
 		};
-		await isolateCachedAsync(cache, fetch, { pollMs: 10 });
-		await isolateCachedAsync(cache, fetch, { pollMs: 10 });
+		await singleFlightCached(cache, fetch, { pollMs: 10 });
+		await singleFlightCached(cache, fetch, { pollMs: 10 });
 		expect(calls).toBe(1);
 	});
 
 	it("coalesces concurrent callers into a single fetch", async () => {
-		const cache = createIsolateCache<number>();
+		const cache = createSingleFlightCache<number>();
 		let calls = 0;
 		const fetch = async () => {
 			calls++;
@@ -54,20 +54,20 @@ describe("isolateCachedAsync", () => {
 			return 7;
 		};
 		const results = await Promise.all(
-			Array.from({ length: 5 }, () => isolateCachedAsync(cache, fetch, { pollMs: 5 })),
+			Array.from({ length: 5 }, () => singleFlightCached(cache, fetch, { pollMs: 5 })),
 		);
 		expect(results).toEqual([7, 7, 7, 7, 7]);
 		expect(calls).toBe(1);
 	});
 
-	it("invalidateIsolateCache forces a refetch", async () => {
-		const cache = createIsolateCache<number>();
+	it("invalidateSingleFlightCache forces a refetch", async () => {
+		const cache = createSingleFlightCache<number>();
 		let n = 0;
 		const fetch = async () => ++n;
-		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(1);
-		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(1);
-		invalidateIsolateCache(cache);
-		expect(await isolateCachedAsync(cache, fetch, { pollMs: 10 })).toBe(2);
+		expect(await singleFlightCached(cache, fetch, { pollMs: 10 })).toBe(1);
+		expect(await singleFlightCached(cache, fetch, { pollMs: 10 })).toBe(1);
+		invalidateSingleFlightCache(cache);
+		expect(await singleFlightCached(cache, fetch, { pollMs: 10 })).toBe(2);
 	});
 
 	it("a stranded owner fetch does not poison later callers", async () => {
@@ -76,9 +76,9 @@ describe("isolateCachedAsync", () => {
 		// in-flight promise" approach every later caller awaited that dead
 		// promise forever. Here later callers poll a value, reclaim the stale
 		// lock after the deadline, and succeed.
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 
-		void isolateCachedAsync(cache, () => neverSettles<string>(), {
+		void singleFlightCached(cache, () => neverSettles<string>(), {
 			deadlineMs: 100,
 			pollMs: 10,
 		});
@@ -86,7 +86,7 @@ describe("isolateCachedAsync", () => {
 
 		await sleep(120);
 
-		const result = await isolateCachedAsync(cache, async () => "recovered", {
+		const result = await singleFlightCached(cache, async () => "recovered", {
 			deadlineMs: 100,
 			pollMs: 10,
 			maxWaitMs: 1000,
@@ -95,9 +95,9 @@ describe("isolateCachedAsync", () => {
 	});
 
 	it("rejects the owner at ownerTimeoutMs instead of hanging forever", async () => {
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 		await expect(
-			isolateCachedAsync(cache, () => neverSettles<string>(), {
+			singleFlightCached(cache, () => neverSettles<string>(), {
 				ownerTimeoutMs: 50,
 				deadlineMs: 60_000, // high so reclaim doesn't mask the owner timeout
 				pollMs: 10,
@@ -109,7 +109,7 @@ describe("isolateCachedAsync", () => {
 		// A slow-but-live fetch: the owner gives up at ownerTimeoutMs, but the
 		// anchored copy keeps running and populates the cache, so the next
 		// caller is served without refetching.
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 		let release!: (value: string) => void;
 		const slow = new Promise<string>((resolve) => {
 			release = resolve;
@@ -117,7 +117,7 @@ describe("isolateCachedAsync", () => {
 		const anchored: Promise<void>[] = [];
 
 		await expect(
-			isolateCachedAsync(cache, () => slow, {
+			singleFlightCached(cache, () => slow, {
 				ownerTimeoutMs: 50,
 				deadlineMs: 60_000,
 				pollMs: 10,
@@ -129,7 +129,7 @@ describe("isolateCachedAsync", () => {
 		await Promise.all(anchored);
 
 		let calls = 0;
-		const result = await isolateCachedAsync(
+		const result = await singleFlightCached(
 			cache,
 			async () => {
 				calls++;
@@ -146,7 +146,7 @@ describe("isolateCachedAsync", () => {
 		// waiter reclaim before the owner finishes — a self-sustaining stampede
 		// that never populates the cache. The helper must raise the effective
 		// deadline above the owner timeout.
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 		let calls = 0;
 		const fetch = async () => {
 			calls++;
@@ -154,29 +154,29 @@ describe("isolateCachedAsync", () => {
 			return "v";
 		};
 		const opts = { deadlineMs: 30, ownerTimeoutMs: 1000, pollMs: 10, maxWaitMs: 5000 };
-		const a = isolateCachedAsync(cache, fetch, opts);
+		const a = singleFlightCached(cache, fetch, opts);
 		await sleep(20);
-		const b = isolateCachedAsync(cache, fetch, opts);
+		const b = singleFlightCached(cache, fetch, opts);
 		expect(await a).toBe("v");
 		expect(await b).toBe("v");
 		expect(calls).toBe(1);
 	});
 
 	it("invalidation frees the lock so a fresh reader doesn't wait out a stale owner", async () => {
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 		// A slow/stuck in-flight owner holds the lock.
-		void isolateCachedAsync(cache, () => neverSettles<string>(), {
+		void singleFlightCached(cache, () => neverSettles<string>(), {
 			deadlineMs: 10_000,
 			pollMs: 10,
 		});
 		expect(cache.lock.ownerStartedAt).not.toBeNull();
 
-		invalidateIsolateCache(cache);
+		invalidateSingleFlightCache(cache);
 		expect(cache.lock.ownerStartedAt).toBeNull();
 
 		// maxWaitMs (200) is far below deadlineMs (10s): without the lock being
 		// freed, the fresh reader would give up before it could ever reclaim.
-		const result = await isolateCachedAsync(cache, async () => "fresh", {
+		const result = await singleFlightCached(cache, async () => "fresh", {
 			deadlineMs: 10_000,
 			pollMs: 10,
 			maxWaitMs: 200,
@@ -185,8 +185,8 @@ describe("isolateCachedAsync", () => {
 	});
 
 	it("ignores a non-positive ownerTimeoutMs instead of rejecting instantly", async () => {
-		const cache = createIsolateCache<string>();
-		const result = await isolateCachedAsync(cache, async () => "v", {
+		const cache = createSingleFlightCache<string>();
+		const result = await singleFlightCached(cache, async () => "v", {
 			ownerTimeoutMs: 0,
 			pollMs: 10,
 		});
@@ -194,13 +194,13 @@ describe("isolateCachedAsync", () => {
 	});
 
 	it("propagates a fetch rejection to the caller and lets the next caller retry", async () => {
-		const cache = createIsolateCache<string>();
+		const cache = createSingleFlightCache<string>();
 		await expect(
-			isolateCachedAsync(cache, () => Promise.reject(new Error("boom")), { pollMs: 10 }),
+			singleFlightCached(cache, () => Promise.reject(new Error("boom")), { pollMs: 10 }),
 		).rejects.toThrow("boom");
 		expect(cache.lock.ownerStartedAt).toBeNull();
 
-		const result = await isolateCachedAsync(cache, async () => "ok", { pollMs: 10 });
+		const result = await singleFlightCached(cache, async () => "ok", { pollMs: 10 });
 		expect(result).toBe("ok");
 	});
 });

--- a/packages/plugins/atproto/src/atproto.ts
+++ b/packages/plugins/atproto/src/atproto.ts
@@ -147,16 +147,116 @@ export async function refreshSession(
 	};
 }
 
-/**
- * In-flight refresh promise for deduplication.
- * Prevents concurrent publishes from racing on token refresh,
- * which would corrupt tokens since PDS invalidates refresh tokens after use.
- */
-let refreshInFlight: Promise<AtSession> | null = null;
+// ── Token-refresh single-flight (poison-immune) ─────────────────
+//
+// Concurrent publishes must not each refresh the session: the PDS rotates
+// (invalidates) the refresh token on use, so a second concurrent refresh would
+// race the first. We coalesce onto one refresh — but deliberately WITHOUT
+// caching an in-flight promise that other calls await. On Cloudflare Workers
+// (workerd) a refresh whose originating request is cancelled mid-flight leaves
+// that promise forever pending, and every later `ensureSession` on the isolate
+// would hang on it until the isolate is evicted (524 at the 100s wall). This
+// is the same isolate-poisoning hazard fixed in core's single-flight cache.
+//
+// Instead, one caller claims a timestamped lock and performs the refresh;
+// concurrent callers poll KV — the source of truth, written by the owner via
+// `persistSession` — for the freshly persisted access token and never await
+// the owner's promise. A cancelled or stuck owner is reclaimed after
+// `refreshDeadlineMs` so a later caller refreshes rather than hanging.
+//
+// State is module-scoped (per isolate), matching the prior implementation.
+
+let refreshDeadlineMs = 15_000;
+let refreshPollMs = 25;
+let refreshMaxWaitMs = 30_000;
+let refreshOwnerStartedAt: number | null = null;
+let refreshGeneration = 0;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
- * Get a valid access token, refreshing if needed.
- * Uses promise deduplication to prevent concurrent refresh races.
+ * Coalesced, poison-immune token refresh. Returns the freshly persisted
+ * access token + DID, or `null` if the refresh could not be completed (the
+ * caller should fall back to a full login).
+ */
+async function refreshAccessDeduped(
+	ctx: PluginContext,
+	pdsHost: string,
+	refreshJwt: string,
+): Promise<{ accessJwt: string; did: string } | null> {
+	const waitStart = Date.now();
+	for (;;) {
+		// 1. Did an owner already publish a fresh token? Check KV (the source
+		// of truth) first, before attempting to claim, so a waiter that wakes
+		// just after the owner finished returns the published token instead of
+		// re-claiming and refreshing again. We only reach this function when
+		// the access token was absent/cleared, so any value here is fresh.
+		const access = await ctx.kv.get<string>("state:accessJwt");
+		if (access) {
+			const did = await ctx.kv.get<string>("state:did");
+			if (did) return { accessJwt: access, did };
+		}
+
+		// 2. No published token yet — claim the lock if it's free or the owner
+		// has held it past the deadline (likely a cancelled request whose
+		// continuation never ran). The claim is synchronous between awaits so
+		// two callers can't both claim.
+		const ownerStartedAt = refreshOwnerStartedAt;
+		if (ownerStartedAt === null || Date.now() - ownerStartedAt > refreshDeadlineMs) {
+			refreshGeneration += 1;
+			const claim = refreshGeneration;
+			refreshOwnerStartedAt = Date.now();
+			try {
+				const session = await refreshSession(ctx, pdsHost, refreshJwt);
+				await persistSession(ctx, session);
+				return { accessJwt: session.accessJwt, did: session.did };
+			} catch {
+				// Refresh failed (e.g. rotated/expired refresh token). Caller
+				// falls back to a full login.
+				return null;
+			} finally {
+				// Release only while still the current owner: a reclaimer may
+				// have taken the lock while this (slow) refresh was running.
+				if (refreshGeneration === claim) {
+					refreshOwnerStartedAt = null;
+				}
+			}
+		}
+
+		// 3. Another caller owns the refresh. Wait and re-check — never await
+		// its (possibly stranded) promise.
+		if (Date.now() - waitStart > refreshMaxWaitMs) {
+			// Give up rather than hang; caller falls back to a full login.
+			return null;
+		}
+		await sleep(refreshPollMs);
+	}
+}
+
+/**
+ * Test-only: reset the refresh single-flight lock and optionally shorten its
+ * timing so the stranded-owner / coalescing paths can be exercised without
+ * waiting out the production deadline.
+ *
+ * @internal
+ */
+export function __resetRefreshSingleFlightForTests(timing?: {
+	deadlineMs?: number;
+	pollMs?: number;
+	maxWaitMs?: number;
+}): void {
+	refreshOwnerStartedAt = null;
+	refreshGeneration = 0;
+	refreshDeadlineMs = timing?.deadlineMs ?? 15_000;
+	refreshPollMs = timing?.pollMs ?? 25;
+	refreshMaxWaitMs = timing?.maxWaitMs ?? 30_000;
+}
+
+/**
+ * Get a valid access token, refreshing if needed. Concurrent refreshes are
+ * coalesced onto one query via a poison-immune single-flight lock (see above).
  */
 export async function ensureSession(ctx: PluginContext): Promise<{
 	accessJwt: string;
@@ -180,24 +280,13 @@ export async function ensureSession(ctx: PluginContext): Promise<{
 		return { accessJwt: existingAccess, did: existingDid, pdsHost };
 	}
 
-	// Try refresh if we have a refresh token (deduplicated)
+	// Try refresh if we have a refresh token (coalesced, poison-immune)
 	if (existingRefresh) {
-		if (!refreshInFlight) {
-			refreshInFlight = refreshSession(ctx, pdsHost, existingRefresh)
-				.then(async (session) => {
-					await persistSession(ctx, session);
-					return session;
-				})
-				.finally(() => {
-					refreshInFlight = null;
-				});
+		const refreshed = await refreshAccessDeduped(ctx, pdsHost, existingRefresh);
+		if (refreshed) {
+			return { accessJwt: refreshed.accessJwt, did: refreshed.did, pdsHost };
 		}
-		try {
-			const session = await refreshInFlight;
-			return { accessJwt: session.accessJwt, did: session.did, pdsHost };
-		} catch {
-			// Refresh failed, fall through to full login
-		}
+		// Refresh failed or timed out, fall through to full login
 	}
 
 	// Full login

--- a/packages/plugins/atproto/tests/atproto.test.ts
+++ b/packages/plugins/atproto/tests/atproto.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
-import { createRecord, normalizePdsHost, rkeyFromUri } from "../src/atproto.js";
+import {
+	__resetRefreshSingleFlightForTests,
+	createRecord,
+	ensureSession,
+	normalizePdsHost,
+	rkeyFromUri,
+} from "../src/atproto.js";
 
 describe("normalizePdsHost", () => {
 	it("defaults to bsky.social", () => {
@@ -102,5 +108,108 @@ describe("createRecord", () => {
 		expect(fetch).toHaveBeenCalledTimes(3);
 		expect(kv.get("state:accessJwt")).toBe("fresh-access");
 		expect(kv.get("state:refreshJwt")).toBe("fresh-refresh");
+	});
+});
+
+describe("ensureSession token-refresh single-flight", () => {
+	afterEach(() => {
+		__resetRefreshSingleFlightForTests();
+		vi.restoreAllMocks();
+	});
+
+	function makeCtx(fetch: ReturnType<typeof vi.fn>) {
+		// No state:accessJwt -> ensureSession takes the refresh path.
+		const kv = new Map<string, unknown>([
+			["settings:pdsHost", "bsky.social"],
+			["settings:handle", "example.com"],
+			["settings:appPassword", "app-password"],
+			["state:refreshJwt", "refresh-token"],
+			["state:did", "did:plc:test"],
+		]);
+		const ctx = {
+			http: { fetch },
+			kv: {
+				get: vi.fn(async (key: string) => kv.get(key)),
+				set: vi.fn(async (key: string, value: unknown) => {
+					kv.set(key, value);
+				}),
+			},
+		} as any;
+		return { ctx, kv };
+	}
+
+	function freshRefreshResponse(): Response {
+		return new Response(
+			JSON.stringify({
+				accessJwt: "fresh-access",
+				refreshJwt: "fresh-refresh",
+				did: "did:plc:test",
+				handle: "example.com",
+			}),
+			{ status: 200 },
+		);
+	}
+
+	it("coalesces concurrent refreshes onto a single PDS call (waiters read KV)", async () => {
+		__resetRefreshSingleFlightForTests({ pollMs: 5 });
+		let refreshCalls = 0;
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const fetch = vi.fn(async (url: string) => {
+			if (url.includes("refreshSession")) {
+				refreshCalls += 1;
+				await gate;
+				return freshRefreshResponse();
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+		const { ctx } = makeCtx(fetch);
+
+		const a = ensureSession(ctx);
+		const b = ensureSession(ctx);
+		// Hold the owner mid-refresh so the second caller parks in the poll
+		// loop, then let it finish.
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		release();
+		const [ra, rb] = await Promise.all([a, b]);
+
+		expect(refreshCalls).toBe(1);
+		expect(ra.accessJwt).toBe("fresh-access");
+		expect(rb.accessJwt).toBe("fresh-access");
+	});
+
+	it("a stranded owner (cancelled request) does not hang later refreshers", async () => {
+		// Regression for the isolate-poisoning class: the old implementation
+		// cached the in-flight refresh *promise*, so a first caller whose
+		// request was cancelled mid-refresh left a never-settling promise that
+		// every later ensureSession on the isolate awaited forever (524). The
+		// lock-and-poll cache must let a later caller reclaim and recover.
+		__resetRefreshSingleFlightForTests({ deadlineMs: 80, pollMs: 10, maxWaitMs: 5000 });
+		let refreshCalls = 0;
+		const fetch = vi.fn(async (url: string) => {
+			if (url.includes("refreshSession")) {
+				refreshCalls += 1;
+				if (refreshCalls === 1) {
+					// Owner A's request is cancelled mid-refresh: never settles.
+					await new Promise(() => {});
+				}
+				return freshRefreshResponse();
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+		const { ctx } = makeCtx(fetch);
+
+		// Owner A claims and strands. Its request is gone; nobody awaits it.
+		const stranded = ensureSession(ctx);
+		void stranded.catch(() => {});
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		// Reader B must reclaim the stale lock and refresh, not hang on A's
+		// dead promise.
+		const recovered = await ensureSession(ctx);
+		expect(recovered.accessJwt).toBe("fresh-access");
+		expect(refreshCalls).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/packages/x402/src/enforcer.ts
+++ b/packages/x402/src/enforcer.ts
@@ -24,53 +24,63 @@ const DEFAULT_MAX_TIMEOUT_SECONDS = 60;
 const DEFAULT_BOT_SCORE_THRESHOLD = 30;
 
 /**
- * Cached resource server instance.
- * Initialized once per process, reused across requests.
+ * Cached, fully-initialized resource server instance.
+ * Built once per isolate/process, reused across requests.
+ *
+ * Deliberately caches only the *ready* server, never an in-flight
+ * initialization promise: on Cloudflare Workers (workerd), a request
+ * cancelled mid-`initialize()` leaves a shared promise forever pending, and
+ * every later request awaiting it hangs until the isolate is evicted
+ * (observed as 524s at the 100s wall). Caching the ready instance instead
+ * means a cancelled initializer simply leaves the cache empty so the next
+ * request rebuilds.
  */
 let _resourceServer: x402ResourceServer | null = null;
-let _initPromise: Promise<void> | null = null;
 
 /**
  * Get or create the x402ResourceServer singleton.
+ *
+ * No cross-request promise sharing (see `_resourceServer`'s note). The cost
+ * is that concurrent cold-start requests may each build a throwaway server
+ * before one wins the assignment — harmless, since construction is cheap and
+ * idempotent with no shared mutable state, and it only happens during the
+ * brief cold-start window.
  */
 async function getResourceServer(config: X402Config): Promise<x402ResourceServer> {
-	if (!_resourceServer) {
-		const facilitatorUrl = config.facilitatorUrl ?? DEFAULT_FACILITATOR_URL;
-		const facilitator = new HTTPFacilitatorClient({ url: facilitatorUrl });
-		const server = new x402ResourceServer(facilitator);
+	const existing = _resourceServer;
+	if (existing) return existing;
 
-		// Register EVM scheme (default)
-		if (config.evm !== false) {
-			try {
-				const evmMod = await import("@x402/evm/exact/server");
-				const evmScheme = new evmMod.ExactEvmScheme();
-				server.register("eip155:*" as `${string}:${string}`, evmScheme);
-			} catch {
-				// @x402/evm not installed -- skip EVM support
-			}
+	const facilitatorUrl = config.facilitatorUrl ?? DEFAULT_FACILITATOR_URL;
+	const facilitator = new HTTPFacilitatorClient({ url: facilitatorUrl });
+	const server = new x402ResourceServer(facilitator);
+
+	// Register EVM scheme (default)
+	if (config.evm !== false) {
+		try {
+			const evmMod = await import("@x402/evm/exact/server");
+			const evmScheme = new evmMod.ExactEvmScheme();
+			server.register("eip155:*" as `${string}:${string}`, evmScheme);
+		} catch {
+			// @x402/evm not installed -- skip EVM support
 		}
-
-		// Register SVM scheme (opt-in)
-		if (config.svm) {
-			try {
-				const svmMod = await import("@x402/svm/exact/server");
-				const svmScheme = new svmMod.ExactSvmScheme();
-				server.register("solana:*" as `${string}:${string}`, svmScheme);
-			} catch {
-				// @x402/svm not installed -- skip Solana support
-			}
-		}
-
-		_resourceServer = server;
-		_initPromise = server.initialize();
 	}
 
-	if (_initPromise) {
-		await _initPromise;
-		_initPromise = null;
+	// Register SVM scheme (opt-in)
+	if (config.svm) {
+		try {
+			const svmMod = await import("@x402/svm/exact/server");
+			const svmScheme = new svmMod.ExactSvmScheme();
+			server.register("solana:*" as `${string}:${string}`, svmScheme);
+		} catch {
+			// @x402/svm not installed -- skip Solana support
+		}
 	}
 
-	return _resourceServer;
+	await server.initialize();
+
+	// Publish only once fully initialized.
+	_resourceServer = server;
+	return server;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1489. That PR fixed the never-settling-promise (isolate-poisoning) hang for `getSiteSettings` and `ensureSearchHealthy`, but 524s persisted in production because **four more caches had the same bug**: each cached an in-flight `Promise` on a long-lived singleton. On workerd, a request cancelled mid-fetch leaves that promise pending forever (its `.catch`/`.finally` self-heal never runs), so every later request that awaits it hangs until the isolate is evicted (524 at the 100s wall). Smart Placement concentrates traffic onto few isolates, making it total.

A comprehensive sweep of every cross-request promise cache in the repo found these four (and confirmed nothing else stores a promise across requests):

1. **`bylines/field-defs-cache.ts`** — the primary culprit. It explicitly cached the resolved `Promise` and runs on **every byline hydration** (content rendering, admin pages, API responses), so it's the only remaining instance on the universal hot path. Matches the observed symptom: both admin and public pages hang, then "heal" after the isolate recycles.
2. **`config/secrets.ts` `resolveSecretsCached`** — `WeakMap<db, Promise<ResolvedSecrets>>`; hits preview-token verification, comments, snapshots.
3. **`x402` enforcer** — shared `_initPromise` for `server.initialize()`; x402-protected routes during cold-isolate init.
4. **`plugin-atproto`** — `refreshInFlight` module promise; AT Protocol syndication token-refresh path.

### Changes

- **Rename** the helper from `IsolateCache`/`isolateCachedAsync` to `SingleFlightCache`/`singleFlightCached` (file `single-flight-cache.ts`). It lives in `core`, which also runs on Node + SQLite, so the Cloudflare-specific "isolate" name was misleading. Internal util (not in the public barrel) — no API change.
- **byline**: cache the value behind a reclaimable single-flight lock (`initWithLock`), preserving the existing cross-isolate persisted-version gate (`options.byline_fields_version`).
- **secrets**: per-db `SingleFlightCache` (Symbol bumped `@1`->`@2`).
- **x402**: cache the *ready* server (assign only after `initialize()` resolves), drop the shared `_initPromise`. Duplicate cold-start init is harmless here, so no lock is needed.
- **atproto**: inline poison-immune lock-and-poll (the plugin can't reach core internals — it imports a type only and ships a sandboxed bundle). One caller claims a timestamped lock and refreshes; concurrent callers poll KV (the source of truth, written via `persistSession`) and never await the owner's promise. A stranded owner is reclaimed after a deadline.

Regression tests reproduce the stranded-owner hang for byline and atproto (both fail against the old promise-caching code, which would await a dead promise forever).


## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — n/a, no UI strings changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

Full core suite: 3976 tests pass. x402: 17 pass. atproto: 11 pass (incl. 2 new regressions). `pnpm typecheck`, `pnpm lint` (0 diagnostics), `pnpm format` all clean.

Note: a pre-existing, unrelated failure in `plugins/atproto/tests/plugin.test.ts` ("declares the expected identity") also fails on `main` — `emdash-plugin.jsonc` has no `version` field there. Left out of scope.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-singleflight-cache-poisoning-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/singleflight-cache-poisoning`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

