### PR TITLE
feat(admin): searchable repeater select sub-fields via Kumo Combobox

### DIFF
--- a/.changeset/searchable-repeater-select.md
+++ b/.changeset/searchable-repeater-select.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Repeater `select` sub-fields now render as a searchable dropdown (Kumo `Combobox`) instead of a plain `Select`. Typing filters the options, which keeps long option lists (e.g. a taxonomy-backed list with 100+ entries) usable inside a repeater row. Short lists behave the same as before.

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -5,7 +5,7 @@
  * Items can be added, removed, and reordered via drag-and-drop.
  */
 
-import { Button, Input, InputArea, Select, Switch } from "@cloudflare/kumo";
+import { Button, Combobox, Input, InputArea, Select, Switch } from "@cloudflare/kumo";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import {
@@ -357,16 +357,28 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 				/>
 			);
 		case "select":
+			// Searchable dropdown (Kumo Combobox) so long option lists in a
+			// repeater row stay usable. Falls back gracefully for short lists.
 			return (
-				<Select
+				<Combobox
 					label={subField.label}
-					value={typeof value === "string" ? value : ""}
-					onValueChange={(v) => onChange(v ?? "")}
-					items={{
-						"": t`Select...`,
-						...Object.fromEntries((subField.options ?? []).map((opt) => [opt, opt])),
-					}}
-				/>
+					value={typeof value === "string" && value ? value : null}
+					onValueChange={(v) => onChange((v as string | null) ?? "")}
+					items={subField.options ?? []}
+				>
+					<Combobox.TriggerValue placeholder={t`Select...`} />
+					<Combobox.Content>
+						<Combobox.Input placeholder={t`Search...`} />
+						<Combobox.Empty />
+						<Combobox.List>
+							{(opt: string) => (
+								<Combobox.Item key={opt} value={opt}>
+									{opt}
+								</Combobox.Item>
+							)}
+						</Combobox.List>
+					</Combobox.Content>
+				</Combobox>
 			);
 		case "image":
 			return (


### PR DESCRIPTION
## What does this PR do?

Repeater `select` sub-fields now render a searchable Kumo `Combobox` (type-to-filter) instead of a plain `Select`, so long option lists stay usable inside a repeater row. Short lists behave the same as before. Admin-only; no schema or data changes.

Discussion: https://github.com/emdash-cms/emdash/discussions/1536

Motivation: a "Services" repeater where each row picks a *Treatment* from ~100 standardized options — an unfiltered dropdown is painful; typing to filter fixes it.

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas)) — see #1536

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — not run locally (no monorepo install in this environment); relying on CI
- [ ] `pnpm lint` passes — relying on CI
- [ ] `pnpm test` passes — relying on CI
- [ ] `pnpm format` has been run — relying on CI
- [ ] I have added/updated tests for my changes (if applicable) — none added; this is a presentational swap of one field renderer
- [x] User-visible strings are wrapped for translation (`t\`Select...\``, `t\`Search...\``)
- [x] I have added a changeset (`@emdash-cms/admin` minor)
- [x] New features link to a Discussion: #1536

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Opus 4.8

## Notes

- Scope is intentionally limited to **repeater sub-fields** (`RepeaterField.tsx`), where long lists are most painful. The top-level `select` field renderer (`ContentEditor.tsx`, which uses `{value,label}` option objects) could get the same treatment as a follow-up — happy to include it if you'd prefer one consistent change.
- `Combobox` degrades fine for short lists, so it's always-on. If you'd rather gate it (a `searchable` field flag or an option-count threshold), I'll adjust.
- Validated in production via a local patch against `@emdash-cms/admin@0.20.0` (a clinic "Services" repeater with a 100+ option treatment list) — filtering works as expected.
