### PR TITLE
feat(comments): reactions + Wilson 'Best' sort (Tier 1)

### DIFF
--- a/.changeset/comment-reactions.md
+++ b/.changeset/comment-reactions.md
@@ -2,14 +2,10 @@
 "emdash": minor
 ---
 
-Add comment reactions (Tier 1 of the best-in-class comments RFC).
+Add comment reactions
 
 Visitors can now react to approved comments (positive-only "like" by default,
-extensible to other reaction types). Reactions are stored first-party in a new
-`_emdash_comment_reactions` table, deduped per voter via a salted IP hash (the
-same privacy primitive as comment `ip_hash`), and exposed through a public,
-honeypot- and rate-limited endpoint at
-`POST/GET /_emdash/api/comments/:collection/:contentId/reactions`.
+extensible to other reaction types). Reactions are deduped per voter via IP hash.
 
 The `<Comments>` component gains two opt-in props:
 

--- a/.changeset/comment-reactions.md
+++ b/.changeset/comment-reactions.md
@@ -1,0 +1,23 @@
+---
+"emdash": minor
+---
+
+Add comment reactions (Tier 1 of the best-in-class comments RFC).
+
+Visitors can now react to approved comments (positive-only "like" by default,
+extensible to other reaction types). Reactions are stored first-party in a new
+`_emdash_comment_reactions` table, deduped per voter via a salted IP hash (the
+same privacy primitive as comment `ip_hash`), and exposed through a public,
+honeypot- and rate-limited endpoint at
+`POST/GET /_emdash/api/comments/:collection/:contentId/reactions`.
+
+The `<Comments>` component gains two opt-in props:
+
+- `reactions` — render a like button per comment and attach live counts.
+- `sort="best"` — order top-level comments by a Reddit-style Wilson score
+  lower bound (`sort="oldest"`, the previous behavior, remains the default).
+
+Posting is progressively enhanced (a tiny inline script, no framework island)
+and emitted only when `reactions` is enabled, so pages that don't use reactions
+ship zero additional JavaScript. Fully additive and backward-compatible: a new
+table, a new route, and new optional props with behavior-preserving defaults.

--- a/packages/core/src/api/handlers/comment-reactions.ts
+++ b/packages/core/src/api/handlers/comment-reactions.ts
@@ -19,6 +19,14 @@ import type { ApiResult } from "../types.js";
 const REACTION_RATE_LIMIT = 30;
 const REACTION_RATE_WINDOW_MINUTES = 10;
 
+/**
+ * Reactions the system accepts. Positive-only for now (matches the shipped
+ * widget); kept as an allowlist so a voter can't spam arbitrary reaction
+ * strings and bloat a comment's count map. Extend (or make configurable) as
+ * the UI grows.
+ */
+const ALLOWED_REACTIONS: ReadonlySet<string> = new Set(["like"]);
+
 export interface ReactionToggleResult {
 	commentId: string;
 	reaction: string;
@@ -51,6 +59,13 @@ export async function handleReactionToggle(
 ): Promise<ApiResult<ReactionToggleResult>> {
 	try {
 		const { collection, contentId, commentId, reaction, voterHash } = params;
+
+		if (!ALLOWED_REACTIONS.has(reaction)) {
+			return {
+				success: false,
+				error: { code: "VALIDATION_ERROR", message: "Unsupported reaction" },
+			};
+		}
 
 		// The comment must exist, be approved, and belong to this content item.
 		const comment = await db

--- a/packages/core/src/api/handlers/comment-reactions.ts
+++ b/packages/core/src/api/handlers/comment-reactions.ts
@@ -1,0 +1,145 @@
+/**
+ * Comment reaction handlers (Tier 1 of the best-in-class comments RFC).
+ *
+ * Business logic for toggling reactions and reading aggregate counts. Route
+ * files stay thin wrappers; these return `ApiResult<T>`.
+ */
+
+import type { Kysely } from "kysely";
+
+import {
+	CommentReactionRepository,
+	type ReactionCounts,
+} from "#db/repositories/comment-reaction.js";
+import type { Database } from "#db/types.js";
+
+import type { ApiResult } from "../types.js";
+
+/** Max reactions a single voter may register per window before throttling. */
+const REACTION_RATE_LIMIT = 30;
+const REACTION_RATE_WINDOW_MINUTES = 10;
+
+export interface ReactionToggleResult {
+	commentId: string;
+	reaction: string;
+	/** true if the reaction was added, false if an existing one was removed */
+	reacted: boolean;
+	/** updated counts for this comment after the toggle */
+	counts: ReactionCounts;
+}
+
+export interface ReactionCountsResult {
+	/** comment id -> reaction counts */
+	reactions: Record<string, ReactionCounts>;
+	/** comment id -> reactions the current voter has active (omitted if anonymous) */
+	viewer?: Record<string, string[]>;
+}
+
+/**
+ * Toggle a reaction for a voter on an approved comment belonging to the given
+ * content item. Rate-limited per voter.
+ */
+export async function handleReactionToggle(
+	db: Kysely<Database>,
+	params: {
+		collection: string;
+		contentId: string;
+		commentId: string;
+		reaction: string;
+		voterHash: string;
+	},
+): Promise<ApiResult<ReactionToggleResult>> {
+	try {
+		const { collection, contentId, commentId, reaction, voterHash } = params;
+
+		// The comment must exist, be approved, and belong to this content item.
+		const comment = await db
+			.selectFrom("_emdash_comments")
+			.select(["id", "status"])
+			.where("id", "=", commentId)
+			.where("collection", "=", collection)
+			.where("content_id", "=", contentId)
+			.executeTakeFirst();
+
+		if (!comment) {
+			return { success: false, error: { code: "NOT_FOUND", message: "Comment not found" } };
+		}
+		if (comment.status !== "approved") {
+			return {
+				success: false,
+				error: { code: "COMMENT_NOT_APPROVED", message: "Cannot react to this comment" },
+			};
+		}
+
+		const repo = new CommentReactionRepository(db);
+
+		const recent = await repo.countRecentByVoter(voterHash, REACTION_RATE_WINDOW_MINUTES);
+		if (recent >= REACTION_RATE_LIMIT) {
+			return {
+				success: false,
+				error: { code: "RATE_LIMITED", message: "Too many reactions. Please try again later." },
+			};
+		}
+
+		const { reacted } = await repo.toggle({ commentId, reaction, voterHash });
+		const countsMap = await repo.countsForComments([commentId]);
+
+		return {
+			success: true,
+			data: { commentId, reaction, reacted, counts: countsMap.get(commentId) ?? {} },
+		};
+	} catch {
+		return {
+			success: false,
+			error: { code: "REACTION_TOGGLE_ERROR", message: "Failed to toggle reaction" },
+		};
+	}
+}
+
+/**
+ * Read aggregate reaction counts for every approved comment on a content item,
+ * plus (optionally) which reactions the current voter has active.
+ */
+export async function handleReactionCounts(
+	db: Kysely<Database>,
+	collection: string,
+	contentId: string,
+	voterHash?: string,
+): Promise<ApiResult<ReactionCountsResult>> {
+	try {
+		const comments = await db
+			.selectFrom("_emdash_comments")
+			.select("id")
+			.where("collection", "=", collection)
+			.where("content_id", "=", contentId)
+			.where("status", "=", "approved")
+			.execute();
+
+		const ids = comments.map((c) => c.id);
+		const repo = new CommentReactionRepository(db);
+
+		const countsMap = await repo.countsForComments(ids);
+		const reactions: Record<string, ReactionCounts> = {};
+		for (const [id, counts] of countsMap) {
+			reactions[id] = counts;
+		}
+
+		const data: ReactionCountsResult = { reactions };
+
+		if (voterHash) {
+			const viewerMap = await repo.viewerReactions(ids, voterHash);
+			const viewer: Record<string, string[]> = {};
+			for (const [id, list] of viewerMap) {
+				viewer[id] = list;
+			}
+			data.viewer = viewer;
+		}
+
+		return { success: true, data };
+	} catch {
+		return {
+			success: false,
+			error: { code: "REACTION_COUNTS_ERROR", message: "Failed to read reactions" },
+		};
+	}
+}

--- a/packages/core/src/api/schemas/comments.ts
+++ b/packages/core/src/api/schemas/comments.ts
@@ -15,6 +15,16 @@ export const createCommentBody = z
 	})
 	.meta({ id: "CreateCommentBody" });
 
+export const createReactionBody = z
+	.object({
+		commentId: z.string().min(1),
+		/** Reaction name. Positive-only ("like") by default; extensible. */
+		reaction: z.string().min(1).max(20).default("like"),
+		/** Honeypot field — hidden in the form, filled only by bots */
+		website_url: z.string().optional(),
+	})
+	.meta({ id: "CreateReactionBody" });
+
 export const commentStatusBody = z
 	.object({
 		status: z.enum(["approved", "pending", "spam", "trash"]),

--- a/packages/core/src/astro/integration/routes.ts
+++ b/packages/core/src/astro/integration/routes.ts
@@ -758,6 +758,11 @@ export function injectCoreRoutes(
 		entrypoint: resolveRoute("api/comments/[collection]/[contentId]/index.ts"),
 	});
 
+	injectRoute({
+		pattern: "/_emdash/api/comments/[collection]/[contentId]/reactions",
+		entrypoint: resolveRoute("api/comments/[collection]/[contentId]/reactions.ts"),
+	});
+
 	// Comment routes (admin)
 	injectRoute({
 		pattern: "/_emdash/api/admin/comments",

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/reactions.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/reactions.ts
@@ -35,8 +35,12 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 	if (dbErr) return dbErr;
 
 	try {
-		// Salted voter hash from request IP (same primitive as comment ip_hash);
-		// shared "unknown" bucket when no trusted IP is available.
+		// Salted voter hash from request IP (same primitive as comment ip_hash).
+		// Behind Cloudflare (CF-Connecting-IP) or a configured trusted proxy this
+		// is per-visitor. Without a trusted IP it collapses to a shared "unknown"
+		// bucket, so reaction dedup degrades for those visitors — a real
+		// per-visitor token is Tier 2 (visitor identity). Operators should set
+		// trustedProxyHeaders; see the comment ingest route for the same note.
 		const meta = extractRequestMeta(request, emdash.config);
 		let voterHash = "unknown";
 		if (meta.ip) {

--- a/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/reactions.ts
+++ b/packages/core/src/astro/routes/api/comments/[collection]/[contentId]/reactions.ts
@@ -1,0 +1,93 @@
+/**
+ * Public comment reaction endpoints (Tier 1 of the best-in-class comments RFC).
+ *
+ * GET  /_emdash/api/comments/:collection/:contentId/reactions
+ *   - Aggregate reaction counts for the content's approved comments, plus the
+ *     current visitor's active reactions.
+ * POST /_emdash/api/comments/:collection/:contentId/reactions
+ *   - Toggle a reaction on a comment. Public, honeypot- and rate-limit-gated.
+ *
+ * Inherits the `/_emdash/api/comments/` public prefix (no auth); the POST still
+ * requires the `X-EmDash-Request: 1` CSRF header like the comment POST.
+ */
+
+import type { APIRoute } from "astro";
+
+import { apiError, apiSuccess, handleError, requireDb, unwrapResult } from "#api/error.js";
+import { handleReactionCounts, handleReactionToggle } from "#api/handlers/comment-reactions.js";
+import { hashIp } from "#api/handlers/comments.js";
+import { isParseError, parseBody } from "#api/parse.js";
+import { createReactionBody } from "#api/schemas.js";
+import { resolveSecretsCached } from "#config/secrets.js";
+import { extractRequestMeta } from "#plugins/request-meta.js";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, request, locals }) => {
+	const { emdash } = locals;
+	const { collection, contentId } = params;
+
+	if (!collection || !contentId) {
+		return apiError("VALIDATION_ERROR", "Collection and content ID required", 400);
+	}
+
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
+
+	try {
+		// Salted voter hash from request IP (same primitive as comment ip_hash);
+		// shared "unknown" bucket when no trusted IP is available.
+		const meta = extractRequestMeta(request, emdash.config);
+		let voterHash = "unknown";
+		if (meta.ip) {
+			const { ipSalt } = await resolveSecretsCached(emdash.db);
+			voterHash = await hashIp(meta.ip, ipSalt);
+		}
+
+		const result = await handleReactionCounts(emdash.db, collection, contentId, voterHash);
+		return unwrapResult(result);
+	} catch (error) {
+		return handleError(error, "Failed to read reactions", "REACTION_COUNTS_ERROR");
+	}
+};
+
+export const POST: APIRoute = async ({ params, request, locals }) => {
+	const { emdash } = locals;
+	const { collection, contentId } = params;
+
+	if (!collection || !contentId) {
+		return apiError("VALIDATION_ERROR", "Collection and content ID required", 400);
+	}
+
+	const dbErr = requireDb(emdash?.db);
+	if (dbErr) return dbErr;
+
+	try {
+		const body = await parseBody(request, createReactionBody);
+		if (isParseError(body)) return body;
+
+		// Anti-spam: honeypot — hidden field filled only by bots. Silently accept.
+		if (body.website_url) {
+			return apiSuccess({ reacted: false, counts: {} });
+		}
+
+		const meta = extractRequestMeta(request, emdash.config);
+		let voterHash = "unknown";
+		if (meta.ip) {
+			const { ipSalt } = await resolveSecretsCached(emdash.db);
+			voterHash = await hashIp(meta.ip, ipSalt);
+		}
+
+		const result = await handleReactionToggle(emdash.db, {
+			collection,
+			contentId,
+			commentId: body.commentId,
+			reaction: body.reaction,
+			voterHash,
+		});
+
+		return unwrapResult(result, 200);
+	} catch (error) {
+		return handleError(error, "Failed to toggle reaction", "REACTION_TOGGLE_ERROR");
+	}
+};

--- a/packages/core/src/comments/query.ts
+++ b/packages/core/src/comments/query.ts
@@ -7,15 +7,25 @@
 
 import type { Kysely } from "kysely";
 
+import { CommentReactionRepository } from "../database/repositories/comment-reaction.js";
 import { CommentRepository } from "../database/repositories/comment.js";
 import type { PublicComment } from "../database/repositories/comment.js";
 import type { Database } from "../database/types.js";
 import { getDb } from "../loader.js";
+import { reactionScore } from "./ranking.js";
 
 export interface GetCommentsOptions {
 	collection: string;
 	contentId: string;
 	threaded?: boolean;
+	/** Attach aggregate reaction counts to each comment. */
+	reactions?: boolean;
+	/**
+	 * Order of top-level comments. `oldest` (default) preserves the existing
+	 * chronological display; `best` ranks by Wilson-scored reactions (implies
+	 * `reactions`). Replies always stay chronological.
+	 */
+	sort?: "oldest" | "best";
 }
 
 export interface GetCommentsResult {
@@ -65,14 +75,61 @@ export async function getCommentsWithDb(
 		limit: MAX_COMMENTS,
 	});
 
-	if (options.threaded) {
-		const threaded = CommentRepository.assembleThreads(result.items);
-		const items = threaded.map((c) => CommentRepository.toPublicComment(c));
-		return { items, total };
+	const items: PublicComment[] = options.threaded
+		? CommentRepository.assembleThreads(result.items).map((c) =>
+				CommentRepository.toPublicComment(c),
+			)
+		: result.items.map((c) => CommentRepository.toPublicComment(c));
+
+	// `best` sort needs reaction data, so it implies reactions.
+	if (options.reactions || options.sort === "best") {
+		await attachReactions(db, items);
+		if (options.sort === "best") {
+			sortByBest(items);
+		}
 	}
 
-	const items = result.items.map((c) => CommentRepository.toPublicComment(c));
 	return { items, total };
+}
+
+/**
+ * Attach aggregate reaction counts to a list of public comments (and their
+ * replies), in a single batched query.
+ */
+async function attachReactions(db: Kysely<Database>, items: PublicComment[]): Promise<void> {
+	const ids: string[] = [];
+	for (const comment of items) {
+		ids.push(comment.id);
+		if (comment.replies) {
+			for (const reply of comment.replies) ids.push(reply.id);
+		}
+	}
+	if (ids.length === 0) return;
+
+	const counts = await new CommentReactionRepository(db).countsForComments(ids);
+
+	const assign = (comment: PublicComment) => {
+		const reactions = counts.get(comment.id);
+		if (reactions) comment.reactions = reactions;
+	};
+	for (const comment of items) {
+		assign(comment);
+		comment.replies?.forEach(assign);
+	}
+}
+
+/**
+ * Sort top-level comments by Wilson-scored reactions (descending), tie-broken
+ * by oldest-first to keep ordering stable.
+ */
+function sortByBest(items: PublicComment[]): void {
+	items.sort((a, b) => {
+		const scoreDelta = reactionScore(b.reactions ?? {}) - reactionScore(a.reactions ?? {});
+		if (scoreDelta !== 0) return scoreDelta;
+		if (a.createdAt < b.createdAt) return -1;
+		if (a.createdAt > b.createdAt) return 1;
+		return 0;
+	});
 }
 
 /**

--- a/packages/core/src/comments/ranking.ts
+++ b/packages/core/src/comments/ranking.ts
@@ -1,0 +1,58 @@
+/**
+ * Comment ranking utilities (Tier 1 of the best-in-class comments RFC).
+ *
+ * Wilson score lower-bound (95% confidence) — the same primitive Reddit uses
+ * for its "Best" comment sort. Ranks by the statistical lower bound of the
+ * positive-reaction proportion rather than the raw count, so a comment with a
+ * couple of reactions can't outrank a heavily-reacted one until it earns
+ * confidence, and a late-but-popular comment still rises (submission time is
+ * irrelevant).
+ *
+ * Positive-only reactions (the recommended default) degrade gracefully: with
+ * `down = 0` the score still increases monotonically with `up` while penalising
+ * low-sample comments — wilson(1,0) ≈ 0.21, wilson(10,0) ≈ 0.73,
+ * wilson(200,0) ≈ 0.98.
+ */
+
+/** z for a 95% two-sided confidence interval. */
+const DEFAULT_Z = 1.96;
+
+/** Reactions that count against a comment when both signals are in use. */
+const NEGATIVE_REACTIONS: ReadonlySet<string> = new Set(["dislike", "down"]);
+
+/**
+ * Wilson score lower bound of the positive proportion.
+ *
+ * @param up   count of positive reactions
+ * @param down count of negative reactions
+ * @returns a score in [0, 1]; 0 when there are no reactions
+ */
+export function wilsonLowerBound(up: number, down: number, z: number = DEFAULT_Z): number {
+	const n = up + down;
+	if (n <= 0) return 0;
+	const phat = up / n;
+	const z2 = z * z;
+	const denom = 1 + z2 / n;
+	const centre = phat + z2 / (2 * n);
+	const margin = z * Math.sqrt((phat * (1 - phat) + z2 / (4 * n)) / n);
+	return (centre - margin) / denom;
+}
+
+/**
+ * Reduce a per-reaction count map to a single rank score via the Wilson
+ * lower bound. Any reaction not in {@link NEGATIVE_REACTIONS} is treated as
+ * positive, so the positive-only default (just `like`) works without special
+ * casing.
+ */
+export function reactionScore(counts: Record<string, number>): number {
+	let up = 0;
+	let down = 0;
+	for (const [reaction, count] of Object.entries(counts)) {
+		if (NEGATIVE_REACTIONS.has(reaction)) {
+			down += count;
+		} else {
+			up += count;
+		}
+	}
+	return wilsonLowerBound(up, down);
+}

--- a/packages/core/src/components/Comments.astro
+++ b/packages/core/src/components/Comments.astro
@@ -21,6 +21,10 @@ interface Props {
 	collection: string;
 	contentId: string;
 	threaded?: boolean;
+	/** Show a like/reaction button per comment (opt-in). */
+	reactions?: boolean;
+	/** Order of top-level comments: chronological (default) or Wilson-ranked. */
+	sort?: "oldest" | "best";
 	class?: string;
 }
 
@@ -28,13 +32,15 @@ const {
 	collection,
 	contentId,
 	threaded = false,
+	reactions = false,
+	sort = "oldest",
 	class: className,
 } = Astro.props;
 
 const collectionInfo = await getCollectionInfo(collection);
 const enabled = collectionInfo?.commentsEnabled ?? false;
 const { items, total } = enabled
-	? await getComments({ collection, contentId, threaded })
+	? await getComments({ collection, contentId, threaded, reactions, sort })
 	: { items: [], total: 0 };
 
 const URL_RE = /https?:\/\/[^\s<>"')\]]+/g;
@@ -62,15 +68,72 @@ function escapeHtml(text: string): string {
 function formatBody(text: string): string {
 	return autoLinkUrls(escapeHtml(text));
 }
+
+// Progressive-enhancement script for reactions. Emitted verbatim (is:inline)
+// only when `reactions` is enabled, so non-reaction pages ship zero extra JS.
+// Avoids template literals internally so it survives the outer backticks.
+const REACTION_SCRIPT = `
+(() => {
+  const sections = document.querySelectorAll('[data-ec-comments][data-ec-reactions]');
+  sections.forEach((section) => {
+    const collection = section.getAttribute('data-collection');
+    const contentId = section.getAttribute('data-content-id');
+    if (!collection || !contentId) return;
+    const base = '/_emdash/api/comments/' + encodeURIComponent(collection) + '/' + encodeURIComponent(contentId) + '/reactions';
+    const headers = { 'X-EmDash-Request': '1' };
+
+    fetch(base, { headers: headers })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((payload) => {
+        const viewer = payload && payload.data && payload.data.viewer;
+        if (!viewer) return;
+        Object.keys(viewer).forEach((commentId) => {
+          (viewer[commentId] || []).forEach((reaction) => {
+            const sel = '.ec-reaction[data-comment-id="' + commentId + '"][data-ec-reaction="' + reaction + '"]';
+            const btn = section.querySelector(sel);
+            if (btn) btn.setAttribute('aria-pressed', 'true');
+          });
+        });
+      })
+      .catch(() => {});
+
+    section.addEventListener('click', (event) => {
+      const btn = event.target.closest('.ec-reaction');
+      if (!btn || !section.contains(btn)) return;
+      const commentId = btn.getAttribute('data-comment-id');
+      const reaction = btn.getAttribute('data-ec-reaction');
+      if (!commentId || !reaction) return;
+      btn.disabled = true;
+      fetch(base, {
+        method: 'POST',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+        body: JSON.stringify({ commentId: commentId, reaction: reaction }),
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((payload) => {
+          const data = payload && payload.data;
+          if (!data) return;
+          btn.setAttribute('aria-pressed', data.reacted ? 'true' : 'false');
+          const countEl = btn.querySelector('[data-ec-reaction-count]');
+          if (countEl) countEl.textContent = String((data.counts && data.counts[reaction]) || 0);
+        })
+        .catch(() => {})
+        .finally(() => { btn.disabled = false; });
+    });
+  });
+})();
+`;
 ---
 
 {
 	enabled && (
+		<Fragment>
 		<section
 			class:list={["ec-comments", className]}
 			data-ec-comments
 			data-collection={collection}
 			data-content-id={contentId}
+			{...(reactions ? { "data-ec-reactions": "" } : {})}
 		>
 			<h3 class="ec-comments-heading">
 				{total === 0
@@ -112,6 +175,25 @@ function formatBody(text: string): string {
 									class="ec-comment-body"
 									set:html={formatBody(comment.body)}
 								/>
+								{reactions && (
+									<div class="ec-comment-actions">
+										<button
+											type="button"
+											class="ec-reaction"
+											data-ec-reaction="like"
+											data-comment-id={comment.id}
+											aria-pressed="false"
+										>
+											<span class="ec-reaction-icon" aria-hidden="true">
+												&#x2661;
+											</span>
+											<span class="ec-reaction-label">Like</span>
+											<span class="ec-reaction-count" data-ec-reaction-count>
+												{comment.reactions?.like ?? 0}
+											</span>
+										</button>
+									</div>
+								)}
 								{threaded && comment.replies && comment.replies.length > 0 && (
 									<ol class="ec-comment-replies">
 										{comment.replies.map((reply: PublicComment) => (
@@ -153,6 +235,21 @@ function formatBody(text: string): string {
 														class="ec-comment-body"
 														set:html={formatBody(reply.body)}
 													/>
+													{reactions && (
+														<div class="ec-comment-actions">
+															<button
+																type="button"
+																class="ec-reaction"
+																data-ec-reaction="like"
+																data-comment-id={reply.id}
+																aria-pressed="false"
+															>
+																<span class="ec-reaction-icon" aria-hidden="true">&#x2661;</span>
+																<span class="ec-reaction-label">Like</span>
+																<span class="ec-reaction-count" data-ec-reaction-count>{reply.reactions?.like ?? 0}</span>
+															</button>
+														</div>
+													)}
 												</article>
 											</li>
 										))}
@@ -164,6 +261,8 @@ function formatBody(text: string): string {
 				</ol>
 			)}
 		</section>
+		{reactions && <script is:inline set:html={REACTION_SCRIPT} />}
+		</Fragment>
 	)
 }
 
@@ -228,5 +327,41 @@ function formatBody(text: string): string {
 		margin-top: 0.5rem;
 		white-space: pre-wrap;
 		word-break: break-word;
+	}
+
+	.ec-comment-actions {
+		margin-top: 0.5rem;
+	}
+
+	.ec-reaction {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font: inherit;
+		font-size: 0.875em;
+		color: inherit;
+		background: none;
+		border: var(--ec-comment-border);
+		border-radius: 999px;
+		padding: 0.15rem 0.6rem;
+		cursor: pointer;
+	}
+
+	.ec-reaction[aria-pressed="true"] {
+		border-color: currentColor;
+		font-weight: 600;
+	}
+
+	.ec-reaction[aria-pressed="true"] .ec-reaction-icon {
+		color: #e0245e;
+	}
+
+	.ec-reaction:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.ec-reaction-count {
+		font-variant-numeric: tabular-nums;
 	}
 </style>

--- a/packages/core/src/database/migrations/044_comment_reactions.ts
+++ b/packages/core/src/database/migrations/044_comment_reactions.ts
@@ -1,0 +1,56 @@
+import type { Kysely } from "kysely";
+
+import { currentTimestamp } from "../dialect-helpers.js";
+
+/**
+ * Comment reactions (Tier 1 of the best-in-class comments RFC).
+ *
+ * One row per (comment, voter, reaction). Toggle semantics are enforced by the
+ * unique index — a voter either has a given reaction on a comment or doesn't.
+ * `voter_hash` is a salted SHA-256 of the visitor's IP (same primitive as
+ * `_emdash_comments.ip_hash`), so no cleartext identity is stored.
+ *
+ * Additive and backward-compatible: a new table, no change to existing schema.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.createTable("_emdash_comment_reactions")
+		.ifNotExists()
+		.addColumn("id", "text", (col) => col.primaryKey())
+		.addColumn("comment_id", "text", (col) =>
+			col.notNull().references("_emdash_comments.id").onDelete("cascade"),
+		)
+		.addColumn("reaction", "text", (col) => col.notNull().defaultTo("like"))
+		.addColumn("voter_hash", "text", (col) => col.notNull())
+		.addColumn("created_at", "text", (col) => col.defaultTo(currentTimestamp(db)))
+		.execute();
+
+	// One reaction of a given type per voter per comment (toggle semantics).
+	await db.schema
+		.createIndex("idx_comment_reactions_unique")
+		.ifNotExists()
+		.on("_emdash_comment_reactions")
+		.columns(["comment_id", "voter_hash", "reaction"])
+		.unique()
+		.execute();
+
+	// Aggregate counts per comment (GROUP BY comment_id, reaction).
+	await db.schema
+		.createIndex("idx_comment_reactions_comment")
+		.ifNotExists()
+		.on("_emdash_comment_reactions")
+		.column("comment_id")
+		.execute();
+
+	// Per-voter rate limiting (recent reactions by a voter).
+	await db.schema
+		.createIndex("idx_comment_reactions_voter")
+		.ifNotExists()
+		.on("_emdash_comment_reactions")
+		.columns(["voter_hash", "created_at"])
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.dropTable("_emdash_comment_reactions").execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -45,6 +45,7 @@ import * as m040 from "./040_byline_i18n.js";
 import * as m041 from "./041_content_locale_list_index.js";
 import * as m042 from "./042_byline_fields.js";
 import * as m043 from "./043_content_references.js";
+import * as m044 from "./044_comment_reactions.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -89,6 +90,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"041_content_locale_list_index": m041,
 	"042_byline_fields": m042,
 	"043_content_references": m043,
+	"044_comment_reactions": m044,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/repositories/comment-reaction.ts
+++ b/packages/core/src/database/repositories/comment-reaction.ts
@@ -1,0 +1,127 @@
+import type { Kysely } from "kysely";
+import { ulid } from "ulidx";
+
+import { SQL_BATCH_SIZE, chunks } from "../../utils/chunks.js";
+import type { Database } from "../types.js";
+
+/** Per-comment reaction counts: `{ like: 12, love: 3 }`. */
+export type ReactionCounts = Record<string, number>;
+
+export interface ToggleReactionInput {
+	commentId: string;
+	reaction: string;
+	voterHash: string;
+}
+
+/**
+ * Repository for comment reactions (likes / emoji).
+ *
+ * Reactions are deduped per (comment, voter, reaction) by a unique index, so
+ * a second toggle of the same reaction by the same voter removes it.
+ */
+export class CommentReactionRepository {
+	constructor(private db: Kysely<Database>) {}
+
+	/**
+	 * Toggle a reaction for a voter on a comment.
+	 *
+	 * @returns `{ reacted: true }` if the reaction was added, `{ reacted: false }`
+	 *   if an existing reaction was removed.
+	 */
+	async toggle(input: ToggleReactionInput): Promise<{ reacted: boolean }> {
+		const existing = await this.db
+			.selectFrom("_emdash_comment_reactions")
+			.select("id")
+			.where("comment_id", "=", input.commentId)
+			.where("voter_hash", "=", input.voterHash)
+			.where("reaction", "=", input.reaction)
+			.executeTakeFirst();
+
+		if (existing) {
+			await this.db.deleteFrom("_emdash_comment_reactions").where("id", "=", existing.id).execute();
+			return { reacted: false };
+		}
+
+		await this.db
+			.insertInto("_emdash_comment_reactions")
+			.values({
+				id: ulid(),
+				comment_id: input.commentId,
+				reaction: input.reaction,
+				voter_hash: input.voterHash,
+				created_at: new Date().toISOString(),
+			})
+			.execute();
+		return { reacted: true };
+	}
+
+	/**
+	 * Aggregate reaction counts for a set of comments.
+	 *
+	 * @returns a Map keyed by comment id; comments with no reactions are absent.
+	 */
+	async countsForComments(commentIds: string[]): Promise<Map<string, ReactionCounts>> {
+		const result = new Map<string, ReactionCounts>();
+		if (commentIds.length === 0) return result;
+
+		for (const batch of chunks(commentIds, SQL_BATCH_SIZE)) {
+			const rows = await this.db
+				.selectFrom("_emdash_comment_reactions")
+				.select(["comment_id", "reaction"])
+				.select((eb) => eb.fn.count<number>("id").as("count"))
+				.where("comment_id", "in", batch)
+				.groupBy(["comment_id", "reaction"])
+				.execute();
+
+			for (const row of rows) {
+				const counts = result.get(row.comment_id) ?? {};
+				counts[row.reaction] = Number(row.count);
+				result.set(row.comment_id, counts);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Which reactions a given voter has set, per comment.
+	 *
+	 * @returns a Map keyed by comment id whose values are the reaction names the
+	 *   voter has active on that comment.
+	 */
+	async viewerReactions(commentIds: string[], voterHash: string): Promise<Map<string, string[]>> {
+		const result = new Map<string, string[]>();
+		if (commentIds.length === 0) return result;
+
+		for (const batch of chunks(commentIds, SQL_BATCH_SIZE)) {
+			const rows = await this.db
+				.selectFrom("_emdash_comment_reactions")
+				.select(["comment_id", "reaction"])
+				.where("comment_id", "in", batch)
+				.where("voter_hash", "=", voterHash)
+				.execute();
+
+			for (const row of rows) {
+				const list = result.get(row.comment_id) ?? [];
+				list.push(row.reaction);
+				result.set(row.comment_id, list);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Count a voter's reactions within a recent time window (for rate limiting).
+	 */
+	async countRecentByVoter(voterHash: string, windowMinutes = 10): Promise<number> {
+		const cutoff = new Date(Date.now() - windowMinutes * 60 * 1000).toISOString();
+		const result = await this.db
+			.selectFrom("_emdash_comment_reactions")
+			.select((eb) => eb.fn.count<number>("id").as("count"))
+			.where("voter_hash", "=", voterHash)
+			.where("created_at", ">", cutoff)
+			.executeTakeFirst();
+		return Number(result?.count ?? 0);
+	}
+}

--- a/packages/core/src/database/repositories/comment-reaction.ts
+++ b/packages/core/src/database/repositories/comment-reaction.ts
@@ -29,20 +29,12 @@ export class CommentReactionRepository {
 	 *   if an existing reaction was removed.
 	 */
 	async toggle(input: ToggleReactionInput): Promise<{ reacted: boolean }> {
-		const existing = await this.db
-			.selectFrom("_emdash_comment_reactions")
-			.select("id")
-			.where("comment_id", "=", input.commentId)
-			.where("voter_hash", "=", input.voterHash)
-			.where("reaction", "=", input.reaction)
-			.executeTakeFirst();
-
-		if (existing) {
-			await this.db.deleteFrom("_emdash_comment_reactions").where("id", "=", existing.id).execute();
-			return { reacted: false };
-		}
-
-		await this.db
+		// Idempotent add: insert, or no-op if this voter already has this
+		// reaction. Using ON CONFLICT (rather than read-then-write) avoids a
+		// TOCTOU race where two concurrent toggles both see "no row" and the
+		// second INSERT violates the unique index — the old path surfaced that
+		// as a 500. The unique index doubles as the conflict target.
+		const inserted = await this.db
 			.insertInto("_emdash_comment_reactions")
 			.values({
 				id: ulid(),
@@ -51,8 +43,21 @@ export class CommentReactionRepository {
 				voter_hash: input.voterHash,
 				created_at: new Date().toISOString(),
 			})
+			.onConflict((oc) => oc.columns(["comment_id", "voter_hash", "reaction"]).doNothing())
+			.executeTakeFirst();
+
+		if ((inserted.numInsertedOrUpdatedRows ?? 0n) > 0n) {
+			return { reacted: true };
+		}
+
+		// The reaction already existed → toggle it off.
+		await this.db
+			.deleteFrom("_emdash_comment_reactions")
+			.where("comment_id", "=", input.commentId)
+			.where("voter_hash", "=", input.voterHash)
+			.where("reaction", "=", input.reaction)
 			.execute();
-		return { reacted: true };
+		return { reacted: false };
 	}
 
 	/**

--- a/packages/core/src/database/repositories/comment.ts
+++ b/packages/core/src/database/repositories/comment.ts
@@ -39,6 +39,8 @@ export interface PublicComment {
 	body: string;
 	createdAt: string;
 	replies?: PublicComment[];
+	/** Aggregate reaction counts (`{ like: 12 }`), attached when requested. */
+	reactions?: Record<string, number>;
 }
 
 export interface CreateCommentInput {

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -382,6 +382,14 @@ export interface CommentTable {
 	updated_at: Generated<string>;
 }
 
+export interface CommentReactionTable {
+	id: string;
+	comment_id: string;
+	reaction: string;
+	voter_hash: string;
+	created_at: Generated<string>;
+}
+
 // Sections
 
 export interface SectionTable {
@@ -433,6 +441,7 @@ export interface Database {
 	_emdash_seo: SeoTable;
 	_emdash_cron_tasks: CronTaskTable;
 	_emdash_comments: CommentTable;
+	_emdash_comment_reactions: CommentReactionTable;
 	_emdash_redirects: RedirectTable;
 	_emdash_404_log: NotFoundLogTable;
 	_emdash_bylines: BylineTable;

--- a/packages/core/tests/integration/comments/reactions.test.ts
+++ b/packages/core/tests/integration/comments/reactions.test.ts
@@ -1,6 +1,7 @@
 import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { handleReactionToggle } from "../../../src/api/handlers/comment-reactions.js";
 import { getCommentsWithDb } from "../../../src/comments/query.js";
 import { CommentReactionRepository } from "../../../src/database/repositories/comment-reaction.js";
 import { CommentRepository } from "../../../src/database/repositories/comment.js";
@@ -129,6 +130,75 @@ describe("CommentReactionRepository", () => {
 			});
 
 			expect(items[0]?.reactions).toEqual({ like: 1 });
+		});
+	});
+
+	describe("handleReactionToggle", () => {
+		const base = { collection: "post", contentId: "content-1" };
+
+		it("toggles a reaction and returns updated counts", async () => {
+			const c = await approvedComment();
+			const r = await handleReactionToggle(db, {
+				...base,
+				commentId: c.id,
+				reaction: "like",
+				voterHash: "v1",
+			});
+			expect(r.success).toBe(true);
+			if (r.success) {
+				expect(r.data.reacted).toBe(true);
+				expect(r.data.counts).toEqual({ like: 1 });
+			}
+		});
+
+		it("rejects an unsupported reaction with VALIDATION_ERROR", async () => {
+			const c = await approvedComment();
+			const r = await handleReactionToggle(db, {
+				...base,
+				commentId: c.id,
+				reaction: "spam",
+				voterHash: "v1",
+			});
+			expect(r.success).toBe(false);
+			if (!r.success) expect(r.error.code).toBe("VALIDATION_ERROR");
+		});
+
+		it("rejects reacting to a non-approved comment", async () => {
+			const c = await approvedComment({ status: "pending" });
+			const r = await handleReactionToggle(db, {
+				...base,
+				commentId: c.id,
+				reaction: "like",
+				voterHash: "v1",
+			});
+			expect(r.success).toBe(false);
+			if (!r.success) expect(r.error.code).toBe("COMMENT_NOT_APPROVED");
+		});
+
+		it("rejects reacting to a missing comment", async () => {
+			const r = await handleReactionToggle(db, {
+				...base,
+				commentId: "does-not-exist",
+				reaction: "like",
+				voterHash: "v1",
+			});
+			expect(r.success).toBe(false);
+			if (!r.success) expect(r.error.code).toBe("NOT_FOUND");
+		});
+
+		it("does not error when two toggles for the same voter race (idempotent add)", async () => {
+			const c = await approvedComment();
+			// Fire both concurrently — the old read-then-write path could throw a
+			// unique-constraint 500 here; ON CONFLICT makes it safe.
+			const [a, b] = await Promise.all([
+				handleReactionToggle(db, { ...base, commentId: c.id, reaction: "like", voterHash: "v1" }),
+				handleReactionToggle(db, { ...base, commentId: c.id, reaction: "like", voterHash: "v1" }),
+			]);
+			expect(a.success).toBe(true);
+			expect(b.success).toBe(true);
+			// Invariant: never more than one row for the same (comment, voter, reaction).
+			const counts = await reactions.countsForComments([c.id]);
+			expect((counts.get(c.id)?.like ?? 0) <= 1).toBe(true);
 		});
 	});
 });

--- a/packages/core/tests/integration/comments/reactions.test.ts
+++ b/packages/core/tests/integration/comments/reactions.test.ts
@@ -1,0 +1,134 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getCommentsWithDb } from "../../../src/comments/query.js";
+import { CommentReactionRepository } from "../../../src/database/repositories/comment-reaction.js";
+import { CommentRepository } from "../../../src/database/repositories/comment.js";
+import type { Database } from "../../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("CommentReactionRepository", () => {
+	let db: Kysely<Database>;
+	let comments: CommentRepository;
+	let reactions: CommentReactionRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		comments = new CommentRepository(db);
+		reactions = new CommentReactionRepository(db);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	function approvedComment(overrides: Record<string, unknown> = {}) {
+		return comments.create({
+			collection: "post",
+			contentId: "content-1",
+			authorName: "Jane",
+			authorEmail: "jane@example.com",
+			body: "Great post!",
+			status: "approved",
+			...overrides,
+		});
+	}
+
+	describe("toggle", () => {
+		it("adds a reaction, then removes it on a second toggle by the same voter", async () => {
+			const c = await approvedComment();
+			expect(await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "a" })).toEqual(
+				{
+					reacted: true,
+				},
+			);
+			expect(await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "a" })).toEqual(
+				{
+					reacted: false,
+				},
+			);
+		});
+
+		it("counts each distinct voter once", async () => {
+			const c = await approvedComment();
+			for (const v of ["a", "b", "c"]) {
+				await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: v });
+			}
+			const counts = await reactions.countsForComments([c.id]);
+			expect(counts.get(c.id)).toEqual({ like: 3 });
+		});
+	});
+
+	describe("countsForComments", () => {
+		it("groups counts by reaction and omits comments with none", async () => {
+			const c1 = await approvedComment();
+			const c2 = await approvedComment();
+			await reactions.toggle({ commentId: c1.id, reaction: "like", voterHash: "a" });
+			await reactions.toggle({ commentId: c1.id, reaction: "love", voterHash: "b" });
+
+			const counts = await reactions.countsForComments([c1.id, c2.id]);
+			expect(counts.get(c1.id)).toEqual({ like: 1, love: 1 });
+			expect(counts.has(c2.id)).toBe(false);
+		});
+	});
+
+	describe("viewerReactions", () => {
+		it("returns only the given voter's reactions", async () => {
+			const c = await approvedComment();
+			await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "a" });
+			await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "b" });
+
+			expect((await reactions.viewerReactions([c.id], "a")).get(c.id)).toEqual(["like"]);
+			expect((await reactions.viewerReactions([c.id], "z")).has(c.id)).toBe(false);
+		});
+	});
+
+	describe("countRecentByVoter", () => {
+		it("counts a voter's recent reactions", async () => {
+			const c = await approvedComment();
+			await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "a" });
+			await reactions.toggle({ commentId: c.id, reaction: "love", voterHash: "a" });
+			expect(await reactions.countRecentByVoter("a")).toBe(2);
+			expect(await reactions.countRecentByVoter("b")).toBe(0);
+		});
+	});
+
+	describe("getCommentsWithDb best-sort", () => {
+		it("orders top-level comments by reaction score and attaches counts", async () => {
+			const low = await approvedComment({ body: "low" });
+			const high = await approvedComment({ body: "high" });
+			const mid = await approvedComment({ body: "mid" });
+
+			for (const v of ["a", "b", "c", "d", "e"]) {
+				await reactions.toggle({ commentId: high.id, reaction: "like", voterHash: v });
+			}
+			for (const v of ["a", "b"]) {
+				await reactions.toggle({ commentId: mid.id, reaction: "like", voterHash: v });
+			}
+			void low;
+
+			const { items } = await getCommentsWithDb(db, {
+				collection: "post",
+				contentId: "content-1",
+				reactions: true,
+				sort: "best",
+			});
+
+			expect(items.map((c) => c.body)).toEqual(["high", "mid", "low"]);
+			expect(items[0]?.reactions).toEqual({ like: 5 });
+		});
+
+		it("attaches counts without reordering under the default sort", async () => {
+			const c = await approvedComment({ body: "only" });
+			await reactions.toggle({ commentId: c.id, reaction: "like", voterHash: "a" });
+
+			const { items } = await getCommentsWithDb(db, {
+				collection: "post",
+				contentId: "content-1",
+				reactions: true,
+			});
+
+			expect(items[0]?.reactions).toEqual({ like: 1 });
+		});
+	});
+});

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -126,6 +126,7 @@ describe("Database Migrations (Integration)", () => {
 			"041_content_locale_list_index",
 			"042_byline_fields",
 			"043_content_references",
+			"044_comment_reactions",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/unit/comments/ranking.test.ts
+++ b/packages/core/tests/unit/comments/ranking.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { reactionScore, wilsonLowerBound } from "../../../src/comments/ranking.js";
+
+describe("wilsonLowerBound", () => {
+	it("returns 0 when there are no reactions", () => {
+		expect(wilsonLowerBound(0, 0)).toBe(0);
+	});
+
+	it("increases monotonically with positive count (positive-only)", () => {
+		const a = wilsonLowerBound(1, 0);
+		const b = wilsonLowerBound(10, 0);
+		const c = wilsonLowerBound(200, 0);
+		expect(a).toBeGreaterThan(0);
+		expect(a).toBeLessThan(b);
+		expect(b).toBeLessThan(c);
+		expect(c).toBeLessThan(1);
+	});
+
+	it("penalizes low-sample comments vs high-sample at the same ratio", () => {
+		// 100% positive but a tiny sample must rank below a large confident sample.
+		expect(wilsonLowerBound(1, 0)).toBeLessThan(wilsonLowerBound(100, 0));
+		expect(wilsonLowerBound(2, 0)).toBeLessThan(wilsonLowerBound(20, 0));
+	});
+
+	it("ranks a high positive ratio above a mixed one at similar volume", () => {
+		expect(wilsonLowerBound(90, 10)).toBeGreaterThan(wilsonLowerBound(50, 50));
+	});
+
+	it("matches the known Wilson value for 10/0 at z=1.96", () => {
+		expect(wilsonLowerBound(10, 0)).toBeCloseTo(0.7224, 3);
+	});
+});
+
+describe("reactionScore", () => {
+	it("treats unknown reactions as positive", () => {
+		expect(reactionScore({ like: 10 })).toBeCloseTo(wilsonLowerBound(10, 0), 10);
+		expect(reactionScore({ love: 5, like: 5 })).toBeCloseTo(wilsonLowerBound(10, 0), 10);
+	});
+
+	it("treats dislike/down as negative", () => {
+		expect(reactionScore({ like: 90, dislike: 10 })).toBeCloseTo(wilsonLowerBound(90, 10), 10);
+		expect(reactionScore({ up: 50, down: 50 })).toBeCloseTo(wilsonLowerBound(50, 50), 10);
+	});
+
+	it("returns 0 for empty counts", () => {
+		expect(reactionScore({})).toBe(0);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds comment reactions (positive-only "like") and a Wilson score "Best" sort to the `<Comments>` component. This is Tier 1 of the [best-in-class comments RFC](https://github.com/emdash-cms/emdash/discussions/1497), approved by @ascorbic.

- New `_emdash_comment_reactions` table (migration `044`) — deduped per voter via a salted IP hash (same privacy primitive as comment `ip_hash`)
- Public, honeypot- and rate-limited endpoint at `GET/POST /_emdash/api/comments/:collection/:contentId/reactions`
- Two opt-in props on `<Comments>`: `reactions` (like button + live counts) and `sort="best"` (Wilson lower-bound ranking for top-level comments, replies stay chronological)
- Progressive enhancement: the inline script is emitted only when `reactions` is enabled — pages without reactions ship zero additional JS
- Fully additive: new table, new route, new optional props with behavior-preserving defaults

Closes #1497 (Tier 1)

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — N/A: no admin UI strings added
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1497

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Sonnet 4.6 (claude-sonnet-4-6)

## Screenshots / test output

**Before** — comments today (chronological, no reactions):

![comments-before](https://github.com/user-attachments/assets/7262958a-9345-414a-83ec-c64bdfa4b5ec)

**After** — `<Comments reactions sort="best" />`:

![comments-after](https://github.com/user-attachments/assets/65072557-047b-4ed6-8ee5-d155bce9b615)

Test output: 118 tests pass, 15 new (Wilson math, toggle/dedupe, counts, rate-limit, best-sort ordering).