### PR TITLE
fix(plugins): hoist id/version regexes into defineNativePlugin to avoid TDZ on Workers (#1370)

### DIFF
--- a/.changeset/fix-define-plugin-tdz.md
+++ b/.changeset/fix-define-plugin-tdz.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Fixes a crash that returned HTTP 500 on every route on Cloudflare Workers when native plugins are registered with `definePlugin`. The plugin id/version validation regexes were module-scoped and could be read before initialization during the worker's circular module init (`Cannot access 'SIMPLE_ID' before initialization`). They are now function-local, so plugin registration is safe regardless of bundle ordering.
+Fixes a crash that returned HTTP 500 on every route on Cloudflare Workers when native plugins are registered with `definePlugin` (`Cannot access 'SIMPLE_ID' before initialization`). Plugin registration is now safe regardless of bundle ordering.

--- a/.changeset/fix-define-plugin-tdz.md
+++ b/.changeset/fix-define-plugin-tdz.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a crash that returned HTTP 500 on every route on Cloudflare Workers when native plugins are registered with `definePlugin`. The plugin id/version validation regexes were module-scoped and could be read before initialization during the worker's circular module init (`Cannot access 'SIMPLE_ID' before initialization`). They are now function-local, so plugin registration is safe regardless of bundle ordering.

--- a/packages/core/src/plugins/define-plugin.ts
+++ b/packages/core/src/plugins/define-plugin.ts
@@ -22,11 +22,6 @@ import type {
 	PluginStorageConfig,
 } from "./types.js";
 
-// Plugin ID validation patterns
-const SIMPLE_ID = /^[a-z0-9-]+$/;
-const SCOPED_ID = /^@[a-z0-9-]+\/[a-z0-9-]+$/;
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+/;
-
 /**
  * Define a native EmDash plugin.
  *
@@ -94,6 +89,20 @@ export function definePlugin<TStorage extends PluginStorageConfig>(
 function defineNativePlugin<TStorage extends PluginStorageConfig>(
 	definition: PluginDefinition<TStorage>,
 ): ResolvedPlugin<TStorage> {
+	// Declared function-local (not module scope) on purpose. Under
+	// `ssr.noExternal` the worker entry can instantiate native plugins during a
+	// circular module init, reaching this function before module-scope consts
+	// initialize -> "Cannot access 'SIMPLE_ID' before initialization" -> every
+	// route 500s on Cloudflare Workers. Call-time consts evaluate after the
+	// literals are parsed, so the temporal dead zone cannot occur regardless of
+	// bundle ordering. See #1370.
+	// oxlint-disable-next-line e18e/prefer-static-regex -- call-time on purpose (see #1370)
+	const SIMPLE_ID = /^[a-z0-9-]+$/;
+	// oxlint-disable-next-line e18e/prefer-static-regex -- call-time on purpose (see #1370)
+	const SCOPED_ID = /^@[a-z0-9-]+\/[a-z0-9-]+$/;
+	// oxlint-disable-next-line e18e/prefer-static-regex -- call-time on purpose (see #1370)
+	const SEMVER_PATTERN = /^\d+\.\d+\.\d+/;
+
 	const {
 		id,
 		version,

--- a/packages/core/tests/unit/plugins/define-plugin.test.ts
+++ b/packages/core/tests/unit/plugins/define-plugin.test.ts
@@ -161,6 +161,24 @@ describe("definePlugin", () => {
 		});
 	});
 
+	// Regression: #1370 — the id/version validation patterns must stay
+	// function-local (evaluated at call time). As module-scope consts, a
+	// circular module init on Cloudflare Workers could reach defineNativePlugin
+	// before they initialized, throwing "Cannot access 'SIMPLE_ID' before
+	// initialization" and 500-ing every route. Validation must keep working.
+	describe("#1370 — call-time validation regexes", () => {
+		it("validates id and version on every call", () => {
+			expect(definePlugin({ id: "first", version: "1.0.0" }).id).toBe("first");
+			expect(definePlugin({ id: "@scope/second", version: "2.3.4" }).version).toBe("2.3.4");
+			expect(() => definePlugin({ id: "Bad_Id", version: "1.0.0" })).toThrow(
+				INVALID_PLUGIN_ID_PATTERN,
+			);
+			expect(() => definePlugin({ id: "ok", version: "nope" })).toThrow(
+				INVALID_PLUGIN_VERSION_PATTERN,
+			);
+		});
+	});
+
 	describe("capability validation", () => {
 		it("accepts valid capabilities", () => {
 			const plugin = definePlugin({


### PR DESCRIPTION
## What does this PR do?

Fixes a crash that returns **HTTP 500 on every route** on Cloudflare Workers (`workerd`) when a site registers native plugins via `definePlugin`.

The plugin id/version validation regexes (`SIMPLE_ID`, `SCOPED_ID`, `SEMVER_PATTERN`) were module-scope `const`s read inside `defineNativePlugin`. Under the integration's `ssr.noExternal: ["emdash", …]`, Rollup re-bundles emdash into the worker and flattens a circular import between the worker entry and this chunk. When a top-level `definePlugin(...)` (a native plugin's default export, mounted via `createPlugin`) runs at module-init time mid-cycle, it reaches `defineNativePlugin` before those `const`s have initialized — and `const` bindings throw inside their temporal dead zone:

```
ReferenceError: Cannot access 'SIMPLE_ID' before initialization
    at defineNativePlugin
    at definePlugin
    at createPlugin
    at <module init>
```

`astro build` / `astro check` pass because it's purely a bundled init-order issue; 0.15.0 was unaffected only because its bundle ordering happened to differ.

Moving the three regexes into the function body makes them evaluate at call time (after the literals are parsed), so the TDZ cannot occur regardless of how the bundler orders the circular init. Validation behavior is byte-identical — they're used only inside `defineNativePlugin`. The `e18e/prefer-static-regex` lint is suppressed on these three lines with a justification: module scope is exactly what triggers the bug, and the per-call compile cost is negligible (once per plugin registration). A leaf-module or `var` alternative would not survive Rollup's chunk flattening — only call-time evaluation is robust.

Closes #1370

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — *not run cleanly locally: branching off `main` left the installed workspace deps (`@emdash-cms/plugin-types`) out of sync, producing unrelated pre-existing errors in `manifest-schema.ts` / `types.ts`. This change is type-neutral and adds no diagnostics in the touched file.*
- [x] `pnpm lint` passes (oxlint, 0 errors repo-wide)
- [x] `pnpm test` passes (targeted: `define-plugin.test.ts` — 40 passed)
- [x] `pnpm format` has been run (oxfmt clean)
- [x] I have added/updated tests for my change
- [ ] User-visible strings wrapped for translation — n/a (no admin UI strings)
- [x] I have added a changeset
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8 (Claude Code)**

## Screenshots / test output

The literal TDZ depends on bundler output, so it isn't reproducible in a plain vitest. The existing suite already covers the validation semantics; this PR adds an issue-anchored regression test, and the manual repro below covers the runtime crash.

Manual repro (Cloudflare adapter site that registers a native plugin):

```
pnpm build
npx wrangler dev --config dist/server/wrangler.json
curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8799/   # 500 before, 200 after
```

Unit test (`packages/core/tests/unit/plugins/define-plugin.test.ts`):

```
 Test Files  1 passed (1)
      Tests  40 passed (40)
```
