### PR TITLE
fix(admin): wire handleContentAuthors onto locals.emdash so the author filter stops 500ing (#1462)

### DIFF
--- a/.changeset/fix-content-authors-wiring.md
+++ b/.changeset/fix-content-authors-wiring.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the admin author filter returning HTTP 500 (`NOT_CONFIGURED` / "EmDash is not initialized") for every collection. The `handleContentAuthors` handler was never exposed on the per-request `locals.emdash` object in middleware, so `GET /_emdash/api/content/{collection}/authors` always tripped its not-initialized guard while sibling content routes worked normally.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -591,6 +591,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 					// Content handlers
 					handleContentList: runtime.handleContentList.bind(runtime),
 					handleContentGet: runtime.handleContentGet.bind(runtime),
+					handleContentAuthors: runtime.handleContentAuthors.bind(runtime),
 					handleContentCreate: runtime.handleContentCreate.bind(runtime),
 					handleContentUpdate: runtime.handleContentUpdate.bind(runtime),
 					handleContentDelete: runtime.handleContentDelete.bind(runtime),

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -38,6 +38,7 @@ const {
 			configuredPlugins: [],
 			handleContentList: ok,
 			handleContentGet: ok,
+			handleContentAuthors: ok,
 			handleContentCreate: ok,
 			handleContentUpdate: ok,
 			handleContentDelete: ok,
@@ -232,6 +233,10 @@ describe("astro middleware prerendered routes", () => {
 		const emdash = locals.emdash as Record<string, unknown>;
 		expect(typeof emdash.handlePluginApiRoute).toBe("function");
 		expect(typeof emdash.handlePublicPluginApiRoute).toBe("function");
+		// Regression for #1462: the author filter route reads
+		// `locals.emdash.handleContentAuthors`; it must be wired onto the
+		// runtime helpers object or every `/authors` request 500s.
+		expect(typeof emdash.handleContentAuthors).toBe("function");
 	});
 
 	it("does not access context.session when prerendering public pages", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the admin author filter returning **HTTP 500 `NOT_CONFIGURED`** ("EmDash is not initialized") on `GET /_emdash/api/content/{collection}/authors`, for every collection.

`locals.emdash` is assembled as an object literal in `middleware.ts`. It wires every content handler — list, get, create, update, delete, all trash handlers, duplicate, publish, schedule, compare, translations, media, revisions — but `handleContentAuthors` was never added. So `locals.emdash.handleContentAuthors` is `undefined` on every request, and the route's guard returns 500 before the handler runs — which is exactly why it's **consistent, affects every collection, and logs no error**. The runtime method (`emdash-runtime.ts`), the standalone handler (`api/handlers/content.ts`), the `EmDashHandlers` type member, and the route itself all already exist — only this one wiring line was missing (it was overlooked when the author filter shipped in #1442).

Closes #1462

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — *not run cleanly locally: branching off `main` left the installed workspace deps (`@emdash-cms/plugin-types`) out of sync, producing unrelated pre-existing errors. This change adds one property to an existing object literal and is type-safe — `runtime.handleContentAuthors` exists and matches the `EmDashHandlers` member signature.*
- [x] `pnpm lint` passes (oxlint, 0 errors)
- [x] `pnpm format` has been run (oxfmt clean)
- [ ] I have added/updated tests — *see note. The `handleContentAuthors` handler itself is already covered by `tests/integration/content/content-list-filters.test.ts`; the omission was in the inline `locals.emdash` assembly, which is only observable through a full middleware boot.*
- [ ] User-visible strings wrapped for translation — n/a (server wiring; no admin UI strings)
- [x] I have added a changeset
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8 (Claude Code)**

## Notes

Why this slipped past CI: `EmDashHandlers` declares `handleContentAuthors` as **required**, yet the assembled object literal omitted it without a typecheck error — so `locals.emdash`'s declared type is looser than the interface. A worthwhile follow-up (kept out of this PR to stay surgical) is to assemble `locals.emdash` through a typed `() => EmDashHandlers` factory or `satisfies EmDashHandlers`, so a missing handler fails `pnpm typecheck` — preventing the whole class of "added a handler + route but forgot to wire it onto `locals.emdash`" bug.

Full root-cause walkthrough in #1462.
