### PR TITLE
i18n(zh-CN): Updated Simplified Chinese translation

### DIFF
--- a/packages/admin/src/locales/zh-CN/messages.po
+++ b/packages/admin/src/locales/zh-CN/messages.po
@@ -456,11 +456,11 @@ msgstr "404 错误"
 
 #: packages/admin/src/components/Redirects.tsx:159
 msgid "410 Content Deleted (Gone)"
-msgstr ""
+msgstr "410 内容已删除（已移除）"
 
 #: packages/admin/src/components/Redirects.tsx:160
 msgid "451 Unavailable for legal reasons"
-msgstr ""
+msgstr "451 因法律原因不可用"
 
 #: packages/admin/src/components/WordPressImport.tsx:1365
 msgid "5. Copy the generated password"
@@ -4347,11 +4347,11 @@ msgstr "将 WordPress 用户 {0} 映射到 EmDash 用户"
 #. placeholder {0}: item.path
 #: packages/admin/src/components/Redirects.tsx:255
 msgid "Mark {0} as Gone (410)"
-msgstr ""
+msgstr "标记 {0} 已删除（410）"
 
 #: packages/admin/src/components/Redirects.tsx:254
 msgid "Mark as Gone (410) — tells search engines it was permanently deleted"
-msgstr ""
+msgstr "标记为已删除（410）— 告知搜索引擎该内容已被永久删除"
 
 #: packages/admin/src/components/comments/CommentInbox.tsx:501
 msgid "Mark as spam"
@@ -7521,7 +7521,7 @@ msgstr "URL 友好的标识符（例如：\"primary\"、\"footer\"）"
 
 #: packages/admin/src/components/MediaDetailPanel.tsx:193
 msgid "URL:"
-msgstr ""
+msgstr "URL:"
 
 #: packages/admin/src/components/Redirects.tsx:110
 msgid "Use [param] or [...rest] in paths for pattern matching."


### PR DESCRIPTION
## What does this PR do?

Updated Simplified Chinese translation


## Type of change

<!-- Check one. If "Feature", a prior Discussion is required — see below. -->

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [x] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
