### PR TITLE
[codex] Avoid blocking route cache misses on cache writes

### DIFF
--- a/.changeset/cloudflare-route-cache-miss.md
+++ b/.changeset/cloudflare-route-cache-miss.md
@@ -1,0 +1,9 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Return route-cache miss responses before Cloudflare Cache API writes finish.
+
+The Cloudflare cache provider now schedules MISS response storage with `waitUntil()`
+instead of awaiting `cache.put()` before returning the rendered page. This prevents
+slow or stalled edge cache writes from blocking otherwise valid visitor responses.

--- a/packages/cloudflare/src/cache/runtime.ts
+++ b/packages/cloudflare/src/cache/runtime.ts
@@ -275,7 +275,7 @@ const factory: CacheProviderFactory<CloudflareCacheConfig> = (config) => {
 			if (maxAge > 0 && response.ok) {
 				const toStore = prepareForCache(response.clone(), maxAge, swr, bookmarkCookie);
 				if (toStore) {
-					await cache.put(cacheKey, toStore);
+					waitUntil(cache.put(cacheKey, toStore));
 				}
 
 				const miss = new Response(response.body, response);

--- a/packages/cloudflare/tests/cache-runtime.test.ts
+++ b/packages/cloudflare/tests/cache-runtime.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cache = {
+	match: vi.fn(),
+	put: vi.fn(),
+	delete: vi.fn(),
+};
+
+const open = vi.fn();
+const waitUntil = vi.fn();
+
+vi.mock("cloudflare:workers", () => ({
+	env: {},
+	waitUntil,
+}));
+
+describe("cloudflare cache runtime", () => {
+	beforeEach(() => {
+		cache.match.mockReset();
+		cache.put.mockReset();
+		cache.delete.mockReset();
+		open.mockReset();
+		waitUntil.mockReset();
+
+		vi.stubGlobal("caches", { open });
+		open.mockResolvedValue(cache);
+		cache.match.mockResolvedValue(undefined);
+		cache.put.mockImplementation(() => new Promise<void>(() => {}));
+	});
+
+	it("does not block a route-cache miss on cache storage", async () => {
+		const { default: createCacheProvider } = await import("../src/cache/runtime.js");
+		const provider = createCacheProvider({ cacheName: "test" });
+		const onRequest = provider.onRequest;
+		const request = new Request("https://example.com/categories");
+
+		expect(onRequest).toBeDefined();
+
+		const response = await onRequest!({
+			request,
+			url: new URL(request.url),
+		}, () =>
+			Promise.resolve(
+				new Response("fresh page", {
+					headers: { "CDN-Cache-Control": "max-age=60, stale-while-revalidate=120" },
+				}),
+			),
+		);
+
+		expect(response.headers.get("X-Astro-Cache")).toBe("MISS");
+		expect(await response.text()).toBe("fresh page");
+		expect(cache.put).toHaveBeenCalledOnce();
+		expect(waitUntil).toHaveBeenCalledOnce();
+		expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise));
+	});
+});

--- a/packages/cloudflare/tests/cache-runtime.test.ts
+++ b/packages/cloudflare/tests/cache-runtime.test.ts
@@ -36,15 +36,17 @@ describe("cloudflare cache runtime", () => {
 
 		expect(onRequest).toBeDefined();
 
-		const response = await onRequest!({
-			request,
-			url: new URL(request.url),
-		}, () =>
-			Promise.resolve(
-				new Response("fresh page", {
-					headers: { "CDN-Cache-Control": "max-age=60, stale-while-revalidate=120" },
-				}),
-			),
+		const response = await onRequest!(
+			{
+				request,
+				url: new URL(request.url),
+			},
+			() =>
+				Promise.resolve(
+					new Response("fresh page", {
+						headers: { "CDN-Cache-Control": "max-age=60, stale-while-revalidate=120" },
+					}),
+				),
 		);
 
 		expect(response.headers.get("X-Astro-Cache")).toBe("MISS");


### PR DESCRIPTION
## What does this PR do?

Schedules Cloudflare route-cache MISS writes with `waitUntil()` instead of awaiting `cache.put()` before returning the rendered response.

The Cloudflare cache runtime was rendering fresh responses on route-cache misses, then waiting for Cache API storage before sending the page. If Cloudflare cache storage was slow or stalled in a colo, an otherwise valid page response could hang. Cache writes are best-effort optimization work, so they should not block visitor responses.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [x] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [ ] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 Codex

## Screenshots / test output

- `pnpm --filter emdash build`
- `pnpm --filter @emdash-cms/cloudflare test`
- `pnpm --filter @emdash-cms/cloudflare typecheck`
- `pnpm --filter @emdash-cms/cloudflare build`
