### PR TITLE
fix(core): search across all collections fails when one has no title field (#1178)

### DIFF
--- a/.changeset/fix-search-titleless-collections.md
+++ b/.changeset/fix-search-titleless-collections.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes search across all collections failing with `D1_ERROR: no such column: c.title` when any search-enabled collection has no `title` field (#1178). `title` is an optional field, not a guaranteed column, so calling `search` (or the MCP `search` tool) without a `collections` filter could error instead of searching everything. Cross-collection search now works regardless of which collections define a title; results from a collection without one simply omit the title, and autocomplete suggestions skip such collections rather than erroring.

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -385,6 +385,27 @@ export class FTSManager {
 	}
 
 	/**
+	 * Bulk variant of `hasTitleColumn()`: which of the given collections have
+	 * a user-defined `title` field. One query instead of one `hasTitleColumn`
+	 * round-trip pair per collection -- callers that check this once per
+	 * collection in a loop (multi-collection search, suggestions) should use
+	 * this instead (AGENTS.md: "one query beats two").
+	 */
+	async getCollectionsWithTitleColumn(collectionSlugs: string[]): Promise<Set<string>> {
+		if (collectionSlugs.length === 0) return new Set();
+
+		const rows = await this.db
+			.selectFrom("_emdash_fields as f")
+			.innerJoin("_emdash_collections as c", "c.id", "f.collection_id")
+			.select(["c.slug as collection_slug"])
+			.where("f.slug", "=", "title")
+			.execute();
+
+		const withTitle = new Set(rows.map((r) => r.collection_slug));
+		return new Set(collectionSlugs.filter((slug) => withTitle.has(slug)));
+	}
+
+	/**
 	 * Enable search for a collection.
 	 *
 	 * Uses rebuildIndex to ensure a clean state -- drop any existing FTS

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -356,6 +356,35 @@ export class FTSManager {
 	}
 
 	/**
+	 * Whether a collection has a user-defined `title` field.
+	 *
+	 * `title` is not a system column on `ec_*` tables -- it exists only when a
+	 * collection defines a field with slug `title`. Search and suggestion SQL
+	 * that selects `c.title` must check this first; otherwise collections
+	 * without a title field raise "no such column: c.title" (#1178).
+	 */
+	async hasTitleColumn(collectionSlug: string): Promise<boolean> {
+		const collection = await this.db
+			.selectFrom("_emdash_collections")
+			.select("id")
+			.where("slug", "=", collectionSlug)
+			.executeTakeFirst();
+
+		if (!collection) {
+			return false;
+		}
+
+		const field = await this.db
+			.selectFrom("_emdash_fields")
+			.select("slug")
+			.where("collection_id", "=", collection.id)
+			.where("slug", "=", "title")
+			.executeTakeFirst();
+
+		return field !== undefined;
+	}
+
+	/**
 	 * Enable search for a collection.
 	 *
 	 * Uses rebuildIndex to ensure a clean state -- drop any existing FTS

--- a/packages/core/src/search/fts-manager.ts
+++ b/packages/core/src/search/fts-manager.ts
@@ -364,24 +364,8 @@ export class FTSManager {
 	 * without a title field raise "no such column: c.title" (#1178).
 	 */
 	async hasTitleColumn(collectionSlug: string): Promise<boolean> {
-		const collection = await this.db
-			.selectFrom("_emdash_collections")
-			.select("id")
-			.where("slug", "=", collectionSlug)
-			.executeTakeFirst();
-
-		if (!collection) {
-			return false;
-		}
-
-		const field = await this.db
-			.selectFrom("_emdash_fields")
-			.select("slug")
-			.where("collection_id", "=", collection.id)
-			.where("slug", "=", "title")
-			.executeTakeFirst();
-
-		return field !== undefined;
+		const withTitle = await this.getCollectionsWithTitleColumn([collectionSlug]);
+		return withTitle.has(collectionSlug);
 	}
 
 	/**

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -99,6 +99,7 @@ export async function searchWithDb(
 
 	// Search each collection and merge results
 	const allResults: SearchResult[] = [];
+	const titleColumns = await ftsManager.getCollectionsWithTitleColumn(collections);
 
 	for (const collection of collections) {
 		const config = await ftsManager.getSearchConfig(collection);
@@ -116,6 +117,7 @@ export async function searchWithDb(
 				limit: limit * 2, // Get extra for merging
 			},
 			config.weights,
+			titleColumns.has(collection),
 		);
 
 		allResults.push(...collectionResults);
@@ -173,6 +175,7 @@ async function searchSingleCollection(
 	query: string,
 	options: CollectionSearchOptions,
 	weights?: Record<string, number>,
+	hasTitle?: boolean,
 ): Promise<SearchResult[]> {
 	// Validate before any raw SQL interpolation
 	validateIdentifier(collection, "collection slug");
@@ -200,9 +203,11 @@ async function searchSingleCollection(
 
 	// `title` is an optional user-defined field, not a system column. Only
 	// select it when the collection actually has one; otherwise the query
-	// errors with "no such column: c.title" (#1178).
-	const hasTitle = await ftsManager.hasTitleColumn(collection);
-	const titleExpr = hasTitle ? sql`c.title` : sql`NULL`;
+	// errors with "no such column: c.title" (#1178). Multi-collection callers
+	// precompute this in bulk and pass it in; single-collection callers fall
+	// back to the per-collection check.
+	const collectionHasTitle = hasTitle ?? (await ftsManager.hasTitleColumn(collection));
+	const titleExpr = collectionHasTitle ? sql`c.title` : sql`NULL`;
 
 	// Build weight string for bm25 if weights provided
 	// Format: bm25(table, weight1, weight2, ...)
@@ -340,9 +345,10 @@ export async function getSuggestions(
 	}
 
 	const suggestions: Suggestion[] = [];
+	const ftsManager = new FTSManager(db);
+	const titleColumns = await ftsManager.getCollectionsWithTitleColumn(collections);
 
 	for (const collection of collections) {
-		const ftsManager = new FTSManager(db);
 		const config = await ftsManager.getSearchConfig(collection);
 		if (!config?.enabled) {
 			continue;
@@ -352,7 +358,7 @@ export async function getSuggestions(
 		// query filters on `c.title IS NOT NULL`). Collections without a
 		// `title` field can't produce one, and selecting `c.title` would
 		// error, so skip them. See #1178.
-		if (!(await ftsManager.hasTitleColumn(collection))) {
+		if (!titleColumns.has(collection)) {
 			continue;
 		}
 

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -198,6 +198,12 @@ async function searchSingleCollection(
 	// Get searchable fields for snippet generation
 	const searchableFields = await ftsManager.getSearchableFields(collection);
 
+	// `title` is an optional user-defined field, not a system column. Only
+	// select it when the collection actually has one; otherwise the query
+	// errors with "no such column: c.title" (#1178).
+	const hasTitle = await ftsManager.hasTitleColumn(collection);
+	const titleExpr = hasTitle ? sql`c.title` : sql`NULL`;
+
 	// Build weight string for bm25 if weights provided
 	// Format: bm25(table, weight1, weight2, ...)
 	// First two weights are for 'id' and 'locale' columns (UNINDEXED, so 0)
@@ -225,11 +231,11 @@ async function searchSingleCollection(
 			snippet: string | null;
 			score: number;
 		}>`
-		SELECT 
+		SELECT
 			c.id,
 			c.slug,
 			c.locale,
-			c.title,
+			${titleExpr} as title,
 			snippet("${sql.raw(ftsTable)}", 2, '<mark>', '</mark>', '...', 32) as snippet,
 			${sql.raw(bm25Expr)} as score
 		FROM "${sql.raw(ftsTable)}" f
@@ -339,6 +345,14 @@ export async function getSuggestions(
 		const ftsManager = new FTSManager(db);
 		const config = await ftsManager.getSearchConfig(collection);
 		if (!config?.enabled) {
+			continue;
+		}
+
+		// Suggestions are title-based (Suggestion.title is required and the
+		// query filters on `c.title IS NOT NULL`). Collections without a
+		// `title` field can't produce one, and selecting `c.title` would
+		// error, so skip them. See #1178.
+		if (!(await ftsManager.hasTitleColumn(collection))) {
 			continue;
 		}
 

--- a/packages/core/tests/integration/search/title-less-collection.test.ts
+++ b/packages/core/tests/integration/search/title-less-collection.test.ts
@@ -97,4 +97,12 @@ describe("search: collection without a title field (#1178)", () => {
 		// throwing (a suggestion requires a title, which it cannot provide).
 		expect(suggestions.every((s) => s.collection !== "note")).toBe(true);
 	});
+
+	it("bulk-resolves title-column membership for a mixed set of collections in one query", async () => {
+		const fts = new FTSManager(db);
+		const withTitle = await fts.getCollectionsWithTitleColumn(["post", "note"]);
+
+		expect(withTitle.has("post")).toBe(true);
+		expect(withTitle.has("note")).toBe(false);
+	});
 });

--- a/packages/core/tests/integration/search/title-less-collection.test.ts
+++ b/packages/core/tests/integration/search/title-less-collection.test.ts
@@ -1,0 +1,100 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { FTSManager } from "../../../src/search/fts-manager.js";
+import { getSuggestions, searchWithDb } from "../../../src/search/query.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * Regression test for #1178.
+ *
+ * `title` is an optional user-defined field, not a system column on `ec_*`
+ * tables. Searching across all collections (no `collections` filter) walked
+ * every search-enabled collection, and the search SQL referenced `c.title`
+ * unconditionally. Any collection without a `title` field made the query throw
+ * `D1_ERROR: no such column: c.title`, which propagated and failed the whole
+ * call. Scoping the search to collections that happen to have a title masked
+ * the bug -- only the "search everything" path tripped it.
+ */
+describe("search: collection without a title field (#1178)", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		const fts = new FTSManager(db);
+
+		// Collection WITH a title field (the typical case).
+		await registry.createCollection({ slug: "post", label: "Posts", supports: ["search"] });
+		await registry.createField("post", {
+			slug: "title",
+			label: "Title",
+			type: "string",
+			searchable: true,
+		});
+		await registry.createField("post", {
+			slug: "body",
+			label: "Body",
+			type: "text",
+			searchable: true,
+		});
+		await fts.enableSearch("post");
+
+		// Collection WITHOUT a title field -- only a searchable "body".
+		await registry.createCollection({ slug: "note", label: "Notes", supports: ["search"] });
+		await registry.createField("note", {
+			slug: "body",
+			label: "Body",
+			type: "text",
+			searchable: true,
+		});
+		await fts.enableSearch("note");
+
+		await repo.create({
+			type: "post",
+			slug: "p1",
+			status: "published",
+			data: { title: "Widget guide", body: "All about widgets" },
+		});
+		await repo.create({
+			type: "note",
+			slug: "n1",
+			status: "published",
+			data: { body: "A note about widgets" },
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("searches across all collections when one lacks a title field", async () => {
+		const res = await searchWithDb(db, "widget");
+
+		const collections = res.items.map((i) => i.collection);
+		expect(collections).toContain("post");
+		expect(collections).toContain("note");
+
+		// The title-less collection still returns a result; its title is simply
+		// absent (SearchResult.title is optional), and the slug is preserved.
+		const note = res.items.find((i) => i.collection === "note");
+		expect(note?.title).toBeUndefined();
+		expect(note?.slug).toBe("n1");
+	});
+
+	it("returns suggestions across all collections, skipping ones without a title", async () => {
+		const suggestions = await getSuggestions(db, "widget");
+
+		// The collection with a title is suggested...
+		expect(suggestions.some((s) => s.collection === "post")).toBe(true);
+		// ...and the title-less collection is silently skipped rather than
+		// throwing (a suggestion requires a title, which it cannot provide).
+		expect(suggestions.every((s) => s.collection !== "note")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the `search` API and MCP `search` tool throwing `D1_ERROR: no such column: c.title` when searching across all collections (no `collections` filter) and any search-enabled collection has no `title` field.

`title` is an optional user-defined field, **not** a system column on `ec_*` tables (the system columns are `id, slug, status, author_id, primary_byline_id, created_at, updated_at, published_at, scheduled_at, deleted_at, version, live_revision_id, draft_revision_id, locale, translation_group`). `searchSingleCollection` and `getSuggestions` selected `c.title` unconditionally, so the cross-collection path errored whenever it reached a collection without a `title` field. Passing an explicit `collections` list that happened to have titles masked the bug — which matches the report (works with `["pages","posts"]`, fails without `collections`).

The codebase already handles this exact gotcha in `api/handlers/dashboard.ts` (`fetchRecentItems` checks `_emdash_fields` for a `title` field and falls back to `slug`); this PR applies the same precedent to search.

### Changes

- Add `FTSManager.hasTitleColumn(slug)` — checks `_emdash_fields` for a `title` field (mirrors the dashboard handler).
- `searchSingleCollection`: select `NULL as title` when the collection has no `title` column (results keep their `slug`; `SearchResult.title` is already optional).
- `getSuggestions`: skip collections without a `title` field (a `Suggestion.title` is required and the query already filters on `c.title IS NOT NULL`, so these collections contribute nothing anyway).
- Regression test reproducing the reported error across the `searchWithDb` and `getSuggestions` "all collections" paths.

Closes #1178

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (oxlint, 0 diagnostics on changed files)
- [x] `pnpm test` passes (targeted: all search/MCP-search/suggest/i18n/schema suites — 138 tests green, incl. the new regression test)
- [x] `pnpm format` has been run (tabs; consistent with surrounding code)
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a (no admin UI strings; server-side error codes only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch)
- [ ] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

Before (new test on the unpatched tree):

```
× searches across all collections when one lacks a title field
× returns suggestions across all collections, skipping ones without a title
  SqliteError: no such column: c.title
    ❯ searchSingleCollection src/search/query.ts:220
    ❯ getSuggestions src/search/query.ts:360
```

After:

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```
