### PR TITLE
fix(core): drop locale code lowercasing that broke mixed-case locales

### DIFF
--- a/.changeset/locale-code-casing.md
+++ b/.changeset/locale-code-casing.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes content filtering by locales with uppercase subtags (e.g. `zh-TW`, `en-US`, `pt-BR`) returning no results on SQLite and D1. The admin content list no longer shows up blank on sites whose locale isn't all-lowercase.

--- a/packages/core/src/api/schemas/common.ts
+++ b/packages/core/src/api/schemas/common.ts
@@ -54,10 +54,7 @@ export const httpUrl = z
 	.refine((url) => HTTP_SCHEME_RE.test(url), "URL must use http or https");
 
 /** BCP 47 locale code — language with optional script/region subtags (e.g. en, en-US, pt-BR, es-419, zh-Hant) */
-export const localeCode = z
-	.string()
-	.regex(/^[a-z]{2,3}(-[a-z0-9]{2,8})*$/i, "Invalid locale code")
-	.transform((v) => v.toLowerCase());
+export const localeCode = z.string().regex(/^[a-z]{2,3}(-[a-z0-9]{2,8})*$/i, "Invalid locale code");
 
 /** Shared `?locale=xx` query shape for endpoints that filter by locale. */
 export const localeFilterQuery = z

--- a/packages/core/tests/unit/api/schemas.test.ts
+++ b/packages/core/tests/unit/api/schemas.test.ts
@@ -6,6 +6,7 @@ import {
 	createFieldBody,
 	updateFieldBody,
 	httpUrl,
+	localeCode,
 	mediaUploadUrlBody,
 	DEFAULT_MAX_UPLOAD_SIZE,
 } from "../../../src/api/schemas/index.js";
@@ -152,6 +153,27 @@ describe("httpUrl validator", () => {
 
 	it("is case-insensitive for scheme", () => {
 		expect(httpUrl.parse("HTTPS://EXAMPLE.COM")).toBe("HTTPS://EXAMPLE.COM");
+	});
+});
+
+describe("localeCode validator", () => {
+	// Regression: a .toLowerCase() transform rewrote ?locale=zh-TW to zh-tw, so the
+	// case-sensitive SQLite/D1 query matched zero rows. Casing must round-trip as configured.
+	it("preserves uppercase subtags", () => {
+		expect(localeCode.parse("zh-TW")).toBe("zh-TW");
+		expect(localeCode.parse("zh-Hant")).toBe("zh-Hant");
+		expect(localeCode.parse("en-US")).toBe("en-US");
+		expect(localeCode.parse("pt-BR")).toBe("pt-BR");
+	});
+
+	it("accepts a bare language code", () => {
+		expect(localeCode.parse("en")).toBe("en");
+	});
+
+	it("rejects malformed locale codes", () => {
+		expect(() => localeCode.parse("e")).toThrow();
+		expect(() => localeCode.parse("en_US")).toThrow();
+		expect(() => localeCode.parse("not a locale")).toThrow();
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

localeCode schema was calling .toLowerCase() on the validated value, rewriting e.g. zh-TW to zh-tw before the query ran. Rows are stored with the casing from defaultLocale and SQLite/D1 compare strings case-sensitively, so the filter matched zero rows — admin content list returned an empty envelope with no error.

Removing the transform keeps read and write casing symmetric.

Simple test is also added for 3 different cases.

Closes #1551

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
