### PR TITLE
fix(core): guide plugin route handlers to ctx.input on consumed body (#1293)

### DIFF
--- a/.changeset/fix-plugin-request-body-guard.md
+++ b/.changeset/fix-plugin-request-body-guard.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Plugin route handlers that call `ctx.request.json()` (or `.text()`, `.formData()`, `.arrayBuffer()`, `.blob()`) now get a clear error pointing them to `ctx.input` instead of the runtime's cryptic "Body has already been read" failure (#1293). EmDash parses the request body once before the handler runs and exposes it as `ctx.input`, leaving `ctx.request`'s stream consumed; the request handed to handlers now guards those body-reading methods with an actionable message. All other request members (`url`, `method`, `headers`, `signal`, …) are unaffected.

--- a/packages/core/src/plugins/routes.ts
+++ b/packages/core/src/plugins/routes.ts
@@ -13,6 +13,42 @@ import { extractRequestMeta } from "./request-meta.js";
 import type { ResolvedPlugin, RouteContext, PluginRoute } from "./types.js";
 
 /**
+ * Body-reading methods on `Request`. EmDash parses the request body once before
+ * the handler runs and exposes the result as `ctx.input`, leaving the underlying
+ * stream consumed. Calling any of these on `ctx.request` would re-read a spent
+ * stream and throw an opaque platform error ("Body is unusable: Body has already
+ * been read") with no hint about `ctx.input` — so the guard replaces them with an
+ * actionable message instead (#1293).
+ */
+const CONSUMED_BODY_METHODS = new Set(["json", "text", "arrayBuffer", "blob", "formData", "bytes"]);
+
+/**
+ * Wrap the request handed to a plugin route handler so an accidental
+ * `ctx.request.json()` (or `.text()`, `.formData()`, …) fails with a message
+ * pointing at `ctx.input` rather than the runtime's cryptic "body already read"
+ * error. Every non-body member passes through unchanged; function members are
+ * bound to the underlying request so methods like `clone()` don't throw an
+ * "Illegal invocation" when called on the proxy.
+ */
+function guardConsumedRequestBody(request: Request): Request {
+	return new Proxy(request, {
+		get(target, prop) {
+			if (typeof prop === "string" && CONSUMED_BODY_METHODS.has(prop)) {
+				return () => {
+					throw new Error(
+						`[emdash] ctx.request.${prop}() is not available inside a plugin route handler: ` +
+							`EmDash has already parsed the request body and exposes it as ctx.input. ` +
+							`Read ctx.input instead of ctx.request.${prop}().`,
+					);
+				};
+			}
+			const value = Reflect.get(target, prop, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
+/**
  * Route metadata (public flag) without the handler.
  * Used by the catch-all route to decide auth before dispatch.
  */
@@ -100,7 +136,10 @@ export class PluginRouteHandler {
 		const routeContext: RouteContext = {
 			...baseContext,
 			input: validatedInput,
-			request: options.request,
+			// The body is already parsed into `input`; guard `ctx.request`'s
+			// body-reading methods so a re-read fails with an actionable message
+			// (#1293). Metadata extraction uses the original request (headers only).
+			request: guardConsumedRequestBody(options.request),
 			requestMeta: extractRequestMeta(options.request, this.trustedProxyHeaders),
 		};
 

--- a/packages/core/tests/unit/plugins/routes.test.ts
+++ b/packages/core/tests/unit/plugins/routes.test.ts
@@ -333,6 +333,94 @@ describe("PluginRouteHandler", () => {
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ hasEmail: true, hasSend: true });
 		});
+
+		it("surfaces an actionable error when a handler reads the consumed request body (#1293)", async () => {
+			// EmDash parses the body once and exposes it as ctx.input; the same
+			// Request is then handed to the handler with its stream already spent.
+			// A handler that instinctively calls ctx.request.json() should get a
+			// message pointing at ctx.input, not the runtime's opaque
+			// "body already read" error.
+			const bodyMethods = ["json", "text", "arrayBuffer", "formData", "blob"] as const;
+			const plugin = createTestPlugin({
+				routes: {
+					echo: {
+						handler: async (ctx) => {
+							const errors: Record<string, string> = {};
+							for (const method of bodyMethods) {
+								try {
+									// eslint-disable-next-line @typescript-eslint/no-explicit-any
+									await (ctx.request as any)[method]();
+									errors[method] = "NO_ERROR";
+								} catch (e) {
+									errors[method] = (e as Error).message;
+								}
+							}
+							return { errors, input: ctx.input };
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("echo", {
+				request: new Request("http://test.com/echo", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ hello: "world" }),
+				}),
+				body: { hello: "world" },
+			});
+
+			expect(result.success).toBe(true);
+			const data = result.data as { errors: Record<string, string>; input: unknown };
+			for (const method of bodyMethods) {
+				expect(data.errors[method]).toContain("ctx.input");
+				expect(data.errors[method]).toContain("[emdash]");
+			}
+			// The parsed body is still available as ctx.input.
+			expect(data.input).toEqual({ hello: "world" });
+		});
+
+		it("passes request url, method, and headers through the body guard (#1293)", async () => {
+			// The guard must not interfere with non-body members — notably the
+			// `headers.forEach` the sandbox-entry adapter relies on.
+			const plugin = createTestPlugin({
+				routes: {
+					meta: {
+						handler: async (ctx) => {
+							const collected: Record<string, string> = {};
+							ctx.request.headers.forEach((value, name) => {
+								collected[name] = value;
+							});
+							return {
+								url: ctx.request.url,
+								method: ctx.request.method,
+								contentType: ctx.request.headers.get("content-type"),
+								forEachSawContentType: collected["content-type"] === "application/json",
+							};
+						},
+					},
+				},
+			});
+			const handler = new PluginRouteHandler(plugin, createMockFactoryOptions());
+
+			const result = await handler.invoke("meta", {
+				request: new Request("http://test.com/meta", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{}",
+				}),
+				body: {},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				url: "http://test.com/meta",
+				method: "POST",
+				contentType: "application/json",
+				forEachSawContentType: true,
+			});
+		});
 	});
 });
 

--- a/skills/creating-plugins/references/api-routes.md
+++ b/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/skills/creating-plugins/references/block-kit.md
+++ b/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {


### PR DESCRIPTION
## What does this PR do?

EmDash parses a plugin route's request body once before the handler runs and exposes it as `ctx.input`, leaving `ctx.request`'s stream consumed. A handler that instinctively called `ctx.request.json()` (or `.text()` / `.formData()` / `.arrayBuffer()` / `.blob()`) re-read a spent stream and got the runtime's opaque `Body has already been read` error with no mention of `ctx.input`.

This wraps the request handed to handlers in a `Proxy` that intercepts the body-reading methods and throws an actionable `[emdash]` message naming `ctx.input`. Every non-body member (`url`, `method`, `headers`, `signal`, …) passes through unchanged, and function members are bound to the underlying request so methods like `clone()` and the sandbox-entry adapter's `headers.forEach` keep working. Also updates the two plugin docs that demonstrated the `ctx.request.json()` footgun.

Closes #1293

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: `plugins/routes.test.ts` + full plugins unit/integration suites — 702 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a — server-side English diagnostic message)
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode

## Screenshots / test output

New tests assert every guarded body method rejects with a message containing `ctx.input` and `[emdash]`, that `ctx.input` still holds the parsed body, and that `url` / `method` / `headers.get` / `headers.forEach` still pass through the guard. Plugins suites: 702 passed.

