### PR TITLE
fix(core): apply baseline security headers set-if-absent so host-set values win (#1393)

### DIFF
--- a/.changeset/fix-1393-security-headers-set-if-absent.md
+++ b/.changeset/fix-1393-security-headers-set-if-absent.md
@@ -2,8 +2,4 @@
 "emdash": patch
 ---
 
-fix(core): apply baseline security headers set-if-absent so host-set values win (#1393)
-
-`finalizeResponse()` unconditionally set `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on every response. Because the middleware registers with `order: 'pre'` (#1282), on the response path it runs after the host app's own middleware, so it overwrote any of these headers the host had already set on its public routes — letting the CMS dictate the security headers of the entire host site.
-
-These three headers are now applied set-if-absent (`if (!res.headers.has(name))`), matching the existing `Content-Security-Policy` guard, so a host that sets a stricter value (e.g. an extended `Permissions-Policy`) on its own routes wins. EmDash still provides its baseline defaults when the host sets nothing.
+Fixes EmDash overriding security headers set by the host site (#1393). The baseline `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` headers were applied unconditionally, overwriting stricter values a host had already set on its own routes. These headers are now applied only when the host hasn't set them — matching the existing `Content-Security-Policy` behavior — so a host's own values win while EmDash still provides defaults when none are set.

--- a/.changeset/fix-1393-security-headers-set-if-absent.md
+++ b/.changeset/fix-1393-security-headers-set-if-absent.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+fix(core): apply baseline security headers set-if-absent so host-set values win (#1393)
+
+`finalizeResponse()` unconditionally set `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on every response. Because the middleware registers with `order: 'pre'` (#1282), on the response path it runs after the host app's own middleware, so it overwrote any of these headers the host had already set on its public routes — letting the CMS dictate the security headers of the entire host site.
+
+These three headers are now applied set-if-absent (`if (!res.headers.has(name))`), matching the existing `Content-Security-Policy` guard, so a host that sets a stricter value (e.g. an extended `Permissions-Policy`) on its own routes wins. EmDash still provides its baseline defaults when the host sets nothing.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -294,9 +294,19 @@ function finalizeResponse(
 	if (astroCookies !== undefined) {
 		Reflect.set(res, ASTRO_COOKIES_SYMBOL, astroCookies);
 	}
-	res.headers.set("X-Content-Type-Options", "nosniff");
-	res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-	res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
+	// Set-if-absent so a host app that sets stricter values on its own routes
+	// wins. The middleware registers `order: 'pre'` (#1282), so on the response
+	// path it runs *after* host middleware; unconditional `set()` would clobber
+	// the host's headers on every public route (#1393). Mirrors the CSP guard.
+	if (!res.headers.has("X-Content-Type-Options")) {
+		res.headers.set("X-Content-Type-Options", "nosniff");
+	}
+	if (!res.headers.has("Referrer-Policy")) {
+		res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+	}
+	if (!res.headers.has("Permissions-Policy")) {
+		res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
+	}
 	if (!res.headers.has("Content-Security-Policy")) {
 		res.headers.set("X-Frame-Options", "SAMEORIGIN");
 	}

--- a/packages/core/tests/unit/astro/middleware-security-headers.test.ts
+++ b/packages/core/tests/unit/astro/middleware-security-headers.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for issue #1393: `finalizeResponse()` unconditionally set
+ * `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on every
+ * response. Because the middleware registers with `order: 'pre'` (#1282), on the
+ * response path it runs *after* the host app's own middleware, so it overwrote
+ * any of these headers the host had already set. CSP was handled defensively
+ * (`if (!res.headers.has(...))`) but these three were not.
+ *
+ * The fix applies the baseline headers set-if-absent, matching the existing CSP
+ * pattern, so a host that sets a stricter value on its own public routes wins.
+ */
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+const { DB_CONFIG_MARKER } = vi.hoisted(() => ({
+	DB_CONFIG_MARKER: { binding: "DB", session: "auto" },
+}));
+
+const { MOCK_RUNTIME, mockGetPublicUrl } = vi.hoisted(() => {
+	const ok = async () => ({ success: true });
+	const getPublicUrl = vi.fn((key: string) => `https://media.example.com/${key}`);
+	return {
+		MOCK_RUNTIME: {
+			storage: { getPublicUrl },
+			db: {},
+			hooks: {},
+			email: null,
+			configuredPlugins: [],
+			handleContentList: ok,
+			handleContentGet: ok,
+			handleContentCreate: ok,
+			handleContentUpdate: ok,
+			handleContentDelete: ok,
+			handleContentListTrashed: ok,
+			handleContentRestore: ok,
+			handleContentPermanentDelete: ok,
+			handleContentCountTrashed: ok,
+			handleContentGetIncludingTrashed: ok,
+			handleContentDuplicate: ok,
+			handleContentPublish: ok,
+			handleContentUnpublish: ok,
+			handleContentSchedule: ok,
+			handleContentUnschedule: ok,
+			handleContentCountScheduled: ok,
+			handleContentDiscardDraft: ok,
+			handleContentCompare: ok,
+			handleContentTranslations: ok,
+			handleMediaList: ok,
+			handleMediaGet: ok,
+			handleMediaCreate: ok,
+			handleMediaUpdate: ok,
+			handleMediaDelete: ok,
+			handleRevisionList: ok,
+			handleRevisionGet: ok,
+			handleRevisionRestore: ok,
+			getPluginRouteMeta: () => null,
+			handlePluginApiRoute: async () => ({ success: true }),
+			getMediaProvider: () => undefined,
+			getMediaProviderList: () => [],
+			collectPageMetadata: async () => [],
+			collectPageFragments: async () => [],
+			ensureSearchHealthy: async () => undefined,
+			getManifest: async () => ({}),
+			getSandboxRunner: () => null,
+			isSandboxBypassed: () => false,
+			syncMarketplacePlugins: async () => undefined,
+			syncRegistryPlugins: async () => undefined,
+			setPluginStatus: async () => undefined,
+		},
+		mockGetPublicUrl: getPublicUrl,
+	};
+});
+
+vi.mock(
+	"virtual:emdash/config",
+	() => ({
+		default: {
+			database: { config: DB_CONFIG_MARKER },
+			auth: { mode: "none" },
+		},
+	}),
+	{ virtual: true },
+);
+
+vi.mock(
+	"virtual:emdash/dialect",
+	() => ({
+		createDialect: vi.fn(),
+		createRequestScopedDb: vi.fn().mockReturnValue(null),
+	}),
+	{ virtual: true },
+);
+
+vi.mock("virtual:emdash/media-providers", () => ({ mediaProviders: [] }), { virtual: true });
+vi.mock("virtual:emdash/plugins", () => ({ plugins: [] }), { virtual: true });
+vi.mock(
+	"virtual:emdash/sandbox-runner",
+	() => ({
+		createSandboxRunner: null,
+		sandboxBypassed: false,
+		sandboxEnabled: false,
+	}),
+	{ virtual: true },
+);
+vi.mock("virtual:emdash/sandboxed-plugins", () => ({ sandboxedPlugins: [] }), { virtual: true });
+vi.mock("virtual:emdash/storage", () => ({ createStorage: null }), { virtual: true });
+vi.mock("virtual:emdash/wait-until", () => ({ waitUntil: undefined }), { virtual: true });
+vi.mock("virtual:emdash/scheduler", () => ({ createScheduler: null }), { virtual: true });
+
+vi.mock("../../../src/emdash-runtime.js", () => ({
+	DB_INIT_DEADLINE_MS: 30_000,
+	EmDashRuntime: {
+		create: async () => MOCK_RUNTIME,
+	},
+}));
+
+vi.mock("../../../src/loader.js", () => ({
+	getDb: vi.fn(async () => ({
+		selectFrom: () => ({
+			selectAll: () => ({
+				limit: () => ({
+					execute: async () => [],
+				}),
+			}),
+		}),
+	})),
+}));
+
+import { createRequestScopedDb } from "virtual:emdash/dialect";
+
+import onRequest from "../../../src/astro/middleware.js";
+
+/** Anonymous GET to a public frontend page (the `runAnon` response path). */
+function anonymousPublicPageContext() {
+	const cookies = {
+		get: vi.fn((name: string) => {
+			if (name === "astro-session") return undefined;
+			return undefined;
+		}),
+		set: vi.fn(),
+	};
+	const astroSession = { get: vi.fn(async () => null) };
+
+	return {
+		request: new Request("https://example.com/contact"),
+		url: new URL("https://example.com/contact"),
+		cookies,
+		locals: {} as Record<string, unknown>,
+		redirect: vi.fn(),
+		isPrerendered: false,
+		session: astroSession,
+	} as Record<string, unknown>;
+}
+
+describe("astro middleware baseline security headers (issue #1393)", () => {
+	beforeEach(() => {
+		vi.mocked(createRequestScopedDb).mockReset().mockReturnValue(null);
+		mockGetPublicUrl.mockClear();
+	});
+
+	it("does not overwrite host-set security headers on public routes", async () => {
+		const context = anonymousPublicPageContext();
+		const hostHeaders = {
+			"Permissions-Policy":
+				"camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=()",
+			"Referrer-Policy": "no-referrer",
+			"X-Content-Type-Options": "nosniff",
+		};
+
+		const response = await onRequest(
+			context as Parameters<typeof onRequest>[0],
+			async () => new Response("ok", { headers: hostHeaders }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Permissions-Policy")).toBe(hostHeaders["Permissions-Policy"]);
+		expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+		expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+	});
+
+	it("still applies EmDash baseline headers when the host sets none", async () => {
+		const context = anonymousPublicPageContext();
+
+		const response = await onRequest(
+			context as Parameters<typeof onRequest>[0],
+			async () => new Response("ok"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+		expect(response.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+		expect(response.headers.get("Permissions-Policy")).toBe(
+			"camera=(), microphone=(), geolocation=(), payment=()",
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

`finalizeResponse()` unconditionally set `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on every response. Because the middleware registers with `order: 'pre'` (#1282), on the response path it runs *after* the host app's own middleware, so it overwrote any of these headers the host had already set on its public routes — letting the CMS dictate the security headers of the entire host site (the reporter's host sets a stricter `Permissions-Policy`).

These three headers are now applied set-if-absent (`if (!res.headers.has(name))`), matching the existing `Content-Security-Policy` guard in the same function, so a host that sets a stricter value on its own routes wins. EmDash still provides its baseline defaults when the host sets nothing.

Closes #1393

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: new + existing astro middleware suites)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode
