### PR TITLE
fix(core): set Cache-Control: private, no-store on editor toolbar-injected HTML (#1398)

### DIFF
--- a/.changeset/fix-1398-toolbar-injection-no-store.md
+++ b/.changeset/fix-1398-toolbar-injection-no-store.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+fix(core): set Cache-Control: private, no-store on editor toolbar-injected HTML (#1398)
+
+The request-context middleware injected the editor toolbar into public HTML for a logged-in editor but, unlike the preview branch, did not set `Cache-Control: private, no-store`. On a site fronted by a shared cache (Cloudflare, etc.), an editor merely browsing the public site primed the edge cache with toolbar-bearing HTML that was then served to all anonymous visitors — leaking the toolbar markup and the fact that a session was active.
+
+`injectToolbar` now sets `Cache-Control: private, no-store` on the actual-injection path, mirroring the preview branch, so toolbar-bearing (session-specific) responses are never shared-cacheable. Responses where no toolbar is injected (non-HTML, or HTML without a `</body>`) keep their original cacheability.

--- a/.changeset/fix-1398-toolbar-injection-no-store.md
+++ b/.changeset/fix-1398-toolbar-injection-no-store.md
@@ -2,8 +2,4 @@
 "emdash": patch
 ---
 
-fix(core): set Cache-Control: private, no-store on editor toolbar-injected HTML (#1398)
-
-The request-context middleware injected the editor toolbar into public HTML for a logged-in editor but, unlike the preview branch, did not set `Cache-Control: private, no-store`. On a site fronted by a shared cache (Cloudflare, etc.), an editor merely browsing the public site primed the edge cache with toolbar-bearing HTML that was then served to all anonymous visitors — leaking the toolbar markup and the fact that a session was active.
-
-`injectToolbar` now sets `Cache-Control: private, no-store` on the actual-injection path, mirroring the preview branch, so toolbar-bearing (session-specific) responses are never shared-cacheable. Responses where no toolbar is injected (non-HTML, or HTML without a `</body>`) keep their original cacheability.
+Fixes the editor toolbar leaking into a shared cache (#1398). When a logged-in editor browsed the public site behind a shared cache (such as Cloudflare), responses carrying the injected toolbar could be cached and then served to anonymous visitors, exposing the toolbar markup and the fact that a session was active. Toolbar-bearing responses are now marked `Cache-Control: private, no-store` so they are never shared-cacheable; responses without an injected toolbar keep their original caching.

--- a/packages/core/src/astro/middleware/request-context.ts
+++ b/packages/core/src/astro/middleware/request-context.ts
@@ -30,10 +30,15 @@ async function injectToolbar(response: Response, toolbarHtml: string): Promise<R
 	if (!html.includes("</body>")) return new Response(html, response);
 
 	const injected = html.replace("</body>", `${toolbarHtml}</body>`);
-	return new Response(injected, {
+	const result = new Response(injected, {
 		status: response.status,
 		headers: response.headers,
 	});
+	// Toolbar-injected HTML is session-specific (its presence reveals an active
+	// editor session); it must never be stored in a shared CDN cache and served
+	// to anonymous visitors. Mirrors the preview branch's guard (#1398).
+	result.headers.set("Cache-Control", "private, no-store");
+	return result;
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {

--- a/packages/core/tests/unit/astro/request-context-toolbar-cache.test.ts
+++ b/packages/core/tests/unit/astro/request-context-toolbar-cache.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for issue #1398: the editor-toolbar injection path did not
+ * set `Cache-Control: private, no-store`, unlike the preview path. On a site
+ * fronted by a shared cache, a logged-in editor merely browsing the public site
+ * primed the edge cache with toolbar-bearing HTML that was then served to all
+ * anonymous visitors — leaking the toolbar markup and the fact a session was
+ * active.
+ *
+ * The fix sets `Cache-Control: private, no-store` on any toolbar-injected
+ * response (centralized in `injectToolbar`), mirroring the preview branch.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+	defineMiddleware: (handler: unknown) => handler,
+}));
+
+import onRequest from "../../../src/astro/middleware/request-context.js";
+
+/** A public-page request from a logged-in editor with no edit cookie / preview token. */
+function editorRequestContext(pathname = "/blog") {
+	return {
+		request: new Request(`https://example.com${pathname}`),
+		url: new URL(`https://example.com${pathname}`),
+		cookies: { get: vi.fn(() => undefined), set: vi.fn() },
+		locals: { user: { id: "u1", role: 30 } },
+	} as unknown as Parameters<typeof onRequest>[0];
+}
+
+describe("editor toolbar injection cache headers (issue #1398)", () => {
+	it("sets Cache-Control: private, no-store on toolbar-injected HTML", async () => {
+		const context = editorRequestContext();
+
+		const response = await onRequest(
+			context,
+			async () =>
+				new Response("<html><body>hello</body></html>", {
+					headers: { "content-type": "text/html" },
+				}),
+		);
+
+		const body = await response.text();
+		// Confirm we are on the actual-injection path, not an early return.
+		expect(body).toContain('id="emdash-toolbar"');
+		expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+	});
+
+	it("does not force no-store on non-HTML responses (no toolbar injected)", async () => {
+		const context = editorRequestContext("/api/data.json");
+
+		const response = await onRequest(
+			context,
+			async () =>
+				new Response('{"ok":true}', {
+					headers: { "content-type": "application/json" },
+				}),
+		);
+
+		// No toolbar was injected, so the response is not session-specific and
+		// must retain its original cacheability.
+		expect(response.headers.get("Cache-Control")).toBeNull();
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The request-context middleware injects the editor toolbar into public HTML for a logged-in editor but, unlike the preview branch, did not set `Cache-Control: private, no-store`. On a site fronted by a shared cache (Cloudflare, etc.), an editor merely browsing the public site primed the edge cache with toolbar-bearing HTML that was then served to all anonymous visitors — leaking the toolbar markup and the fact that a session was active.

`injectToolbar` now sets `Cache-Control: private, no-store` on the actual-injection path, mirroring the preview branch, so toolbar-bearing (session-specific) responses are never shared-cacheable. Responses where no toolbar is injected (non-HTML, or HTML without a `</body>`) keep their original cacheability.

Closes #1398

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: new + toolbar + cache-hints suites)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode