### PR TITLE
fix(core): fail fast with an actionable error for plugins without an entrypoint (#1416)

### DIFF
--- a/.changeset/fix-1416-plugins-missing-entrypoint.md
+++ b/.changeset/fix-1416-plugins-missing-entrypoint.md
@@ -2,8 +2,4 @@
 "emdash": patch
 ---
 
-fix(core): fail fast with an actionable error for plugins without an entrypoint (#1416)
-
-`generatePluginsModule` assumed every plugin descriptor had a file entrypoint and emitted `import pluginDefN from "${descriptor.entrypoint}";`. For an in-process plugin — an inline `definePlugin({...})` result passed directly to `plugins: []` — `entrypoint` is `undefined`, so the generated virtual module contained `import pluginDef0 from "undefined";` and the build failed deep in Rollup with the cryptic `Rollup failed to resolve import "undefined" from "virtual:emdash/plugins"`.
-
-The generator now throws a clear, actionable error that names the offending plugin and explains that `plugins: []` entries must resolve to a file/package entrypoint (bundled at build time), so an inline `definePlugin({...})` result is not supported — move the plugin into its own module and reference it via a factory that returns a descriptor with an `entrypoint`.
+Fixes a cryptic build failure when a configured plugin has no resolvable entrypoint (#1416). Passing an inline `definePlugin({...})` result directly to `plugins: []` previously failed deep in the bundler with an unhelpful "failed to resolve import" error. The build now fails fast with a clear message that names the offending plugin and explains that `plugins: []` entries must resolve to a file or package entrypoint — move the plugin into its own module and reference it from there.

--- a/.changeset/fix-1416-plugins-missing-entrypoint.md
+++ b/.changeset/fix-1416-plugins-missing-entrypoint.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+fix(core): fail fast with an actionable error for plugins without an entrypoint (#1416)
+
+`generatePluginsModule` assumed every plugin descriptor had a file entrypoint and emitted `import pluginDefN from "${descriptor.entrypoint}";`. For an in-process plugin — an inline `definePlugin({...})` result passed directly to `plugins: []` — `entrypoint` is `undefined`, so the generated virtual module contained `import pluginDef0 from "undefined";` and the build failed deep in Rollup with the cryptic `Rollup failed to resolve import "undefined" from "virtual:emdash/plugins"`.
+
+The generator now throws a clear, actionable error that names the offending plugin and explains that `plugins: []` entries must resolve to a file/package entrypoint (bundled at build time), so an inline `definePlugin({...})` result is not supported — move the plugin into its own module and reference it via a factory that returns a descriptor with an `entrypoint`.

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -206,6 +206,21 @@ export function generatePluginsModule(descriptors: PluginDescriptor[]): string {
 	let needsAdapter = false;
 
 	descriptors.forEach((descriptor, index) => {
+		// Every `plugins: []` entry must resolve to a file/package entrypoint that
+		// can be statically imported and bundled at build time. An in-process
+		// `definePlugin({...})` result passed directly has no entrypoint; without
+		// this guard the generator emitted `import pluginDefN from "undefined";`,
+		// which failed deep in Rollup with `failed to resolve import "undefined"`
+		// (#1416). Fail fast with an actionable message instead.
+		if (!descriptor.entrypoint) {
+			throw new Error(
+				`[emdash] Plugin "${descriptor.id}" has no \`entrypoint\`. The astro integration's ` +
+					`\`plugins: []\` requires plugins that resolve to a file/package entrypoint so they can be ` +
+					`bundled at build time; an in-process \`definePlugin({...})\` result passed directly is not ` +
+					`supported. Move the plugin into its own module and reference it via a factory that returns ` +
+					`a descriptor with an \`entrypoint\` (e.g. \`plugins: [myPlugin()]\`).`,
+			);
+		}
 		if (descriptor.format === "standard") {
 			// Standard format: import default export, wrap with adaptSandboxEntry
 			needsAdapter = true;

--- a/packages/core/tests/unit/plugins/standard-format.test.ts
+++ b/packages/core/tests/unit/plugins/standard-format.test.ts
@@ -155,6 +155,36 @@ describe("generatePluginsModule() standard format", () => {
 		expect(code).toBe("export const plugins = [];");
 	});
 
+	it("throws an actionable error when a descriptor has no entrypoint (issue #1416)", () => {
+		// In-process plugins -- an inline `definePlugin({...})` result passed
+		// directly to `plugins: []` -- have no file entrypoint. The generator
+		// used to emit `import pluginDef0 from "undefined";`, which failed deep
+		// in Rollup with `failed to resolve import "undefined"`. It must instead
+		// fail fast with a message that names the offending plugin and explains
+		// the constraint. (The type bypass mirrors the reporter's scenario: a
+		// `PluginDescriptor` whose required `entrypoint` is missing at runtime.)
+		const descriptors = [
+			{
+				id: "misarico-resend-email",
+				version: "0.0.0",
+				capabilities: ["hooks.email-transport:register"],
+			},
+		] as unknown as PluginDescriptor[];
+
+		let error: Error | undefined;
+		try {
+			generatePluginsModule(descriptors);
+		} catch (e) {
+			error = e as Error;
+		}
+
+		expect(error).toBeDefined();
+		expect(error!.message).toContain("misarico-resend-email");
+		expect(error!.message).toMatch(/entrypoint/i);
+		// The cryptic failure mode must be gone.
+		expect(error!.message).not.toContain('"undefined"');
+	});
+
 	it("serializes descriptor metadata for standard plugins", () => {
 		const descriptors: PluginDescriptor[] = [
 			{


### PR DESCRIPTION
## What does this PR do?

`generatePluginsModule` assumed every plugin descriptor had a file entrypoint and emitted `import pluginDefN from "${descriptor.entrypoint}";`. For an in-process plugin — an inline `definePlugin({...})` result passed directly to `plugins: []` — `entrypoint` is `undefined`, so the generated virtual module contained `import pluginDef0 from "undefined";` and the build failed deep in Rollup with the cryptic `Rollup failed to resolve import "undefined" from "virtual:emdash/plugins"`.

The generator now throws a clear, actionable error that names the offending plugin and explains that `plugins: []` entries must resolve to a file/package entrypoint (bundled at build time), so an inline `definePlugin({...})` result is not supported — move the plugin into its own module and reference it via a factory that returns a descriptor with an `entrypoint`.

Closes #1416

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted: tests/unit/plugins — 600 tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [x] I have added a changeset

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode