### PR TITLE
fix(core): grant plugin media write access on storage-only backends (#1313)

### DIFF
--- a/.changeset/media-write-r2-binding.md
+++ b/.changeset/media-write-r2-binding.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix `ctx.media.upload()` and `ctx.media.delete()` being unavailable to in-process plugins on storage backends that don't support presigned URLs, such as the Cloudflare R2 Worker binding (#1313). A plugin granted `media:write` previously lost all write access whenever `getUploadUrl` was unset — even though `upload()` only needs a storage backend — forcing plugins to bypass the media API and write to the bucket directly. Write access is now granted when either a presigned-URL provider or a direct storage backend is configured. Calling `media.getUploadUrl()` on a backend without presigned-URL support now throws a clear "not supported" error instead of silently stripping `upload()` from the context.

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -432,14 +432,20 @@ export function createMediaAccess(db: Kysely<Database>): MediaAccess {
 
 /**
  * Create full media access with write operations.
- * If storage is not provided, upload() will throw at call time.
+ *
+ * `getUploadUrlFn` is optional: when omitted (e.g. the R2 Worker binding has no
+ * presigned-URL support), getUploadUrl() throws at call time but upload() and
+ * delete() remain available. If `storage` is not provided, upload() throws at
+ * call time. See #1313.
  */
 export function createMediaAccessWithWrite(
 	db: Kysely<Database>,
-	getUploadUrlFn: (
-		filename: string,
-		contentType: string,
-	) => Promise<{ uploadUrl: string; mediaId: string }>,
+	getUploadUrlFn:
+		| ((
+				filename: string,
+				contentType: string,
+		  ) => Promise<{ uploadUrl: string; mediaId: string }>)
+		| undefined,
 	storage?: Storage,
 ): MediaAccessWithWrite {
 	const mediaRepo = new MediaRepository(db);
@@ -448,7 +454,15 @@ export function createMediaAccessWithWrite(
 	return {
 		...readAccess,
 
-		getUploadUrl: getUploadUrlFn,
+		getUploadUrl:
+			getUploadUrlFn ??
+			(async (): Promise<{ uploadUrl: string; mediaId: string }> => {
+				throw new Error(
+					"getUploadUrl() is not supported by the configured storage backend " +
+						"(e.g. the R2 Worker binding does not support presigned URLs). " +
+						"Use media.upload() instead.",
+				);
+			}),
 
 		async upload(
 			filename: string,
@@ -842,8 +856,10 @@ export interface PluginContextFactoryOptions {
 	 */
 	storage?: Storage;
 	/**
-	 * Function to generate upload URLs for media.
-	 * If not provided, media write operations will throw.
+	 * Function to generate presigned upload URLs for media.
+	 * Optional: if omitted but `storage` is configured, media write operations
+	 * still work via direct uploads (media.upload()); only media.getUploadUrl()
+	 * throws. See #1313.
 	 */
 	getUploadUrl?: (
 		filename: string,
@@ -923,8 +939,14 @@ export class PluginContextFactory {
 		}
 
 		// Capability-gated: media
+		//
+		// media:write grants write access whenever the plugin can actually write —
+		// i.e. when EITHER a presigned-URL provider (getUploadUrl) OR a direct
+		// storage backend is configured. The R2 Worker binding provides storage
+		// but no presigned URLs, so gating solely on getUploadUrl wrongly stripped
+		// upload()/delete() from plugins on that adapter (#1313).
 		let media: MediaAccess | MediaAccessWithWrite | undefined;
-		if (capabilities.has("media:write") && this.getUploadUrl) {
+		if (capabilities.has("media:write") && (this.getUploadUrl || this.storage)) {
 			media = createMediaAccessWithWrite(this.db, this.getUploadUrl, this.storage);
 		} else if (capabilities.has("media:read")) {
 			media = createMediaAccess(this.db);

--- a/packages/core/tests/integration/plugins/capabilities.test.ts
+++ b/packages/core/tests/integration/plugins/capabilities.test.ts
@@ -28,7 +28,8 @@ import {
 	createUrlHelper,
 	createUserAccess,
 } from "../../../src/plugins/context.js";
-import type { ResolvedPlugin } from "../../../src/plugins/types.js";
+import type { MediaAccessWithWrite, ResolvedPlugin } from "../../../src/plugins/types.js";
+import type { Storage } from "../../../src/storage/types.js";
 
 // Test regex patterns
 const NOT_ALLOWED_FETCH_REGEX = /not allowed to fetch from host/;
@@ -720,6 +721,99 @@ describe("Capability Enforcement Integration (v2)", () => {
 
 			const ctx = factory.createContext(plugin);
 			expect(ctx.users).toBeUndefined();
+		});
+	});
+
+	describe("Media Access write gate (#1313)", () => {
+		// Minimal in-memory storage stub. createMediaAccessWithWrite.upload()
+		// only touches storage.upload()/storage.delete(), so a partial stub is
+		// sufficient; cast to Storage to satisfy the factory option type.
+		function createMemoryStorage(): Storage {
+			const store = new Map<string, Uint8Array>();
+			return {
+				async upload(opts: { key: string; body: Uint8Array }) {
+					store.set(opts.key, opts.body);
+				},
+				async delete(key: string) {
+					store.delete(key);
+				},
+				async exists(key: string) {
+					return store.has(key);
+				},
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- partial stub for tests
+			} as unknown as Storage;
+		}
+
+		it("grants write media (upload/delete) when storage is configured without getUploadUrl", () => {
+			// Regression for #1313: the R2 Worker binding provides storage but no
+			// presigned-URL support, so getUploadUrl is never set. upload() only
+			// needs storage, so media:write must still expose write access.
+			const factory = new PluginContextFactory({ db, storage: createMemoryStorage() });
+
+			const plugin = createTestPlugin({
+				id: "uploader",
+				capabilities: ["media:write", "media:read"],
+			});
+			const ctx = factory.createContext(plugin);
+
+			expect(ctx.media).toBeDefined();
+			const media = ctx.media as MediaAccessWithWrite;
+			expect(typeof media.upload).toBe("function");
+			expect(typeof media.delete).toBe("function");
+		});
+
+		it("upload() persists bytes through the configured storage backend", async () => {
+			const factory = new PluginContextFactory({ db, storage: createMemoryStorage() });
+			const plugin = createTestPlugin({ id: "uploader", capabilities: ["media:write"] });
+			const ctx = factory.createContext(plugin);
+
+			const media = ctx.media as MediaAccessWithWrite;
+			const result = await media.upload(
+				"memory.jpg",
+				"image/jpeg",
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			expect(result.storageKey).toMatch(/\.jpg$/);
+			expect(result.url).toBe(`/_emdash/api/media/file/${result.storageKey}`);
+		});
+
+		it("getUploadUrl() throws a clear error when no presign provider is configured", async () => {
+			const factory = new PluginContextFactory({ db, storage: createMemoryStorage() });
+			const plugin = createTestPlugin({ id: "uploader", capabilities: ["media:write"] });
+			const ctx = factory.createContext(plugin);
+
+			const media = ctx.media as MediaAccessWithWrite;
+			await expect(media.getUploadUrl("x.jpg", "image/jpeg")).rejects.toThrow(/not support/i);
+		});
+
+		it("still grants write media when getUploadUrl is configured (existing behavior)", () => {
+			const factory = new PluginContextFactory({
+				db,
+				getUploadUrl: async () => ({ uploadUrl: "http://example.com/upload", mediaId: "m1" }),
+			});
+			const plugin = createTestPlugin({ id: "uploader", capabilities: ["media:write"] });
+			const ctx = factory.createContext(plugin);
+
+			expect(ctx.media).toBeDefined();
+			expect(typeof (ctx.media as MediaAccessWithWrite).upload).toBe("function");
+		});
+
+		it("provides read-only media for media:read", () => {
+			const factory = new PluginContextFactory({ db });
+			const plugin = createTestPlugin({ id: "reader", capabilities: ["media:read"] });
+			const ctx = factory.createContext(plugin);
+
+			expect(ctx.media).toBeDefined();
+			expect("upload" in ctx.media!).toBe(false);
+		});
+
+		it("provides no media when media:write has neither storage, getUploadUrl, nor read", () => {
+			const factory = new PluginContextFactory({ db });
+			const plugin = createTestPlugin({ id: "none", capabilities: ["media:write"] });
+			const ctx = factory.createContext(plugin);
+
+			expect(ctx.media).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## What does this PR do?

Fixes `ctx.media.upload()` and `ctx.media.delete()` being silently unavailable to in-process (native) plugins on storage backends that don't support presigned URLs — notably the Cloudflare R2 Worker binding.

In `PluginContextFactory.createContext`, media write access was gated on `this.getUploadUrl` being truthy:

```ts
if (capabilities.has("media:write") && this.getUploadUrl) {
  media = createMediaAccessWithWrite(this.db, this.getUploadUrl, this.storage);
}
```

But `upload()` never uses `getUploadUrl` — it only needs `storage`. The R2 Worker binding intentionally provides `storage` but no presigned-URL support, so `getUploadUrl` is never set and a plugin granted `media:write` loses **all** write access despite having a fully functional storage backend. The only workaround today is to bypass the media API and write to the bucket binding directly.

This is the same gap the `@emdash-cms/cloudflare` sandbox wrapper already papers over by setting `getUploadUrl` to a stub that throws — confirming the intent is for `upload()` to work on the binding.

### The fix

- Gate media write access on `(this.getUploadUrl || this.storage)`, so a plugin can write whenever it actually can — via a presign provider **or** a direct storage backend.
- Make `getUploadUrlFn` optional in `createMediaAccessWithWrite`. When no presign provider is configured, `media.getUploadUrl()` now throws a clear "not supported — use media.upload() instead" error rather than silently stripping `upload()`/`delete()` from the context.
- No change to behavior when `getUploadUrl` **is** configured.

Closes #1313

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — `packages/core` plugin suites: 706 passed
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset (if this PR changes a published package)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

New tests in `packages/core/tests/integration/plugins/capabilities.test.ts` (describe: "Media Access write gate (#1313)") cover:

- `media:write` + storage (no `getUploadUrl`) → `upload()`/`delete()` available (the regression)
- `upload()` round-trips bytes through the storage backend
- `getUploadUrl()` rejects with a clear error when no presign provider exists
- existing `getUploadUrl`-configured path still grants write
- `media:read` stays read-only; `media:write` with neither storage nor presign nor read → no media access

```
Test Files  30 passed (30)
     Tests  706 passed (706)
```
