### PR TITLE
fix(core): accept Markdown for portableText fields in MCP content tools

### DIFF
--- a/.changeset/mcp-markdown-portable-text.md
+++ b/.changeset/mcp-markdown-portable-text.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Lets the MCP `content_create` and `content_update` tools accept a Markdown string for rich text (portableText) fields, converting it to Portable Text automatically — the same behaviour the EmDash client already has. Passing a Portable Text JSON array still works. Authoring rich text as a single Markdown string avoids the large nested JSON payloads that agents frequently emit as malformed JSON, causing the tool call to fail before it reaches the server. `content_get` and `content_list` gain an optional `markdown` flag (default false) that returns rich text fields as Markdown instead of Portable Text arrays.

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -18,6 +18,8 @@ import { contentBylineInputSchema, contentSeoInput } from "#api/schemas.js";
 
 import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
+import { convertDataForRead, convertDataForWrite } from "../client/portable-text.js";
+import type { FieldSchema } from "../client/portable-text.js";
 
 const COLLECTION_SLUG_PATTERN = /^[a-z][a-z0-9_]*$/;
 /** http(s) scheme matcher used by `settings_update` URL validation. */
@@ -268,6 +270,65 @@ function getEmDash(extra: { authInfo?: { extra?: Record<string, unknown> } }): E
 	return getExtra(extra).emdash;
 }
 
+async function getCollectionFields(
+	ec: EmDashHandlers,
+	collection: string,
+): Promise<FieldSchema[] | null> {
+	try {
+		const { SchemaRegistry } = await import("../schema/index.js");
+		const col = await new SchemaRegistry(ec.db).getCollectionWithFields(collection);
+		return col ? col.fields : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Convert markdown strings to Portable Text for any `portableText` field in
+ * `data`, mirroring what EmDashClient does on write. Agents author rich text
+ * as markdown rather than hand-building Portable Text JSON arrays, which they
+ * get subtly wrong — a malformed array fails the field's `z.array(...)`
+ * validation and surfaces to the caller as an opaque schema error. Fields that
+ * already hold a PT array (or any non-string) pass through untouched, so
+ * callers can still send Portable Text directly. Best-effort: if the schema
+ * can't be loaded the data is returned unchanged and the handler validates it.
+ */
+async function convertWriteData(
+	ec: EmDashHandlers,
+	collection: string,
+	data: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const fields = await getCollectionFields(ec, collection);
+	if (!fields) return data;
+	return convertDataForWrite(data, fields);
+}
+
+/**
+ * Convert `portableText` field values on each item's `data` back to markdown
+ * strings — the inverse of {@link convertWriteData}, opted into via the
+ * `markdown` argument on the read tools (reads default to Portable Text for
+ * backwards compatibility). Mutates each item's `data` in place. Best-effort:
+ * if the schema can't be loaded the items are left as Portable Text.
+ */
+async function applyReadMarkdown(
+	ec: EmDashHandlers,
+	collection: string,
+	items: Array<Record<string, unknown>>,
+): Promise<void> {
+	const fields = await getCollectionFields(ec, collection);
+	if (!fields) return;
+	for (const item of items) {
+		if (item.data && typeof item.data === "object") {
+			item.data = convertDataForRead(
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by typeof check above
+				item.data as Record<string, unknown>,
+				fields,
+				false,
+			);
+		}
+	}
+}
+
 /**
  * Enforce a scope requirement on the current request.
  *
@@ -460,6 +521,12 @@ export function createMcpServer(): McpServer {
 					.string()
 					.optional()
 					.describe("Filter by locale (e.g. 'en', 'fr'). Only relevant when i18n is enabled."),
+				markdown: z
+					.boolean()
+					.optional()
+					.describe(
+						"Return rich text (portableText) fields as Markdown strings instead of Portable Text arrays (default false).",
+					),
 			}),
 			annotations: { readOnlyHint: true },
 		},
@@ -469,16 +536,26 @@ export function createMcpServer(): McpServer {
 			// Subscribers must only see published content; force the status
 			// filter regardless of caller-supplied value.
 			const status = canReadDrafts(extra) ? args.status : "published";
-			return unwrap(
-				await ec.handleContentList(args.collection, {
-					status,
-					limit: args.limit,
-					cursor: args.cursor,
-					orderBy: args.orderBy,
-					order: args.order,
-					locale: args.locale,
-				}),
-			);
+			const result = await ec.handleContentList(args.collection, {
+				status,
+				limit: args.limit,
+				cursor: args.cursor,
+				orderBy: args.orderBy,
+				order: args.order,
+				locale: args.locale,
+			});
+			if (result.success && args.markdown) {
+				const payload = result.data;
+				if (
+					payload &&
+					typeof payload === "object" &&
+					"items" in payload &&
+					Array.isArray(payload.items)
+				) {
+					await applyReadMarkdown(ec, args.collection, payload.items);
+				}
+			}
+			return unwrap(result);
 		},
 	);
 
@@ -498,6 +575,12 @@ export function createMcpServer(): McpServer {
 					.optional()
 					.describe(
 						"Locale to scope slug lookup (e.g. 'fr'). Only affects slug resolution; IDs are globally unique.",
+					),
+				markdown: z
+					.boolean()
+					.optional()
+					.describe(
+						"Return rich text (portableText) fields as Markdown strings instead of Portable Text arrays (default false).",
 					),
 			}),
 			annotations: { readOnlyHint: true },
@@ -527,6 +610,9 @@ export function createMcpServer(): McpServer {
 					});
 				}
 			}
+			if (result.success && args.markdown && result.data?.item) {
+				await applyReadMarkdown(ec, args.collection, [result.data.item]);
+			}
 			return unwrap(result);
 		},
 	);
@@ -538,9 +624,12 @@ export function createMcpServer(): McpServer {
 			description:
 				"Create a new content item in a collection. The 'data' object should " +
 				"contain field values matching the collection's schema (use " +
-				"schema_get_collection to check). Rich text fields accept Portable Text " +
-				"JSON arrays. A slug is auto-generated if not provided. Items are created " +
-				"as 'draft' by default — use content_publish to make them live.",
+				"schema_get_collection to check). For rich text (portableText) fields, " +
+				"pass a Markdown string — this is the recommended format and is converted " +
+				"to Portable Text automatically. (A Portable Text JSON array is also " +
+				"accepted, but prefer Markdown: a large nested array is easy to emit as " +
+				"malformed JSON.) A slug is auto-generated if not provided. Items are " +
+				"created as 'draft' by default — use content_publish to make them live.",
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug (e.g. 'posts', 'pages')"),
 				data: z
@@ -581,6 +670,8 @@ export function createMcpServer(): McpServer {
 				);
 			}
 
+			const data = await convertWriteData(emdash, args.collection, args.data);
+
 			// Publishing requires publish permission — create as draft then publish
 			if (args.status === "published") {
 				const user = { id: userId, role: getExtra(extra).userRole };
@@ -591,7 +682,7 @@ export function createMcpServer(): McpServer {
 					);
 				}
 				const result = await emdash.handleContentCreate(args.collection, {
-					data: args.data,
+					data,
 					slug: args.slug,
 					authorId: userId,
 					locale: args.locale,
@@ -607,7 +698,7 @@ export function createMcpServer(): McpServer {
 
 			return unwrap(
 				await emdash.handleContentCreate(args.collection, {
-					data: args.data,
+					data,
 					slug: args.slug,
 					authorId: userId,
 					locale: args.locale,
@@ -623,7 +714,9 @@ export function createMcpServer(): McpServer {
 			title: "Update Content",
 			description:
 				"Update an existing content item. Only include fields you want to change " +
-				"in the 'data' object — unspecified fields are left unchanged. Pass the " +
+				"in the 'data' object — unspecified fields are left unchanged. Rich text " +
+				"(portableText) fields accept a Markdown string (recommended, converted " +
+				"automatically) or a Portable Text JSON array. Pass the " +
 				"_rev token from content_get to enable optimistic concurrency checking " +
 				"(the update fails if the item was modified since you read it). " +
 				"`seo` and `bylines` are persisted alongside the field updates in a " +
@@ -690,6 +783,10 @@ export function createMcpServer(): McpServer {
 			const ownerId = extractContentAuthorId(existing.data);
 			requireOwnership(extra, ownerId, "content:edit_own", "content:edit_any");
 
+			const data = args.data
+				? await convertWriteData(emdash, args.collection, args.data)
+				: args.data;
+
 			// Writing publishedAt directly (incl. clearing to null) overwrites
 			// historical record — gate behind publish_any, mirroring the REST PUT
 			// route. Status-driven publishes are gated separately below.
@@ -716,7 +813,7 @@ export function createMcpServer(): McpServer {
 					args.publishedAt !== undefined
 				) {
 					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
-						data: args.data,
+						data,
 						slug: args.slug,
 						authorId: userId,
 						locale: args.locale,
@@ -740,7 +837,7 @@ export function createMcpServer(): McpServer {
 					args.publishedAt !== undefined
 				) {
 					const updateResult = await emdash.handleContentUpdate(args.collection, resolvedId, {
-						data: args.data,
+						data,
 						slug: args.slug,
 						authorId: userId,
 						locale: args.locale,
@@ -756,7 +853,7 @@ export function createMcpServer(): McpServer {
 
 			return unwrap(
 				await emdash.handleContentUpdate(args.collection, resolvedId, {
-					data: args.data,
+					data,
 					slug: args.slug,
 					authorId: userId,
 					locale: args.locale,

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -284,14 +284,10 @@ async function getCollectionFields(
 }
 
 /**
- * Convert markdown strings to Portable Text for any `portableText` field in
- * `data`, mirroring what EmDashClient does on write. Agents author rich text
- * as markdown rather than hand-building Portable Text JSON arrays, which they
- * get subtly wrong — a malformed array fails the field's `z.array(...)`
- * validation and surfaces to the caller as an opaque schema error. Fields that
- * already hold a PT array (or any non-string) pass through untouched, so
- * callers can still send Portable Text directly. Best-effort: if the schema
- * can't be loaded the data is returned unchanged and the handler validates it.
+ * Convert markdown strings to Portable Text for `portableText` fields on write.
+ * Non-string values pass through, so callers may still send Portable Text. If
+ * the schema can't be loaded, data is returned unchanged for the handler to
+ * validate.
  */
 async function convertWriteData(
 	ec: EmDashHandlers,
@@ -304,11 +300,9 @@ async function convertWriteData(
 }
 
 /**
- * Convert `portableText` field values on each item's `data` back to markdown
- * strings — the inverse of {@link convertWriteData}, opted into via the
- * `markdown` argument on the read tools (reads default to Portable Text for
- * backwards compatibility). Mutates each item's `data` in place. Best-effort:
- * if the schema can't be loaded the items are left as Portable Text.
+ * Convert `portableText` field values on each item's `data` to markdown,
+ * mutating in place. Inverse of {@link convertWriteData}, gated on the read
+ * tools' `markdown` argument.
  */
 async function applyReadMarkdown(
 	ec: EmDashHandlers,
@@ -625,11 +619,11 @@ export function createMcpServer(): McpServer {
 				"Create a new content item in a collection. The 'data' object should " +
 				"contain field values matching the collection's schema (use " +
 				"schema_get_collection to check). For rich text (portableText) fields, " +
-				"pass a Markdown string — this is the recommended format and is converted " +
-				"to Portable Text automatically. (A Portable Text JSON array is also " +
-				"accepted, but prefer Markdown: a large nested array is easy to emit as " +
-				"malformed JSON.) A slug is auto-generated if not provided. Items are " +
-				"created as 'draft' by default — use content_publish to make them live.",
+				"pass a Markdown string — converted to Portable Text automatically; prefer " +
+				"this. Pass a Portable Text JSON array only for complex content Markdown " +
+				"can't express (custom blocks, embeds). A slug is auto-generated if not " +
+				"provided. Items are created as 'draft' by default — use content_publish " +
+				"to make them live.",
 			inputSchema: z.object({
 				collection: z.string().describe("Collection slug (e.g. 'posts', 'pages')"),
 				data: z
@@ -716,7 +710,8 @@ export function createMcpServer(): McpServer {
 				"Update an existing content item. Only include fields you want to change " +
 				"in the 'data' object — unspecified fields are left unchanged. Rich text " +
 				"(portableText) fields accept a Markdown string (recommended, converted " +
-				"automatically) or a Portable Text JSON array. Pass the " +
+				"automatically); use a Portable Text JSON array only for complex content " +
+				"Markdown can't express (custom blocks, embeds). Pass the " +
 				"_rev token from content_get to enable optimistic concurrency checking " +
 				"(the update fails if the item was modified since you read it). " +
 				"`seo` and `bylines` are persisted alongside the field updates in a " +

--- a/packages/core/tests/integration/mcp/markdown-portable-text.test.ts
+++ b/packages/core/tests/integration/mcp/markdown-portable-text.test.ts
@@ -1,0 +1,175 @@
+/**
+ * MCP content_create / content_update — Markdown -> Portable Text conversion.
+ *
+ * Agents emit the `content_create` arguments as one inline JSON blob. A rich
+ * text field authored as a deeply nested Portable Text array makes that blob
+ * large and easy to truncate/mis-escape, so the whole tool call fails to parse
+ * before any handler runs. Accepting a Markdown string for `portableText`
+ * fields collapses the array to a single scalar, mirroring what EmDashClient
+ * already does on write. A Portable Text array is still accepted unchanged.
+ */
+
+import { Role } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Database } from "../../../src/database/types.js";
+import {
+	connectMcpHarness,
+	extractJson,
+	extractText,
+	type McpHarness,
+} from "../../utils/mcp-runtime.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+const ADMIN_ID = "user_admin";
+
+interface PtSpan {
+	_type: string;
+	text?: string;
+	marks?: string[];
+}
+interface PtBlock {
+	_type: string;
+	style?: string;
+	children?: PtSpan[];
+}
+
+describe("MCP markdown -> Portable Text on write", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	it("content_create converts a Markdown string for a portableText field", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: {
+				collection: "post",
+				data: {
+					title: "Weighing flour",
+					content: "# Heading\n\nA paragraph with **bold** text.",
+				},
+			},
+		});
+		expect(created.isError, extractText(created)).toBeFalsy();
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const content = extractJson<{ item: { data: { content: PtBlock[] } } }>(got).item.data.content;
+
+		expect(Array.isArray(content)).toBe(true);
+		expect(content[0]?._type).toBe("block");
+		expect(content[0]?.style).toBe("h1");
+		expect(content[0]?.children?.[0]?.text).toBe("Heading");
+
+		const para = content[1];
+		expect(para?.style).toBe("normal");
+		const bold = para?.children?.find((s) => s.marks?.includes("strong"));
+		expect(bold?.text).toBe("bold");
+	});
+
+	it("content_create leaves an already-Portable-Text value untouched", async () => {
+		const block: PtBlock = {
+			_type: "block",
+			style: "normal",
+			children: [{ _type: "span", text: "Pre-authored", marks: [] }],
+		};
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: {
+				collection: "post",
+				data: { title: "Direct PT", content: [block] },
+			},
+		});
+		expect(created.isError, extractText(created)).toBeFalsy();
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const content = extractJson<{ item: { data: { content: PtBlock[] } } }>(got).item.data.content;
+		expect(content[0]?.children?.[0]?.text).toBe("Pre-authored");
+	});
+
+	it("content_get returns Portable Text by default and Markdown when requested", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: {
+				collection: "post",
+				data: { title: "Round trip", content: "## Sub\n\nBody text." },
+			},
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const def = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const defContent = extractJson<{ item: { data: { content: unknown } } }>(def).item.data.content;
+		expect(Array.isArray(defContent)).toBe(true);
+
+		const md = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id, markdown: true },
+		});
+		const mdContent = extractJson<{ item: { data: { content: unknown } } }>(md).item.data.content;
+		expect(typeof mdContent).toBe("string");
+		expect(mdContent).toContain("## Sub");
+		expect(mdContent).toContain("Body text.");
+	});
+
+	it("content_list returns Markdown for portableText fields when requested", async () => {
+		await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "Listed", content: "# Listed body" } },
+		});
+
+		const listed = await harness.client.callTool({
+			name: "content_list",
+			arguments: { collection: "post", markdown: true },
+		});
+		const items = extractJson<{ items: Array<{ data: { content?: unknown } }> }>(listed).items;
+		const withContent = items.find((i) => i.data.content != null);
+		expect(typeof withContent?.data.content).toBe("string");
+		expect(withContent?.data.content).toContain("# Listed body");
+	});
+
+	it("content_update converts a Markdown string for a portableText field", async () => {
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: { collection: "post", data: { title: "T", content: "Initial." } },
+		});
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const updated = await harness.client.callTool({
+			name: "content_update",
+			arguments: {
+				collection: "post",
+				id,
+				data: { content: "## Updated\n\nNew body." },
+			},
+		});
+		expect(updated.isError, extractText(updated)).toBeFalsy();
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const content = extractJson<{ item: { data: { content: PtBlock[] } } }>(got).item.data.content;
+		expect(content[0]?.style).toBe("h2");
+		expect(content[0]?.children?.[0]?.text).toBe("Updated");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Agents drive the MCP `content_create` tool by emitting the whole arguments object as one inline JSON blob. When a rich text (`portableText`) field is authored as a deeply nested Portable Text array, that blob gets large and the model frequently truncates or mis-escapes it — so the entire tool call fails to parse (`Invalid input for tool content_create: JSON parsing failed: Text: {...}`) *before* any server code runs. It's not a serialization bug in EmDash; it's that we were forcing the model down the one path it's worst at (hand-emitting a big nested JSON tree).

This wires the same Markdown↔Portable Text conversion the EmDash client already uses into the MCP tools:

- `content_create` / `content_update` now accept a **Markdown string** for `portableText` fields and convert it to Portable Text before calling the handlers. A Portable Text JSON array is still accepted unchanged (conversion only touches string values on `portableText` fields). Collapsing the nested array into one flat scalar is trivial for a model to emit correctly.
- `content_get` / `content_list` gain an optional `markdown` flag (**default `false`**, so the response shape is unchanged for existing consumers) that returns rich text as Markdown instead of Portable Text arrays.
- The tool descriptions now steer callers toward Markdown and explain why.

Conversion is best-effort: if the collection schema can't be loaded, data passes through and the handler validates it as before.

Closes #

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) <!-- ran the full MCP integration + unit suite (336 tests) -->
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI strings; MCP tool descriptions are not localized -->
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion <!-- n/a: bug fix -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
Test Files  19 passed (19)
     Tests  336 passed (336)
```
(full `packages/core` MCP integration + unit suites, including the new `markdown-portable-text.test.ts`)