### PR TITLE
feat(core): add byline management MCP tools

### DIFF
--- a/.changeset/mcp-byline-tools.md
+++ b/.changeset/mcp-byline-tools.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds byline management to the MCP server: `byline_list`, `byline_get`, `byline_create`, `byline_update`, `byline_delete`, and `byline_translations` tools, plus a `bylines` argument on `content_create` so credits can be attached at creation time (previously only `content_update` accepted them).

--- a/packages/core/src/astro/types.ts
+++ b/packages/core/src/astro/types.ts
@@ -265,6 +265,7 @@ export interface EmDashHandlers {
 			slug?: string;
 			status?: string;
 			authorId?: string;
+			bylines?: Array<{ bylineId: string; roleLabel?: string | null }>;
 			locale?: string;
 			translationOf?: string;
 			createdAt?: string | null;

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -14,7 +14,12 @@ import { canActOnOwn, hasPermission, Role } from "@emdash-cms/auth";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { contentBylineInputSchema, contentSeoInput } from "#api/schemas.js";
+import {
+	bylineCreateBody,
+	bylineUpdateBody,
+	contentBylineInputSchema,
+	contentSeoInput,
+} from "#api/schemas.js";
 
 import type { EmDashHandlers } from "../astro/types.js";
 import { hasScope } from "../auth/api-tokens.js";
@@ -321,6 +326,11 @@ async function applyReadMarkdown(
 			);
 		}
 	}
+}
+
+async function invalidateBylines(): Promise<void> {
+	const { invalidateBylineCache } = await import("../bylines/index.js");
+	invalidateBylineCache();
 }
 
 /**
@@ -644,6 +654,12 @@ export function createMcpServer(): McpServer {
 					.describe(
 						"ID of the content item this is a translation of. Links items in the same translation group.",
 					),
+				bylines: z
+					.array(contentBylineInputSchema)
+					.optional()
+					.describe(
+						"Bylines to credit. Each entry references an existing byline by id (see byline_list / byline_create) with an optional roleLabel. The first entry becomes the primary byline.",
+					),
 			}),
 			annotations: { destructiveHint: false },
 		},
@@ -681,6 +697,7 @@ export function createMcpServer(): McpServer {
 					authorId: userId,
 					locale: args.locale,
 					translationOf: args.translationOf,
+					bylines: args.bylines,
 				});
 				if (!result.success) return unwrap(result);
 				const itemId = extractContentId(result.data);
@@ -697,6 +714,7 @@ export function createMcpServer(): McpServer {
 					authorId: userId,
 					locale: args.locale,
 					translationOf: args.translationOf,
+					bylines: args.bylines,
 				}),
 			);
 		},
@@ -1252,6 +1270,183 @@ export function createMcpServer(): McpServer {
 				});
 			}
 			return unwrap(result);
+		},
+	);
+
+	// =====================================================================
+	// Byline tools
+	// =====================================================================
+
+	server.registerTool(
+		"byline_list",
+		{
+			title: "List Bylines",
+			description:
+				"List bylines (author/contributor credits) with optional filtering and " +
+				"pagination. Bylines are standalone records referenced by content items; " +
+				"use the returned id with content_create/content_update or byline_get. Use " +
+				"the nextCursor value from the response to fetch the next page.",
+			inputSchema: z.object({
+				search: z.string().optional().describe("Filter by display name or slug substring"),
+				isGuest: z.boolean().optional().describe("Filter by guest (true) or linked-user (false)"),
+				userId: z.string().optional().describe("Filter to the byline linked to a CMS user ID"),
+				locale: z.string().optional().describe("Filter by locale (omit for all)"),
+				limit: z.number().int().min(1).max(100).optional().describe("Max items (default 50)"),
+				cursor: z.string().min(1).max(2048).optional().describe("Pagination cursor"),
+			}),
+			annotations: { readOnlyHint: true },
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:read");
+			const ec = getEmDash(extra);
+			try {
+				const { BylineRepository } = await import("../database/repositories/byline.js");
+				const repo = new BylineRepository(ec.db);
+				return jsonResult(
+					await repo.findMany({
+						search: args.search,
+						isGuest: args.isGuest,
+						userId: args.userId,
+						locale: args.locale,
+						limit: args.limit,
+						cursor: args.cursor,
+					}),
+				);
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_LIST_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"byline_get",
+		{
+			title: "Get Byline",
+			description:
+				"Get a single byline by its ID, including bio, avatar, website, linked " +
+				"user, and any custom fields.",
+			inputSchema: z.object({
+				id: z.string().describe("Byline ID"),
+			}),
+			annotations: { readOnlyHint: true },
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:read");
+			const ec = getEmDash(extra);
+			try {
+				const { BylineRepository } = await import("../database/repositories/byline.js");
+				const byline = await new BylineRepository(ec.db).findById(args.id);
+				if (!byline) return respondError("NOT_FOUND", `Byline '${args.id}' not found`);
+				return jsonResult(byline);
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_GET_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"byline_create",
+		{
+			title: "Create Byline",
+			description:
+				"Create a new byline (author/contributor credit). The slug must be unique " +
+				"and contain only lowercase letters, digits, and hyphens. Link the byline " +
+				"to a CMS user via userId, or leave it as a standalone guest credit. The " +
+				"returned id can then be passed to content_create/content_update bylines.",
+			inputSchema: z.object({ ...bylineCreateBody.shape }),
+			annotations: { destructiveHint: false },
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:write");
+			requireRole(extra, Role.EDITOR);
+			const ec = getEmDash(extra);
+			try {
+				const { handleBylineCreate } = await import("../api/handlers/bylines.js");
+				const result = await handleBylineCreate(ec.db, args);
+				if (result.success) await invalidateBylines();
+				return unwrap(result);
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_CREATE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"byline_update",
+		{
+			title: "Update Byline",
+			description:
+				"Update an existing byline. Any field can be omitted to leave it " +
+				"unchanged. Renaming the slug must not collide with another byline.",
+			inputSchema: z.object({
+				id: z.string().describe("Byline ID to update"),
+				...bylineUpdateBody.shape,
+			}),
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:write");
+			requireRole(extra, Role.EDITOR);
+			const ec = getEmDash(extra);
+			try {
+				const { handleBylineUpdate } = await import("../api/handlers/bylines.js");
+				const { id, ...input } = args;
+				const result = await handleBylineUpdate(ec.db, id, input);
+				if (result.success) await invalidateBylines();
+				return unwrap(result);
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_UPDATE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"byline_delete",
+		{
+			title: "Delete Byline",
+			description:
+				"Permanently delete a byline. Any content crediting this byline loses the " +
+				"association, and it is cleared as a primary byline where set.",
+			inputSchema: z.object({
+				id: z.string().describe("Byline ID to delete"),
+			}),
+			annotations: { destructiveHint: true },
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:write");
+			requireRole(extra, Role.EDITOR);
+			const ec = getEmDash(extra);
+			try {
+				const { BylineRepository } = await import("../database/repositories/byline.js");
+				const deleted = await new BylineRepository(ec.db).delete(args.id);
+				if (!deleted) return respondError("NOT_FOUND", `Byline '${args.id}' not found`);
+				await invalidateBylines();
+				return jsonResult({ deleted: args.id });
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_DELETE_ERROR");
+			}
+		},
+	);
+
+	server.registerTool(
+		"byline_translations",
+		{
+			title: "List Byline Translations",
+			description:
+				"Return every locale variant of a byline, identified via its shared translation_group.",
+			inputSchema: z.object({
+				id: z.string().describe("Byline id (or translation_group)"),
+			}),
+			annotations: { readOnlyHint: true },
+		},
+		async (args, extra) => {
+			requireScope(extra, "content:read");
+			const ec = getEmDash(extra);
+			try {
+				const { handleBylineTranslations } = await import("../api/handlers/bylines.js");
+				return unwrap(await handleBylineTranslations(ec.db, args.id));
+			} catch (error) {
+				return respondHandlerError(error, "BYLINE_TRANSLATIONS_ERROR");
+			}
 		},
 	);
 

--- a/packages/core/tests/integration/mcp/bylines.test.ts
+++ b/packages/core/tests/integration/mcp/bylines.test.ts
@@ -1,0 +1,195 @@
+/**
+ * MCP byline tools + content_create byline attachment.
+ *
+ * Covers the byline CRUD tools (byline_list/get/create/update/delete/
+ * translations) and the new `bylines` argument on content_create, which
+ * forwards to the same setContentBylines path content_update already used.
+ */
+
+import { Role } from "@emdash-cms/auth";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Database } from "../../../src/database/types.js";
+import {
+	connectMcpHarness,
+	extractJson,
+	extractText,
+	isErrorResult,
+	type McpHarness,
+} from "../../utils/mcp-runtime.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+const ADMIN_ID = "user_admin";
+const AUTHOR_ID = "user_author";
+
+interface Byline {
+	id: string;
+	slug: string;
+	displayName: string;
+	isGuest: boolean;
+	websiteUrl: string | null;
+}
+
+describe("MCP byline tools", () => {
+	let db: Kysely<Database>;
+	let harness: McpHarness;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+	});
+
+	afterEach(async () => {
+		if (harness) await harness.cleanup();
+		await teardownTestDatabase(db);
+	});
+
+	async function createByline(slug: string, displayName: string): Promise<Byline> {
+		const result = await harness.client.callTool({
+			name: "byline_create",
+			arguments: { slug, displayName, isGuest: true },
+		});
+		expect(result.isError, extractText(result)).toBeFalsy();
+		return extractJson<Byline>(result);
+	}
+
+	it("creates, gets, lists, updates and deletes a byline", async () => {
+		const created = await createByline("jane-doe", "Jane Doe");
+		expect(created.slug).toBe("jane-doe");
+		expect(created.displayName).toBe("Jane Doe");
+
+		const got = await harness.client.callTool({
+			name: "byline_get",
+			arguments: { id: created.id },
+		});
+		expect(extractJson<Byline>(got).displayName).toBe("Jane Doe");
+
+		const listed = await harness.client.callTool({
+			name: "byline_list",
+			arguments: { search: "Jane" },
+		});
+		const items = extractJson<{ items: Byline[] }>(listed).items;
+		expect(items.some((b) => b.id === created.id)).toBe(true);
+
+		const updated = await harness.client.callTool({
+			name: "byline_update",
+			arguments: { id: created.id, displayName: "Jane Q. Doe" },
+		});
+		expect(extractJson<Byline>(updated).displayName).toBe("Jane Q. Doe");
+
+		const deleted = await harness.client.callTool({
+			name: "byline_delete",
+			arguments: { id: created.id },
+		});
+		expect(extractJson<{ deleted: string }>(deleted).deleted).toBe(created.id);
+
+		const gone = await harness.client.callTool({
+			name: "byline_get",
+			arguments: { id: created.id },
+		});
+		expect(isErrorResult(gone)).toBe(true);
+		expect(extractText(gone)).toContain("NOT_FOUND");
+	});
+
+	it("rejects a non-http websiteUrl (httpUrl validation preserved)", async () => {
+		const result = await harness.client.callTool({
+			name: "byline_create",
+			arguments: { slug: "evil", displayName: "Evil", websiteUrl: "javascript:alert(1)" },
+		});
+		expect(isErrorResult(result)).toBe(true);
+	});
+
+	it("byline_delete on a missing id returns NOT_FOUND", async () => {
+		const result = await harness.client.callTool({
+			name: "byline_delete",
+			arguments: { id: "does-not-exist" },
+		});
+		expect(isErrorResult(result)).toBe(true);
+		expect(extractText(result)).toContain("NOT_FOUND");
+	});
+
+	it("denies byline_create to an AUTHOR (below EDITOR)", async () => {
+		await harness.cleanup();
+		harness = await connectMcpHarness({ db, userId: AUTHOR_ID, userRole: Role.AUTHOR });
+
+		const result = await harness.client.callTool({
+			name: "byline_create",
+			arguments: { slug: "no-go", displayName: "No Go", isGuest: true },
+		});
+		expect(isErrorResult(result)).toBe(true);
+		expect(extractText(result)).toContain("INSUFFICIENT_PERMISSIONS");
+	});
+
+	it("byline_translations returns the byline's own translation group", async () => {
+		const jane = await createByline("jane-tr", "Jane Tr");
+		const result = await harness.client.callTool({
+			name: "byline_translations",
+			arguments: { id: jane.id },
+		});
+		expect(result.isError, extractText(result)).toBeFalsy();
+		const items = extractJson<{ items: Byline[] }>(result).items;
+		expect(items.some((b) => b.id === jane.id)).toBe(true);
+	});
+
+	it("content_create attaches bylines on the publish path", async () => {
+		const jane = await createByline("jane-pub", "Jane Pub");
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: {
+				collection: "post",
+				data: { title: "Published with byline" },
+				status: "published",
+				bylines: [{ bylineId: jane.id }],
+			},
+		});
+		expect(created.isError, extractText(created)).toBeFalsy();
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{ item: { status: string; primaryBylineId: string | null } }>(
+			got,
+		).item;
+		expect(item.status).toBe("published");
+		expect(item.primaryBylineId).toBe(jane.id);
+	});
+
+	it("content_create attaches bylines and sets the primary", async () => {
+		const jane = await createByline("jane-author", "Jane Author");
+		const john = await createByline("john-editor", "John Editor");
+
+		const created = await harness.client.callTool({
+			name: "content_create",
+			arguments: {
+				collection: "post",
+				data: { title: "Co-authored" },
+				bylines: [
+					{ bylineId: jane.id, roleLabel: "Author" },
+					{ bylineId: john.id, roleLabel: "Editor" },
+				],
+			},
+		});
+		expect(created.isError, extractText(created)).toBeFalsy();
+		const id = extractJson<{ item: { id: string } }>(created).item.id;
+
+		const got = await harness.client.callTool({
+			name: "content_get",
+			arguments: { collection: "post", id },
+		});
+		const item = extractJson<{
+			item: {
+				primaryBylineId: string | null;
+				bylines?: Array<{ byline: { id: string }; roleLabel: string | null }>;
+			};
+		}>(got).item;
+
+		expect(item.primaryBylineId).toBe(jane.id);
+		expect(item.bylines).toHaveLength(2);
+		expect(item.bylines?.[0]?.byline.id).toBe(jane.id);
+		expect(item.bylines?.[0]?.roleLabel).toBe("Author");
+		expect(item.bylines?.[1]?.byline.id).toBe(john.id);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds byline (author/contributor credit) management to the MCP server, and lets `content_create` attach bylines at creation time.

**New tools** (mirroring the taxonomy tool pattern and the REST `/api/admin/bylines` routes):
- `byline_list` — paginated, filter by search / isGuest / userId / locale
- `byline_get` — fetch one by id
- `byline_create` / `byline_update` / `byline_delete`
- `byline_translations` — locale variants via the shared translation group

**`content_create` now accepts `bylines`** — previously only `content_update` did, so creating a credited item over MCP took two calls. The handler already supported it; the tool just wasn't forwarding it (and the `EmDashHandlers` create type was missing the field).

**Authorization:** reads gate on `content:read` (consistent with `content_list`/`taxonomy_list`); writes on `content:write` + `requireRole(EDITOR)`, which matches the `bylines:manage` permission floor and the established menus/taxonomies scope-grant pattern (there is no dedicated byline token scope). Write tools call `invalidateBylineCache()` on success, mirroring the REST routes — without it, MCP byline edits would serve stale credits.

Input validation reuses the REST zod schemas (`bylineCreateBody`/`bylineUpdateBody`), preserving the `httpUrl` guard on `websiteUrl` (rejects `javascript:`/`data:` URLs).

> Builds on #1563 (merged). Rebased onto `main`; the diff here is byline-only.

Closes #

## Type of change

- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))

<!-- Note: this extends an existing subsystem (MCP tools) with parity to the REST byline API rather than introducing a new product concept. Happy to open a Discussion if a maintainer wants one before merge. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) <!-- full MCP integration + unit suite (341 tests) incl. new bylines.test.ts (7 cases) -->
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) <!-- n/a: no admin UI; MCP tool descriptions are not localized -->
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion <!-- pending: see note under Type of change -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
Test Files  20 passed (20)
     Tests  341 passed (341)
```
New `bylines.test.ts` covers CRUD round-trips, `httpUrl` rejection, AUTHOR-denied (INSUFFICIENT_PERMISSIONS), `byline_translations`, and `content_create` byline attach on both the draft and publish paths.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-mcp-byline-tools-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/mcp-byline-tools`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->

