### PR TITLE
fix(core): treat export-seed --with-content=all as all collections (#1329)

### DIFF
--- a/.changeset/export-seed-with-content-all.md
+++ b/.changeset/export-seed-with-content-all.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `emdash export-seed --with-content=all` exporting no content. The literal `all` value documented in the flag's help is now treated as "every collection" (like the bare `--with-content`), instead of being matched against a collection named "all" and silently exporting nothing. Closes #1329.

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -153,8 +153,10 @@ export async function exportSeed(db: Kysely<Database>, withContent?: string): Pr
 
 	// 7. Export content (if requested)
 	if (withContent !== undefined) {
+		// `""`, `"true"` (bare `--with-content`) and the documented `"all"` all
+		// mean "every collection"; anything else is a comma-separated allowlist.
 		const collections =
-			withContent === "" || withContent === "true"
+			withContent === "" || withContent === "true" || withContent === "all"
 				? null // all collections
 				: withContent
 						.split(",")

--- a/packages/core/tests/unit/seed/export-seed-with-content-all.test.ts
+++ b/packages/core/tests/unit/seed/export-seed-with-content-all.test.ts
@@ -1,0 +1,52 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { exportSeed } from "../../../src/cli/commands/export-seed.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { setI18nConfig } from "../../../src/i18n/config.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+describe("exportSeed: --with-content=all", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		setI18nConfig(null);
+		db = await setupTestDatabase();
+
+		const registry = new SchemaRegistry(db);
+		await registry.createCollection({ slug: "posts", label: "Posts" });
+		await registry.createField("posts", { slug: "title", label: "Title", type: "string" });
+		await registry.createCollection({ slug: "pages", label: "Pages" });
+		await registry.createField("pages", { slug: "title", label: "Title", type: "string" });
+
+		const contentRepo = new ContentRepository(db);
+		await contentRepo.create({
+			type: "posts",
+			slug: "hello",
+			status: "published",
+			data: { title: "Hello World" },
+		});
+		await contentRepo.create({
+			type: "pages",
+			slug: "about",
+			status: "published",
+			data: { title: "About" },
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		setI18nConfig(null);
+	});
+
+	it("exports every collection's content when withContent is the literal 'all'", async () => {
+		// The CLI help documents `all` as a valid value, so it must behave like
+		// the "" / "true" sentinel rather than being treated as a collection name.
+		const seed = await exportSeed(db, "all");
+
+		expect(seed.content?.posts?.map((e) => e.slug)).toEqual(["hello"]);
+		expect(seed.content?.pages?.map((e) => e.slug)).toEqual(["about"]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `emdash export-seed --with-content=all` exporting no content.

`exportSeed` treated the `withContent` value as a comma-separated allowlist of collection names. The documented `all` value matched no collection, so the seed's `content` came back empty. (`""` and `"true"`, produced by the bare `--with-content` flag, already meant "every collection".)

Fix: treat `""`, `"true"`, and `"all"` as "all collections"; anything else stays a comma-separated allowlist.

Closes #1329.

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset (if this PR changes a published package)

## AI-generated code disclosure
- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode

## Screenshots / test output
New test `packages/core/tests/unit/seed/export-seed-with-content-all.test.ts`: seeds posts + pages with content, calls `exportSeed(db, "all")`, asserts both collections' entries are exported.