### PR TITLE
fix: set urlPattern "/{slug}" on the pages collection in starter seeds (#1062)

### DIFF
--- a/templates/starter-cloudflare/seed/seed.json
+++ b/templates/starter-cloudflare/seed/seed.json
@@ -46,6 +46,7 @@
 			"slug": "pages",
 			"label": "Pages",
 			"labelSingular": "Page",
+			"urlPattern": "/{slug}",
 			"supports": ["drafts", "revisions", "search"],
 			"fields": [
 				{

--- a/templates/starter/seed/seed.json
+++ b/templates/starter/seed/seed.json
@@ -46,6 +46,7 @@
 			"slug": "pages",
 			"label": "Pages",
 			"labelSingular": "Page",
+			"urlPattern": "/{slug}",
 			"supports": ["drafts", "revisions", "search"],
 			"fields": [
 				{


### PR DESCRIPTION
## What does this PR do?

The `starter` and `starter-cloudflare` templates ship a root `[slug].astro` route for pages, but the seeded `pages` collection has no `urlPattern`. As a result the admin "View" link and the visual-editing overlay resolve to a URL that doesn't match the route the template provides. This declares `urlPattern: "/{slug}"` so the collection lines up with the route already present in both templates.

Closes #1062

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, seed JSON is template data validated by the existing template build
- [ ] User-visible strings wrapped for translation — n/a, no admin UI strings
- [ ] I have added a changeset — n/a, `templates/*` are not published packages

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode
