### PR TITLE
fix(core): add offset pagination to getEmDashCollection for numbered archives (#1364)

### DIFF
--- a/.changeset/collection-offset-pagination.md
+++ b/.changeset/collection-offset-pagination.md
@@ -1,0 +1,18 @@
+---
+"emdash": minor
+---
+
+Adds offset pagination to `getEmDashCollection` for numbered archive routes
+
+`getEmDashCollection` now accepts an `offset` option alongside `limit`, so you can render numbered archive URLs like `/page/2` or `/tag/security/page/3` without walking cursors or over-fetching from the start:
+
+```ts
+const perPage = 20;
+const { entries, hasMore } = await getEmDashCollection("posts", {
+  limit: perPage,
+  offset: (page - 1) * perPage,
+  orderBy: { published_at: "desc" },
+});
+```
+
+Results now include a `hasMore` boolean whenever `limit` is set, so you can show a "next page" link without an extra count query. `offset` is ignored when a `cursor` is supplied — cursor (keyset) pagination still wins.

--- a/.changeset/collection-offset-pagination.md
+++ b/.changeset/collection-offset-pagination.md
@@ -9,9 +9,9 @@ Adds offset pagination to `getEmDashCollection` for numbered archive routes
 ```ts
 const perPage = 20;
 const { entries, hasMore } = await getEmDashCollection("posts", {
-  limit: perPage,
-  offset: (page - 1) * perPage,
-  orderBy: { published_at: "desc" },
+	limit: perPage,
+	offset: (page - 1) * perPage,
+	orderBy: { published_at: "desc" },
 });
 ```
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -40,6 +40,8 @@ The `options` parameter accepts the following filter:
 interface CollectionFilter {
 	status?: "draft" | "published" | "archived";
 	limit?: number;
+	cursor?: string; // Keyset pagination — pass a previous `nextCursor`
+	offset?: number; // Offset pagination — skip N entries (use with `limit`)
 	where?: Record<string, string | string[]>; // Filter by field or taxonomy
 }
 ```
@@ -52,6 +54,8 @@ The function resolves to a `CollectionResult`:
 interface CollectionResult<T> {
 	entries: ContentEntry<T>[]; // Empty array if error or none found
 	error?: Error; // Set if query failed
+	nextCursor?: string; // Cursor for the next keyset page, if any
+	hasMore?: boolean; // Whether more entries exist beyond this page (when `limit` is set)
 }
 ```
 
@@ -75,6 +79,16 @@ const { entries: latest } = await getEmDashCollection("posts", {
 const { entries: newsPosts } = await getEmDashCollection("posts", {
 	status: "published",
 	where: { category: "news" },
+});
+
+// Numbered archive page (e.g. /page/3) with offset pagination
+const perPage = 20;
+const page = Number(Astro.params.page ?? 1);
+const { entries: pagePosts, hasMore } = await getEmDashCollection("posts", {
+	status: "published",
+	limit: perPage,
+	offset: (page - 1) * perPage,
+	orderBy: { published_at: "desc" },
 });
 
 // Handle errors

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -615,6 +615,13 @@ export interface CollectionFilter {
 	 */
 	cursor?: string;
 	/**
+	 * Skip this many rows before returning results (offset pagination).
+	 * Use with `limit` for numbered archive routes (`/page/2`):
+	 * `offset = (page - 1) * perPage`. Ignored unless it is a positive
+	 * integer, and ignored entirely when `cursor` is set (cursor wins).
+	 */
+	offset?: number;
+	/**
 	 * Filter by field values, taxonomy terms, byline credits, or ranges.
 	 *
 	 * Taxonomy names are detected automatically and filtered via JOIN.
@@ -750,6 +757,17 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 				// Cursor pagination: over-fetch by 1 to detect next page
 				const fetchLimit = limit ? limit + 1 : undefined;
 
+				// Offset pagination (numbered archive routes). Keyset (cursor)
+				// and offset are mutually exclusive ways to express "the next
+				// page" — when both are supplied, cursor wins and offset is
+				// dropped so the two don't stack into a double skip. Only a
+				// positive integer applies; 0 / negative / fractional are no-ops.
+				const rawOffset = cursor ? undefined : filter?.offset;
+				const offset =
+					typeof rawOffset === "number" && Number.isInteger(rawOffset) && rawOffset > 0
+						? rawOffset
+						: undefined;
+
 				// Build cursor condition if cursor is provided
 				const cursorCondition = cursor ? buildCursorCondition(cursor, orderBy) : null;
 
@@ -866,6 +884,20 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 						type,
 						tableName,
 					);
+
+					// LIMIT/OFFSET clause. SQLite only accepts OFFSET when a
+					// LIMIT is present, so a bare offset uses `LIMIT -1`
+					// (unbounded); Postgres takes a standalone OFFSET.
+					let limitOffsetClause = sql``;
+					if (fetchLimit != null && offset != null) {
+						limitOffsetClause = sql`LIMIT ${fetchLimit} OFFSET ${offset}`;
+					} else if (fetchLimit != null) {
+						limitOffsetClause = sql`LIMIT ${fetchLimit}`;
+					} else if (offset != null) {
+						limitOffsetClause = isPostgres(db)
+							? sql`OFFSET ${offset}`
+							: sql`LIMIT -1 OFFSET ${offset}`;
+					}
 					result = await sql<Record<string, unknown>>`
 						SELECT *, ${termsSelect}, ${bylinesSelect} FROM ${sql.ref(tableName)}
 						WHERE deleted_at IS NULL
@@ -876,7 +908,7 @@ export function emdashLoader(): LiveLoader<EntryData, EntryFilter, CollectionFil
 						${bylineCond}
 						${fieldCondsSQL ? sql`AND ${fieldCondsSQL}` : sql``}
 						${orderByClause}
-						${fetchLimit ? sql`LIMIT ${fetchLimit}` : sql``}
+						${limitOffsetClause}
 					`.execute(db);
 				}
 

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -603,24 +603,17 @@ export interface WhereRange {
 export type WhereValue = string | string[] | WhereRange;
 
 /**
- * Filter for loadCollection - type is required
+ * Fields shared by every collection filter, independent of pagination mode.
+ *
+ * Cursor and offset pagination are mutually exclusive, so they live on the
+ * `CursorCollectionFilter` / `OffsetCollectionFilter` variants rather than
+ * here. Use the {@link CollectionFilter} union for any value that may be
+ * either.
  */
-export interface CollectionFilter {
+export interface CollectionFilterBase {
 	type: string;
 	status?: "draft" | "published" | "archived";
 	limit?: number;
-	/**
-	 * Opaque cursor for keyset pagination.
-	 * Pass the `nextCursor` value from a previous result to fetch the next page.
-	 */
-	cursor?: string;
-	/**
-	 * Skip this many rows before returning results (offset pagination).
-	 * Use with `limit` for numbered archive routes (`/page/2`):
-	 * `offset = (page - 1) * perPage`. Ignored unless it is a positive
-	 * integer, and ignored entirely when `cursor` is set (cursor wins).
-	 */
-	offset?: number;
 	/**
 	 * Filter by field values, taxonomy terms, byline credits, or ranges.
 	 *
@@ -647,6 +640,37 @@ export interface CollectionFilter {
 	 */
 	locale?: string;
 }
+
+/** Keyset-paginated collection filter. Cannot also carry an `offset`. */
+export interface CursorCollectionFilter extends CollectionFilterBase {
+	/**
+	 * Opaque cursor for keyset pagination.
+	 * Pass the `nextCursor` value from a previous result to fetch the next page.
+	 */
+	cursor?: string;
+	offset?: never;
+}
+
+/** Offset-paginated collection filter. Cannot also carry a `cursor`. */
+export interface OffsetCollectionFilter extends CollectionFilterBase {
+	/**
+	 * Skip this many rows before returning results (offset pagination).
+	 * Use with `limit` for numbered archive routes (`/page/2`):
+	 * `offset = (page - 1) * perPage`. Ignored unless it is a positive
+	 * integer.
+	 */
+	offset?: number;
+	cursor?: never;
+}
+
+/**
+ * Filter for loadCollection - type is required.
+ *
+ * A union of the cursor and offset pagination variants: supplying both
+ * `cursor` and `offset` is a compile-time error, since they are mutually
+ * exclusive ways to express "the next page" (cursor wins at runtime).
+ */
+export type CollectionFilter = CursorCollectionFilter | OffsetCollectionFilter;
 
 /**
  * Filter for loadEntry - type and id are required

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -96,41 +96,17 @@ export type OrderBySpec = Record<string, SortDirection>;
 
 export type { WhereRange, WhereValue };
 
-export interface CollectionFilter {
+/**
+ * Fields shared by every collection query, independent of pagination mode.
+ *
+ * Cursor and offset pagination are mutually exclusive, so they live on the
+ * `CursorCollectionFilter` / `OffsetCollectionFilter` variants rather than
+ * here. Use the {@link CollectionFilter} union for any value that may be
+ * either.
+ */
+export interface CollectionFilterBase {
 	status?: "draft" | "published" | "archived";
 	limit?: number;
-	/**
-	 * Opaque cursor for keyset pagination.
-	 * Pass the `nextCursor` value from a previous result to fetch the next page.
-	 * @example
-	 * ```ts
-	 * const cursor = Astro.url.searchParams.get("cursor") ?? undefined;
-	 * const { entries, nextCursor } = await getEmDashCollection("posts", {
-	 *   limit: 10,
-	 *   cursor,
-	 * });
-	 * ```
-	 */
-	cursor?: string;
-	/**
-	 * Skip this many entries before returning results (offset pagination).
-	 *
-	 * Use with `limit` to render numbered archive routes like `/page/2`
-	 * without walking cursors or over-fetching from the start:
-	 *
-	 * ```ts
-	 * const perPage = 20;
-	 * const { entries, hasMore } = await getEmDashCollection("posts", {
-	 *   limit: perPage,
-	 *   offset: (page - 1) * perPage,
-	 *   orderBy: { published_at: "desc" },
-	 * });
-	 * ```
-	 *
-	 * Only a positive integer applies. Ignored when `cursor` is set —
-	 * cursor (keyset) and offset are mutually exclusive; cursor wins.
-	 */
-	offset?: number;
 	/**
 	 * Filter by field values, taxonomy terms, byline credits, or ranges.
 	 *
@@ -165,6 +141,56 @@ export interface CollectionFilter {
 	 */
 	locale?: string;
 }
+
+/** Keyset-paginated query filter. Cannot also carry an `offset`. */
+export interface CursorCollectionFilter extends CollectionFilterBase {
+	/**
+	 * Opaque cursor for keyset pagination.
+	 * Pass the `nextCursor` value from a previous result to fetch the next page.
+	 * @example
+	 * ```ts
+	 * const cursor = Astro.url.searchParams.get("cursor") ?? undefined;
+	 * const { entries, nextCursor } = await getEmDashCollection("posts", {
+	 *   limit: 10,
+	 *   cursor,
+	 * });
+	 * ```
+	 */
+	cursor?: string;
+	offset?: never;
+}
+
+/** Offset-paginated query filter. Cannot also carry a `cursor`. */
+export interface OffsetCollectionFilter extends CollectionFilterBase {
+	/**
+	 * Skip this many entries before returning results (offset pagination).
+	 *
+	 * Use with `limit` to render numbered archive routes like `/page/2`
+	 * without walking cursors or over-fetching from the start:
+	 *
+	 * ```ts
+	 * const perPage = 20;
+	 * const { entries, hasMore } = await getEmDashCollection("posts", {
+	 *   limit: perPage,
+	 *   offset: (page - 1) * perPage,
+	 *   orderBy: { published_at: "desc" },
+	 * });
+	 * ```
+	 *
+	 * Only a positive integer applies.
+	 */
+	offset?: number;
+	cursor?: never;
+}
+
+/**
+ * Filter for `getEmDashCollection`.
+ *
+ * A union of the cursor and offset pagination variants: supplying both
+ * `cursor` and `offset` is a compile-time error, since they are mutually
+ * exclusive ways to express "the next page" (cursor wins at runtime).
+ */
+export type CollectionFilter = CursorCollectionFilter | OffsetCollectionFilter;
 
 export interface ContentEntry<T = Record<string, unknown>> {
 	id: string;
@@ -663,12 +689,19 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 		filter?.locale ?? ctx?.locale ?? (isI18nEnabled() ? i18nConfig!.defaultLocale : undefined);
 
 	const requestedLimit = filter?.limit;
+	// cursor and offset are mutually exclusive on the loader filter union, so
+	// spread only the one in play (cursor wins) rather than emitting both keys.
+	const pageParam =
+		filter?.cursor !== undefined
+			? { cursor: filter.cursor }
+			: filter?.offset !== undefined
+				? { offset: filter.offset }
+				: {};
 	const result = await getLiveCollection(COLLECTION_NAME, {
 		type,
 		status: filter?.status,
 		limit: requestedLimit && requestedLimit > 0 ? requestedLimit + 1 : filter?.limit,
-		cursor: filter?.cursor,
-		offset: filter?.offset,
+		...pageParam,
 		where: filter?.where,
 		orderBy: filter?.orderBy,
 		locale: resolvedLocale,

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -401,6 +401,7 @@ export async function getEmDashCollection<T extends string, D = InferCollectionD
 interface CachedCollectionValue {
 	entries: unknown[];
 	nextCursor?: string;
+	hasMore?: boolean;
 	cacheHint: CacheHint;
 }
 
@@ -428,6 +429,7 @@ async function loadCollectionCached<T extends string, D = InferCollectionData<T>
 				value: {
 					entries: result.entries.map(entrySnapshot),
 					nextCursor: result.nextCursor,
+					hasMore: result.hasMore,
 					cacheHint: result.cacheHint,
 				},
 			};
@@ -441,6 +443,7 @@ async function loadCollectionCached<T extends string, D = InferCollectionData<T>
 	return {
 		entries: snapshot.value.entries.map((entry) => reviveEntry<D>(entry)),
 		nextCursor: snapshot.value.nextCursor,
+		hasMore: snapshot.value.hasMore,
 		cacheHint: snapshot.value.cacheHint,
 	};
 }

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -113,6 +113,25 @@ export interface CollectionFilter {
 	 */
 	cursor?: string;
 	/**
+	 * Skip this many entries before returning results (offset pagination).
+	 *
+	 * Use with `limit` to render numbered archive routes like `/page/2`
+	 * without walking cursors or over-fetching from the start:
+	 *
+	 * ```ts
+	 * const perPage = 20;
+	 * const { entries, hasMore } = await getEmDashCollection("posts", {
+	 *   limit: perPage,
+	 *   offset: (page - 1) * perPage,
+	 *   orderBy: { published_at: "desc" },
+	 * });
+	 * ```
+	 *
+	 * Only a positive integer applies. Ignored when `cursor` is set —
+	 * cursor (keyset) and offset are mutually exclusive; cursor wins.
+	 */
+	offset?: number;
+	/**
 	 * Filter by field values, taxonomy terms, byline credits, or ranges.
 	 *
 	 * Taxonomy names are detected automatically and filtered via JOIN.
@@ -176,6 +195,12 @@ export interface CollectionResult<T> {
 	 * Pass this as `cursor` in the next query to get the next page.
 	 */
 	nextCursor?: string;
+	/**
+	 * Whether more entries exist beyond this page. Set whenever `limit` is
+	 * provided (cursor or offset pagination), so numbered archive routes can
+	 * render a "next page" link without computing a total count.
+	 */
+	hasMore?: boolean;
 }
 
 /**
@@ -417,7 +442,10 @@ export function bucketFilter(filter: CollectionFilter | undefined): BucketedFilt
 		limit === undefined ||
 		limit >= BUCKET_LIMIT_THRESHOLD ||
 		limit <= 0 ||
-		filter?.cursor !== undefined
+		filter?.cursor !== undefined ||
+		// Offset paginates a deliberate page window; its limit is part of the
+		// pagination contract, so don't round it up the way "recent N" widgets get.
+		filter?.offset !== undefined
 	) {
 		return { fetchFilter: filter, requestedLimit: undefined };
 	}
@@ -449,7 +477,8 @@ export function sliceCollectionResult<D>(
 	// buildCursorCondition in loader.ts — it filters strictly past this row.
 	const lastEntry = sliced.at(-1);
 	const nextCursor = lastEntry ? encodeEntryCursor(lastEntry, orderBy) : undefined;
-	return { ...cached, entries: sliced, nextCursor };
+	// Truncating to the requested limit means at least one more entry existed.
+	return { ...cached, entries: sliced, nextCursor, hasMore: true };
 }
 
 /** Map of database column names to camelCase keys present on entry.data. */
@@ -533,6 +562,7 @@ function collectionCacheKey(type: string, filter?: CollectionFilter): string {
 		filter.status ?? "",
 		filter.limit ?? "",
 		filter.cursor ?? "",
+		filter.offset ?? "",
 		filter.where ? stableStringify(filter.where) : "",
 		filter.orderBy ? JSON.stringify(filter.orderBy) : "",
 		filter.locale ?? "",
@@ -638,6 +668,7 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 		status: filter?.status,
 		limit: requestedLimit && requestedLimit > 0 ? requestedLimit + 1 : filter?.limit,
 		cursor: filter?.cursor,
+		offset: filter?.offset,
 		where: filter?.where,
 		orderBy: filter?.orderBy,
 		locale: resolvedLocale,
@@ -652,6 +683,9 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 	const hasMore = requestedLimit != null && requestedLimit > 0 && entries.length > requestedLimit;
 	const pageEntries = hasMore ? entries.slice(0, requestedLimit) : entries;
 	const nextCursor = hasMore ? encodeEntryCursor(pageEntries.at(-1), filter?.orderBy) : undefined;
+	// `hasMore` is only meaningful when a limit bounds the page; otherwise the
+	// query returned everything and there is no "next page" to report.
+	const hasMoreResult = requestedLimit != null && requestedLimit > 0 ? hasMore : undefined;
 
 	const isEditMode = ctx?.editMode ?? false;
 	const entriesWithEdit = pageEntries.map((entry: ContentEntry<D>) => {
@@ -675,7 +709,12 @@ async function getEmDashCollectionUncached<T extends string, D = InferCollection
 		hydrateEntryTerms(type, entriesWithEdit, resolvedLocale),
 	]);
 
-	return { entries: entriesWithEdit, nextCursor, cacheHint: cacheHint ?? {} };
+	return {
+		entries: entriesWithEdit,
+		nextCursor,
+		hasMore: hasMoreResult,
+		cacheHint: cacheHint ?? {},
+	};
 }
 
 /**

--- a/packages/core/tests/unit/loader-offset-pagination.test.ts
+++ b/packages/core/tests/unit/loader-offset-pagination.test.ts
@@ -1,0 +1,112 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { handleContentCreate } from "../../src/api/index.js";
+import type { Database } from "../../src/database/types.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+describe("Loader offset pagination", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	async function createPublishedPost(title: string) {
+		const result = await handleContentCreate(db, "post", {
+			data: { title },
+			status: "published",
+		});
+		if (!result.success) throw new Error("Failed to create post");
+		return result.data!.item;
+	}
+
+	async function seedAlphabet() {
+		// Deterministic order regardless of created_at second-resolution.
+		const titles = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"];
+		for (const title of titles) {
+			await createPublishedPost(title);
+		}
+	}
+
+	it("skips the first `offset` rows", async () => {
+		await seedAlphabet();
+		const loader = emdashLoader();
+
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", limit: 2, offset: 2, orderBy: { title: "asc" } },
+			}),
+		);
+
+		expect(result.entries!.map((e) => e.data.title)).toEqual(["Charlie", "Delta"]);
+	});
+
+	it("renders disjoint numbered pages with limit + offset", async () => {
+		await seedAlphabet();
+		const loader = emdashLoader();
+		const perPage = 2;
+
+		const pageTitles: string[][] = [];
+		for (let page = 1; page <= 3; page++) {
+			const result = await runWithContext({ editMode: false, db }, () =>
+				loader.loadCollection!({
+					filter: {
+						type: "post",
+						limit: perPage,
+						offset: (page - 1) * perPage,
+						orderBy: { title: "asc" },
+					},
+				}),
+			);
+			pageTitles.push(result.entries!.map((e) => String(e.data.title)));
+		}
+
+		expect(pageTitles).toEqual([["Alpha", "Bravo"], ["Charlie", "Delta"], ["Echo"]]);
+	});
+
+	it("returns an empty page when offset is past the end", async () => {
+		await seedAlphabet();
+		const loader = emdashLoader();
+
+		const result = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", limit: 2, offset: 100, orderBy: { title: "asc" } },
+			}),
+		);
+
+		expect(result.entries).toHaveLength(0);
+	});
+
+	it("ignores offset when a cursor is also supplied (cursor wins)", async () => {
+		await seedAlphabet();
+		const loader = emdashLoader();
+
+		const page1 = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: { type: "post", limit: 2, orderBy: { title: "asc" } },
+			}),
+		);
+		expect(page1.entries!.map((e) => e.data.title)).toEqual(["Alpha", "Bravo"]);
+
+		// cursor continues after Bravo; offset must be ignored, not stacked.
+		const page2 = await runWithContext({ editMode: false, db }, () =>
+			loader.loadCollection!({
+				filter: {
+					type: "post",
+					limit: 2,
+					cursor: page1.nextCursor,
+					offset: 2,
+					orderBy: { title: "asc" },
+				},
+			}),
+		);
+		expect(page2.entries!.map((e) => e.data.title)).toEqual(["Charlie", "Delta"]);
+	});
+});

--- a/packages/core/tests/unit/query-collection-bucketing.test.ts
+++ b/packages/core/tests/unit/query-collection-bucketing.test.ts
@@ -71,6 +71,11 @@ describe("getEmDashCollection limit bucketing", () => {
 			fetchFilter: { limit: 4, cursor: "abc" },
 			requestedLimit: undefined,
 		});
+		// offset-paginated calls bypass bucketing for the same reason
+		expect(bucketFilter({ limit: 4, offset: 8 })).toEqual({
+			fetchFilter: { limit: 4, offset: 8 },
+			requestedLimit: undefined,
+		});
 	});
 
 	it("paginating from a slice-produced cursor returns the correct next page", async () => {

--- a/packages/core/tests/unit/query-collection-offset.test.ts
+++ b/packages/core/tests/unit/query-collection-offset.test.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Database } from "../../src/database/types.js";
+import type { CollectionFilter } from "../../src/query.js";
 import { getEmDashCollection } from "../../src/query.js";
 import { runWithContext } from "../../src/request-context.js";
 import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
@@ -101,5 +102,15 @@ describe("getEmDashCollection offset pagination", () => {
 		expect(getLiveCollection).toHaveBeenCalledTimes(2);
 		const offsets = vi.mocked(getLiveCollection).mock.calls.map((c) => (c[1] as any).offset);
 		expect(offsets).toEqual([0, 20]);
+	});
+
+	it("rejects supplying both cursor and offset (compile-time)", () => {
+		// Each pagination mode is valid on its own...
+		const cursorOnly: CollectionFilter = { limit: 10, cursor: "abc" };
+		const offsetOnly: CollectionFilter = { limit: 10, offset: 20 };
+		// ...but they are mutually exclusive, so combining them is a type error.
+		// @ts-expect-error cursor and offset cannot be supplied together
+		const both: CollectionFilter = { limit: 10, cursor: "abc", offset: 20 };
+		expect([cursorOnly, offsetOnly, both]).toHaveLength(3);
 	});
 });

--- a/packages/core/tests/unit/query-collection-offset.test.ts
+++ b/packages/core/tests/unit/query-collection-offset.test.ts
@@ -1,0 +1,105 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Database } from "../../src/database/types.js";
+import { getEmDashCollection } from "../../src/query.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+vi.mock("astro:content", () => ({
+	getLiveCollection: vi.fn(),
+}));
+
+import { getLiveCollection } from "astro:content";
+
+describe("getEmDashCollection offset pagination", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		vi.mocked(getLiveCollection).mockReset();
+	});
+
+	function makeEntries(count: number) {
+		return Array.from({ length: count }, (_, i) => ({
+			id: `slug-${i + 1}`,
+			data: {
+				id: `db-id-${i + 1}`,
+				title: `Post ${i + 1}`,
+				createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, count - i)).toISOString(),
+				status: "published",
+			},
+		}));
+	}
+
+	async function run<T>(fn: () => Promise<T>) {
+		return runWithContext({ editMode: false, db }, fn);
+	}
+
+	it("forwards offset to the live loader", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: makeEntries(3),
+			cacheHint: {},
+		} as any);
+
+		await run(() => getEmDashCollection("post", { limit: 20, offset: 40 }));
+
+		expect(getLiveCollection).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(getLiveCollection).mock.calls[0]![1]).toMatchObject({ offset: 40 });
+	});
+
+	it("reports hasMore=true when the loader returns more than the requested limit", async () => {
+		// limit 20 over-fetches as 21; loader returns 21 ⇒ a next page exists.
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: makeEntries(21),
+			cacheHint: {},
+		} as any);
+
+		const result = await run(() => getEmDashCollection("post", { limit: 20, offset: 0 }));
+
+		expect(result.entries).toHaveLength(20);
+		expect(result.hasMore).toBe(true);
+	});
+
+	it("reports hasMore=false on the final page", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: makeEntries(5),
+			cacheHint: {},
+		} as any);
+
+		const result = await run(() => getEmDashCollection("post", { limit: 20, offset: 40 }));
+
+		expect(result.entries).toHaveLength(5);
+		expect(result.hasMore).toBe(false);
+	});
+
+	it("leaves hasMore undefined when no limit is given", async () => {
+		vi.mocked(getLiveCollection).mockResolvedValue({
+			entries: makeEntries(5),
+			cacheHint: {},
+		} as any);
+
+		const result = await run(() => getEmDashCollection("post"));
+
+		expect(result.hasMore).toBeUndefined();
+	});
+
+	it("keeps offset out of the request-cache key so different pages don't collide", async () => {
+		vi.mocked(getLiveCollection)
+			.mockResolvedValueOnce({ entries: makeEntries(20), cacheHint: {} } as any)
+			.mockResolvedValueOnce({ entries: makeEntries(20), cacheHint: {} } as any);
+
+		await run(async () => {
+			await getEmDashCollection("post", { limit: 20, offset: 0 });
+			await getEmDashCollection("post", { limit: 20, offset: 20 });
+		});
+
+		expect(getLiveCollection).toHaveBeenCalledTimes(2);
+		const offsets = vi.mocked(getLiveCollection).mock.calls.map((c) => (c[1] as any).offset);
+		expect(offsets).toEqual([0, 20]);
+	});
+});

--- a/packages/core/tests/unit/query-collection-offset.test.ts
+++ b/packages/core/tests/unit/query-collection-offset.test.ts
@@ -88,7 +88,7 @@ describe("getEmDashCollection offset pagination", () => {
 		expect(result.hasMore).toBeUndefined();
 	});
 
-	it("keeps offset out of the request-cache key so different pages don't collide", async () => {
+	it("includes offset in the request-cache key so distinct pages don't collide", async () => {
 		vi.mocked(getLiveCollection)
 			.mockResolvedValueOnce({ entries: makeEntries(20), cacheHint: {} } as any)
 			.mockResolvedValueOnce({ entries: makeEntries(20), cacheHint: {} } as any);


### PR DESCRIPTION
## What does this PR do?

`getEmDashCollection` only supported cursor/keyset pagination, so numbered archive routes (`/page/2`, `/tag/security/page/3`) had no efficient option — they had to either walk cursors page-by-page or over-fetch from the start and slice (fetching up to 1,000 rows to render 20 on `/page/50`).

This adds an additive `offset` option to the public `CollectionFilter` (and the underlying loader filter), so numbered archives become a one-liner:

```ts
const perPage = 20;
const { entries, hasMore } = await getEmDashCollection("posts", {
  limit: perPage,
  offset: (page - 1) * perPage,
  orderBy: { published_at: "desc" },
});
```

Details:

- **`offset` is applied as a SQL `OFFSET`**, cross-dialect: SQLite only accepts `OFFSET` with a `LIMIT`, so a bare offset uses `LIMIT -1` (unbounded); Postgres takes a standalone `OFFSET`.
- **`offset` and `cursor` are mutually exclusive** — cursor (keyset) wins when both are set, so the two don't stack into a double skip. Only a positive integer applies (0 / negative / fractional are no-ops).
- **New `hasMore` on `CollectionResult`**, set whenever `limit` is provided, computed from the existing over-fetch-by-one — so archive routes can render a "next page" link without an extra count query.
- Offset calls **bypass limit bucketing** (their limit is part of the pagination contract), and `offset` is part of the request-cache key so distinct pages don't collide.

Closes #1364

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings (site-side query API + docs)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a, additive API closing a triaged bug report

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode

## Screenshots / test output

```
Test Files  5 passed (5)
     Tests  31 passed (31)
```

New tests: `loader-offset-pagination.test.ts` (skip/disjoint pages/past-end/cursor-wins), `query-collection-offset.test.ts` (offset forwarding, `hasMore` semantics, cache-key separation), plus a bucketing-exemption case in `query-collection-bucketing.test.ts`.