### PR TITLE
fix(core): implement pagination for search() and searchCollection() (#1463)

### DIFF
--- a/.changeset/search-pagination.md
+++ b/.changeset/search-pagination.md
@@ -11,8 +11,8 @@ Both `search()` and `searchCollection()` now honour `cursor` and return a `nextC
 ```ts
 let cursor: string | undefined;
 do {
-  const { items, nextCursor } = await search("quarterly report", { limit: 20, cursor });
-  render(items);
-  cursor = nextCursor;
+	const { items, nextCursor } = await search("quarterly report", { limit: 20, cursor });
+	render(items);
+	cursor = nextCursor;
 } while (cursor);
 ```

--- a/.changeset/search-pagination.md
+++ b/.changeset/search-pagination.md
@@ -1,0 +1,18 @@
+---
+"emdash": minor
+---
+
+Implements pagination for `search()` and `searchCollection()`
+
+`search()` advertised keyset pagination through its types (`options.cursor`, `SearchResponse.nextCursor`) but never read the cursor or returned one, so results were silently capped at `limit` with no way to load a second page.
+
+Both `search()` and `searchCollection()` now honour `cursor` and return a `nextCursor` whenever more matches exist. Pass the previous `nextCursor` back as `cursor` to walk subsequent pages; it becomes `undefined` on the last page. The `/_emdash/api/search` endpoint accepts a `cursor` query parameter and returns `nextCursor` in its response (a malformed cursor returns a 400 `INVALID_CURSOR`).
+
+```ts
+let cursor: string | undefined;
+do {
+  const { items, nextCursor } = await search("quarterly report", { limit: 20, cursor });
+  render(items);
+  cursor = nextCursor;
+} while (cursor);
+```

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -347,6 +347,16 @@ results.items.forEach(result => {
 	console.log(result.snippet); // Contains <mark> tags
 	console.log(result.score);
 });
+
+// Paginate: pass the previous nextCursor back as `cursor` to get the next page.
+// nextCursor is undefined once there are no more results.
+if (results.nextCursor) {
+	const next = await search("hello world", {
+		collections: ["posts", "pages"],
+		limit: 20,
+		cursor: results.nextCursor,
+	});
+}
 ```
 
 ## Error handling

--- a/packages/core/src/api/schemas/search.ts
+++ b/packages/core/src/api/schemas/search.ts
@@ -13,6 +13,7 @@ export const searchQuery = z
 		status: z.string().optional(),
 		locale: localeCode.optional(),
 		limit: z.coerce.number().int().min(1).max(100).optional(),
+		cursor: z.string().optional(),
 	})
 	.meta({ id: "SearchQuery" });
 

--- a/packages/core/src/astro/routes/api/search/index.ts
+++ b/packages/core/src/astro/routes/api/search/index.ts
@@ -55,10 +55,12 @@ export const GET: APIRoute = async ({ url, locals }) => {
 			status,
 			locale: query.locale,
 			limit: query.limit,
+			cursor: query.cursor,
 		});
 
 		return apiSuccess(result);
 	} catch (error) {
+		// handleError maps a malformed pagination cursor to a 400 INVALID_CURSOR.
 		return handleError(error, "Search failed", "SEARCH_ERROR");
 	}
 };

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1737,6 +1737,12 @@ export function createMcpServer(): McpServer {
 					.optional()
 					.describe("Filter results by locale (omit to search all locales)"),
 				limit: z.number().int().min(1).max(50).optional().describe("Max results (default 20)"),
+				cursor: z
+					.string()
+					.min(1)
+					.max(2048)
+					.optional()
+					.describe("Pagination cursor from a previous response"),
 			}),
 			annotations: { readOnlyHint: true },
 		},
@@ -1749,6 +1755,7 @@ export function createMcpServer(): McpServer {
 					collections: args.collections,
 					locale: args.locale,
 					limit: args.limit,
+					cursor: args.cursor,
 				});
 				return jsonResult(results);
 			} catch (error) {

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -7,6 +7,7 @@
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
 
+import { encodeCursor, decodeCursor, InvalidCursorError } from "../database/repositories/types.js";
 import type { Database } from "../database/types.js";
 import { validateIdentifier } from "../database/validate.js";
 import { getDb } from "../loader.js";
@@ -20,6 +21,38 @@ import type {
 	Suggestion,
 	SearchStats,
 } from "./types.js";
+
+/**
+ * Marker stored in the `id` slot of a search pagination cursor.
+ *
+ * Search results are merged from per-collection FTS queries and re-sorted by
+ * score, so there is no single stable keyset column to encode (the way
+ * `getEmDashCollection` encodes `(orderValue, id)`). We page over the merged,
+ * score-sorted set by offset instead, carried as the cursor's `orderValue`.
+ * Reusing `encodeCursor`/`decodeCursor` keeps the opaque base64-JSON shape and
+ * the `InvalidCursorError` handling consistent with the rest of the API.
+ */
+const SEARCH_CURSOR_MARKER = "search";
+
+/** Encode the next-page offset into an opaque search cursor. */
+function encodeSearchCursor(offset: number): string {
+	return encodeCursor(String(offset), SEARCH_CURSOR_MARKER);
+}
+
+/**
+ * Decode a search cursor back to its offset. Throws `InvalidCursorError` for a
+ * malformed cursor or one that doesn't carry a non-negative integer offset, so
+ * a client pagination bug surfaces immediately rather than silently restarting
+ * from the first page.
+ */
+function decodeSearchOffset(cursor: string): number {
+	const { orderValue } = decodeCursor(cursor);
+	const offset = Number(orderValue);
+	if (!Number.isInteger(offset) || offset < 0) {
+		throw new InvalidCursorError(cursor);
+	}
+	return offset;
+}
 
 /** Pattern to split on whitespace for query term extraction */
 const WHITESPACE_SPLIT_PATTERN = /\s+/;
@@ -86,6 +119,7 @@ export async function searchWithDb(
 	const ftsManager = new FTSManager(db);
 	const limit = options.limit ?? 20;
 	const status = options.status ?? "published";
+	const offset = options.cursor ? decodeSearchOffset(options.cursor) : 0;
 
 	// Get searchable collections
 	let collections = options.collections;
@@ -96,6 +130,12 @@ export async function searchWithDb(
 	if (collections.length === 0) {
 		return { items: [] };
 	}
+
+	// To rank the merged window [offset, offset + limit) correctly, each
+	// collection must contribute its own top (offset + limit) rows — in the
+	// worst case the entire window comes from one collection. The extra +1
+	// row detects whether a further page exists.
+	const perCollectionLimit = offset + limit + 1;
 
 	// Search each collection and merge results
 	const allResults: SearchResult[] = [];
@@ -113,7 +153,7 @@ export async function searchWithDb(
 			{
 				status,
 				locale: options.locale,
-				limit: limit * 2, // Get extra for merging
+				limit: perCollectionLimit,
 			},
 			config.weights,
 		);
@@ -124,10 +164,13 @@ export async function searchWithDb(
 	// Sort by score descending
 	allResults.sort((a, b) => b.score - a.score);
 
-	// Apply limit
-	const items = allResults.slice(0, limit);
+	// Page the merged set by offset. A nextCursor is issued only when at least
+	// one result exists past this page.
+	const items = allResults.slice(offset, offset + limit);
+	const hasMore = allResults.length > offset + limit;
+	const nextCursor = hasMore ? encodeSearchCursor(offset + limit) : undefined;
 
-	return { items };
+	return { items, nextCursor };
 }
 
 /**
@@ -159,9 +202,25 @@ export async function searchCollection(
 		return { items: [] };
 	}
 
-	const items = await searchSingleCollection(db, collection, query, options, config.weights);
+	const limit = options.limit ?? 20;
+	const offset = options.cursor ? decodeSearchOffset(options.cursor) : 0;
 
-	return { items };
+	// Over-fetch the [offset, offset + limit) window plus one row to detect a
+	// further page, then slice. Keeps the FTS SQL (LIMIT-only) unchanged and
+	// the cursor contract identical to the cross-collection path.
+	const fetched = await searchSingleCollection(
+		db,
+		collection,
+		query,
+		{ status: options.status, locale: options.locale, limit: offset + limit + 1 },
+		config.weights,
+	);
+
+	const items = fetched.slice(offset, offset + limit);
+	const hasMore = fetched.length > offset + limit;
+	const nextCursor = hasMore ? encodeSearchCursor(offset + limit) : undefined;
+
+	return { items, nextCursor };
 }
 
 /**

--- a/packages/core/src/search/query.ts
+++ b/packages/core/src/search/query.ts
@@ -45,10 +45,16 @@ function encodeSearchCursor(offset: number): string {
  * a client pagination bug surfaces immediately rather than silently restarting
  * from the first page.
  */
+/** Upper bound on a decoded search offset, to cap the per-collection row fetch a forged cursor can trigger. */
+const MAX_SEARCH_OFFSET = 10_000;
+
 function decodeSearchOffset(cursor: string): number {
-	const { orderValue } = decodeCursor(cursor);
+	const { orderValue, id } = decodeCursor(cursor);
+	if (id !== SEARCH_CURSOR_MARKER) {
+		throw new InvalidCursorError(cursor);
+	}
 	const offset = Number(orderValue);
-	if (!Number.isInteger(offset) || offset < 0) {
+	if (!Number.isInteger(offset) || offset < 0 || offset > MAX_SEARCH_OFFSET) {
 		throw new InvalidCursorError(cursor);
 	}
 	return offset;

--- a/packages/core/tests/integration/mcp/search.test.ts
+++ b/packages/core/tests/integration/mcp/search.test.ts
@@ -325,6 +325,47 @@ describe("search", () => {
 		expect(extractJson<{ items: unknown[] }>(pubQuery).items.length).toBeGreaterThan(0);
 	});
 
+	it("paginates results via the cursor argument", async () => {
+		await setupSearchablePostCollection(db);
+		harness = await connectMcpHarness({ db, userId: ADMIN_ID, userRole: Role.ADMIN });
+
+		for (let i = 0; i < 5; i++) {
+			const c = await harness.client.callTool({
+				name: "content_create",
+				arguments: {
+					collection: "post",
+					data: { title: `paginated item ${i}`, body: "common-cursor-text" },
+				},
+			});
+			await harness.client.callTool({
+				name: "content_publish",
+				arguments: {
+					collection: "post",
+					id: extractJson<{ item: { id: string } }>(c).item.id,
+				},
+			});
+		}
+
+		const firstPage = await harness.client.callTool({
+			name: "search",
+			arguments: { query: "common-cursor-text", limit: 2 },
+		});
+		const firstData = extractJson<{ items: Array<{ id: string }>; nextCursor?: string }>(firstPage);
+		expect(firstData.items).toHaveLength(2);
+		expect(firstData.nextCursor).toBeTruthy();
+
+		const secondPage = await harness.client.callTool({
+			name: "search",
+			arguments: { query: "common-cursor-text", limit: 2, cursor: firstData.nextCursor },
+		});
+		const secondData = extractJson<{ items: Array<{ id: string }> }>(secondPage);
+		expect(secondData.items).toHaveLength(2);
+		const firstIds = new Set(firstData.items.map((i) => i.id));
+		for (const item of secondData.items) {
+			expect(firstIds.has(item.id)).toBe(false);
+		}
+	});
+
 	it("any logged-in user (SUBSCRIBER) can search", async () => {
 		await setupSearchablePostCollection(db);
 		harness = await connectMcpHarness({ db, userId: SUBSCRIBER_ID, userRole: Role.SUBSCRIBER });

--- a/packages/core/tests/integration/search/pagination.test.ts
+++ b/packages/core/tests/integration/search/pagination.test.ts
@@ -2,6 +2,7 @@ import type { Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { ContentRepository } from "../../../src/database/repositories/content.js";
+import { encodeCursor } from "../../../src/database/repositories/types.js";
 import type { Database } from "../../../src/database/types.js";
 import { SchemaRegistry } from "../../../src/schema/registry.js";
 import { FTSManager } from "../../../src/search/fts-manager.js";
@@ -81,6 +82,22 @@ describe("search pagination", () => {
 	it("rejects a malformed cursor instead of silently restarting", async () => {
 		await expect(
 			searchWithDb(db, "report", { collections: ["post"], limit: 2, cursor: "not-a-cursor" }),
+		).rejects.toThrow(/Invalid pagination cursor/);
+	});
+
+	it("rejects a cursor from another endpoint even if its orderValue is numeric", async () => {
+		const foreignCursor = encodeCursor("1", "content-list");
+
+		await expect(
+			searchWithDb(db, "report", { collections: ["post"], limit: 2, cursor: foreignCursor }),
+		).rejects.toThrow(/Invalid pagination cursor/);
+	});
+
+	it("rejects a cursor whose offset exceeds the max search offset", async () => {
+		const hugeCursor = encodeCursor("999999999", "search");
+
+		await expect(
+			searchWithDb(db, "report", { collections: ["post"], limit: 2, cursor: hugeCursor }),
 		).rejects.toThrow(/Invalid pagination cursor/);
 	});
 

--- a/packages/core/tests/integration/search/pagination.test.ts
+++ b/packages/core/tests/integration/search/pagination.test.ts
@@ -1,0 +1,100 @@
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { SchemaRegistry } from "../../../src/schema/registry.js";
+import { FTSManager } from "../../../src/search/fts-manager.js";
+import { searchCollection, searchWithDb } from "../../../src/search/query.js";
+import { createPostFixture } from "../../utils/fixtures.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+/**
+ * `search()` / `searchCollection()` advertise keyset pagination via
+ * `options.cursor` and `SearchResponse.nextCursor`. These tests pin that the
+ * advertised contract actually works: a cursor walks disjoint pages that cover
+ * every match exactly once, and the cursor stops at the end.
+ */
+describe("search pagination", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		repo = new ContentRepository(db);
+
+		const registry = new SchemaRegistry(db);
+		const ftsManager = new FTSManager(db);
+		await registry.updateField("post", "title", { searchable: true });
+		await ftsManager.enableSearch("post");
+
+		// Five published posts that all match the query "report".
+		for (let i = 1; i <= 5; i++) {
+			await repo.create(
+				createPostFixture({
+					slug: `report-${i}`,
+					status: "published",
+					data: { title: `Quarterly report number ${i}` },
+				}),
+			);
+		}
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("returns a nextCursor when more results exist beyond the limit", async () => {
+		const page = await searchWithDb(db, "report", { collections: ["post"], limit: 2 });
+
+		expect(page.items).toHaveLength(2);
+		expect(page.nextCursor).toBeTruthy();
+	});
+
+	it("omits nextCursor on the final page", async () => {
+		const page = await searchWithDb(db, "report", { collections: ["post"], limit: 10 });
+
+		expect(page.items).toHaveLength(5);
+		expect(page.nextCursor).toBeUndefined();
+	});
+
+	it("walks disjoint pages covering every match exactly once", async () => {
+		const seen: string[] = [];
+		let cursor: string | undefined;
+		let guard = 0;
+
+		do {
+			const page: { items: { id: string }[]; nextCursor?: string } = await searchWithDb(
+				db,
+				"report",
+				{ collections: ["post"], limit: 2, cursor },
+			);
+			expect(page.items.length).toBeLessThanOrEqual(2);
+			seen.push(...page.items.map((r) => r.id));
+			cursor = page.nextCursor;
+		} while (cursor && ++guard < 10);
+
+		expect(seen).toHaveLength(5);
+		expect(new Set(seen).size).toBe(5);
+	});
+
+	it("rejects a malformed cursor instead of silently restarting", async () => {
+		await expect(
+			searchWithDb(db, "report", { collections: ["post"], limit: 2, cursor: "not-a-cursor" }),
+		).rejects.toThrow(/Invalid pagination cursor/);
+	});
+
+	it("paginates a single-collection search the same way", async () => {
+		const seen: string[] = [];
+		let cursor: string | undefined;
+		let guard = 0;
+
+		do {
+			const page = await searchCollection(db, "post", "report", { limit: 2, cursor });
+			seen.push(...page.items.map((r) => r.id));
+			cursor = page.nextCursor;
+		} while (cursor && ++guard < 10);
+
+		expect(new Set(seen).size).toBe(5);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The search API advertised keyset pagination through its types — `SearchOptions.cursor` and `SearchResponse.nextCursor` — but `searchWithDb` never read the incoming cursor nor populated `nextCursor`. Results were silently capped at `limit` with no way to fetch a second page, so any "load more" wired against the documented shape got a button that never appears (and a `cursor` that's discarded).

This implements real pagination for both `search()` and `searchCollection()`.

**Why offset, not pure keyset:** search results are merged from per-collection FTS queries and re-sorted by `bm25` score, so there's no single stable keyset column to encode the way `getEmDashCollection` encodes `(orderValue, id)`. Instead we page the merged, score-sorted set by **offset**, carried opaquely in the cursor's `orderValue` — reusing `encodeCursor`/`decodeCursor` so the cursor keeps the same base64-JSON shape and `InvalidCursorError` handling as the rest of the API.

Each collection fetches its top `(offset + limit + 1)` rows, which is exactly what's needed for the merged window `[offset, offset + limit)` to rank correctly even when the whole window comes from one collection, plus one row to detect a further page. A `nextCursor` is issued only when at least one result exists past the page.

- `search()` / `searchWithDb` and `searchCollection()` both honour `cursor` and return `nextCursor`.
- The `/_emdash/api/search` endpoint now accepts a `cursor` query param and returns `nextCursor`; a malformed cursor surfaces as `400 INVALID_CURSOR` via the existing `handleError` mapping.

Closes #1463

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, no admin UI strings (server-side search API + docs)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a, makes an already-advertised API actually work

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 ultracode

## Screenshots / test output

New `tests/integration/search/pagination.test.ts` covers: nextCursor presence past the limit, omission on the final page, a cursor walk over disjoint pages covering every match exactly once, malformed-cursor rejection, and single-collection pagination.

```
Test Files  8 passed (8)
     Tests  45 passed (45)
```