### PR TITLE
fix(core): skip setup probe during prerender so it isn't baked into static pages

### DIFF
--- a/.changeset/fix-setup-probe-prerender-redirect.md
+++ b/.changeset/fix-setup-probe-prerender-redirect.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fix the setup probe baking a redirect to `/_emdash/admin/setup` into prerendered pages. On a build whose database is empty (e.g. CI/first deploy), the anonymous setup probe saw a missing migrations table and returned `context.redirect("/_emdash/admin/setup")`; a prerendered route serializes that into static HTML and ships the redirect to production. The probe is now skipped entirely when `context.isPrerendered` is true — there is no live visitor to send to the wizard at build time, and the build database is legitimately empty. Live (SSR) requests are unaffected.

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -430,7 +430,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 				// Do a one-time lightweight probe using the same getDb() instance the
 				// page will use: if the migrations table doesn't exist, no migrations
 				// have ever run -- redirect to the setup wizard.
-				if (!isSetupVerified()) {
+				// Skip the probe when prerendering: a prerendered route is built to
+				// static HTML, so returning context.redirect("/_emdash/admin/setup")
+				// below would bake that redirect into the page and ship it to
+				// production. The build database is legitimately empty in CI and there
+				// is no live visitor to send to the wizard at build time (session reads
+				// are already skipped for prerender above for the same reason).
+				if (!isSetupVerified() && !context.isPrerendered) {
 					const t0 = performance.now();
 					try {
 						const { getDb } = await import("../loader.js");

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -593,4 +593,26 @@ describe("astro middleware setup probe", () => {
 		expect(next).toHaveBeenCalledTimes(1);
 		expect(response.status).toBe(200);
 	});
+
+	it("does NOT redirect to setup during prerender even when migrations are missing (regression)", async () => {
+		// A prerendered route is built to static HTML. If the setup probe ran at
+		// build time it would see CI's legitimately-empty database, report a
+		// missing migrations table, and bake context.redirect("/_emdash/admin/setup")
+		// into every prerendered page -- shipping that redirect to production. The
+		// probe must be skipped entirely when prerendering.
+		vi.mocked(getDb).mockResolvedValue(
+			getDbThatFailsProbe(new Error("no such table: _emdash_migrations")) as never,
+		);
+
+		const { context, redirect } = anonymousCategoryPageContext();
+		context.isPrerendered = true;
+		const next = vi.fn(async () => new Response("page"));
+
+		const response = await onRequest(context as Parameters<typeof onRequest>[0], next);
+
+		expect(redirect).not.toHaveBeenCalled();
+		expect(getDb).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(200);
+	});
 });


### PR DESCRIPTION
## What does this PR do?

The anonymous setup probe redirects to `/_emdash/admin/setup` when the migrations
table is missing. During **prerender** the build database is legitimately empty
(CI / first deploy), so the probe reports a missing table and returns
`context.redirect(...)` — which a prerendered route serializes into static HTML,
shipping a redirect to the setup wizard on **every prerendered page** in
production. There is no live visitor to send to the wizard at build time, so this
skips the probe entirely when `context.isPrerendered` is true (session reads are
already skipped for prerender for the same reason). Live SSR requests are
unaffected.

Reproduced deterministically on a Cloudflare Workers build (Workers Builds) with
an empty CI D1: prerendered pages were emitted as setup-redirect HTML.

Related: #1042 (the runtime/transient variant of this probe redirecting
incorrectly, addressed by #1345). This PR covers the build-time/prerender case.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (packages/core: 4023 passed; added a failing-without-fix regression test)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings are wrapped for translation (N/A — no admin UI strings)
- [x] I have added a changeset (`emdash` patch)
- [ ] New features link to an approved Discussion (N/A — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (1M context)

## Screenshots / test output

`pnpm --filter ./packages/core test` → 274 files, 4023 passed.
New regression test fails on `main` (probe redirects during prerender) and passes
with this change.
