### PR TITLE
fix(ci): clear stale query-count label/comment when snapshots match base

### DIFF
--- a/.github/workflows/query-counts-label.yml
+++ b/.github/workflows/query-counts-label.yml
@@ -1,16 +1,21 @@
 name: Query Counts — Label
 
-# Applies the "query-count changed" label when a PR's diff touches either
-# snapshot file. The label is informational — it flags that the PR alters
-# per-route DB query counts (either because the author's change regressed
-# them, or because the Apply workflow auto-updated the baseline).
+# Manages the "query-count changed" label and a diff comment on PRs that
+# alter per-route DB query counts. When a PR's snapshot files differ from
+# base, the label and a comparison comment are added; when they match base
+# again (e.g. the delta was reverted, or base caught up via a merge), both
+# are removed.
+#
+# Deliberately NOT path-filtered. A `paths:` filter would create a catch-22:
+# the workflow could never run to clear a stale label/comment once a
+# previously-changed snapshot matched base again, because at that point the
+# PR diff no longer touches the snapshot files. The script below is cheap
+# (a couple of API reads) and decides what to do from the actual base/head
+# diff on every run.
 on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
-    paths:
-      - scripts/query-counts.snapshot.sqlite.json
-      - scripts/query-counts.snapshot.d1.json
 
 permissions:
   pull-requests: write
@@ -20,30 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const label = 'query-count changed';
-            // Create the label if it doesn't exist yet. Ignore 422 (already exists).
-            try {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-                color: 'fbca04',
-                description: 'PR diff modifies query-count snapshot files',
-              });
-            } catch (err) {
-              if (err.status !== 422) throw err;
-            }
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [label],
-            });
-
-      - name: Comment query-count diff
+      - name: Sync query-count label and diff comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -51,6 +33,7 @@ jobs:
             const pr = context.payload.pull_request;
             const baseRef = pr.base.sha;
             const headRef = pr.head.sha;
+            const label = 'query-count changed';
 
             // Fetch a JSON file at a given ref. Returns {} if the file
             // doesn't exist on that ref (e.g. snapshot added in this PR).
@@ -129,9 +112,42 @@ jobs:
               );
             }
 
-            const marker = '<!-- query-count-diff -->';
+            const hasChange = sections.length > 0;
 
-            // Find an existing bot comment so we can upsert in place.
+            // Label: present iff the snapshots differ from base on this run.
+            if (hasChange) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: 'fbca04',
+                  description: 'PR diff modifies query-count snapshot files',
+                });
+              } catch (err) {
+                if (err.status !== 422) throw err; // 422 = already exists
+              }
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [label],
+              });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: label,
+                });
+              } catch (err) {
+                if (err.status !== 404) throw err; // 404 = label not applied
+              }
+            }
+
+            // Comment: upsert when changed, delete when not.
+            const marker = '<!-- query-count-diff -->';
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
@@ -142,9 +158,10 @@ jobs:
               (c) => typeof c.body === 'string' && c.body.includes(marker),
             );
 
-            if (sections.length === 0) {
-              // Snapshot files unchanged on this run; remove any stale comment
-              // (e.g. earlier push had a delta that has since been reverted).
+            if (!hasChange) {
+              // Snapshots match base on this run; remove any stale comment
+              // (e.g. an earlier push had a delta that base has since caught
+              // up to, or it was reverted).
               if (prior) {
                 await github.rest.issues.deleteComment({
                   owner,


### PR DESCRIPTION
## What does this PR do?

Fixes a catch-22 in the **Query Counts — Label** workflow that leaves a stale "query counts dropped" comment on PRs whose net diff no longer changes any counts.

The workflow was path-filtered on the snapshot files:

```yaml
on:
  pull_request_target:
    paths:
      - scripts/query-counts.snapshot.sqlite.json
      - scripts/query-counts.snapshot.d1.json
```

The script already self-heals (removes the label / deletes the comment when base and head match), but the `paths:` filter means it only runs when the PR diff *touches* the snapshot files. Once a previously-changed snapshot matches base again — reverted, or base caught up via a merge — the PR diff no longer touches those files, so the workflow never runs and the self-heal can never fire. The stale comment lingers.

Real-world trigger: #1579 (Astro 7 upgrade). Its early CI run committed a snapshot delta (16->9) and posted a `-28 queries` comment. After #1580 fixed the harness and the branch merged main, the head snapshots matched base again — net diff: zero snapshot changes — but the path-filtered workflow couldn't run to clear the now-wrong comment.

**Fix:** drop the `paths:` filter and let the script decide from the actual base/head diff on every run — add the label + upsert the comment when snapshots differ, remove the label + delete the comment when they match. The job only reads snapshot files via the API and manages labels/comments; it never checks out or executes PR code, so removing the filter doesn't change the `pull_request_target` security posture.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (n/a — CI YAML only, no source changed)
- [x] `pnpm lint` passes (n/a — CI YAML only)
- [x] `pnpm test` passes (n/a — CI YAML only)
- [x] `pnpm format` has been run (prettier-clean)
- [ ] I have added/updated tests for my changes (n/a — workflow change, not unit-testable here)
- [ ] User-visible strings in the admin UI are wrapped for translation (n/a)
- [ ] I have added a changeset (n/a — no published package changed)
- [ ] New features link to an approved Discussion (n/a — bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Notes

The stale comment already on #1579 won't clear until this lands on `main` (pull_request_target uses the base branch's workflow definition) and #1579 gets another push. It can also be deleted by hand in the meantime.