### PR TITLE
fix(core): make the dev-bypass token idempotent by name

### DIFF
--- a/.changeset/dev-bypass-token-idempotent.md
+++ b/.changeset/dev-bypass-token-idempotent.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the dev setup-bypass endpoint accumulating duplicate `dev-bypass-token` access tokens. Re-running it (for example after a dev reset) now replaces the previous token with a fresh one instead of adding another row.

--- a/packages/core/src/api/handlers/api-tokens.ts
+++ b/packages/core/src/api/handlers/api-tokens.ts
@@ -173,6 +173,25 @@ export async function handleApiTokenRevoke(
 }
 
 /**
+ * Delete every token with the given name for a user, returning how many were
+ * removed. Token names aren't unique, so this is a bulk delete — used by the
+ * dev-bypass flow to keep a single `dev-bypass-token` instead of minting a new
+ * one on every reset.
+ */
+export async function deleteApiTokensByName(
+	db: Kysely<Database>,
+	userId: string,
+	name: string,
+): Promise<number> {
+	const result = await db
+		.deleteFrom("_emdash_api_tokens")
+		.where("user_id", "=", userId)
+		.where("name", "=", name)
+		.executeTakeFirst();
+	return Number(result.numDeletedRows ?? 0n);
+}
+
+/**
  * Resolve a raw API token (ec_pat_...) to a user ID and scopes.
  * Updates last_used_at on successful lookup.
  * Returns null if the token is invalid or expired.

--- a/packages/core/src/astro/routes/api/setup/dev-bypass.ts
+++ b/packages/core/src/astro/routes/api/setup/dev-bypass.ts
@@ -23,7 +23,7 @@ import { ulid } from "ulidx";
 
 import { apiError, apiSuccess, handleError } from "#api/error.js";
 import { escapeHtml } from "#api/escape.js";
-import { handleApiTokenCreate } from "#api/handlers/api-tokens.js";
+import { deleteApiTokensByName, handleApiTokenCreate } from "#api/handlers/api-tokens.js";
 import { getPublicOrigin } from "#api/public-url.js";
 import { isSafeRedirect } from "#api/redirect.js";
 import { runMigrations } from "#db/migrations/runner.js";
@@ -134,6 +134,10 @@ async function handleDevBypass(context: Parameters<APIRoute>[0]): Promise<Respon
 		// Optionally create a PAT token (?token=1) for headless/CLI testing.
 		let token: string | undefined;
 		if (url.searchParams.has("token")) {
+			// Idempotent by name: a prior reset can leave a stale dev-bypass-token,
+			// and the raw token is only available at creation, so drop any existing
+			// one and mint a fresh, usable PAT rather than accumulating duplicates.
+			await deleteApiTokensByName(emdash.db, user.id, "dev-bypass-token");
 			const result = await handleApiTokenCreate(emdash.db, user.id, {
 				name: "dev-bypass-token",
 				scopes: [

--- a/packages/core/tests/unit/api-tokens.test.ts
+++ b/packages/core/tests/unit/api-tokens.test.ts
@@ -1,0 +1,76 @@
+import type { Kysely } from "kysely";
+import { ulid } from "ulidx";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	deleteApiTokensByName,
+	handleApiTokenCreate,
+	handleApiTokenList,
+} from "../../src/api/handlers/api-tokens.js";
+import type { Database } from "../../src/database/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../utils/test-db.js";
+
+describe("api tokens", () => {
+	let db: Kysely<Database>;
+	let userId: string;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+		userId = ulid();
+		const now = new Date().toISOString();
+		// Tokens reference users (FK), so create one first.
+		await db
+			.insertInto("users")
+			.values({
+				id: userId,
+				email: "dev@example.com",
+				name: "Dev",
+				avatar_url: null,
+				role: 50,
+				email_verified: 1,
+				disabled: 0,
+				data: null,
+				created_at: now,
+				updated_at: now,
+			})
+			.execute();
+	});
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("deleteApiTokensByName removes only the matching name for that user", async () => {
+		await handleApiTokenCreate(db, userId, { name: "dev-bypass-token", scopes: ["admin"] });
+		await handleApiTokenCreate(db, userId, { name: "dev-bypass-token", scopes: ["admin"] });
+		await handleApiTokenCreate(db, userId, { name: "keepme", scopes: ["admin"] });
+
+		const removed = await deleteApiTokensByName(db, userId, "dev-bypass-token");
+		expect(removed).toBe(2);
+
+		const list = await handleApiTokenList(db, userId);
+		expect(list.success).toBe(true);
+		if (list.success) {
+			expect(list.data.items.map((t) => t.name)).toEqual(["keepme"]);
+		}
+	});
+
+	it("re-issuing the dev-bypass token leaves exactly one row (idempotent by name)", async () => {
+		// The dev-bypass `?token=1` path drops the prior token before minting a
+		// fresh one. Running it twice (e.g. across a reset) must not accumulate.
+		for (let i = 0; i < 2; i++) {
+			await deleteApiTokensByName(db, userId, "dev-bypass-token");
+			const res = await handleApiTokenCreate(db, userId, {
+				name: "dev-bypass-token",
+				scopes: ["admin"],
+			});
+			expect(res.success).toBe(true);
+		}
+
+		const list = await handleApiTokenList(db, userId);
+		expect(list.success).toBe(true);
+		if (list.success) {
+			const devTokens = list.data.items.filter((t) => t.name === "dev-bypass-token");
+			expect(devTokens).toHaveLength(1);
+		}
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The dev setup-bypass endpoint (`GET /_emdash/api/setup/dev-bypass?token=1`) minted a fresh `dev-bypass-token` PAT on every call. Because the token's raw value is only available at creation, the e2e harness (`global-setup` and `refresh-server-pat` after a dev reset) re-runs it to obtain a usable token — so on the Cloudflare lane, where D1 persists across tests within a shard, duplicate `dev-bypass-token` rows accumulated. The API-tokens settings test then tripped Playwright strict mode, since its `text=dev-bypass-token` locator matched more than one row:

```
strict mode violation: locator('text=dev-bypass-token') resolved to 2 elements
```

This makes the dev-bypass token idempotent by name: it deletes any existing `dev-bypass-token` for the user before creating a new one, so exactly one row exists while callers still receive a usable raw token. Adds a small `deleteApiTokensByName` handler for the delete.

Surfaced while reviewing #1378 (object cache); the failure is unrelated to that work — its merge of `main` simply reshuffled e2e sharding and exposed this pre-existing isolation bug.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — new `api-tokens.test.ts` unit tests, plus the existing `api-tokens.spec.ts` e2e
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable). _n/a — no admin UI strings; dev-only endpoint._
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion _n/a — bug fix, not a feature._

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
api-tokens.test.ts — 2 passed (idempotent-by-name + scoped delete)
pnpm lint — 0 diagnostics; pnpm typecheck — clean
```
