### PR TITLE
fix(core): scope admin stylesheet to its route in dev

### DIFF
--- a/.changeset/admin-css-isolation.md
+++ b/.changeset/admin-css-isolation.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the admin stylesheet leaking onto public routes in `astro dev`. The compiled Kumo/Tailwind theme was injected into every page's `<head>`, overriding host `:root` tokens (`--text-base`, `--text-lg`, ...) and styling otherwise-unstyled pages. The admin shell now loads its stylesheet as a route-scoped `<link>`, so public routes are unaffected — matching production behaviour.

--- a/e2e/tests/admin-css-isolation.spec.ts
+++ b/e2e/tests/admin-css-isolation.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Admin CSS isolation (#1281)
+ *
+ * The admin shell imports the compiled Kumo/Tailwind v4 stylesheet. In
+ * `astro dev`, Astro injects every CSS module reachable from the project's
+ * Vite graph into every page's <head>, so a top-level `import "...styles.css"`
+ * in the admin route leaked the admin theme onto public, non-admin routes —
+ * overriding host `:root` tokens (`--text-base`, `--text-lg`, ...) and applying
+ * admin author styling to otherwise-unstyled pages.
+ *
+ * Importing the stylesheet as `?url` keeps it out of the page CSS graph and
+ * scopes it to a route-local <link>. These tests pin both halves: the leak is
+ * gone from public routes, and the admin route still pulls the stylesheet in.
+ */
+
+import { test, expect } from "../fixtures";
+
+const TAILWIND_SIGNATURE = "tailwindcss v4";
+const KUMO_SIGNATURE = "kumo";
+const ADMIN_STYLESHEET_LINK = /<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/;
+
+test.describe("admin CSS isolation", () => {
+	test("public routes do not include the admin stylesheet", async ({ page }) => {
+		await page.goto("/");
+
+		const inlineStyles = await page.$$eval("style", (nodes) =>
+			nodes.map((n) => n.textContent ?? ""),
+		);
+		const leaked = inlineStyles.find(
+			(css) => css.includes(TAILWIND_SIGNATURE) && css.includes(KUMO_SIGNATURE),
+		);
+		expect(leaked, "admin Tailwind/Kumo theme leaked into a public route's inline <style>").toBe(
+			undefined,
+		);
+
+		const linkedHrefs = await page.$$eval("link[rel='stylesheet']", (nodes) =>
+			nodes.map((n) => n.getAttribute("href") ?? ""),
+		);
+		expect(linkedHrefs.some((href) => href.includes("admin"))).toBe(false);
+
+		const textBase = await page.evaluate(() =>
+			getComputedStyle(document.documentElement).getPropertyValue("--text-base").trim(),
+		);
+		expect(textBase, "Kumo's --text-base bled onto the host :root").toBe("");
+	});
+
+	test("admin route still loads the admin stylesheet", async ({ request }) => {
+		const response = await request.get("/_emdash/admin");
+		const html = await response.text();
+
+		const match = html.match(ADMIN_STYLESHEET_LINK);
+		expect(match, "admin shell is missing its <link rel=stylesheet>").not.toBeNull();
+
+		const cssResponse = await request.get(match![1]!);
+		const css = await cssResponse.text();
+		expect(css).toContain(TAILWIND_SIGNATURE);
+		expect(css).toContain(KUMO_SIGNATURE);
+	});
+});

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -307,6 +307,10 @@ export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
  * On Cloudflare, the adapter handles its own externalization — setting
  * ssr.external there conflicts with @cloudflare/vite-plugin's validation.
  */
+// Matches the admin stylesheet import with or without a trailing query (e.g.
+// `?url`), so both forms resolve to dist rather than the source alias.
+const ADMIN_STYLES_ALIAS = /^@emdash-cms\/admin\/styles\.css/;
+
 const NODE_NATIVE_EXTERNALS = [
 	"better-sqlite3",
 	"bindings",
@@ -353,8 +357,12 @@ export function createViteConfig(
 			// The styles.css alias must come before the package alias, otherwise
 			// Vite's prefix matching on "@emdash-cms/admin" would resolve
 			// "@emdash-cms/admin/styles.css" through the source directory.
+			// Regex (not string) so the `?url` variant — admin.astro imports the
+			// stylesheet as `?url` to keep it out of the page CSS graph — also
+			// resolves to dist; a string `find` only matches on a `/` or end
+			// boundary, so `styles.css?url` would slip through to the source alias.
 			alias: [
-				{ find: "@emdash-cms/admin/styles.css", replacement: resolve(adminDistPath, "styles.css") },
+				{ find: ADMIN_STYLES_ALIAS, replacement: resolve(adminDistPath, "styles.css") },
 				{ find: "@emdash-cms/admin", replacement: useSource ? adminSourcePath : adminDistPath },
 				// `use-sync-external-store/shim` is a React <18 polyfill that ships
 				// only as CJS. It's pulled in transitively by `@tiptap/react`. With

--- a/packages/core/src/astro/routes/admin.astro
+++ b/packages/core/src/astro/routes/admin.astro
@@ -5,7 +5,10 @@
  * This page serves the EmDash admin React SPA.
  * AdminWrapper imports plugin admin modules and passes them to AdminApp.
  */
-import "@emdash-cms/admin/styles.css";
+// `?url` keeps the admin stylesheet out of the page's CSS module graph so
+// Astro's dev SSR doesn't inject it into every public route's <head>. We emit
+// it as a route-scoped <link> below instead. See #1281.
+import adminStylesUrl from "@emdash-cms/admin/styles.css?url";
 // Use package-qualified import so Astro generates a proper module URL
 // (relative imports resolve to absolute paths which break client hydration)
 import AdminWrapper from "emdash/routes/PluginRegistry";
@@ -28,6 +31,7 @@ const pageTitle = adminConfig?.siteName ? `${adminConfig.siteName} Admin` : "EmD
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="stylesheet" href={adminStylesUrl} />
 		<Font cssVariable="--font-emdash" />
 		{adminConfig?.favicon ? (
 			<link rel="icon" href={adminConfig.favicon} />


### PR DESCRIPTION
## What does this PR do?

In `astro dev`, the admin shell route imported the compiled Kumo/Tailwind v4 stylesheet as a top-level CSS module (`import "@emdash-cms/admin/styles.css"`). Astro's dev SSR injects every CSS module reachable from the project's Vite graph into **every** page's `<head>`, so the admin theme leaked onto public, non-admin routes — overriding host `:root` tokens (`--text-base`, `--text-lg`, `--radius-md`, ...) and applying admin author styling to otherwise-unstyled pages. Production was already correct (Vite chunks the admin CSS into the admin route's own asset); this was a dev/prod skew.

The fix takes the stylesheet out of the page CSS module graph:

- `admin.astro` now imports it as `?url` and emits a route-scoped `<link rel="stylesheet">` in the admin `<head>`, so it never enters other routes' dev graph.
- The Vite alias that redirects `@emdash-cms/admin/styles.css` to the built `dist/styles.css` is now a regex (`/^@emdash-cms\/admin\/styles\.css/`). A string `find` only matches on a `/` or end-of-string boundary, so `styles.css?url` would slip through to the source alias; the regex resolves both forms to dist while preserving the `?url` query.
- Added `e2e/tests/admin-css-isolation.spec.ts` pinning both halves: public routes carry no admin Tailwind/Kumo `<style>` and no host `--text-base`, and the admin route still serves the stylesheet via `<link>`.

This is the recommended fix (Option A) from the investigation bot's diagnosis on #1281.

Closes #1281

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. — n/a, no UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

`e2e/tests/admin-css-isolation.spec.ts` — both specs pass with the fix and fail without it (confirmed by reverting the import: the public-leak assertion and the admin-`<link>` assertion both fail). Node and Cloudflare demo production builds succeed and emit/reference the hashed `/_astro/styles.<hash>.css` asset.

```
Running 2 tests using 1 worker
  ✓ admin CSS isolation › public routes do not include the admin stylesheet
  ✓ admin CSS isolation › admin route still loads the admin stylesheet
  2 passed (16.3s)
```
