### PR TITLE
feat(admin): add built-in stars widget for numeric fields

### DIFF
--- a/.changeset/star-rating-widget.md
+++ b/.changeset/star-rating-widget.md
@@ -1,0 +1,6 @@
+---
+"@emdash-cms/admin": minor
+"emdash": minor
+---
+
+Adds a built-in `stars` widget for integer and number fields. Set a field's `widget` to `"stars"` to edit it as clickable stars instead of a number input, with `options.max` controlling how many stars show (default 5). Clicking a star sets the rating, clicking the current rating clears it. The stored value stays a plain integer, so themes read it without any extra runtime.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -50,6 +50,7 @@ import { ImageFieldRenderer, type ImageFieldValue } from "./ImageFieldRenderer.j
 import { PluginFieldErrorBoundary } from "./PluginFieldErrorBoundary.js";
 import { RepeaterField } from "./RepeaterField.js";
 import { RouterLinkButton } from "./RouterLinkButton.js";
+import { BUILTIN_WIDGET_STARS, StarRatingField } from "./StarRatingField.js";
 
 /** Autosave debounce delay in milliseconds */
 const AUTOSAVE_DELAY = 2000;
@@ -1116,6 +1117,28 @@ function FieldRenderer({
 	const labelClass = minimal ? "text-kumo-subtle/50 text-xs font-normal" : undefined;
 
 	const handleChange = React.useCallback((v: unknown) => onChange(name, v), [onChange, name]);
+
+	// Built-in widgets are referenced by a bare name (no "pluginId:" prefix).
+	// They override the default editor for their field kind without a plugin.
+	if (
+		field.widget === BUILTIN_WIDGET_STARS &&
+		(field.kind === "number" || field.kind === "integer")
+	) {
+		const widgetOptions =
+			field.options && !Array.isArray(field.options) ? field.options : undefined;
+		const max = typeof widgetOptions?.max === "number" ? widgetOptions.max : undefined;
+		return (
+			<StarRatingField
+				id={id}
+				label={label}
+				value={value}
+				onChange={handleChange}
+				max={max}
+				required={field.required}
+				minimal={minimal}
+			/>
+		);
+	}
 
 	// Check for plugin field widget override
 	if (field.widget) {

--- a/packages/admin/src/components/StarRatingField.tsx
+++ b/packages/admin/src/components/StarRatingField.tsx
@@ -1,0 +1,99 @@
+import { useLingui } from "@lingui/react/macro";
+import { Star } from "@phosphor-icons/react";
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+/** Built-in widget name that selects the star rating editor for a numeric field. */
+export const BUILTIN_WIDGET_STARS = "stars";
+
+/** Default number of stars when a field does not set `options.max`. */
+export const DEFAULT_STAR_MAX = 5;
+
+export interface StarRatingFieldProps {
+	id: string;
+	label: string;
+	/** Stored value. Coerced to an integer in the range 0..max. */
+	value: unknown;
+	onChange: (value: number) => void;
+	/** Highest rating, from the field's `options.max` (default 5). */
+	max?: number;
+	required?: boolean;
+	/** When true, render compactly (used inside nested editors). */
+	minimal?: boolean;
+}
+
+function clampMax(max: number | undefined): number {
+	if (typeof max !== "number" || !Number.isFinite(max) || max < 1) {
+		return DEFAULT_STAR_MAX;
+	}
+	return Math.floor(max);
+}
+
+/**
+ * Star rating editor for integer/number fields. Click a star to set the value,
+ * click the current value again to clear it. The stored value is a plain
+ * integer (0 means unrated), so themes can read it without any widget runtime.
+ *
+ * Selected by setting a field's `widget` to `"stars"`; `options.max` controls
+ * how many stars render.
+ */
+export function StarRatingField({
+	id,
+	label,
+	value,
+	onChange,
+	max,
+	required,
+	minimal,
+}: StarRatingFieldProps) {
+	const { t } = useLingui();
+	const starCount = clampMax(max);
+	const current = typeof value === "number" && Number.isFinite(value) ? Math.round(value) : 0;
+	const [hovered, setHovered] = React.useState(0);
+	const shown = hovered || current;
+	const labelId = `${id}-label`;
+
+	return (
+		<div id={id}>
+			{!minimal && label ? (
+				<span
+					id={labelId}
+					className={cn("mb-1 block text-sm font-medium leading-none text-kumo-default")}
+				>
+					{label}
+				</span>
+			) : null}
+			<div
+				role="radiogroup"
+				aria-labelledby={!minimal && label ? labelId : undefined}
+				aria-label={minimal || !label ? t`Rating` : undefined}
+				aria-required={required}
+				className="flex items-center gap-1"
+				onMouseLeave={() => setHovered(0)}
+			>
+				{Array.from({ length: starCount }, (_, i) => i + 1).map((n) => {
+					const filled = n <= shown;
+					return (
+						<button
+							key={n}
+							type="button"
+							role="radio"
+							aria-checked={n === current}
+							aria-label={t`${n} of ${starCount}`}
+							className="cursor-pointer rounded-sm border-0 bg-transparent p-0.5 text-kumo-subtle/40 transition-colors hover:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-kumo-accent data-[filled=true]:text-amber-400"
+							data-filled={filled}
+							onClick={() => onChange(n === current ? 0 : n)}
+							onMouseEnter={() => setHovered(n)}
+						>
+							<Star weight={filled ? "fill" : "regular"} className="h-6 w-6" />
+						</button>
+					);
+				})}
+				<span className="ms-2 text-sm text-kumo-subtle">
+					{current}/{starCount}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/packages/admin/tests/components/StarRatingField.test.tsx
+++ b/packages/admin/tests/components/StarRatingField.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Star rating field tests.
+ *
+ * The `stars` built-in widget renders an integer/number field as clickable
+ * stars (1..max). Clicking a star sets that value, clicking the current value
+ * clears it back to 0. `options.max` controls how many stars render.
+ */
+
+import * as React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import { StarRatingField } from "../../src/components/StarRatingField";
+import { render } from "../utils/render.tsx";
+
+describe("StarRatingField", () => {
+	it("renders five stars by default", async () => {
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={0} onChange={vi.fn()} />,
+		);
+
+		const stars = screen.getByRole("radio").all();
+		expect(stars.length).toBe(5);
+		await expect.element(screen.getByText("0/5")).toBeInTheDocument();
+	});
+
+	it("honors options.max via the max prop", async () => {
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={2} max={3} onChange={vi.fn()} />,
+		);
+
+		const stars = screen.getByRole("radio").all();
+		expect(stars.length).toBe(3);
+		await expect.element(screen.getByText("2/3")).toBeInTheDocument();
+	});
+
+	it("falls back to the default when max is invalid", async () => {
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={0} max={0} onChange={vi.fn()} />,
+		);
+
+		expect(screen.getByRole("radio").all().length).toBe(5);
+	});
+
+	it("sets the value when a star is clicked", async () => {
+		const onChange = vi.fn();
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={0} onChange={onChange} />,
+		);
+
+		await screen.getByRole("radio", { name: "4 of 5" }).click();
+		expect(onChange).toHaveBeenCalledWith(4);
+	});
+
+	it("clears the value when the current star is clicked again", async () => {
+		const onChange = vi.fn();
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={3} onChange={onChange} />,
+		);
+
+		await screen.getByRole("radio", { name: "3 of 5" }).click();
+		expect(onChange).toHaveBeenCalledWith(0);
+	});
+
+	it("marks the current value as checked", async () => {
+		const screen = await render(
+			<StarRatingField id="rating" label="Rating" value={2} onChange={vi.fn()} />,
+		);
+
+		await expect
+			.element(screen.getByRole("radio", { name: "2 of 5" }))
+			.toHaveAttribute("aria-checked", "true");
+		await expect
+			.element(screen.getByRole("radio", { name: "1 of 5" }))
+			.toHaveAttribute("aria-checked", "false");
+	});
+});

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -152,6 +152,7 @@ export interface FieldWidgetOptions {
 	showPreview?: boolean; // For image/file
 	collection?: string; // For reference - which collection to reference
 	allowMultiple?: boolean; // For reference
+	max?: number; // For the "stars" widget - highest rating (default 5)
 	[key: string]: unknown;
 }
 
@@ -197,6 +198,11 @@ export interface Field {
 	unique: boolean;
 	defaultValue?: unknown;
 	validation?: FieldValidation;
+	/**
+	 * Editor widget for this field. A bare name selects a built-in widget
+	 * (currently `"stars"` for integer/number fields, using `options.max`).
+	 * A `"pluginId:widgetName"` value selects a plugin-provided widget.
+	 */
 	widget?: string;
 	options?: FieldWidgetOptions;
 	sortOrder: number;


### PR DESCRIPTION
## What does this PR do?

Adds a built-in `stars` widget for integer and number fields. Set a field's `widget` to `"stars"` to edit it as clickable stars instead of a number input; `options.max` controls how many stars show (default 5). Clicking a star sets the rating, clicking the current rating clears it. The stored value stays a plain integer, so themes read it with no widget runtime.

A standalone userland version is published at https://github.com/dennisklappe/emdash-plugin-stars, which motivated proposing this as a built-in.

Discussion: https://github.com/emdash-cms/emdash/discussions/1595

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (no `messages.po` changes included)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to a Discussion: https://github.com/emdash-cms/emdash/discussions/1595

## AI-generated code disclosure

- [x] This PR includes AI-generated code. Model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

New `StarRatingField` tests (6) pass in the Playwright/Chromium runner: default 5 stars, `options.max`, invalid-max fallback, click-to-set, click-to-clear, aria-checked. `pnpm typecheck` (core + admin), `pnpm lint`, and `pnpm format` all pass.
