### PR TITLE
fix(tests): isolate Astro dev-server lock per integration suite (#1604)

### DIFF
--- a/packages/core/tests/integration/.gitignore
+++ b/packages/core/tests/integration/.gitignore
@@ -1,0 +1,4 @@
+# Per-suite fixture copies created by createTestServer (server.ts).
+# Each run gets its own srv-* root; they're removed on cleanup but may
+# linger if a suite crashes.
+.servers/

--- a/packages/core/tests/integration/client/concurrent-servers.test.ts
+++ b/packages/core/tests/integration/client/concurrent-servers.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression test for #1604.
+ *
+ * Integration suites boot a real Astro dev server each and vitest runs
+ * test files in parallel. Astro's "another dev server is already running"
+ * guard is scoped to the project root (a lockfile at `<root>/.astro/dev.json`),
+ * not to the port -- so when every suite shares one fixture directory, the
+ * second server to start aborts on the shared lock even though it requested a
+ * distinct port.
+ *
+ * This test reproduces that race inside a single suite: it boots two servers
+ * concurrently and asserts both come up and serve seeded content. Before the
+ * fix (servers run in-place from the shared fixture) the second server loses
+ * the lock and `createTestServer` times out. After the fix (each server gets
+ * its own copied fixture root) both succeed.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+
+import type { TestServerContext } from "../server.js";
+import { assertNodeVersion, createTestServer } from "../server.js";
+
+const PORT_A = 4402;
+const PORT_B = 4403;
+
+describe("Concurrent dev servers (#1604)", () => {
+	const contexts: TestServerContext[] = [];
+
+	afterAll(async () => {
+		await Promise.all(contexts.map((ctx) => ctx.cleanup()));
+	});
+
+	it("boots two servers from the same fixture in parallel without colliding on the Astro lock", async () => {
+		assertNodeVersion();
+
+		// Start both concurrently so they race for the (previously shared) lock.
+		const [a, b] = await Promise.all([
+			createTestServer({ port: PORT_A }),
+			createTestServer({ port: PORT_B }),
+		]);
+		contexts.push(a, b);
+
+		// Distinct roots -- the fix gives each server its own copied fixture.
+		expect(a.cwd).not.toBe(b.cwd);
+
+		// Both must actually serve their independently seeded content.
+		const [collectionsA, collectionsB] = await Promise.all([
+			a.client.collections(),
+			b.client.collections(),
+		]);
+		for (const collections of [collectionsA, collectionsB]) {
+			const slugs = collections.map((c: { slug: string }) => c.slug);
+			expect(slugs).toContain("posts");
+			expect(slugs).toContain("pages");
+		}
+	});
+});

--- a/packages/core/tests/integration/client/concurrent-servers.test.ts
+++ b/packages/core/tests/integration/client/concurrent-servers.test.ts
@@ -33,12 +33,17 @@ describe("Concurrent dev servers (#1604)", () => {
 	it("boots two servers from the same fixture in parallel without colliding on the Astro lock", async () => {
 		assertNodeVersion();
 
+		// Track each server the moment it starts so a partial failure (one boots,
+		// the other rejects) still leaves the successful server cleanable in
+		// afterAll -- Promise.all would otherwise short-circuit before we push it.
+		async function startTracked(port: number): Promise<TestServerContext> {
+			const ctx = await createTestServer({ port });
+			contexts.push(ctx);
+			return ctx;
+		}
+
 		// Start both concurrently so they race for the (previously shared) lock.
-		const [a, b] = await Promise.all([
-			createTestServer({ port: PORT_A }),
-			createTestServer({ port: PORT_B }),
-		]);
-		contexts.push(a, b);
+		const [a, b] = await Promise.all([startTracked(PORT_A), startTracked(PORT_B)]);
 
 		// Distinct roots -- the fix gives each server its own copied fixture.
 		expect(a.cwd).not.toBe(b.cwd);

--- a/packages/core/tests/integration/server.ts
+++ b/packages/core/tests/integration/server.ts
@@ -17,7 +17,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
-import { join, resolve, sep as SEP } from "node:path";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import { EmDashClient } from "../../src/client/index.js";
@@ -178,7 +178,7 @@ export async function createTestServer(options: TestServerOptions): Promise<Test
 	// large and provided via symlink below).
 	cpSync(FIXTURE_DIR, workDir, {
 		recursive: true,
-		filter: (src) => !src.includes(`${SEP}node_modules`),
+		filter: (src) => !src.split(/[\\/]/).includes("node_modules"),
 	});
 	const dbPath = join(workDir, "test.db");
 	const uploadsDir = join(workDir, "uploads");

--- a/packages/core/tests/integration/server.ts
+++ b/packages/core/tests/integration/server.ts
@@ -16,9 +16,8 @@
  */
 
 import { execFile, spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { join, resolve, sep as SEP } from "node:path";
 import { promisify } from "node:util";
 
 import { EmDashClient } from "../../src/client/index.js";
@@ -36,6 +35,10 @@ const FIXTURE_DIR = resolve(import.meta.dirname, "fixture");
 // Borrow node_modules from demos/simple — it has all the deps we need
 // and is maintained by pnpm workspace resolution.
 const DONOR_NODE_MODULES = resolve(import.meta.dirname, "../../../../demos/simple/node_modules");
+// Parent dir for per-suite fixture copies. In-repo (not os.tmpdir()) so the
+// project root shares a real path tree with emdash's source — see
+// createTestServer's doc comment. Gitignored via tests/integration/.gitignore.
+const SERVERS_BASE = resolve(import.meta.dirname, ".servers");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -145,9 +148,21 @@ async function waitForServer(url: string, timeoutMs: number): Promise<void> {
 /**
  * Create an Astro dev server for integration testing.
  *
- * Runs the fixture in-place to avoid Astro virtual module resolution
- * issues with symlinked temp dirs. Uses a temp directory only for the
- * database file — source files stay at their real paths.
+ * Each server runs from its own copied fixture root. Astro's "another dev
+ * server is already running" guard locks on the project root
+ * (`<root>/.astro/dev.json`), not the port, so suites that share one fixture
+ * dir collide when vitest runs them in parallel (#1604). A per-suite root keeps
+ * the lock isolated and parallelism intact.
+ *
+ * Two non-obvious constraints on that copy:
+ *   - Source files are copied (not symlinked) so the project root resolves to a
+ *     real path — symlinking the root broke Astro virtual module resolution.
+ *   - The copy lives inside the repo (next to this file), not in `os.tmpdir()`.
+ *     `emdash`'s `.astro` UI components (e.g. Comments.astro) resolve through
+ *     the symlinked `node_modules` back to their real path under `packages/core`.
+ *     With a root under `/tmp`, Astro mis-joins that real path onto the temp
+ *     root ("/tmp/.../home/.../Comments.astro") and SSR 500s with "No cached
+ *     compile metadata found". A root sharing the real path tree avoids it.
  */
 export async function createTestServer(options: TestServerOptions): Promise<TestServerContext> {
 	const { port, timeout = 90_000, seed = true } = options;
@@ -156,32 +171,34 @@ export async function createTestServer(options: TestServerOptions): Promise<Test
 	// --- 0. Ensure workspace is built ---
 	await ensureBuilt();
 
-	// --- 1. Run fixture in-place, temp dir only for DB ---
-	const workDir = FIXTURE_DIR;
-	const tempDataDir = mkdtempSync(join(tmpdir(), "emdash-integration-"));
-	const dbPath = join(tempDataDir, "test.db");
-	const uploadsDir = join(tempDataDir, "uploads");
+	// --- 1. Copy the fixture into a private per-suite root (in-repo, see above) ---
+	mkdirSync(SERVERS_BASE, { recursive: true });
+	const workDir = mkdtempSync(join(SERVERS_BASE, "srv-"));
+	// Real copy of the source fixture (everything but node_modules, which is
+	// large and provided via symlink below).
+	cpSync(FIXTURE_DIR, workDir, {
+		recursive: true,
+		filter: (src) => !src.includes(`${SEP}node_modules`),
+	});
+	const dbPath = join(workDir, "test.db");
+	const uploadsDir = join(workDir, "uploads");
 	mkdirSync(uploadsDir, { recursive: true });
 
-	// Ensure node_modules symlink exists in the fixture dir.
-	// Multiple test suites may race to create this — handle EEXIST gracefully.
-	// The symlink is intentionally never removed: it's shared across concurrent
-	// test suites and gitignored, so cleanup of one suite must not break others.
-	const fixtureNodeModules = join(FIXTURE_DIR, "node_modules");
-	if (!existsSync(fixtureNodeModules)) {
-		try {
-			symlinkSync(DONOR_NODE_MODULES, fixtureNodeModules);
-		} catch (err: unknown) {
-			if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-		}
-	}
+	// Borrow the donor node_modules via symlink (resolution still hits real
+	// paths, which is why astro.config.mjs sets vite.server.fs.strict: false).
+	symlinkSync(DONOR_NODE_MODULES, join(workDir, "node_modules"));
 
 	// --- 2. Start dev server ---
-	const astroBin = join(fixtureNodeModules, ".bin", "astro");
+	const astroBin = join(workDir, "node_modules", ".bin", "astro");
 	const server = spawn(astroBin, ["dev", "--port", String(port)], {
 		cwd: workDir,
 		env: {
 			...process.env,
+			// Force foreground mode: `astro dev` otherwise detects coding-agent
+			// environments and re-spawns itself as a detached background process,
+			// which our SIGTERM cleanup can't reach (leaking the port). With this
+			// set, the spawned process *is* the server, matching CI behavior.
+			ASTRO_DEV_BACKGROUND: "1",
 			EMDASH_TEST_DB: `file:${dbPath}`,
 			EMDASH_TEST_UPLOADS: uploadsDir,
 			...options.env,
@@ -219,8 +236,9 @@ export async function createTestServer(options: TestServerOptions): Promise<Test
 			await new Promise((r) => setTimeout(r, 500));
 		}
 
-		// Remove temp data directory
-		rmSync(tempDataDir, { recursive: true, force: true });
+		// Remove the temp fixture root (source copy, DB, uploads, and the
+		// node_modules symlink — rmSync removes the link, not the target).
+		rmSync(workDir, { recursive: true, force: true });
 	}
 
 	try {


### PR DESCRIPTION
## What does this PR do?

Fixes the flaky **Integration Tests** CI job, which intermittently failed with `Another astro dev server is already running` / `Server ... did not start within 90000ms`.

**Root cause:** each integration suite boots a real `astro dev` server, and vitest runs test files in parallel. Astro's "already running" guard locks on the **project root** (`<root>/.astro/dev.json`), not the port. Because every suite ran the fixture in-place from one shared `FIXTURE_DIR`, the second server to start lost the lock and `waitForServer` spun out the full 90s timeout. It's timing-dependent, hence the flake.

**Fix:** `createTestServer` now copies the fixture into a private **per-suite root**, so the Astro lock is isolated and parallelism is preserved. Two non-obvious constraints (documented in code):

1. **Copy, don't symlink** the source files — symlinking the root breaks Astro virtual-module resolution (the original reason for running in-place).
2. **The root must live inside the repo**, not `os.tmpdir()`. With a `/tmp` root, Astro mis-joins the real path of `emdash`'s `.astro` UI components (e.g. `Comments.astro`, resolved via the symlinked `node_modules`) onto the temp root and SSR-500s with *"No cached compile metadata found"*. A root sharing the real path tree avoids this.

Also forces foreground mode (`ASTRO_DEV_BACKGROUND=1`) so the spawned process *is* the server and `SIGTERM` cleanup actually frees the port. Adds `tests/integration/.gitignore` for the per-suite copies.

A side benefit: because servers no longer run in-place, test runs no longer dirty the tracked `fixture/emdash-env.d.ts`.

**Reproducing test** (per the repo's TDD-for-bugs rule): `concurrent-servers.test.ts` boots two servers from the fixture concurrently and asserts each gets its own root and serves its own seeded content. It fails against the old shared-root code and passes with the fix.

Closes #1604

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — ran the full integration config (7 files / 74 tests) green across 3 consecutive parallel runs
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation — n/a, test-only change, no UI strings
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) — n/a, change is confined to `tests/integration/`, no published package source touched
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
 Test Files  7 passed (7)
      Tests  74 passed (74)
   Duration  34.29s   (parallel; ~123s test-time → parallelism preserved)
```
Green across 3 consecutive runs; no orphaned servers or leftover dirs after cleanup.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
