### PR TITLE
fix(core): use JSX comment in EmDashMedia component embed branch

### DIFF
--- a/.changeset/fix-emdash-media-jsx-comment.md
+++ b/.changeset/fix-emdash-media-jsx-comment.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes a build failure in the `EmDashMedia` component. The component-embed branch contained HTML comments (`<!-- ... -->`) inside a JSX expression, which the Astro compiler rejects with "Unexpected token", breaking every production `astro build` and returning 500s in dev on any page that renders media. The note is now a JSX comment.

--- a/packages/core/src/components/EmDashMedia.astro
+++ b/packages/core/src/components/EmDashMedia.astro
@@ -158,9 +158,8 @@ const finalAlt = alt ?? (embed?.type === "image" ? embed.alt : undefined) ?? med
 	</audio>
 )}
 
+{/* Custom component embeds (Mux player, etc.) require dynamic import. Placeholder until that lands. */}
 {embed?.type === "component" && (
-	<!-- Custom component embeds (Mux player, etc.) require dynamic import -->
-	<!-- For now, show a placeholder - full implementation TBD -->
 	<div class="emdash-media-component" data-package={embed.package} data-export={embed.export}>
 		<p>Custom media component: {embed.package}</p>
 	</div>


### PR DESCRIPTION
## What does this PR do?

`packages/core/src/components/EmDashMedia.astro` places two HTML comments
(`<!-- ... -->`) **inside a JSX expression**:

```astro
{embed?.type === "component" && (
	<!-- Custom component embeds (Mux player, etc.) require dynamic import -->
	<!-- For now, show a placeholder - full implementation TBD -->
	<div class="emdash-media-component" ...>
```

HTML comments are not valid tokens inside an Astro/JSX expression. The Astro 7
compiler rejects them with:

```
[CompilerError] Unexpected token
  .../emdash/src/components/EmDashMedia.astro:162:2
```

Impact:
- **Any production `astro build` fails** for sites that depend on `emdash`
  (both `node` and `cloudflare` templates) — the build aborts at this component.
- In `dev`, every rendered route that pulls in this component (anything using
  the media component, and via the Base layout the home/post/search pages)
  returns a 500.

The fix moves the note to a top-level JSX comment (`{/* ... */}`) so the
conditional expression contains a single element. No behavioural change.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

n/a — User-visible admin UI string translation: no admin UI strings touched (single Astro component fix), so no `messages.po` changes.

n/a — Tests: the failure is a compile-time Astro template error; there is no unit-test seam for it. Verified by building a real scaffolded site (see below).

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Scaffolded a fresh `cloudflare` blog site on the current published `emdash`,
dropped in the patched component, and ran `npm run build`:

```
[emdash] Build complete
[build] Complete!
```

Builds cleanly; dev no longer 500s on media-bearing pages.

Repo checks on this branch:

```
pnpm typecheck  → all packages Done, no errors
pnpm lint       → oxlint --type-aware --deny-warnings, exit 0
pnpm test       → 285 files, 4105 tests passed (packages/core)
pnpm format     → clean, no changes
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-emdash-media-jsx-comment-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/emdash-media-jsx-comment`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
