### PR TITLE
perf(core): batch cold-start init reads into one round trip

### DIFF
--- a/.changeset/faster-cold-start-init-reads.md
+++ b/.changeset/faster-cold-start-init-reads.md
@@ -1,5 +1,6 @@
 ---
 "emdash": patch
+"@emdash-cms/cloudflare": patch
 ---
 
 Cuts cold-start latency by batching runtime initialization reads into a single round trip. On a fresh isolate (or Worker), the auto-seed check, plugin-state load, and site-info load now run as one batched query on backends that support it (Cloudflare D1, Durable Objects) instead of several serialized round trips. On D1 this roughly halves runtime init time on cold start. Other backends (Node/SQLite) are unaffected.

--- a/.changeset/faster-cold-start-init-reads.md
+++ b/.changeset/faster-cold-start-init-reads.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Cuts cold-start latency by batching runtime initialization reads into a single round trip. On a fresh isolate (or Worker), the auto-seed check, plugin-state load, and site-info load now run as one batched query on backends that support it (Cloudflare D1, Durable Objects) instead of several serialized round trips. On D1 this roughly halves runtime init time on cold start. Other backends (Node/SQLite) are unaffected.

--- a/packages/cloudflare/src/db/d1.ts
+++ b/packages/cloudflare/src/db/d1.ts
@@ -87,6 +87,22 @@ export function createDialect(config: D1Config): Dialect {
 	return new EmDashD1Dialect({ database: db });
 }
 
+/**
+ * Coalescing D1 dialect for the runtime's cold-start read phase, where the
+ * core runtime batches its init reads into one `batch()` round trip. Carries
+ * no Sessions-API bookmark — cold-start reads need no read-your-writes
+ * guarantee — so plain coalescing over the raw binding suffices. Each call
+ * returns a fresh dialect; this must never back the long-lived singleton,
+ * whose coalescing buffer would be shared across requests.
+ */
+export function createCoalescingDialect(config: D1Config): Dialect {
+	const db = getBinding(config);
+	if (!db) {
+		throw new Error(`D1 binding "${config.binding}" not found in environment.`);
+	}
+	return new CoalescingD1Dialect({ database: db });
+}
+
 // =========================================================================
 // D1 Read Replica Session Support
 //

--- a/packages/cloudflare/src/db/do-sql.ts
+++ b/packages/cloudflare/src/db/do-sql.ts
@@ -77,7 +77,21 @@ function bindingError(binding: string): Error {
  * slightly stale. It never loses or corrupts a write. Request traffic is
  * unaffected — it uses isolated per-request sinks in `createRequestScopedDb`.
  */
-const singletonBookmarkSinks = new Map<string, BookmarkSink>();
+// Stored on globalThis behind a Symbol key so Vite SSR chunk duplication can't
+// produce two maps — the singleton dialect and the cold-start coalescing dialect
+// must resolve the *same* BookmarkSink object to share read-your-writes state
+// (same pattern as core's request-cache.ts / settings/index.ts).
+const SINGLETON_BOOKMARK_SINKS_KEY = Symbol.for("emdash:do-singleton-bookmark-sinks");
+const g = globalThis as Record<symbol, unknown>;
+const singletonBookmarkSinks: Map<string, BookmarkSink> =
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis singleton pattern (see core request-cache.ts)
+	(g[SINGLETON_BOOKMARK_SINKS_KEY] as Map<string, BookmarkSink> | undefined) ??
+	(() => {
+		const m = new Map<string, BookmarkSink>();
+		g[SINGLETON_BOOKMARK_SINKS_KEY] = m;
+		return m;
+	})();
+
 function getSingletonBookmarkSink(config: DurableObjectsConfig): BookmarkSink {
 	const key = `${config.binding}:${config.name ?? DEFAULT_NAME}`;
 	let sink = singletonBookmarkSinks.get(key);

--- a/packages/cloudflare/src/db/do-sql.ts
+++ b/packages/cloudflare/src/db/do-sql.ts
@@ -62,6 +62,33 @@ function bindingError(binding: string): Error {
 }
 
 /**
+ * Bookmark sinks for the non-request-scoped dialects, keyed by DO identity.
+ *
+ * Read-after-write on the DO backend rides a bookmark: a write records the
+ * current bookmark; a later read passes it so a replica blocks until it has
+ * caught up. The singleton (migrations, scheduled tasks) and the cold-start
+ * read connection both need to see each other's writes — a migration runs on
+ * the singleton, then the runtime's cold-start reads must observe it — so they
+ * share one sink per DO. Bookmarks are global to the database, so the sink is
+ * valid across the fresh-per-query stubs each dialect resolves.
+ *
+ * Best-effort under concurrency: bookmarks are opaque, so out-of-order writes
+ * can leave the sink pointing at an older bookmark and a later read served
+ * slightly stale. It never loses or corrupts a write. Request traffic is
+ * unaffected — it uses isolated per-request sinks in `createRequestScopedDb`.
+ */
+const singletonBookmarkSinks = new Map<string, BookmarkSink>();
+function getSingletonBookmarkSink(config: DurableObjectsConfig): BookmarkSink {
+	const key = `${config.binding}:${config.name ?? DEFAULT_NAME}`;
+	let sink = singletonBookmarkSinks.get(key);
+	if (!sink) {
+		sink = {};
+		singletonBookmarkSinks.set(key, sink);
+	}
+	return sink;
+}
+
+/**
  * Create a DO SQL dialect from config. Used for the singleton Kysely instance
  * (runtime-init migrations, scheduled tasks, and any query outside a request
  * scope).
@@ -70,32 +97,36 @@ function bindingError(binding: string): Error {
  * stub: a DO stub is a per-request I/O object. We resolve a fresh stub on every
  * query instead. The hot read/write path uses `createRequestScopedDb`, which
  * reuses one stub for the whole request.
- *
- * The singleton gets its own bookmark sink so read-after-write on these paths
- * stays consistent even when replicas exist. Migrations probe schema right
- * after altering it (`hasColumn` after `ALTER TABLE`), and scheduled publishing
- * reads due rows then writes status. With a sink, each write records its
- * bookmark and the following read waits for it -- correct regardless of which
- * (fresh-per-query) stub instance serves the read, because bookmarks are global.
  */
 export function createDialect(config: DurableObjectsConfig): Dialect {
 	const ns = getNamespace(config);
 	if (!ns) throw bindingError(config.binding);
 	const id = ns.idFromName(config.name ?? DEFAULT_NAME);
-	// Best-effort under concurrency: this sink is shared across all concurrent
-	// callers of the singleton (cron, after()-deferred maintenance). Bookmarks
-	// are opaque so we can't enforce monotonic advance; if two concurrent writes
-	// return out of order, a later read on the singleton may wait for the older
-	// bookmark and serve a slightly stale read. It never loses or corrupts a
-	// write, and never affects request traffic (which uses isolated per-request
-	// sinks). The consumers that need read-after-write here (migrations under the
-	// init lock, the sequential publishDueContent loop) are strictly awaited, so
-	// the sink stays monotonic for them.
-	const bookmarkSink: BookmarkSink = {};
 	return new DOSqlDialect({
 		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Rpc type limitation with unknown row types
 		resolveStub: () => ns.get(id) as unknown as EmDashDBStub,
-		bookmarkSink,
+		bookmarkSink: getSingletonBookmarkSink(config),
+		onRpc: recordRpc,
+	});
+}
+
+/**
+ * Coalescing DO SQL dialect for the runtime's cold-start read phase, where the
+ * core runtime batches its init reads into one `batchQuery` RPC. Shares the
+ * singleton's bookmark sink so reads issued right after a migration (run on the
+ * singleton) wait for the replica to catch up — read-your-writes across the two
+ * connections. Resolves a fresh stub per query like {@link createDialect}. Each
+ * call returns a fresh dialect; this must never back the long-lived singleton,
+ * whose coalescing buffer would be shared across requests.
+ */
+export function createCoalescingDialect(config: DurableObjectsConfig): Dialect {
+	const ns = getNamespace(config);
+	if (!ns) throw bindingError(config.binding);
+	const id = ns.idFromName(config.name ?? DEFAULT_NAME);
+	return new CoalescingDOSqlDialect({
+		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Rpc type limitation with unknown row types
+		resolveStub: () => ns.get(id) as unknown as EmDashDBStub,
+		bookmarkSink: getSingletonBookmarkSink(config),
 		onRpc: recordRpc,
 	});
 }

--- a/packages/core/src/astro/integration/virtual-modules.ts
+++ b/packages/core/src/astro/integration/virtual-modules.ts
@@ -96,14 +96,21 @@ export function generateDialectModule(opts: {
 			`export const createDialect = undefined;`,
 			`export const dialectType = "sqlite";`,
 			`export const createRequestScopedDb = (_opts) => null;`,
+			`export const createCoalescingDialect = undefined;`,
 		].join("\n");
 	}
 	const type = opts.type ?? "sqlite";
+
+	// Namespace access (not a named re-export) so backends that don't export
+	// createCoalescingDialect yield `undefined` rather than a build error.
+	const coalescingReExport = `import * as _dialectModule from "${entrypoint}";
+export const createCoalescingDialect = _dialectModule.createCoalescingDialect;`;
 
 	if (supportsRequestScope) {
 		return `
 import { createDialect as _createDialect } from "${entrypoint}";
 export { createRequestScopedDb } from "${entrypoint}";
+${coalescingReExport}
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
 `;
@@ -111,6 +118,7 @@ export const dialectType = ${JSON.stringify(type)};
 
 	return `
 import { createDialect as _createDialect } from "${entrypoint}";
+${coalescingReExport}
 export const createDialect = _createDialect;
 export const dialectType = ${JSON.stringify(type)};
 export const createRequestScopedDb = (_opts) => null;

--- a/packages/core/src/astro/middleware.ts
+++ b/packages/core/src/astro/middleware.ts
@@ -12,6 +12,7 @@ import type { Kysely } from "kysely";
 import virtualConfig from "virtual:emdash/config";
 // @ts-ignore - virtual module
 import {
+	createCoalescingDialect as virtualCreateCoalescingDialect,
 	createDialect as virtualCreateDialect,
 	createRequestScopedDb as virtualCreateRequestScopedDb,
 } from "virtual:emdash/dialect";
@@ -179,6 +180,10 @@ function buildDependencies(config: EmDashConfig): RuntimeDependencies {
 		config,
 		plugins: getPlugins(),
 		createDialect: virtualCreateDialect as (config: Record<string, unknown>) => unknown,
+		// Optional: only batching backends (D1, DO) export this; undefined otherwise.
+		createCoalescingDialect: virtualCreateCoalescingDialect as
+			| ((config: Record<string, unknown>) => unknown)
+			| undefined,
 		createStorage: virtualCreateStorage as ((config: Record<string, unknown>) => Storage) | null,
 		createScheduler: virtualCreateScheduler as CreateSchedulerFn | null,
 		sandboxEnabled: sandboxModule.sandboxEnabled as boolean,

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -262,6 +262,16 @@ export interface RuntimeDependencies {
 	plugins: ResolvedPlugin[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	createDialect: (config: any) => Dialect;
+	/**
+	 * Factory for a dialect that batches same-turn reads into one round trip
+	 * ({@link EmDashRuntime.create} uses it for the cold-start read phase).
+	 * Present only on batching backends (D1, DO); absent backends fall back to
+	 * the singleton. Returns a fresh connection each call — it must never be the
+	 * long-lived singleton, whose coalescing buffer would be shared across
+	 * requests.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	createCoalescingDialect?: (config: any) => Dialect | null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	createStorage: ((config: any) => Storage) | null;
 	sandboxEnabled: boolean;
@@ -367,6 +377,28 @@ function getDbHolder(): DbHolder {
 	if (!holder) {
 		holder = { cache: new Map<string, Kysely<Database>>(), lock: createInitLock() };
 		globalSymbolStore[DB_HOLDER_KEY] = holder;
+	}
+	return holder;
+}
+
+/**
+ * Auto-seed runs at most once per isolate per database. Its lock + "done" set
+ * live on globalThis (same bundler-duplication reasoning as the db cache) so a
+ * reclaimed-and-rerun `create()` can't seed a second time concurrently. The
+ * lock polls rather than sharing a promise, so it is safe to await across a
+ * cancelled owner in workerd.
+ */
+const SEED_HOLDER_KEY = Symbol.for("emdash:seed-state");
+interface SeedHolder {
+	done: Set<string>;
+	lock: InitLock;
+}
+function getSeedHolder(): SeedHolder {
+	// eslint-disable-next-line typescript/no-unsafe-type-assertion -- globalThis symbol slot, written only below
+	let holder = globalSymbolStore[SEED_HOLDER_KEY] as SeedHolder | undefined;
+	if (!holder) {
+		holder = { done: new Set<string>(), lock: createInitLock() };
+		globalSymbolStore[SEED_HOLDER_KEY] = holder;
 	}
 	return holder;
 }
@@ -998,47 +1030,156 @@ export class EmDashRuntime {
 		// Initialize storage (sync)
 		const storage = EmDashRuntime.getStorage(deps);
 
-		// Fetch plugin states and site info concurrently — independent reads
-		// against different tables (_plugin_state vs options), so they share
-		// one round-trip window instead of paying two sequential ones. Each
-		// phase() wrapper still records that phase's own duration, and each
-		// body keeps its own non-fatal catch.
 		let pluginStates: Map<string, string> = new Map();
 		let siteInfo: { siteName?: string; siteUrl?: string; locale?: string } | undefined;
-		await Promise.all([
-			// Fetch plugin states from database
+		// "Already set up" by default so a read failure (e.g. tables absent on a
+		// pre-migration db) skips seeding rather than seeding a half-built db.
+		let seedGate = { collectionCount: 1, setupDone: true };
+
+		// Seeding must only touch the configured singleton, never a borrowed
+		// per-request db (playground / DO preview) or the loader-fallback db.
+		const reqCtx = getRequestContext();
+		const ownsConfiguredDb = !!deps.config.database && !(reqCtx?.dbIsIsolated && reqCtx.db);
+
+		// Run the init reads on a coalescing connection so the concurrent
+		// same-turn reads flush as one batch() round trip. The singleton can't:
+		// its plain SqliteAdapter reports supportsMultipleConnections=false, so
+		// Kysely's connection mutex serializes concurrent reads into N round
+		// trips. The connection is per-init and discarded — the long-lived
+		// singleton must never coalesce or one request's reads could land in
+		// another's batch. Backends without a coalescing dialect (Node/SQLite)
+		// fall back to the singleton, where serialization costs nothing.
+		let readDb = db;
+		let readDbDisposable: Kysely<Database> | undefined;
+		if (ownsConfiguredDb && deps.createCoalescingDialect && deps.config.database) {
+			try {
+				const dialect = deps.createCoalescingDialect(deps.config.database.config);
+				if (dialect) {
+					readDb = new Kysely<Database>({ dialect, log: kyselyLogOption() });
+					readDbDisposable = readDb;
+				}
+			} catch {
+				readDb = db;
+			}
+		}
+		const optionsRepo = new OptionsRepository(readDb);
+
+		const readSiteInfo = async () => {
+			const siteOpts = await optionsRepo.getMany<string>([
+				"emdash:site_title",
+				"emdash:site_url",
+				"emdash:locale",
+			]);
+			return {
+				siteName: siteOpts.get("emdash:site_title") ?? undefined,
+				siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
+				locale: siteOpts.get("emdash:locale") ?? undefined,
+			};
+		};
+
+		const coldStartReads: Array<Promise<void>> = [
 			phase("rt.plugins", "Plugin states", async () => {
 				try {
-					const states = await db
+					const states = await readDb
 						.selectFrom("_plugin_state")
 						.select(["plugin_id", "status"])
 						.execute();
 					pluginStates = new Map(states.map((s) => [s.plugin_id, s.status]));
 				} catch {
-					// Plugin state table may not exist yet
+					// _plugin_state may not exist yet on a pre-migration db.
 				}
 			}),
-			// Load site info for plugin context extensions (1 batch query instead of 3)
 			phase("rt.site", "Site info options", async () => {
 				try {
-					const optionsRepo = new OptionsRepository(db);
-					const siteOpts = await optionsRepo.getMany<string>([
-						"emdash:site_title",
-						"emdash:site_url",
-						"emdash:locale",
-					]);
-					siteInfo = {
-						siteName: siteOpts.get("emdash:site_title") ?? undefined,
-						siteUrl: siteOpts.get("emdash:site_url") ?? undefined,
-						locale: siteOpts.get("emdash:locale") ?? undefined,
-					};
+					siteInfo = await readSiteInfo();
 				} catch {
-					// Options table may not exist yet (pre-setup)
+					// options may not exist yet on a pre-migration db.
 				}
 			}),
-		]);
+		];
 
-		// Build set of enabled plugins
+		if (ownsConfiguredDb) {
+			coldStartReads.push(
+				phase("rt.seedcheck", "Auto-seed gate", async () => {
+					try {
+						const [collectionCount, setupOption] = await Promise.all([
+							readDb
+								.selectFrom("_emdash_collections")
+								.select((eb) => eb.fn.countAll<number>().as("count"))
+								.executeTakeFirstOrThrow(),
+							readDb
+								.selectFrom("options")
+								.select("value")
+								.where("name", "=", "emdash:setup_complete")
+								.executeTakeFirst(),
+						]);
+						const setupDone = (() => {
+							try {
+								return !!setupOption && JSON.parse(setupOption.value) === true;
+							} catch {
+								return false;
+							}
+						})();
+						seedGate = { collectionCount: collectionCount.count, setupDone };
+					} catch {
+						// Leave the "already set up" default so a read failure never
+						// triggers a seed onto a half-built db.
+					}
+				}),
+			);
+		}
+
+		await Promise.all(coldStartReads);
+
+		// Auto-seed the default schema for a first load that skipped the setup
+		// wizard (the wizard and dev-bypass apply seeds explicitly). Run under a
+		// per-isolate lock keyed by the configured db so a reclaimed-and-rerun
+		// create() can't apply the seed a second time concurrently.
+		if (seedGate.collectionCount === 0 && !seedGate.setupDone) {
+			const seedKey = deps.config.database?.entrypoint ?? "default";
+			const seedHolder = getSeedHolder();
+			try {
+				await initWithLock(
+					seedHolder.lock,
+					() => (seedHolder.done.has(seedKey) ? true : undefined),
+					async () => {
+						const { applySeed } = await import("./seed/apply.js");
+						const { loadSeed } = await import("./seed/load.js");
+						const { validateSeed } = await import("./seed/validate.js");
+
+						const seed = await loadSeed();
+						const validation = validateSeed(seed);
+						if (validation.valid) {
+							await applySeed(db, seed, { onConflict: "skip" });
+							console.log("Auto-seeded default collections");
+						}
+						seedHolder.done.add(seedKey);
+						return true;
+					},
+					{ deadlineMs: DB_INIT_DEADLINE_MS, anchor: (promise) => after(() => promise) },
+				);
+				// The site-info read ran before the seed wrote its defaults, so
+				// refresh the snapshot the plugin context sees.
+				try {
+					siteInfo = await readSiteInfo();
+				} catch {
+					// Non-fatal — plugin context falls back to undefined fields.
+				}
+			} catch {
+				// Non-fatal — a failed seed (e.g. missing seed module) leaves the
+				// site un-seeded; a later request retries.
+			}
+		}
+
+		// The read connection is single-use; everything below uses the singleton.
+		if (readDbDisposable) {
+			try {
+				await readDbDisposable.destroy();
+			} catch {
+				// Non-fatal — the underlying binding is shared and needs no teardown.
+			}
+		}
+
 		const enabledPlugins = new Set<string>();
 		for (const plugin of deps.plugins) {
 			const status = pluginStates.get(plugin.id);
@@ -1444,45 +1585,9 @@ export class EmDashRuntime {
 				// cleanup-flag check costs an extra `options.get()` on every
 				// isolate cold boot forever. Cheaper to leave it.
 
-				// Auto-seed schema if no collections exist and setup hasn't run.
-				// This covers first-load on sites that skip the setup wizard.
-				// Dev-bypass and the wizard apply seeds explicitly.
-				try {
-					const [collectionCount, setupOption] = await Promise.all([
-						db
-							.selectFrom("_emdash_collections")
-							.select((eb) => eb.fn.countAll<number>().as("count"))
-							.executeTakeFirstOrThrow(),
-						db
-							.selectFrom("options")
-							.select("value")
-							.where("name", "=", "emdash:setup_complete")
-							.executeTakeFirst(),
-					]);
-
-					const setupDone = (() => {
-						try {
-							return setupOption && JSON.parse(setupOption.value) === true;
-						} catch {
-							return false;
-						}
-					})();
-
-					if (collectionCount.count === 0 && !setupDone) {
-						const { applySeed } = await import("./seed/apply.js");
-						const { loadSeed } = await import("./seed/load.js");
-						const { validateSeed } = await import("./seed/validate.js");
-
-						const seed = await loadSeed();
-						const validation = validateSeed(seed);
-						if (validation.valid) {
-							await applySeed(db, seed, { onConflict: "skip" });
-							console.log("Auto-seeded default collections");
-						}
-					}
-				} catch {
-					// Tables may not exist yet. Non-fatal.
-				}
+				// This returns a migrated but possibly unseeded db; create() runs
+				// the seed gate and applies the seed, batched with its other init
+				// reads.
 
 				// Publish only while still the current owner: a reclaimed slow
 				// init must not flip the cached Kysely identity back after the

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -35,6 +35,10 @@ declare module "virtual:emdash/dialect" {
 	export const createDialect: ((config: unknown) => Dialect) | undefined;
 	export const dialectType: DatabaseDialectType | undefined;
 
+	// Optional coalescing dialect for the runtime's cold-start read batch.
+	// Only batching backends (D1, DO) export it; undefined otherwise.
+	export const createCoalescingDialect: ((config: unknown) => Dialect | null) | undefined;
+
 	/**
 	 * Adapter-owned per-request scoping. Returns null when the configured
 	 * adapter has no per-request semantics (non-D1, or D1 with sessions

--- a/packages/core/tests/integration/runtime/create.test.ts
+++ b/packages/core/tests/integration/runtime/create.test.ts
@@ -11,14 +11,17 @@
 import { randomUUID } from "node:crypto";
 
 import Database from "better-sqlite3";
-import { SqliteDialect } from "kysely";
+import { Kysely, SqliteDialect } from "kysely";
 import { describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_COMMENT_MODERATOR_PLUGIN_ID } from "../../../src/comments/moderator.js";
+import { runMigrations } from "../../../src/database/migrations/runner.js";
+import type { Database as EmDashDatabase } from "../../../src/database/types.js";
 import { EmDashRuntime } from "../../../src/emdash-runtime.js";
 import type { RuntimeDependencies } from "../../../src/emdash-runtime.js";
 import { definePlugin } from "../../../src/plugins/define-plugin.js";
 import type { ContentBeforeSaveHandler } from "../../../src/plugins/types.js";
+import { runWithContext } from "../../../src/request-context.js";
 
 function createDeps(): RuntimeDependencies {
 	return {
@@ -58,11 +61,11 @@ describe("EmDashRuntime.create — cold boot", () => {
 		const runtime = await EmDashRuntime.create(createDeps(), timings);
 
 		try {
-			// Every phase records its own entry exactly once — including the
-			// parallelized rt.plugins / rt.site pair.
+			// Every phase records its own entry exactly once.
 			const names = timings.map((t) => t.name);
 			for (const expected of [
 				"rt.db",
+				"rt.seedcheck",
 				"rt.plugins",
 				"rt.site",
 				"rt.sandbox",
@@ -108,6 +111,160 @@ describe("EmDashRuntime.create — cold boot", () => {
 			);
 		} finally {
 			await runtime.stopCron();
+		}
+	});
+
+	// The init read phase feeds plugin enablement: a plugin marked inactive in
+	// _plugin_state must be excluded from the pipeline, so its exclusive hook is
+	// never auto-selected. A shared DB seeds the _plugin_state row before
+	// create() reads it.
+	it("excludes a plugin disabled in _plugin_state from the initial pipeline", async () => {
+		const sqlite = new Database(":memory:");
+		const setupDb = new Kysely<EmDashDatabase>({
+			dialect: new SqliteDialect({ database: sqlite }),
+		});
+		await runMigrations(setupDb);
+		await setupDb
+			.insertInto("_plugin_state")
+			.values({ plugin_id: "test-exclusive-provider", version: "1.0.0", status: "inactive" })
+			.execute();
+		// Mark setup complete so create() doesn't attempt the (test-unavailable)
+		// virtual seed module; keeps the run focused on the plugin-state read.
+		await setupDb
+			.insertInto("options")
+			.values({ name: "emdash:setup_complete", value: "true" })
+			.execute();
+
+		const deps: RuntimeDependencies = {
+			...createDeps(),
+			createDialect: () => new SqliteDialect({ database: sqlite }),
+		};
+		const runtime = await EmDashRuntime.create(deps);
+		try {
+			// Disabled provider is not in the pipeline -> no candidate -> unselected.
+			expect(runtime.hooks.getExclusiveSelection("content:beforeSave")).toBeUndefined();
+			// The always-enabled built-in moderator is unaffected.
+			expect(runtime.hooks.getExclusiveSelection("comment:moderate")).toBe(
+				DEFAULT_COMMENT_MODERATOR_PLUGIN_ID,
+			);
+		} finally {
+			await runtime.stopCron();
+			await setupDb.destroy();
+		}
+	});
+
+	// When a coalescing dialect is provided, the cold-start read phase must run
+	// on it (one batched round trip), not the singleton. Prove the routing: the
+	// coalescing db marks the provider inactive while the singleton leaves it
+	// enabled, so reading from the coalescing db excludes the provider and
+	// leaves its exclusive hook unselected.
+	it("routes the cold-start read phase through createCoalescingDialect", async () => {
+		const singletonSqlite = new Database(":memory:");
+		const singletonSetup = new Kysely<EmDashDatabase>({
+			dialect: new SqliteDialect({ database: singletonSqlite }),
+		});
+		await runMigrations(singletonSetup);
+		await singletonSetup
+			.insertInto("options")
+			.values({ name: "emdash:setup_complete", value: "true" })
+			.execute();
+
+		const coalescingSqlite = new Database(":memory:");
+		const coalescingSetup = new Kysely<EmDashDatabase>({
+			dialect: new SqliteDialect({ database: coalescingSqlite }),
+		});
+		await runMigrations(coalescingSetup);
+		await coalescingSetup
+			.insertInto("_plugin_state")
+			.values({ plugin_id: "test-exclusive-provider", version: "1.0.0", status: "inactive" })
+			.execute();
+		await coalescingSetup
+			.insertInto("options")
+			.values({ name: "emdash:setup_complete", value: "true" })
+			.execute();
+
+		let coalescingCalls = 0;
+		const deps: RuntimeDependencies = {
+			...createDeps(),
+			createDialect: () => new SqliteDialect({ database: singletonSqlite }),
+			createCoalescingDialect: () => {
+				coalescingCalls += 1;
+				return new SqliteDialect({ database: coalescingSqlite });
+			},
+		};
+		const runtime = await EmDashRuntime.create(deps);
+		try {
+			// The read phase built exactly one coalescing connection...
+			expect(coalescingCalls).toBe(1);
+			// ...and read plugin state from it (provider inactive there), so the
+			// provider is excluded and its exclusive hook is unselected. Reading
+			// from the singleton (provider enabled) would have selected it.
+			expect(runtime.hooks.getExclusiveSelection("content:beforeSave")).toBeUndefined();
+		} finally {
+			await runtime.stopCron();
+			// create() destroys the read connection, which closes coalescingSqlite;
+			// the setup handles may already be closed.
+			try {
+				await singletonSetup.destroy();
+			} catch {
+				// already closed
+			}
+			try {
+				await coalescingSetup.destroy();
+			} catch {
+				// already closed
+			}
+		}
+	});
+
+	// A per-request isolated db (playground / DO preview) must never be
+	// auto-seeded. With an isolated, empty, not-set-up db, a broken guard would
+	// run the gate (rt.seedcheck appears) and attempt a seed; assert neither
+	// happens.
+	it("does not run the auto-seed gate for an isolated request db", async () => {
+		const sqlite = new Database(":memory:");
+		const isolated = new Kysely<EmDashDatabase>({
+			dialect: new SqliteDialect({ database: sqlite }),
+		});
+		await runMigrations(isolated);
+		// Sentinel: mark the configured provider inactive ONLY in the isolated
+		// db. If create() reads plugin state from this db (proving it honored
+		// ctx.db), the provider is excluded and its exclusive hook is unselected.
+		// If it silently used a different db, the provider would be selected and
+		// the assertion below would fail — so this proves the routing, which a
+		// bare "collections still 0" check cannot.
+		await isolated
+			.insertInto("_plugin_state")
+			.values({ plugin_id: "test-exclusive-provider", version: "1.0.0", status: "inactive" })
+			.execute();
+		// Empty + not set up: this is exactly the state that WOULD seed on the
+		// configured-singleton path. The guard must skip it for an isolated db.
+		const before = await isolated
+			.selectFrom("_emdash_collections")
+			.select((eb) => eb.fn.countAll<number>().as("count"))
+			.executeTakeFirstOrThrow();
+		expect(before.count).toBe(0);
+
+		const timings: Array<{ name: string; dur: number; desc?: string }> = [];
+		const runtime = await runWithContext(
+			{ editMode: false, db: isolated, dbIsIsolated: true },
+			() => EmDashRuntime.create(createDeps(), timings),
+		);
+		try {
+			// create() read plugin state from the ISOLATED db (honored ctx.db):
+			// the sentinel inactive row excluded the provider from the pipeline.
+			expect(runtime.hooks.getExclusiveSelection("content:beforeSave")).toBeUndefined();
+			// Guard skipped the gate entirely: no rt.seedcheck phase.
+			expect(timings.map((t) => t.name)).not.toContain("rt.seedcheck");
+			// And nothing was seeded onto the borrowed db.
+			const after = await isolated
+				.selectFrom("_emdash_collections")
+				.select((eb) => eb.fn.countAll<number>().as("count"))
+				.executeTakeFirstOrThrow();
+			expect(after.count).toBe(0);
+		} finally {
+			await runtime.stopCron();
+			await isolated.destroy();
 		}
 	});
 });

--- a/packages/core/tests/unit/astro/middleware-prerender.test.ts
+++ b/packages/core/tests/unit/astro/middleware-prerender.test.ts
@@ -100,6 +100,8 @@ vi.mock(
 	() => ({
 		createDialect: vi.fn(),
 		createRequestScopedDb: vi.fn().mockReturnValue(null),
+		// Absent on non-batching backends; the runtime falls back to the singleton.
+		createCoalescingDialect: undefined,
 	}),
 	{ virtual: true },
 );


### PR DESCRIPTION
## What does this PR do?

Reduces cold-start runtime-init latency by batching the reads `EmDashRuntime.create()` issues on a fresh isolate (the auto-seed gate, plugin-state load, and site-info load).

Previously these serialized on the singleton DB connection: its plain `SqliteAdapter` reports `supportsMultipleConnections: false`, so Kysely's connection mutex runs concurrent reads one at a time. This PR runs the read phase through a short-lived **coalescing** connection, so the same-tick reads collapse into a single `batch()` (D1) / `batchQuery` RPC (Durable Objects). Migrations still run on the non-coalescing singleton; the read connection is built per-init and discarded.

Measured on the demo sites via `infra/perf-monitor` (server-side `Server-Timing` `rt.*` phases, cold isolates across global probes):

| backend | baseline cold init (`rt`) | this PR |
| --- | --- | --- |
| D1 (`blog-demo`) | ~135ms | ~67ms (~2x) |
| Durable Objects (`do-demo`) | ~94ms / ~926ms (near/far region) | ~56ms / ~529ms (~40-45%) |

The tell: with the change, `rt.seedcheck`, `rt.plugins`, and `rt.site` report identical per-region durations (one batched round trip); on `main` `rt.site` is ~2x `rt.plugins` (serialized) and the seed gate sits inside a larger `rt.db`.

Backends without a coalescing dialect (Node/SQLite) transparently fall back to the singleton — synchronous, so batching is moot there.

## Type of change

- [ ] Bug fix
- [ ] Feature (requires maintainer-approved Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Implementation notes

- `packages/cloudflare/src/db/d1.ts` and `db/do-sql.ts` export `createCoalescingDialect`. On DO the singleton and the cold-start read connection **share one bookmark sink per database**, so reads issued right after a migration keep read-your-writes across replicas (the original relied on the singleton's sink). D1 needs no sink — its singleton and coalescing dialects both use the raw binding with no session, so reads hit the primary.
- `generateDialectModule` re-exports `createCoalescingDialect` via a namespace import, yielding `undefined` for backends that don't provide it (core then falls back to the singleton).
- Auto-seed is single-flighted per isolate via the existing `initWithLock` primitive (poll-based, workerd-safe), keyed by the configured database, so a reclaimed-and-rerun `create()` cannot apply the seed a second time.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (4101 core + 185 cloudflare; plus 3 new runtime tests)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings wrapped for translation — n/a (no admin UI strings; no `messages.po` changes)
- [x] I have added a changeset (bumps `emdash` and `@emdash-cms/cloudflare`)
- [ ] New features link to an approved Discussion — n/a (performance improvement, not a feature)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode). Authored and adversarially self-reviewed across multiple model passes; measured on real D1/DO deployments before submitting.

## Screenshots / test output

Cold `rt.*` from `perf-monitor` showed `rt.seedcheck == rt.plugins == rt.site` per region with this change (one batched round trip) vs. serialized phases on `main`.
