### PR TITLE
ci: commit query-text snapshots, not just the count snapshots

### DIFF
--- a/.github/workflows/query-counts-apply.yml
+++ b/.github/workflows/query-counts-apply.yml
@@ -159,7 +159,13 @@ jobs:
         run: |
           cp "$RUNNER_TEMP/qc-artifact/query-counts.snapshot.sqlite.json" scripts/
           cp "$RUNNER_TEMP/qc-artifact/query-counts.snapshot.d1.json" scripts/
-          git add scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json
+          cp "$RUNNER_TEMP/qc-artifact/query-counts.queries.sqlite.json" scripts/
+          cp "$RUNNER_TEMP/qc-artifact/query-counts.queries.d1.json" scripts/
+          git add \
+            scripts/query-counts.snapshot.sqlite.json \
+            scripts/query-counts.snapshot.d1.json \
+            scripts/query-counts.queries.sqlite.json \
+            scripts/query-counts.queries.d1.json
           if git diff --staged --quiet; then
             echo "no_diff=true" >> "$GITHUB_OUTPUT"
             echo "Artifact matches the PR head — nothing to push (probably a race with a newer commit)."

--- a/.github/workflows/query-counts.yml
+++ b/.github/workflows/query-counts.yml
@@ -37,17 +37,25 @@ jobs:
         id: drift
         run: |
           mkdir -p query-counts-out
-          if git diff --quiet scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json; then
+          # Track both the count snapshots and the query-text snapshots. The
+          # query-text files (.queries.*.json) record the actual SQL per route;
+          # without them here a change that alters a query's text but not the
+          # count (e.g. adding a column to a folded subquery) would never be
+          # committed back, leaving the D1 text snapshot silently stale.
+          counts="scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json"
+          queries="scripts/query-counts.queries.sqlite.json scripts/query-counts.queries.d1.json"
+          if git diff --quiet $counts $queries; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No drift — snapshots match the committed baseline."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            cp scripts/query-counts.snapshot.sqlite.json query-counts-out/
-            cp scripts/query-counts.snapshot.d1.json query-counts-out/
-            git diff scripts/query-counts.snapshot.sqlite.json scripts/query-counts.snapshot.d1.json > query-counts-out/snapshots.diff
+            cp $counts $queries query-counts-out/
+            git diff $counts $queries > query-counts-out/snapshots.diff
             echo "${{ github.event.pull_request.number }}" > query-counts-out/pr-number
             echo "Drift detected — uploading artifact for the Apply workflow."
-            cat query-counts-out/snapshots.diff
+            # Log only the count diff; the query-text diffs can be large and
+            # are carried in the artifact for the Apply workflow to commit.
+            git diff $counts
           fi
 
       - name: Upload snapshot artifact


### PR DESCRIPTION
## What does this PR do?

The query-count harness writes four snapshot files: the two `*.snapshot.{sqlite,d1}.json` *count* files and the two `*.queries.{sqlite,d1}.json` *query-text* files (the actual SQL per route, so a count change shows which query moved). The `Query Counts` workflow regenerates all four with `--update`, but its drift detection and the `Query Counts — Apply` workflow only ever tracked and committed the two count files.

As a result the query-text files were regenerated in CI and discarded. They only changed when a contributor ran the harness locally and committed them by hand. The D1 text file is the worst case: refreshing it needs a wrangler preview run (`--target d1 --update`), which rarely happens, so it silently drifted. On the recent hydration-fold PR it stayed frozen at its pre-fold contents (separate byline/term queries, bare `SELECT * FROM ec_pages`) for the entire PR even though the emitted SQL had changed.

This makes both workflows track and commit all four files:

- **Measure** (`query-counts.yml`): drift detection now diffs the query-text files too, and the artifact carries all four. (The job log still prints only the count diff, since the query-text diffs can be large; the full diffs ride along in the artifact.)
- **Apply** (`query-counts-apply.yml`): copies and `git add`s all four before committing.

So a change that alters a query's text but not its count now keeps the recorded SQL accurate automatically, instead of leaving the D1 text snapshot stale.

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes <!-- n/a: CI workflow YAML only, no source changed -->
- [ ] `pnpm lint` passes <!-- n/a: no source files touched (oxlint does not cover workflow YAML) -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: no testable code path; behavior is in GitHub Actions -->
- [ ] `pnpm format` has been run <!-- n/a: YAML workflows only -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a: CI workflow change -->
- [ ] User-visible strings ... <!-- n/a: no UI -->
- [ ] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package) <!-- n/a: no published package changed -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

The follow-up effect will be visible the next time a PR alters D1 SQL: the emdashbot "ci: update query-count snapshots" commit will include the `queries.d1.json` change alongside the count snapshots, instead of leaving it stale.
