### PR TITLE
fix(builds): raise Node heap for Workers Builds installs via NODE_OPTIONS

### DIFF
--- a/apps/aggregator/wrangler.jsonc
+++ b/apps/aggregator/wrangler.jsonc
@@ -113,6 +113,7 @@
 		"crons": ["*/5 * * * *"],
 	},
 	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
 		// Jetstream endpoint. Override per environment for self-hosted relays
 		// or staging backends.
 		"JETSTREAM_URL": "wss://jetstream2.us-east.bsky.network/subscribe",

--- a/demos/playground/wrangler.jsonc
+++ b/demos/playground/wrangler.jsonc
@@ -3,6 +3,9 @@
 	"name": "emdash-playground",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	// Custom entrypoint that exports EmDashPreviewDB
 	"main": "./src/worker.ts",
 	"durable_objects": {

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -9,6 +9,9 @@
 		},
 	],
 	"compatibility_flags": ["global_fetch_strictly_public", "nodejs_compat"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"name": "docs",
 	"main": "./src/worker.ts",
 	"assets": {

--- a/i18n/wrangler.jsonc
+++ b/i18n/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
 	"name": "emdash-i18n",
 	"compatibility_date": "2026-04-01",
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"assets": {
 		"directory": "./dist",
 	},

--- a/infra/blog-demo/wrangler.jsonc
+++ b/infra/blog-demo/wrangler.jsonc
@@ -5,6 +5,9 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"placement": { "mode": "targeted", "region": "aws:eu-west-2" },
 	"routes": [
 		{

--- a/infra/cache-demo/wrangler.jsonc
+++ b/infra/cache-demo/wrangler.jsonc
@@ -5,6 +5,9 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-02-24",
 	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"placement": { "mode": "targeted", "region": "aws:eu-west-2" },
 	"routes": [
 		{

--- a/infra/discord-bot/wrangler.jsonc
+++ b/infra/discord-bot/wrangler.jsonc
@@ -12,6 +12,7 @@
 		},
 	],
 	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
 		"GITHUB_OWNER_LOGIN": "ascorbic",
 		"GITHUB_REPO": "emdash-cms/emdash",
 	},

--- a/infra/do-demo/wrangler.jsonc
+++ b/infra/do-demo/wrangler.jsonc
@@ -11,6 +11,9 @@
 	// site locally, temporarily drop "replica_routing" from this list; the DO
 	// driver works without it (single primary, no replicas).
 	"compatibility_flags": ["nodejs_compat", "experimental", "replica_routing"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	// No smart placement: we want the Worker at the edge near the reader so it
 	// hits the nearest read replica. Writes/auth proxy to the primary internally.
 	"routes": [

--- a/infra/do-solo-demo/wrangler.jsonc
+++ b/infra/do-solo-demo/wrangler.jsonc
@@ -9,6 +9,9 @@
 	// so the perf dashboard can attribute any do-demo vs do-solo-demo delta to
 	// replicas specifically. "experimental" is kept for parity with do-demo.
 	"compatibility_flags": ["nodejs_compat", "experimental"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"routes": [
 		{
 			"pattern": "do-solo-demo.emdashcms.com",

--- a/infra/flue-review/wrangler.jsonc
+++ b/infra/flue-review/wrangler.jsonc
@@ -77,6 +77,7 @@
 		},
 	],
 	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
 		// emdashbot GitHub App. Not secret (app id is public; installation id is
 		// low-sensitivity). Only the private key and webhook secret are secrets.
 		// Owner/repo come from the webhook payload, so they aren't configured here.

--- a/infra/perf-monitor/wrangler.jsonc
+++ b/infra/perf-monitor/wrangler.jsonc
@@ -5,6 +5,9 @@
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-04-01",
 	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"routes": [
 		{
 			"pattern": "perf.emdashcms.com",

--- a/infra/plugins-site/wrangler.jsonc
+++ b/infra/plugins-site/wrangler.jsonc
@@ -3,6 +3,9 @@
 	"name": "emdash-plugins-site",
 	"account_id": "1f74638c495bc9f0330ce5c8e64c1b6b",
 	"compatibility_date": "2026-04-01",
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"assets": {
 		"directory": "./public",
 		"not_found_handling": "404-page",

--- a/packages/marketplace/wrangler.jsonc
+++ b/packages/marketplace/wrangler.jsonc
@@ -2,6 +2,9 @@
 	"name": "emdash-marketplace",
 	"main": "src/index.ts",
 	"compatibility_date": "2026-02-25",
+	"vars": {
+		"NODE_OPTIONS": "--max-old-space-size=6144",
+	},
 	"routes": [
 		{
 			"pattern": "marketplace.emdashcms.com",


### PR DESCRIPTION
## What does this PR do?

Demo and infra deploys on Workers Builds have been OOMing during `pnpm install --frozen-lockfile` (`FATAL ERROR: Reached heap limit ... JavaScript heap out of memory`). The crash hits at ~2.26 GB, which is V8's default old-space cap on this Node — not the container limit. The Workers Builds container actually has 8 GB, so the install is dying at 2 GB with ~6 GB free. The monorepo's install peak (1747 packages plus pnpm's supply-chain verification over the full lockfile) sits right at that 2 GB line, so it tips over nondeterministically — recent builds both passed and failed on adjacent commits.

This sets `NODE_OPTIONS=--max-old-space-size=6144` as a build environment variable on the Workers that deploy via Workers Builds. Per the [Workers Builds docs](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/#environment-variables), wrangler `vars` are injected into the build environment, so this reaches the managed install step (which we can't otherwise prefix). It has no runtime effect — workerd ignores `NODE_OPTIONS`. Verified working via a dashboard build var before codifying it here.

Applied to the deployed demo + infra Workers only:

- `infra/blog-demo`, `infra/cache-demo`, `infra/do-demo`, `infra/do-solo-demo`, `infra/plugins-site`, `demos/playground`, `docs`
- `apps/aggregator`, `infra/discord-bot`, `infra/flue-review`, `infra/perf-monitor`, `packages/marketplace`, `i18n`

Deliberately **not** applied to `templates/*` (shipped to end users as starters — shouldn't carry our build workaround) or the test/fixture configs.

Closes #

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes <!-- n/a: config-only, no source changed -->
- [ ] `pnpm lint` passes <!-- n/a: no source touched -->
- [ ] `pnpm test` passes (or targeted tests for my change) <!-- n/a: no testable code path; effect is in Workers Builds -->
- [ ] `pnpm format` has been run <!-- n/a: hand-edited JSONC matching existing tab/trailing-comma style -->
- [ ] I have added/updated tests for my changes (if applicable) <!-- n/a -->
- [ ] User-visible strings ... <!-- n/a: no UI -->
- [ ] I have added a changeset (if this PR changes a published package) <!-- n/a: no published package changed; only deploy configs -->
- [ ] New features link to an approved Discussion <!-- n/a: not a feature -->

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

Build OOM signature (e.g. emdash-demo-blog build `ac27bfec`):

```
Installing project dependencies: pnpm install --frozen-lockfile
...
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Failed: error occurred while installing tools or dependencies
```
