### PR TITLE
test(core): fix integration harness for Astro 7 background dev server

### DIFF
--- a/packages/core/tests/integration/server.ts
+++ b/packages/core/tests/integration/server.ts
@@ -16,7 +16,7 @@
  */
 
 import { execFile, spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -36,6 +36,23 @@ const FIXTURE_DIR = resolve(import.meta.dirname, "fixture");
 // Borrow node_modules from demos/simple — it has all the deps we need
 // and is maintained by pnpm workspace resolution.
 const DONOR_NODE_MODULES = resolve(import.meta.dirname, "../../../../demos/simple/node_modules");
+
+// Astro 7 writes a `.astro/dev.json` lock file recording the running dev
+// server's PID/port and refuses to start a second server for the same project
+// root (see astro/dist/cli/dev/index.js → checkExistingServer). Every suite
+// shares this fixture as its project root, so a stale or live lock from a
+// sibling/previous run trips the "Another astro dev server is already running"
+// guard. We run these server suites serially (fileParallelism: false in
+// vitest.integration.config.ts) and clear any leftover lock before each spawn.
+const DEV_LOCK_FILE = join(FIXTURE_DIR, ".astro", "dev.json");
+
+function removeStaleDevLock(): void {
+	try {
+		unlinkSync(DEV_LOCK_FILE);
+	} catch (err: unknown) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -177,11 +194,20 @@ export async function createTestServer(options: TestServerOptions): Promise<Test
 	}
 
 	// --- 2. Start dev server ---
+	// Clear any leftover lock from an ungracefully-killed sibling/previous run
+	// so Astro 7 doesn't refuse to start with "Another astro dev server is
+	// already running."
+	removeStaleDevLock();
+
 	const astroBin = join(fixtureNodeModules, ".bin", "astro");
 	const server = spawn(astroBin, ["dev", "--port", String(port)], {
 		cwd: workDir,
 		env: {
 			...process.env,
+			// Astro 7 auto-detaches `astro dev` into a JSON-logging background
+			// process when it detects an AI coding agent (am-i-vibing). That
+			// breaks this spawn-and-pipe harness, so force foreground mode.
+			ASTRO_DEV_BACKGROUND: "0",
 			EMDASH_TEST_DB: `file:${dbPath}`,
 			EMDASH_TEST_UPLOADS: uploadsDir,
 			...options.env,
@@ -218,6 +244,10 @@ export async function createTestServer(options: TestServerOptions): Promise<Test
 			server.kill("SIGKILL");
 			await new Promise((r) => setTimeout(r, 500));
 		}
+
+		// SIGTERM/SIGKILL bypass Astro's graceful stop handler, so the dev
+		// lock file is left behind pointing at our now-dead PID. Clear it.
+		removeStaleDevLock();
 
 		// Remove temp data directory
 		rmSync(tempDataDir, { recursive: true, force: true });

--- a/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
+++ b/packages/core/tests/integration/smoke/site-matrix-smoke.test.ts
@@ -179,12 +179,22 @@ async function bootSite(site: SiteCase): Promise<BootedServer> {
 		rmSync(join(site.dir, file), { force: true });
 	}
 
+	// Astro 7 records a `.astro/dev.json` lock for the running dev server and
+	// refuses to start a second one for the same project root. Sites are
+	// rebooted across describe blocks (runtime + MCP), and SIGTERM bypasses
+	// the graceful stop that clears the lock, so drop any leftover lock first.
+	rmSync(join(site.dir, ".astro", "dev.json"), { force: true });
+
 	const baseUrl = `http://localhost:${site.port}`;
 	const serverProcess = spawn("pnpm", ["exec", "astro", "dev", "--port", String(site.port)], {
 		cwd: site.dir,
 		env: {
 			...process.env,
 			CI: "true",
+			// Force foreground mode -- Astro 7 detaches `astro dev` into a
+			// background process when it detects an AI coding agent, which
+			// breaks this spawn-and-pipe harness.
+			ASTRO_DEV_BACKGROUND: "0",
 		},
 		stdio: "pipe",
 	});

--- a/packages/core/vitest.integration.config.ts
+++ b/packages/core/vitest.integration.config.ts
@@ -10,5 +10,10 @@ export default defineConfig({
 		// migrations + seed can take 30-60s.
 		testTimeout: 30_000,
 		hookTimeout: 120_000,
+		// Every suite boots an Astro dev server against the same fixture
+		// project root. Astro 7 writes a `.astro/dev.json` lock there and
+		// refuses to start a second server for the same root, so the suites
+		// must not run concurrently. Each suite still uses a distinct port.
+		fileParallelism: false,
 	},
 });


### PR DESCRIPTION
## What does this PR do?

Astro 7 introduced a background dev server feature that writes a `.astro/dev.json` lock file at the project root (recording the running server's PID/port) and refuses to start a second `astro dev` for the same root, printing "Another astro dev server is already running."

The integration test harness boots one Astro dev server per test file, all against the **shared** `packages/core/tests/integration/fixture` root on distinct ports, run in parallel by Vitest. The first server to boot writes the lock; later-starting servers see it (alive) and fail to start. This is what broke CI on the Integration Tests job (e.g. `oauth-discovery` and `field-widgets` failing while `cli` held the lock on port 4398).

Fixes:

- **Run the server-based integration suites serially** (`fileParallelism: false` in `vitest.integration.config.ts`) so two servers never coexist on the shared fixture root. Each suite still uses its own port.
- **Clear any stale `.astro/dev.json`** before each spawn and on cleanup. `SIGTERM`/`SIGKILL` bypass Astro's graceful stop handler that normally removes the lock, so a killed server leaves a lock pointing at a dead PID.
- **Force foreground mode** via `ASTRO_DEV_BACKGROUND=0`. Astro 7 auto-detaches `astro dev` into a JSON-logging background process when `am-i-vibing` detects an AI coding agent, which breaks this spawn-and-pipe harness.

The same foreground opt-out and lock cleanup are applied to the smoke harness (`site-matrix-smoke.test.ts`).

Closes #

## Type of change

- [x] Tests

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — ran `vitest run --config vitest.integration.config.ts`: 6 files, 73 tests pass serially in ~31s
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a, this is a test-harness fix
- [ ] User-visible strings... — n/a, no admin UI
- [ ] I have added a [changeset]... — n/a, no published package changed (test harness + Vitest config only)
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (opencode)

## Screenshots / test output

```
 Test Files  6 passed (6)
      Tests  73 passed (73)
   Duration  31.38s
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-astro7-dev-server-test-harness-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/astro7-dev-server-test-harness`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
