### PR TITLE
Fix/admin sidebar layout + use native Kumo sidebar behavior

### DIFF
--- a/.changeset/kumo-style-order.md
+++ b/.changeset/kumo-style-order.md
@@ -2,4 +2,4 @@
 "@emdash-cms/admin": patch
 ---
 
-Fixes Kumo style loading order in the admin stylesheet.
+Fixes Kumo style loading and updates the admin sidebar to use Kumo's native collapse and theme behavior.

--- a/.changeset/kumo-style-order.md
+++ b/.changeset/kumo-style-order.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes Kumo style loading order in the admin stylesheet.

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -8,12 +8,12 @@
  * available throughout the app via PluginAdminContext.
  */
 
-import { Toasty } from "@cloudflare/kumo";
+import { LinkProvider, Toasty, type LinkComponentProps } from "@cloudflare/kumo";
 import { i18n } from "@lingui/core";
 import type { Messages } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { RouterProvider } from "@tanstack/react-router";
+import { Link, RouterProvider, type LinkProps } from "@tanstack/react-router";
 import * as React from "react";
 
 import { ThemeProvider } from "./components/ThemeProvider";
@@ -34,6 +34,43 @@ const queryClient = new QueryClient({
 
 // Create the router with query client context
 const router = createAdminRouter(queryClient);
+
+const KumoRouterLink = React.forwardRef<HTMLAnchorElement, LinkComponentProps>(
+	({ href, to, target, download, children, ...props }, ref) => {
+		const destination = href ?? to ?? "";
+		const isRouterPath = destination.startsWith("/") && !destination.startsWith("//");
+		const shouldUseAnchor = !isRouterPath || target || download != null;
+		const linkProps = props as LinkComponentProps & {
+			"aria-current"?: React.AriaAttributes["aria-current"];
+			"data-active"?: boolean | string;
+		};
+		const ariaCurrent =
+			linkProps["aria-current"] ?? (linkProps["data-active"] ? "page" : undefined);
+
+		if (shouldUseAnchor) {
+			return (
+				<a ref={ref} href={destination} target={target} download={download} {...props}>
+					{children}
+				</a>
+			);
+		}
+
+		return (
+			<Link
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Kumo provides runtime hrefs; TanStack requires literal route types.
+				{...(props as Omit<LinkProps, "to" | "children">)}
+				ref={ref}
+				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Kumo provides runtime hrefs; TanStack requires literal route types.
+				to={destination as "/"}
+				aria-current={ariaCurrent}
+			>
+				{children}
+			</Link>
+		);
+	},
+);
+
+KumoRouterLink.displayName = "KumoRouterLink";
 
 export interface AdminAppProps {
 	/** Plugin admin modules keyed by plugin ID */
@@ -76,7 +113,9 @@ export function AdminApp({
 						<AuthProviderProvider authProviders={authProviders}>
 							<PluginAdminProvider pluginAdmins={pluginAdmins}>
 								<QueryClientProvider client={queryClient}>
-									<RouterProvider router={router} />
+									<LinkProvider component={KumoRouterLink}>
+										<RouterProvider router={router} />
+									</LinkProvider>
 								</QueryClientProvider>
 							</PluginAdminProvider>
 						</AuthProviderProvider>

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -47,7 +47,14 @@ function normalizeAdminHref(href: string): string {
 
 function getAnchorHref(destination: string, routerDestination: string): string {
 	if (routerDestination.startsWith("/") && !routerDestination.startsWith("//")) {
-		return `${ADMIN_BASEPATH}${routerDestination === "/" ? "" : routerDestination}`;
+		if (
+			routerDestination === "/" ||
+			routerDestination.startsWith("/?") ||
+			routerDestination.startsWith("/#")
+		) {
+			return `${ADMIN_BASEPATH}${routerDestination.slice(1)}`;
+		}
+		return `${ADMIN_BASEPATH}${routerDestination}`;
 	}
 	return destination;
 }

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -34,12 +34,31 @@ const queryClient = new QueryClient({
 
 // Create the router with query client context
 const router = createAdminRouter(queryClient);
+const ADMIN_BASEPATH = "/_emdash/admin";
+
+function normalizeAdminHref(href: string): string {
+	if (href === ADMIN_BASEPATH) return "/";
+	if (href.startsWith(`${ADMIN_BASEPATH}/`)) return href.slice(ADMIN_BASEPATH.length);
+	if (href.startsWith(`${ADMIN_BASEPATH}?`) || href.startsWith(`${ADMIN_BASEPATH}#`)) {
+		return `/${href.slice(ADMIN_BASEPATH.length)}`;
+	}
+	return href;
+}
+
+function getAnchorHref(destination: string, routerDestination: string): string {
+	if (routerDestination.startsWith("/") && !routerDestination.startsWith("//")) {
+		return `${ADMIN_BASEPATH}${routerDestination === "/" ? "" : routerDestination}`;
+	}
+	return destination;
+}
 
 const KumoRouterLink = React.forwardRef<HTMLAnchorElement, LinkComponentProps>(
 	({ href, to, target, download, children, ...props }, ref) => {
 		const destination = href ?? to ?? "";
-		const isRouterPath = destination.startsWith("/") && !destination.startsWith("//");
-		const shouldUseAnchor = !isRouterPath || target || download != null;
+		const hasSearchOrHash = destination.includes("?") || destination.includes("#");
+		const routerDestination = normalizeAdminHref(destination);
+		const isRouterPath = routerDestination.startsWith("/") && !routerDestination.startsWith("//");
+		const shouldUseAnchor = !isRouterPath || hasSearchOrHash || target || download != null;
 		const linkProps = props as LinkComponentProps & {
 			"aria-current"?: React.AriaAttributes["aria-current"];
 			"data-active"?: boolean | string;
@@ -48,8 +67,12 @@ const KumoRouterLink = React.forwardRef<HTMLAnchorElement, LinkComponentProps>(
 			linkProps["aria-current"] ?? (linkProps["data-active"] ? "page" : undefined);
 
 		if (shouldUseAnchor) {
+			const anchorHref =
+				hasSearchOrHash && !target && download == null
+					? getAnchorHref(destination, routerDestination)
+					: destination;
 			return (
-				<a ref={ref} href={destination} target={target} download={download} {...props}>
+				<a ref={ref} href={anchorHref} target={target} download={download} {...props}>
 					{children}
 				</a>
 			);
@@ -61,7 +84,7 @@ const KumoRouterLink = React.forwardRef<HTMLAnchorElement, LinkComponentProps>(
 				{...(props as Omit<LinkProps, "to" | "children">)}
 				ref={ref}
 				// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Kumo provides runtime hrefs; TanStack requires literal route types.
-				to={destination as "/"}
+				to={routerDestination as "/"}
 				aria-current={ariaCurrent}
 			>
 				{children}

--- a/packages/admin/src/components/Header.tsx
+++ b/packages/admin/src/components/Header.tsx
@@ -39,7 +39,7 @@ export function Header() {
 	const initials = (initialsSource[0] ?? "U").toUpperCase();
 
 	return (
-		<header className="sticky top-0 z-10 flex h-16 items-center justify-between border-b bg-kumo-base px-4">
+		<header className="sticky top-0 z-10 flex h-[58px] items-center justify-between border-b bg-kumo-elevated px-4">
 			{/* Sidebar toggle — collapses to icon mode on desktop, opens drawer on mobile */}
 			<Sidebar.Trigger className="cursor-pointer rtl:rotate-180" />
 

--- a/packages/admin/src/components/Shell.tsx
+++ b/packages/admin/src/components/Shell.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
 import { useCurrentUser } from "../lib/api/current-user";
+import { getLocaleDir } from "../locales/config.js";
+import { useLocale } from "../locales/useLocale.js";
 import { AdminCommandPalette } from "./AdminCommandPalette";
 import { Header } from "./Header";
 import { Sidebar, SidebarNav } from "./Sidebar";
@@ -35,6 +37,8 @@ export function Shell({ children, manifest }: ShellProps) {
 	const [welcomeModalOpen, setWelcomeModalOpen] = React.useState(false);
 
 	const { data: user } = useCurrentUser();
+	const { locale } = useLocale();
+	const sidebarSide = getLocaleDir(locale) === "rtl" ? "right" : "left";
 
 	// Show welcome modal on first login
 	React.useEffect(() => {
@@ -46,8 +50,10 @@ export function Shell({ children, manifest }: ShellProps) {
 	return (
 		<Sidebar.Provider
 			defaultOpen
+			side={sidebarSide}
 			style={
 				{
+					"--sidebar-bg": "var(--color-kumo-elevated)",
 					height: "100svh",
 					minHeight: "0",
 					overflow: "hidden",

--- a/packages/admin/src/components/Shell.tsx
+++ b/packages/admin/src/components/Shell.tsx
@@ -51,7 +51,6 @@ export function Shell({ children, manifest }: ShellProps) {
 					height: "100svh",
 					minHeight: "0",
 					overflow: "hidden",
-					"--sidebar-width-icon": "53px",
 				} as React.CSSProperties
 			}
 		>

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Sidebar as KumoSidebar, Tooltip, useSidebar } from "@cloudflare/kumo";
+import { Sidebar as KumoSidebar, useSidebar } from "@cloudflare/kumo";
 import { useLingui } from "@lingui/react/macro";
 import {
 	SquaresFour,
@@ -40,7 +40,6 @@ import * as React from "react";
 import { fetchCommentCounts } from "../lib/api/comments";
 import { useCurrentUser } from "../lib/api/current-user";
 import { resolvePluginPagePath, usePluginAdmins } from "../lib/plugin-context";
-import { cn } from "../lib/utils";
 import { BrandIcon } from "./Logo.js";
 
 // Re-export for Shell.tsx and Header.tsx
@@ -236,56 +235,35 @@ export function resolveNavIcon(name?: string): React.ElementType {
 }
 
 /**
- * Navigation item rendered as a TanStack Router <Link> inside kumo's
- * Sidebar.MenuItem. Styled to match kumo MenuButton appearance.
- * This approach guarantees client-side navigation works correctly.
+ * Navigation item rendered with Kumo's native Sidebar.MenuButton. Kumo's
+ * LinkProvider maps the href to TanStack Router for client-side navigation.
  */
 function NavMenuLink({ item, isActive }: { item: NavItem; isActive: boolean }) {
-	const { state } = useSidebar();
 	const Icon = item.icon;
-	const iconClassName = cn(
-		"emdash-nav-icon size-[18px] shrink-0 transition-colors duration-200",
-		isActive ? "text-white" : "text-white/60 group-hover/menu-button:text-white/90",
-	);
-
-	const link = (
-		<Link
-			// eslint-disable-next-line typescript/no-unsafe-type-assertion -- TanStack Router requires literal route types
-			to={item.to as "/"}
-			params={item.params}
-			aria-current={isActive ? "page" : undefined}
-			data-active={isActive || undefined}
-			data-sidebar="menu-button"
-			className={cn(
-				"emdash-nav-link group/menu-button flex w-full min-w-0 items-center gap-2.5 rounded-md no-underline outline-none cursor-pointer",
-				"min-h-[36px] px-3 py-1.5 text-[13px]",
-				"transition-all duration-200 ease-out",
-				isActive ? "bg-kumo-brand text-white" : "text-white/70 hover:text-white hover:bg-white/8",
-				"focus-visible:ring-2 focus-visible:ring-kumo-brand/50",
-			)}
-		>
-			<React.Suspense fallback={<PuzzlePiece className={iconClassName} aria-hidden="true" />}>
-				<Icon className={iconClassName} aria-hidden="true" />
-			</React.Suspense>
-			<span className="emdash-nav-label flex flex-1 items-center min-w-0 text-start overflow-hidden">
-				{item.label}
-				{item.badge != null && item.badge > 0 && (
-					<KumoSidebar.MenuBadge>{item.badge}</KumoSidebar.MenuBadge>
-				)}
-			</span>
-		</Link>
-	);
+	function IconComponent({ className }: { className?: string }) {
+		return <NavIcon icon={Icon} className={className} />;
+	}
 
 	return (
-		<KumoSidebar.MenuItem>
-			{state === "collapsed" ? (
-				<Tooltip content={item.label} side="right" asChild>
-					{link}
-				</Tooltip>
-			) : (
-				link
+		<KumoSidebar.MenuButton
+			href={resolveItemPath(item)}
+			active={isActive}
+			tooltip={item.label}
+			icon={IconComponent}
+		>
+			{item.label}
+			{item.badge != null && item.badge > 0 && (
+				<KumoSidebar.MenuBadge>{item.badge}</KumoSidebar.MenuBadge>
 			)}
-		</KumoSidebar.MenuItem>
+		</KumoSidebar.MenuButton>
+	);
+}
+
+function NavIcon({ icon: Icon, className }: { icon: React.ElementType; className?: string }) {
+	return (
+		<React.Suspense fallback={<PuzzlePiece className={className} aria-hidden="true" />}>
+			<Icon className={className} aria-hidden="true" />
+		</React.Suspense>
 	);
 }
 
@@ -436,190 +414,76 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 	}
 
 	return (
-		<>
-			{/* Injected styles — Tailwind 4 strips [data-sidebar] attribute selectors from CSS files.
-			    All sidebar-specific overrides go here to avoid conflicting with kumo's inline styles. */}
-			<style
-				dangerouslySetInnerHTML={{
-					__html: `
-			/* Classic dark chrome — override kumo tokens within the sidebar */
-			.emdash-sidebar {
-				--color-kumo-base: #1d2327;
-				/* Kumo 2.4 paints the surface via bg-(--sidebar-bg) on an inner
-				   container, resolved from the wrapper's light --color-kumo-base. */
-				--sidebar-bg: #1d2327;
-				--color-kumo-tint: rgba(255,255,255,0.1);
-				--color-kumo-line: rgba(255,255,255,0.08);
-				--color-kumo-brand: #2271b1;
-				--text-color-kumo-default: #fff;
-				--text-color-kumo-subtle: rgba(255,255,255,0.7);
-				--text-color-kumo-strong: #fff;
-				background-color: #1d2327 !important;
-				color: #fff !important;
-				border-color: rgba(255,255,255,0.08) !important;
-			}
-			/* Group labels — uppercase muted style */
-			.emdash-sidebar [data-sidebar="group-label"] {
-				color: rgba(255,255,255,0.45) !important;
-				font-size: 11px !important;
-				text-transform: uppercase;
-				letter-spacing: 0.06em;
-				font-weight: 600;
-				padding-left: 0.75rem;
-				padding-right: 0.75rem;
-			}
-			.emdash-sidebar [data-sidebar="group-label"] svg {
-				color: rgba(255,255,255,0.3);
-			}
-			.emdash-sidebar [data-sidebar="group-label"]:hover svg {
-				color: rgba(255,255,255,0.6);
-			}
-			/* Separators */
-			.emdash-sidebar [data-sidebar="separator"] {
-				border-color: rgba(255,255,255,0.06) !important;
-				margin: 0.5rem 0.75rem;
-			}
-			/* Header/footer borders */
-			.emdash-sidebar [data-sidebar="header"] {
-				border-bottom: 1px solid rgba(255,255,255,0.08);
-			}
-			.emdash-sidebar [data-sidebar="footer"] {
-				border-top: 1px solid rgba(255,255,255,0.08);
-			}
+		<KumoSidebar className="emdash-sidebar" aria-label={t`Admin navigation`}>
+			<KumoSidebar.Header>
+				<Link
+					to="/"
+					className="flex w-full min-w-0 items-center gap-2 px-3 py-1 group-data-[state=collapsed]/sidebar:justify-center group-data-[state=collapsed]/sidebar:px-0"
+				>
+					<BrandIcon
+						logoUrl={manifest.admin?.logo}
+						siteName={manifest.admin?.siteName}
+						className="size-5 shrink-0"
+						aria-hidden="true"
+					/>
+					<span className="font-semibold truncate group-data-[state=collapsed]/sidebar:hidden">
+						{manifest.admin?.siteName || "EmDash"}
+					</span>
+				</Link>
+			</KumoSidebar.Header>
 
-			/* Collapsed separators — thin centered line */
-			.emdash-sidebar[data-state="collapsed"] [data-sidebar="separator"] {
-				margin: 0.375rem 0.625rem;
-			}
-			/* Collapsed: tighten group spacing */
-			.emdash-sidebar[data-state="collapsed"] [data-sidebar="group"] {
-				gap: 0.125rem;
-			}
-			.emdash-sidebar[data-state="collapsed"] [data-sidebar="menu"] {
-				gap: 0.125rem;
-			}
-
-			/* Collapsed: nav links — center icon, hide text */
-			.emdash-sidebar[data-state="collapsed"] .emdash-nav-link {
-				justify-content: center;
-				padding: 0.5rem 0;
-				gap: 0;
-				min-height: 36px;
-			}
-			.emdash-sidebar[data-state="collapsed"] .emdash-nav-label {
-				display: none !important;
-			}
-			/* Collapsed: brand link */
-			.emdash-sidebar[data-state="collapsed"] .emdash-brand-link {
-				justify-content: center;
-				padding-left: 0;
-				padding-right: 0;
-			}
-			.emdash-sidebar[data-state="collapsed"] .emdash-brand-text {
-				display: none !important;
-			}
-
-			/* Mobile drawer slide animation from left (LTR) */
-			[data-starting-style]:has(> .emdash-sidebar[data-mobile="true"]),
-			[data-ending-style]:has(> .emdash-sidebar[data-mobile="true"]) {
-				transform: translateX(-100%);
-			}
-
-			/* Mobile drawer slide animation from right (RTL) */
-			[dir="rtl"] [data-starting-style]:has(> .emdash-sidebar[data-mobile="true"]),
-			[dir="rtl"] [data-ending-style]:has(> .emdash-sidebar[data-mobile="true"]) {
-				transform: translateX(100%);
-				--tw-translate-x: 100%;
-			}
-
-			/* RTL: Position drawer on right side */
-			[dir="rtl"] :has(> .emdash-sidebar[data-mobile="true"]) {
-				left: auto;
-				right: 0;
-			}
-		`,
-				}}
-			/>
-			<KumoSidebar className="emdash-sidebar" aria-label={t`Admin navigation`}>
-				<KumoSidebar.Header>
-					<Link
-						to="/"
-						className="emdash-brand-link flex w-full min-w-0 items-center gap-2 px-3 py-1"
-					>
-						<BrandIcon
-							logoUrl={manifest.admin?.logo}
-							siteName={manifest.admin?.siteName}
-							className="size-5 shrink-0"
-							aria-hidden="true"
+			<KumoSidebar.Content>
+				{/* Dashboard — standalone */}
+				<KumoSidebar.Group>
+					<KumoSidebar.Menu>
+						<NavMenuLink
+							item={{ to: "/", label: t`Dashboard`, icon: SquaresFour }}
+							isActive={isItemActive("/", currentPath)}
 						/>
-						<span className="emdash-brand-text font-semibold truncate">
-							{manifest.admin?.siteName || "EmDash"}
-						</span>
-					</Link>
-				</KumoSidebar.Header>
+					</KumoSidebar.Menu>
+				</KumoSidebar.Group>
 
-				<KumoSidebar.Content>
-					{/* Dashboard — standalone */}
+				{/* Content — collections + media */}
+				{visibleContent.length > 1 && (
 					<KumoSidebar.Group>
+						<KumoSidebar.GroupLabel>{t`Content`}</KumoSidebar.GroupLabel>
 						<KumoSidebar.Menu>
-							<NavMenuLink
-								item={{ to: "/", label: t`Dashboard`, icon: SquaresFour }}
-								isActive={isItemActive("/", currentPath)}
-							/>
+							{renderNavItems(visibleContent.filter((i) => i.to !== "/"))}
 						</KumoSidebar.Menu>
 					</KumoSidebar.Group>
+				)}
 
-					<KumoSidebar.Separator />
+				{/* Manage — comments, menus, taxonomies, etc. */}
+				{visibleManage.length > 0 && (
+					<KumoSidebar.Group>
+						<KumoSidebar.GroupLabel>{t`Manage`}</KumoSidebar.GroupLabel>
+						<KumoSidebar.Menu>{renderNavItems(visibleManage)}</KumoSidebar.Menu>
+					</KumoSidebar.Group>
+				)}
 
-					{/* Content — collections + media */}
-					{visibleContent.length > 1 && (
-						<KumoSidebar.Group>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Content`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.Menu>
-								{renderNavItems(visibleContent.filter((i) => i.to !== "/"))}
-							</KumoSidebar.Menu>
-						</KumoSidebar.Group>
-					)}
+				{/* Admin — content types, users, plugins, import */}
+				{visibleAdmin.length > 0 && (
+					<KumoSidebar.Group>
+						<KumoSidebar.GroupLabel>{t`Admin`}</KumoSidebar.GroupLabel>
+						<KumoSidebar.Menu>{renderNavItems(visibleAdmin)}</KumoSidebar.Menu>
+					</KumoSidebar.Group>
+				)}
 
-					<KumoSidebar.Separator />
+				{/* Plugin pages */}
+				{visiblePlugins.length > 0 && (
+					<KumoSidebar.Group>
+						<KumoSidebar.GroupLabel>{t`Plugins`}</KumoSidebar.GroupLabel>
+						<KumoSidebar.Menu>{renderNavItems(visiblePlugins)}</KumoSidebar.Menu>
+					</KumoSidebar.Group>
+				)}
+			</KumoSidebar.Content>
 
-					{/* Manage — comments, menus, taxonomies, etc. */}
-					{visibleManage.length > 0 && (
-						<KumoSidebar.Group>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Manage`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.Menu>{renderNavItems(visibleManage)}</KumoSidebar.Menu>
-						</KumoSidebar.Group>
-					)}
-
-					<KumoSidebar.Separator />
-
-					{/* Admin — content types, users, plugins, import */}
-					{visibleAdmin.length > 0 && (
-						<KumoSidebar.Group>
-							<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Admin`}</KumoSidebar.GroupLabel>
-							<KumoSidebar.Menu>{renderNavItems(visibleAdmin)}</KumoSidebar.Menu>
-						</KumoSidebar.Group>
-					)}
-
-					{/* Plugin pages */}
-					{visiblePlugins.length > 0 && (
-						<>
-							<KumoSidebar.Separator />
-							<KumoSidebar.Group>
-								<KumoSidebar.GroupLabel className="[&>span]:text-start [&_svg]:rtl:-scale-x-100 [&_svg]:rtl:-scale-y-100">{t`Plugins`}</KumoSidebar.GroupLabel>
-								<KumoSidebar.Menu>{renderNavItems(visiblePlugins)}</KumoSidebar.Menu>
-							</KumoSidebar.Group>
-						</>
-					)}
-				</KumoSidebar.Content>
-
-				<KumoSidebar.Footer>
-					<p className="emdash-nav-label px-3 py-2 text-[11px] text-white/30">
-						{manifest.admin?.siteName || "EmDash CMS"} v{manifest.version || "0.0.0"}
-						{manifest.commit && ` (${manifest.commit})`}
-					</p>
-				</KumoSidebar.Footer>
-			</KumoSidebar>
-		</>
+			<KumoSidebar.Footer>
+				<p className="px-3 py-2 text-[11px] text-kumo-subtle group-data-[state=collapsed]/sidebar:hidden">
+					{manifest.admin?.siteName || "EmDash CMS"} v{manifest.version || "0.0.0"}
+					{manifest.commit && ` (${manifest.commit})`}
+				</p>
+			</KumoSidebar.Footer>
+		</KumoSidebar>
 	);
 }

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -436,7 +436,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 
 			<KumoSidebar.Content>
 				{/* Dashboard — standalone */}
-				<KumoSidebar.Group>
+				<KumoSidebar.Group className="mt-2 md:mt-1.5">
 					<KumoSidebar.Menu>
 						<NavMenuLink
 							item={{ to: "/", label: t`Dashboard`, icon: SquaresFour }}

--- a/packages/admin/src/components/Sidebar.tsx
+++ b/packages/admin/src/components/Sidebar.tsx
@@ -239,6 +239,7 @@ export function resolveNavIcon(name?: string): React.ElementType {
  * LinkProvider maps the href to TanStack Router for client-side navigation.
  */
 function NavMenuLink({ item, isActive }: { item: NavItem; isActive: boolean }) {
+	const { state } = useSidebar();
 	const Icon = item.icon;
 	function IconComponent({ className }: { className?: string }) {
 		return <NavIcon icon={Icon} className={className} />;
@@ -248,7 +249,7 @@ function NavMenuLink({ item, isActive }: { item: NavItem; isActive: boolean }) {
 		<KumoSidebar.MenuButton
 			href={resolveItemPath(item)}
 			active={isActive}
-			tooltip={item.label}
+			tooltip={state === "collapsed" ? item.label : undefined}
 			icon={IconComponent}
 		>
 			{item.label}
@@ -343,6 +344,7 @@ export function SidebarNav({ manifest }: SidebarNavProps) {
 
 	const adminItems: NavItem[] = [
 		{ to: "/content-types", label: t`Content Types`, icon: Database, minRole: ROLE_ADMIN },
+		{ ...BYLINE_SCHEMA_NAV_ITEM, label: t`Byline Schema`, icon: FileText },
 		{ to: "/users", label: t`Users`, icon: Users, minRole: ROLE_ADMIN },
 		{ to: "/plugins-manager", label: t`Plugins`, icon: PuzzlePiece, minRole: ROLE_ADMIN },
 	];

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -109,6 +109,11 @@ body {
 	color: var(--text-color-kumo-default);
 }
 
+[data-sidebar-popup] {
+	width: var(--sidebar-width);
+	transition-property: transform, translate, opacity !important;
+}
+
 /* Fix text selection contrast */
 ::selection {
 	background-color: var(--color-kumo-interact);

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -38,8 +38,9 @@
 
 [data-theme="classic"]:not([data-mode="dark"]) {
 	/* Surfaces */
+	--color-kumo-canvas: oklch(98.75% 0 0);
 	--color-kumo-base: #ffffff;
-	--color-kumo-elevated: #f0f0f1;
+	--color-kumo-elevated: oklch(98.75% 0 0);
 	--color-kumo-recessed: #dcdcde;
 	--color-kumo-overlay: #ffffff;
 	--color-kumo-control: #ffffff;
@@ -50,7 +51,7 @@
 	--color-kumo-interact: #c3c4c7;
 
 	/* Borders */
-	--color-kumo-line: #c3c4c7;
+	--color-kumo-line: oklch(14.5% 0 0 / 0.1);
 	--color-kumo-ring: #2271b1;
 
 	/* Text hierarchy */

--- a/packages/admin/src/styles.css
+++ b/packages/admin/src/styles.css
@@ -8,12 +8,12 @@
  * - User preference stored in localStorage, applied via data-mode attribute on <html>
  */
 
-@import "tailwindcss";
-@import "@cloudflare/kumo/styles/tailwind";
-@plugin "@tailwindcss/typography";
-
 /* Scan Kumo component JS for Tailwind utility classes (e.g. Dialog centering) */
-@source "../node_modules/@cloudflare/kumo/dist";
+@source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
+
+@import "@cloudflare/kumo/styles";
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 /* Map Tailwind dark: variant to kumo's data-mode attribute */
 @custom-variant dark (&:where([data-mode="dark"], [data-mode="dark"] *));


### PR DESCRIPTION
## What does this PR do?

Updates the admin sidebar to use Kumo’s native sidebar behavior and fixes sidebar/header layout polish.

This PR:
- Loads Kumo styles before Tailwind so Kumo component styles are preserved.
- Uses Kumo `LinkProvider` for sidebar navigation.
- Removes custom injected sidebar CSS in favor of Kumo sidebar primitives.
- Aligns the admin header with Kumo’s sidebar header height.
- Uses Kumo’s native sidebar side handling for RTL.
- Keeps panels/buttons white while using subtle Cloudflare-style chrome surfaces.
- Lightens light-mode borders to better match Kumo/Cloudflare dashboard styling.
- Shows sidebar tooltips only when collapsed.
- Fixes mobile sidebar drawer width/slide behavior under Tailwind 4.
- Restores the Byline Schema admin nav item for admins.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: OpenCode, GPT-5.5

## Screenshots / test output

Verified:
- `pnpm install`
- `pnpm --dir packages/admin build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --dir packages/admin exec vitest run`

Admin tests:
- 82 test files passed
- 1016 tests passed

Notes:
- Vitest warned about mixed `vitest@4.1.5` and `@vitest/browser@4.1.8`.
- Some unrelated tests print existing Kumo input accessible-name warnings.

Manual verification:
- Mobile sidebar drawer opens/closes with slide animation.
- Sidebar tooltips only show when collapsed.
- Light/dark sidebar surfaces and borders checked.

## Screenshots

#### Light Mode

<img width="900" alt="Light mode admin sidebar comparison" src="https://github.com/user-attachments/assets/5ec13a70-b95f-4d34-a3be-c276e790eca3" />

#### Dark Mode

<img width="900" alt="Dark mode admin sidebar comparison" src="https://github.com/user-attachments/assets/85d20669-d073-44b4-8b74-22e460063197" />

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-admin-sidebar-layout-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/admin-sidebar-layout`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
