### PR TITLE
fix(core): keep plugin cron alive in astro dev under Cloudflare adapter

### DIFF
--- a/.changeset/plugin-cron-undefined-in-dev.md
+++ b/.changeset/plugin-cron-undefined-in-dev.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes `ctx.cron` being undefined during `astro dev` under the `@astrojs/cloudflare` adapter, which silently prevented plugins from scheduling cron tasks and stopped the `cron` hook from ever firing in local dev. The in-process scheduler now keys off Astro's command rather than Vite's, so plugin cron, scheduled publishing, and cleanup run again.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -159,7 +159,10 @@ export interface VitePluginOptions {
 /**
  * Creates the EmDash virtual modules Vite plugin.
  */
-export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
+export function createVirtualModulesPlugin(
+	options: VitePluginOptions,
+	astroCommand: "dev" | "build" | "preview" | "sync",
+): Plugin {
 	const { serializableConfig, resolvedConfig, pluginDescriptors, astroConfig } = options;
 
 	let viteCommand: "build" | "serve" | undefined;
@@ -294,8 +297,16 @@ export function createVirtualModulesPlugin(options: VitePluginOptions): Plugin {
 			// Generate scheduler module — a NodeCronScheduler factory on
 			// long-lived runtimes, or null under the Cloudflare adapter where
 			// a Cron Trigger drives scheduled work instead.
+			//
+			// Decide from Astro's command, not Vite's config.command: the
+			// Cloudflare adapter builds the worker bundle via a nested Vite
+			// *build* pass even during `astro dev`, so viteCommand reports
+			// "build" and would wrongly suppress the in-process timer (#1635).
+			// Astro's command stays "dev", which is the only case that should
+			// fall through to a NodeCronScheduler.
 			if (id === RESOLVED_VIRTUAL_SCHEDULER_ID) {
-				return generateSchedulerModule(astroConfig.adapter?.name, viteCommand);
+				const schedulerCommand = astroCommand === "dev" ? "serve" : "build";
+				return generateSchedulerModule(astroConfig.adapter?.name, schedulerCommand);
 			}
 		},
 	};
@@ -382,7 +393,7 @@ export function createViteConfig(
 		},
 		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Monorepo has both vite 6 (docs) and vite 7 (core). tsgo resolves correctly.
 		plugins: [
-			createVirtualModulesPlugin(options),
+			createVirtualModulesPlugin(options, command),
 			// In dev mode with source alias, compile Lingui macros on the fly
 			// and redirect locale .mjs imports to dist/.
 			// In production, macros are pre-compiled by tsdown in the admin package.

--- a/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
+++ b/packages/core/tests/unit/astro/integration/virtual-modules.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { Plugin } from "vite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -9,7 +10,12 @@ import {
 	generateDialectModule,
 	generateSchedulerModule,
 	generateSeedModule,
+	RESOLVED_VIRTUAL_SCHEDULER_ID,
 } from "../../../../src/astro/integration/virtual-modules.js";
+import {
+	createVirtualModulesPlugin,
+	type VitePluginOptions,
+} from "../../../../src/astro/integration/vite-config.js";
 
 describe("generateConfigModule", () => {
 	it("round-trips the serialisable config shape via default export", () => {
@@ -95,6 +101,49 @@ describe("generateSchedulerModule", () => {
 	it("emits a NodeCronScheduler factory when no adapter is configured", () => {
 		const out = generateSchedulerModule(undefined, "build");
 		expect(out).toContain("export function createScheduler(executor)");
+	});
+});
+
+describe("createVirtualModulesPlugin scheduler wiring", () => {
+	// Invoke a Vite plugin hook that may be a function or { handler } object.
+	function callHook<T>(hook: unknown, ...args: unknown[]): T {
+		const fn = typeof hook === "function" ? hook : (hook as { handler: unknown }).handler;
+		return (fn as (...a: unknown[]) => T)(...args);
+	}
+
+	function buildPlugin(
+		adapterName: string | undefined,
+		command: "dev" | "build" | "preview" | "sync",
+	): Plugin {
+		const options = {
+			serializableConfig: {},
+			resolvedConfig: {},
+			pluginDescriptors: [],
+			astroConfig: { adapter: adapterName ? { name: adapterName } : undefined },
+		} as unknown as VitePluginOptions;
+		return createVirtualModulesPlugin(options, command);
+	}
+
+	it("keeps the Node timer under the Cloudflare adapter during `astro dev` even when Vite reports command 'build'", () => {
+		// The Cloudflare adapter produces the worker bundle via a nested Vite
+		// *build* pass during `astro dev`, so Vite's config.command resolves to
+		// "build". The scheduler decision must use Astro's command ("dev")
+		// instead, otherwise plugin cron silently no-ops in local dev (#1635).
+		const plugin = buildPlugin("@astrojs/cloudflare", "dev");
+		callHook(plugin.configResolved, { command: "build" });
+
+		const out = callHook<string>(plugin.load, RESOLVED_VIRTUAL_SCHEDULER_ID);
+		expect(out).toContain('import { NodeCronScheduler } from "emdash"');
+		expect(out).not.toContain("createScheduler = null");
+	});
+
+	it("disables the timer under the Cloudflare adapter for a production build", () => {
+		const plugin = buildPlugin("@astrojs/cloudflare", "build");
+		callHook(plugin.configResolved, { command: "build" });
+
+		const out = callHook<string>(plugin.load, RESOLVED_VIRTUAL_SCHEDULER_ID);
+		expect(out).toContain("export const createScheduler = null");
+		expect(out).not.toContain("NodeCronScheduler");
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes plugin cron being silently inert during `astro dev` under the `@astrojs/cloudflare` adapter.

The scheduler virtual module (`virtual:emdash/scheduler`) decides whether to inject a `NodeCronScheduler` based on a command. It was reading Vite's `config.command`, which the Cloudflare adapter reports as `"build"` even during `astro dev` — the adapter produces the worker bundle via a nested Vite *build* pass. As a result `generateSchedulerModule` returned `createScheduler = null`, the middleware skipped `setContextFactory({ cronReschedule })`, and `ctx.cron` was left `undefined`. Plugins could not call `ctx.cron.schedule(...)`, `_emdash_cron_tasks` stayed empty, and the plugin `cron` hook never fired.

The fix threads Astro's authoritative `command` into the virtual-modules plugin and bases the scheduler decision on it (`dev` → in-process timer, everything else → null under Cloudflare). `astro dev` now keeps the `NodeCronScheduler` regardless of how the Cloudflare adapter pre-bundles the worker, so plugin cron, scheduled publishing, and cleanup run again in local dev.

Closes #1635

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin UI strings in this change
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

Added `createVirtualModulesPlugin scheduler wiring` tests reproducing the bug (Cloudflare adapter + Astro command `dev` while Vite reports `build`). Written test-first: the reproducing test failed (scheduler resolved to `null`) before the fix, passes after.

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
