### PR TITLE
ci: harden GitHub Actions and route fork auto-format through workflow_run

### DIFF
--- a/.github/workflows/auto-extract.yml
+++ b/.github/workflows/auto-extract.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Commit the extracted locale catalogs back to main. Nothing else.
+          permission-contents: write
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/auto-format-apply.yml
+++ b/.github/workflows/auto-format-apply.yml
@@ -1,19 +1,18 @@
-name: Query Counts — Apply
+name: Auto Format — Apply
 
-# Runs after the "Query Counts" workflow completes on a PR. This job has
-# elevated permissions to push back to the PR branch and comment, but it
-# never executes code from the PR — it only downloads the inert JSON +
-# diff artifact produced by the measure job.
+# Stage 2 of 2. Runs after "Auto Format" completes on a PR. This job has
+# elevated permissions to push the formatted patch back to the PR branch,
+# but it never executes code from the PR — it only downloads the inert
+# patch artifact, checks out the measured head SHA, and applies the diff.
 on:
   workflow_run:
-    workflows: ["Query Counts"]
+    workflows: ["Auto Format"]
     types: [completed]
 
 permissions:
-  # actions:read is needed for listWorkflowRunArtifacts /
-  # downloadArtifact. pull-requests:read is needed for pulls.get in the
-  # Resolve PR step. contents:read is a safety default; the commit-back
-  # step uses the app token, not GITHUB_TOKEN.
+  # actions:read is needed for listWorkflowRunArtifacts / downloadArtifact.
+  # pull-requests:read is needed for pulls.get in the Resolve PR step.
+  # contents:read is a safety default; the push-back steps use the app token.
   actions: read
   contents: read
   pull-requests: read
@@ -25,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download snapshot artifact
+      - name: Download patch artifact
         id: download
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -37,10 +36,10 @@ jobs:
               repo: context.repo.repo,
               run_id: context.payload.workflow_run.id,
             });
-            const artifact = data.artifacts.find((a) => a.name === 'query-counts-snapshots');
+            const artifact = data.artifacts.find((a) => a.name === 'auto-format-patch');
             if (!artifact) {
               core.setOutput('found', 'false');
-              core.info('No snapshot artifact — nothing to apply.');
+              core.info('No patch artifact — nothing to apply.');
               return;
             }
             const download = await github.rest.actions.downloadArtifact({
@@ -51,19 +50,18 @@ jobs:
             });
             // Stage the artifact under RUNNER_TEMP, not GITHUB_WORKSPACE.
             // GITHUB_WORKSPACE is wiped by the later actions/checkout step
-            // (clean: true is the default), which would delete our payload
-            // before the Apply step can copy it into scripts/. RUNNER_TEMP
-            // sits outside the workspace and survives checkout.
-            const outDir = path.join(process.env.RUNNER_TEMP, 'qc-artifact');
+            // (clean: true is the default), which would delete the payload
+            // before the Apply step can reach it. RUNNER_TEMP sits outside
+            // the workspace and survives checkout.
+            const outDir = path.join(process.env.RUNNER_TEMP, 'af-artifact');
             fs.mkdirSync(outDir, { recursive: true });
             fs.writeFileSync(path.join(outDir, 'artifact.zip'), Buffer.from(download.data));
             core.setOutput('found', 'true');
-            core.setOutput('dir', outDir);
 
       - name: Unpack artifact
         if: steps.download.outputs.found == 'true'
         run: |
-          cd "$RUNNER_TEMP/qc-artifact"
+          cd "$RUNNER_TEMP/af-artifact"
           unzip -o artifact.zip
           ls -la
 
@@ -77,7 +75,7 @@ jobs:
             const path = require('node:path');
             const prNumber = Number(
               fs.readFileSync(
-                path.join(process.env.RUNNER_TEMP, 'qc-artifact', 'pr-number'),
+                path.join(process.env.RUNNER_TEMP, 'af-artifact', 'pr-number'),
                 'utf8',
               ).trim(),
             );
@@ -85,11 +83,9 @@ jobs:
               core.setFailed(`Invalid PR number in artifact: ${prNumber}`);
               return;
             }
-            // Cross-check: fetch the PR directly and verify its head SHA
-            // matches the workflow_run's head SHA. This is more robust
-            // than listPullRequestsAssociatedWithCommit, which doesn't
-            // reliably surface fork PRs from the base repo's API view
-            // and was rejecting valid fork artifacts as "not associated".
+            // Cross-check: fetch the PR and verify its head SHA matches the
+            // workflow_run's head SHA, so a forged artifact can't redirect
+            // the push at an unrelated branch.
             const headSha = context.payload.workflow_run.head_sha;
             let pr;
             try {
@@ -105,18 +101,15 @@ jobs:
             }
             if (pr.head.sha !== headSha) {
               core.setFailed(
-                `PR #${prNumber} head SHA (${pr.head.sha}) does not match workflow_run head SHA (${headSha}). The branch has likely moved on; the next PR event will trigger a fresh measure+apply.`,
+                `PR #${prNumber} head SHA (${pr.head.sha}) does not match workflow_run head SHA (${headSha}). The branch has moved on; the next PR event will re-run format+apply.`,
               );
               return;
             }
             core.setOutput('number', String(pr.number));
             core.setOutput('ref', pr.head.ref);
-            // Use the workflow_run's head_sha — the commit that was
-            // actually measured — rather than the PR's current head.
-            // If the branch has moved on since, we want to push onto
-            // the measured commit (and let the push fail non-fast-
-            // forward) rather than apply stale snapshots to a newer
-            // tree.
+            // Push onto the exact commit that was formatted. If the branch
+            // has advanced since, the push fails non-fast-forward rather than
+            // applying a stale patch to a newer tree.
             core.setOutput('sha', headSha);
             core.setOutput('full_name', pr.head.repo.full_name);
             const isFork = pr.head.repo.fork
@@ -130,10 +123,12 @@ jobs:
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Push the updated snapshots back to the PR branch. Nothing else.
+          # Push the formatted commit (contents) and comment on push failure
+          # (pull-requests). Nothing else.
           permission-contents: write
+          permission-pull-requests: write
 
-      # --- Same-repo PRs: checkout the pinned SHA and push directly ---
+      # --- Same-repo PRs: checkout the measured SHA and push directly ---
 
       - name: Checkout (same-repo)
         if: steps.download.outputs.found == 'true' && steps.pr.outputs.is_fork == 'false'
@@ -141,11 +136,11 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.sha }}
           token: ${{ steps.app-token.outputs.token }}
-          # Intentional: the same-repo push step below pushes the
-          # updated snapshots back to the PR branch using this credential.
+          # The same-repo push step below pushes the formatted commit back to
+          # the PR branch using this credential.
           persist-credentials: true
 
-      # --- Fork PRs: checkout the fork at the pinned SHA so we can push back ---
+      # --- Fork PRs: checkout the fork at the measured SHA so we can push back ---
 
       - name: Checkout (fork)
         if: steps.download.outputs.found == 'true' && steps.pr.outputs.is_fork == 'true'
@@ -155,22 +150,15 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
 
-      - name: Apply snapshots
+      - name: Apply patch
         if: steps.download.outputs.found == 'true'
         id: apply
         run: |
-          cp "$RUNNER_TEMP/qc-artifact/query-counts.snapshot.sqlite.json" scripts/
-          cp "$RUNNER_TEMP/qc-artifact/query-counts.snapshot.d1.json" scripts/
-          cp "$RUNNER_TEMP/qc-artifact/query-counts.queries.sqlite.json" scripts/
-          cp "$RUNNER_TEMP/qc-artifact/query-counts.queries.d1.json" scripts/
-          git add \
-            scripts/query-counts.snapshot.sqlite.json \
-            scripts/query-counts.snapshot.d1.json \
-            scripts/query-counts.queries.sqlite.json \
-            scripts/query-counts.queries.d1.json
+          git apply "$RUNNER_TEMP/af-artifact/format.patch"
+          git add -A
           if git diff --staged --quiet; then
             echo "no_diff=true" >> "$GITHUB_OUTPUT"
-            echo "Artifact matches the PR head — nothing to push (probably a race with a newer commit)."
+            echo "Patch is a no-op against the checked-out head — nothing to push."
           else
             echo "no_diff=false" >> "$GITHUB_OUTPUT"
           fi
@@ -187,14 +175,12 @@ jobs:
           set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "ci: update query-count snapshots"
-          # Detached-HEAD push onto the PR branch. If the branch has
-          # advanced past the measured SHA, this fails with a non-fast-
-          # forward — safe outcome, since applying stale counts to a
-          # newer tree would hide a regression. The next PR event will
-          # kick off a fresh measure+apply against the new head.
+          git commit -m "style: format"
+          # Detached-HEAD push onto the PR branch. If the branch has advanced
+          # past the measured SHA, this fails non-fast-forward — the next PR
+          # event re-runs format+apply against the new head.
           if ! git push origin "HEAD:$HEAD_REF"; then
-            echo "::error::Non-fast-forward push — the PR branch moved past the measured SHA $HEAD_SHA. Rerun the harness against the new head (the next PR event will do this automatically)." >&2
+            echo "::error::Non-fast-forward push — the PR branch moved past the measured SHA $HEAD_SHA. The next PR event will re-run format+apply." >&2
             exit 1
           fi
 
@@ -203,25 +189,39 @@ jobs:
           steps.download.outputs.found == 'true'
           && steps.pr.outputs.is_fork == 'true'
           && steps.apply.outputs.no_diff == 'false'
+        id: push-fork
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_REF: ${{ steps.pr.outputs.ref }}
           FULL_NAME: ${{ steps.pr.outputs.full_name }}
         run: |
-          set -e
           git config user.name "emdashbot[bot]"
           git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "ci: update query-count snapshots"
+          git commit -m "style: format"
+          # Push the formatted commit to the fork via the app token, supplied
+          # through GIT_ASKPASS so it never lands in process args or git config.
           export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
           printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
           chmod +x "$GIT_ASKPASS"
           git remote add fork "https://x-access-token@github.com/$FULL_NAME.git"
-          # Fail the workflow if we can't push — most likely cause is
-          # "Allow edits by maintainers" being disabled on the fork PR.
-          # The reviewer needs to know the snapshots couldn't be applied.
-          if ! git push fork "HEAD:$HEAD_REF"; then
-            rm -f "$GIT_ASKPASS"
-            echo "::error::Failed to push snapshots to fork. The contributor may have 'Allow edits by maintainers' disabled. They need to run 'pnpm query-counts --target sqlite --update && pnpm query-counts --target d1 --update' locally and commit, or re-enable maintainer edits." >&2
-            exit 1
+          if git push fork "HEAD:$HEAD_REF"; then
+            echo "push_failed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
           fi
           rm -f "$GIT_ASKPASS"
+
+      - name: Comment on push failure
+        if: steps.push-fork.outputs.push_failed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: `Could not push formatting changes to this fork. The contributor may have "Allow edits by maintainers" disabled.\n\nPlease run the formatter locally:\n\n\`\`\`\npnpm format\n\`\`\``,
+            });

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,7 +1,12 @@
 name: Auto Format
 
+# Stage 1 of 2 (producer). Runs with the default read-only token and never
+# pushes or comments, so it is safe to format PR-authored code — including
+# from forks. The companion "Auto Format — Apply" workflow (triggered by
+# workflow_run) commits the result back with elevated permissions, isolated
+# from PR-authored code.
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [opened, synchronize]
 
@@ -11,115 +16,43 @@ permissions:
 jobs:
   format:
     name: Format
-    # Skip bot-authored commits to avoid infinite loops
+    # Skip the bot's own format commits to avoid a re-format loop.
     if: github.actor != 'emdashbot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Get PR details
-        id: pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const pr = context.payload.pull_request;
-            const isFork = pr.head.repo.fork || pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
-            core.setOutput('ref', pr.head.ref);
-            core.setOutput('sha', pr.head.sha);
-            core.setOutput('number', pr.number.toString());
-            core.setOutput('is_fork', isFork.toString());
-            core.setOutput('full_name', pr.head.repo.full_name);
-
-      # --- Same-repo PRs: checkout and push directly ---
-
-      - name: Checkout (same-repo)
-        if: steps.pr.outputs.is_fork == 'false'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ steps.pr.outputs.ref }}
-          token: ${{ steps.app-token.outputs.token }}
-          # Intentional: the same-repo push step below pushes the
-          # formatted changes back to the PR branch using this credential.
-          persist-credentials: true
-
-      # --- Fork PRs: checkout the fork at the pinned SHA ---
-
-      - name: Checkout (fork)
-        if: steps.pr.outputs.is_fork == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ steps.pr.outputs.full_name }}
-          ref: ${{ steps.pr.outputs.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Run formatter
         run: npx oxfmt --ignore-path .gitignore
 
-      - name: Check for changes
-        id: diff
+      - name: Compute patch
+        id: patch
         run: |
           git add -A
           if git diff --staged --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Already formatted — nothing to apply."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            mkdir -p auto-format-out
+            git diff --staged > auto-format-out/format.patch
+            echo "${{ github.event.pull_request.number }}" > auto-format-out/pr-number
+            echo "Formatting changes detected — uploading patch for the Apply workflow."
           fi
 
-      # --- Same-repo: push directly ---
-
-      - name: Commit and push (same-repo)
-        if: steps.pr.outputs.is_fork == 'false' && steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name "emdashbot[bot]"
-          git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "style: format"
-          git push
-
-      # --- Fork: push via git with GIT_ASKPASS ---
-
-      - name: Commit and push (fork)
-        if: steps.pr.outputs.is_fork == 'true' && steps.diff.outputs.changed == 'true'
-        id: push-fork
-        run: |
-          git config user.name "emdashbot[bot]"
-          git config user.email "emdashbot[bot]@users.noreply.github.com"
-          git commit -m "style: format"
-          # Push to the fork using the app token via GIT_ASKPASS to avoid
-          # leaking the token in process args or git config
-          export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
-          printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
-          chmod +x "$GIT_ASKPASS"
-          git remote add fork "https://x-access-token@github.com/${{ steps.pr.outputs.full_name }}.git"
-          if git push fork "HEAD:${{ steps.pr.outputs.ref }}"; then
-            echo "push_failed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "push_failed=true" >> "$GITHUB_OUTPUT"
-          fi
-          rm -f "$GIT_ASKPASS"
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Comment on push failure
-        if: steps.push-fork.outputs.push_failed == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Upload patch artifact
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.number }},
-              body: `Could not push formatting changes to this fork. The contributor may have "Allow edits by maintainers" disabled.\n\nPlease run the formatter locally:\n\n\`\`\`\npnpm format\n\`\`\``,
-            });
+          name: auto-format-patch
+          path: auto-format-out/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -43,7 +43,7 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             mkdir -p auto-format-out
-            git diff --staged > auto-format-out/format.patch
+            git diff --staged --binary > auto-format-out/format.patch
             echo "${{ github.event.pull_request.number }}" > auto-format-out/pr-number
             echo "Formatting changes detected — uploading patch for the Apply workflow."
           fi

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Read PR metadata and submit the approving review. Nothing else.
+          permission-pull-requests: write
 
       - name: Fetch Dependabot metadata
         id: metadata
@@ -36,6 +38,9 @@ jobs:
       - name: Auto-approve patch and minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -44,5 +49,5 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
               event: 'APPROVE',
-              body: 'Auto-approved: ${{ steps.metadata.outputs.update-type }} update for ${{ steps.metadata.outputs.dependency-names }}.',
+              body: `Auto-approved: ${process.env.UPDATE_TYPE} update for ${process.env.DEPENDENCY_NAMES}.`,
             });

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -27,10 +27,12 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Push the formatted commit (contents), and react to / comment on
-          # the triggering PR comment (pull-requests). Nothing else.
+          # Push the formatted commit (contents), comment on the PR
+          # (pull-requests), and react to the triggering comment via the
+          # issues/comments reactions API (issues). Nothing else.
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
 
       - name: Get PR details
         id: pr

--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Push the formatted commit (contents), and react to / comment on
+          # the triggering PR comment (pull-requests). Nothing else.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Get PR details
         id: pr
@@ -111,8 +115,8 @@ jobs:
           export GIT_ASKPASS="$RUNNER_TEMP/git-askpass.sh"
           printf '#!/bin/sh\necho "%s"\n' "$APP_TOKEN" > "$GIT_ASKPASS"
           chmod +x "$GIT_ASKPASS"
-          git remote add fork "https://x-access-token@github.com/${{ steps.pr.outputs.full_name }}.git"
-          if git push fork "HEAD:${{ steps.pr.outputs.ref }}"; then
+          git remote add fork "https://x-access-token@github.com/$FULL_NAME.git"
+          if git push fork "HEAD:$HEAD_REF"; then
             echo "push_failed=false" >> "$GITHUB_OUTPUT"
           else
             echo "push_failed=true" >> "$GITHUB_OUTPUT"
@@ -120,6 +124,8 @@ jobs:
           rm -f "$GIT_ASKPASS"
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FULL_NAME: ${{ steps.pr.outputs.full_name }}
+          HEAD_REF: ${{ steps.pr.outputs.ref }}
 
       - name: Comment on push failure
         if: steps.push-fork.outputs.push_failed == 'true'
@@ -136,10 +142,12 @@ jobs:
 
       - name: React to comment (result)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHANGED: ${{ steps.diff.outputs.changed }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const changed = '${{ steps.diff.outputs.changed }}' === 'true';
+            const changed = process.env.CHANGED === 'true';
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # changesets/action pushes release commits/tags and opens the
+          # release PR (contents + pull-requests). npm publish auth is the
+          # separate NODE_AUTH_TOKEN; OIDC provenance is the job's id-token.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -27,6 +27,8 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: templates
           owner: emdash-cms
+          # Push the synced templates to emdash-cms/templates. Nothing else.
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/sync-templates.yml
+++ b/.github/workflows/sync-templates.yml
@@ -27,8 +27,10 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: templates
           owner: emdash-cms
-          # Push the synced templates to emdash-cms/templates. Nothing else.
+          # Push the sync branch (contents) and open/update the sync PR via
+          # `gh pr create` (pull-requests) on emdash-cms/templates. Nothing else.
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -53,7 +53,11 @@ jobs:
 
       - name: Run zizmor
         if: steps.decide.outputs.analyze == 'true'
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Pin the tool version (the action defaults to `latest`) so a new
+          # zizmor release can't surface findings that block unrelated PRs.
+          version: "1.26.1"
 
       # When skipped, upload an empty SARIF so the ruleset rule passes.
       - name: Write empty SARIF

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,10 +16,12 @@ rules:
       # CLA assistant must comment on PRs from forks; runs a pinned third-party
       # action and does not execute any code from the PR.
       - cla.yml
-      # Auto-format runs against trusted same-repo branches only (gated by
-      # `github.event.pull_request.head.repo.full_name == github.repository`
-      # downstream). Fork PRs are routed through format-command instead.
-      - auto-format.yml
+      # auto-format-apply uses workflow_run to commit the formatted patch
+      # computed by the untrusted `auto-format` workflow. The trusted job only
+      # consumes the inert patch artifact, verifies the PR head SHA matches the
+      # workflow_run head SHA, applies the diff, and pushes back via an app
+      # token. It never checks out or executes PR-controlled code.
+      - auto-format-apply.yml
       # Lunaria only reads localized content and posts a status comment; does
       # not execute PR-controlled code.
       - lunaria.yml
@@ -45,5 +47,29 @@ rules:
   # so workflow-level vs job-level scoping makes no real difference. A future
   # PR may split the `label` job to a separate file with narrower permissions.
   excessive-permissions:
+    ignore:
+      - cla.yml
+
+  # pkg.pr.new is a preview-release service, not npm registry publishing. It
+  # authenticates via its own GitHub OIDC flow (no long-lived token), so npm
+  # trusted publishing does not apply. The real npm publish (release.yml) uses
+  # OIDC provenance via the job's id-token: write.
+  use-trusted-publishing:
+    ignore:
+      - preview-releases.yml
+
+  # investigate.yml is the bot's reproduction runner. It installs the
+  # maintainer-owned bgproc / agent-browser CLIs globally at runtime so the
+  # agent doesn't self-install them mid-run. This is not a production build,
+  # and pinning these dev tools by version would add churn without a real
+  # supply-chain gain here.
+  adhoc-packages:
+    ignore:
+      - investigate.yml
+
+  # contributor-assistant/github-action is archived upstream but pinned by
+  # SHA, and has no maintained drop-in replacement. The CLA flow is critical;
+  # replacing the action is a separate, deliberate migration.
+  archived-uses:
     ignore:
       - cla.yml


### PR DESCRIPTION
## What does this PR do?

Tightens the security posture of the repo's GitHub Actions and unblocks fork auto-formatting, which `actions/checkout@v7` now refuses under `pull_request_target` ("Refusing to check out fork pull request code from a 'pull_request_target' workflow").

Scope is **Actions security tightening in general** — it resolves every finding the newer zizmor surfaces, either by fixing it or by adding a documented ignore.

- **Scope app tokens** (`github-app`, HIGH): every `create-github-app-token` now requests only the permissions it uses instead of the app's blanket installation set — `auto-extract` / `sync-templates` (`contents`), `release` / `format-command` / `auto-format-apply` (`contents`+`pull-requests`), `dependabot-approve` (`pull-requests`), `query-counts-apply` (`contents`).
- **Close template injection** (`template-injection`): attacker-influenceable values moved out of `run:`/`script:` blocks into `env` — Dependabot dependency names in `dependabot-approve`, and fork `ref`/`full_name` (a branch name can legally contain `$(...)`) in `format-command` and `query-counts-apply`.
- **Route fork auto-format through `workflow_run`**: `auto-format.yml` is now an unprivileged `pull_request` producer that formats PR code (safe — no secrets) and uploads a patch artifact; the new `auto-format-apply.yml` applies it with elevated permissions via `workflow_run`, cross-checking the PR head SHA and **never executing PR-authored code**. Mirrors the existing `query-counts-apply` pattern.
- **Bump + pin zizmor**: `zizmor-action` `v0.5.6 → v0.5.7`, tool pinned to `1.26.1` (the action floats `latest` by default, which would let a future release block unrelated PRs).
- **Documented ignores** (in `.github/zizmor.yml`, with justifications) for findings needing external setup or a deliberate migration: `use-trusted-publishing` (pkg.pr.new is a preview service with its own OIDC), `adhoc-packages` (the bot runner installs its CLIs at runtime by design), `archived-uses` (the CLA action is archived upstream but SHA-pinned, no clean drop-in).

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a, no package code changed (workflow YAML only)
- [ ] `pnpm lint` passes — n/a, no package code changed
- [ ] `pnpm test` passes — n/a, no package code changed
- [ ] `pnpm format` has been run — n/a, no source files changed
- [ ] User-visible strings wrapped for translation — n/a, no admin UI changes
- [ ] I have added a changeset — n/a, no published package changed (CI/tooling only)
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

Verified with the pinned tool against the repo config — clean across all 29 workflows:

```
$ zizmor 1.26.1 --offline .github/workflows/
No findings to report. Good job! (16 ignored, 104 suppressed)
```

Before this change the same scan reported 5 HIGH (`github-app`), 1 MEDIUM, 1 LOW, and informational findings. CI parity confirmed: `zizmor-action` defaults to the `regular` persona (matching the run above) and uploads SARIF rather than hard-failing.
