### PR TITLE
fix(core): silence React 19 external store warning

### DIFF
--- a/.changeset/fresh-buckets-exercise.md
+++ b/.changeset/fresh-buckets-exercise.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes React 19 development console warnings from the visual editing toolbar's `useSyncExternalStore` dependency path.

--- a/packages/core/src/astro/integration/shims/use-sync-external-store-with-selector.js
+++ b/packages/core/src/astro/integration/shims/use-sync-external-store-with-selector.js
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+const objectIs =
+	typeof Object.is === "function"
+		? Object.is
+		: (x, y) => (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
+
+export function useSyncExternalStoreWithSelector(
+	subscribe,
+	getSnapshot,
+	getServerSnapshot,
+	selector,
+	isEqual,
+) {
+	const instRef = React.useRef(null);
+	if (instRef.current === null) {
+		instRef.current = { hasValue: false, value: null };
+	}
+	const inst = instRef.current;
+
+	const [getSelection, getServerSelection] = React.useMemo(() => {
+		let hasMemo = false;
+		let memoizedSnapshot;
+		let memoizedSelection;
+
+		const memoizedSelector = (nextSnapshot) => {
+			if (!hasMemo) {
+				hasMemo = true;
+				memoizedSnapshot = nextSnapshot;
+				const nextSelection = selector(nextSnapshot);
+				if (isEqual !== undefined && inst.hasValue) {
+					const currentSelection = inst.value;
+					if (isEqual(currentSelection, nextSelection)) {
+						memoizedSelection = currentSelection;
+						return currentSelection;
+					}
+				}
+				memoizedSelection = nextSelection;
+				return nextSelection;
+			}
+
+			const previousSelection = memoizedSelection;
+			if (objectIs(memoizedSnapshot, nextSnapshot)) {
+				return previousSelection;
+			}
+
+			const nextSelection = selector(nextSnapshot);
+			if (isEqual !== undefined && isEqual(previousSelection, nextSelection)) {
+				memoizedSnapshot = nextSnapshot;
+				return previousSelection;
+			}
+
+			memoizedSnapshot = nextSnapshot;
+			memoizedSelection = nextSelection;
+			return nextSelection;
+		};
+
+		return [
+			() => memoizedSelector(getSnapshot()),
+			getServerSnapshot === undefined ? undefined : () => memoizedSelector(getServerSnapshot()),
+		];
+	}, [getSnapshot, getServerSnapshot, selector, isEqual]);
+
+	const value = React.useSyncExternalStore(subscribe, getSelection, getServerSelection);
+	React.useEffect(() => {
+		inst.hasValue = true;
+		inst.value = value;
+	}, [inst, value]);
+	React.useDebugValue(value);
+	return value;
+}

--- a/packages/core/src/astro/integration/shims/use-sync-external-store.js
+++ b/packages/core/src/astro/integration/shims/use-sync-external-store.js
@@ -1,0 +1,1 @@
+export { useSyncExternalStore } from "react";

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -145,6 +145,15 @@ function resolveAdminSource(projectRoot: string): string | undefined {
 	return undefined;
 }
 
+function resolveIntegrationShim(fileName: string): string {
+	const currentDir = dirname(fileURLToPath(import.meta.url));
+	const sourceShimPath = resolve(currentDir, "shims", fileName);
+	if (existsSync(sourceShimPath)) {
+		return sourceShimPath;
+	}
+	return resolve(currentDir, "..", "..", "src", "astro", "integration", "shims", fileName);
+}
+
 export interface VitePluginOptions {
 	/** Serializable config (database, storage, auth descriptors) */
 	serializableConfig: Record<string, unknown>;
@@ -351,6 +360,10 @@ export function createViteConfig(
 
 	const adminSourcePath = isDev ? resolveAdminSource(projectRoot) : undefined;
 	const useSource = adminSourcePath !== undefined;
+	const useSyncExternalStoreShimPath = resolveIntegrationShim("use-sync-external-store.js");
+	const useSyncExternalStoreWithSelectorShimPath = resolveIntegrationShim(
+		"use-sync-external-store-with-selector.js",
+	);
 
 	return {
 		// Astro SSR routes resolve version.ts from source (not tsdown dist),
@@ -381,14 +394,29 @@ export function createViteConfig(
 				// dep scanner can't reach it for pre-bundling — so the browser is
 				// served raw `module.exports` and hydration fails with
 				// `SyntaxError: ... does not provide an export named
-				// 'useSyncExternalStore'`. Redirect both shim entry points to the
-				// main `use-sync-external-store` package, which on React >=18
-				// (our peer-dep floor) delegates to React's built-in hook.
+				// 'useSyncExternalStore'`. Redirect both shim entry points to a
+				// tiny ESM shim file that re-exports React's built-in hook, and
+				// redirect the selector entry points to an ESM wrapper around that
+				// hook. The absolute file paths are required because Vite/Rolldown
+				// dependency optimization applies aliases without EmDash's virtual
+				// module plugin. This also avoids the package main entry's React
+				// 18+ dev warning.
+				{
+					find: "use-sync-external-store/shim/with-selector.js",
+					replacement: useSyncExternalStoreWithSelectorShimPath,
+				},
+				{
+					find: "use-sync-external-store/shim/with-selector",
+					replacement: useSyncExternalStoreWithSelectorShimPath,
+				},
 				{
 					find: "use-sync-external-store/shim/index.js",
-					replacement: "use-sync-external-store",
+					replacement: useSyncExternalStoreShimPath,
 				},
-				{ find: "use-sync-external-store/shim", replacement: "use-sync-external-store" },
+				{
+					find: "use-sync-external-store/shim",
+					replacement: useSyncExternalStoreShimPath,
+				},
 			],
 		},
 		// eslint-disable-next-line typescript/no-unsafe-type-assertion -- Monorepo has both vite 6 (docs) and vite 7 (core). tsgo resolves correctly.

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -1,4 +1,5 @@
-import { basename } from "node:path";
+import { existsSync } from "node:fs";
+import { basename, isAbsolute } from "node:path";
 
 import type { AstroConfig } from "astro";
 import { describe, expect, it } from "vitest";
@@ -104,23 +105,49 @@ describe("createViteConfig use-sync-external-store shim aliasing", () => {
 		);
 	}
 
+	function getAliasReplacement(config: ReturnType<typeof createViteConfig>, find: string) {
+		const alias = getAlias(config, find);
+		if (!alias || typeof alias !== "object" || !("replacement" in alias)) {
+			throw new Error(`Missing alias for ${find}`);
+		}
+		if (typeof alias.replacement !== "string") {
+			throw new Error(`Alias replacement for ${find} is not a string`);
+		}
+		return alias.replacement;
+	}
+
 	// Regression: with pnpm + React 18+, @tiptap/react pulls in
 	// `use-sync-external-store/shim` (CJS). Vite can't pre-bundle from the
 	// virtual store, so browsers get raw CJS and InlinePortableTextEditor
-	// fails to hydrate. The aliases redirect the shim to the main package,
-	// which delegates to React's built-in hook on React >=18.
+	// fails to hydrate. The aliases redirect the shim to ESM files that use
+	// React's built-in hook without loading the warning-only package main
+	// entry on React 18+.
 	for (const adapter of ["@astrojs/node", "@astrojs/cloudflare"] as const) {
-		it(`redirects use-sync-external-store/shim to the main package on ${adapter}`, () => {
+		it(`redirects use-sync-external-store/shim to React-backed ESM shim files on ${adapter}`, () => {
 			const config = buildConfig(adapter);
 
-			const indexAlias = getAlias(config, "use-sync-external-store/shim/index.js");
-			const shimAlias = getAlias(config, "use-sync-external-store/shim");
+			const withSelectorPath = getAliasReplacement(
+				config,
+				"use-sync-external-store/shim/with-selector.js",
+			);
+			const withSelectorBarePath = getAliasReplacement(
+				config,
+				"use-sync-external-store/shim/with-selector",
+			);
+			const indexPath = getAliasReplacement(config, "use-sync-external-store/shim/index.js");
+			const shimPath = getAliasReplacement(config, "use-sync-external-store/shim");
 
-			expect(indexAlias).toMatchObject({ replacement: "use-sync-external-store" });
-			expect(shimAlias).toMatchObject({ replacement: "use-sync-external-store" });
+			expect(isAbsolute(withSelectorPath)).toBe(true);
+			expect(existsSync(withSelectorPath)).toBe(true);
+			expect(withSelectorBarePath).toBe(withSelectorPath);
+			expect(basename(withSelectorPath)).toBe("use-sync-external-store-with-selector.js");
+			expect(isAbsolute(indexPath)).toBe(true);
+			expect(existsSync(indexPath)).toBe(true);
+			expect(shimPath).toBe(indexPath);
+			expect(basename(indexPath)).toBe("use-sync-external-store.js");
 		});
 
-		it(`lists the more-specific shim alias before the directory alias on ${adapter}`, () => {
+		it(`lists the more-specific shim aliases before the directory alias on ${adapter}`, () => {
 			const config = buildConfig(adapter);
 			const aliases = Array.isArray(config.resolve?.alias) ? config.resolve.alias : [];
 
@@ -130,10 +157,15 @@ describe("createViteConfig use-sync-external-store shim aliasing", () => {
 						typeof alias === "object" && alias !== null && "find" in alias && alias.find === find,
 				);
 
+			const withSelectorIdx = findIndex("use-sync-external-store/shim/with-selector.js");
+			const withSelectorBareIdx = findIndex("use-sync-external-store/shim/with-selector");
 			const indexIdx = findIndex("use-sync-external-store/shim/index.js");
 			const shimIdx = findIndex("use-sync-external-store/shim");
 
+			expect(withSelectorIdx).toBeGreaterThanOrEqual(0);
+			expect(withSelectorBareIdx).toBeGreaterThan(withSelectorIdx);
 			expect(indexIdx).toBeGreaterThanOrEqual(0);
+			expect(shimIdx).toBeGreaterThan(withSelectorBareIdx);
 			expect(shimIdx).toBeGreaterThan(indexIdx);
 		});
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes React 19 dev-console warnings from the visual editing toolbar's transitive `use-sync-external-store/shim` imports.

EmDash already aliases the shim because Vite can otherwise serve the raw CJS shim from pnpm's virtual store. The remaining issue is that the shim package entry logs a warning in development on React 18+ because it only re-exports React's built-in hook.

This keeps the CJS workaround but points the shim imports, including `shim/with-selector`, at small absolute ESM shim files shipped with EmDash. The absolute file paths are intentional: Vite/Rolldown dependency optimization applies aliases without EmDash's virtual module plugin, so virtual IDs can become unloadable during pre-bundling.

Issue: none filed.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`. N/A: no admin UI strings changed.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: N/A, bug fix.

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: GPT-5 via Codex

## Screenshots / test output

- `pnpm lint:json | jq '.diagnostics | length'` -> `0`
- `pnpm lint:quick` -> clean
- `pnpm typecheck` -> pass
- `pnpm lint` -> pass
- `pnpm format` -> ran
- `pnpm --filter emdash test -- run packages/core/tests/unit/astro/vite-config.test.ts packages/core/tests/unit/astro/integration/virtual-modules.test.ts` -> pass
- `pnpm build` -> pass
- `node scripts/query-counts.mjs --target sqlite --update --skip-seed` -> pass; no query-count snapshot diff

Note: `pnpm test` was run after `pnpm build`; all packages passed until `@emdash-cms/sandbox-workerd`, where the existing workerd integration test failed to bind its fixed local port `127.0.0.1:18788` in `enforces wall-time limit`. The same fixed-port failure reproduced when rerun in isolation and appears unrelated to this React/Vite alias change.
