### PR TITLE
fix: store translation_group in taxonomy parent_id to stop cross-locale parent leak

### DIFF
--- a/.changeset/fix-1347-taxonomy-parent-locale.md
+++ b/.changeset/fix-1347-taxonomy-parent-locale.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes hierarchical taxonomy terms losing their parent in translated locales. A child term now stores its parent's translation group instead of a locale-bound row id, so translating a parent automatically re-nests its existing children in every locale instead of flattening them to the root. A forward-only migration backfills existing parent links.

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -95,12 +95,16 @@ export interface TaxonomyDefTranslationsResponse {
  * Build tree structure from flat terms
  */
 function buildTree(flatTerms: TermWithCount[]): TermWithCount[] {
-	const map = new Map<string, TermWithCount>();
+	// `parentId` holds the parent's translation_group, so resolve links by group
+	// within the (already locale-filtered) set. Keying by row id would drop the
+	// link for every non-default locale, flattening the translated tree.
+	const byGroup = new Map<string, TermWithCount>();
 	const roots: TermWithCount[] = [];
-	for (const term of flatTerms) map.set(term.id, term);
+	for (const term of flatTerms) byGroup.set(term.translationGroup ?? term.id, term);
 	for (const term of flatTerms) {
-		if (term.parentId && map.has(term.parentId)) {
-			map.get(term.parentId)!.children.push(term);
+		const parent = term.parentId ? byGroup.get(term.parentId) : undefined;
+		if (parent) {
+			parent.children.push(term);
 		} else {
 			roots.push(term);
 		}
@@ -422,13 +426,6 @@ async function validateParentTerm(
 ): Promise<{ code: "VALIDATION_ERROR"; message: string } | null> {
 	if (parentId === undefined || parentId === null) return null;
 
-	if (termId !== undefined && parentId === termId) {
-		return {
-			code: "VALIDATION_ERROR",
-			message: "A term cannot be its own parent",
-		};
-	}
-
 	const parent = await repo.findById(parentId);
 	if (!parent) {
 		return {
@@ -443,6 +440,22 @@ async function validateParentTerm(
 		};
 	}
 
+	// Parentage keys off translation_group (what `parent_id` persists), so the
+	// self-parent and cycle checks compare groups, not row ids — picking a
+	// sibling translation of the term as its parent is still self-parenting.
+	const parentGroup = parent.translationGroup ?? parent.id;
+	let termGroup: string | null = null;
+	if (termId !== undefined) {
+		const term = await repo.findById(termId);
+		termGroup = term ? (term.translationGroup ?? term.id) : termId;
+		if (parentGroup === termGroup) {
+			return {
+				code: "VALIDATION_ERROR",
+				message: "A term cannot be its own parent",
+			};
+		}
+	}
+
 	// Walk up the parent chain. Two checks fold into one walk:
 	//   - Cycle detection (only on update — a non-existent term-being-
 	//     created can't be its own ancestor): if the walk revisits termId
@@ -454,11 +467,13 @@ async function validateParentTerm(
 	// The depth-exceeded error fires only when we hit the limit AND there
 	// was still chain to walk — a legitimate chain of exactly MAX_DEPTH
 	// ancestors exits with `cursor === null` and is accepted.
+	// `parent_id` stores a translation_group, which always equals the anchor
+	// row's id, so findById(cursor) still resolves each ancestor.
 	const MAX_DEPTH = 100;
 	let cursor: string | null = parent.parentId;
 	let steps = 0;
 	while (cursor !== null && steps < MAX_DEPTH) {
-		if (termId !== undefined && cursor === termId) {
+		if (termGroup !== null && cursor === termGroup) {
 			return {
 				code: "VALIDATION_ERROR",
 				message: "Cycle detected: cannot make a descendant the parent",
@@ -504,7 +519,7 @@ export async function handleTermCreate(
 		const repo = new TaxonomyRepository(db);
 
 		// Coerce empty-string parentId to undefined (treat as "no parent").
-		let parentId =
+		const parentId =
 			input.parentId === "" || input.parentId === undefined ? undefined : input.parentId;
 
 		// Conflict check is scoped to locale (per-locale slugs are unique).
@@ -521,23 +536,10 @@ export async function handleTermCreate(
 			};
 		}
 
-		// If creating a translation whose parent is the translated sibling of
-		// the source's parent, try to resolve the parent in the same locale.
-		if (input.translationOf && parentId) {
-			const source = await repo.findById(input.translationOf);
-			if (source?.parentId === parentId && input.locale) {
-				const sourceParent = await repo.findById(parentId);
-				if (sourceParent?.translationGroup) {
-					const translatedParent = await db
-						.selectFrom("taxonomies")
-						.select("id")
-						.where("translation_group", "=", sourceParent.translationGroup)
-						.where("locale", "=", input.locale)
-						.executeTakeFirst();
-					if (translatedParent) parentId = translatedParent.id;
-				}
-			}
-		}
+		// No locale re-pointing needed: `repo.create` persists the parent's
+		// translation_group in `parent_id`, so a child stays nested under the
+		// parent in every locale automatically — including parents translated
+		// after the child was created.
 
 		// Validate parentId: must exist AND belong to the same taxonomy.
 		// (Cycle check is N/A on create — the term doesn't exist yet.)
@@ -606,7 +608,9 @@ export async function handleTermGet(
 		}
 
 		const count = await repo.countEntriesWithTerm(term.id);
-		const children = await repo.findChildren(term.id);
+		// Children share this term's translation_group as their parent_id; scope
+		// to the term's own locale so the response stays within one locale's tree.
+		const children = await repo.findChildren(term.id, term.locale);
 
 		return {
 			success: true,
@@ -791,6 +795,9 @@ export async function handleTermDelete(
 			};
 		}
 
+		// Block deletion if the term's group still parents any child in any
+		// locale — children store this group in parent_id, so removing the term
+		// would orphan them (or null their parent_id via the self-FK).
 		const children = await repo.findChildren(term.id);
 		if (children.length > 0) {
 			return {

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -420,14 +420,17 @@ export async function handleTermList(
  *   - `parentId === null` -> caller intends to detach; no-op here.
  *   - parent must exist (FK exists -> term row not soft-deleted).
  *   - parent must live in the same taxonomy.
- *   - if `termId` is provided (update path), reject `parentId === termId`
- *     (self-parent) and walk up the parent chain to detect cycles.
+ *   - reject a parent in the term's own translation_group (self-parent),
+ *     including the create path: a translation inherits its source's group, so
+ *     `selfGroup` carries that prospective group when `termId` is absent.
+ *   - on update, walk up the parent chain to detect cycles.
  */
 async function validateParentTerm(
 	repo: TaxonomyRepository,
 	taxonomyName: string,
 	termId: string | undefined,
 	parentId: string | null | undefined,
+	selfGroup?: string | null,
 ): Promise<{ code: "VALIDATION_ERROR"; message: string } | null> {
 	if (parentId === undefined || parentId === null) return null;
 
@@ -449,16 +452,16 @@ async function validateParentTerm(
 	// self-parent and cycle checks compare groups, not row ids — picking a
 	// sibling translation of the term as its parent is still self-parenting.
 	const parentGroup = parent.translationGroup ?? parent.id;
-	let termGroup: string | null = null;
+	let termGroup: string | null = selfGroup ?? null;
 	if (termId !== undefined) {
 		const term = await repo.findById(termId);
 		termGroup = term ? (term.translationGroup ?? term.id) : termId;
-		if (parentGroup === termGroup) {
-			return {
-				code: "VALIDATION_ERROR",
-				message: "A term cannot be its own parent",
-			};
-		}
+	}
+	if (termGroup !== null && parentGroup === termGroup) {
+		return {
+			code: "VALIDATION_ERROR",
+			message: "A term cannot be its own parent",
+		};
 	}
 
 	// Walk up the parent chain. Two checks fold into one walk:
@@ -546,9 +549,24 @@ export async function handleTermCreate(
 		// parent in every locale automatically — including parents translated
 		// after the child was created.
 
+		// A translation inherits its source's translation_group; pass that
+		// prospective group so validateParentTerm can reject a parent in the same
+		// group (cross-locale self-parent) even though the term doesn't exist yet.
+		let selfGroup: string | null = null;
+		if (input.translationOf) {
+			const source = await repo.findById(input.translationOf);
+			selfGroup = source ? (source.translationGroup ?? source.id) : null;
+		}
+
 		// Validate parentId: must exist AND belong to the same taxonomy.
 		// (Cycle check is N/A on create — the term doesn't exist yet.)
-		const parentError = await validateParentTerm(repo, taxonomyName, undefined, parentId);
+		const parentError = await validateParentTerm(
+			repo,
+			taxonomyName,
+			undefined,
+			parentId,
+			selfGroup,
+		);
 		if (parentError) {
 			return { success: false, error: parentError };
 		}

--- a/packages/core/src/api/handlers/taxonomies.ts
+++ b/packages/core/src/api/handlers/taxonomies.ts
@@ -95,14 +95,19 @@ export interface TaxonomyDefTranslationsResponse {
  * Build tree structure from flat terms
  */
 function buildTree(flatTerms: TermWithCount[]): TermWithCount[] {
-	// `parentId` holds the parent's translation_group, so resolve links by group
-	// within the (already locale-filtered) set. Keying by row id would drop the
-	// link for every non-default locale, flattening the translated tree.
-	const byGroup = new Map<string, TermWithCount>();
+	// `parentId` holds the parent's translation_group, so resolve links by group.
+	// Key by (locale, group): a child's parent lives in the same locale, and an
+	// unfiltered list mixes locales whose translated siblings share a group —
+	// keying by group alone would collide and misattach children across locales.
+	const byLocaleGroup = new Map<string, TermWithCount>();
 	const roots: TermWithCount[] = [];
-	for (const term of flatTerms) byGroup.set(term.translationGroup ?? term.id, term);
 	for (const term of flatTerms) {
-		const parent = term.parentId ? byGroup.get(term.parentId) : undefined;
+		byLocaleGroup.set(`${term.locale}::${term.translationGroup ?? term.id}`, term);
+	}
+	for (const term of flatTerms) {
+		const parent = term.parentId
+			? byLocaleGroup.get(`${term.locale}::${term.parentId}`)
+			: undefined;
 		if (parent) {
 			parent.children.push(term);
 		} else {

--- a/packages/core/src/cli/commands/export-seed.ts
+++ b/packages/core/src/cli/commands/export-seed.ts
@@ -375,9 +375,10 @@ async function exportTaxonomies(
 		// Terms in this def's locale.
 		const terms = await termRepo.findByName(def.name, { locale: def.locale });
 
-		// id -> slug for parent resolution within this locale.
-		const idToSlug = new Map<string, string>();
-		for (const term of terms) idToSlug.set(term.id, term.slug);
+		// translation_group -> slug for parent resolution within this locale.
+		// `parentId` stores the parent's translation_group, not a row id.
+		const groupToSlug = new Map<string, string>();
+		for (const term of terms) groupToSlug.set(term.translationGroup ?? term.id, term.slug);
 
 		// translation_group -> seed id of the anchor term.
 		const termGroupToSeedId = new Map<string, string>();
@@ -396,7 +397,7 @@ async function exportTaxonomies(
 				description: typeof term.data?.description === "string" ? term.data.description : undefined,
 			};
 
-			if (term.parentId) seedTerm.parent = idToSlug.get(term.parentId);
+			if (term.parentId) seedTerm.parent = groupToSlug.get(term.parentId);
 
 			if (i18nEnabled && term.locale) {
 				seedTerm.locale = term.locale;

--- a/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
+++ b/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
@@ -18,8 +18,12 @@ import { sql } from "kysely";
  * its anchor row's id, so the self-FK on `parent_id` stays valid. We only
  * rewrite when that anchor row still exists; if a parent's anchor was deleted
  * but a sibling translation survives, the existing locale-bound id is left as-is
- * rather than rewritten to a dangling FK value. The correlated subquery is a
- * no-op for rows that already hold a group (an anchor row's id resolves to
+ * rather than rewritten to a dangling FK value. Such a child then renders as a
+ * root rather than nested — an accepted degradation for an already-inconsistent
+ * dataset (its `translation_group` already points at a deleted row, which breaks
+ * `content_taxonomies` joins too). New deletes can't recreate this state: a
+ * parent with children in any locale is undeletable. The correlated subquery is
+ * a no-op for rows that already hold a group (an anchor row's id resolves to
  * itself), so the migration is safe to re-run.
  *
  * Dialect-independent: the correlated-subquery `UPDATE` runs on SQLite (incl.

--- a/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
+++ b/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
@@ -1,0 +1,57 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+/**
+ * Store the parent's `translation_group` in `taxonomies.parent_id` instead of a
+ * locale-bound row id.
+ *
+ * Before this, a term's `parent_id` pointed at one specific parent *row* (one
+ * locale). A child translated in another locale could end up parented to a row
+ * in a different locale, silently flattening that locale's tree (#1347). Every
+ * other taxonomy i18n relationship already keys off `translation_group`
+ * (`content_taxonomies.taxonomy_id`, `_emdash_menu_items.reference_id`), so this
+ * aligns parentage with that model: a child links to the parent *concept* and
+ * stays nested in whichever locale that parent has been translated into.
+ *
+ * Backfill rewrites every existing `parent_id` from the referenced parent row's
+ * id to that parent's `translation_group`. A `translation_group` always equals
+ * its anchor row's id, which exists, so the self-FK on `parent_id` stays valid.
+ * The correlated subquery is a no-op for rows that already hold a group (an
+ * anchor row's id resolves to itself), so the migration is safe to re-run.
+ *
+ * Dialect-independent: the correlated-subquery `UPDATE` runs on SQLite (incl.
+ * D1) and Postgres alike.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await sql`
+		UPDATE taxonomies
+		SET parent_id = (
+			SELECT p.translation_group FROM taxonomies p WHERE p.id = taxonomies.parent_id
+		)
+		WHERE parent_id IS NOT NULL
+			AND EXISTS (
+				SELECT 1 FROM taxonomies p
+				WHERE p.id = taxonomies.parent_id AND p.translation_group IS NOT NULL
+			)
+	`.execute(db);
+}
+
+/**
+ * Map each `parent_id` group back to the row id of the parent in the same
+ * locale (the pre-migration shape). Rows with no same-locale parent are left as
+ * they are rather than nulled, so a rollback never silently detaches a subtree.
+ */
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await sql`
+		UPDATE taxonomies
+		SET parent_id = COALESCE(
+			(
+				SELECT c.id FROM taxonomies c
+				WHERE c.translation_group = taxonomies.parent_id
+					AND c.locale = taxonomies.locale
+			),
+			parent_id
+		)
+		WHERE parent_id IS NOT NULL
+	`.execute(db);
+}

--- a/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
+++ b/packages/core/src/database/migrations/045_taxonomy_parent_group.ts
@@ -14,10 +14,13 @@ import { sql } from "kysely";
  * stays nested in whichever locale that parent has been translated into.
  *
  * Backfill rewrites every existing `parent_id` from the referenced parent row's
- * id to that parent's `translation_group`. A `translation_group` always equals
- * its anchor row's id, which exists, so the self-FK on `parent_id` stays valid.
- * The correlated subquery is a no-op for rows that already hold a group (an
- * anchor row's id resolves to itself), so the migration is safe to re-run.
+ * id to that parent's `translation_group`. A `translation_group` normally equals
+ * its anchor row's id, so the self-FK on `parent_id` stays valid. We only
+ * rewrite when that anchor row still exists; if a parent's anchor was deleted
+ * but a sibling translation survives, the existing locale-bound id is left as-is
+ * rather than rewritten to a dangling FK value. The correlated subquery is a
+ * no-op for rows that already hold a group (an anchor row's id resolves to
+ * itself), so the migration is safe to re-run.
  *
  * Dialect-independent: the correlated-subquery `UPDATE` runs on SQLite (incl.
  * D1) and Postgres alike.
@@ -31,7 +34,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 		WHERE parent_id IS NOT NULL
 			AND EXISTS (
 				SELECT 1 FROM taxonomies p
-				WHERE p.id = taxonomies.parent_id AND p.translation_group IS NOT NULL
+				WHERE p.id = taxonomies.parent_id
+					AND p.translation_group IS NOT NULL
+					-- Only rewrite to a translation_group that is itself a live row
+					-- id, so the self-FK on parent_id can never dangle.
+					AND EXISTS (SELECT 1 FROM taxonomies a WHERE a.id = p.translation_group)
 			)
 	`.execute(db);
 }

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -46,6 +46,7 @@ import * as m041 from "./041_content_locale_list_index.js";
 import * as m042 from "./042_byline_fields.js";
 import * as m043 from "./043_content_references.js";
 import * as m044 from "./044_comment_reactions.js";
+import * as m045 from "./045_taxonomy_parent_group.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -91,6 +92,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"042_byline_fields": m042,
 	"043_content_references": m043,
 	"044_comment_reactions": m044,
+	"045_taxonomy_parent_group": m045,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -64,7 +64,15 @@ export class TaxonomyRepository {
 
 		// Empty-string parentId is coerced to null defensively. Higher layers
 		// also normalize this — see handleTermCreate / handleTermUpdate.
-		const parentId = input.parentId === undefined || input.parentId === "" ? null : input.parentId;
+		// `parent_id` stores the parent's locale-agnostic translation_group (not a
+		// row id), mirroring content_taxonomies.taxonomy_id, so a child stays
+		// nested in every locale's tree. resolveTranslationGroup accepts either a
+		// row id or an already-resolved group, so this is idempotent.
+		const parentInput =
+			input.parentId === undefined || input.parentId === "" ? null : input.parentId;
+		const parentId = parentInput
+			? ((await this.resolveTranslationGroup(parentInput)) ?? parentInput)
+			: null;
 
 		let translationGroup = id;
 		if (input.translationOf) {
@@ -150,14 +158,26 @@ export class TaxonomyRepository {
 		return rows.map((row) => this.rowToTaxonomy(row));
 	}
 
-	async findChildren(parentId: string): Promise<Taxonomy[]> {
-		const rows = await this.db
+	/**
+	 * Children of a term. Accepts a term id OR a translation_group and resolves
+	 * to the group, since `parent_id` stores the parent's translation_group.
+	 * Pass `locale` to scope to one locale's tree (children share the parent's
+	 * group across locales); omit it to find children in every locale (used to
+	 * block deletes that would orphan a sibling translation's subtree).
+	 */
+	async findChildren(parentIdOrGroup: string, locale?: string): Promise<Taxonomy[]> {
+		const group = await this.resolveTranslationGroup(parentIdOrGroup);
+		if (!group) return [];
+
+		let query = this.db
 			.selectFrom("taxonomies")
 			.selectAll()
-			.where("parent_id", "=", parentId)
+			.where("parent_id", "=", group)
 			.orderBy("label", "asc")
-			.orderBy("id", "asc")
-			.execute();
+			.orderBy("id", "asc");
+		if (locale !== undefined) query = query.where("locale", "=", locale);
+
+		const rows = await query.execute();
 		return rows.map((row) => this.rowToTaxonomy(row));
 	}
 
@@ -184,7 +204,12 @@ export class TaxonomyRepository {
 		if (input.label !== undefined) updates.label = input.label;
 		if (input.parentId !== undefined) {
 			// Defense in depth: empty-string parentId means null (no parent).
-			updates.parent_id = input.parentId === "" ? null : input.parentId;
+			// Otherwise persist the parent's translation_group (locale-agnostic),
+			// matching create() — see the note there.
+			updates.parent_id =
+				input.parentId === "" || input.parentId === null
+					? null
+					: ((await this.resolveTranslationGroup(input.parentId)) ?? input.parentId);
 		}
 		if (input.data !== undefined) updates.data = JSON.stringify(input.data);
 

--- a/packages/core/src/database/repositories/taxonomy.ts
+++ b/packages/core/src/database/repositories/taxonomy.ts
@@ -70,9 +70,7 @@ export class TaxonomyRepository {
 		// row id or an already-resolved group, so this is idempotent.
 		const parentInput =
 			input.parentId === undefined || input.parentId === "" ? null : input.parentId;
-		const parentId = parentInput
-			? ((await this.resolveTranslationGroup(parentInput)) ?? parentInput)
-			: null;
+		const parentId = parentInput ? await this.resolveParentRef(parentInput) : null;
 
 		let translationGroup = id;
 		if (input.translationOf) {
@@ -209,7 +207,7 @@ export class TaxonomyRepository {
 			updates.parent_id =
 				input.parentId === "" || input.parentId === null
 					? null
-					: ((await this.resolveTranslationGroup(input.parentId)) ?? input.parentId);
+					: await this.resolveParentRef(input.parentId);
 		}
 		if (input.data !== undefined) updates.data = JSON.stringify(input.data);
 
@@ -417,6 +415,26 @@ export class TaxonomyRepository {
 			.where("taxonomy_id", "=", group)
 			.executeTakeFirst();
 		return Number(result?.count ?? 0);
+	}
+
+	/**
+	 * Resolve a parent reference (a row id or a translation_group) to the value
+	 * persisted in `parent_id`: the parent's translation_group, which is
+	 * locale-agnostic so the child stays nested in every locale. A
+	 * translation_group normally equals its anchor row's id, which satisfies the
+	 * self-FK on `parent_id`. If that anchor row is missing (a translation whose
+	 * anchor was deleted), fall back to the id we were given so we never write a
+	 * dangling FK value.
+	 */
+	private async resolveParentRef(idOrGroup: string): Promise<string> {
+		const group = await this.resolveTranslationGroup(idOrGroup);
+		if (!group) return idOrGroup;
+		const anchor = await this.db
+			.selectFrom("taxonomies")
+			.select("id")
+			.where("id", "=", group)
+			.executeTakeFirst();
+		return anchor ? group : idOrGroup;
 	}
 
 	private async resolveTranslationGroup(idOrGroup: string): Promise<string | null> {

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -677,11 +677,11 @@ function rowToTaxonomyDef(row: {
  * Build tree structure from flat terms
  */
 function buildTree(flatTerms: TaxonomyTermRow[], counts: Map<string, number>): TaxonomyTerm[] {
-	// parent_id holds the parent's translation_group, so index nodes by group
-	// and link children by it. The flat set is already locale-filtered, so each
-	// group resolves to that locale's row — keying by row id would break links
-	// in every non-default locale and flatten the translated tree.
-	const byGroup = new Map<string, TaxonomyTerm>();
+	// parent_id holds the parent's translation_group, so link children by it.
+	// Key by (locale, group): a child's parent lives in the same locale, and an
+	// unfiltered set mixes locales whose translated siblings share a group —
+	// keying by group alone would collide and misattach children across locales.
+	const byLocaleGroup = new Map<string, TaxonomyTerm>();
 	const nodes: TaxonomyTerm[] = [];
 	const roots: TaxonomyTerm[] = [];
 
@@ -698,12 +698,14 @@ function buildTree(flatTerms: TaxonomyTermRow[], counts: Map<string, number>): T
 			locale: term.locale,
 			translationGroup: term.translation_group,
 		};
-		byGroup.set(term.translation_group ?? term.id, node);
+		byLocaleGroup.set(`${term.locale}::${term.translation_group ?? term.id}`, node);
 		nodes.push(node);
 	}
 
 	for (const node of nodes) {
-		const parent = node.parentId ? byGroup.get(node.parentId) : undefined;
+		const parent = node.parentId
+			? byLocaleGroup.get(`${node.locale}::${node.parentId}`)
+			: undefined;
 		if (parent) {
 			parent.children.push(node);
 		} else {

--- a/packages/core/src/taxonomies/index.ts
+++ b/packages/core/src/taxonomies/index.ts
@@ -250,7 +250,9 @@ async function loadTerm(
 	let childrenQuery = db
 		.selectFrom("taxonomies")
 		.selectAll()
-		.where("parent_id", "=", row.id)
+		// Children store the parent's translation_group in parent_id (not a row
+		// id), so a translated parent still owns its children in its own locale.
+		.where("parent_id", "=", row.translation_group ?? row.id)
 		.orderBy("label", "asc");
 	const termLocale = row.locale;
 	if (termLocale) childrenQuery = childrenQuery.where("locale", "=", termLocale);
@@ -675,11 +677,16 @@ function rowToTaxonomyDef(row: {
  * Build tree structure from flat terms
  */
 function buildTree(flatTerms: TaxonomyTermRow[], counts: Map<string, number>): TaxonomyTerm[] {
-	const map = new Map<string, TaxonomyTerm>();
+	// parent_id holds the parent's translation_group, so index nodes by group
+	// and link children by it. The flat set is already locale-filtered, so each
+	// group resolves to that locale's row — keying by row id would break links
+	// in every non-default locale and flatten the translated tree.
+	const byGroup = new Map<string, TaxonomyTerm>();
+	const nodes: TaxonomyTerm[] = [];
 	const roots: TaxonomyTerm[] = [];
 
 	for (const term of flatTerms) {
-		map.set(term.id, {
+		const node: TaxonomyTerm = {
 			id: term.id,
 			name: term.name,
 			slug: term.slug,
@@ -690,14 +697,17 @@ function buildTree(flatTerms: TaxonomyTermRow[], counts: Map<string, number>): T
 			count: counts.get(term.translation_group ?? term.id) ?? 0,
 			locale: term.locale,
 			translationGroup: term.translation_group,
-		});
+		};
+		byGroup.set(term.translation_group ?? term.id, node);
+		nodes.push(node);
 	}
 
-	for (const term of map.values()) {
-		if (term.parentId && map.has(term.parentId)) {
-			map.get(term.parentId)!.children.push(term);
+	for (const node of nodes) {
+		const parent = node.parentId ? byGroup.get(node.parentId) : undefined;
+		if (parent) {
+			parent.children.push(node);
 		} else {
-			roots.push(term);
+			roots.push(node);
 		}
 	}
 

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -127,6 +127,7 @@ describe("Database Migrations (Integration)", () => {
 			"042_byline_fields",
 			"043_content_references",
 			"044_comment_reactions",
+			"045_taxonomy_parent_group",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();

--- a/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
+++ b/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
@@ -367,6 +367,24 @@ describeEachDialect("taxonomy parent stays nested across locales (#1347)", (dial
 		expect(news.children.map((c) => c.slug)).toEqual(["breaking"]);
 	});
 
+	it("rejects a translation parented to its own translation group", async () => {
+		const enTerm = await unwrap(
+			handleTermCreate(ctx.db, "categories", { slug: "news", label: "News", locale: "en" }),
+		);
+		// Creating an FR translation of enTerm whose parent is enTerm (same group)
+		// is a cross-locale self-parent and must be rejected, not silently stored.
+		const res = await handleTermCreate(ctx.db, "categories", {
+			slug: "actus",
+			label: "Actus",
+			locale: "fr",
+			parentId: enTerm.id,
+			translationOf: enTerm.id,
+		});
+		expect(res.success).toBe(false);
+		if (res.success) throw new Error("expected validation failure");
+		expect(res.error.code).toBe("VALIDATION_ERROR");
+	});
+
 	it("rejects a parent that belongs to a different taxonomy", async () => {
 		await insertHierarchicalDef(ctx.db, "tags");
 		const otherParent = await unwrap(

--- a/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
+++ b/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
@@ -324,6 +324,49 @@ describeEachDialect("taxonomy parent stays nested across locales (#1347)", (dial
 		expect(enList.data.terms[0]!.children.map((c) => c.slug)).toEqual(["breaking"]);
 	});
 
+	it("keeps each locale's child under its own parent in an unfiltered list", async () => {
+		const enParent = await unwrap(
+			handleTermCreate(ctx.db, "categories", { slug: "news", label: "News", locale: "en" }),
+		);
+		const enChild = await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "breaking",
+				label: "Breaking",
+				locale: "en",
+				parentId: enParent.id,
+			}),
+		);
+		const frParent = await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "actus",
+				label: "Actus",
+				locale: "fr",
+				translationOf: enParent.id,
+			}),
+		);
+		await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "actualites",
+				label: "Actualités",
+				locale: "fr",
+				parentId: frParent.id,
+				translationOf: enChild.id,
+			}),
+		);
+
+		// No locale filter: rows from both locales are returned. Each child must
+		// stay under the parent in its own locale, not collapse onto a shared
+		// translation_group key.
+		const list = await handleTermList(ctx.db, "categories");
+		if (!list.success) throw new Error(list.error.message);
+		const roots = list.data.terms.toSorted((a, b) => a.slug.localeCompare(b.slug));
+		expect(roots.map((t) => t.slug)).toEqual(["actus", "news"]);
+		const actus = roots[0]!;
+		const news = roots[1]!;
+		expect(actus.children.map((c) => c.slug)).toEqual(["actualites"]);
+		expect(news.children.map((c) => c.slug)).toEqual(["breaking"]);
+	});
+
 	it("rejects a parent that belongs to a different taxonomy", async () => {
 		await insertHierarchicalDef(ctx.db, "tags");
 		const otherParent = await unwrap(

--- a/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
+++ b/packages/core/tests/integration/taxonomies/taxonomy-locale-terms.test.ts
@@ -15,13 +15,20 @@
 import { Role, type RoleLevel } from "@emdash-cms/auth";
 import type { APIContext } from "astro";
 import type { Kysely } from "kysely";
+import { ulid } from "ulidx";
 import { afterEach, beforeEach, expect, it } from "vitest";
 
 import { handleContentGet } from "../../../src/api/handlers/content.js";
 import {
+	handleTermCreate,
+	handleTermList,
+	type TermWithCount,
+} from "../../../src/api/handlers/taxonomies.js";
+import {
 	GET as getTerms,
 	POST as postTerms,
 } from "../../../src/astro/routes/api/content/[collection]/[id]/terms/[taxonomy].js";
+import { up as up045 } from "../../../src/database/migrations/045_taxonomy_parent_group.js";
 import { ContentRepository } from "../../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../../src/database/repositories/taxonomy.js";
 import type { Database } from "../../../src/database/types.js";
@@ -227,3 +234,191 @@ describeEachDialect("content terms route locale-awareness (#1218)", (dialect) =>
 		expect(ids).toEqual([fx.frTagId]);
 	});
 });
+
+/**
+ * Parent links are stored as the parent's translation_group, not a locale-bound
+ * row id, so a child stays nested under the parent in every locale (#1347).
+ */
+async function insertHierarchicalDef(db: Kysely<Database>, name: string): Promise<void> {
+	await db
+		.insertInto("_emdash_taxonomy_defs")
+		.values({
+			id: ulid(),
+			name,
+			label: name,
+			label_singular: null,
+			hierarchical: 1,
+			collections: JSON.stringify([]),
+			locale: "en",
+			translation_group: ulid(),
+		})
+		.execute();
+}
+
+function findInTree(terms: TermWithCount[], slug: string): TermWithCount | undefined {
+	for (const term of terms) {
+		if (term.slug === slug) return term;
+		const nested = findInTree(term.children, slug);
+		if (nested) return nested;
+	}
+	return undefined;
+}
+
+describeEachDialect("taxonomy parent stays nested across locales (#1347)", (dialect) => {
+	let ctx: DialectTestContext;
+
+	beforeEach(async () => {
+		ctx = await setupForDialectWithCollections(dialect);
+		await insertHierarchicalDef(ctx.db, "categories");
+	});
+
+	afterEach(async () => {
+		await teardownForDialect(ctx);
+	});
+
+	it("nests a child under a parent translated AFTER the child", async () => {
+		// Child is translated before the parent: the FR parent does not exist
+		// when the FR child is created.
+		const enParent = await unwrap(
+			handleTermCreate(ctx.db, "categories", { slug: "news", label: "News", locale: "en" }),
+		);
+		const enChild = await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "breaking",
+				label: "Breaking",
+				locale: "en",
+				parentId: enParent.id,
+			}),
+		);
+		await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "actualites",
+				label: "Actualités",
+				locale: "fr",
+				parentId: enParent.id,
+				translationOf: enChild.id,
+			}),
+		);
+
+		// Now translate the parent into FR.
+		await unwrap(
+			handleTermCreate(ctx.db, "categories", {
+				slug: "actus",
+				label: "Actus",
+				locale: "fr",
+				translationOf: enParent.id,
+			}),
+		);
+
+		const frList = await handleTermList(ctx.db, "categories", { locale: "fr" });
+		if (!frList.success) throw new Error(frList.error.message);
+		// The FR child must be nested under the FR parent, not flattened to root.
+		expect(frList.data.terms.map((t) => t.slug)).toEqual(["actus"]);
+		const frParent = frList.data.terms[0]!;
+		expect(frParent.children.map((c) => c.slug)).toEqual(["actualites"]);
+
+		// EN tree is unaffected.
+		const enList = await handleTermList(ctx.db, "categories", { locale: "en" });
+		if (!enList.success) throw new Error(enList.error.message);
+		expect(enList.data.terms.map((t) => t.slug)).toEqual(["news"]);
+		expect(enList.data.terms[0]!.children.map((c) => c.slug)).toEqual(["breaking"]);
+	});
+
+	it("rejects a parent that belongs to a different taxonomy", async () => {
+		await insertHierarchicalDef(ctx.db, "tags");
+		const otherParent = await unwrap(
+			handleTermCreate(ctx.db, "tags", { slug: "misc", label: "Misc", locale: "en" }),
+		);
+		const res = await handleTermCreate(ctx.db, "categories", {
+			slug: "orphan",
+			label: "Orphan",
+			locale: "en",
+			parentId: otherParent.id,
+		});
+		expect(res.success).toBe(false);
+		if (res.success) throw new Error("expected validation failure");
+		expect(res.error.code).toBe("VALIDATION_ERROR");
+	});
+
+	it("backfills legacy locale-bound parent_id to the translation_group", async () => {
+		// Simulate pre-#1347 rows by writing locale-bound parent ids directly.
+		const enParentId = ulid();
+		const group = enParentId; // anchor row: translation_group == id
+		const frParentId = ulid();
+		const enChildId = ulid();
+		const childGroup = enChildId;
+		const frChildId = ulid();
+
+		await ctx.db
+			.insertInto("taxonomies")
+			.values([
+				{
+					id: enParentId,
+					name: "categories",
+					slug: "news",
+					label: "News",
+					parent_id: null,
+					data: null,
+					locale: "en",
+					translation_group: group,
+				},
+				{
+					id: frParentId,
+					name: "categories",
+					slug: "actus",
+					label: "Actus",
+					parent_id: null,
+					data: null,
+					locale: "fr",
+					translation_group: group,
+				},
+				{
+					id: enChildId,
+					name: "categories",
+					slug: "breaking",
+					label: "Breaking",
+					parent_id: enParentId, // legacy: anchor row id (== group)
+					data: null,
+					locale: "en",
+					translation_group: childGroup,
+				},
+				{
+					id: frChildId,
+					name: "categories",
+					slug: "actualites",
+					label: "Actualités",
+					parent_id: frParentId, // legacy: cross-locale row id (the bug)
+					data: null,
+					locale: "fr",
+					translation_group: childGroup,
+				},
+			])
+			.execute();
+
+		await up045(ctx.db);
+
+		const repo = new TaxonomyRepository(ctx.db);
+		const frChild = await repo.findById(frChildId);
+		const enChild = await repo.findById(enChildId);
+		// Both children now reference the parent's translation_group.
+		expect(frChild!.parentId).toBe(group);
+		expect(enChild!.parentId).toBe(group);
+
+		// And the FR tree renders nested rather than flattened.
+		const frList = await handleTermList(ctx.db, "categories", { locale: "fr" });
+		if (!frList.success) throw new Error(frList.error.message);
+		const frParent = findInTree(frList.data.terms, "actus");
+		expect(frParent?.children.map((c) => c.slug)).toEqual(["actualites"]);
+	});
+});
+
+async function unwrap<T>(
+	p: Promise<
+		| { success: true; data: { term: T } }
+		| { success: false; error: { code: string; message: string } }
+	>,
+): Promise<T> {
+	const res = await p;
+	if (!res.success) throw new Error(`${res.error.code}: ${res.error.message}`);
+	return res.data.term;
+}


### PR DESCRIPTION
## What does this PR do?

Hierarchical taxonomy terms encoded a term's parent as a locale-bound row id, but every other taxonomy translation relationship keys off the locale-agnostic translation group. Because of that mismatch, a child term translated into a second locale could end up pointing at a parent row from a different locale. The per-locale tree then quietly collapsed: the child rendered at the root instead of under its parent, with no error to signal anything was wrong. A best-effort patch in the create path only helped when the translated parent already existed, and it never repaired children that were created earlier.

The fix is to treat parentage the same way the rest of the taxonomy code already treats cross-locale identity, by storing the parent's translation group rather than one locale's row. A child now links to the parent concept, so translating that parent later automatically re-nests the children that were waiting on it, in whichever locales they live. Reads resolve a parent within the child's own locale, so an unfiltered list that mixes locales keeps each child under the right parent instead of colliding on the shared group. Validation now compares groups too, which means a translation can no longer be parented to its own group, and a forward-only migration rewrites the parent links that already exist so current trees render correctly after upgrade.

This is backwards compatible: the migration is additive and forward-only, and the stored value stays a real row id (the group's anchor), so the existing foreign key on the column still holds.

Closes #1347

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible admin UI strings wrapped for translation (n/a: server-side handlers and a migration only, no admin UI strings)
- [x] I have added a changeset (this changes a published package)
- [ ] New features link to an approved Discussion (n/a: bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8

## Screenshots / test output

Lint, typecheck, and the taxonomy, migration, and seed suites pass (342 tests). New cases cover a child nesting under a parent that is translated after it, a mixed-locale list keeping each child under its own parent, the migration converting a legacy cross-locale link, and the rejection of invalid or self-referential parents.

AI was used for assistance.
