### PR TITLE
chore(release): publish already-versioned 0.24.0

### DIFF
--- a/.changeset/fix-1347-taxonomy-parent-locale.md
+++ b/.changeset/fix-1347-taxonomy-parent-locale.md
@@ -1,5 +1,0 @@
----
-"emdash": patch
----
-
-Fixes hierarchical taxonomy terms losing their parent in translated locales. A child term now stores its parent's translation group instead of a locale-bound row id, so translating a parent automatically re-nests its existing children in every locale instead of flattening them to the root. A forward-only migration backfills existing parent links.

--- a/.changeset/fresh-buckets-exercise.md
+++ b/.changeset/fresh-buckets-exercise.md
@@ -1,5 +1,0 @@
----
-"emdash": patch
----
-
-Fixes React 19 development console warnings from the visual editing toolbar's `useSyncExternalStore` dependency path.


### PR DESCRIPTION
## What does this PR do?

Removes two stray changesets so the next Release run publishes the already-versioned **0.24.0**.

`main` is at `0.24.0` in every `package.json` and the `0.24.0` changelog is written, but **0.24.0 was never published to npm** (latest published is `0.23.0`, no `emdash@0.24.0` tag exists). The release PR #1629 was merged while these two changesets had already raced onto `main`. The merge applied the 0.24.0 bumps but left the two changesets in place, so the post-merge Release run found pending changesets, prepared `0.24.1` (PR #1650), and skipped the 0.24.0 publish entirely.

With these two changesets removed, `main` has zero pending changesets. The Release run then makes `changeset version` a no-op and falls through to `changeset publish`, releasing the already-versioned 0.24.0 with full artifacts (npm + git tag + GitHub release + plugin tarballs) via the normal changesets/action path.

These changesets document #1646 and #1644, which belong in **0.24.1**. They are restored in an immediate follow-up PR, which cuts 0.24.1 with their text and attribution intact. #1650 has been closed in favor of this recovery.

No published-package source changes; this only touches `.changeset/` release metadata.

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — n/a, no source change
- [ ] `pnpm lint` passes — n/a, no source change
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, no source change
- [ ] `pnpm format` has been run — n/a, only deletes changeset files
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] User-visible strings wrapped for translation — n/a
- [ ] I have added a changeset — intentionally n/a: this PR removes changesets as a release-mechanics fix and does not change a published package
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (OpenCode)

## Screenshots / test output

n/a — release metadata only.
