### PR TITLE
chore(release): restore #1646/#1644 changesets for 0.24.1

### DIFF
--- a/.changeset/fix-1347-taxonomy-parent-locale.md
+++ b/.changeset/fix-1347-taxonomy-parent-locale.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Fixes hierarchical taxonomy terms losing their parent in translated locales. A child term now stores its parent's translation group instead of a locale-bound row id, so translating a parent automatically re-nests its existing children in every locale instead of flattening them to the root. A forward-only migration backfills existing parent links.
+
+pr: 1646
+commit: c962929fa718479762ef8bded4a0b6c39eb43e0e
+author: mvanhorn

--- a/.changeset/fresh-buckets-exercise.md
+++ b/.changeset/fresh-buckets-exercise.md
@@ -1,0 +1,9 @@
+---
+"emdash": patch
+---
+
+Fixes React 19 development console warnings from the visual editing toolbar's `useSyncExternalStore` dependency path.
+
+pr: 1644
+commit: d64c961f89cf97303c4ffb3341f05424356120f0
+author: masonjames


### PR DESCRIPTION
## What does this PR do?

Restores the two changesets that #1651 temporarily removed to publish the already-versioned **0.24.0** (now live on npm + tag + GitHub release).

With 0.24.0 published, these two fixes belong in **0.24.1**. Merging this PR makes the next Release run open a fresh `ci: release` PR for 0.24.1; merging that publishes 0.24.1.

Each changeset carries pinned `@changesets/changelog-github` magic lines so the generated changelog credits the original PRs and authors, not this release PR:

- `fix-1347-taxonomy-parent-locale.md` -> `pr: 1646`, `author: mvanhorn`, `commit: c962929…`
- `fresh-buckets-exercise.md` -> `pr: 1644`, `author: masonjames`, `commit: d64c961…`

Without the override, `changelog-github` falls back to the commit that re-added the files (this PR), which would strip @mvanhorn's and @masonjames's credit. The magic lines are parsed and removed from the rendered summary, reproducing the exact line the now-closed #1650 generated.

No published-package source changes; this only touches `.changeset/` release metadata.

Closes #

## Type of change

- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] `pnpm typecheck` passes — n/a, no source change
- [ ] `pnpm lint` passes — n/a, no source change
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a, no source change
- [ ] `pnpm format` has been run — n/a, changeset metadata only
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] User-visible strings wrapped for translation — n/a
- [x] I have added a changeset — restores the two changesets for the 0.24.1 release
- [ ] New features link to an approved Discussion — n/a, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (OpenCode)

## Screenshots / test output

n/a — release metadata only.
