### PR TITLE
feat(admin): searchable combobox for repeater sub-field selects

### DIFF
--- a/.changeset/repeater-subfield-searchable-select.md
+++ b/.changeset/repeater-subfield-searchable-select.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds search/typeahead to `select` sub-fields inside repeater fields. Long option lists (for example taxonomy-derived options) are now filterable as you type instead of a plain scrolling dropdown.

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -5,7 +5,7 @@
  * Items can be added, removed, and reordered via drag-and-drop.
  */
 
-import { Button, Input, InputArea, Select, Switch } from "@cloudflare/kumo";
+import { Button, Combobox, Input, InputArea, Switch } from "@cloudflare/kumo";
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 import {
@@ -356,18 +356,33 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 					required={subField.required}
 				/>
 			);
-		case "select":
+		case "select": {
+			// Searchable combobox so long option lists (e.g. taxonomy-derived
+			// options) stay usable inside repeater rows, rather than a plain
+			// scrolling select.
+			const options = Array.isArray(subField.options) ? subField.options : [];
 			return (
-				<Select
+				<Combobox
 					label={subField.label}
-					value={typeof value === "string" ? value : ""}
-					onValueChange={(v) => onChange(v ?? "")}
-					items={{
-						"": t`Select...`,
-						...Object.fromEntries((subField.options ?? []).map((opt) => [opt, opt])),
-					}}
-				/>
+					value={typeof value === "string" && value ? value : null}
+					onValueChange={(v) => onChange(typeof v === "string" ? v : "")}
+					items={options}
+					required={subField.required}
+				>
+					<Combobox.TriggerInput placeholder={t`Select...`} />
+					<Combobox.Content>
+						<Combobox.Empty>{t`No results`}</Combobox.Empty>
+						<Combobox.List>
+							{(opt: string) => (
+								<Combobox.Item key={opt} value={opt}>
+									{opt}
+								</Combobox.Item>
+							)}
+						</Combobox.List>
+					</Combobox.Content>
+				</Combobox>
 			);
+		}
 		case "image":
 			return (
 				<ImageFieldRenderer

--- a/packages/admin/tests/components/RepeaterField.test.tsx
+++ b/packages/admin/tests/components/RepeaterField.test.tsx
@@ -114,4 +114,24 @@ describe("RepeaterField sub-field types", () => {
 
 		expect(onChange).toHaveBeenCalledWith([{ image: null, caption: "" }]);
 	});
+
+	it("renders a searchable combobox for select sub-fields", async () => {
+		const screen = await render(
+			<RepeaterField
+				label="Services"
+				id="services"
+				value={[{ service: "CT" }]}
+				onChange={vi.fn()}
+				subFields={[
+					{ slug: "service", type: "select", label: "Service", options: ["MRI", "CT", "PET"] },
+				]}
+			/>,
+		);
+
+		// Select sub-field → searchable typeahead input (role "combobox"),
+		// not a plain native select, and it reflects the stored value.
+		const input = screen.getByRole("combobox");
+		await expect.element(input).toBeVisible();
+		await expect.element(input).toHaveValue("CT");
+	});
 });


### PR DESCRIPTION
## What does this PR do?

Repeater rows frequently bind a `select` sub-field to a large, often taxonomy-derived option set. `SubFieldInput` (in `RepeaterField.tsx`) rendered a plain `Select` for `type: "select"`, so a long option list became an unfiltered scrolling dropdown — painful per row.

This renders sub-field selects with the Kumo `Combobox` (typeahead) instead, so options are filterable as you type. Behavior is unchanged for short lists; the stored value still round-trips as a plain string.

Discussed in https://github.com/emdash-cms/emdash/discussions/1656. This is the focused, self-contained half of that discussion (the broader "plugin field widgets in repeater sub-fields" idea is a potential follow-up).

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`packages/admin` — clean)
- [x] `pnpm lint` passes (changed files clean; see note)
- [x] `pnpm test` passes (or targeted tests for my change) — `packages/admin` `RepeaterField.test.tsx`, 6 passed
- [x] `pnpm format` has been run (Prettier clean on changed files)
- [x] I have added/updated tests for my changes (if applicable)
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) — `t\`Select...\`` (reused) and `t\`No results\`` (new). No `messages.po` changes included.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [x] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/1656

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Opus 4.8

## Screenshots / test output

```
 RUN  v4.1.5 /tmp/emdash-pr/packages/admin
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

New test: "renders a searchable combobox for select sub-fields" — a `select` sub-field with options renders a `role="combobox"` typeahead input that reflects the stored value.

> Note: `packages/admin` typecheck and the `RepeaterField` test suite pass locally. I could not run the repo-wide `pnpm build`/`pnpm lint` in my sandbox because `@emdash-cms/admin`'s `tsdown` build hits an unrelated Node 24 `ERR_INTERNAL_ASSERTION`; that does not affect typecheck or vitest, which exercise this change. Repo CI runs in a clean environment.