### PR TITLE
Add after-restore hook

### DIFF
--- a/.changeset/content-restore-hook.md
+++ b/.changeset/content-restore-hook.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Adds a content restore hook for plugins to react when trashed entries are restored.

--- a/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
+++ b/docs/src/content/docs/plugins/creating-plugins/hooks.mdx
@@ -215,6 +215,12 @@ Runs after content is reverted from live to draft. Requires `content:read` capab
 
 **Event:** `{ content, collection }` — **Returns:** `Promise<void>`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Requires `content:read` capability.
+
+**Event:** `{ content, collection }` — **Returns:** `Promise<void>`
+
 ## Media hooks
 
 ### `media:beforeUpload`
@@ -380,6 +386,7 @@ Hooks default to 5000ms. Bump the timeout for slower work:
 | `content:afterDelete`    | After content delete          | `void`                               | No        |
 | `content:afterPublish`   | After content publish         | `void`                               | No        |
 | `content:afterUnpublish` | After content unpublish       | `void`                               | No        |
+| `content:afterRestore`   | After content restore         | `void`                               | No        |
 | `media:beforeUpload`     | Before file upload            | Modified file info or `void`         | No        |
 | `media:afterUpload`      | After file upload             | `void`                               | No        |
 | `cron`                   | Scheduled task fires          | `void`                               | No        |

--- a/docs/src/content/docs/reference/hooks.mdx
+++ b/docs/src/content/docs/reference/hooks.mdx
@@ -17,6 +17,7 @@ The following table lists every hook, what triggers it, what it can modify, and 
 | `content:afterSave`     | After content is saved                | Nothing           | No        |
 | `content:beforeDelete`  | Before content is deleted             | Can cancel        | No        |
 | `content:afterDelete`   | After content is deleted              | Nothing           | No        |
+| `content:afterRestore`  | After content is restored             | Nothing           | No        |
 | `media:beforeUpload`    | Before file is uploaded               | File metadata     | No        |
 | `media:afterUpload`     | After file is uploaded                | Nothing           | No        |
 | `cron`                  | Scheduled task fires                  | Nothing           | No        |
@@ -151,6 +152,31 @@ hooks: {
   },
 }
 ```
+
+### `content:afterRestore`
+
+Runs after trashed content is restored. Requires `content:read` capability.
+
+```ts
+hooks: {
+  "content:afterRestore": async (event, ctx) => {
+    ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+  },
+}
+```
+
+#### Event
+
+```ts
+interface ContentPublishStateChangeEvent {
+	content: Record<string, unknown>;
+	collection: string;
+}
+```
+
+#### Return Value
+
+No return value expected.
 
 ## Media Hooks
 

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -1087,15 +1087,15 @@ export async function handleContentRestore(
 	db: Kysely<Database>,
 	collection: string,
 	id: string,
-): Promise<ApiResult<{ restored: true }>> {
+): Promise<ApiResult<{ restored: true; item: ContentItem }>> {
 	try {
-		const restored = await withTransaction(db, async (trx) => {
+		const item = await withTransaction(db, async (trx) => {
 			const repo = new ContentRepository(trx);
 			const resolvedId = (await resolveIdIncludingTrashed(repo, collection, id)) ?? id;
 			return repo.restore(collection, resolvedId);
 		});
 
-		if (!restored) {
+		if (!item) {
 			return {
 				success: false,
 				error: {
@@ -1107,7 +1107,7 @@ export async function handleContentRestore(
 
 		return {
 			success: true,
-			data: { restored: true },
+			data: { restored: true, item },
 		};
 	} catch (error) {
 		console.error("Content restore error:", error);

--- a/packages/core/src/database/repositories/content.ts
+++ b/packages/core/src/database/repositories/content.ts
@@ -656,19 +656,22 @@ export class ContentRepository {
 	/**
 	 * Restore content from trash
 	 */
-	async restore(type: string, id: string): Promise<boolean> {
+	async restore(type: string, id: string): Promise<ContentItem | null> {
 		const tableName = getTableName(type);
 
-		const result = await sql`
+		const result = await sql<Record<string, unknown>>`
 			UPDATE ${sql.ref(tableName)}
 			SET deleted_at = NULL
 			WHERE id = ${id}
 			AND deleted_at IS NOT NULL
+			RETURNING *
 		`.execute(this.db);
 
-		const changed = (result.numAffectedRows ?? 0n) > 0n;
-		if (changed) invalidateCollectionCache(type);
-		return changed;
+		const restored = result.rows[0];
+		if (!restored) return null;
+
+		invalidateCollectionCache(type);
+		return this.mapRow(type, restored);
 	}
 
 	/**

--- a/packages/core/src/emdash-runtime.ts
+++ b/packages/core/src/emdash-runtime.ts
@@ -2643,7 +2643,14 @@ export class EmDashRuntime {
 	}
 
 	async handleContentRestore(collection: string, id: string) {
-		return handleContentRestore(this.db, collection, id);
+		const result = await handleContentRestore(this.db, collection, id);
+
+		// Run afterRestore hooks (fire-and-forget)
+		if (result.success) {
+			this.runAfterRestoreHooks(contentItemToRecord(result.data.item), collection);
+		}
+
+		return result;
 	}
 
 	async handleContentPermanentDelete(collection: string, id: string) {
@@ -3208,6 +3215,37 @@ export class EmDashRuntime {
 					console.error(`EmDash: Sandboxed plugin ${pluginId} afterUnpublish error:`, err),
 				);
 		}
+	}
+
+	private runAfterRestoreHooks(content: Record<string, unknown>, collection: string): void {
+		after(async () => {
+			// Trusted plugins
+			if (this.hooks.hasHooks("content:afterRestore")) {
+				try {
+					await this.hooks.runContentAfterRestore(content, collection);
+				} catch (err) {
+					console.error("EmDash afterRestore hook error:", err);
+				}
+			}
+
+			// Sandboxed plugins
+			const tasks: Promise<void>[] = [];
+			for (const [pluginKey, plugin] of this.sandboxedPlugins) {
+				const [pluginId] = pluginKey.split(":");
+				if (!pluginId || !this.isPluginEnabled(pluginId)) continue;
+
+				tasks.push(
+					(async () => {
+						try {
+							await plugin.invokeHook("content:afterRestore", { content, collection });
+						} catch (err) {
+							console.error(`EmDash: Sandboxed plugin ${pluginId} afterRestore error:`, err);
+						}
+					})(),
+				);
+			}
+			await Promise.allSettled(tasks);
+		});
 	}
 
 	private async handleSandboxedRoute(

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -49,6 +49,7 @@ import type {
 	CommentModerateHandler,
 	ContentAfterDeleteHandler,
 	ContentAfterPublishHandler,
+	ContentAfterRestoreHandler,
 	ContentAfterSaveHandler,
 	ContentAfterUnpublishHandler,
 	ContentBeforeDeleteHandler,
@@ -97,6 +98,7 @@ export interface HookHandlers {
 	"content:afterDelete": ContentAfterDeleteHandler;
 	"content:afterPublish": ContentAfterPublishHandler;
 	"content:afterUnpublish": ContentAfterUnpublishHandler;
+	"content:afterRestore": ContentAfterRestoreHandler;
 	"media:beforeUpload": MediaBeforeUploadHandler;
 	"media:afterUpload": MediaAfterUploadHandler;
 	cron: CronHandler;

--- a/packages/core/src/plugins/hooks.ts
+++ b/packages/core/src/plugins/hooks.ts
@@ -32,6 +32,7 @@ import type {
 	ContentBeforeDeleteHandler,
 	ContentAfterDeleteHandler,
 	ContentAfterPublishHandler,
+	ContentAfterRestoreHandler,
 	ContentAfterUnpublishHandler,
 	MediaBeforeUploadHandler,
 	MediaAfterUploadHandler,
@@ -66,6 +67,7 @@ type HookNameV2 =
 	| "content:afterDelete"
 	| "content:afterPublish"
 	| "content:afterUnpublish"
+	| "content:afterRestore"
 	| "media:beforeUpload"
 	| "media:afterUpload"
 	| "cron"
@@ -93,6 +95,7 @@ interface HookHandlerMap {
 	"content:afterDelete": ContentAfterDeleteHandler;
 	"content:afterPublish": ContentAfterPublishHandler;
 	"content:afterUnpublish": ContentAfterUnpublishHandler;
+	"content:afterRestore": ContentAfterRestoreHandler;
 	"media:beforeUpload": MediaBeforeUploadHandler;
 	"media:afterUpload": MediaAfterUploadHandler;
 	cron: CronHandler;
@@ -220,6 +223,7 @@ export class HookPipeline {
 			this.registerPluginHook(plugin, "content:afterDelete");
 			this.registerPluginHook(plugin, "content:afterPublish");
 			this.registerPluginHook(plugin, "content:afterUnpublish");
+			this.registerPluginHook(plugin, "content:afterRestore");
 			this.registerPluginHook(plugin, "media:beforeUpload");
 			this.registerPluginHook(plugin, "media:afterUpload");
 			this.registerPluginHook(plugin, "cron");
@@ -264,6 +268,7 @@ export class HookPipeline {
 		["content:afterDelete", "content:read"],
 		["content:afterPublish", "content:read"],
 		["content:afterUnpublish", "content:read"],
+		["content:afterRestore", "content:read"],
 		// Media
 		["media:beforeUpload", "media:write"],
 		["media:afterUpload", "media:read"],
@@ -695,6 +700,46 @@ export class HookPipeline {
 		collection: string,
 	): Promise<HookResult<void>[]> {
 		const hooks = this.getTypedHooks("content:afterUnpublish");
+		const results: HookResult<void>[] = [];
+
+		for (const hook of hooks) {
+			const { handler } = hook;
+			const event: ContentPublishStateChangeEvent = { content, collection };
+			const ctx = this.getContext(hook.pluginId);
+			const start = Date.now();
+
+			try {
+				await this.executeWithTimeout(() => handler(event, ctx), hook.timeout);
+				results.push({
+					success: true,
+					pluginId: hook.pluginId,
+					duration: Date.now() - start,
+				});
+			} catch (error) {
+				results.push({
+					success: false,
+					error: error instanceof Error ? error : new Error(String(error)),
+					pluginId: hook.pluginId,
+					duration: Date.now() - start,
+				});
+
+				if (hook.errorPolicy === "abort") {
+					throw error;
+				}
+			}
+		}
+
+		return results;
+	}
+
+	/**
+	 * Run content:afterRestore hooks (fire-and-forget).
+	 */
+	async runContentAfterRestore(
+		content: Record<string, unknown>,
+		collection: string,
+	): Promise<HookResult<void>[]> {
+		const hooks = this.getTypedHooks("content:afterRestore");
 		const results: HookResult<void>[] = [];
 
 		for (const hook of hooks) {

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -148,6 +148,7 @@ export type {
 	ContentAfterSaveHandler,
 	ContentBeforeDeleteHandler,
 	ContentAfterDeleteHandler,
+	ContentAfterRestoreHandler,
 	MediaBeforeUploadHandler,
 	MediaAfterUploadHandler,
 	LifecycleHandler,

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -371,6 +371,17 @@ export class PluginManager {
 	}
 
 	/**
+	 * Run content:afterRestore hooks across all active plugins
+	 */
+	async runContentAfterRestore(
+		content: Record<string, unknown>,
+		collection: string,
+	): Promise<HookResult<void>[]> {
+		this.ensureInitialized();
+		return this.hookPipeline!.runContentAfterRestore(content, collection);
+	}
+
+	/**
 	 * Run media:beforeUpload hooks across all active plugins
 	 */
 	async runMediaBeforeUpload(file: { name: string; type: string; size: number }): Promise<{

--- a/packages/core/src/plugins/manifest-schema.ts
+++ b/packages/core/src/plugins/manifest-schema.ts
@@ -97,6 +97,7 @@ export const HOOK_NAMES = [
 	"content:afterDelete",
 	"content:afterPublish",
 	"content:afterUnpublish",
+	"content:afterRestore",
 	"media:beforeUpload",
 	"media:afterUpload",
 	"cron",

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -791,6 +791,11 @@ export type ContentAfterUnpublishHandler = (
 	ctx: PluginContext,
 ) => Promise<void>;
 
+export type ContentAfterRestoreHandler = (
+	event: ContentPublishStateChangeEvent,
+	ctx: PluginContext,
+) => Promise<void>;
+
 export type MediaBeforeUploadHandler = (
 	event: MediaUploadEvent,
 	ctx: PluginContext,
@@ -976,6 +981,7 @@ export interface PluginHooks {
 	"content:afterUnpublish"?:
 		| HookConfig<ContentAfterUnpublishHandler>
 		| ContentAfterUnpublishHandler;
+	"content:afterRestore"?: HookConfig<ContentAfterRestoreHandler> | ContentAfterRestoreHandler;
 
 	// Media hooks
 	"media:beforeUpload"?: HookConfig<MediaBeforeUploadHandler> | MediaBeforeUploadHandler;
@@ -1295,6 +1301,7 @@ export interface ResolvedPluginHooks {
 	"content:afterDelete"?: ResolvedHook<ContentAfterDeleteHandler>;
 	"content:afterPublish"?: ResolvedHook<ContentAfterPublishHandler>;
 	"content:afterUnpublish"?: ResolvedHook<ContentAfterUnpublishHandler>;
+	"content:afterRestore"?: ResolvedHook<ContentAfterRestoreHandler>;
 	"media:beforeUpload"?: ResolvedHook<MediaBeforeUploadHandler>;
 	"media:afterUpload"?: ResolvedHook<MediaAfterUploadHandler>;
 	cron?: ResolvedHook<CronHandler>;

--- a/packages/core/tests/integration/i18n/i18n.test.ts
+++ b/packages/core/tests/integration/i18n/i18n.test.ts
@@ -829,7 +829,7 @@ describe("i18n (Integration)", () => {
 
 			// Restore
 			const restored = await repo.restore("post", post.id);
-			expect(restored).toBe(true);
+			expect(restored).toEqual(expect.objectContaining({ id: post.id, locale: "en" }));
 
 			const found = await repo.findById("post", post.id);
 			expect(found).not.toBeNull();

--- a/packages/core/tests/integration/search/fts-corruption.test.ts
+++ b/packages/core/tests/integration/search/fts-corruption.test.ts
@@ -178,7 +178,9 @@ describe("FTS corruption on publish (SQLITE_CORRUPT_VTAB)", () => {
 		// Restore -- OLD has `deleted_at IS NOT NULL` (not in index), NEW
 		// has `deleted_at IS NULL`. The UPDATE trigger must NOT issue
 		// `'delete'` here.
-		await expect(repo.restore("pages", created.id)).resolves.toBe(true);
+		await expect(repo.restore("pages", created.id)).resolves.toEqual(
+			expect.objectContaining({ id: created.id }),
+		);
 		await expect(
 			sql
 				.raw(`INSERT INTO _emdash_fts_pages(_emdash_fts_pages) VALUES('integrity-check')`)

--- a/packages/core/tests/unit/plugins/hooks.test.ts
+++ b/packages/core/tests/unit/plugins/hooks.test.ts
@@ -471,6 +471,7 @@ describe("HookPipeline", () => {
 					"content:afterDelete": createTestHook("writer", vi.fn()),
 					"content:afterPublish": createTestHook("writer", vi.fn()),
 					"content:afterUnpublish": createTestHook("writer", vi.fn()),
+					"content:afterRestore": createTestHook("writer", vi.fn()),
 				},
 			});
 
@@ -481,6 +482,7 @@ describe("HookPipeline", () => {
 			expect(pipeline.hasHooks("content:afterDelete")).toBe(true);
 			expect(pipeline.hasHooks("content:afterPublish")).toBe(true);
 			expect(pipeline.hasHooks("content:afterUnpublish")).toBe(true);
+			expect(pipeline.hasHooks("content:afterRestore")).toBe(true);
 		});
 
 		it("skips content:afterPublish without content:read capability", () => {
@@ -533,6 +535,32 @@ describe("HookPipeline", () => {
 
 			const pipeline = new HookPipeline([plugin]);
 			expect(pipeline.hasHooks("content:afterUnpublish")).toBe(true);
+		});
+
+		it("skips content:afterRestore without content:read capability", () => {
+			const plugin = createTestPlugin({
+				id: "no-cap",
+				capabilities: [],
+				hooks: {
+					"content:afterRestore": createTestHook("no-cap", vi.fn()),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin]);
+			expect(pipeline.hasHooks("content:afterRestore")).toBe(false);
+		});
+
+		it("registers content:afterRestore with content:read capability", () => {
+			const plugin = createTestPlugin({
+				id: "has-cap",
+				capabilities: ["content:read"],
+				hooks: {
+					"content:afterRestore": createTestHook("has-cap", vi.fn()),
+				},
+			});
+
+			const pipeline = new HookPipeline([plugin]);
+			expect(pipeline.hasHooks("content:afterRestore")).toBe(true);
 		});
 	});
 

--- a/packages/core/tests/unit/plugins/restore-hooks.test.ts
+++ b/packages/core/tests/unit/plugins/restore-hooks.test.ts
@@ -1,0 +1,119 @@
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EmDashConfig } from "../../../src/astro/integration/runtime.js";
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import { EmDashRuntime } from "../../../src/emdash-runtime.js";
+import { definePlugin } from "../../../src/plugins/define-plugin.js";
+import { createHookPipeline } from "../../../src/plugins/hooks.js";
+import type { ContentPublishStateChangeEvent } from "../../../src/plugins/types.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../../utils/test-db.js";
+
+async function flushDeferredHooks(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function buildRuntime(
+	db: Kysely<Database>,
+	afterRestore: (event: ContentPublishStateChangeEvent) => void,
+): EmDashRuntime {
+	const plugin = definePlugin({
+		id: "restore-sync-test",
+		version: "1.0.0",
+		capabilities: ["content:read"],
+		hooks: {
+			"content:afterRestore": (event) => {
+				afterRestore(event);
+			},
+		},
+	});
+	const config: EmDashConfig = {};
+	const pipelineFactoryOptions = { db } as const;
+	const hooks = createHookPipeline([plugin], pipelineFactoryOptions);
+	const runtimeDeps = {
+		config,
+		plugins: [plugin],
+		// eslint-disable-next-line typescript/no-explicit-any -- match RuntimeDependencies signature
+		createDialect: (() => {
+			throw new Error("createDialect not used in this test");
+		}) as any,
+		createStorage: null,
+		sandboxEnabled: false,
+		sandboxedPluginEntries: [],
+		createSandboxRunner: null,
+	};
+
+	return new EmDashRuntime({
+		db,
+		storage: null,
+		configuredPlugins: [],
+		sandboxedPlugins: new Map(),
+		sandboxedPluginEntries: [],
+		hooks,
+		enabledPlugins: new Set(),
+		pluginStates: new Map(),
+		config,
+		mediaProviders: new Map(),
+		mediaProviderEntries: [],
+		cronExecutor: null,
+		cronScheduler: null,
+		emailPipeline: null,
+		allPipelinePlugins: [plugin],
+		pipelineFactoryOptions,
+		runtimeDeps,
+		pipelineRef: { current: hooks },
+	});
+}
+
+describe("content restore hooks", () => {
+	let db: Kysely<Database>;
+	let repo: ContentRepository;
+	let afterRestore: ReturnType<typeof vi.fn>;
+	let runtime: EmDashRuntime;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		repo = new ContentRepository(db);
+		afterRestore = vi.fn();
+		runtime = buildRuntime(db, afterRestore);
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("fires content:afterRestore with the restored content item", async () => {
+		const item = await repo.create({
+			type: "post",
+			slug: "restored-post",
+			status: "published",
+			data: { title: "Restored post" },
+		});
+		await repo.delete("post", item.id);
+
+		const result = await runtime.handleContentRestore("post", item.id);
+		await flushDeferredHooks();
+
+		expect(result.success).toBe(true);
+		if (!result.success) throw new Error("restore failed");
+		expect(result.data.item).toEqual(
+			expect.objectContaining({
+				id: item.id,
+				slug: "restored-post",
+				status: "published",
+			}),
+		);
+		expect(afterRestore).toHaveBeenCalledTimes(1);
+		expect(afterRestore).toHaveBeenCalledWith(
+			expect.objectContaining({
+				collection: "post",
+				content: expect.objectContaining({
+					id: item.id,
+					slug: "restored-post",
+					status: "published",
+				}),
+			}),
+		);
+	});
+});

--- a/skills/creating-plugins/references/hooks.md
+++ b/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blank/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/blog/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |

--- a/templates/starter/.agents/skills/creating-plugins/references/hooks.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/hooks.md
@@ -189,6 +189,19 @@ Runs after content is unpublished (reverted to draft). Side effects only.
 Event: `{ content: Record<string, unknown>, collection: string }`
 Returns: `void`
 
+### `content:afterRestore`
+
+Runs after trashed content is restored. Side effects only.
+
+```typescript
+"content:afterRestore": async (event, ctx) => {
+	ctx.log.info(`Restored ${event.collection}/${event.content.id}`);
+}
+```
+
+Event: `{ content: Record<string, unknown>, collection: string }`
+Returns: `void`
+
 ## Media Hooks
 
 ### `media:beforeUpload`
@@ -430,6 +443,7 @@ Use `"continue"` for non-critical operations (analytics, notifications, external
 | `content:afterDelete`    | After delete         | `content:read`                   | `void`                       |
 | `content:afterPublish`   | After publish        | `content:read`                   | `void`                       |
 | `content:afterUnpublish` | After unpublish      | `content:read`                   | `void`                       |
+| `content:afterRestore`   | After restore        | `content:read`                   | `void`                       |
 | `media:beforeUpload`     | Before upload        | —                                | Modified file info or `void` |
 | `media:afterUpload`      | After upload         | —                                | `void`                       |
 | `email:beforeSend`       | Before email send    | `hooks.email-events:register`    | Modified message or `false`  |


### PR DESCRIPTION
- **refactor(core): return restored content item**
Refactored the restore content call in core as to avoid extra db lookups, now "restore" returns the restored item.

- **feat(core): add content restore hook**
- **docs: add content restore hook docs**

## What does this PR do?

Adds a hook so plugins can be notified when an item is restored from the bin, so plugins can keep up with what posts are visible.

Closes #

## Type of change

- [ ] Bug fix
- [X] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [X] `pnpm typecheck` passes
- [X] `pnpm lint` passes
- [X] `pnpm test` passes (or targeted tests for my change)
- [X] `pnpm format` has been run
- [X] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [X] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [x] New features link to an approved Discussion: (Discussed in internal gchat)

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box and name the model(s)/tool(s) you used. Naming the model lets reviewers run the review pass with a different model family to catch family-specific blind spots. -->

- [X] This PR includes AI-generated code — model/tool: GPT-5.5 <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->

## Screenshots / test output

<!-- Optional. Include if the change is visual or if you want to show test results. -->
