### PR TITLE
fix(admin): show pointer cursor on the Log out menu button

### DIFF
--- a/.changeset/logout-button-cursor.md
+++ b/.changeset/logout-button-cursor.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": patch
+---
+
+Fixes the pointer cursor not showing when hovering the "Log out" button in the admin user menu.

--- a/packages/admin/src/components/Header.tsx
+++ b/packages/admin/src/components/Header.tsx
@@ -95,7 +95,7 @@ export function Header() {
 							<hr className="my-1" />
 							<button
 								onClick={handleLogout}
-								className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-kumo-danger hover:bg-kumo-danger/10 w-full text-start"
+								className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-kumo-danger hover:bg-kumo-danger/10 w-full text-start cursor-pointer"
 							>
 								<SignOut className="h-4 w-4" />
 								{t`Log out`}


### PR DESCRIPTION
## What does this PR do?

Fixes the missing pointer cursor when hovering the **Log out** button in the admin user dropdown menu.

The Log out item is a native `<button>` (`packages/admin/src/components/Header.tsx`), which defaults to the `default` cursor. Its sibling menu items (Security Settings, Settings) render as TanStack `<Link>` → `<a>` elements, which get `cursor: pointer` for free. So Log out was the only item without hover-cursor feedback. Added `cursor-pointer` to match — consistent with the existing convention in this file (`Sidebar.Trigger` already sets `cursor-pointer`).

One-line className change, no behavior or markup change.

Closes #<!-- no linked issue -->

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — `@emdash-cms/admin` clean
- [x] `pnpm lint` passes — `lint:quick` 0 diagnostics
- [ ] `pnpm test` passes (or targeted tests for my change) — **n/a**, CSS-only class change with no testable behavior
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — **n/a**, a hover cursor style isn't unit-testable
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — **n/a**, no strings added or changed
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — `@emdash-cms/admin` patch
- [ ] New features link to an approved Discussion — **n/a**, bug fix opened by a maintainer

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: **Claude Opus 4.8 (via OpenCode)**

## Screenshots / test output

Before: hovering **Log out** shows the default arrow cursor (the two links above it show a pointer). After: **Log out** shows the pointer cursor like its siblings.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-logout-button-cursor-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/logout-button-cursor`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
