### PR TITLE
fix(db): restore idx_taxonomies_parent dropped by migration 036

### DIFF
--- a/.changeset/restore-taxonomy-parent-index.md
+++ b/.changeset/restore-taxonomy-parent-index.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Restores the missing `idx_taxonomies_parent` index on `taxonomies(parent_id)`, which was silently dropped by the i18n table rebuild in an earlier version. Installs upgrade automatically; hierarchical (parent/child) taxonomy lookups are indexed again.

--- a/packages/core/src/database/migrations/036_i18n_menus_and_taxonomies.ts
+++ b/packages/core/src/database/migrations/036_i18n_menus_and_taxonomies.ts
@@ -199,6 +199,15 @@ async function rebuildTaxonomies(db: Kysely<unknown>, defaultLocale: string): Pr
 		.on("taxonomies")
 		.column("translation_group")
 		.execute();
+	// Dropping the old table dropped idx_taxonomies_parent (from 015); recreate
+	// it here for parity with rebuildMenuItems/rebuildContentTaxonomies. Existing
+	// installs recover it via migration 047.
+	await db.schema
+		.createIndex("idx_taxonomies_parent")
+		.ifNotExists()
+		.on("taxonomies")
+		.column("parent_id")
+		.execute();
 }
 
 async function rebuildTaxonomyDefs(db: Kysely<unknown>, defaultLocale: string): Promise<void> {
@@ -569,6 +578,13 @@ async function rebuildTaxonomiesDown(db: Kysely<unknown>): Promise<void> {
 	await db.schema.dropTable("taxonomies").execute();
 	await sql`ALTER TABLE taxonomies_old RENAME TO taxonomies`.execute(db);
 	await db.schema.createIndex("idx_taxonomies_name").on("taxonomies").column("name").execute();
+	// Restore the pre-036 (migration 015) parent index so the rollback is faithful.
+	await db.schema
+		.createIndex("idx_taxonomies_parent")
+		.ifNotExists()
+		.on("taxonomies")
+		.column("parent_id")
+		.execute();
 }
 
 async function rebuildTaxonomyDefsDown(db: Kysely<unknown>): Promise<void> {

--- a/packages/core/src/database/migrations/047_restore_taxonomy_parent_index.ts
+++ b/packages/core/src/database/migrations/047_restore_taxonomy_parent_index.ts
@@ -1,0 +1,29 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Restore `idx_taxonomies_parent` on `taxonomies(parent_id)` (#1665).
+ *
+ * Migration 015 created this index, but 036's SQLite table rebuild
+ * (`taxonomies_new` → drop → rename) dropped every index attached to the old
+ * table and only recreated `name`/`locale`/`translation_group`. The parent
+ * index — which backs hierarchical (parent/child) lookups — was silently lost
+ * on any install migrated through 036. The Postgres path in 036 alters the
+ * table in place and keeps its indexes, so it is unaffected; `ifNotExists`
+ * makes this a no-op there.
+ *
+ * Forward-only: 036 has already shipped, so existing installs only recover the
+ * index here. Fresh installs also get it in 036's rebuild for parity with the
+ * other rebuilt tables, making this a no-op for them.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.createIndex("idx_taxonomies_parent")
+		.ifNotExists()
+		.on("taxonomies")
+		.column("parent_id")
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.dropIndex("idx_taxonomies_parent").ifExists().execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -48,6 +48,7 @@ import * as m043 from "./043_content_references.js";
 import * as m044 from "./044_comment_reactions.js";
 import * as m045 from "./045_taxonomy_parent_group.js";
 import * as m046 from "./046_media_usage_index.js";
+import * as m047 from "./047_restore_taxonomy_parent_index.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -95,6 +96,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"044_comment_reactions": m044,
 	"045_taxonomy_parent_group": m045,
 	"046_media_usage_index": m046,
+	"047_restore_taxonomy_parent_index": m047,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -1,4 +1,5 @@
 import type { Kysely } from "kysely";
+import { sql } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { createDatabase } from "../../../src/database/connection.js";
@@ -131,6 +132,7 @@ describe("Database Migrations (Integration)", () => {
 			"044_comment_reactions",
 			"045_taxonomy_parent_group",
 			"046_media_usage_index",
+			"047_restore_taxonomy_parent_index",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();
@@ -340,6 +342,17 @@ describe("Database Migrations (Integration)", () => {
 			.executeTakeFirst();
 
 		expect(child?.parent_id).toBe(parentId);
+	});
+
+	it("should keep idx_taxonomies_parent after the full migration chain (regression for #1665)", async () => {
+		await runMigrations(db);
+
+		const indexes = await sql<{ name: string }>`
+			SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'taxonomies'
+		`.execute(db);
+		const names = new Set(indexes.rows.map((r) => r.name));
+
+		expect(names).toContain("idx_taxonomies_parent");
 	});
 
 	it("should create content_taxonomies junction table", async () => {

--- a/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
+++ b/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
@@ -173,6 +173,10 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 					`idx_${table}_translation_group`,
 				);
 			}
+
+			// The taxonomies rebuild drops the table (and its indexes); it must
+			// recreate the parent index it inherited from 015 (regression #1665).
+			expect(names).toContain("idx_taxonomies_parent");
 		});
 
 		it("backfills translation_group = id for pre-existing rows", async () => {


### PR DESCRIPTION
## What does this PR do?

Restores the `idx_taxonomies_parent` index on `taxonomies(parent_id)`, which was silently dropped by the i18n table rebuild in migration `036`.

Migration `015` created the index. `036`'s SQLite/D1 rebuild of `taxonomies` (`taxonomies_new` → `DROP TABLE` → rename) drops every index attached to the old table, but `rebuildTaxonomies` only recreated `name`, `locale`, and `translation_group` — the parent index was left out. Its sibling rebuilds (`rebuildMenuItems` → `idx_menu_items_parent`, `rebuildContentTaxonomies` → `idx_content_taxonomies_term`) *do* restore their parent index, confirming this was an oversight. No later migration restored it, so any install migrated through `036` has been running hierarchical taxonomy lookups without it.

Impact verified with `EXPLAIN QUERY PLAN`: the repository's actual parent queries (`findChildren`, `getTaxonomyTerm`, `list({ parentId })`) are single-probe `WHERE parent_id = ?` lookups that plan as a full `SCAN taxonomies` without the index and `SEARCH … USING INDEX` with it. SQLite's automatic (transient) indexing does **not** cover these — it only kicks in for repeated probes (join inner side / correlated subqueries), which these queries are not.

Changes:
- Adds forward-only migration `047_restore_taxonomy_parent_index` (`createIndex().ifNotExists()`, dialect-independent; no-op on Postgres where the in-place `pgWiden` path kept the index).
- Recreates the index in `036`'s `rebuildTaxonomies` (fresh installs) and `rebuildTaxonomiesDown` (faithful rollback to the pre-036 / `015` state), for parity with the sibling rebuilds.

Closes #1665

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] ~User-visible strings in the admin UI are wrapped for translation~ — n/a, no admin UI or user-facing strings (DB migration + tests only)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] ~New features link to an approved Discussion~ — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

Regression test (fails before the fix, passes after) plus the full migration suite:

```
Test Files  21 passed (21)
     Tests  202 passed (202)
```

`EXPLAIN QUERY PLAN` for `SELECT * FROM taxonomies WHERE parent_id = ? AND locale = ? ORDER BY label`:

```
== WITHOUT idx_taxonomies_parent ==
  SCAN taxonomies
  USE TEMP B-TREE FOR ORDER BY
== WITH idx_taxonomies_parent ==
  SEARCH taxonomies USING INDEX idx_taxonomies_parent (parent_id=?)
  USE TEMP B-TREE FOR ORDER BY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)