### PR TITLE
Fix (code): fallbackLocale entry not returned

### DIFF
--- a/.changeset/tender-rivers-admire.md
+++ b/.changeset/tender-rivers-admire.md
@@ -2,4 +2,4 @@
 "emdash": patch
 ---
 
-Added condition to check if getLiveEntry error is Astro's `LiveEntryNotFoundError` inside localeChain loop. This make sure to check every possible language chain before returning `LiveEntryNotFoundError` to the `error` field.
+Fixes fallback locale resolution for single entries so an entry is returned from the fallback locale when the requested locale has no matching live entry.

--- a/.changeset/tender-rivers-admire.md
+++ b/.changeset/tender-rivers-admire.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Added condition to check if getLiveEntry error is Astro's `LiveEntryNotFoundError` inside localeChain loop. This make sure to check every possible language chain before returning `LiveEntryNotFoundError` to the `error` field.

--- a/.changeset/tender-rivers-admire.md
+++ b/.changeset/tender-rivers-admire.md
@@ -1,5 +1,5 @@
 ---
-"emdash": minor
+"emdash": patch
 ---
 
 Added condition to check if getLiveEntry error is Astro's `LiveEntryNotFoundError` inside localeChain loop. This make sure to check every possible language chain before returning `LiveEntryNotFoundError` to the `error` field.

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -24,6 +24,8 @@
  * import resolves there at typecheck time without our help.
  */
 
+import { LiveEntryNotFoundError } from "astro/content/runtime";
+
 import { encodeCursor } from "./database/repositories/types.js";
 import { getFallbackChain, getI18nConfig, isI18nEnabled } from "./i18n/config.js";
 import {
@@ -869,6 +871,9 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 			});
 
 			if (baseError) {
+				// Entry not Found but localeChain not finished yet
+				if (baseError instanceof LiveEntryNotFoundError && typeof localeChain[i + 1] == "string")
+					continue;
 				return { entry: null, error: baseError, isPreview: serveDrafts, cacheHint: {} };
 			}
 
@@ -942,6 +947,9 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 
 			const { entry, error, cacheHint } = await getLiveEntry(COLLECTION_NAME, { type, id, locale });
 			if (error) {
+				// Entry not Found but localeChain not finished yet
+				if (error instanceof LiveEntryNotFoundError && typeof localeChain[i + 1] == "string")
+					continue;
 				return { entry: null, error, isPreview: false, cacheHint: {} };
 			}
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -871,9 +871,8 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 			});
 
 			if (baseError) {
-				// Entry not Found but localeChain not finished yet
-				if (baseError instanceof LiveEntryNotFoundError && typeof localeChain[i + 1] == "string")
-					continue;
+				// Entry not found but localeChain not finished yet
+				if (LiveEntryNotFoundError.is(baseError)) continue;
 				return { entry: null, error: baseError, isPreview: serveDrafts, cacheHint: {} };
 			}
 
@@ -947,9 +946,8 @@ export async function getEmDashEntry<T extends string, D = InferCollectionData<T
 
 			const { entry, error, cacheHint } = await getLiveEntry(COLLECTION_NAME, { type, id, locale });
 			if (error) {
-				// Entry not Found but localeChain not finished yet
-				if (error instanceof LiveEntryNotFoundError && typeof localeChain[i + 1] == "string")
-					continue;
+				// Entry not found but localeChain not finished yet
+				if (LiveEntryNotFoundError.is(error)) continue;
 				return { entry: null, error, isPreview: false, cacheHint: {} };
 			}
 

--- a/packages/core/tests/unit/query-fallback-locale.test.ts
+++ b/packages/core/tests/unit/query-fallback-locale.test.ts
@@ -1,0 +1,123 @@
+import { LiveEntryNotFoundError } from "astro/content/runtime";
+import type { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContentRepository } from "../../src/database/repositories/content.js";
+import type { Database } from "../../src/database/types.js";
+import { setI18nConfig } from "../../src/i18n/config.js";
+import { getEmDashEntry } from "../../src/query.js";
+import { runWithContext } from "../../src/request-context.js";
+import { setupTestDatabaseWithCollections, teardownTestDatabase } from "../utils/test-db.js";
+
+vi.mock("astro:content", () => ({
+	getLiveCollection: vi.fn(),
+	getLiveEntry: vi.fn(),
+}));
+
+import { getLiveEntry } from "astro:content";
+
+describe("query helpers fallback locale resolution", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+		setI18nConfig({
+			defaultLocale: "id",
+			locales: ["id", "en"],
+		});
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+		setI18nConfig(null);
+		vi.mocked(getLiveEntry).mockReset();
+	});
+
+	const createMockPost = (repo: ContentRepository, status: "published" | "draft") =>
+		repo.create({
+			type: "post",
+			slug: "hello-world",
+			data: { title: "Halo Dunia", status },
+			locale: "id",
+		});
+
+	it("getEmDashEntry resolves entry with defaultLocale when requested locale has no live entry", async () => {
+		const contentRepo = new ContentRepository(db);
+		const post = await createMockPost(contentRepo, "published");
+
+		vi.mocked(getLiveEntry).mockImplementation(async (_, options) => {
+			if (options.locale === "en") {
+				return {
+					entry: undefined,
+					error: new LiveEntryNotFoundError("post", "hello-world"),
+				} as any;
+			}
+			if (options.locale === "id") {
+				return {
+					entry: {
+						id: "hello-world",
+						data: {
+							id: post.id,
+							title: "Halo Dunia",
+							status: "published",
+							locale: "id",
+						},
+					},
+					error: undefined,
+				} as any;
+			}
+			return { entry: undefined, error: new LiveEntryNotFoundError("post", "hello-world") } as any;
+		});
+
+		const { entry, fallbackLocale, error } = await runWithContext({ editMode: false, db }, () =>
+			getEmDashEntry("post", "hello-world", { locale: "en" }),
+		);
+
+		expect(error).toBeUndefined();
+		expect(entry).not.toBeNull();
+		expect(entry?.data.title).toBe("Halo Dunia");
+		expect(entry?.data.locale).toBe("id");
+		expect(fallbackLocale).toBe("id");
+	});
+
+	it("getEmDashEntry resolves entry with defaultLocale in draft/preview mode when requested locale has no live entry", async () => {
+		const contentRepo = new ContentRepository(db);
+		const post = await createMockPost(contentRepo, "draft");
+
+		vi.mocked(getLiveEntry).mockImplementation(async (_, options) => {
+			if (options.locale === "en") {
+				return {
+					entry: undefined,
+					error: new LiveEntryNotFoundError("post", "hello-world"),
+				} as any;
+			}
+			if (options.locale === "id") {
+				return {
+					entry: {
+						id: "hello-world",
+						data: {
+							id: post.id,
+							title: "Halo Dunia",
+							status: "draft",
+							locale: "id",
+						},
+					},
+					error: undefined,
+				} as any;
+			}
+			return { entry: undefined, error: new LiveEntryNotFoundError("post", "hello-world") } as any;
+		});
+
+		const { entry, fallbackLocale, error, isPreview } = await runWithContext(
+			{ editMode: true, db },
+			() => getEmDashEntry("post", "hello-world", { locale: "en" }),
+		);
+
+		expect(error).toBeUndefined();
+		expect(entry).not.toBeNull();
+		expect(entry?.data.title).toBe("Halo Dunia");
+		expect(entry?.data.locale).toBe("id");
+		expect(fallbackLocale).toBe("id");
+		expect(isPreview).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Added condition to check if `getLiveEntry` error (invoked by `getEmDashEntry`) is Astro's `LiveEntryNotFoundError` inside localeChain loop. This make sure to check every possible language chain before returning empty `entry` field.

Closes #1679 

## Type of change

- [X] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [X] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [X] `pnpm typecheck` passes
- [X] `pnpm lint` passes
- [X] `pnpm test` passes (or targeted tests for my change)
- [X] `pnpm format` has been run
- [X] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [X] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [ ] This PR includes AI-generated code — model/tool: <!-- e.g. Claude Opus 4.7, GPT-5.5, Cursor + Sonnet 4.6, Copilot -->
