### PR TITLE
fix(core): restore idx_content_taxonomies_term after partial-apply retry (#1701)

### DIFF
--- a/.changeset/restore-content-taxonomies-term-index.md
+++ b/.changeset/restore-content-taxonomies-term-index.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Restores the `idx_content_taxonomies_term` index on SQLite/D1 installs that lost it when migration 036 was retried after a partial apply, so taxonomy reverse-lookups are indexed again. The index is now recreated unconditionally during 036 to prevent the same loss on any future partial apply.

--- a/packages/core/src/database/migrations/036_i18n_menus_and_taxonomies.ts
+++ b/packages/core/src/database/migrations/036_i18n_menus_and_taxonomies.ts
@@ -259,27 +259,32 @@ async function rebuildContentTaxonomies(db: Kysely<unknown>): Promise<void> {
 	// is load-bearing — if the translation_group seed ever changes, this needs
 	// an explicit remap *after* `rebuildTaxonomies` runs.
 	const fks = await sql<{ id: number }>`PRAGMA foreign_key_list(content_taxonomies)`.execute(db);
-	if (fks.rows.length === 0) return;
+	if (fks.rows.length > 0) {
+		await sql.raw(`DROP TABLE IF EXISTS "content_taxonomies_new"`).execute(db);
+		await db.schema
+			.createTable("content_taxonomies_new")
+			.addColumn("collection", "text", (c) => c.notNull())
+			.addColumn("entry_id", "text", (c) => c.notNull())
+			.addColumn("taxonomy_id", "text", (c) => c.notNull())
+			.addPrimaryKeyConstraint("content_taxonomies_pk", ["collection", "entry_id", "taxonomy_id"])
+			.execute();
 
-	await sql.raw(`DROP TABLE IF EXISTS "content_taxonomies_new"`).execute(db);
-	await db.schema
-		.createTable("content_taxonomies_new")
-		.addColumn("collection", "text", (c) => c.notNull())
-		.addColumn("entry_id", "text", (c) => c.notNull())
-		.addColumn("taxonomy_id", "text", (c) => c.notNull())
-		.addPrimaryKeyConstraint("content_taxonomies_pk", ["collection", "entry_id", "taxonomy_id"])
-		.execute();
+		await sql`
+			INSERT OR IGNORE INTO content_taxonomies_new (collection, entry_id, taxonomy_id)
+			SELECT collection, entry_id, taxonomy_id FROM content_taxonomies
+		`.execute(db);
 
-	await sql`
-		INSERT OR IGNORE INTO content_taxonomies_new (collection, entry_id, taxonomy_id)
-		SELECT collection, entry_id, taxonomy_id FROM content_taxonomies
-	`.execute(db);
+		await db.schema.dropTable("content_taxonomies").execute();
+		await sql`ALTER TABLE content_taxonomies_new RENAME TO content_taxonomies`.execute(db);
+	}
 
-	await db.schema.dropTable("content_taxonomies").execute();
-	await sql`ALTER TABLE content_taxonomies_new RENAME TO content_taxonomies`.execute(db);
-
-	// SQLite drops indexes when the underlying table is dropped. Restore the
-	// taxonomy_id index from migration 015.
+	// Recreate the taxonomy_id index from migration 015 unconditionally, OUTSIDE
+	// the FK-presence guard above. The rebuild both strips the FK and drops the
+	// old table's indexes, but D1 auto-commits each DDL statement — so a first
+	// run that failed after the drop leaves the table with no FK and no index.
+	// The retry then finds zero FKs and skips the rebuild; if the index recreate
+	// lived inside that guard it would never run and the index would be lost for
+	// good (#1701). `IF NOT EXISTS` keeps this a no-op once present.
 	await sql`CREATE INDEX IF NOT EXISTS idx_content_taxonomies_term ON content_taxonomies(taxonomy_id)`.execute(
 		db,
 	);

--- a/packages/core/src/database/migrations/048_restore_content_taxonomies_term_index.ts
+++ b/packages/core/src/database/migrations/048_restore_content_taxonomies_term_index.ts
@@ -1,0 +1,32 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Restore `idx_content_taxonomies_term` on `content_taxonomies(taxonomy_id)` (#1701).
+ *
+ * Migration 015 created this index. 036's SQLite/D1 table rebuild recreated it,
+ * but the recreate was gated behind an FK-presence early-return: if a first run
+ * committed the rebuild (stripping the FK and dropping the old index) and then
+ * failed before the recreate, the retry saw zero FKs, skipped the whole body,
+ * and never restored the index — while 036 was still recorded as applied. The
+ * result was an install missing only this one index, with no forward migration
+ * to recover it (the sibling `idx_taxonomies_parent` case was fixed by 047).
+ *
+ * 036 has since been fixed to recreate the index unconditionally, so fresh
+ * installs are fine. This recovers the index on installs that hit the trap
+ * before that fix. The Postgres path in 036 alters in place and keeps its
+ * indexes, so it is unaffected; `ifNotExists` makes this a no-op there.
+ *
+ * Forward-only.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.createIndex("idx_content_taxonomies_term")
+		.ifNotExists()
+		.on("content_taxonomies")
+		.column("taxonomy_id")
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema.dropIndex("idx_content_taxonomies_term").ifExists().execute();
+}

--- a/packages/core/src/database/migrations/runner.ts
+++ b/packages/core/src/database/migrations/runner.ts
@@ -49,6 +49,7 @@ import * as m044 from "./044_comment_reactions.js";
 import * as m045 from "./045_taxonomy_parent_group.js";
 import * as m046 from "./046_media_usage_index.js";
 import * as m047 from "./047_restore_taxonomy_parent_index.js";
+import * as m048 from "./048_restore_content_taxonomies_term_index.js";
 
 const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"001_initial": m001,
@@ -97,6 +98,7 @@ const MIGRATIONS: Readonly<Record<string, Migration>> = Object.freeze({
 	"045_taxonomy_parent_group": m045,
 	"046_media_usage_index": m046,
 	"047_restore_taxonomy_parent_index": m047,
+	"048_restore_content_taxonomies_term_index": m048,
 });
 
 /** Total number of registered migrations. Exported for use in tests. */

--- a/packages/core/tests/integration/database/migrations.test.ts
+++ b/packages/core/tests/integration/database/migrations.test.ts
@@ -133,6 +133,7 @@ describe("Database Migrations (Integration)", () => {
 			"045_taxonomy_parent_group",
 			"046_media_usage_index",
 			"047_restore_taxonomy_parent_index",
+			"048_restore_content_taxonomies_term_index",
 		];
 
 		await db.deleteFrom("_emdash_migrations").where("name", "in", trailing).execute();
@@ -353,6 +354,17 @@ describe("Database Migrations (Integration)", () => {
 		const names = new Set(indexes.rows.map((r) => r.name));
 
 		expect(names).toContain("idx_taxonomies_parent");
+	});
+
+	it("should keep idx_content_taxonomies_term after the full migration chain (regression for #1701)", async () => {
+		await runMigrations(db);
+
+		const indexes = await sql<{ name: string }>`
+			SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'content_taxonomies'
+		`.execute(db);
+		const names = new Set(indexes.rows.map((r) => r.name));
+
+		expect(names).toContain("idx_content_taxonomies_term");
 	});
 
 	it("should create content_taxonomies junction table", async () => {

--- a/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
+++ b/packages/core/tests/unit/database/migrations/036_i18n_menus_and_taxonomies.test.ts
@@ -177,6 +177,42 @@ describe("036_i18n_menus_and_taxonomies migration", () => {
 			// The taxonomies rebuild drops the table (and its indexes); it must
 			// recreate the parent index it inherited from 015 (regression #1665).
 			expect(names).toContain("idx_taxonomies_parent");
+
+			// The content_taxonomies rebuild likewise drops the table and its
+			// indexes; it must recreate the taxonomy_id index from 015.
+			expect(names).toContain("idx_content_taxonomies_term");
+		});
+
+		it("restores idx_content_taxonomies_term on a partial-apply retry (regression for #1701)", async () => {
+			// Simulate a first run that committed the content_taxonomies rebuild
+			// (FK stripped, old index dropped) but failed before recreating the
+			// index. D1 DDL auto-commits per statement, so the rebuild survives an
+			// up() that never resolved; the retry re-enters up() from the top with
+			// the FK already gone and the index still missing.
+			await db.destroy();
+			db = createDatabase({ url: ":memory:" });
+			await seedPreMigrationSchema(db);
+			await sql`DROP TABLE content_taxonomies`.execute(db);
+			await sql`
+				CREATE TABLE content_taxonomies (
+					collection TEXT NOT NULL,
+					entry_id TEXT NOT NULL,
+					taxonomy_id TEXT NOT NULL,
+					PRIMARY KEY (collection, entry_id, taxonomy_id)
+				)
+			`.execute(db);
+
+			// Sanity: the partial state has no FK and no term index.
+			const fks = await sql`PRAGMA foreign_key_list(content_taxonomies)`.execute(db);
+			expect(fks.rows.length).toBe(0);
+
+			await up(db);
+
+			const indexes = await sql<{ name: string }>`
+				SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'content_taxonomies'
+			`.execute(db);
+			const names = new Set(indexes.rows.map((r) => r.name));
+			expect(names).toContain("idx_content_taxonomies_term");
 		});
 
 		it("backfills translation_group = id for pre-existing rows", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes migration `036_i18n_menus_and_taxonomies` permanently losing the
`idx_content_taxonomies_term` index on `content_taxonomies(taxonomy_id)` on
SQLite/D1 after a partial-apply retry.

In `rebuildContentTaxonomies`, the index recreate lived **inside** an
FK-presence early-return. D1 auto-commits each DDL statement, but Kysely only
records a migration as applied after `up()` resolves. So a first run that
committed the table rebuild (stripping the FK, dropping the old index) then
failed before the `CREATE INDEX` leaves the table with **no FK and no index** —
and 036 is *not* marked applied. On retry, `up()` re-enters, sees zero FKs,
early-returns, and never recreates the index; the other rebuilds run and 036 is
then marked applied. Net result: 036 recorded as successfully applied with only
`idx_content_taxonomies_term` missing and no forward migration to recover it.

The fix:

1. Move the `CREATE INDEX IF NOT EXISTS idx_content_taxonomies_term` **out** of
   the FK guard so it runs unconditionally whenever the table exists — closing
   the trap for any future partial apply.
2. Add forward-only migration `048_restore_content_taxonomies_term_index` to
   restore the index on installs that already hit the trap (idempotent,
   `ifNotExists`; no-op on Postgres, which alters in place).

Same bug class as #1665 / migration 047 (which restored `idx_taxonomies_parent`),
but for `content_taxonomies`. The Postgres path is unaffected.

Closes #1701

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes <!-- verified via tsc --noEmit on packages/core -->
- [x] `pnpm lint` passes <!-- oxlint --type-aware on the changed files: 0 diagnostics -->
- [x] `pnpm test` passes (or targeted tests for my change) <!-- migration unit + integration suites: 56 passing -->
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no UI/string changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

```
Test Files  4 passed (4)
     Tests  56 passed (56)
```

New/updated tests:
- Unit (`036_..._test.ts`): reproduces the partial-apply retry (FK stripped,
  index dropped → re-run `up()`) and asserts the index is restored; plus a
  normal-run assertion that 036 recreates `idx_content_taxonomies_term`.
- Integration (`migrations.test.ts`): asserts the index survives the full
  migration chain (regression for #1701); registers 048 in the trailing list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
