### PR TITLE
feat(admin): taxonomy-backed options for repeater select sub-fields

### DIFF
--- a/.changeset/repeater-subfield-taxonomy-options.md
+++ b/.changeset/repeater-subfield-taxonomy-options.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/admin": minor
+---
+
+Adds taxonomy-backed options to `select` sub-fields inside repeater fields. Setting a sub-field's options to the single sentinel `@taxonomy:<name>` now fills its searchable dropdown with that taxonomy's live terms, so repeater rows can pick from a managed vocabulary that stays in sync as terms are added — instead of hardcoding the list in the collection schema.

--- a/packages/admin/src/components/ContentEditor.tsx
+++ b/packages/admin/src/components/ContentEditor.tsx
@@ -795,6 +795,9 @@ export function ContentEditor({
 											field.kind === "portableText" ? handleBlockSidebarClose : undefined
 										}
 										manifest={manifest}
+										// Existing entry: use its own locale. New entry: use the
+										// URL `?locale=` (passed in via `entryLocale`).
+										entryLocale={item?.locale ?? entryLocale}
 									/>
 								);
 								return fieldEl;
@@ -1090,6 +1093,12 @@ interface FieldRendererProps {
 	onBlockSidebarOpen?: (panel: BlockSidebarPanel) => void;
 	/** Callback when a block node closes its sidebar */
 	onBlockSidebarClose?: () => void;
+	/**
+	 * Content locale of the entry being edited (existing entry's own locale,
+	 * or the URL `?locale=` for new entries). Locale-aware field editors
+	 * (e.g. taxonomy-backed repeater selects) scope their lookups to it.
+	 */
+	entryLocale?: string | null;
 	/** Admin manifest for resolving sandboxed field widget elements */
 	manifest?: import("../lib/api/client.js").AdminManifest | null;
 }
@@ -1108,6 +1117,7 @@ function FieldRenderer({
 	onBlockSidebarOpen,
 	onBlockSidebarClose,
 	manifest,
+	entryLocale,
 }: FieldRendererProps) {
 	const { t } = useLingui();
 	const pluginAdmins = usePluginAdmins();
@@ -1384,6 +1394,7 @@ function FieldRenderer({
 					subFields={subFields}
 					minItems={typeof validation?.minItems === "number" ? validation.minItems : undefined}
 					maxItems={typeof validation?.maxItems === "number" ? validation.maxItems : undefined}
+					locale={entryLocale}
 				/>
 			);
 		}

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -50,6 +50,12 @@ export interface RepeaterFieldProps {
 	subFields: RepeaterSubFieldDef[];
 	minItems?: number;
 	maxItems?: number;
+	/**
+	 * Content locale of the entry being edited. Scopes taxonomy-backed select
+	 * sub-fields to the entry's locale so multi-locale installs don't mix
+	 * translation variants in one dropdown.
+	 */
+	locale?: string | null;
 }
 
 type RepeaterItem = Record<string, unknown> & { _key: string };
@@ -73,6 +79,7 @@ export function RepeaterField({
 	subFields,
 	minItems = 0,
 	maxItems,
+	locale,
 }: RepeaterFieldProps) {
 	const { t } = useLingui();
 	const rawItems = Array.isArray(value) ? value : [];
@@ -202,6 +209,7 @@ export function RepeaterField({
 									onChange={(fieldSlug, fieldValue) =>
 										handleItemChange(item._key, fieldSlug, fieldValue)
 									}
+									locale={locale}
 								/>
 							))}
 						</div>
@@ -220,6 +228,7 @@ interface SortableRepeaterItemProps {
 	onToggleCollapse: () => void;
 	onRemove?: () => void;
 	onChange: (fieldSlug: string, value: unknown) => void;
+	locale?: string | null;
 }
 
 function SortableRepeaterItem({
@@ -230,6 +239,7 @@ function SortableRepeaterItem({
 	onToggleCollapse,
 	onRemove,
 	onChange,
+	locale,
 }: SortableRepeaterItemProps) {
 	const { t } = useLingui();
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -296,6 +306,7 @@ function SortableRepeaterItem({
 							subField={sf}
 							value={item[sf.slug]}
 							onChange={(v) => onChange(sf.slug, v)}
+							locale={locale}
 						/>
 					))}
 				</div>
@@ -308,6 +319,7 @@ interface SubFieldInputProps {
 	subField: RepeaterSubFieldDef;
 	value: unknown;
 	onChange: (value: unknown) => void;
+	locale?: string | null;
 }
 
 /**
@@ -322,17 +334,22 @@ function TaxonomySubFieldCombobox({
 	value,
 	onChange,
 	required,
+	locale,
 }: {
 	taxonomyName: string;
 	label: string;
 	value: unknown;
 	onChange: (value: unknown) => void;
 	required?: boolean;
+	locale?: string | null;
 }) {
 	const { t } = useLingui();
+	// Shares the ["taxonomy-terms", name, locale] cache with TaxonomyManager /
+	// TaxonomySidebar, so term creates/updates elsewhere in the admin
+	// invalidate this dropdown too instead of it lagging a stale window behind.
 	const { data: terms = [] } = useQuery<TaxonomyTerm[]>({
-		queryKey: ["repeater-subfield-taxonomy-terms", taxonomyName],
-		queryFn: () => fetchTerms(taxonomyName),
+		queryKey: ["taxonomy-terms", taxonomyName, locale ?? undefined],
+		queryFn: () => fetchTerms(taxonomyName, { locale: locale ?? undefined }),
 		staleTime: 30_000,
 	});
 	const options = terms.map((term) => term.label);
@@ -359,7 +376,7 @@ function TaxonomySubFieldCombobox({
 	);
 }
 
-function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
+function SubFieldInput({ subField, value, onChange, locale }: SubFieldInputProps) {
 	const { t } = useLingui();
 	switch (subField.type) {
 		case "string":
@@ -432,6 +449,7 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 						value={value}
 						onChange={onChange}
 						required={subField.required}
+						locale={locale}
 					/>
 				);
 			}

--- a/packages/admin/src/components/RepeaterField.tsx
+++ b/packages/admin/src/components/RepeaterField.tsx
@@ -18,12 +18,20 @@ import { CSS } from "@dnd-kit/utilities";
 import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import { Plus, Trash, DotsSixVertical, CaretDown } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import * as React from "react";
 
+import { fetchTerms, type TaxonomyTerm } from "../lib/api";
 import { fromDatetimeLocalInputValue, toDatetimeLocalInputValue } from "../lib/datetime-local.js";
 import { cn } from "../lib/utils.js";
 import { CaretNext } from "./ArrowIcons.js";
 import { ImageFieldRenderer, type ImageFieldValue } from "./ImageFieldRenderer.js";
+
+/**
+ * Sentinel used in a `select` sub-field's `options` to bind its choices to a
+ * taxonomy's live terms instead of a static list, e.g. `["@taxonomy:tag"]`.
+ */
+const TAXONOMY_OPTION_PREFIX = "@taxonomy:";
 
 interface RepeaterSubFieldDef {
 	slug: string;
@@ -302,6 +310,55 @@ interface SubFieldInputProps {
 	onChange: (value: unknown) => void;
 }
 
+/**
+ * A `select` sub-field whose choices are the live terms of a taxonomy. Used
+ * when the sub-field's `options` is the `@taxonomy:<name>` sentinel, so
+ * repeater rows can pick from a managed vocabulary that stays in sync as terms
+ * are added — no need to duplicate the term list in the collection schema.
+ */
+function TaxonomySubFieldCombobox({
+	taxonomyName,
+	label,
+	value,
+	onChange,
+	required,
+}: {
+	taxonomyName: string;
+	label: string;
+	value: unknown;
+	onChange: (value: unknown) => void;
+	required?: boolean;
+}) {
+	const { t } = useLingui();
+	const { data: terms = [] } = useQuery<TaxonomyTerm[]>({
+		queryKey: ["repeater-subfield-taxonomy-terms", taxonomyName],
+		queryFn: () => fetchTerms(taxonomyName),
+		staleTime: 30_000,
+	});
+	const options = terms.map((term) => term.label);
+	return (
+		<Combobox
+			label={label}
+			value={typeof value === "string" && value ? value : null}
+			onValueChange={(v) => onChange(typeof v === "string" ? v : "")}
+			items={options}
+			required={required}
+		>
+			<Combobox.TriggerInput placeholder={t`Select...`} />
+			<Combobox.Content>
+				<Combobox.Empty>{t`No results`}</Combobox.Empty>
+				<Combobox.List>
+					{(opt: string) => (
+						<Combobox.Item key={opt} value={opt}>
+							{opt}
+						</Combobox.Item>
+					)}
+				</Combobox.List>
+			</Combobox.Content>
+		</Combobox>
+	);
+}
+
 function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 	const { t } = useLingui();
 	switch (subField.type) {
@@ -361,6 +418,23 @@ function SubFieldInput({ subField, value, onChange }: SubFieldInputProps) {
 			// options) stay usable inside repeater rows, rather than a plain
 			// scrolling select.
 			const options = Array.isArray(subField.options) ? subField.options : [];
+			// A leading `@taxonomy:<name>` sentinel binds the choices to a live
+			// taxonomy's terms instead of the static option list.
+			const taxonomyName =
+				typeof options[0] === "string" && options[0].startsWith(TAXONOMY_OPTION_PREFIX)
+					? options[0].slice(TAXONOMY_OPTION_PREFIX.length)
+					: null;
+			if (taxonomyName) {
+				return (
+					<TaxonomySubFieldCombobox
+						taxonomyName={taxonomyName}
+						label={subField.label}
+						value={value}
+						onChange={onChange}
+						required={subField.required}
+					/>
+				);
+			}
 			return (
 				<Combobox
 					label={subField.label}


### PR DESCRIPTION
## What does this PR do?

Extends the searchable repeater `select` combobox (added in #1657) so its choices can be **taxonomy-backed**. When a `select` sub-field's `options` is the single sentinel `@taxonomy:<name>`, the dropdown is populated with that taxonomy's live terms (via the existing `GET /taxonomies/:name/terms` API) instead of a static list.

This finishes the "taxonomy-derived options" case that #1657 already anticipates in its own code comment: today a repeater `select` can only offer a hardcoded list duplicated in the collection schema, which drifts out of sync as terms are added/renamed. With this change, e.g. a "services" repeater can reference `@taxonomy:treatment` and always reflect the managed vocabulary.

Behavior:
- Only a leading `@taxonomy:` option triggers the taxonomy lookup; every existing static-list `select` sub-field is untouched.
- Terms are fetched with `@tanstack/react-query` (`staleTime` 30s) and rendered through the same `Combobox` markup as the static case, so search/empty/placeholder behavior is identical.
- Option values remain the term **labels**, matching the stored string shape of a `select` sub-field.

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

Discussion: https://github.com/emdash-cms/emdash/discussions/1705

> Note: this is a small, additive follow-up to the already-merged #1657 (same sub-field, same component, the case its comment foreshadows) rather than a net-new surface. Opened the Ideas Discussion above per the Feature policy — happy to adjust the API shape (e.g. a typed `optionsTaxonomy` field instead of the string sentinel) if you'd prefer.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (for the changed file; the only local errors are pre-existing `implicit any` in the unrelated `RegistryPluginDetail.tsx`)
- [x] `pnpm lint` passes (`oxlint --type-aware --deny-warnings` clean on the changed file)
- [ ] `pnpm test` passes (or targeted tests for my change) — `RepeaterField` has no unit-test module; behavior verified manually, consistent with #1657
- [x] `pnpm format` has been run (`oxfmt` + `prettier` clean)
- [ ] I have added/updated tests for my changes (if applicable) — N/A, UI component with no existing test harness
- [x] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (reuses the existing `t\`Select...\`` / `t\`No results\`` strings; no `messages.po` changes)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`@emdash-cms/admin`: minor)
- [x] New features link to an approved Discussion — https://github.com/emdash-cms/emdash/discussions/1705 (opened for maintainer approval)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Opus 4.8
