### PR TITLE
feat(admin): fall back to the site title for admin branding

### DIFF
--- a/.changeset/admin-sidebar-site-title.md
+++ b/.changeset/admin-sidebar-site-title.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Brands the admin with the site's own title when no build-time `admin.siteName` is configured. The admin sidebar previously always showed "EmDash", so operators running several EmDash backends couldn't tell them apart at a glance. The manifest now falls back to the Site Title (Settings → General, then the title captured during setup), WordPress-style. An explicit `admin.siteName` still wins, and sites with neither keep the "EmDash" default.

--- a/packages/core/src/astro/routes/api/manifest.ts
+++ b/packages/core/src/astro/routes/api/manifest.ts
@@ -11,6 +11,7 @@ import type { APIRoute } from "astro";
 
 import { handleError } from "#api/error.js";
 import { getAuthMode } from "#auth/mode.js";
+import { OptionsRepository } from "#db/repositories/options.js";
 
 import { COMMIT, VERSION } from "../../../version.js";
 import type { EmDashManifest } from "../../types.js";
@@ -39,7 +40,25 @@ export const GET: APIRoute = async ({ locals }) => {
 		// doesn't assign it to globalThis, so getStoredConfig() always returned
 		// null and the React SPA never received custom logo/siteName/favicon.
 		// See issue #835.
-		const adminBranding = emdash?.config?.admin;
+		let adminBranding = emdash?.config?.admin;
+
+		// When no build-time `admin.siteName` is configured, brand the admin with
+		// the site's own title so multi-site operators can tell backends apart
+		// (WordPress-style: wp-admin always shows the site name). Precedence:
+		// explicit `admin.siteName` → Site Title (Settings → General) → the title
+		// captured by the setup wizard → the bundled "EmDash" default in the SPA.
+		if (!adminBranding?.siteName && emdash?.db) {
+			try {
+				const options = new OptionsRepository(emdash.db);
+				const titles = await options.getMany<string>(["site:title", "emdash:site_title"]);
+				const siteTitle = titles.get("site:title") || titles.get("emdash:site_title");
+				if (siteTitle) {
+					adminBranding = { ...adminBranding, siteName: siteTitle };
+				}
+			} catch {
+				// options table may not exist yet (pre-setup) — keep the default.
+			}
+		}
 
 		// Check if self-signup is enabled (any allowed domain with enabled = 1)
 		// Only relevant for passkey auth — external auth providers handle their own signup


### PR DESCRIPTION
## What does this PR do?

The admin sidebar header (and the version line in its footer) always shows the hardcoded "EmDash" label unless a build-time `admin.siteName` is configured. Operators running several EmDash backends can't tell at a glance which site's admin they're in — every tab looks identical.

This adds a WordPress-style fallback in the manifest route: when no explicit `admin.siteName` is configured, `manifest.admin.siteName` is filled from the site's own title. Precedence:

**build-time `admin.siteName` → Site Title (Settings → General, `site:title`) → the title captured by the setup wizard (`emdash:site_title`) → the bundled "EmDash" default in the SPA**

The admin SPA is untouched — the sidebar already renders `manifest.admin?.siteName || "EmDash"`, so the header, footer, and `BrandIcon` alt text all pick this up automatically. Both option keys are read with a single `getMany` batch, wrapped in try/catch so a pre-setup database keeps the default. No behavior change for sites that configure `admin.siteName` or have no title yet.

Complements #1505 (Site Icon as the admin favicon): favicon + sidebar title together make each backend instantly recognizable.

Discussion: https://github.com/emdash-cms/emdash/discussions/1706

Closes #

## Type of change

- [ ] Bug fix
- [x] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`emdash` package — clean)
- [x] `pnpm lint` passes (`oxlint --type-aware --deny-warnings` clean on the changed file)
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a: single manifest-route fallback with no existing route test harness; behavior verified manually
- [x] `pnpm format` has been run (`oxfmt` + `prettier` clean)
- [ ] I have added/updated tests for my changes (if applicable) — see above
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no strings added; no `messages.po` changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash`: minor)
- [x] New features link to an approved Discussion — https://github.com/emdash-cms/emdash/discussions/1706 (opened for maintainer approval)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

Single-file change in `packages/core/src/astro/routes/api/manifest.ts` (+ changeset). Reuses the existing `OptionsRepository.getMany` batch read.
