### PR TITLE
fix(core): create the slug-change 301 auto-redirect on publish

### DIFF
--- a/.changeset/publish-slug-change-redirect.md
+++ b/.changeset/publish-slug-change-redirect.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes slug-change 301 auto-redirects not being created for published entries in revision-supporting collections. Editing a published entry's slug in the admin stages the change as `_slug` inside a draft revision; on "Publish", `ContentRepository.publish()` synced the new slug straight into the content table — bypassing `handleContentUpdate`, the only place auto-redirects were created. Since collections support drafts + revisions by default, the advertised "Auto: slug change" redirect effectively never fired for the standard editing flow, silently breaking old URLs. Publishing now leaves a 301 from the old URL behind whenever an already-published entry's slug changes. First publishes are excluded (a draft's URL was never public), and direct API slug updates behave as before.

--- a/packages/core/src/api/handlers/content.ts
+++ b/packages/core/src/api/handlers/content.ts
@@ -327,6 +327,36 @@ async function resolveSearchColumns(db: Kysely<Database>, collection: string): P
 	return columns;
 }
 
+/**
+ * Create a 301 auto-redirect from an entry's old URL to its new one after a
+ * slug change, using the collection's URL pattern. Shared by
+ * handleContentUpdate (direct slug edits) and handleContentPublish (slug edits
+ * staged as `_slug` in a draft revision, which only land on publish).
+ */
+async function createSlugChangeRedirect(
+	db: Kysely<Database>,
+	collection: string,
+	oldSlug: string,
+	newSlug: string,
+	contentId: string,
+): Promise<void> {
+	const collectionRow = await db
+		.selectFrom("_emdash_collections")
+		.select("url_pattern")
+		.where("slug", "=", collection)
+		.executeTakeFirst();
+
+	const redirectRepo = new RedirectRepository(db);
+	await redirectRepo.createAutoRedirect(
+		collection,
+		oldSlug,
+		newSlug,
+		contentId,
+		collectionRow?.url_pattern ?? null,
+	);
+	invalidateRedirectCache();
+}
+
 /** Matches a date-only `YYYY-MM-DD` bound (no time component). */
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -865,21 +895,7 @@ export async function handleContentUpdate(
 
 			// Create auto-redirect when slug changes
 			if (oldSlug && body.slug) {
-				const collectionRow = await trx
-					.selectFrom("_emdash_collections")
-					.select("url_pattern")
-					.where("slug", "=", collection)
-					.executeTakeFirst();
-
-				const redirectRepo = new RedirectRepository(trx);
-				await redirectRepo.createAutoRedirect(
-					collection,
-					oldSlug,
-					body.slug,
-					resolvedId,
-					collectionRow?.url_pattern ?? null,
-				);
-				invalidateRedirectCache();
+				await createSlugChangeRedirect(trx, collection, oldSlug, body.slug, resolvedId);
 			}
 
 			// Sync non-translatable fields to sibling locales in the same
@@ -1362,7 +1378,34 @@ export async function handleContentPublish(
 		const item = await withTransaction(db, async (trx) => {
 			const repo = new ContentRepository(trx);
 			const resolvedId = (await resolveId(repo, collection, id)) ?? id;
-			return repo.publish(collection, resolvedId, options.publishedAt, options.requireScheduledDue);
+
+			// Capture the pre-publish state. For revision-supporting collections a
+			// slug edit is staged as `_slug` in the draft revision and only lands
+			// on the live `slug` column here, inside `repo.publish()` — it never
+			// passes through handleContentUpdate, where slug-change auto-redirects
+			// are normally created.
+			const existing = await repo.findById(collection, resolvedId);
+
+			const published = await repo.publish(
+				collection,
+				resolvedId,
+				options.publishedAt,
+				options.requireScheduledDue,
+			);
+
+			// Leave a 301 behind when publishing changed the slug of an entry that
+			// was already published — its old URL was live and may be indexed or
+			// linked. A first publish is excluded: a draft's URL was never public.
+			if (
+				existing?.status === "published" &&
+				existing.slug &&
+				published.slug &&
+				existing.slug !== published.slug
+			) {
+				await createSlugChangeRedirect(trx, collection, existing.slug, published.slug, resolvedId);
+			}
+
+			return published;
 		});
 
 		const hasSeo = await collectionHasSeo(db, collection);

--- a/packages/core/tests/unit/api/content-handlers.test.ts
+++ b/packages/core/tests/unit/api/content-handlers.test.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import {
@@ -6,9 +6,11 @@ import {
 	handleContentDuplicate,
 	handleContentGet,
 	handleContentList,
+	handleContentPublish,
 	handleContentUpdate,
 } from "../../../src/api/index.js";
 import { BylineRepository } from "../../../src/database/repositories/byline.js";
+import { RevisionRepository } from "../../../src/database/repositories/revision.js";
 import { UserRepository } from "../../../src/database/repositories/user.js";
 import type { Database } from "../../../src/database/types.js";
 import { setI18nConfig } from "../../../src/i18n/config.js";
@@ -688,5 +690,103 @@ describe("Content Handlers — list total", () => {
 		expect(result.success).toBe(true);
 		expect(result.data?.items).toHaveLength(2);
 		expect(result.data?.total).toBe(8);
+	});
+});
+
+describe("Content Handlers — slug-change auto-redirect on publish", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabaseWithCollections();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	/**
+	 * Stage a slug change the way the runtime does for revision-supporting
+	 * collections: write `_slug` into a draft revision and point the entry's
+	 * `draft_revision_id` at it, leaving the live `slug` column untouched.
+	 */
+	async function stageDraftSlugChange(
+		collection: string,
+		entryId: string,
+		data: Record<string, unknown>,
+		newSlug: string,
+	): Promise<void> {
+		const revisionRepo = new RevisionRepository(db);
+		const revision = await revisionRepo.create({
+			collection,
+			entryId,
+			data: { ...data, _slug: newSlug },
+		});
+		await sql`
+			UPDATE ${sql.ref(`ec_${collection}`)}
+			SET draft_revision_id = ${revision.id}
+			WHERE id = ${entryId}
+		`.execute(db);
+	}
+
+	it("creates a 301 from the old URL when publishing a staged slug change", async () => {
+		const created = await handleContentCreate(db, "post", {
+			data: { title: "Hello" },
+			slug: "hello",
+			status: "published",
+		});
+		expect(created.success).toBe(true);
+		const id = created.data!.item.id;
+
+		await stageDraftSlugChange("post", id, { title: "Hello" }, "hello-world");
+
+		const published = await handleContentPublish(db, "post", id);
+		expect(published.success).toBe(true);
+		expect(published.data?.item.slug).toBe("hello-world");
+
+		const redirects = await db.selectFrom("_emdash_redirects").selectAll().execute();
+		expect(redirects).toHaveLength(1);
+		expect(redirects[0]).toMatchObject({
+			source: "/post/hello",
+			destination: "/post/hello-world",
+			type: 301,
+			auto: 1,
+		});
+	});
+
+	it("does not create a redirect on first publish (draft URL was never live)", async () => {
+		const created = await handleContentCreate(db, "post", {
+			data: { title: "Fresh" },
+			slug: "fresh-draft",
+			status: "draft",
+		});
+		expect(created.success).toBe(true);
+		const id = created.data!.item.id;
+
+		await stageDraftSlugChange("post", id, { title: "Fresh" }, "fresh-final");
+
+		const published = await handleContentPublish(db, "post", id);
+		expect(published.success).toBe(true);
+		expect(published.data?.item.slug).toBe("fresh-final");
+
+		const redirects = await db.selectFrom("_emdash_redirects").selectAll().execute();
+		expect(redirects).toHaveLength(0);
+	});
+
+	it("does not create a redirect when republishing without a slug change", async () => {
+		const created = await handleContentCreate(db, "post", {
+			data: { title: "Stable" },
+			slug: "stable",
+			status: "published",
+		});
+		expect(created.success).toBe(true);
+		const id = created.data!.item.id;
+
+		await stageDraftSlugChange("post", id, { title: "Stable (edited)" }, "stable");
+
+		const published = await handleContentPublish(db, "post", id);
+		expect(published.success).toBe(true);
+
+		const redirects = await db.selectFrom("_emdash_redirects").selectAll().execute();
+		expect(redirects).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## What does this PR do?

EmDash already creates a 301 "Auto: slug change" redirect when a content slug changes — but only inside `handleContentUpdate`. For collections that support drafts + revisions (**the default** for every collection), the admin's slug edit never takes that path:

1. Saving a published entry stages the new slug as `_slug` inside the **draft revision** (`emdash-runtime.ts` explicitly passes `slug: undefined` to `handleContentUpdate` when `usesDraftRevisions` is true).
2. Clicking **Publish** promotes the revision, and `ContentRepository.publish()` syncs `revision.data._slug` straight into the live `slug` column with raw SQL — bypassing the redirect logic entirely.

So for the standard editing flow, changing a published entry's slug silently breaks the old URL: no redirect row is ever created, old links 404, and search engines lose the page.

This PR makes `handleContentPublish` capture the pre-publish state and create the 301 when an **already-published** entry's slug changes during publish, via a `createSlugChangeRedirect` helper shared with the existing `handleContentUpdate` path (same `createAutoRedirect` repository call — URL-pattern aware, chain-collapsing, deduped by source). First publishes are excluded: a draft's URL was never public, so there is nothing to redirect.

Covered by three new handler tests: staged slug change on a published entry creates the 301; first publish creates none; republish without a slug change creates none.

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes (`emdash` package — clean)
- [x] `pnpm lint` passes (`oxlint --type-aware --deny-warnings` clean on changed files)
- [x] `pnpm test` passes (`tests/unit/api/content-handlers.test.ts` — 34 passed, incl. 3 new)
- [x] `pnpm format` has been run (`oxfmt` clean)
- [x] I have added/updated tests for my changes (3 new tests for the publish path)
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a, no admin changes
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash`: patch)
- [x] New features link to an approved Discussion — n/a (bug fix)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

```
✓ tests/unit/api/content-handlers.test.ts (34 tests) 1.22s
  ✓ Content Handlers — slug-change auto-redirect on publish
    ✓ creates a 301 from the old URL when publishing a staged slug change
    ✓ does not create a redirect on first publish (draft URL was never live)
    ✓ does not create a redirect when republishing without a slug change
Test Files  1 passed (1) · Tests  34 passed (34)
```
