### PR TITLE
docs: add a deployed schema-evolution guide for D1 sites (#442)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -218,6 +218,7 @@ export default defineConfig({
 					items: [
 						{ label: "Deploy to Cloudflare", slug: "deployment/cloudflare" },
 						{ label: "Deploy to Node.js", slug: "deployment/nodejs" },
+						{ label: "Evolving a Deployed Site", slug: "deployment/schema-evolution" },
 						{ label: "Database Options", slug: "deployment/database" },
 						{ label: "Storage Options", slug: "deployment/storage" },
 						{ label: "Object Cache", slug: "deployment/object-cache" },

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -68,6 +68,8 @@ Database migrations run automatically on the first request after deployment, and
 
 If the database is empty (no collections) and the setup wizard hasn't been completed, EmDash also applies a seed file on first boot. The seed is read at build time from `.emdash/seed.json`, the path in `package.json#emdash.seed`, or `seed/seed.json` — whichever is found first — and inlined into the bundle. If none is present, a built-in default seed is used. Subsequent deploys against an existing database leave its content alone.
 
+To change the schema or content model of a site that is already deployed, see [Evolving a Deployed Site](/deployment/schema-evolution/).
+
 ## Deploy
 
 Deploy to Cloudflare Workers:

--- a/docs/src/content/docs/deployment/schema-evolution.mdx
+++ b/docs/src/content/docs/deployment/schema-evolution.mdx
@@ -1,0 +1,125 @@
+---
+title: Evolving a Deployed Site
+description: Change the schema and content model of a live EmDash site, and keep your seed file in sync.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+EmDash stores collections, fields, and taxonomies in the database, next to the content itself. Deploying new code does not change them: a deploy replaces the Worker (or server) code, while the schema and content in the database stay as they are. This page explains how to change the content model of a site that is already deployed, using Cloudflare D1 as the running example. The same workflows apply to the other [database options](/deployment/database/).
+
+## What changes what
+
+A site goes through four distinct workflows. Each one touches a different layer:
+
+| Workflow                       | What changes                       | How                                                                    |
+| ------------------------------ | ---------------------------------- | ---------------------------------------------------------------------- |
+| Content editing                | Entries, media, settings           | Admin panel or [content API](/reference/api/)                          |
+| Code deploy                    | Templates, config, EmDash version  | `wrangler deploy` — leaves schema and content untouched                |
+| First-time bootstrap           | Everything, from empty             | Migrations + seed file + setup wizard, automatic on first boot         |
+| Schema evolution               | Collections, fields, taxonomies    | Admin panel or `emdash schema` against the live site (this page)       |
+
+The seed file only participates in the third row. It is applied once, when the database is empty and the setup wizard has not been completed. Deploying a changed seed file against an existing database does nothing — evolving a live site's schema always happens through the admin panel or the API.
+
+<Aside type="note">
+	EmDash's internal tables (users, revisions, redirects, options) are migrated automatically: pending
+	migrations run on the first request after a deploy. Your content model is never changed by a
+	migration — it belongs to you.
+</Aside>
+
+## Change the schema in the admin panel
+
+The admin panel is the primary way to evolve a deployed site. Open **Content Types** in the admin and add, edit, or remove collections and fields. Changes take effect immediately — the content API, the loader, and the editing UI all read the schema from the database at runtime.
+
+See [Collections & Fields](/concepts/collections/) for the available field types, validation rules, and widget options.
+
+After changing the schema, regenerate the TypeScript types your templates use. The `emdash types` command reads the schema from a running instance, so it can point at the deployed site directly:
+
+```bash
+npx emdash types --url https://example.com
+```
+
+## Change the schema from the CLI
+
+The `emdash schema` commands talk to a running instance over its REST API, so they work against a deployed site the same way they work against local dev. Authenticate once with the device flow:
+
+```bash
+npx emdash login --url https://example.com
+```
+
+Alternatively, create an API token in the admin under **Settings → API Tokens** and pass it with `--token` or the `EMDASH_TOKEN` environment variable — useful for CI.
+
+Then evolve the schema with the same commands you would use locally:
+
+```bash
+npx emdash schema add-field posts subtitle --type string --label "Subtitle" --url https://example.com
+npx emdash schema remove-field posts legacy_field --url https://example.com
+npx emdash schema create projects --label Projects --url https://example.com
+```
+
+Because these commands are plain CLI calls, they can be scripted: a repeatable "migration" for your content model is a shell script of `emdash schema` calls, checked into your repository and run against each environment in turn.
+
+See the [CLI reference](/reference/cli/#emdash-schema) for the full command list.
+
+<Aside type="caution">
+	Removing a field deletes its column and data. Test schema changes against a preview environment
+	before running them against production — see [Rehearse changes on a preview
+	environment](#rehearse-changes-on-a-preview-environment).
+</Aside>
+
+## Keep the seed file in sync
+
+The seed file embedded in your build determines what a **fresh** database initializes to: a new preview environment, a disaster-recovery rebuild, or a second deployment of the same site. If the seed still describes the starter blog while production has evolved into something else, every fresh environment bootstraps with the wrong model.
+
+The build embeds the first seed file found at `.emdash/seed.json`, the path in `package.json#emdash.seed`, or `seed/seed.json`. If none is present, a built-in default seed (the starter blog model) is embedded, and `astro dev` logs a warning.
+
+After evolving a deployed site's schema, export the live model back into your repository. `emdash export-seed` reads a local SQLite file, and `wrangler d1 export` produces one from the deployed D1 database:
+
+```bash
+npx wrangler d1 export emdash-db --remote --output=./prod.sql
+sqlite3 prod.db < prod.sql
+npx emdash export-seed --database prod.db > .emdash/seed.json
+```
+
+The exported seed contains the settings, collections, taxonomies, menus, and widget areas of the live site. Add `--with-content` to include entries. Commit the updated `.emdash/seed.json` together with the code that depends on the new schema, so a fresh environment always bootstraps to a model the code understands.
+
+## Rehearse changes on a preview environment
+
+A destructive schema change (removing a field, restructuring a collection) is safest rehearsed against a disposable copy of production.
+
+<Steps>
+
+1. Add a preview environment with its own D1 database to `wrangler.jsonc`:
+
+   ```jsonc
+   {
+   	"env": {
+   		"preview": {
+   			"d1_databases": [{ "binding": "DB", "database_name": "emdash-db-preview" }],
+   		},
+   	},
+   }
+   ```
+
+2. Copy production into it:
+
+   ```bash
+   npx wrangler d1 export emdash-db --remote --output=./prod.sql
+   npx wrangler d1 execute emdash-db-preview --remote --file=./prod.sql
+   ```
+
+3. Deploy and run the schema change against the preview URL:
+
+   ```bash
+   npx wrangler deploy --env preview
+   npx emdash schema remove-field posts legacy_field --url https://preview.example.com
+   ```
+
+4. Verify the site renders and the admin behaves as expected, then run the same commands against production.
+
+</Steps>
+
+## Recover from a wrong turn
+
+- **A field was removed by mistake.** The column and its data are gone from the live database. Restore from a D1 [Time Travel](https://developers.cloudflare.com/d1/reference/time-travel/) point-in-time backup, or re-add the field and restore its values from an earlier `wrangler d1 export`.
+- **A fresh environment bootstrapped with the wrong model.** The embedded seed was stale or missing. Update `.emdash/seed.json` (see [Keep the seed file in sync](#keep-the-seed-file-in-sync)), rebuild, and point the deploy at an empty database to bootstrap again.
+- **The schema and the templates disagree.** Deploys and schema changes are independent, so order them deliberately: additive schema changes (new collection, new optional field) go first, then the code that uses them. For removals, deploy the code that stops using the field first, then remove the field.


### PR DESCRIPTION
## What does this PR do?

Addresses the documentation side of #442: EmDash has no explicit story for evolving an **already-deployed** site's schema/content model. Fresh bootstrap, code deploys, and content editing are documented — but the fourth workflow (changing collections/fields on a live Cloudflare D1 site) is where users get lost, and where #442's author ended up treating a fresh database as the escape hatch.

The tooling for this actually exists — `emdash schema` / `emdash types` work against a deployed URL with a token, `emdash export-seed` + `wrangler d1 export` can round-trip the live model back into the repo — it's just never assembled into a workflow anywhere in the docs.

This adds a new **Deployment → Evolving a Deployed Site** page covering:

- **What changes what** — a table of the four workflows (content editing, code deploy, first bootstrap, schema evolution) and the explicit statement that deploys never touch schema/content and the seed only applies to an empty database (the two surprises reported in #442).
- **Schema changes in the admin panel** and **from the CLI** against the live URL (`emdash login` device flow / API tokens, scriptable `emdash schema` calls as repeatable content-model migrations).
- **Keeping the seed in sync** — the `wrangler d1 export` → `sqlite3` → `emdash export-seed` recipe, plus the stale-embedded-seed gotcha (#442's point 4; the build warning for the default-seed fallback already exists).
- **Rehearsing destructive changes on a preview environment** (copy prod D1 into a preview DB, run the change there first).
- **Recovering from a wrong turn** (Time Travel, additive-first ordering of schema vs code changes).

Also links the new page from the Cloudflare deploy guide's First Boot section and adds it to the sidebar.

Docs-only — no package changes, so no changeset.

Closes #

Refs #442

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes — n/a (docs only); `pnpm --filter docs build` passes (76 pages)
- [x] `pnpm lint` passes — n/a (MDX content)
- [x] `pnpm test` passes — n/a (docs only)
- [x] `pnpm format` has been run (`prettier` clean on all changed files)
- [x] I have added/updated tests for my changes (if applicable) — n/a
- [x] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [x] I have added a changeset (if this PR changes a published package) — n/a, docs only
- [x] New features link to an approved Discussion — n/a (documentation)

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

`pnpm --filter docs build` completes cleanly; the new page renders at `/deployment/schema-evolution/` and is indexed by Pagefind. Written against the [docs style guide](https://emdash.dev/contributing/docs-style-guide/) (evergreen phrasing, full-sentence code-block intros, `<Steps>` for the preview rehearsal procedure).
