### PR TITLE
fix(core): exclude first-party packages from the workerd dep optimizer

### DIFF
--- a/.changeset/tender-onions-refuse.md
+++ b/.changeset/tender-onions-refuse.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes MCP tools and content writes failing in Cloudflare dev servers with `The file does not exist at ".../deps_ssr/..."` after Vite re-optimizes dependencies, which previously required a dev server restart. Also pre-bundles the migration runner, image transform endpoint, and `astro/zod` so the first setup, image, or content request no longer triggers a mid-session re-optimization and worker reload.

--- a/packages/core/src/astro/integration/vite-config.ts
+++ b/packages/core/src/astro/integration/vite-config.ts
@@ -444,7 +444,18 @@ export function createViteConfig(
 						// during pre-bundling and can't resolve them. Vite's exclude
 						// uses prefix matching (id.startsWith(m + "/")), so
 						// "virtual:emdash" matches all "virtual:emdash/*" imports.
-						exclude: ["virtual:emdash"],
+						//
+						// First-party packages must also stay excluded. In a
+						// real install (unlike the workspace symlink, which Vite never
+						// optimizes), the optimizer bundles their dist and code-splits
+						// lazily-executed dynamic imports (MCP tools, content
+						// validation) into hashed chunks. A mid-session re-optimization
+						// deletes those chunks while loaded modules still reference
+						// them, so every content write fails with "The file does not
+						// exist at .../deps_ssr/..." until the dev server restarts.
+						// Their CJS deps are still pre-bundled via the "parent > dep"
+						// include entries below, which resolve through excluded parents.
+						exclude: ["virtual:emdash", "emdash", "@emdash-cms/admin", "@emdash-cms/cloudflare"],
 						include: [
 							// EmDash direct deps
 							"emdash > @portabletext/toolkit",
@@ -455,6 +466,9 @@ export function createViteConfig(
 							"emdash > jose",
 							"emdash > jpeg-js",
 							"emdash > kysely",
+							// Only imported by the migration runner, so the first
+							// dev-bypass/setup request would otherwise discover it.
+							"emdash > kysely/migration",
 							"emdash > mime/lite",
 							"emdash > modern-tar",
 							"emdash > sanitize-html",
@@ -496,6 +510,7 @@ export function createViteConfig(
 							// Top-level deps (use astro > path for pnpm compat)
 							"astro > zod/v4",
 							"astro > zod/v4/core",
+							"astro/zod",
 							// zod-generator imports the bare `zod` entry, not `zod/v4`
 							"emdash > zod",
 							"@emdash-cms/cloudflare > kysely-d1",
@@ -507,6 +522,9 @@ export function createViteConfig(
 							"astro/assets/fonts/runtime.js",
 							"astro/assets/services/noop",
 							"@astrojs/cloudflare/image-service",
+							// Only imported by the /_image route, so the first image
+							// request would otherwise discover it.
+							"@astrojs/cloudflare/image-transform-endpoint",
 						],
 					},
 				}

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -79,51 +79,6 @@ describe("createViteConfig admin aliasing", () => {
 	});
 });
 
-describe("createViteConfig Cloudflare SSR dep optimization", () => {
-	const externalProjectRoot = new URL("file:///workspace/emdash-site/");
-
-	function buildConfig() {
-		return createViteConfig(
-			{
-				serializableConfig: {},
-				resolvedConfig: {} as never,
-				pluginDescriptors: [],
-				astroConfig: {
-					root: externalProjectRoot,
-					adapter: { name: "@astrojs/cloudflare" },
-				} as AstroConfig,
-			},
-			"dev",
-		);
-	}
-
-	// Regression: in a real install (not the workspace symlink, which Vite
-	// never optimizes), the workerd optimizer bundles noExternal'd dists and
-	// code-splits their lazily-executed dynamic imports (MCP tools, content
-	// validation) into hashed chunks. Any mid-session re-optimization deletes
-	// those chunks while loaded modules still point at them, so every content
-	// write fails with "The file does not exist at .../deps_ssr/..." until
-	// the dev server restarts. The monorepo can't catch a violation, so this
-	// pins the rule: whatever is served to workerd from node_modules must
-	// also be excluded from its optimizer.
-	it("excludes every noExternal package from the workerd optimizer", () => {
-		const config = buildConfig();
-		const ssr = config.ssr as {
-			noExternal?: string[];
-			optimizeDeps?: { exclude?: string[] };
-		};
-		const noExternal = ssr.noExternal ?? [];
-		const exclude = ssr.optimizeDeps?.exclude ?? [];
-
-		expect(noExternal.length).toBeGreaterThan(0);
-		for (const pkg of noExternal) {
-			expect(exclude).toContain(pkg);
-		}
-		// Not noExternal, but its dist reaches workerd the same way.
-		expect(exclude).toContain("@emdash-cms/cloudflare");
-	});
-});
-
 describe("createViteConfig use-sync-external-store shim aliasing", () => {
 	const externalProjectRoot = new URL("file:///workspace/emdash-site/");
 

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -97,35 +97,30 @@ describe("createViteConfig Cloudflare SSR dep optimization", () => {
 		);
 	}
 
-	// Regression: in a real install (not the workspace symlink, which
-	// Vite never optimizes), the workerd optimizer bundles emdash's dist and
-	// code-splits its lazily-executed dynamic imports (MCP tools, content
+	// Regression: in a real install (not the workspace symlink, which Vite
+	// never optimizes), the workerd optimizer bundles noExternal'd dists and
+	// code-splits their lazily-executed dynamic imports (MCP tools, content
 	// validation) into hashed chunks. Any mid-session re-optimization deletes
 	// those chunks while loaded modules still point at them, so every content
-	// write fails with "The file does not exist at .../deps_ssr/..." until the
-	// dev server restarts. First-party packages must stay excluded.
-	it("excludes first-party packages from the workerd optimizer", () => {
+	// write fails with "The file does not exist at .../deps_ssr/..." until
+	// the dev server restarts. The monorepo can't catch a violation, so this
+	// pins the rule: whatever is served to workerd from node_modules must
+	// also be excluded from its optimizer.
+	it("excludes every noExternal package from the workerd optimizer", () => {
 		const config = buildConfig();
-		const ssr = config.ssr as { optimizeDeps?: { exclude?: string[] } };
+		const ssr = config.ssr as {
+			noExternal?: string[];
+			optimizeDeps?: { exclude?: string[] };
+		};
+		const noExternal = ssr.noExternal ?? [];
 		const exclude = ssr.optimizeDeps?.exclude ?? [];
 
-		expect(exclude).toContain("emdash");
-		expect(exclude).toContain("@emdash-cms/admin");
+		expect(noExternal.length).toBeGreaterThan(0);
+		for (const pkg of noExternal) {
+			expect(exclude).toContain(pkg);
+		}
+		// Not noExternal, but its dist reaches workerd the same way.
 		expect(exclude).toContain("@emdash-cms/cloudflare");
-		expect(exclude).toContain("virtual:emdash");
-	});
-
-	// These are only reached on the first request to their route/feature, so
-	// the startup pass misses them; each late discovery re-optimizes and
-	// reloads the worker mid-session.
-	it("pre-bundles deps that are only discovered after startup", () => {
-		const config = buildConfig();
-		const ssr = config.ssr as { optimizeDeps?: { include?: string[] } };
-		const include = ssr.optimizeDeps?.include ?? [];
-
-		expect(include).toContain("emdash > kysely/migration");
-		expect(include).toContain("astro/zod");
-		expect(include).toContain("@astrojs/cloudflare/image-transform-endpoint");
 	});
 });
 

--- a/packages/core/tests/unit/astro/vite-config.test.ts
+++ b/packages/core/tests/unit/astro/vite-config.test.ts
@@ -79,6 +79,56 @@ describe("createViteConfig admin aliasing", () => {
 	});
 });
 
+describe("createViteConfig Cloudflare SSR dep optimization", () => {
+	const externalProjectRoot = new URL("file:///workspace/emdash-site/");
+
+	function buildConfig() {
+		return createViteConfig(
+			{
+				serializableConfig: {},
+				resolvedConfig: {} as never,
+				pluginDescriptors: [],
+				astroConfig: {
+					root: externalProjectRoot,
+					adapter: { name: "@astrojs/cloudflare" },
+				} as AstroConfig,
+			},
+			"dev",
+		);
+	}
+
+	// Regression: in a real install (not the workspace symlink, which
+	// Vite never optimizes), the workerd optimizer bundles emdash's dist and
+	// code-splits its lazily-executed dynamic imports (MCP tools, content
+	// validation) into hashed chunks. Any mid-session re-optimization deletes
+	// those chunks while loaded modules still point at them, so every content
+	// write fails with "The file does not exist at .../deps_ssr/..." until the
+	// dev server restarts. First-party packages must stay excluded.
+	it("excludes first-party packages from the workerd optimizer", () => {
+		const config = buildConfig();
+		const ssr = config.ssr as { optimizeDeps?: { exclude?: string[] } };
+		const exclude = ssr.optimizeDeps?.exclude ?? [];
+
+		expect(exclude).toContain("emdash");
+		expect(exclude).toContain("@emdash-cms/admin");
+		expect(exclude).toContain("@emdash-cms/cloudflare");
+		expect(exclude).toContain("virtual:emdash");
+	});
+
+	// These are only reached on the first request to their route/feature, so
+	// the startup pass misses them; each late discovery re-optimizes and
+	// reloads the worker mid-session.
+	it("pre-bundles deps that are only discovered after startup", () => {
+		const config = buildConfig();
+		const ssr = config.ssr as { optimizeDeps?: { include?: string[] } };
+		const include = ssr.optimizeDeps?.include ?? [];
+
+		expect(include).toContain("emdash > kysely/migration");
+		expect(include).toContain("astro/zod");
+		expect(include).toContain("@astrojs/cloudflare/image-transform-endpoint");
+	});
+});
+
 describe("createViteConfig use-sync-external-store shim aliasing", () => {
 	const externalProjectRoot = new URL("file:///workspace/emdash-site/");
 


### PR DESCRIPTION
## What does this PR do?

Fixes MCP tools and content writes failing in Cloudflare dev servers with `[INTERNAL_ERROR] The file does not exist at ".../node_modules/.vite/deps_ssr/validation-XXXX.js?v=..."` after Vite re-optimizes dependencies mid-session. Once this happened, every content write kept failing until the dev server was restarted.

**Root cause.** In a real install, the workerd dep optimizer bundles emdash's dist and code-splits its lazily-executed dynamic imports (the MCP tool callbacks, the content-validation handler) into hashed chunks. Any dependency discovered after startup — the `/_image` route pulling in `@astrojs/cloudflare/image-transform-endpoint`, the first setup request pulling in `kysely/migration` — triggers a re-optimization that deletes those chunks while already-loaded modules still reference them. The worker reload can itself die on a stale chunk mid-churn (`[vite] An error happened during full reload: The file does not exist at ...`), leaving the running program permanently poisoned. The failing chunk in the reported error (`validation-CY1gk4Ar-Dswqb-JQ.js`) is emdash's own dist file `validation-CY1gk4Ar.mjs` re-chunked by the optimizer.

This never reproduced in the monorepo because Vite does not optimize workspace-linked packages — every in-repo dev session already runs emdash unoptimized, which is exactly the behavior this PR gives real installs.

**Fix.**

- Exclude `emdash`, `@emdash-cms/admin`, and `@emdash-cms/cloudflare` from `ssr.optimizeDeps` in the Cloudflare branch, so their modules are served unoptimized and their chunks can never dangle. Their CJS deps are still pre-bundled via the existing `parent > dep` include entries, which resolve through excluded parents (Vite's documented pattern).
- Pre-bundle the three deps still discovered after startup (`emdash > kysely/migration`, `astro/zod`, `@astrojs/cloudflare/image-transform-endpoint`), so a template site performs zero re-optimizations after boot.

**Verification.** Reproduced and verified against a standalone site outside the workspace (copied from `templates/starter-cloudflare`, installed with published packages, then with a `pnpm pack`ed build of this branch): cold start → setup dev-bypass → MCP initialize/tools-list → concurrent `/_image` + admin traffic → `content_create` with Markdown conversion → publish → page render. Before: multiple failed worker reloads with the exact reported error. After: zero missing-chunk errors and zero re-optimization events; all MCP tools work on first use.

No linked issue — reported directly from the EmDash Build sandbox, where the first `content_create` call after a site spin-up failed every time.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change) — full `packages/core` unit suite (3001 tests)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a: the change is optimizer config with no unit-testable logic; asserting the config literals back at themselves would be tautological. The bug only manifests with a non-symlinked emdash install under workerd, so an automated repro needs a packed-tarball CI lane (candidate for a follow-up Discussion). Verified manually as described above.
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable) — n/a, no UI strings
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

Failing state (published emdash in a standalone site, first MCP-adjacent churn):

```
✨ dependency optimized: emdash/media/local-runtime
✨ optimized dependencies changed. reloading
[vite] An error happened during full reload
The file does not exist at ".../node_modules/.vite/deps_ssr/handler-CTT8V1im.js?v=513ab8f1" which is in the optimize deps directory. The dependency might be incompatible with the dep optimizer. Try adding it to `optimizeDeps.exclude`.
```

With this branch (same site, same sequence): no `does not exist` lines, no re-optimizations after startup, and the first `content_create` tool call succeeds.

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://fix-cf-dev-optimizer-stale-chunks-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `fix/cf-dev-optimizer-stale-chunks`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
