### PR TITLE
feat(core): gate bylines and taxonomy terms behind includeContent

### DIFF
--- a/.changeset/seed-include-content-gating.md
+++ b/.changeset/seed-include-content-gating.md
@@ -1,0 +1,5 @@
+---
+"emdash": minor
+---
+
+Excluding sample content when seeding (`emdash seed --no-content`, or unchecking "Include sample content" in the setup wizard) now also skips the seed's sample bylines and taxonomy terms, so a schema-only setup starts with no sample data at all. Taxonomy definitions, collections, menus, and other structure are still applied. The dev-only setup bypass endpoint accepts `?content=0` to do the same.

--- a/packages/core/src/astro/routes/api/setup/dev-bypass.ts
+++ b/packages/core/src/astro/routes/api/setup/dev-bypass.ts
@@ -10,6 +10,8 @@
  * Usage:
  * - GET with redirect: /_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
  * - POST for API: Returns JSON with setup info
+ * - ?content=0 (or ?content=false): apply schema/structure only, skipping
+ *   sample content entries, bylines, and taxonomy terms
  *
  * For agent/browser testing, navigate to:
  *   /_emdash/api/setup/dev-bypass?redirect=/_emdash/admin
@@ -57,12 +59,15 @@ async function handleDevBypass(context: Parameters<APIRoute>[0]): Promise<Respon
 		const migrations = await runMigrations(emdash.db);
 		console.log("[setup-dev-bypass] Migrations applied:", migrations.applied);
 
-		// Apply seed (user seed or built-in default)
+		// Apply seed (user seed or built-in default). `?content=0` (or `false`)
+		// applies schema/structure only — no sample content, bylines, or terms.
+		const contentParam = url.searchParams.get("content");
+		const includeContent = contentParam !== "0" && contentParam !== "false";
 		const seed = await loadSeed();
 		const validation = validateSeed(seed);
 		if (validation.valid) {
 			const seedResult = await applySeed(emdash.db, seed, {
-				includeContent: true,
+				includeContent,
 				onConflict: "skip",
 				storage: emdash.storage ?? undefined,
 			});

--- a/packages/core/src/cli/commands/seed.ts
+++ b/packages/core/src/cli/commands/seed.ts
@@ -108,7 +108,7 @@ export const seedCommand = defineCommand({
 		},
 		"no-content": {
 			type: "boolean",
-			description: "Skip sample content",
+			description: "Skip sample data (content entries, bylines, taxonomy terms)",
 			default: false,
 		},
 		"on-conflict": {

--- a/packages/core/src/seed/apply.ts
+++ b/packages/core/src/seed/apply.ts
@@ -296,7 +296,7 @@ export async function applySeed(
 				defSeedIdMap.set(taxonomy.id, { id: defId, translationGroup: defTranslationGroup });
 
 			// Create terms (if provided)
-			if (taxonomy.terms && taxonomy.terms.length > 0) {
+			if (includeContent && taxonomy.terms && taxonomy.terms.length > 0) {
 				const termRepo = new TaxonomyRepository(db);
 
 				if (taxonomy.hierarchical) {
@@ -355,7 +355,7 @@ export async function applySeed(
 	}
 
 	// 6. Bylines
-	if (seed.bylines) {
+	if (includeContent && seed.bylines) {
 		const bylineRepo = new BylineRepository(db);
 		for (const byline of seed.bylines) {
 			const existing = await bylineRepo.findBySlug(byline.slug);

--- a/packages/core/src/seed/types.ts
+++ b/packages/core/src/seed/types.ts
@@ -288,7 +288,12 @@ export interface SeedBylineCredit {
  * Options for applying a seed
  */
 export interface SeedApplyOptions {
-	/** Include sample content (default: false) */
+	/**
+	 * Include sample data: content entries, bylines, and taxonomy terms
+	 * (default: false). Schema and structure (collections, fields, taxonomy
+	 * definitions, menus, settings, redirects, widget areas, sections) are
+	 * always applied.
+	 */
 	includeContent?: boolean;
 
 	/** How to handle conflicts (default: "skip") */

--- a/packages/core/tests/integration/seed-on-conflict.test.ts
+++ b/packages/core/tests/integration/seed-on-conflict.test.ts
@@ -378,13 +378,13 @@ describe("applySeed onConflict modes", () => {
 		});
 
 		it("throws on existing byline", async () => {
-			// Seed without collections to get past collections step
-			const seed = createTestSeed({ collections: [] });
-			await applySeed(db, seed);
+			// Seed without collections (and their content) to get past those steps
+			const seed = createTestSeed({ collections: [], content: {} });
+			await applySeed(db, seed, { includeContent: true });
 
-			await expect(applySeed(db, seed, { onConflict: "error" })).rejects.toThrow(
-				'Conflict: byline "jane-doe" already exists',
-			);
+			await expect(
+				applySeed(db, seed, { includeContent: true, onConflict: "error" }),
+			).rejects.toThrow('Conflict: byline "jane-doe" already exists');
 		});
 
 		it("throws on existing redirect", async () => {

--- a/packages/core/tests/unit/astro/setup-dev-bypass.test.ts
+++ b/packages/core/tests/unit/astro/setup-dev-bypass.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Dev-bypass seed gating.
+ *
+ * The route seeds sample data by default; `?content=0` (or `false`) applies
+ * schema/structure only so an agent or test harness can start from a clean
+ * site without deleting seeded entries afterwards.
+ */
+
+import type { APIContext } from "astro";
+import type { Kysely } from "kysely";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { ContentRepository } from "../../../src/database/repositories/content.js";
+import type { Database } from "../../../src/database/types.js";
+import type { SeedFile } from "../../../src/seed/types.js";
+import { setupTestDatabase, teardownTestDatabase } from "../../utils/test-db.js";
+
+const fixtureSeed: SeedFile = {
+	version: "1",
+	settings: { title: "Fixture Site" },
+	collections: [
+		{
+			slug: "posts",
+			label: "Posts",
+			fields: [{ slug: "title", label: "Title", type: "string" }],
+		},
+	],
+	taxonomies: [
+		{
+			name: "tags",
+			label: "Tags",
+			hierarchical: false,
+			collections: ["posts"],
+			terms: [{ slug: "sample-tag", label: "Sample Tag" }],
+		},
+	],
+	bylines: [{ id: "sample", slug: "sample-author", displayName: "Sample Author" }],
+	content: {
+		posts: [{ id: "post-1", slug: "sample-post", data: { title: "Sample Post" } }],
+	},
+	menus: [
+		{
+			name: "primary",
+			label: "Primary",
+			items: [{ type: "custom", label: "Home", url: "/" }],
+		},
+	],
+};
+
+vi.mock("virtual:emdash/seed", () => ({ seed: fixtureSeed, userSeed: null }), { virtual: true });
+
+import { GET } from "../../../src/astro/routes/api/setup/dev-bypass.js";
+
+function makeContext(db: Kysely<Database>, search = ""): APIContext {
+	return {
+		locals: { emdash: { db, storage: null, config: {} } },
+		url: new URL(`http://localhost:4321/_emdash/api/setup/dev-bypass${search}`),
+		session: undefined,
+	} as unknown as APIContext;
+}
+
+async function countPosts(db: Kysely<Database>) {
+	const { items } = await new ContentRepository(db).findMany("posts", {});
+	return items.length;
+}
+
+async function countRows(db: Kysely<Database>, table: "taxonomies" | "_emdash_bylines") {
+	const rows = await db.selectFrom(table).select("id").execute();
+	return rows.length;
+}
+
+describe("setup dev-bypass seed gating", () => {
+	let db: Kysely<Database>;
+
+	beforeEach(async () => {
+		db = await setupTestDatabase();
+	});
+
+	afterEach(async () => {
+		await teardownTestDatabase(db);
+	});
+
+	it("seeds sample data by default", async () => {
+		const response = await GET(makeContext(db));
+		expect(response.status).toBe(200);
+
+		expect(await countPosts(db)).toBe(1);
+		expect(await countRows(db, "taxonomies")).toBe(1);
+		expect(await countRows(db, "_emdash_bylines")).toBe(1);
+	});
+
+	it("applies schema only with ?content=0", async () => {
+		const response = await GET(makeContext(db, "?content=0"));
+		expect(response.status).toBe(200);
+
+		expect(await countPosts(db)).toBe(0);
+		expect(await countRows(db, "taxonomies")).toBe(0);
+		expect(await countRows(db, "_emdash_bylines")).toBe(0);
+
+		// Schema and structure still apply
+		const collections = await db
+			.selectFrom("_emdash_collections")
+			.select("slug")
+			.where("slug", "=", "posts")
+			.execute();
+		expect(collections).toHaveLength(1);
+
+		const taxonomyDefs = await db
+			.selectFrom("_emdash_taxonomy_defs")
+			.select("name")
+			.where("name", "=", "tags")
+			.execute();
+		expect(taxonomyDefs).toHaveLength(1);
+
+		const menus = await db
+			.selectFrom("_emdash_menus")
+			.select("name")
+			.where("name", "=", "primary")
+			.execute();
+		expect(menus).toHaveLength(1);
+	});
+
+	it("accepts ?content=false", async () => {
+		const response = await GET(makeContext(db, "?content=false"));
+		expect(response.status).toBe(200);
+
+		expect(await countPosts(db)).toBe(0);
+	});
+});

--- a/packages/core/tests/unit/seed/apply.test.ts
+++ b/packages/core/tests/unit/seed/apply.test.ts
@@ -170,7 +170,31 @@ describe("applySeed", () => {
 			expect(row?.translation_group).toBe(row?.id);
 		});
 
-		it("should create flat taxonomy terms", async () => {
+		it("should not create terms by default", async () => {
+			const seed: SeedFile = {
+				version: "1",
+				taxonomies: [
+					{
+						name: "tags",
+						label: "Tags",
+						hierarchical: false,
+						collections: ["posts"],
+						terms: [{ slug: "javascript", label: "JavaScript" }],
+					},
+				],
+			};
+
+			const result = await applySeed(db, seed);
+
+			expect(result.taxonomies.created).toBe(1);
+			expect(result.taxonomies.terms).toBe(0);
+
+			const termRepo = new TaxonomyRepository(db);
+			const term = await termRepo.findBySlug("tags", "javascript");
+			expect(term).toBeFalsy();
+		});
+
+		it("should create flat taxonomy terms when includeContent is true", async () => {
 			const seed: SeedFile = {
 				version: "1",
 				taxonomies: [
@@ -188,7 +212,7 @@ describe("applySeed", () => {
 				],
 			};
 
-			const result = await applySeed(db, seed);
+			const result = await applySeed(db, seed, { includeContent: true });
 
 			expect(result.taxonomies.created).toBe(1);
 			expect(result.taxonomies.terms).toBe(3);
@@ -213,7 +237,7 @@ describe("applySeed", () => {
 				],
 			};
 
-			const result = await applySeed(db, seed);
+			const result = await applySeed(db, seed, { includeContent: true });
 
 			expect(result.taxonomies.terms).toBe(4);
 
@@ -261,7 +285,7 @@ describe("applySeed", () => {
 				],
 			};
 
-			const result = await applySeed(db, seed);
+			const result = await applySeed(db, seed, { includeContent: true });
 
 			// Definition already exists, so not created
 			expect(result.taxonomies.created).toBe(0);
@@ -673,6 +697,21 @@ describe("applySeed", () => {
 			expect(entry?.primaryBylineId).toBe(credits[0]?.byline.id);
 		});
 
+		it("should not create bylines by default", async () => {
+			const seed: SeedFile = {
+				version: "1",
+				bylines: [{ id: "editorial", slug: "editorial", displayName: "Editorial" }],
+			};
+
+			const result = await applySeed(db, seed);
+
+			expect(result.bylines.created).toBe(0);
+
+			const bylineRepo = new BylineRepository(db);
+			const byline = await bylineRepo.findBySlug("editorial");
+			expect(byline).toBeFalsy();
+		});
+
 		it("should seed a byline avatar as a media row and link it", async () => {
 			const seed: SeedFile = {
 				version: "1",
@@ -691,7 +730,7 @@ describe("applySeed", () => {
 				],
 			};
 
-			const result = await applySeed(db, seed);
+			const result = await applySeed(db, seed, { includeContent: true });
 
 			expect(result.bylines.created).toBe(1);
 			// The avatar created a backing media row.
@@ -716,10 +755,14 @@ describe("applySeed", () => {
 			const bylineRepo = new BylineRepository(db);
 
 			// First seed: no avatar.
-			await applySeed(db, {
-				version: "1",
-				bylines: [{ id: "grace", slug: "grace-hopper", displayName: "Grace Hopper" }],
-			});
+			await applySeed(
+				db,
+				{
+					version: "1",
+					bylines: [{ id: "grace", slug: "grace-hopper", displayName: "Grace Hopper" }],
+				},
+				{ includeContent: true },
+			);
 			const before = await bylineRepo.findBySlug("grace-hopper");
 			expect(before?.avatarMediaId).toBeNull();
 
@@ -737,7 +780,7 @@ describe("applySeed", () => {
 						},
 					],
 				},
-				{ onConflict: "update" },
+				{ onConflict: "update", includeContent: true },
 			);
 
 			expect(result.bylines.updated).toBe(1);
@@ -760,7 +803,7 @@ describe("applySeed", () => {
 						},
 					],
 				},
-				{ onConflict: "update" },
+				{ onConflict: "update", includeContent: true },
 			);
 			expect(rerun.media.created).toBe(0);
 			const mediaRows = await db
@@ -1400,7 +1443,7 @@ describe("applySeed", () => {
 				],
 			};
 
-			await applySeed(db, seed);
+			await applySeed(db, seed, { includeContent: true });
 
 			const terms = await db
 				.selectFrom("taxonomies")


### PR DESCRIPTION
## What does this PR do?

Gates seed bylines and taxonomy terms behind `includeContent`, alongside content entries. Previously `includeContent: false` produced a half-clean site: no posts or pages, but the template's sample authors ("EmDash Editorial") and sample terms (`development`, `webdev`, …) were still created, and anything wanting a schema-only site had to delete them afterwards. Schema and structure (collections, fields, taxonomy definitions, menus, settings, redirects, widget areas, sections) still apply unconditionally.

Also adds `?content=0` (or `?content=false`) to the dev-bypass setup endpoint so headless/agent flows can provision schema-only; the default is unchanged.

Gating bylines is safe because the only references to seed bylines come from seed content, which is gated by the same flag. Two knock-on behaviour changes to be aware of:

- The pre-wizard runtime auto-seed (which passes no `includeContent`) becomes schema-only; the wizard re-applies the seed with the user's choice and `onConflict: "skip"` fills in sample data then.
- Unchecking "Include sample content" in the setup wizard now also skips sample bylines and terms.

## Type of change

- [ ] Bug fix
- [x] Feature (maintainer-initiated — requested directly by @ascorbic, no Discussion)
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (`pnpm lint:json | jq '.diagnostics | length'` → 0)
- [x] `pnpm test` passes (full core unit suite: 3004 passed)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes
- [ ] User-visible strings wrapped for translation — n/a, no admin UI changes (the wizard's existing "Include sample content" label already covers the new semantics)
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets)
- [ ] New features link to an approved Discussion — n/a, maintainer-initiated

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Fable 5 (Claude Code)

## Screenshots / test output

New tests (written first, red → green):

- `apply.test.ts`: `should not create terms by default`, `should not create bylines by default`; existing term/byline tests updated to pass `includeContent: true`.
- `setup-dev-bypass.test.ts`: route-level coverage of the default, `?content=0`, and `?content=false` (fixture seed via `virtual:emdash/seed` mock, real in-memory DB).

```
Test Files  219 passed (219)
     Tests  3004 passed (3004)
```

<!-- emdash:playground-preview:start -->

---

### Try this PR

**[Open a fresh playground →](https://feat-seed-include-content-gating-emdash-playground.emdash-cms.workers.dev)**

A full working EmDash site, deployed from this branch. Each visit gets its own session-scoped sandbox: no login needed and no shared state. Try the admin, edit content, hit the public site.

<sub>Tracks `feat/seed-include-content-gating`. Updated automatically when the playground redeploys.</sub>

<!-- emdash:playground-preview:end -->
