### PR TITLE
docs(cloudflare): warn that D1 sessions are incompatible with global_fetch_strictly_public

### DIFF
--- a/.changeset/d1-session-strictly-public-warning.md
+++ b/.changeset/d1-session-strictly-public-warning.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Documents that D1 read replica sessions (`session: "auto"` / `"primary-first"`) are incompatible with the `global_fetch_strictly_public` compatibility flag, which silently blocks the D1 Sessions API and hangs every SSR request without logging an error.

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -94,9 +94,16 @@ emdash({
 
 You also need to enable read replication on the D1 database itself in the Cloudflare dashboard or via the REST API.
 
-:::caution
-Read replica sessions are incompatible with the [`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public) compatibility flag. With that flag in your `wrangler.jsonc`, the internal request the D1 Sessions API makes to route queries to replicas is silently blocked, and every SSR request hangs until the Worker is killed — with nothing in the logs (`outcome: "canceled"`, no exceptions). The hang may only begin once replicas finish provisioning, so it can pass an initial post-deploy check and surface hours later. If your Worker needs that flag (for example, to fetch its own origin), keep `session` disabled. See [#1273](https://github.com/emdash-cms/emdash/issues/1273).
-:::
+<Aside type="caution">
+	Read replica sessions are incompatible with the
+	[`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)
+	compatibility flag. With that flag in your `wrangler.jsonc`, the internal request the D1 Sessions
+	API makes to route queries to replicas is silently blocked, and every SSR request hangs until the
+	Worker is killed — with nothing in the logs (`outcome: "canceled"`, no exceptions). The hang may
+	only begin once replicas finish provisioning, so it can pass an initial post-deploy check and
+	surface hours later. If your Worker needs that flag (for example, to fetch its own origin), keep
+	`session` disabled. See [#1273](https://github.com/emdash-cms/emdash/issues/1273).
+</Aside>
 
 See [Database Options — Read Replicas](/deployment/database/#read-replicas) for session modes and how bookmark-based consistency works.
 

--- a/docs/src/content/docs/deployment/cloudflare.mdx
+++ b/docs/src/content/docs/deployment/cloudflare.mdx
@@ -94,6 +94,10 @@ emdash({
 
 You also need to enable read replication on the D1 database itself in the Cloudflare dashboard or via the REST API.
 
+:::caution
+Read replica sessions are incompatible with the [`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public) compatibility flag. With that flag in your `wrangler.jsonc`, the internal request the D1 Sessions API makes to route queries to replicas is silently blocked, and every SSR request hangs until the Worker is killed — with nothing in the logs (`outcome: "canceled"`, no exceptions). The hang may only begin once replicas finish provisioning, so it can pass an initial post-deploy check and surface hours later. If your Worker needs that flag (for example, to fetch its own origin), keep `session` disabled. See [#1273](https://github.com/emdash-cms/emdash/issues/1273).
+:::
+
 See [Database Options — Read Replicas](/deployment/database/#read-replicas) for session modes and how bookmark-based consistency works.
 
 ## Object Cache

--- a/docs/src/content/docs/deployment/database.mdx
+++ b/docs/src/content/docs/deployment/database.mdx
@@ -111,6 +111,16 @@ export default defineConfig({
 	REST API. The `session` option only controls EmDash's client-side session management.
 </Aside>
 
+<Aside type="caution">
+	Sessions are incompatible with the
+	[`global_fetch_strictly_public`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)
+	compatibility flag: the internal request the D1 Sessions API makes to route queries to replicas
+	is silently blocked, and every SSR request hangs with nothing in the logs. The hang may only
+	begin once replicas finish provisioning, so it can pass an initial post-deploy check. If your
+	Worker needs that flag, keep `session` disabled. See
+	[#1273](https://github.com/emdash-cms/emdash/issues/1273).
+</Aside>
+
 <Aside>
 	Anonymous visitors may see data that is a few seconds stale. For a CMS this is expected — content
 	changes are not real-time, and if you have route caching enabled the response is already stale by

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -66,6 +66,15 @@ export interface D1Config {
 	 *
 	 * Read replication must also be enabled on the D1 database itself
 	 * (via dashboard or REST API).
+	 *
+	 * **Warning:** incompatible with the `global_fetch_strictly_public`
+	 * compatibility flag. With that flag set, the internal request the D1
+	 * Sessions API makes to route queries to replicas is silently blocked
+	 * and every SSR request hangs until the Worker is killed — with no
+	 * error logged (`outcome: "canceled"`, empty `exceptions`). The hang
+	 * may only start once replicas finish provisioning, so it can pass an
+	 * initial post-deploy check. Remove the flag or keep sessions
+	 * disabled. See https://github.com/emdash-cms/emdash/issues/1273.
 	 */
 	session?: "disabled" | "auto" | "primary-first";
 


### PR DESCRIPTION
## What does this PR do?

Documents the known incompatibility between D1 read replica sessions (`d1({ session: 'auto' | 'primary-first' })`) and the `global_fetch_strictly_public` compatibility flag, reported in #1273.

With that flag set, the internal request the D1 Sessions API makes to route queries to replicas is silently blocked by the runtime's fetch-isolation policy: every SSR request hangs until the Worker is killed, with nothing in the logs (`outcome: "canceled"`, empty `exceptions`). I hit this in production yesterday (details in [my comment on #1273](https://github.com/emdash-cms/emdash/issues/1273#issuecomment-4862392108)) — with the extra twist that the hang only began once replicas finished provisioning, so an initial post-deploy check passed and the site broke hours later.

Since the combination is currently completely undiscoverable until you find #1273, this adds a warning in the three places someone would look before enabling sessions:

- `D1Config.session` JSDoc in `@emdash-cms/cloudflare` (surfaces in editor tooltips at the moment of configuration),
- the **Read Replicas** section of the Cloudflare deployment guide,
- the **Read Replicas** section of the database options guide.

Docs-only wording change; no behavior change. A changeset is included because the JSDoc lives in the published `@emdash-cms/cloudflare` package.

Related to #1273 (does not close it — a runtime guard/auto-detection could still be a future fix).

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [x] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude Fable 5

## Screenshots / test output

Formatting verified with `prettier --check` on the touched files; `pnpm --filter @emdash-cms/cloudflare typecheck` passes after building workspace deps.