### PR TITLE
fix(cloudflare): make cloudflareEmail() return a bundlable plugin descriptor

### DIFF
--- a/.changeset/cloudflare-email-entrypoint.md
+++ b/.changeset/cloudflare-email-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"@emdash-cms/cloudflare": patch
+---
+
+Fixes `cloudflareEmail()` failing the Astro build. It now returns a plugin descriptor with a bundlable entrypoint instead of an in-process plugin definition, so the documented `plugins: [cloudflareEmail({...})]` usage builds again.

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -61,6 +61,10 @@
       "types": "./dist/plugins/index.d.mts",
       "default": "./dist/plugins/index.mjs"
     },
+    "./plugins/cloudflare-email": {
+      "types": "./dist/plugins/cloudflare-email.d.mts",
+      "default": "./dist/plugins/cloudflare-email.mjs"
+    },
     "./media/images-runtime": {
       "types": "./dist/media/images-runtime.d.mts",
       "default": "./dist/media/images-runtime.mjs"

--- a/packages/cloudflare/src/plugins/cloudflare-email.ts
+++ b/packages/cloudflare/src/plugins/cloudflare-email.ts
@@ -40,7 +40,8 @@
  * ```
  */
 
-import type { PluginContext, PluginDefinition } from "emdash";
+import type { PluginContext, PluginDescriptor, ResolvedPlugin } from "emdash";
+import { definePlugin } from "emdash";
 import type { EmailDeliverEvent } from "emdash/plugin";
 
 /**
@@ -143,13 +144,8 @@ export function createCloudflareEmailDeliver(
 	};
 }
 
-/**
- * Create a Cloudflare Email Sending provider plugin definition.
- *
- * Pass it to the emdash() integration's plugins array, activate it under
- * Admin → Extensions, then select it under Settings → Email.
- */
-export function cloudflareEmail(config: CloudflareEmailConfig): PluginDefinition {
+/** Validate the sender address early so misconfiguration fails at config time. */
+function assertValidFrom(config: CloudflareEmailConfig): void {
 	const fromEmail = typeof config.from === "string" ? config.from : config.from?.email;
 	if (!fromEmail || !fromEmail.includes("@")) {
 		throw new Error(
@@ -157,8 +153,19 @@ export function cloudflareEmail(config: CloudflareEmailConfig): PluginDefinition
 				"Cloudflare Email Sending rejects messages without a verified sender address.",
 		);
 	}
+}
 
-	return {
+/**
+ * Instantiate the Cloudflare Email Sending provider plugin.
+ *
+ * Called by the generated `virtual:emdash/plugins` module with the
+ * `options` from the {@link cloudflareEmail} descriptor. Use
+ * `cloudflareEmail()` in the astro config — this export exists so the
+ * integration can bundle the plugin from a static entrypoint.
+ */
+export function createPlugin(config: CloudflareEmailConfig): ResolvedPlugin {
+	assertValidFrom(config);
+	return definePlugin({
 		id: "cloudflare-email",
 		version: "1.0.0",
 		capabilities: ["hooks.email-transport:register"],
@@ -168,6 +175,31 @@ export function cloudflareEmail(config: CloudflareEmailConfig): PluginDefinition
 				handler: createCloudflareEmailDeliver(config),
 			},
 		},
+	});
+}
+
+/**
+ * Create a Cloudflare Email Sending provider plugin descriptor.
+ *
+ * Pass it to the emdash() integration's plugins array, activate it under
+ * Admin → Extensions, then select it under Settings → Email.
+ *
+ * Returns a `PluginDescriptor` (not an in-process definition): the astro
+ * integration requires every `plugins: []` entry to resolve to a bundlable
+ * `entrypoint`, so the descriptor points at this module and the integration
+ * imports {@link createPlugin} from it at build time (#1721).
+ */
+export function cloudflareEmail(
+	config: CloudflareEmailConfig,
+): PluginDescriptor<CloudflareEmailConfig> {
+	assertValidFrom(config);
+	return {
+		id: "cloudflare-email",
+		version: "1.0.0",
+		entrypoint: "@emdash-cms/cloudflare/plugins/cloudflare-email",
+		format: "native",
+		options: config,
+		capabilities: ["hooks.email-transport:register"],
 	};
 }
 

--- a/packages/cloudflare/tests/plugins-cloudflare-email.test.ts
+++ b/packages/cloudflare/tests/plugins-cloudflare-email.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
 	cloudflareEmail,
 	createCloudflareEmailDeliver,
+	createPlugin,
 	type CloudflareEmailConfig,
 } from "../src/plugins/cloudflare-email.js";
 
@@ -26,13 +27,16 @@ function fakeEnv(sendImpl?: () => Promise<{ messageId?: string }>) {
 }
 
 describe("cloudflareEmail()", () => {
-	it("returns a plugin definition with an exclusive email:deliver hook", () => {
-		const plugin = cloudflareEmail({ from: "cms@mails.example.com" });
-		expect(plugin.id).toBe("cloudflare-email");
-		expect(plugin.capabilities).toEqual(["hooks.email-transport:register"]);
-		const hook = plugin.hooks?.["email:deliver"];
-		expect(hook).toBeDefined();
-		expect(hook).toMatchObject({ exclusive: true });
+	it("returns a descriptor with a bundlable entrypoint (not an in-process definition)", () => {
+		// The astro integration rejects `plugins: []` entries without an
+		// `entrypoint` (#1721), so the documented usage must produce a
+		// descriptor the integration can statically import at build time.
+		const descriptor = cloudflareEmail({ from: "cms@mails.example.com" });
+		expect(descriptor.id).toBe("cloudflare-email");
+		expect(descriptor.entrypoint).toBe("@emdash-cms/cloudflare/plugins/cloudflare-email");
+		expect(descriptor.format).toBe("native");
+		expect(descriptor.options).toEqual({ from: "cms@mails.example.com" });
+		expect(descriptor.capabilities).toEqual(["hooks.email-transport:register"]);
 	});
 
 	it("rejects a missing or invalid from address", () => {
@@ -40,6 +44,37 @@ describe("cloudflareEmail()", () => {
 		expect(() =>
 			cloudflareEmail({ from: { email: "not-an-address" } } as CloudflareEmailConfig),
 		).toThrow(/config\.from is required/);
+	});
+});
+
+describe("createPlugin()", () => {
+	it("returns a resolved plugin with an exclusive email:deliver hook", () => {
+		const plugin = createPlugin({ from: "cms@mails.example.com" });
+		expect(plugin.id).toBe("cloudflare-email");
+		expect(plugin.capabilities).toEqual(["hooks.email-transport:register"]);
+		const hook = plugin.hooks["email:deliver"];
+		expect(hook).toBeDefined();
+		expect(hook).toMatchObject({ exclusive: true });
+	});
+
+	it("rejects a missing or invalid from address", () => {
+		expect(() => createPlugin({ from: "" })).toThrow(/config\.from is required/);
+	});
+
+	it("round-trips the descriptor options the virtual plugins module passes back", async () => {
+		const descriptor = cloudflareEmail({ from: "cms@mails.example.com" });
+		// Simulate what the generated virtual:emdash/plugins module does:
+		// `createPlugin(descriptor.options)`.
+		const plugin = createPlugin(descriptor.options as CloudflareEmailConfig);
+		const hook = plugin.hooks["email:deliver"];
+		expect(hook).toBeDefined();
+
+		// The handler resolves the env via cloudflare:workers, which is not
+		// available in vitest — assert it fails with the runtime-guard error
+		// rather than a config error, proving the wiring is intact.
+		await expect(hook?.handler(event, fakeCtx())).rejects.toThrow(
+			/cloudflare:workers is not available/,
+		);
 	});
 });
 

--- a/packages/cloudflare/tsdown.config.ts
+++ b/packages/cloudflare/tsdown.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
 		"src/sandbox/index.ts",
 		"src/worker.ts",
 		"src/plugins/index.ts",
+		// Standalone entry: cloudflareEmail() descriptors reference this module
+		// as their `entrypoint`, so the astro integration can statically import
+		// `createPlugin` from it (#1721).
+		"src/plugins/cloudflare-email.ts",
 		// Media provider runtimes
 		"src/media/images-runtime.ts",
 		"src/media/stream-runtime.ts",


### PR DESCRIPTION
## What does this PR do?

The documented `plugins: [cloudflareEmail({...})]` usage (from #1433) fails the Astro build: `cloudflareEmail()` returned a raw in-process plugin definition with no `entrypoint`, but the integration's `plugins: []` rejects entries without a bundlable entrypoint (guard added in #1416/#1560), so the two features were mutually incompatible.

This implements option 1 from the issue: `cloudflareEmail()` now returns a proper `PluginDescriptor` (`format: "native"`, `options`, `capabilities`) whose `entrypoint` points at a new dedicated subpath export, `@emdash-cms/cloudflare/plugins/cloudflare-email`. That module exports `createPlugin(options)`, so the generated `virtual:emdash/plugins` module instantiates it like any other native plugin. The sender-address validation still runs at config time (fail fast in `astro.config.mjs`) and again inside `createPlugin()`.

The subpath export (rather than reusing `./plugins`) keeps `createPlugin` from colliding with other plugin factories that may live in the barrel later.

No documented call-site changes — the README/#1433 example now builds as written.

Closes #1721

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings in the admin UI are [wrapped for translation](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#internationalization-i18n) (if applicable). Do not include `messages.po` changes except in translation PRs — a workflow extracts catalogs on merge to `main`.
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (if this PR changes a published package)
- [ ] New features link to an approved Discussion: https://github.com/emdash-cms/emdash/discussions/...

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Cursor + Claude

## Screenshots / test output

```
 Test Files  15 passed (15)
      Tests  214 passed (214)
```

(`attw --pack` in the package `check` script fails identically on unmodified `main` — pre-existing, unrelated to this change.)