### PR TITLE
perf(core): drive folded term hydration from the pivot on SQLite (#1722)

### DIFF
--- a/.changeset/folded-term-hydration-join-order.md
+++ b/.changeset/folded-term-hydration-join-order.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes slow collection-list pages on SQLite/D1: folded taxonomy-term hydration now drives its subquery from the content–taxonomy pivot instead of scanning every term in the locale per row, so list pages no longer read tens of thousands of rows on sites with large taxonomies.

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -116,12 +116,23 @@ function foldedHydrationSelects(db: Kysely<any>, type: string, outer: string) {
 	const agg = (inner: RawBuilder<unknown>) =>
 		pg ? sql`coalesce(json_agg(${inner}), '[]'::json)` : sql`json_group_array(${inner})`;
 
+	// Pin the join order for the per-entry hydration subqueries on SQLite (#1722).
+	// SQLite honours `CROSS JOIN` ordering, forcing the join to drive from the
+	// pivot (`content_taxonomies` / `_emdash_content_bylines`) by
+	// `(collection, entry_id)` and probe the term/byline table by
+	// `translation_group`. Without it, a stats-blind D1 planner (D1 never runs
+	// ANALYZE / maintains `sqlite_stat1`) is free to drive the correlated
+	// subquery from `taxonomies`/`_emdash_bylines` by `locale`, scanning every
+	// row in the locale per emitted entry. Postgres keeps statistics and rejects
+	// `CROSS JOIN … ON`, so it stays a plain `JOIN` there.
+	const foldJoin = pg ? sql`JOIN` : sql`CROSS JOIN`;
+
 	const termObj = obj(
 		"'id', t.id, 'name', t.name, 'slug', t.slug, 'label', t.label, 'parent_id', t.parent_id, 'locale', t.locale, 'translation_group', t.translation_group",
 	);
 	// Filter terms to the entry's own locale (matches #1441: terms render in the
 	// entry's resolved locale, not all locale variants of the attached group).
-	const terms = sql`(SELECT ${agg(termObj)} FROM ${sql.ref("content_taxonomies")} AS ct JOIN ${sql.ref("taxonomies")} AS t ON t.translation_group = ct.taxonomy_id WHERE ct.collection = ${type} AND ct.entry_id = ${o}.id AND t.locale = ${o}.locale) AS ${sql.ref("_emdash_terms")}`;
+	const terms = sql`(SELECT ${agg(termObj)} FROM ${sql.ref("content_taxonomies")} AS ct ${foldJoin} ${sql.ref("taxonomies")} AS t ON t.translation_group = ct.taxonomy_id WHERE ct.collection = ${type} AND ct.entry_id = ${o}.id AND t.locale = ${o}.locale) AS ${sql.ref("_emdash_terms")}`;
 
 	const bylineInner = obj(
 		"'id', b.id, 'slug', b.slug, 'displayName', b.display_name, 'bio', b.bio, 'avatarMediaId', b.avatar_media_id, 'avatarStorageKey', m.storage_key, 'avatarAlt', m.alt, 'avatarBlurhash', m.blurhash, 'avatarDominantColor', m.dominant_color, 'websiteUrl', b.website_url, 'userId', b.user_id, 'isGuest', b.is_guest, 'createdAt', b.created_at, 'updatedAt', b.updated_at, 'locale', b.locale, 'translationGroup', b.translation_group",
@@ -132,7 +143,7 @@ function foldedHydrationSelects(db: Kysely<any>, type: string, outer: string) {
 			)
 		: sql.raw("json_object('roleLabel', cb.role_label, 'sortOrder', cb.sort_order, 'byline', ");
 	const credit = sql`${creditObj}${bylineInner})`;
-	const bylines = sql`(SELECT ${agg(credit)} FROM ${sql.ref("_emdash_content_bylines")} AS cb JOIN ${sql.ref("_emdash_bylines")} AS b ON b.translation_group = cb.byline_id LEFT JOIN ${sql.ref("media")} AS m ON m.id = b.avatar_media_id WHERE cb.collection_slug = ${type} AND cb.content_id = ${o}.id AND b.locale = ${o}.locale) AS ${sql.ref("_emdash_bylines")}`;
+	const bylines = sql`(SELECT ${agg(credit)} FROM ${sql.ref("_emdash_content_bylines")} AS cb ${foldJoin} ${sql.ref("_emdash_bylines")} AS b ON b.translation_group = cb.byline_id LEFT JOIN ${sql.ref("media")} AS m ON m.id = b.avatar_media_id WHERE cb.collection_slug = ${type} AND cb.content_id = ${o}.id AND b.locale = ${o}.locale) AS ${sql.ref("_emdash_bylines")}`;
 	return { terms, bylines };
 }
 

--- a/packages/core/tests/integration/loader-fold-plan.test.ts
+++ b/packages/core/tests/integration/loader-fold-plan.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Query-plan shape of the folded taxonomy-term hydration subquery (#1722).
+ *
+ * `foldedHydrationSelects` folds per-entry term hydration into the content query
+ * as a correlated JSON-array subquery. On D1 / stats-blind SQLite (no ANALYZE,
+ * no `sqlite_stat1`) the planner is free to pick the join order, and a plain
+ * `JOIN` lets it drive the subquery from `taxonomies` by locale — enumerating
+ * *every term in the locale* and probing the pivot once per emitted row. On a
+ * site with thousands of terms that's tens of thousands of rows read per list
+ * page, paid on every cache miss.
+ *
+ * The fix pins the join order with `CROSS JOIN` on the SQLite path so the
+ * subquery always drives from the `content_taxonomies` pivot by
+ * `(collection, entry_id)` and probes `taxonomies` by `translation_group` — a
+ * handful of reads per entry, independent of taxonomy size and of statistics.
+ *
+ * This asserts the *plan*, not the output (output is covered by loader-fold).
+ * Since the planner is stats-blind here, the plan is schema-driven and does not
+ * depend on row counts — this DB matches D1's shape exactly.
+ *
+ * SQLite-only: `EXPLAIN QUERY PLAN` and `CROSS JOIN … ON` are SQLite concerns;
+ * Postgres keeps statistics and is unaffected.
+ */
+
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect } from "kysely";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { runMigrations } from "../../src/database/migrations/runner.js";
+import { ContentRepository } from "../../src/database/repositories/content.js";
+import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
+import type { Database as DatabaseSchema } from "../../src/database/types.js";
+import { emdashLoader } from "../../src/loader.js";
+import { runWithContext } from "../../src/request-context.js";
+import { SchemaRegistry } from "../../src/schema/registry.js";
+
+interface CapturedQuery {
+	sql: string;
+	parameters: readonly unknown[];
+}
+
+let sqlite: Database.Database;
+let db: Kysely<DatabaseSchema>;
+let captured: CapturedQuery[];
+
+beforeEach(async () => {
+	captured = [];
+	sqlite = new Database(":memory:");
+	db = new Kysely<DatabaseSchema>({
+		dialect: new SqliteDialect({ database: sqlite }),
+		log(event) {
+			if (event.level === "query") {
+				captured.push({
+					sql: event.query.sql,
+					parameters: event.query.parameters,
+				});
+			}
+		},
+	});
+
+	// Deliberately no ANALYZE: matches D1, which never maintains sqlite_stat1.
+	await runMigrations(db);
+	const registry = new SchemaRegistry(db);
+	await registry.createCollection({ slug: "post", label: "Posts", labelSingular: "Post" });
+	await registry.createField("post", { slug: "title", label: "Title", type: "string" });
+
+	// eslint-disable-next-line typescript/no-explicit-any -- schema type vs Database type
+	const anyDb = db as any;
+	const content = new ContentRepository(anyDb);
+	const tax = new TaxonomyRepository(anyDb);
+	const post = await content.create({
+		type: "post",
+		slug: "tagged",
+		data: { title: "Tagged" },
+		locale: "en",
+	});
+	await anyDb
+		.updateTable("ec_post")
+		.set({ status: "published" })
+		.where("id", "=", post.id)
+		.execute();
+	// A handful of terms in the active locale; two attached to the entry. The plan
+	// is stats-blind so the count is immaterial — the point is the join *order*.
+	for (let i = 0; i < 8; i++) {
+		const term = await tax.create({
+			name: "tag",
+			slug: `tag-${i}`,
+			label: `Tag ${i}`,
+			locale: "en",
+		});
+		if (i < 2) await tax.attachToEntry("post", post.id, term.id);
+	}
+});
+
+afterEach(async () => {
+	await db.destroy();
+});
+
+/** better-sqlite3 only binds primitives; coerce the JS values Kysely captured. */
+function bindable(p: unknown): unknown {
+	if (typeof p === "boolean") return p ? 1 : 0;
+	if (p instanceof Date) return p.toISOString();
+	if (p === undefined) return null;
+	return p;
+}
+
+function explain(query: CapturedQuery): string {
+	const rows = sqlite
+		.prepare(`EXPLAIN QUERY PLAN ${query.sql}`)
+		.all(...query.parameters.map(bindable)) as { detail: string }[];
+	return rows.map((r) => r.detail).join("\n");
+}
+
+it("drives folded term hydration from the content_taxonomies pivot, not taxonomies-by-locale", async () => {
+	const loader = emdashLoader();
+	// Running the real loader query also proves the SQL executes on SQLite.
+	await runWithContext({ editMode: false, db }, () =>
+		loader.loadCollection({ filter: { type: "post" } }),
+	);
+
+	// The folded list query is the one exposing the `_emdash_terms` alias.
+	const foldedQuery = captured.find((q) => q.sql.includes("_emdash_terms"));
+	expect(foldedQuery, "expected the loader to emit a folded list query").toBeDefined();
+
+	const plan = explain(foldedQuery!);
+
+	// Bad plan: the subquery drives from `taxonomies` by locale, scanning every
+	// term in the locale (`SEARCH t USING INDEX idx_taxonomies_locale`).
+	expect(plan).not.toContain("idx_taxonomies_locale");
+	// Good plan: probe `taxonomies` by translation_group, one row per attached
+	// term — only reachable when the pivot drives the join.
+	expect(plan).toContain("idx_taxonomies_translation_group");
+});

--- a/packages/core/tests/integration/loader-fold-plan.test.ts
+++ b/packages/core/tests/integration/loader-fold-plan.test.ts
@@ -1,22 +1,25 @@
 /**
- * Query-plan shape of the folded taxonomy-term hydration subquery (#1722).
+ * Query-plan shape of the folded per-entry hydration subqueries (#1722).
  *
- * `foldedHydrationSelects` folds per-entry term hydration into the content query
- * as a correlated JSON-array subquery. On D1 / stats-blind SQLite (no ANALYZE,
- * no `sqlite_stat1`) the planner is free to pick the join order, and a plain
- * `JOIN` lets it drive the subquery from `taxonomies` by locale — enumerating
- * *every term in the locale* and probing the pivot once per emitted row. On a
- * site with thousands of terms that's tens of thousands of rows read per list
- * page, paid on every cache miss.
+ * `foldedHydrationSelects` folds per-entry term *and* byline hydration into the
+ * content query as correlated JSON-array subqueries. On D1 / stats-blind SQLite
+ * (no ANALYZE, no `sqlite_stat1`) the planner is free to pick the join order,
+ * and a plain `JOIN` lets it drive a subquery from the term/byline table by
+ * locale — enumerating *every row in the locale* and probing the pivot once per
+ * emitted row. On a site with thousands of terms that's tens of thousands of
+ * rows read per list page, paid on every cache miss.
  *
- * The fix pins the join order with `CROSS JOIN` on the SQLite path so the
- * subquery always drives from the `content_taxonomies` pivot by
- * `(collection, entry_id)` and probes `taxonomies` by `translation_group` — a
- * handful of reads per entry, independent of taxonomy size and of statistics.
+ * The fix pins the join order with `CROSS JOIN` on the SQLite path so each
+ * subquery always drives from its pivot (`content_taxonomies` /
+ * `_emdash_content_bylines`) by `(collection, entry_id)` and probes the
+ * term/byline table by `translation_group` — a handful of reads per entry,
+ * independent of taxonomy/byline size and of statistics.
  *
  * This asserts the *plan*, not the output (output is covered by loader-fold).
  * Since the planner is stats-blind here, the plan is schema-driven and does not
- * depend on row counts — this DB matches D1's shape exactly.
+ * depend on row counts — this DB matches D1's shape exactly. Both `foldJoin`
+ * consumers (`loadCollection` and `loadEntry`) and both subqueries (taxonomy and
+ * byline) are guarded, since the fix hardened the join order for all of them.
  *
  * SQLite-only: `EXPLAIN QUERY PLAN` and `CROSS JOIN … ON` are SQLite concerns;
  * Postgres keeps statistics and is unaffected.
@@ -27,6 +30,7 @@ import { Kysely, SqliteDialect } from "kysely";
 import { afterEach, beforeEach, expect, it } from "vitest";
 
 import { runMigrations } from "../../src/database/migrations/runner.js";
+import { BylineRepository } from "../../src/database/repositories/byline.js";
 import { ContentRepository } from "../../src/database/repositories/content.js";
 import { TaxonomyRepository } from "../../src/database/repositories/taxonomy.js";
 import type { Database as DatabaseSchema } from "../../src/database/types.js";
@@ -68,6 +72,7 @@ beforeEach(async () => {
 	const anyDb = db as any;
 	const content = new ContentRepository(anyDb);
 	const tax = new TaxonomyRepository(anyDb);
+	const byline = new BylineRepository(anyDb);
 	const post = await content.create({
 		type: "post",
 		slug: "tagged",
@@ -79,8 +84,10 @@ beforeEach(async () => {
 		.set({ status: "published" })
 		.where("id", "=", post.id)
 		.execute();
-	// A handful of terms in the active locale; two attached to the entry. The plan
-	// is stats-blind so the count is immaterial — the point is the join *order*.
+	// A handful of terms and bylines in the active locale; two of each attached to
+	// the entry. The plan is stats-blind so the count is immaterial — the point is
+	// the join *order*. Attaching real rows also proves the SQL executes.
+	const attachedBylines: string[] = [];
 	for (let i = 0; i < 8; i++) {
 		const term = await tax.create({
 			name: "tag",
@@ -89,7 +96,18 @@ beforeEach(async () => {
 			locale: "en",
 		});
 		if (i < 2) await tax.attachToEntry("post", post.id, term.id);
+		const author = await byline.create({
+			displayName: `Author ${i}`,
+			slug: `author-${i}`,
+			locale: "en",
+		});
+		if (i < 2) attachedBylines.push(author.id);
 	}
+	await byline.setContentBylines(
+		"post",
+		post.id,
+		attachedBylines.map((bylineId) => ({ bylineId, roleLabel: "Author" })),
+	);
 });
 
 afterEach(async () => {
@@ -111,23 +129,53 @@ function explain(query: CapturedQuery): string {
 	return rows.map((r) => r.detail).join("\n");
 }
 
-it("drives folded term hydration from the content_taxonomies pivot, not taxonomies-by-locale", async () => {
+/**
+ * Assert both folded subqueries drive from their pivot rather than scanning the
+ * term/byline table by locale. Bad plan: the subquery drives from
+ * `taxonomies`/`_emdash_bylines` by locale, scanning every row in the locale.
+ * Good plan: probe the term/byline table by translation_group, one row per
+ * attached entry — only reachable when the pivot drives the join.
+ */
+function assertPivotDrivenFold(plan: string): void {
+	// Taxonomy subquery.
+	expect(plan, "taxonomy subquery must not scan taxonomies by locale").not.toContain(
+		"idx_taxonomies_locale",
+	);
+	expect(plan, "taxonomy subquery must probe taxonomies by translation_group").toContain(
+		"idx_taxonomies_translation_group",
+	);
+	// Byline subquery. Its `(translation_group, locale)` composite unique index
+	// already yields the pivot-driven plan today, so `CROSS JOIN` is a no-op here
+	// — this guards against a future byline-index change silently regressing it.
+	expect(plan, "byline subquery must not scan bylines by locale").not.toContain(
+		"idx__emdash_bylines_locale",
+	);
+	expect(plan, "byline subquery must probe bylines by translation_group").toContain(
+		"idx_bylines_group_locale_unique",
+	);
+}
+
+/** The folded query is the one exposing the `_emdash_terms` alias. */
+function foldedQueryPlan(): string {
+	const foldedQuery = captured.find((q) => q.sql.includes("_emdash_terms"));
+	expect(foldedQuery, "expected the loader to emit a folded query").toBeDefined();
+	return explain(foldedQuery!);
+}
+
+it("drives folded hydration from the pivot on loadCollection, not term/byline-by-locale", async () => {
 	const loader = emdashLoader();
 	// Running the real loader query also proves the SQL executes on SQLite.
 	await runWithContext({ editMode: false, db }, () =>
 		loader.loadCollection({ filter: { type: "post" } }),
 	);
+	assertPivotDrivenFold(foldedQueryPlan());
+});
 
-	// The folded list query is the one exposing the `_emdash_terms` alias.
-	const foldedQuery = captured.find((q) => q.sql.includes("_emdash_terms"));
-	expect(foldedQuery, "expected the loader to emit a folded list query").toBeDefined();
-
-	const plan = explain(foldedQuery!);
-
-	// Bad plan: the subquery drives from `taxonomies` by locale, scanning every
-	// term in the locale (`SEARCH t USING INDEX idx_taxonomies_locale`).
-	expect(plan).not.toContain("idx_taxonomies_locale");
-	// Good plan: probe `taxonomies` by translation_group, one row per attached
-	// term — only reachable when the pivot drives the join.
-	expect(plan).toContain("idx_taxonomies_translation_group");
+it("drives folded hydration from the pivot on loadEntry, not term/byline-by-locale", async () => {
+	const loader = emdashLoader();
+	captured = [];
+	await runWithContext({ editMode: false, db }, () =>
+		loader.loadEntry({ filter: { type: "post", id: "tagged", locale: "en" } }),
+	);
+	assertPivotDrivenFold(foldedQueryPlan());
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a query-plan regression in folded taxonomy-term hydration. `foldedHydrationSelects` (`packages/core/src/loader.ts`) folds per-entry term hydration into the content query as a correlated JSON-array subquery using a plain `JOIN`. On stats-blind SQLite/D1 (D1 never runs `ANALYZE` / maintains `sqlite_stat1`), the planner is free to drive that subquery from `taxonomies` **by locale** — enumerating every term in the locale and probing the pivot once per emitted row:

```
SEARCH t USING INDEX idx_taxonomies_locale (locale=?)          -- ALL terms in the locale
SEARCH ct USING COVERING INDEX ... (collection=? AND entry_id=? AND taxonomy_id=?)
```

On a site with ~1,540 terms in the active locale, a single unfiltered 25-row list page reads ≈ 25 × 1,540 ≈ **38.5K rows** — the floor for every list page, paid on every cache miss.

The fix pins the join order with `CROSS JOIN` on the SQLite path so the subquery always drives from the `content_taxonomies` pivot by `(collection, entry_id)` and probes `taxonomies` by `translation_group` — a handful of reads per entry, independent of taxonomy size and of statistics:

```
SEARCH ct USING COVERING INDEX ... (collection=? AND entry_id=?)
SEARCH t USING INDEX idx_taxonomies_translation_group (translation_group=?)
```

Postgres keeps statistics and rejects `CROSS JOIN … ON`, so it remains a plain `JOIN` there (byte-identical SQL to before). The byline subquery in the same function gets the same `CROSS JOIN` hardening for consistency and future-proofing — its composite `(translation_group, locale)` unique index already yields the pivot-driven plan today, so this is a no-op there but guards against future index changes.

Closes #1722

## Type of change

- [ ] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [x] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 diagnostics)
- [x] `pnpm test` passes (targeted: 548 tests across loader/query/fold/taxonomy/byline suites)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [ ] User-visible strings — n/a, no admin UI strings; no `messages.po` changes included
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) (`emdash` patch)
- [ ] New features link to an approved Discussion — n/a, this is a performance fix, not a feature

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Opus 4.8 (Claude Code)

## Screenshots / test output

New regression test (`packages/core/tests/integration/loader-fold-plan.test.ts`) captures the **real loader query**, runs `EXPLAIN QUERY PLAN` on a stats-blind (D1-shaped) SQLite DB, and asserts the taxonomy subquery drives from the pivot (`idx_taxonomies_translation_group`) rather than scanning `idx_taxonomies_locale`. It was written test-first: it failed against the old plain-`JOIN` code and passes after the fix.

```
 Test Files  44 passed (44)
      Tests  548 passed (548)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
