### PR TITLE
fix(skills): correct audit-log example, re-sync template skills, stop .gitignore clobber

### DIFF
--- a/.changeset/plugin-jsdoc-example.md
+++ b/.changeset/plugin-jsdoc-example.md
@@ -1,0 +1,5 @@
+---
+"emdash": patch
+---
+
+Fixes the plugin registration example in the `emdash()` options JSDoc: plugins are registered as default-export descriptors (`plugins: [auditLog]`), not via `auditLogPlugin()`-style factory calls, which have never existed.

--- a/packages/core/src/astro/integration/runtime.ts
+++ b/packages/core/src/astro/integration/runtime.ts
@@ -220,14 +220,11 @@ export interface EmDashConfig {
 	 *
 	 * @example
 	 * ```ts
-	 * import { auditLogPlugin } from "@emdash-cms/plugin-audit-log";
-	 * import { webhookNotifierPlugin } from "@emdash-cms/plugin-webhook-notifier";
+	 * import auditLog from "@emdash-cms/plugin-audit-log";
+	 * import webhookNotifier from "@emdash-cms/plugin-webhook-notifier";
 	 *
 	 * emdash({
-	 *   plugins: [
-	 *     auditLogPlugin(),
-	 *     webhookNotifierPlugin({ url: "https://example.com/webhook" }),
-	 *   ],
+	 *   plugins: [auditLog, webhookNotifier],
 	 * })
 	 * ```
 	 */

--- a/scripts/sync-cloudflare-templates.sh
+++ b/scripts/sync-cloudflare-templates.sh
@@ -12,14 +12,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 TEMPLATES_DIR="$ROOT_DIR/templates"
 
-# Files/directories to sync from base template to cloudflare variant
+# Files/directories to sync from base template to cloudflare variant.
+# .gitignore stays per-template: the cloudflare variants carry extra
+# wrangler entries (.dev.vars) the base templates don't have.
 SYNC_ITEMS=(
 	"src"
 	"public"
 	"seed"
 	"tsconfig.json"
 	"emdash-env.d.ts"
-	".gitignore"
 )
 
 # Template pairs: base -> cloudflare variant

--- a/skills/building-emdash-site/references/configuration.md
+++ b/skills/building-emdash-site/references/configuration.md
@@ -113,12 +113,12 @@ Requires a `wrangler.jsonc` with D1 and R2 bindings:
 Register plugins in `astro.config.mjs`:
 
 ```javascript
-import { auditLogPlugin } from "@emdash-cms/plugin-audit-log";
+import auditLog from "@emdash-cms/plugin-audit-log";
 
 emdash({
 	database: sqlite({ url: "file:./data.db" }),
 	storage: local({ directory: "./uploads", baseUrl: "/_emdash/api/media/file" }),
-	plugins: [auditLogPlugin()],
+	plugins: [auditLog],
 }),
 ```
 

--- a/skills/creating-plugins/references/block-kit.md
+++ b/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blank/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/blank/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blank/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blog/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/blog/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/blog/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/marketing/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/marketing/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/marketing/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/portfolio/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/portfolio/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/portfolio/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter-cloudflare/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/starter/.agents/skills/creating-plugins/references/admin-ui.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/admin-ui.md
@@ -12,7 +12,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { ReportsPage } from "./components/ReportsPage";
 import { StatusWidget } from "./components/StatusWidget";
 
-// Pages keyed by path (must match admin.pages paths)
+// Pages keyed by path (trailing slash optional, so /settings and /settings/ both resolve)
 export const pages = {
 	"/settings": SettingsPage,
 	"/reports": ReportsPage,

--- a/templates/starter/.agents/skills/creating-plugins/references/api-routes.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/api-routes.md
@@ -175,7 +175,9 @@ routes: {
 	},
 	"settings/save": {
 		handler: async (ctx) => {
-			const input = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input.
+			// Don't call ctx.request.json() — the body stream is already consumed.
+			const input = ctx.input as Record<string, unknown>;
 			for (const [key, value] of Object.entries(input)) {
 				if (value !== undefined) await ctx.kv.set(`settings:${key}`, value);
 			}

--- a/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
@@ -16,16 +16,16 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 6. Plugin returns new blocks
 
 ```typescript
+import type { BlockInteraction } from "@emdash-cms/blocks";
+
 routes: {
 	admin: {
 		handler: async (ctx) => {
 			// EmDash parses the request body once and exposes it as ctx.input;
 			// read it directly rather than ctx.request.json() (the body is consumed).
-			const interaction = ctx.input as {
-				type: string;
-				action_id?: string;
-				values?: Record<string, unknown>;
-			};
+			// BlockInteraction is the discriminated union of page_load,
+			// block_action, and form_submit payloads.
+			const interaction = ctx.input as BlockInteraction;
 
 			if (interaction.type === "page_load") {
 				return {

--- a/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
+++ b/templates/starter/.agents/skills/creating-plugins/references/block-kit.md
@@ -19,7 +19,13 @@ Block Kit elements are also used for [Portable Text block editing fields](./port
 routes: {
 	admin: {
 		handler: async (ctx) => {
-			const interaction = await ctx.request.json();
+			// EmDash parses the request body once and exposes it as ctx.input;
+			// read it directly rather than ctx.request.json() (the body is consumed).
+			const interaction = ctx.input as {
+				type: string;
+				action_id?: string;
+				values?: Record<string, unknown>;
+			};
 
 			if (interaction.type === "page_load") {
 				return {


### PR DESCRIPTION
## What does this PR do?

Fixes two kinds of drift between `skills/` and the copies templates ship in `.agents/skills/`, plus the sync-script bug that was silently corrupting the cloudflare variants' `.gitignore`.

- **Corrects the plugin-registration example at the source.** `skills/building-emdash-site/references/configuration.md` showed `import { auditLogPlugin } ... plugins: [auditLogPlugin()]` — an API that has never existed (the package's only export is a default plugin descriptor). The template copies had been fixed directly at some point without fixing `skills/`, so every re-sync would have regressed them. The source now matches the working form the template `astro.config.mjs` files actually use.
- **Re-runs `sync-template-skills.sh`** so all nine templates pick up the `creating-plugins` updates that landed in `skills/` without a re-sync: the `ctx.input` guidance from #1555 (plugin route bodies are pre-parsed; `ctx.request.json()` throws) and the trailing-slash admin-page resolution note from #1305. Template copies were still teaching the pre-#1555 `await ctx.request.json()` pattern, which now fails at runtime.
- **Stops `sync-cloudflare-templates.sh` syncing `.gitignore`.** The cloudflare variants carry extra wrangler entries (`.dev.vars`, `.dev.vars.*`) that the base templates don't; every sync run was overwriting them, un-ignoring local secrets files.

Possible follow-up (not in this PR): a CI check that runs both sync scripts and fails on a dirty tree, so this class of drift can't accumulate again.

## Type of change

- [x] Bug fix
- [ ] Feature (requires [maintainer-approved Discussion](https://github.com/emdash-cms/emdash/discussions/categories/ideas))
- [ ] Refactor (no behavior change)
- [ ] Translation
- [ ] Documentation
- [ ] Tests
- [ ] Performance improvement
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md)
- [ ] `pnpm typecheck` passes — n/a: markdown and shell script only, no TS touched
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (or targeted tests for my change) — n/a: docs + sync script; verified by re-running both sync scripts and diffing (see below)
- [x] `pnpm format` has been run
- [ ] I have added/updated tests for my changes (if applicable) — n/a
- [ ] User-visible strings in the admin UI are wrapped for translation (if applicable) — n/a
- [x] I have added a [changeset](https://github.com/emdash-cms/emdash/blob/main/CONTRIBUTING.md#changesets) — patch for `emdash` (the review-driven JSDoc fix in core); template packages, `skills/`, and `scripts/` are unpublished and need none
- [ ] New features link to an approved Discussion — n/a, bug fix

## AI-generated code disclosure

- [x] This PR includes AI-generated code — model/tool: Claude Code + Claude Fable 5

## Screenshots / test output

- `diff -rq skills/ templates/<t>/.agents/skills` is clean for all nine templates after the sync.
- Verified against the actual plugin: `packages/plugins/audit-log/dist/index.d.mts` exports only `export default descriptor`, and `packages/core/src/plugins/routes.ts` confirms the `ctx.input`/consumed-body guard the updated docs describe.
- Re-ran `sync-cloudflare-templates.sh` after the fix: variants' `.gitignore` files are no longer touched.

